### PR TITLE
chore: remove low value percy snapshots

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-component.cy.ts
@@ -1,7 +1,7 @@
 import type { SinonStub } from 'sinon'
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 import { getPathForPlatform } from '../../src/paths'
-import { snapshotAUTPanel } from './support/snapshot-aut-panel'
+// import { snapshotAUTPanel } from './support/snapshot-aut-panel'
 
 describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 10000 }, () => {
   context('default config', () => {
@@ -24,19 +24,22 @@ describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 
       cy.contains('Canary').should('be.visible')
       cy.findByTestId('viewport').click()
 
-      snapshotAUTPanel('browsers open')
+      // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+      // snapshotAUTPanel('browsers open')
       cy.contains('Canary').should('be.hidden')
       cy.contains('The viewport determines the width and height of your application under test. By default the viewport will be 500px by 500px for component testing.')
       .should('be.visible')
 
-      snapshotAUTPanel('viewport info open')
+      // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+      // snapshotAUTPanel('viewport info open')
 
       cy.get('body').click()
 
       cy.findByTestId('playground-activator').click()
       cy.findByTestId('playground-selector').clear().type('[data-cy-root]')
 
-      snapshotAUTPanel('cy.get selector')
+      // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+      // snapshotAUTPanel('cy.get selector')
 
       cy.findByTestId('playground-num-elements').contains('1 match')
 
@@ -50,7 +53,8 @@ describe('Cypress In Cypress CT', { viewportWidth: 1500, defaultCommandTimeout: 
 
       cy.findByTestId('playground-selector').clear().type('Component Test')
 
-      snapshotAUTPanel('cy.contains selector')
+      // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+      // snapshotAUTPanel('cy.contains selector')
 
       cy.findByTestId('playground-num-elements').contains('1 match')
 

--- a/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
@@ -1,5 +1,5 @@
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
-import { snapshotAUTPanel } from './support/snapshot-aut-panel'
+// import { snapshotAUTPanel } from './support/snapshot-aut-panel'
 import { getPathForPlatform } from '../../src/paths'
 
 describe('Cypress In Cypress E2E', { viewportWidth: 1500, defaultCommandTimeout: 10000 }, () => {
@@ -28,7 +28,8 @@ describe('Cypress In Cypress E2E', { viewportWidth: 1500, defaultCommandTimeout:
     .focus()
     .type('{esc}')
 
-    snapshotAUTPanel('browsers open')
+    // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+    // snapshotAUTPanel('browsers open')
 
     cy.contains('Canary').should('be.hidden')
 
@@ -36,14 +37,16 @@ describe('Cypress In Cypress E2E', { viewportWidth: 1500, defaultCommandTimeout:
     cy.contains('The viewport determines the width and height of your application under test. By default the viewport will be 1000px by 660px for end-to-end testing.')
     .should('be.visible')
 
-    snapshotAUTPanel('viewport info open')
+    // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+    // snapshotAUTPanel('viewport info open')
 
     cy.get('body').click()
 
     cy.findByTestId('playground-activator').click()
     cy.findByTestId('playground-selector').clear().type('li')
 
-    snapshotAUTPanel('cy.get selector')
+    // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+    // snapshotAUTPanel('cy.get selector')
 
     cy.findByTestId('playground-num-elements').contains('3 matches')
 
@@ -64,7 +67,8 @@ describe('Cypress In Cypress E2E', { viewportWidth: 1500, defaultCommandTimeout:
 
     cy.findByTestId('playground-selector').clear().type('Item 1')
 
-    snapshotAUTPanel('cy.contains selector')
+    // TODO: restore when Percy CSS is fixed. See https://github.com/cypress-io/cypress/issues/23435
+    // snapshotAUTPanel('cy.contains selector')
 
     cy.findByTestId('playground-num-elements').contains('1 match')
 

--- a/packages/app/cypress/e2e/runner/cloud-debug-filter.cy.ts
+++ b/packages/app/cypress/e2e/runner/cloud-debug-filter.cy.ts
@@ -55,12 +55,6 @@ describe('cloud debug test filtering', () => {
     cy.get('@reporterPanel').then((el) => el.width(500))
     cy.get('@reporterPanel').percySnapshot('wide')
 
-    cy.get('@reporterPanel').then((el) => el.width(350))
-    cy.get('@reporterPanel').percySnapshot('medium')
-
-    cy.get('@reporterPanel').then((el) => el.width(250))
-    cy.get('@reporterPanel').percySnapshot('narrow')
-
     cy.get('@reporterPanel').then((el) => el.width(150))
     cy.get('@reporterPanel').percySnapshot('skinny')
   })

--- a/packages/app/src/components/Blank.cy.tsx
+++ b/packages/app/src/components/Blank.cy.tsx
@@ -14,19 +14,19 @@ describe('initial', () => {
 })
 
 describe('testIsolationBlankPage', () => {
-  it('works', () => {
+  beforeEach(() => {
     getContainerEl()!.innerHTML = testIsolationBlankPage()
-
     cy.get('[data-cy="cypress-logo"]')
     cy.get('[data-cy="text"]').should('have.text', 'Default blank page')
     cy.get('[data-cy="subtext"]').should('have.text', 'This page was cleared by navigating to about:blank.All active session data (cookies, localStorage and sessionStorage) across all domains are cleared.')
+  })
 
+  it('works', () => {
     cy.percySnapshot()
   })
 
   it('works with small viewport', () => {
     cy.viewport(200, 500)
-    getContainerEl()!.innerHTML = testIsolationBlankPage()
 
     cy.percySnapshot()
   })
@@ -35,12 +35,14 @@ describe('testIsolationBlankPage', () => {
 describe('visitFailure', () => {
   it('works', () => {
     getContainerEl()!.innerHTML = visitFailure({ url: 'http://foo.cypress.io' })
-
-    cy.percySnapshot()
   })
 
   it('works with details', () => {
     getContainerEl()!.innerHTML = visitFailure({ url: 'http://foo.cypress.io', status: 404, statusText: 'Not Found', contentType: 'text/html' })
+
+    cy.get('p').contains('Sorry, we could not load:')
+    cy.get('a').contains('http://foo.cypress.io').should('have.attr', 'href', 'http://foo.cypress.io')
+    cy.get('p').contains('404 - Not Found (text/html)')
 
     cy.percySnapshot()
   })

--- a/packages/app/src/components/SpecPatterns.cy.tsx
+++ b/packages/app/src/components/SpecPatterns.cy.tsx
@@ -9,8 +9,6 @@ describe('<SpecPatterns />', () => {
 
     cy.get('[data-cy="spec-pattern"]').contains('cypress/e2e/**/*.cy.{js,jsx,ts,tsx}')
     cy.get('[data-cy="file-match-indicator"]').contains('50 matches')
-
-    cy.percySnapshot()
   })
 
   it('renders component spec pattern', () => {

--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -209,27 +209,18 @@ describe('<DebugContainer />', () => {
     context('over limit', () => {
       it('handled usage exceeded', () => {
         mountTestRun('overLimit')
-
         cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
-
-        cy.percySnapshot()
       })
 
       it('handles retention exceeded', () => {
         mountTestRun('overLimitRetention')
-
         cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
-
-        cy.percySnapshot()
       })
 
       it('does not show passing message if run is hidden', () => {
         mountTestRun('overLimitPassed')
-
         cy.contains('Well Done!').should('not.exist')
-
         cy.contains('All your tests passed.').should('not.exist')
-
         cy.findByRole('link', { name: 'Contact admin' }).should('be.visible').should('have.attr', 'href', 'http://localhost:3000?utmMedium=Debug+Tab&utmSource=Binary%3A+Launchpad')
       })
     })

--- a/packages/app/src/debug/DebugContainer.cy.tsx
+++ b/packages/app/src/debug/DebugContainer.cy.tsx
@@ -169,10 +169,10 @@ describe('<DebugContainer />', () => {
       it('renders', () => {
         mountTestRun('allSkipped')
 
+        cy.findByTestId('collapsible').should('be.visible')
+        cy.contains('h3', 'Incomplete')
         cy.contains('The browser server never connected.').should('be.visible')
         cy.contains('2 of 3 specs skipped').should('be.visible')
-
-        cy.percySnapshot()
       })
     })
 
@@ -180,9 +180,9 @@ describe('<DebugContainer />', () => {
       it('renders', () => {
         mountTestRun('noTests')
 
+        cy.findByTestId('collapsible').should('be.visible')
+        cy.contains('h3', 'Incomplete')
         cy.contains('Run has no tests').should('be.visible')
-
-        cy.percySnapshot()
       })
     })
 
@@ -190,19 +190,19 @@ describe('<DebugContainer />', () => {
       it('renders with CI information', () => {
         mountTestRun('timedOutWithCi')
 
+        cy.findByTestId('collapsible').should('be.visible')
+        cy.contains('h3', 'Incomplete')
         cy.contains('Circle CI #1234').should('have.attr', 'href', 'https://circleci.com').should('be.visible')
         cy.contains('Archive this run to remove it').should('be.visible')
-
-        cy.percySnapshot()
       })
 
       it('renders without CI information', () => {
         mountTestRun('timedOutWithoutCi')
 
+        cy.findByTestId('collapsible').should('be.visible')
+        cy.contains('h3', 'Incomplete')
         cy.contains('Circle CI #1234').should('not.exist')
         cy.contains('Archive this run to remove it').should('be.visible')
-
-        cy.percySnapshot()
       })
     })
 

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -123,8 +123,6 @@ describe('<DebugFailedTest/>', () => {
       .and('match', /utm_campaign/)
       .and('match', /utm_source/)
     })
-
-    cy.percySnapshot()
   })
 
   it('contains multiple titleParts segments', { viewportWidth: 1200 }, () => {

--- a/packages/app/src/debug/DebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/DebugFailedTest.cy.tsx
@@ -139,8 +139,6 @@ describe('<DebugFailedTest/>', () => {
     ))
 
     assertRowContents(multipleTitleParts)
-
-    cy.percySnapshot()
   })
 
   it('tests multiple groups', { viewportWidth: 1200 }, () => {

--- a/packages/app/src/debug/DebugPageHeader.cy.tsx
+++ b/packages/app/src/debug/DebugPageHeader.cy.tsx
@@ -98,7 +98,6 @@ describe('<DebugPageHeader />', {
       })
 
       cy.findByTestId(`debug-runNumber-${status}`).should('be.visible')
-      cy.percySnapshot()
     })
   })
 

--- a/packages/app/src/debug/DebugPendingRunCounts.cy.tsx
+++ b/packages/app/src/debug/DebugPendingRunCounts.cy.tsx
@@ -9,8 +9,6 @@ describe('<DebugPendingRunCounts />', () => {
     )
 
     cy.contains('2 of 20').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('renders counts of zeros input is undefined', () => {
@@ -21,7 +19,5 @@ describe('<DebugPendingRunCounts />', () => {
     )
 
     cy.contains('0 of 0').should('be.visible')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/DebugPendingRunSplash.cy.tsx
+++ b/packages/app/src/debug/DebugPendingRunSplash.cy.tsx
@@ -4,9 +4,8 @@ describe('<DebugPendingRunSplash />', () => {
   it('renders as expected', () => {
     cy.mount(<DebugPendingRunSplash/>)
 
-    cy.contains('Failures will be displayed here')
-
-    cy.percySnapshot()
+    cy.findByTestId('title').contains('Testing in progress...')
+    cy.findByTestId('splash-subtitle').contains('Failures will be displayed here')
   })
 
   it('renders scheduled to complete message', () => {
@@ -14,7 +13,5 @@ describe('<DebugPendingRunSplash />', () => {
 
     cy.contains('Scheduled to complete...')
     cy.findByTestId('splash-subtitle').should('not.exist')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/DebugResults.cy.tsx
+++ b/packages/app/src/debug/DebugResults.cy.tsx
@@ -17,8 +17,6 @@ describe('<DebugResults />', () => {
         cy.get(`[title=${defaultMessages.runs.results.pending}]`).should('contain.text', cloudRun.totalPending)
       })
     })
-
-    cy.percySnapshot()
   })
 })
 

--- a/packages/app/src/debug/DebugRunNavigation.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigation.cy.tsx
@@ -241,8 +241,6 @@ describe('<DebugRunNavigation />', () => {
 
     cy.contains('We found more than 100 runs.').should('be.visible')
     cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf/?utm_medium=Debug+Tab&utm_campaign=Run+Navigation+Limit&utm_source=Binary%3A+Launchpad')
-
-    cy.percySnapshot()
   })
 
   describe('Switch to latest run button', () => {

--- a/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
+++ b/packages/app/src/debug/DebugRunNavigationLimitMessage.cy.tsx
@@ -5,8 +5,6 @@ describe('DebugRunNavigationLimitMessage', () => {
     cy.mount(<DebugRunNavigationLimitMessage cloudProjectUrl="https://cloud.cypress.io/projects/ypt4pf/" />)
 
     cy.findByRole('link', { name: 'Go to Cypress Cloud to see all runs' }).should('be.visible').should('have.attr', 'href', 'https://cloud.cypress.io/projects/ypt4pf/?utm_medium=Debug+Tab&utm_campaign=Run+Navigation+Limit&utm_source=Binary%3A+Launchpad')
-
-    cy.percySnapshot()
   })
 
   it('does not render link if cloudProjectUrl is falsy', () => {

--- a/packages/app/src/debug/DebugRunStates.cy.tsx
+++ b/packages/app/src/debug/DebugRunStates.cy.tsx
@@ -27,7 +27,8 @@ describe('Debug page states', () => {
     it('renders', () => {
       cy.mount(<DebugPassed />)
 
-      cy.percySnapshot()
+      cy.contains('Well Done!')
+      cy.contains('All your tests passed')
     })
   })
 
@@ -35,17 +36,19 @@ describe('Debug page states', () => {
     it('renders for single spec', () => {
       cy.mount(<DebugErrored errors={[mockError]} totalSkippedSpecs={1} totalSpecs={1} />)
 
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Incomplete')
+      cy.contains(mockError)
       cy.contains('1 of 1 spec skipped').should('be.visible')
-
-      cy.percySnapshot()
     })
 
     it('renders for plural specs', () => {
       cy.mount(<DebugErrored errors={[mockError]} totalSkippedSpecs={4} totalSpecs={50} />)
 
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Incomplete')
+      cy.contains(mockError)
       cy.contains('4 of 50 specs skipped').should('be.visible')
-
-      cy.percySnapshot()
     })
   })
 
@@ -53,7 +56,9 @@ describe('Debug page states', () => {
     it('renders', () => {
       cy.mount(<DebugNoTests />)
 
-      cy.percySnapshot()
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Incomplete')
+      cy.contains('Run has no tests')
     })
   })
 
@@ -61,14 +66,21 @@ describe('Debug page states', () => {
     it('renders without CI information', () => {
       cy.mount(<DebugTimedout totalSkippedSpecs={4} totalSpecs={50} />)
 
-      cy.percySnapshot()
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Incomplete')
+      cy.contains('The run started but never completed. This can happen when the run is cancelled from CI or when Cypress crashes while running tests. Archive this run to remove it from the runs list and analytics.')
+      cy.contains('4 of 50 specs skipped')
     })
 
     it('renders with CI information', () => {
       cy.mount(<DebugTimedout
         ci={{ id: '123', url: 'https://circleci.com/', formattedProvider: 'CircleCI', ciBuildNumberFormatted: '12345' }} totalSkippedSpecs={4} totalSpecs={50} />)
 
-      cy.percySnapshot()
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Incomplete')
+      cy.contains('The run started but never completed. This can happen when the run is cancelled from CI or when Cypress crashes while running tests. Check your CircleCI #12345 logs for more information. Archive this run to remove it from the runs list and analytics.')
+      cy.findByTestId('external').contains('CircleCI #12345').should('have.attr', 'href', 'https://circleci.com/')
+      cy.contains('4 of 50 specs skipped')
     })
   })
 
@@ -87,7 +99,9 @@ describe('Debug page states', () => {
           />,
         )
 
-        cy.percySnapshot()
+        cy.contains('You\'ve reached your monthly test result limit')
+        cy.contains('Your Free Cypress Cloud plan includes 100 monthly recorded test results. Contact your Cypress Cloud admin to upgrade your plan and view more test results.')
+        cy.findByTestId('external').contains('Contact admin')
       })
 
       it('displays messaging for plan admins', () => {
@@ -103,7 +117,9 @@ describe('Debug page states', () => {
           />,
         )
 
-        cy.percySnapshot()
+        cy.contains('You\'ve reached your monthly test result limit')
+        cy.contains('Your Free Cypress Cloud plan includes 100 monthly recorded test results. Upgrade your plan now to view more test results.')
+        cy.findByTestId('external').contains('Upgrade plan')
       })
     })
 
@@ -121,7 +137,9 @@ describe('Debug page states', () => {
           />,
         )
 
-        cy.percySnapshot()
+        cy.contains('Beyond data retention')
+        cy.contains('Your data retention limit is 30 days and these tests ran 60 days ago. Upgrade your plan to increase your data retention limit.')
+        cy.findByTestId('external').contains('Contact admin')
       })
 
       it('displays messaging for plan admins', () => {
@@ -137,7 +155,9 @@ describe('Debug page states', () => {
           />,
         )
 
-        cy.percySnapshot()
+        cy.contains('Beyond data retention')
+        cy.contains('Your data retention limit is 30 days and these tests ran 60 days ago. Upgrade your plan to increase your data retention limit.')
+        cy.findByTestId('external').contains('Upgrade plan')
       })
     })
 
@@ -158,7 +178,9 @@ describe('Debug page states', () => {
           />,
         )
 
-        cy.percySnapshot()
+        cy.contains('You\'ve reached your monthly test result limit')
+        cy.contains('Your Free Cypress Cloud plan includes 30 monthly recorded test results. Upgrade your plan now to view more test results.')
+        cy.findByTestId('external').contains('Upgrade plan')
       })
     })
   })
@@ -166,8 +188,12 @@ describe('Debug page states', () => {
   context('cancelled', () => {
     it('renders', () => {
       cy.mount(<DebugCancelledAlert totalSpecs={5} totalSkippedSpecs={2} cancellation={{ cancelledAt: '2019-01-25T02:00:00.000Z', cancelledBy: { email: 'adams@cypress.io', fullName: 'Test Tester' } }} />)
-
-      cy.percySnapshot()
+      cy.findByTestId('collapsible').should('be.visible')
+      cy.get('h3').contains('Manually cancelled')
+      cy.contains('2 of 5 specs skipped')
+      cy.findByTestId('cancelled-by-user-avatar').should('have.attr', 'style', 'background-image: url("https://s.gravatar.com/avatar/402f6cafb6c02371c2c23c5215ae3d85?size=48&default=mm");')
+      cy.contains('Test Tester')
+      cy.contains('Jan 24, 2019 9:00 PM')
     })
   })
 })

--- a/packages/app/src/debug/DebugSpecLimitBanner.cy.tsx
+++ b/packages/app/src/debug/DebugSpecLimitBanner.cy.tsx
@@ -19,9 +19,6 @@ describe('<DebugSpecLimitBanner />', () => {
     .and('match', /utm_campaign/)
     .and('match', /utm_source/)
 
-    cy.viewport(1000, 400)
-    cy.percySnapshot('large viewport')
-
     cy.viewport(600, 400)
     cy.percySnapshot('small viewport')
   })
@@ -34,8 +31,8 @@ describe('<DebugSpecLimitBanner />', () => {
       />
     ))
 
+    cy.get('li').contains('Cypress renders up to 100 failed test results')
+    cy.get('li').contains('This run has 120 failed tests')
     cy.get('a').should('not.exist')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
+++ b/packages/app/src/debug/GroupedDebugFailedTest.cy.tsx
@@ -85,7 +85,5 @@ describe('<GroupedDebugFailedTest/>', () => {
       cy.findByTestId('debug-artifacts').should('be.visible').children().should('have.length', 3)
       cy.findByTestId('stats-metadata').children().should('have.length', 3)
     }))
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/LayeredBrowserIcons.cy.tsx
+++ b/packages/app/src/debug/LayeredBrowserIcons.cy.tsx
@@ -34,7 +34,5 @@ describe('<LayeredBrowserIcons/>', () => {
     cy.get('@allIcons').each((ele) => {
       cy.wrap(ele).find('svg').should('exist')
     })
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/debug/StatsMetadata.cy.tsx
+++ b/packages/app/src/debug/StatsMetadata.cy.tsx
@@ -235,7 +235,5 @@ describe('<StatsMetadata />', () => {
         cy.findByTestId(testingOrder[index]).should('be.visible')
       }
     })
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/navigation/SidebarNavigation.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigation.cy.tsx
@@ -102,10 +102,21 @@ describe('SidebarNavigation', () => {
     cy.contains('.v-popper--some-open--tooltip', 'test-project').should('be.visible')
     cy.findByTestId('sidebar-header').trigger('mouseout')
 
+    cy.findByTestId('sidebar-link-specs-page').trigger('mouseenter')
+    cy.contains('.v-popper--some-open--tooltip', 'Specs').should('be.visible')
+    cy.findByTestId('sidebar-link-specs-page').trigger('mouseout')
+
     cy.findByTestId('sidebar-link-runs-page').trigger('mouseenter')
     cy.contains('.v-popper--some-open--tooltip', 'Runs').should('be.visible')
     cy.findByTestId('sidebar-link-runs-page').trigger('mouseout')
-    cy.percySnapshot()
+
+    cy.findByTestId('sidebar-link-debug-page').trigger('mouseenter')
+    cy.contains('.v-popper--some-open--tooltip', 'Debug').should('be.visible')
+    cy.findByTestId('sidebar-link-debug-page').trigger('mouseout')
+
+    cy.findByTestId('sidebar-link-settings-page').trigger('mouseenter')
+    cy.contains('.v-popper--some-open--tooltip', 'Settings').should('be.visible')
+    cy.findByTestId('sidebar-link-settings-page').trigger('mouseout')
   })
 
   it('opens a modal to switch testing type', { viewportWidth: 1280 }, () => {

--- a/packages/app/src/navigation/SidebarNavigation.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigation.cy.tsx
@@ -149,7 +149,7 @@ describe('SidebarNavigation', () => {
     it('renders passing badge if run status is "RUNNING" with no failures', () => {
       mountComponent({ cloudProject: { status: 'RUNNING', numFailedTests: 0 } })
       cy.findByLabelText('Relevant run is passing').should('be.visible').contains('0')
-      cy.percySnapshot('Debug Badge:failed:single-digit')
+      cy.percySnapshot('Debug Badge:passed:single-digit')
     })
 
     it('renders failure badge if run status is "RUNNING" with failures', () => {
@@ -166,20 +166,18 @@ describe('SidebarNavigation', () => {
     it('renders success badge when status is "PASSED"', () => {
       mountComponent({ cloudProject: { status: 'PASSED', numFailedTests: 0 } })
       cy.findByLabelText('Relevant run passed').should('be.visible').contains('0')
-      cy.percySnapshot('Debug Badge:passed')
     })
 
     it('renders failure badge', () => {
       mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 1 } })
       cy.findByLabelText('Relevant run had 1 test failure').should('be.visible').contains('1')
-      cy.percySnapshot('Debug Badge:failed:single-digit')
 
       mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 10 } })
       cy.findByLabelText('Relevant run had 10 test failures').should('be.visible').contains('10')
-      cy.percySnapshot('Debug Badge:failed:double-digit')
 
       mountComponent({ cloudProject: { status: 'FAILED', numFailedTests: 100 } })
       cy.findByLabelText('Relevant run had 100 test failures').should('be.visible').contains('99+')
+
       cy.percySnapshot('Debug Badge:failed:truncated')
     })
 

--- a/packages/app/src/navigation/SidebarNavigation.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigation.cy.tsx
@@ -64,8 +64,10 @@ describe('SidebarNavigation', () => {
     })
 
     cy.findByText('test-project').should('be.visible')
-    cy.findByTestId('sidebar-link-specs-page').should('have.class', 'router-link-active') // assert active link to prevent percy flake
-    cy.percySnapshot()
+    cy.findByTestId('sidebar-link-specs-page').should('be.visible').should('have.class', 'router-link-active').contains('Specs') // assert active link to prevent percy flake
+    cy.findAllByTestId('sidebar-link-runs-page').should('be.visible').should('not.have.class', 'router-link-active').contains('Runs')
+    cy.findAllByTestId('sidebar-link-debug-page').should('be.visible').should('not.have.class', 'router-link-active').contains('Debug')
+    cy.findAllByTestId('sidebar-link-settings-page').should('be.visible').should('not.have.class', 'router-link-active').contains('Settings')
   })
 
   it('automatically collapses when viewport decreases < 1024px', () => {
@@ -109,7 +111,10 @@ describe('SidebarNavigation', () => {
   it('opens a modal to switch testing type', { viewportWidth: 1280 }, () => {
     mountComponent()
     cy.findByTestId('sidebar-header').click()
-    cy.percySnapshot()
+    cy.get('button').contains('E2E Testing')
+    cy.contains('p', 'Build and test the entire experience of your application from end-to-end to ensure each flow matches your expectations.')
+    cy.get('button').contains('Component Testing')
+    cy.contains('p', 'Build and test your components from your design system in isolation in order to ensure each state matches your expectations.')
   })
 
   it('opens a modal to show keyboard shortcuts', () => {

--- a/packages/app/src/navigation/SidebarNavigationHeader.cy.tsx
+++ b/packages/app/src/navigation/SidebarNavigationHeader.cy.tsx
@@ -9,7 +9,6 @@ describe('SidebarNavigationHeader', () => {
 
     cy.get('[data-cy="testing-type-e2e"]').should('exist')
     cy.contains('test-project')
-    cy.percySnapshot()
   })
 
   it('renders component icon', () => {
@@ -26,6 +25,5 @@ describe('SidebarNavigationHeader', () => {
 
     cy.get('[data-cy="testing-type-component"]').should('exist')
     cy.contains('test-project')
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/runner/SnapshotControls.cy.tsx
+++ b/packages/app/src/runner/SnapshotControls.cy.tsx
@@ -11,10 +11,6 @@ const snapshotControlsSelector = '[data-testid=snapshot-controls]'
 const unpinButtonSelector = '[data-testid=unpin]'
 
 describe('SnapshotControls', { viewportHeight: 200, viewportWidth: 500 }, () => {
-  afterEach(() => {
-    cy.wait(100).percySnapshot()
-  })
-
   const mountSnapshotControls = (
     eventManager = createEventManager(),
     autIframe = createTestAutIframe(),

--- a/packages/app/src/runner/SnapshotToggle.cy.tsx
+++ b/packages/app/src/runner/SnapshotToggle.cy.tsx
@@ -6,14 +6,12 @@ describe('<SnapshotToggle/>', () => {
 
     cy.mount(() => (<SnapshotToggle class="m-20" messages={messages} />))
 
-    cy.percySnapshot('before')
     .get('body')
     .findByText('2')
     .click()
     .parent()
     .findByText('1')
     .click()
-    .percySnapshot('after')
   })
 
   it('renders longer text', () => {
@@ -21,14 +19,12 @@ describe('<SnapshotToggle/>', () => {
 
     cy.mount(() => (<SnapshotToggle class="m-20" messages={messages} />))
 
-    cy.percySnapshot('before')
     .get('body')
     .findByText('Request')
     .click()
     .parent()
     .findByText('Response')
     .click()
-    .percySnapshot('after')
   })
 
   it('emits a select event with the active message', () => {

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.cy.tsx
@@ -20,15 +20,18 @@ function renderWithGql (gqlVal: SpecRunnerHeaderFragment) {
 describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
   it('renders', () => {
     const autStore = useAutStore()
+    const autUrl = 'http://localhost:4000'
 
-    autStore.updateUrl('http://localhost:4000')
+    autStore.updateUrl(autUrl)
     cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
       render: (gqlVal) => {
         return renderWithGql(gqlVal)
       },
     })
 
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').should('be.visible').should('have.value', autUrl)
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('disabled selector playground button when isRunning is true', () => {
@@ -43,7 +46,9 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     })
 
     cy.get('[data-cy="playground-activator"]').should('be.disabled')
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').should('be.visible')
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('disabled selector playground button when isLoading is true', () => {
@@ -58,7 +63,9 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     })
 
     cy.get('[data-cy="playground-activator"]').should('be.disabled')
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').should('be.visible')
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('enables selector playground button by default', () => {
@@ -69,13 +76,16 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     })
 
     cy.get('[data-cy="playground-activator"]').should('not.be.disabled')
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').should('be.visible')
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('shows url section if currentTestingType is e2e', () => {
     const autStore = useAutStore()
+    const autUrl = 'http://localhost:3000'
 
-    autStore.updateUrl('http://localhost:3000')
+    autStore.updateUrl(autUrl)
 
     cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
       onResult: (gql) => {
@@ -87,15 +97,18 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     })
 
     cy.get('[data-cy="aut-url"]').should('exist')
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').should('be.visible').should('have.value', autUrl)
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('url section handles long url/small viewport', {
     viewportWidth: 500,
   }, () => {
     const autStore = useAutStore()
+    const autUrl = 'http://localhost:3000/pretty/long/url.spec.jsx'
 
-    autStore.updateUrl('http://localhost:3000/pretty/long/url.spec.jsx')
+    autStore.updateUrl(autUrl)
 
     cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
       onResult: (gql) => {
@@ -107,14 +120,17 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     })
 
     cy.get('[data-cy="aut-url"]').should('exist')
+    cy.findByTestId('aut-url-input').should('be.visible').should('have.value', autUrl)
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
     cy.percySnapshot()
   })
 
   it('links to aut url', () => {
     const autStore = useAutStore()
-    const url = 'http://localhost:3000/todo'
+    const autUrl = 'http://localhost:3000/todo'
 
-    autStore.updateUrl(url)
+    autStore.updateUrl(autUrl)
 
     cy.mountFragment(SpecRunnerHeaderFragmentDoc, {
       onResult: (gql) => {
@@ -125,8 +141,9 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
       },
     })
 
-    cy.findByTestId('aut-url-input').invoke('val').should('contain', url)
-    cy.percySnapshot()
+    cy.findByTestId('aut-url-input').invoke('val').should('contain', autUrl)
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('does not show url section if currentTestingType is component', () => {
@@ -143,9 +160,10 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
       },
     })
 
-    cy.get('[data-cy="playground-activator"]').should('be.visible')
-    cy.get('[data-cy="aut-url"]').should('not.exist')
-    cy.percySnapshot()
+    cy.findByTestId('playground-activator').should('be.visible')
+    cy.findByTestId('aut-url').should('not.exist')
+    cy.findByTestId('select-browser').should('be.visible').contains('Electron 73')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('shows current browser and possible browsers', () => {
@@ -222,10 +240,11 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
     .should('be.visible')
     .should('have.attr', 'href', 'https://on.cypress.io/viewport')
 
+    cy.contains('The viewport determines the width and height of your application under test. By default the viewport will be 500px by 500px for end-to-end testing.')
     cy.contains('Additionally, you can override this value in your cypress.config.ts or via the cy.viewport() command.')
     .should('be.visible')
 
-    cy.percySnapshot()
+    cy.findByTestId('viewport-docs').should('have.attr', 'href', 'https://on.cypress.io/viewport')
   })
 
   it('disables browser dropdown button when isRunning is true', () => {
@@ -242,8 +261,10 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
       },
     })
 
+    cy.findByTestId('select-browser').should('be.visible').contains('Chrome 78')
     cy.get('[data-cy="select-browser"] > button').should('be.disabled')
-    cy.percySnapshot()
+    cy.findByTestId('aut-url').should('be.visible')
+    cy.findByTestId('viewport').should('be.visible').contains('500x500')
   })
 
   it('opens and closes selector playground', () => {
@@ -253,12 +274,10 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
       },
     })
 
-    cy.get('[data-cy="playground-activator"]').click()
+    cy.findByTestId('playground-activator').click()
     cy.get('#selector-playground').should('be.visible')
 
-    cy.percySnapshot()
-
-    cy.get('[data-cy="playground-activator"]').click()
+    cy.findByTestId('playground-activator').click()
     cy.get('#selector-playground').should('not.exist')
   })
 })

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.cy.tsx
@@ -177,8 +177,11 @@ describe('SpecRunnerHeaderOpenMode', { viewportHeight: 500 }, () => {
       },
     })
 
+    cy.findByTestId('select-browser').contains('Fake Browser')
+
     cy.get('[data-cy="select-browser"] > button img').should('have.attr', 'src', allBrowsersIcons.generic)
-    cy.percySnapshot()
+
+    cy.findByTestId('viewport').contains('500x500')
   })
 
   it('shows current viewport info', () => {

--- a/packages/app/src/runner/SpecRunnerHeaderRunMode.cy.tsx
+++ b/packages/app/src/runner/SpecRunnerHeaderRunMode.cy.tsx
@@ -56,8 +56,6 @@ describe('SpecRunnerHeaderRunMode', { viewportHeight: 500 }, () => {
       cy.contains('The viewport determines').should('not.exist')
       cy.contains('Chrome 1').click()
       cy.contains('Firefox').should('not.exist')
-
-      cy.percySnapshot()
     })
   })
 
@@ -72,9 +70,8 @@ describe('SpecRunnerHeaderRunMode', { viewportHeight: 500 }, () => {
 
       cy.mount(<SpecRunnerHeaderRunMode />)
 
+      cy.get('[data-cy="select-browser"] > button img').should('have.attr', 'src', allBrowsersIcons.Chrome)
       cy.get('[data-cy="select-browser"] > button').should('be.disabled')
-
-      cy.percySnapshot()
     })
   })
 
@@ -90,7 +87,7 @@ describe('SpecRunnerHeaderRunMode', { viewportHeight: 500 }, () => {
       cy.mount(<SpecRunnerHeaderRunMode />)
 
       cy.get('[data-cy="select-browser"] > button img').should('have.attr', 'src', allBrowsersIcons.generic)
-      cy.percySnapshot()
+      cy.get('[data-cy="select-browser"] > button').should('be.disabled')
     })
   })
 })

--- a/packages/app/src/runner/automation/AutomationDisconnected.cy.tsx
+++ b/packages/app/src/runner/automation/AutomationDisconnected.cy.tsx
@@ -5,7 +5,10 @@ describe('AutomationDisconnected', () => {
   it('should relaunch browser', () => {
     cy.mount(<AutomationDisconnected />)
 
-    cy.percySnapshot()
+    cy.findByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'The Cypress extension has disconnected.')
+    cy.contains('p', 'Cypress cannot run tests without this extension.')
+    cy.get('a').contains('Read more about browser management').should('have.attr', 'href', 'https://on.cypress.io/launching-browsers')
 
     const relaunchStub = cy.stub()
 

--- a/packages/app/src/runner/automation/AutomationMissing.cy.tsx
+++ b/packages/app/src/runner/automation/AutomationMissing.cy.tsx
@@ -14,7 +14,10 @@ describe('AutomationMissing', () => {
       },
     })
 
-    cy.percySnapshot()
+    cy.findByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'The Cypress extension is missing.')
+    cy.contains('p', 'Cypress cannot run tests without this extension. Please choose another browser.')
+    cy.findByTestId('external').contains('Read more about browser management').should('have.attr', 'href', 'https://on.cypress.io/launching-browsers')
 
     const selectBrowserStub = cy.stub()
 

--- a/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
+++ b/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
@@ -28,8 +28,6 @@ describe('SelectorPlayground', () => {
     cy.spy(autIframe, 'toggleSelectorHighlight')
     cy.get('[data-cy="selected-playground-method"]').should('contain', 'cy.get')
     cy.get('[data-cy="playground-selector"]').should('have.value', 'body')
-
-    cy.percySnapshot()
   })
 
   it('toggles enabled', () => {

--- a/packages/app/src/runs/RunCard.cy.tsx
+++ b/packages/app/src/runs/RunCard.cy.tsx
@@ -74,8 +74,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
 
       cy.contains(CloudRunStubs.allPassing.commitInfo.branch as string)
       .should('be.visible')
-
-      cy.percySnapshot()
     })
   })
 
@@ -100,8 +98,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
 
       // this is the human readable commit time from the stub
       cy.contains('an hour ago').should('be.visible')
-
-      cy.percySnapshot()
     })
   })
 
@@ -122,8 +118,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
 
       // this is the human readable commit time from the stub
       cy.contains('01:01:01').should('be.visible')
-
-      cy.percySnapshot()
     })
 
     it('displays mm:ss format for run duration if duration is less than an hour', () => {
@@ -142,8 +136,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
 
       // this is the human readable commit time from the stub
       cy.contains('01:01').should('be.visible')
-
-      cy.percySnapshot()
     })
   })
 
@@ -163,8 +155,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
       })
 
       cy.get('[data-cy="run-tag"]').should('have.length', 2).each(($el, i) => cy.wrap($el).contains(`tag${i}`))
-
-      cy.percySnapshot()
     })
 
     it('truncates tags if > 2', () => {
@@ -182,8 +172,6 @@ describe('<RunCard />', { viewportHeight: 400 }, () => {
       })
 
       cy.get('[data-cy="run-tag"]').should('have.length', 3).last().contains('+4')
-
-      cy.percySnapshot()
     })
   })
 })

--- a/packages/app/src/runs/RunResults.cy.tsx
+++ b/packages/app/src/runs/RunResults.cy.tsx
@@ -17,8 +17,6 @@ describe('<RunResults />', { viewportHeight: 150, viewportWidth: 250 }, () => {
         cy.get(`[title=${defaultMessages.runs.results.pending}]`).should('contain.text', cloudRun.totalPending)
       })
     })
-
-    cy.percySnapshot()
   })
 
   it('renders flaky ribbon', () => {
@@ -32,7 +30,5 @@ describe('<RunResults />', { viewportHeight: 150, viewportWidth: 250 }, () => {
     })
 
     cy.contains('4 Flaky')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/runs/RunsConnectSuccessAlert.spec.tsx
+++ b/packages/app/src/runs/RunsConnectSuccessAlert.spec.tsx
@@ -41,9 +41,6 @@ describe('<RunConnectSuccessAlert />', { viewportHeight: 400 }, () => {
           )
         },
       })
-
-      cy.viewport(1000, 800)
-      cy.percySnapshot()
     })
   })
 })

--- a/packages/app/src/runs/RunsContainer.cy.tsx
+++ b/packages/app/src/runs/RunsContainer.cy.tsx
@@ -98,7 +98,6 @@ describe('<RunsContainer />', { keystrokeDelay: 0 }, () => {
       const text = defaultMessages.runs.empty
 
       cy.contains(text.title).should('be.visible')
-      cy.percySnapshot()
     })
   })
 

--- a/packages/app/src/runs/RunsErrorRenderer.spec.tsx
+++ b/packages/app/src/runs/RunsErrorRenderer.spec.tsx
@@ -16,7 +16,10 @@ describe('<RunsErrorRenderer />', () => {
       },
     })
 
-    cy.percySnapshot()
+    cy.contains('h2', 'Cannot connect to Cypress Cloud')
+    cy.contains('p', 'The request times out when trying to retrieve the recorded runs from Cypress Cloud. Please refresh the page to try again and visit out Support page if this behavior continues.')
+    cy.findByTestId('external').contains('Support page').should('have.attr', 'href', 'https://www.cypressstatus.com/')
+    cy.contains('button', 'Try again')
   })
 
   it('should show a "not found" error and opens reconnect modal', () => {
@@ -43,7 +46,6 @@ describe('<RunsErrorRenderer />', () => {
     cy.contains('button', text.notFound.button).click()
 
     cy.get('@loginConnectSpy').should('have.been.calledWith', { utmMedium: 'Runs Tab' })
-    cy.percySnapshot()
   })
 
   describe('unauthorized', () => {
@@ -62,7 +64,9 @@ describe('<RunsErrorRenderer />', () => {
         },
       })
 
-      cy.percySnapshot()
+      cy.contains('h2', 'Request access to view the recorded runs')
+      cy.contains('p', 'This is a private project that you do not currently have access to. Please request access from the project owner in order to view the list of runs.')
+      cy.contains('button', 'Request access')
     })
 
     it('should display an "access requested" error', () => {
@@ -81,7 +85,9 @@ describe('<RunsErrorRenderer />', () => {
         },
       })
 
-      cy.percySnapshot()
+      cy.contains('h2', 'Your access request for this project has been sent.')
+      cy.contains('p', 'The owner of this project has been notified of your request. We\'ll notify you via email when your access request has been granted.')
+      cy.contains('button', 'Request Sent').should('be.disabled')
     })
   })
 })

--- a/packages/app/src/settings/SettingsCard.cy.tsx
+++ b/packages/app/src/settings/SettingsCard.cy.tsx
@@ -63,7 +63,6 @@ describe('<SettingsCard />', () => {
     ))
 
     cy.contains(collapsibleSelector, title).focus().type(' ')
-
-    cy.percySnapshot()
+    cy.findByTestId('setting-expanded-container').contains('The body of the content').should('be.visible')
   })
 })

--- a/packages/app/src/settings/SettingsContainer.cy.tsx
+++ b/packages/app/src/settings/SettingsContainer.cy.tsx
@@ -10,8 +10,9 @@ describe('<SettingsContainer />', { viewportHeight: 800, viewportWidth: 900 }, (
   it('renders sections collapsed by default', () => {
     cy.findByTestId('settings').should('be.visible')
     cy.findByTestId('setting-expanded-container').should('not.exist')
-
-    cy.percySnapshot()
+    cy.findByText(defaultMessages.settingsPage.experiments.title).should('not.exist')
+    cy.findByText(defaultMessages.settingsPage.editor.title).should('not.exist')
+    cy.findByText(defaultMessages.settingsPage.projectId.title).should('not.exist')
   })
 
   it('expands and collapses project settings', () => {
@@ -20,7 +21,6 @@ describe('<SettingsContainer />', { viewportHeight: 800, viewportWidth: 900 }, (
     cy.findByText(defaultMessages.settingsPage.experiments.title).scrollIntoView().should('be.visible')
     cy.findByText(defaultMessages.settingsPage.specPattern.title).scrollIntoView().should('be.visible')
     cy.findByText(defaultMessages.settingsPage.config.title).scrollIntoView().should('be.visible')
-    cy.percySnapshot()
     cy.findByText('Project settings').click()
 
     cy.findByText(defaultMessages.settingsPage.experiments.title).should('not.exist')
@@ -32,7 +32,6 @@ describe('<SettingsContainer />', { viewportHeight: 800, viewportWidth: 900 }, (
     cy.findByText(defaultMessages.settingsPage.editor.title).should('be.visible')
     cy.findByText(defaultMessages.settingsPage.proxy.title).should('be.visible')
     cy.findByText(defaultMessages.settingsPage.testingPreferences.title).should('be.visible')
-    cy.percySnapshot()
 
     cy.findByText('Device settings').click()
 
@@ -43,7 +42,6 @@ describe('<SettingsContainer />', { viewportHeight: 800, viewportWidth: 900 }, (
     cy.contains('Cypress Cloud settings').click()
 
     cy.findByText(defaultMessages.settingsPage.projectId.title).scrollIntoView().should('be.visible')
-    cy.percySnapshot()
     cy.findByText('Cypress Cloud settings').click()
 
     cy.findByText(defaultMessages.settingsPage.projectId.title).should('not.exist')

--- a/packages/app/src/settings/SettingsSection.cy.tsx
+++ b/packages/app/src/settings/SettingsSection.cy.tsx
@@ -21,7 +21,5 @@ describe('<SettingsSection />', () => {
     .get('h1').should('contain.text', title)
     .get('p').should('contain.text', description)
     .get('code').should('contain.text', code)
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/device/ExternalEditorSettings.cy.tsx
+++ b/packages/app/src/settings/device/ExternalEditorSettings.cy.tsx
@@ -13,8 +13,6 @@ describe('<ExternalEditorSettings />', () => {
     })
 
     cy.findByText(editorText.noEditorSelectedPlaceholder).should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('renders the title and description', () => {

--- a/packages/app/src/settings/device/ExternalEditorSettings.cy.tsx
+++ b/packages/app/src/settings/device/ExternalEditorSettings.cy.tsx
@@ -33,16 +33,13 @@ describe('<ExternalEditorSettings />', () => {
       },
     })
 
-    const optionsSelector = '[role=option]'
-    const inputSelector = '[aria-haspopup=true]'
-
-    cy.get(inputSelector).click()
-    .get(optionsSelector).should('be.visible')
-    .get(optionsSelector).then(($options) => {
+    cy.get('[aria-haspopup=true]').click()
+    .get('[role=option]').should('be.visible')
+    .then(($options) => {
       cy.wrap($options.first()).click()
-
-      cy.percySnapshot()
     })
+
+    cy.get('[aria-expanded="false"]').contains('VS Code')
   })
 
   it('can input a custom binary', () => {
@@ -60,7 +57,5 @@ describe('<ExternalEditorSettings />', () => {
     cy.get('[data-cy="custom-editor"]').should('exist')
 
     cy.findByPlaceholderText(editorText.customPathPlaceholder).type('/usr/bin').should('have.value', '/usr/bin')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/device/ProxySettings.cy.tsx
+++ b/packages/app/src/settings/device/ProxySettings.cy.tsx
@@ -15,13 +15,13 @@ describe('<ProxySettings />', {
       render: (gql) => <div class="p-[24px]"><ProxySettings gql={gql} /></div>,
     })
 
+    cy.contains('h2', 'Proxy settings')
+    cy.contains('p', 'Cypress auto-detected the following proxy settings from your operating system.')
     cy.findByText('Proxy bypass list')
     .get('[data-testid=bypass-list]').should('have.text', 'proxy-bypass')
 
     cy.findByText('Proxy server')
     .get('[data-testid=proxy-server]').should('have.text', 'proxy-server')
-
-    cy.percySnapshot()
   })
 
   it('renders the title and description', () => {

--- a/packages/app/src/settings/device/TestingPreferences.cy.tsx
+++ b/packages/app/src/settings/device/TestingPreferences.cy.tsx
@@ -3,16 +3,6 @@ import { TestingPreferencesFragmentDoc } from '../../generated/graphql-test'
 import TestingPreferences from './TestingPreferences.vue'
 
 describe('<TestingPreferences />', () => {
-  it('renders', () => {
-    cy.mountFragment(TestingPreferencesFragmentDoc, {
-      render: (gql) => (<div class="p-[24px]">
-        <TestingPreferences gql={gql} />
-      </div>),
-    })
-
-    cy.percySnapshot()
-  })
-
   it('renders the title and description', () => {
     const testingPreferences = defaultMessages.settingsPage.testingPreferences
 

--- a/packages/app/src/settings/project/CloudSettings.cy.tsx
+++ b/packages/app/src/settings/project/CloudSettings.cy.tsx
@@ -41,8 +41,6 @@ describe('<CloudSettings />', () => {
     cy.findByText(defaultMessages.settingsPage.projectId.title).should('not.exist')
     cy.findByText(defaultMessages.runs.connect.buttonUser).should('be.visible')
     cy.findByText(defaultMessages.settingsPage.recordKey.title).should('not.exist')
-
-    cy.percySnapshot()
   })
 
   it('hides Record Key when not present', () => {

--- a/packages/app/src/settings/project/CloudSettings.cy.tsx
+++ b/packages/app/src/settings/project/CloudSettings.cy.tsx
@@ -64,6 +64,6 @@ describe('<CloudSettings />', () => {
 
     cy.findByText(defaultMessages.settingsPage.recordKey.title).should('not.exist')
 
-    cy.percySnapshot()
+    cy.get('button').contains('Connect to Cypress Cloud')
   })
 })

--- a/packages/app/src/settings/project/CodeBox.cy.tsx
+++ b/packages/app/src/settings/project/CodeBox.cy.tsx
@@ -9,7 +9,6 @@ describe('<CodeBox/>', () => {
       </div>))
 
     cy.findByText('123456789').should('be.visible')
-    cy.percySnapshot()
   })
 
   it('renders the confidential', () => {
@@ -21,7 +20,6 @@ describe('<CodeBox/>', () => {
     cy.findByText('123456789').should('not.exist')
     cy.get('[aria-label="Record Key Visibility Toggle"]').click()
     cy.findByText('123456789').should('be.visible')
-    cy.percySnapshot()
   })
 
   it('renders the icon', () => {

--- a/packages/app/src/settings/project/Config.cy.tsx
+++ b/packages/app/src/settings/project/Config.cy.tsx
@@ -16,13 +16,10 @@ describe('<Config/>', { viewportWidth: 1200, viewportHeight: 1600 }, () => {
     cy.get('[data-cy="config-code"]').contains('reporter')
     cy.get('[data-cy="config-legend"]').contains('default')
     cy.contains(defaultMessages.settingsPage.config.title)
-
     // TODO: write a support file helper for ignoring the {0} values etc
     each(defaultMessages.settingsPage.config.description.split('{0}'), (description) => {
       cy.contains(description)
     })
-
-    cy.percySnapshot()
   })
 
   it('matches up legends with values', () => {

--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -199,8 +199,6 @@ describe('<ConfigCode />', () => {
           browser.minSupportedVersion && cy.contains(`minSupportedVersion: ${browser.minSupportedVersion},`)
           browser.majorVersion && cy.contains(`majorVersion: ${browser.majorVersion},`)
         })
-
-        cy.percySnapshot()
       } else {
         throw new Error('Missing browsers to render')
       }

--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -74,9 +74,6 @@ describe('<ConfigCode />', () => {
         .should('be.visible')
         .should('contain.text', 'plugin')
       })
-
-      // Take a snapshot of the last case
-      cy.percySnapshot()
     })
 
     it('shows the objectTest nicely', () => {

--- a/packages/app/src/settings/project/ExperimentRow.cy.tsx
+++ b/packages/app/src/settings/project/ExperimentRow.cy.tsx
@@ -38,7 +38,5 @@ describe('<ExperimentRow />', () => {
       cy.findByText(expDisabled.description).should('be.visible')
       cy.findByText(expDisabled.key).should('be.visible')
     })
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/project/Experiments.cy.tsx
+++ b/packages/app/src/settings/project/Experiments.cy.tsx
@@ -21,7 +21,5 @@ describe('<Experiments />', { viewportWidth: 800, viewportHeight: 600 }, () => {
       cy.contains(`[data-cy="experiment-${exp.field}"]`, expName)
       .should('contain', exp.value ? 'Enabled' : 'Disabled')
     })
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/project/ProjectId.cy.tsx
+++ b/packages/app/src/settings/project/ProjectId.cy.tsx
@@ -25,7 +25,5 @@ describe('<ProjectId />', () => {
 
     cy.findByText(givenProjectId).should('be.visible')
     cy.findByText('Copy')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/project/ProjectSettings.cy.tsx
+++ b/packages/app/src/settings/project/ProjectSettings.cy.tsx
@@ -16,7 +16,5 @@ describe('<ProjectSettings />', () => {
     })
 
     cy.findByText(defaultMessages.settingsPage.experiments.title).should('be.visible')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/project/RecordKey.cy.tsx
+++ b/packages/app/src/settings/project/RecordKey.cy.tsx
@@ -46,7 +46,5 @@ describe('<RecordKey />', () => {
     cy.contains('button', defaultMessages.clipboard.copy)
     .should('be.visible')
     .and('not.be.disabled')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/settings/project/SpecPatterns.cy.tsx
+++ b/packages/app/src/settings/project/SpecPatterns.cy.tsx
@@ -18,7 +18,5 @@ describe('<SpecPatterns />', () => {
     cy.get('[data-cy="file-match-indicator"]').contains('50 matches')
     cy.get('[data-cy="spec-pattern"]').contains('cypress/e2e/**/*.cy.{js,jsx,ts,tsx}')
     cy.get('[data-cy="external"]').should('have.attr', 'href').and('eq', 'https://on.cypress.io/test-type-options')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/AverageDuration.cy.tsx
+++ b/packages/app/src/specs/AverageDuration.cy.tsx
@@ -23,7 +23,6 @@ describe('<AverageDuration />', () => {
 
     it('renders nothing', () => {
       cy.findByTestId('average-duration').should('not.exist')
-      cy.percySnapshot()
     })
   })
 
@@ -35,7 +34,6 @@ describe('<AverageDuration />', () => {
 
       it('renders zero duration', () => {
         cy.findByTestId('average-duration').contains('0:00')
-        cy.percySnapshot()
       })
     })
 
@@ -46,7 +44,6 @@ describe('<AverageDuration />', () => {
 
       it('shows correct time', () => {
         cy.findByTestId('average-duration').contains('0:00')
-        cy.percySnapshot()
       })
     })
   })
@@ -58,7 +55,6 @@ describe('<AverageDuration />', () => {
 
     it('shows correct time', () => {
       cy.findByTestId('average-duration').contains('0:12')
-      cy.percySnapshot()
     })
   })
 
@@ -71,7 +67,6 @@ describe('<AverageDuration />', () => {
       it('shows correct time', () => {
         // 2:00 = 120 seconds
         cy.findByTestId('average-duration').contains('2:00')
-        cy.percySnapshot()
       })
     })
 
@@ -83,7 +78,6 @@ describe('<AverageDuration />', () => {
       it('shows correct time', () => {
         // 2:34 = 154 seconds
         cy.findByTestId('average-duration').contains('2:34')
-        cy.percySnapshot()
       })
     })
   })
@@ -97,7 +91,6 @@ describe('<AverageDuration />', () => {
       it('shows correct time', () => {
         // 2:02:34 = 7354 seconds
         cy.findByTestId('average-duration').contains('2:02:34')
-        cy.percySnapshot()
       })
     })
 
@@ -109,7 +102,6 @@ describe('<AverageDuration />', () => {
       it('shows correct time', () => {
         // 42:02:34 = 151354 seconds
         cy.findByTestId('average-duration').contains('42:02:34')
-        cy.percySnapshot()
       })
     })
   })

--- a/packages/app/src/specs/CreateSpecModal.cy.tsx
+++ b/packages/app/src/specs/CreateSpecModal.cy.tsx
@@ -298,7 +298,5 @@ describe('defaultSpecFileName', () => {
 
     cy.get('[data-cy="card"]').contains('Create new spec').click()
     cy.get('input').invoke('val').should('contain', 'spec.cy.js')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/InlineSpecList.cy.tsx
+++ b/packages/app/src/specs/InlineSpecList.cy.tsx
@@ -72,7 +72,11 @@ describe('InlineSpecList', () => {
       cy.get(newSpecSelector).click()
       cy.contains(defaultMessages.createSpec.newSpecModalTitle).should('be.visible')
 
-      cy.percySnapshot()
+      cy.contains(defaultMessages.createSpec.e2e.importFromScaffold.header).should('be.visible')
+      cy.contains(defaultMessages.createSpec.e2e.importFromScaffold.description).should('be.visible')
+
+      cy.contains(defaultMessages.createSpec.e2e.importTemplateSpec.header).should('be.visible')
+      cy.contains(defaultMessages.createSpec.e2e.importTemplateSpec.description).should('be.visible')
     })
 
     it('should handle spec refresh', () => {

--- a/packages/app/src/specs/InlineSpecListHeader.cy.tsx
+++ b/packages/app/src/specs/InlineSpecListHeader.cy.tsx
@@ -82,7 +82,6 @@ describe('InlineSpecListHeader', () => {
     useRunAllSpecsStore()
 
     mountWithProps({ isRunAllSpecsAllowed: true })
-    cy.percySnapshot()
 
     cy.get('[data-cy=run-all-specs-for-all]').as('run-all-btn').realHover()
     cy.contains(`Run ${EXPECTED_SPEC_COUNT} specs`).should('be.visible')

--- a/packages/app/src/specs/InlineSpecListTree.cy.tsx
+++ b/packages/app/src/specs/InlineSpecListTree.cy.tsx
@@ -97,7 +97,5 @@ describe('InlineSpecListTree', () => {
     .should('contain', 'Spec-C')
     .should('contain', 'utils')
     .and('contain', 'Spec-D')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/LastUpdatedHeader.cy.tsx
+++ b/packages/app/src/specs/LastUpdatedHeader.cy.tsx
@@ -27,14 +27,12 @@ describe('<LastUpdatedHeader />', () => {
   it('mounts correctly with git unavailable', () => {
     mountWithProps(false)
 
-    cy.findByTestId('last-updated-header').trigger('mouseenter')
+    cy.findByTestId('last-updated-header').contains('Last updated').trigger('mouseenter')
 
     const expectedTooltipText = defaultMessages.specPage.lastUpdated.tooltip.gitInfoUnavailable
     .replace('{0}', defaultMessages.specPage.lastUpdated.tooltip.gitInfo)
 
     cy.get(popperContentSelector).should('have.text', expectedTooltipText)
-
-    cy.percySnapshot()
   })
 
   it('delays popping tooltip', () => {

--- a/packages/app/src/specs/NoSpecsPage.cy.tsx
+++ b/packages/app/src/specs/NoSpecsPage.cy.tsx
@@ -40,8 +40,6 @@ describe('<NoSpecsPage />', { viewportHeight: 655, viewportWidth: 1032 }, () => 
     it('renders the correct text for component testing', () => {
       cy.get(pageTitleSelector).should('contain.text', messages.page.defaultPatternNoSpecs.title)
       .get(pageDescriptionSelector).should('contain.text', messages.page.defaultPatternNoSpecs.component.description)
-
-      cy.percySnapshot()
     })
   })
 
@@ -74,7 +72,6 @@ describe('<NoSpecsPage />', { viewportHeight: 655, viewportWidth: 1032 }, () => 
       cy.contains(text.importFromScaffold.description).should('be.visible')
       cy.contains(text.importTemplateSpec.header).should('be.visible')
       cy.contains(text.importTemplateSpec.description).should('be.visible')
-      cy.percySnapshot()
     })
   })
 

--- a/packages/app/src/specs/RequestAccessButton.cy.tsx
+++ b/packages/app/src/specs/RequestAccessButton.cy.tsx
@@ -32,8 +32,6 @@ describe('<RequestAccessButton />', () => {
       cy.get(requestAccessButtonSelector)
       .should('be.visible')
       .and('contain.text', messages.requestAccessButton)
-
-      cy.percySnapshot()
     })
 
     it('triggers mutation on button click', () => {
@@ -83,8 +81,6 @@ describe('<RequestAccessButton />', () => {
       cy.get(requestSentButton)
       .should('be.visible')
       .and('contain.text', messages.requestSentButton)
-
-      cy.percySnapshot()
     })
   })
 })

--- a/packages/app/src/specs/SpecFileItem.cy.tsx
+++ b/packages/app/src/specs/SpecFileItem.cy.tsx
@@ -8,8 +8,6 @@ describe('SpecFileItem', () => {
       </div>))
 
     cy.contains('Hello.spec.jsx').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('renders a SpecFileItem with the base filename and extension when selected', () => {
@@ -19,8 +17,6 @@ describe('SpecFileItem', () => {
       </div>))
 
     cy.contains('Hello.spec.jsx').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('truncates spec name if it exceeds container width and provides title for full spec name', () => {

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
@@ -168,9 +168,7 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .should('be.visible')
           .and('contain', get(defaultMessages, msgKeys.noAccess).replace('{0}', get(defaultMessages, msgKeys.docs)))
 
-          cy.contains('button', defaultMessages.specPage.requestSentButton).should('be.visible')
-
-          cy.percySnapshot()
+          cy.contains('button', defaultMessages.specPage.requestSentButton).should('be.visible').should('be.disabled')
         })
       })
 

--- a/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
+++ b/packages/app/src/specs/SpecHeaderCloudDataTooltip.cy.tsx
@@ -112,8 +112,6 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .and('contain', get(defaultMessages, msgKeys.connected).replace('{0}', get(defaultMessages, msgKeys.docs)))
 
           cy.findByTestId('cloud-data-tooltip-content').find('button').should('not.exist')
-
-          cy.percySnapshot()
         })
       })
 
@@ -134,8 +132,6 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .click()
 
           cy.get('@showLoginConnectSpy').should('have.been.calledOnce')
-
-          cy.percySnapshot()
         })
       })
 
@@ -152,7 +148,6 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .and('contain', get(defaultMessages, msgKeys.noAccess).replace('{0}', get(defaultMessages, msgKeys.docs)))
 
           cy.contains('button', defaultMessages.specPage.requestAccessButton).should('be.visible')
-          cy.percySnapshot()
         })
       })
 
@@ -189,8 +184,6 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .click()
 
           cy.get('@showLoginConnectSpy').should('have.been.calledOnce')
-
-          cy.percySnapshot()
         })
       })
 
@@ -211,8 +204,6 @@ describe('<SpecHeaderCloudDataTooltip />', () => {
           .click()
 
           cy.get('@showLoginConnectSpy').should('have.been.calledOnce')
-
-          cy.percySnapshot()
         })
       })
 

--- a/packages/app/src/specs/SpecItem.cy.tsx
+++ b/packages/app/src/specs/SpecItem.cy.tsx
@@ -38,8 +38,6 @@ describe('SpecItem', () => {
         expect(highlightedElementColor).to.equal(parentColor)
       })
     })
-
-    cy.percySnapshot()
   }),
   it('truncates spec name if it exceeds container width and provides title for full spec name', () => {
     const specFileName = `${'Long'.repeat(20)}Name`

--- a/packages/app/src/specs/SpecNameDisplay.cy.tsx
+++ b/packages/app/src/specs/SpecNameDisplay.cy.tsx
@@ -8,7 +8,5 @@ describe('<SpecNameDisplay />', () => {
     cy.findByText('.cy.tsx').should('be.visible')
 
     cy.findByTestId('spec-filename').should('have.attr', 'title', 'myFileName.cy.tsx')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/SpecsList.cy.tsx
+++ b/packages/app/src/specs/SpecsList.cy.tsx
@@ -178,23 +178,6 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
             })
           })
         })
-
-        it('displays the list as expected visually at various widths', () => {
-          cy.get('[data-cy="spec-list-file"]')
-          .should('have.length.above', 2)
-          .should('have.length.below', specs.length)
-
-          cy.wait(100) // there's an intentional 50ms delay in the code, lets just wait it out
-
-          cy.viewport(500, 850)
-          cy.percySnapshot('narrowest')
-          cy.viewport(650, 850)
-          cy.percySnapshot('narrow')
-          cy.viewport(800, 850)
-          cy.percySnapshot('medium')
-          cy.viewport(1200, 850)
-          cy.percySnapshot('wide')
-        })
       })
     })
 

--- a/packages/app/src/specs/SpecsList.cy.tsx
+++ b/packages/app/src/specs/SpecsList.cy.tsx
@@ -194,8 +194,6 @@ describe('<SpecsList />', { keystrokeDelay: 0 }, () => {
           cy.percySnapshot('medium')
           cy.viewport(1200, 850)
           cy.percySnapshot('wide')
-          cy.viewport(2000, 850)
-          cy.percySnapshot('widest')
         })
       })
     })

--- a/packages/app/src/specs/SpecsListBanners.cy.tsx
+++ b/packages/app/src/specs/SpecsListBanners.cy.tsx
@@ -10,16 +10,17 @@ import { UserProjectStatusStore, useUserProjectStatusStore } from '@packages/fro
 import type { UserProjectStatusState } from '@packages/frontend-shared/src/store/user-project-status-store'
 
 const AlertSelector = 'alert-header'
+const AlertBody = 'alert-body'
 const AlertCloseBtnSelector = 'alert-suffix-icon'
 
 type BannerKey = keyof typeof BannerIds
 type BannerId = typeof BannerIds[BannerKey]
 
 describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1000 }, () => {
-  const validateBaseRender = () => {
+  const validateBaseRender = (title: string, content: string) => {
     it('should render as expected', () => {
-      cy.findByTestId(AlertSelector).should('be.visible')
-      cy.percySnapshot()
+      cy.findByTestId(AlertSelector).should('be.visible').contains(title)
+      cy.findByTestId(AlertBody).should('be.visible').contains(content)
     })
   }
 
@@ -198,7 +199,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       cy.mountFragment(SpecsListBannersFragmentDoc, { render: (gql) => <SpecsListBanners gql={gql} isSpecNotFound={visible} /> })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'Spec not found',
+      'It is possible that the file has been moved or deleted. Please choose from the list of specs below.',
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -216,7 +221,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       cy.mountFragment(SpecsListBannersFragmentDoc, { render: (gql) => <SpecsListBanners gql={gql} isOffline={visible} /> })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'No internet connection',
+      'Please check your internet connection to resolve this issue. When your internet connection is fixed, we will automatically attempt to fetch the run metrics from Cypress Cloud.',
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -236,7 +245,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       cy.mountFragment(SpecsListBannersFragmentDoc, { render: (gql) => <SpecsListBanners gql={gql} onRefetchFailedCloudData={refetchCallback} isFetchError={visible} /> })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'Lost connection',
+      `The request timed out or failed when trying to retrieve the recorded run metrics from Cypress Cloud. The information that you're seeing in the table below may be incomplete as a result.`,
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -264,7 +277,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       cy.mountFragment(SpecsListBannersFragmentDoc, { render: (gql) => <SpecsListBanners gql={gql} isProjectNotFound={visible} /> })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      `Couldn't find your project`,
+      'We were unable to find an existing project matching the projectId: "test-project-id" set in your Cypress config file. You can reconnect with an existing project or create a new project.',
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -306,7 +323,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'Request access to project',
+      'This is a private project that you do not currently have access to. Please request access from the project owner in order to view the list of runs.',
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -341,7 +362,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'Request access to project',
+      `The owner of this project has been notified of your request. We'll notify you via email when your access request has been granted.`,
+    )
+
     validateCloseControl()
     validateCloseOnPropChange(visible)
     validateReopenOnPropChange(visible)
@@ -494,7 +519,11 @@ describe('<SpecsListBanners />', { viewportHeight: 260, defaultCommandTimeout: 1
       })
     })
 
-    validateBaseRender()
+    validateBaseRender(
+      'React component testing is available for this project',
+      'You can now use Cypress to develop and test individual components without running your whole application. Generate the config in just a few clicks.',
+    )
+
     validateCloseControl()
     validateSmartNotificationBehaviors(BannerIds.CT_052023_AVAILABLE, 'component-testing-banner', gql)
 

--- a/packages/app/src/specs/SpecsListHeader.cy.tsx
+++ b/packages/app/src/specs/SpecsListHeader.cy.tsx
@@ -94,17 +94,11 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     .should('be.visible')
     .and('have.attr', 'aria-live', 'polite')
 
-    cy.percySnapshot('No matches')
-
     mountWithSpecCount(1)
     cy.contains('1 match').should('be.visible')
 
-    cy.percySnapshot('Singular Match')
-
     mountWithSpecCount(100)
     cy.contains('100 matches').should('be.visible')
-
-    cy.percySnapshot('Plural Match')
   })
 
   it('shows the count correctly while searching', () => {

--- a/packages/app/src/specs/SpecsListHeader.cy.tsx
+++ b/packages/app/src/specs/SpecsListHeader.cy.tsx
@@ -79,8 +79,6 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     .click()
     .get('@show-spec-pattern-modal')
     .should('have.been.called')
-
-    cy.percySnapshot()
   })
 
   it('shows the count correctly when not searching', () => {
@@ -124,7 +122,5 @@ describe('<SpecsListHeader />', { keystrokeDelay: 0 }, () => {
     cy.contains('0 of 1 match').should('be.visible')
     cy.contains('1 of 1 match').should('be.visible')
     cy.contains('5 of 22 matches').should('be.visible')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/banners/TrackedBanner.cy.tsx
+++ b/packages/app/src/specs/banners/TrackedBanner.cy.tsx
@@ -8,8 +8,6 @@ describe('<TrackedBanner />', () => {
 
     cy.findByText('Test Content').should('be.visible')
     cy.findByTestId('alert-suffix-icon').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('should record when banner is made visible', () => {

--- a/packages/app/src/specs/flaky-badge/FlakyBadge.cy.tsx
+++ b/packages/app/src/specs/flaky-badge/FlakyBadge.cy.tsx
@@ -10,7 +10,5 @@ describe('<FlakyBadge />', () => {
     cy.findByTestId(flakyBadgeTestId)
     .should('have.text', defaultMessages.specPage.flaky.badgeLabel)
     .and('be.visible')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/app/src/specs/flaky-badge/FlakySpecSummary.cy.tsx
+++ b/packages/app/src/specs/flaky-badge/FlakySpecSummary.cy.tsx
@@ -1,66 +1,44 @@
 import FlakySpecSummary from './FlakySpecSummary.vue'
 
 describe('<FlakySpecSummary />', () => {
-  it('low severity', () => {
-    cy.mount(
-      <FlakySpecSummary
-        specName="test"
-        specExtension=".cy.tsx"
-        severity="low"
-        totalFlakyRuns={4}
-        totalRuns={50}
-        runsSinceLastFlake={15}
-      />,
-    )
-
-    cy.percySnapshot()
-  })
-
-  it('medium severity', () => {
-    cy.mount(
-      <FlakySpecSummary
-        specName="test"
-        specExtension=".cy.tsx"
-        severity="medium"
-        totalFlakyRuns={14}
-        totalRuns={50}
-        runsSinceLastFlake={5}
-      />,
-    )
-
-    cy.percySnapshot()
-  })
-
-  it('high severity', () => {
-    cy.mount(
-      <FlakySpecSummary
-        specName="test"
-        specExtension=".cy.tsx"
-        severity="high"
-        totalFlakyRuns={24}
-        totalRuns={50}
-        runsSinceLastFlake={2}
-      />,
-    )
-
-    cy.percySnapshot()
-  })
-
-  it('loading state', () => {
-    // Ensure component handles malformed/incomplete data without blowing up
-    cy.mount(
-      <FlakySpecSummary
-        specName="test"
-        specExtension=".cy.tsx"
-        severity={'unknown_value' as any}
-        totalFlakyRuns={null as any}
-        totalRuns={null as any}
-        runsSinceLastFlake={null as any}
-      />,
-    )
+  it('severities', () => {
+    cy.mount(() =>
+      <div>
+        <FlakySpecSummary
+          specName="test"
+          specExtension=".cy.tsx"
+          severity="low"
+          totalFlakyRuns={4}
+          totalRuns={50}
+          runsSinceLastFlake={15}
+        />
+        <FlakySpecSummary
+          specName="test"
+          specExtension=".cy.tsx"
+          severity="medium"
+          totalFlakyRuns={14}
+          totalRuns={50}
+          runsSinceLastFlake={5}
+        />
+        <FlakySpecSummary
+          specName="test"
+          specExtension=".cy.tsx"
+          severity="high"
+          totalFlakyRuns={24}
+          totalRuns={50}
+          runsSinceLastFlake={2}
+        />
+        <FlakySpecSummary
+          specName="test"
+          specExtension=".cy.tsx"
+          severity={'unknown_value'}
+          totalFlakyRuns={null}
+          totalRuns={null}
+          runsSinceLastFlake={null}
+        />,
+      </div>)
 
     cy.findByTestId('flaky-specsummary-loading-1').should('be.visible')
-
     cy.percySnapshot()
   })
 

--- a/packages/app/src/specs/flaky-badge/FlakySpecSummary.cy.tsx
+++ b/packages/app/src/specs/flaky-badge/FlakySpecSummary.cy.tsx
@@ -32,8 +32,11 @@ describe('<FlakySpecSummary />', () => {
           specName="test"
           specExtension=".cy.tsx"
           severity={'unknown_value'}
+          // @ts-ignore
           totalFlakyRuns={null}
+          // @ts-ignore
           totalRuns={null}
+          // @ts-ignore
           runsSinceLastFlake={null}
         />,
       </div>)

--- a/packages/app/src/specs/flaky-badge/FlakySpecSummary.vue
+++ b/packages/app/src/specs/flaky-badge/FlakySpecSummary.vue
@@ -86,9 +86,9 @@ const props = defineProps<{
   specName: string
   specExtension: string
   severity: string
-  totalFlakyRuns: number
-  totalRuns: number
-  runsSinceLastFlake: number
+  totalFlakyRuns: number | null
+  totalRuns: number | null
+  runsSinceLastFlake: number | null
 }>()
 
 const flakyRate = computed(() => {

--- a/packages/app/src/specs/flaky-badge/FlakySpecSummary.vue
+++ b/packages/app/src/specs/flaky-badge/FlakySpecSummary.vue
@@ -86,9 +86,9 @@ const props = defineProps<{
   specName: string
   specExtension: string
   severity: string
-  totalFlakyRuns: number | null
-  totalRuns: number | null
-  runsSinceLastFlake: number | null
+  totalFlakyRuns: number
+  totalRuns: number
+  runsSinceLastFlake: number
 }>()
 
 const flakyRate = computed(() => {

--- a/packages/app/src/specs/generators/ExpandableFileList.cy.tsx
+++ b/packages/app/src/specs/generators/ExpandableFileList.cy.tsx
@@ -50,7 +50,6 @@ describe('<ExpandableFileList />', { viewportHeight: 500, viewportWidth: 400 }, 
 
     it('correctly formats a difficult file', () => {
       cy.get('body').contains('[...all]')
-      cy.percySnapshot()
     })
   })
 
@@ -73,8 +72,6 @@ describe('<ExpandableFileList />', { viewportHeight: 500, viewportWidth: 400 }, 
 
       </div>))
       .get(noResultsSelector).should('be.visible')
-
-      cy.percySnapshot()
 
       cy.get('[data-testid=add-file]')
       .click()

--- a/packages/app/src/specs/generators/GeneratorSuccess.cy.tsx
+++ b/packages/app/src/specs/generators/GeneratorSuccess.cy.tsx
@@ -12,7 +12,7 @@ describe('<${spec.baseName} />', () => {
   it('renders', () => {
     // https://on.cypress.io/mount
     mount(<${spec.baseName} />)
-  })
+  }) 
 })
 `.trim()
 
@@ -21,8 +21,6 @@ describe('<GeneratorSuccess />', () => {
     cy.mount(() => (<GeneratorSuccess file={{ ...spec, contents: content }} />))
     .get('body')
     .contains(spec.relative)
-
-    cy.percySnapshot()
   })
 
   it('can be collapsed to hide the content', () => {

--- a/packages/app/src/specs/generators/GeneratorSuccess.cy.tsx
+++ b/packages/app/src/specs/generators/GeneratorSuccess.cy.tsx
@@ -32,23 +32,9 @@ describe('<GeneratorSuccess />', () => {
     .wait(200) // just to show off the animation
     .get(targetSelector)
     .click()
-
-    cy.percySnapshot()
-  })
-
-  it('can be expanded to show the content', () => {
-    cy.mount(() => (<GeneratorSuccess file={{ ...spec, contents: content }} />))
-    .get(targetSelector)
-    .click()
-    .click()
     .get('code .line')
     .should('be.visible')
     .should('have.length', content.split('\n').length)
-    .wait(200) // just to show off the animation
-    .get(targetSelector)
-    .click()
-
-    cy.percySnapshot()
   })
 
   it('handles really long file names and really long content', () => {

--- a/packages/app/src/specs/generators/component/ReactComponentList.cy.tsx
+++ b/packages/app/src/specs/generators/component/ReactComponentList.cy.tsx
@@ -18,8 +18,6 @@ describe('ReactComponentList', () => {
     cy.mount(<ReactComponentList file={mockFile} />)
 
     cy.contains('No components found').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('renders error state if errored is true', () => {
@@ -30,8 +28,6 @@ describe('ReactComponentList', () => {
     cy.mount(<ReactComponentList file={mockFile} />)
 
     cy.contains('Unable to parse file').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('fetches and displays a list of components', () => {
@@ -40,8 +36,6 @@ describe('ReactComponentList', () => {
     cy.contains('FooBar').should('be.visible')
     cy.contains('BarFoo').should('be.visible')
     cy.contains('FooBarBaz').should('be.visible')
-
-    cy.percySnapshot()
   })
 
   it('calls selectItem on click', () => {

--- a/packages/frontend-shared/src/components/Alert.cy.tsx
+++ b/packages/frontend-shared/src/components/Alert.cy.tsx
@@ -38,18 +38,6 @@ const prefixIcon = () => <CoffeeIcon data-cy="coffee-icon"/>
 const suffixIcon = () => <LoadingIcon data-cy="loading-icon" class="animate-spin"/>
 
 describe('<Alert />', () => {
-  describe('classes', () => {
-    it('can change the text and background color for the alert', () => {
-      cy.mount(() =>
-        (<div class="flex flex-col m-[8px] gap-[8px]">
-          <Alert headerClass="underline text-pink-500 bg-pink-100" bodyClass="bg-pink-50" icon={suffixIcon}>test</Alert>
-          <Alert headerClass="underline text-teal-500 bg-teal-100" bodyClass="bg-teal-50" icon={suffixIcon}>test</Alert>
-        </div>))
-
-      cy.percySnapshot()
-    })
-  })
-
   describe('title', () => {
     it('can accept slot as title slot', () => {
       cy.mount(() => (<Alert dismissible status="success"
@@ -234,8 +222,8 @@ describe('<Alert />', () => {
   })
 })
 
-describe('playground', () => {
-  it('renders', () => {
+describe('<Alert />', () => {
+  it('renders various alerts with customizations', () => {
     const { modelValue, methods } = makeDismissibleProps()
 
     cy.mount(() => {
@@ -259,11 +247,12 @@ describe('playground', () => {
             {...methods}>Close me, please!</Alert>
           <Alert v-slots={{ suffixIcon }} collapsible status="default">A notice.</Alert>
           <Alert>Default alert</Alert>
+          <Alert headerClass="underline text-pink-500 bg-pink-100" bodyClass="bg-pink-50" icon={suffixIcon}>test</Alert>
+          <Alert headerClass="underline text-teal-500 bg-teal-100" bodyClass="bg-teal-50" icon={suffixIcon}>test</Alert>
         </div>
       )
     })
 
-    cy.contains('Coffee, please').should('be.visible')
     cy.percySnapshot()
   })
 })

--- a/packages/frontend-shared/src/components/Card.cy.tsx
+++ b/packages/frontend-shared/src/components/Card.cy.tsx
@@ -53,13 +53,16 @@ describe('Card', { viewportHeight: 400 }, () => {
     // health check that expected icons and hover icons are present in the dom
     cy.get('svg').should('have.length', 4)
 
-    cy.percySnapshot('both cards unfocused')
+    // cy.percySnapshot('both cards unfocused') TODO: Find out why focus state is not capptured in Percy.
 
+    cy.get('@e2eTitle').should('not.be.focused')
     cy.get('@e2eTitle').focus()
-    cy.percySnapshot('card-1 focused')
+    cy.get('@e2eTitle').should('be.focused')
+    // cy.percySnapshot('card-1 focused') TODO: Find out why focus state is not capptured in Percy.
 
     cy.get('@ctTitle').focus()
-    cy.percySnapshot('card-2 focused')
+    cy.get('@ctTitle').should('be.focused')
+    // cy.percySnapshot('card-2 focused') TODO: Find out why focus state is not capptured in Percy.
 
     // clicks work on card or button
     cy.get('[data-cy="card"]').eq(0).click()

--- a/packages/frontend-shared/src/components/CopyText.cy.tsx
+++ b/packages/frontend-shared/src/components/CopyText.cy.tsx
@@ -11,7 +11,6 @@ describe('<CopyText />', () => {
 
     cy.contains('button', defaultMessages.clipboard.copy)
     .should('be.visible')
-    .percySnapshot()
   })
 
   it('overflows nicely', { viewportWidth: 800, viewportHeight: 120 }, () => {

--- a/packages/frontend-shared/src/components/InlineCodeFragment.cy.tsx
+++ b/packages/frontend-shared/src/components/InlineCodeFragment.cy.tsx
@@ -6,6 +6,5 @@ describe('<InlineCodeFragment/>', () => {
 
     cy.contains('I am code')
     .should('be.visible')
-    .percySnapshot()
   })
 })

--- a/packages/frontend-shared/src/components/NoInternetConnection.cy.tsx
+++ b/packages/frontend-shared/src/components/NoInternetConnection.cy.tsx
@@ -16,7 +16,5 @@ describe('<NoInternetConnection />', () => {
     cy.log('Mount with slot content')
     cy.mount(() => <NoInternetConnection> Extra Text </NoInternetConnection>)
     cy.contains('Extra Text').should('be.visible')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/frontend-shared/src/components/ResultCounts.cy.tsx
+++ b/packages/frontend-shared/src/components/ResultCounts.cy.tsx
@@ -21,8 +21,6 @@ describe('<ResultCounts />', () => {
     validateResult(defaultMessages.runs.results.pending, 3)
     validateResult(defaultMessages.runs.results.passed, 2)
     validateResult(defaultMessages.runs.results.failed, 1)
-
-    cy.percySnapshot()
   })
 
   it('renders zero contents', () => {
@@ -38,8 +36,6 @@ describe('<ResultCounts />', () => {
     validateResult(defaultMessages.runs.results.pending, 0)
     validateResult(defaultMessages.runs.results.passed, 0)
     validateResult(defaultMessages.runs.results.failed, 0)
-
-    cy.percySnapshot()
   })
 
   it('renders string range values', () => {
@@ -55,8 +51,6 @@ describe('<ResultCounts />', () => {
     validateResult(defaultMessages.runs.results.pending, '5-5')
     validateResult(defaultMessages.runs.results.passed, '2-20')
     validateResult(defaultMessages.runs.results.failed, '1-2')
-
-    cy.percySnapshot()
   })
 
   it('changes order of status signs with the order prop', () => {

--- a/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
+++ b/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
@@ -116,19 +116,14 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
       cy.mount(() => <div class="h-10 p-12"><ShikiHighlight code={code.repeat(5)} lang="ts" copyButton={true} /></div>)
       cy.get('button').validateWithinViewport()
 
-      cy.percySnapshot('copy button initially within viewport')
-
       cy.scrollTo('bottom', { duration: 100 })
       .get('button')
       .validateWithinViewport()
-
-      cy.percySnapshot('copy button remains within viewport on scroll down')
 
       cy.scrollTo('top', { duration: 100 })
       .get('button')
       .validateWithinViewport()
 
-      cy.percySnapshot('copy button remains within viewport on scroll up')
       cy.contains(code)
     })
   })

--- a/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
+++ b/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
@@ -86,12 +86,6 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
     cy.percySnapshot()
   })
 
-  it('display inline and remove some of the padding when "inline"', { viewportWidth: 300, viewportHeight: 100 }, () => {
-    cy.mount(() => <ShikiHighlight code={'project: xv123456'} lang="yaml" inline />)
-    cy.get('.shiki').should('be.visible')
-    cy.percySnapshot()
-  })
-
   it('show line numbers when the prop is passed', () => {
     cy.mount(() => <div class="p-12"><ShikiHighlight code={code} lang="ts" lineNumbers /></div>)
     cy.get('.shiki').should('be.visible')

--- a/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
+++ b/packages/frontend-shared/src/components/ShikiHighlight.cy.tsx
@@ -42,7 +42,6 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
     </div>))
 
     cy.contains(devServerCode).should('be.visible')
-    cy.percySnapshot()
   })
 
   it('trims whitespace to show the correct number of lines', { viewportWidth: 500, viewportHeight: 500 }, () => {
@@ -83,6 +82,7 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
   it('render the code without arguments', () => {
     cy.mount(() => <div class="p-12"><ShikiHighlight code={code} lang="ts" /></div>)
     cy.get('.shiki').should('be.visible')
+    cy.contains(code)
     cy.percySnapshot()
   })
 
@@ -95,12 +95,14 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
   it('show line numbers when the prop is passed', () => {
     cy.mount(() => <div class="p-12"><ShikiHighlight code={code} lang="ts" lineNumbers /></div>)
     cy.get('.shiki').should('be.visible')
+    cy.contains(code)
     cy.percySnapshot()
   })
 
   it('show line numbers with initial line when the prop is passed', () => {
     cy.mount(() => <div class="p-12"><ShikiHighlight code={code} lang="ts" lineNumbers initialLine={10} /></div>)
     cy.get('.shiki').should('be.visible')
+    cy.contains(code)
     cy.percySnapshot()
   })
 
@@ -113,7 +115,7 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
     it('should render when specified "true"', () => {
       cy.mount(() => <div class="p-12"><ShikiHighlight code={code} lang="ts" copyButton={true} /></div>)
       cy.get('button').should('be.visible')
-      cy.percySnapshot()
+      cy.contains(code)
     })
 
     it('should remain visible when content becomes scrollable', () => {
@@ -133,6 +135,7 @@ describe('<ShikiHighlight/>', { viewportWidth: 800, viewportHeight: 500 }, () =>
       .validateWithinViewport()
 
       cy.percySnapshot('copy button remains within viewport on scroll up')
+      cy.contains(code)
     })
   })
 })

--- a/packages/frontend-shared/src/components/ShikiHighlight.vue
+++ b/packages/frontend-shared/src/components/ShikiHighlight.vue
@@ -1,8 +1,7 @@
 <!--
 Styling syntax highlighting is a bit messy.
 
-### There are three main presentational styles:
-1. Inline
+### There are two main presentational styles:
 2. Multi-line with line numbers
 3. Multi-line without line numbers
 
@@ -43,10 +42,9 @@ shikiWrapperClasses computed property.
          *    with line-numbers, the breaks will create a new line.
          */
         {
-          'inline': props.inline,
           'wrap': props.wrap,
           'line-numbers': props.lineNumbers,
-          'p-[8px]': !props.lineNumbers && !props.inline && !props.codeframe,
+          'p-[8px]': !props.lineNumbers && !props.codeframe,
           'p-[2px]': props.codeframe,
         },
 
@@ -92,7 +90,6 @@ const props = withDefaults(defineProps<{
   initialLine?: number
   lang: CyLangType | undefined
   lineNumbers?: boolean
-  inline?: boolean
   wrap?: boolean
   copyOnClick?: boolean
   copyButton?: boolean
@@ -101,7 +98,6 @@ const props = withDefaults(defineProps<{
   class?: string | string[] | Record<string, any>
 }>(), {
   lineNumbers: false,
-  inline: false,
   wrap: false,
   copyOnClick: false,
   codeframe: false,
@@ -161,10 +157,6 @@ avoid colliding with styles elsewhere in the document.
 
 <style lang="scss" scoped>
 $offset: 1.1em;
-
-.inline:deep(.shiki) {
-  @apply bg-gray-50 py-1 px-2 text-gray-500 inline-block;
-}
 
 .shiki-wrapper {
   &:deep(.shiki) {

--- a/packages/frontend-shared/src/components/StandardModal.cy.tsx
+++ b/packages/frontend-shared/src/components/StandardModal.cy.tsx
@@ -57,8 +57,6 @@ describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () =>
 
       cy.contains('h2', title).should('be.visible')
       cy.contains(body).should('be.visible')
-
-      cy.percySnapshot()
     })
 
     it('bare variant renders without padding in body', () => {
@@ -89,7 +87,8 @@ describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () =>
       .closest(`[data-cy=standard-modal].${testClass}`)
       .should('exist')
 
-      cy.percySnapshot()
+      cy.findByTestId('external').should('be.visible').should('have.attr', 'href', 'https://on.cypress.io')
+      cy.findByLabelText('Close').should('be.visible')
     })
 
     it('automatically closes tooltips on open', () => {
@@ -124,8 +123,6 @@ describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () =>
       // Verify tooltip is no longer open once modal was opened
       cy.findByTestId('tooltip-content')
       .should('not.exist')
-
-      cy.percySnapshot()
     })
   })
 

--- a/packages/frontend-shared/src/components/TerminalPrompt.cy.tsx
+++ b/packages/frontend-shared/src/components/TerminalPrompt.cy.tsx
@@ -11,7 +11,6 @@ describe('<TerminalPrompt />', () => {
 
     cy.contains('button', defaultMessages.clipboard.copy)
     .should('be.visible')
-    .percySnapshot()
   })
 
   it('overflows nicely', { viewportWidth: 800, viewportHeight: 120 }, () => {

--- a/packages/frontend-shared/src/gql-components/ChooseExternalEditor.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/ChooseExternalEditor.cy.tsx
@@ -26,13 +26,9 @@ describe('ChooseExternalEditor', { viewportHeight: 400, viewportWidth: 300 }, ()
     cy.contains('Atom').should('be.visible')
     cy.contains('Vim').should('be.visible')
 
-    cy.percySnapshot('open')
-
     cy.contains('Vim').click()
     cy.contains('Vim').should('be.visible')
     cy.contains('Atom').should('not.exist')
-
-    cy.percySnapshot('selected')
 
     cy.get('[data-cy="custom-editor"]').should('not.exist')
 
@@ -43,7 +39,5 @@ describe('ChooseExternalEditor', { viewportHeight: 400, viewportWidth: 300 }, ()
     cy.findByLabelText(defaultMessages.settingsPage.editor.customPathPlaceholder)
     .type('test/path')
     .should('have.value', 'test/path')
-
-    cy.percySnapshot('custom editor input')
   })
 })

--- a/packages/frontend-shared/src/gql-components/ChooseExternalEditor.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/ChooseExternalEditor.cy.tsx
@@ -21,9 +21,6 @@ describe('ChooseExternalEditor', { viewportHeight: 400, viewportWidth: 300 }, ()
     .should('be.visible')
     .as('chooseEditor')
 
-    // initial
-    cy.percySnapshot()
-
     cy.get('@chooseEditor').click()
     cy.contains('On Computer').should('be.visible')
     cy.contains('Atom').should('be.visible')

--- a/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/HeaderBarContent.cy.tsx
@@ -22,8 +22,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       render: (gqlVal) => <div class="border-current border h-[700px] resize overflow-auto"><HeaderBarContent gql={gqlVal} show-browsers={true} /></div>,
     })
 
-    cy.percySnapshot('before browsers open')
-
     cy.findByTestId('top-nav-active-browser')
     .should('be.visible')
     .click()
@@ -63,10 +61,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
   })
 
   describe('breadcrumbs', () => {
-    afterEach(() => {
-      cy.percySnapshot()
-    })
-
     context('with current project', () => {
       const currentProject = {
         title: 'app',
@@ -93,8 +87,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
         })
 
         cy.get('.truncate').contains('application-program/hard-drive-parse').should('be.visible')
-
-        cy.percySnapshot()
 
         cy.get('.truncate').realHover()
         cy.get('.v-popper__popper--shown').contains('application-program/hard-drive-parse')
@@ -134,7 +126,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
     mountFragmentWithData()
 
     cy.findByTestId('top-nav-active-browser').should('not.exist')
-    cy.percySnapshot()
     cy.contains('button', text.docsMenu.docsHeading).click()
 
     cy.wrap(Object.values(text.docsMenu)).each((menuItem) => {
@@ -143,14 +134,14 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       }
     })
 
-    cy.percySnapshot()
     cy.get('body').click()
     cy.contains('a', text.docsMenu.firstTest).should('not.be.visible')
-    cy.percySnapshot('after click')
   })
 
   it('docs menu has expected links with no current project', () => {
     mountFragmentWithData({ currentProject: null })
+
+    cy.contains('a', 'Projects').should('not.exist')
 
     // we render without a current project to validate ciSetup and fasterTests links
     // because outside of global mode, those are buttons that trigger popups
@@ -189,10 +180,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       })
     })
 
-    afterEach(() => {
-      cy.percySnapshot()
-    })
-
     // https://github.com/cypress-io/cypress/issues/21842
     it('shows docs menu correctly on small viewports', () => {
       // Simulate the small viewport.
@@ -203,6 +190,8 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
 
       // docs menu flex direction is column when viewport width is small
       cy.findByTestId('docs-menu-container').should('have.css', 'flex-direction', 'column')
+
+      cy.percySnapshot()
     })
 
     it('shows docs menu correctly on wider viewports', () => {
@@ -214,6 +203,7 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
 
       // docs menu flex direction is row when viewport width is big enough.
       cy.findByTestId('docs-menu-container').should('have.css', 'flex-direction', 'row')
+      cy.percySnapshot()
     })
   })
 
@@ -237,7 +227,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
     })
 
     cy.contains('a', '8.7.0').should('be.visible').and('have.attr', 'href', 'https://on.cypress.io/changelog#8-7-0')
-    cy.percySnapshot()
   })
 
   it('shows hint and modal to upgrade to latest version of cypress', () => {
@@ -278,9 +267,7 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
       ),
     })
 
-    cy.contains('v8.6.0 • Upgrade').should('be.visible')
-    cy.percySnapshot('before upgrade click')
-    cy.contains('v8.6.0 • Upgrade').click()
+    cy.contains('v8.6.0 • Upgrade').should('be.visible').click()
     cy.findByTestId('latest-version').contains('8.7.0')
     cy.findByTestId('current-version').contains('8.6.0')
     cy.findByTestId('update-hint').should('be.visible')
@@ -290,10 +277,11 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
     cy.contains(`${defaultMessages.topNav.updateCypress.title} 8.7.0`).should('be.visible')
     cy.contains('test-project').should('be.visible')
     cy.findByDisplayValue('yarn add -D cypress@8.7.0').should('be.visible')
-    cy.percySnapshot('after upgrade modal open')
+    cy.get('p').contains('You are currently running Version 8.6.0 of Cypress. To upgrade to the latest version for your project, first close this app, then paste the command below into your terminal:')
 
     cy.get('body').type('{esc}') // dismiss modal with keyboard
     cy.contains(`${defaultMessages.topNav.updateCypress.title} 8.7.0`).should('not.exist')
+    cy.percySnapshot()
   })
 
   it('the logged in state is correctly presented in header', () => {
@@ -339,14 +327,9 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
 
     cy.contains('Project').should('not.exist')
     cy.contains('Test Page').should('be.visible')
-    cy.percySnapshot()
   })
 
   describe('prompts', () => {
-    afterEach(() => {
-      cy.percySnapshot()
-    })
-
     describe('the CI prompt', () => {
       context('opens on click', () => {
         beforeEach(() => {
@@ -360,7 +343,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
 
         it('opens on menu item click', () => {
           cy.contains(defaultMessages.topNav.docsMenu.prompts.ci1.description).should('be.visible')
-          cy.percySnapshot()
         })
 
         it('is dismissible from X icon', () => {
@@ -486,7 +468,6 @@ describe('<HeaderBarContent />', { viewportWidth: 1000, viewportHeight: 750 }, (
         })
 
         it('opens on menu item click', () => {
-          cy.percySnapshot()
           cy.contains(defaultMessages.topNav.docsMenu.prompts.orchestration1.title).should('be.visible')
           cy.contains('Getting Started').should('not.exist')
         })

--- a/packages/frontend-shared/src/gql-components/StatusBadge.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/StatusBadge.cy.tsx
@@ -27,9 +27,7 @@ describe('<StatusBadge />', () => {
     ))
 
     cy.findByText('not configured').should('be.visible')
-    cy.percySnapshot()
     cy.findByText('toggle').click()
     cy.findByText('configured').should('be.visible')
-    cy.percySnapshot()
   })
 })

--- a/packages/frontend-shared/src/gql-components/TestingTypePicker.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/TestingTypePicker.cy.tsx
@@ -32,13 +32,9 @@ describe('TestingTypePicker', () => {
       cy.contains(defaultMessages.setupPage.testingCard.configured).should('be.visible')
     })
 
-    cy.percySnapshot('before click')
-
     cy.contains(e2e.name).click()
     cy.contains(component.name).click()
     cy.get('@pick').should('have.been.calledTwice')
-
-    cy.percySnapshot('after click - focus')
   })
 
   it('shows disabled ct when not invoked from cli', () => {
@@ -60,7 +56,5 @@ describe('TestingTypePicker', () => {
     }).click()
 
     cy.get('@pick').should('not.have.been.called')
-
-    cy.percySnapshot()
   })
 })

--- a/packages/frontend-shared/src/gql-components/error/BaseError.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/error/BaseError.cy.tsx
@@ -15,20 +15,21 @@ const customMessage = `Don't worry, just click the "It's fixed now" button to tr
 const customStack = 'some err message\n  at fn (foo.js:1:1)'
 
 describe('<BaseError />', () => {
-  afterEach(() => {
-    cy.percySnapshot()
-  })
-
   it('renders the default error the correct messages', () => {
     cy.mountFragment(BaseErrorFragmentDoc, {
       render: (gqlVal) => <BaseError gql={gqlVal} showButtons={false} />,
     })
     .get(headerSelector)
     .should('contain.text', cy.gqlStub.ErrorWrapper.title)
+
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'OriginalError')
     .get(messageSelector)
     .should('contain.text', cy.gqlStub.ErrorWrapper.errorMessage.replace(/\`/g, '').slice(0, 10))
     .get(retryButtonSelector)
     .should('not.exist')
+
+    cy.contains('a', 'https://on.cypress.io/support-file-missing-or-invalid').should('have.attr', 'href', 'https://on.cypress.io/support-file-missing-or-invalid')
   })
 
   context('retry action', () => {
@@ -47,36 +48,55 @@ describe('<BaseError />', () => {
 
     it('renders the retry button and docs button', () => {
       mountFragmentWithError()
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
       cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
-      cy.get(docsButtonSelector).should('exist')
+      cy.contains(docsButtonSelector, docsButton.configGuide.text).should('have.attr', 'href', docsButton.configGuide.link)
     })
 
     it('renders the expected docs button for unknown errors', () => {
       mountFragmentWithError({ errorStack: 'UNKNOWN ERROR' })
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
+      cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
       cy.contains(docsButtonSelector, docsButton.docsHomepage.text)
       .should('have.attr', 'href', docsButton.docsHomepage.link)
+
+      cy.contains('UNKNOWN ERROR')
     })
 
     it('renders the expected docs button for Cypress Cloud errors', () => {
       mountFragmentWithError({ errorType: 'CLOUD_GRAPHQL_ERROR' })
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
+      cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
       cy.contains(docsButtonSelector, docsButton.cloudGuide.text)
       .should('have.attr', 'href', docsButton.cloudGuide.link)
+
+      cy.contains('OriginalError: foobar')
     })
 
     it('renders the expected docs button for errors that are known and unrelated to Cypress Cloud', () => {
       mountFragmentWithError({ errorType: 'CONFIG_VALIDATION_ERROR' })
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
+      cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
       cy.contains(docsButtonSelector, docsButton.configGuide.text)
       .should('have.attr', 'href', docsButton.configGuide.link)
     })
 
     it(`emits a 'retry' event when clicked`, () => {
       mountFragmentWithError()
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
       cy.get(retryButtonSelector)
       .should('not.be.disabled')
       .click()
       .click()
       .get('@retry')
       .should('have.been.calledTwice')
+
+      cy.contains('OriginalError: foobar')
     })
 
     it('does not render retry or docs buttons when showButtons prop is false', () => {
@@ -84,8 +104,11 @@ describe('<BaseError />', () => {
         render: (gqlVal) => <BaseError gql={gqlVal} showButtons={false} />,
       })
 
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
       cy.get(retryButtonSelector).should('not.exist')
       cy.get(docsButtonSelector).should('not.exist')
+      cy.contains('OriginalError: foobar')
     })
   })
 
@@ -96,6 +119,8 @@ describe('<BaseError />', () => {
       },
       render: (gqlVal) => <BaseError gql={gqlVal} />,
     }).then(() => {
+      cy.findAllByTestId('collapsible').should('be.visible')
+      cy.contains('h3', 'OriginalError')
       cy.get('[data-cy=stack-open-true]').should('not.exist')
       cy.contains(cy.i18n.launchpadErrors.generic.stackTraceLabel).click()
       cy.contains('Error: foobar').should('be.visible')
@@ -118,6 +143,9 @@ describe('<BaseError />', () => {
     .should('contain.text', customHeaderMessage)
     .and('contain.text', customMessage)
     .and('contain.text', customStack)
+
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'OriginalError')
   })
 
   it('renders the header and message slots', () => {
@@ -137,6 +165,9 @@ describe('<BaseError />', () => {
     .get('body')
     .should('contain.text', customHeaderMessage)
     .and('contain.text', customMessage)
+
+    cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
+    cy.contains(docsButtonSelector, cy.i18n.launchpadErrors.generic.docsButton.configGuide.text).should('have.attr', 'href', cy.i18n.launchpadErrors.generic.docsButton.configGuide.link)
   })
 
   it('renders the header and message slots with codeframe', () => {
@@ -174,7 +205,12 @@ describe('<BaseError />', () => {
         <BaseError gql={gqlVal} />),
     })
 
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'OriginalError')
+    cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
+    cy.contains(docsButtonSelector, cy.i18n.launchpadErrors.generic.docsButton.configGuide.text).should('have.attr', 'href', cy.i18n.launchpadErrors.generic.docsButton.configGuide.link)
     cy.findByText('cypress/e2e/file.cy.js:12:25').should('be.visible')
+    cy.contains('Error: foobar').should('be.visible')
   })
 
   // https://github.com/cypress-io/cypress/issues/22103
@@ -215,5 +251,11 @@ describe('<BaseError />', () => {
     })
 
     cy.findByText(`${longFileName}:12:25`).should('have.css', 'word-break', 'break-all')
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'OriginalError')
+    cy.contains(retryButtonSelector, cy.i18n.launchpadErrors.generic.retryButton)
+    cy.contains(docsButtonSelector, cy.i18n.launchpadErrors.generic.docsButton.configGuide.text).should('have.attr', 'href', cy.i18n.launchpadErrors.generic.docsButton.configGuide.link)
+    cy.contains('Error: foobar').should('be.visible')
+    cy.percySnapshot('')
   })
 })

--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -157,7 +157,12 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
-    cy.percySnapshot()
+
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'TSError')
+    cy.contains('p', 'Your configFile is invalid:')
+    cy.contains('p', 'cy-projects/config-with-ts-syntax-error/cypress.config.ts')
+    cy.contains('p', 'It threw an error when required, check the stack trace below:')
 
     cy.withCtx(async (ctx) => {
       await ctx.actions.file.writeFileInProject('cypress.config.ts', 'export default { e2e: { supportFile: false } }')
@@ -199,7 +204,11 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
-    cy.percySnapshot()
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'Error')
+    cy.contains('p', 'Your configFile is invalid:')
+    cy.contains('p', 'cy-projects/config-with-import-error/cypress.config.js')
+    cy.contains('p', 'It threw an error when required, check the stack trace below:')
 
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.js:3:23')
   })
@@ -210,8 +219,11 @@ describe('Launchpad: Error System Tests', () => {
     cy.visitLaunchpad()
     cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
-    cy.percySnapshot()
-
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.contains('h3', 'TSError')
+    cy.contains('p', 'Your configFile is invalid:')
+    cy.contains('p', 'cy-projects/config-with-ts-module-error/cypress.config.ts')
+    cy.contains('p', 'It threw an error when required, check the stack trace below:')
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.ts:6:10')
   })
 })
@@ -224,7 +236,10 @@ describe('setupNodeEvents', () => {
     cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
-    cy.percySnapshot()
+    cy.findAllByTestId('collapsible').should('be.visible')
+    cy.get('h3').contains('Error running e2e.setupNodeEvents()')
+    cy.get('p').contains('The integrationFolder configuration option is now invalid when set on the config object in Cypress version 10.0.0.')
+    cy.get('p').contains('It is now renamed to specPattern and configured separately as a end to end testing property: e2e.specPattern')
   })
 
   it('throws an error when in setupNodeEvents updating a config value on a clone of config that was removed in 10.X', () => {

--- a/packages/launchpad/src/components/code/FileRow.cy.tsx
+++ b/packages/launchpad/src/components/code/FileRow.cy.tsx
@@ -117,10 +117,10 @@ describe('FileRow', () => {
     cy.contains(changesRequiredDescription).should('be.visible')
     cy.get('pre').should('have.length', 2)
 
-    cy.percySnapshot('row starts open')
+    cy.get('.shiki').should('be.visible')
     cy.contains('cypress/integration/command.js').click()
 
-    cy.percySnapshot('row collapses after click')
+    cy.get('.shiki').should('not.be.visible')
   })
 
   it('responds nice to small screens', { viewportWidth: 500 }, () => {

--- a/packages/launchpad/src/migration/MajorVersionWelcome.cy.tsx
+++ b/packages/launchpad/src/migration/MajorVersionWelcome.cy.tsx
@@ -47,10 +47,6 @@ describe('<MajorVersionWelcome />', { viewportWidth: 1280, viewportHeight: 1400 
     cy.contains('11.0.0 Released last month')
     cy.contains('10.0.0 Released 6 months ago')
 
-    // doing these here since cy.clock will keep text content static
-    // for percy
-    cy.percySnapshot('looks good at full size')
-
     cy.viewport(1280, 500)
 
     cy.percySnapshot('content overflows inside box')

--- a/packages/launchpad/src/migration/OptOutModal.cy.tsx
+++ b/packages/launchpad/src/migration/OptOutModal.cy.tsx
@@ -7,7 +7,6 @@ describe('<OptOutModal/>', { viewportWidth: 1119 }, () => {
 
     cy.findByText('Rename folder only.').click()
     cy.contains('I may need to change my').should('be.visible')
-    cy.percySnapshot()
   })
 
   it('shows correct text with hasCustomIntegrationFolder', () => {

--- a/packages/launchpad/src/setup/InstallDependencies.cy.tsx
+++ b/packages/launchpad/src/setup/InstallDependencies.cy.tsx
@@ -88,6 +88,5 @@ describe('<InstallDependencies />', () => {
 
     cy.findByLabelText('Dismiss').click()
     cy.contains('You\'ve successfully installed all required dependencies.').should('not.exist')
-    cy.percySnapshot('installation completed after banner dismissed')
   })
 })

--- a/packages/launchpad/src/setup/OpenBrowserList.cy.tsx
+++ b/packages/launchpad/src/setup/OpenBrowserList.cy.tsx
@@ -86,8 +86,6 @@ describe('<OpenBrowserList />', () => {
     cy.get('[data-cy-browser]').each((browser) => cy.wrap(browser).should('have.attr', 'aria-disabled', 'true'))
     cy.get('[data-cy="launch-button"]').should('not.exist')
     cy.contains('button', defaultMessages.openBrowser.openingE2E.replace('{browser}', 'Electron')).should('be.disabled')
-
-    cy.percySnapshot()
   })
 
   it('shows browser is open', () => {
@@ -130,8 +128,6 @@ describe('<OpenBrowserList />', () => {
 
     cy.contains('button', defaultMessages.openBrowser.running.replace('{browser}', 'Electron')).should('be.disabled')
     cy.contains('button', defaultMessages.openBrowser.focus).should('not.exist')
-
-    cy.percySnapshot()
   })
 
   // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23099

--- a/packages/launchpad/src/setup/SelectFrameworkOrBundler.cy.tsx
+++ b/packages/launchpad/src/setup/SelectFrameworkOrBundler.cy.tsx
@@ -75,7 +75,9 @@ describe('<SelectFrameworkOrBundler />', () => {
       />
     ))
 
-    cy.percySnapshot()
+    cy.contains('button', 'Solid.js').click()
+    cy.findByTestId('external').should('have.attr', 'href', 'https://on.cypress.io/component-integrations?utm_medium=Select+Framework+Dropdown&utm_source=Binary%3A+Launchpad&utm_campaign=Browse+third-party+frameworks').contains('Browse our list of third-party framework integrations')
+    cy.get('[data-testid="icon-check"]').should('be.visible')
   })
 
   it('should select the value', () => {

--- a/packages/launchpad/src/setup/TestingTypeCards.cy.tsx
+++ b/packages/launchpad/src/setup/TestingTypeCards.cy.tsx
@@ -21,7 +21,7 @@ describe('TestingTypeCards', () => {
       cy.findAllByText(defaultMessages.setupPage.testingCard.notConfigured).should('have.length', 2)
 
       cy.contains('Build and test the entire experience of your application').should('be.visible')
-      cy.percySnapshot()
+      cy.contains('Build and test your components from your design system in isolation in order to ensure each state matches your expectations.').should('be.visible')
     })
   })
 
@@ -39,7 +39,8 @@ describe('TestingTypeCards', () => {
       },
     }).then(() => {
       cy.findAllByText(defaultMessages.setupPage.testingCard.configured).should('have.length', 2)
-      cy.percySnapshot()
+      cy.contains('Build and test the entire experience of your application').should('be.visible')
+      cy.contains('Build and test your components from your design system in isolation in order to ensure each state matches your expectations.').should('be.visible')
     })
   })
 
@@ -60,7 +61,7 @@ describe('TestingTypeCards', () => {
       cy.findAllByText(defaultMessages.setupPage.testingCard.notConfigured).should('have.length', 1)
 
       cy.contains('Build and test the entire experience of your application').should('be.visible')
-      cy.percySnapshot()
+      cy.contains('Build and test your components from your design system in isolation in order to ensure each state matches your expectations.').should('be.visible')
     })
   })
 
@@ -78,8 +79,9 @@ describe('TestingTypeCards', () => {
       },
     })
 
+    cy.contains('Build and test the entire experience of your application').should('be.visible')
+    cy.contains('Build and test your components from your design system in isolation in order to ensure each state matches your expectations.').should('be.visible')
     cy.findAllByText(defaultMessages.setupPage.testingCard.configured).should('have.length', 1)
     cy.findAllByText(defaultMessages.setupPage.testingCard.running).should('have.length', 1)
-    cy.percySnapshot()
   })
 })


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-internal/issues/587

### Additional details
This PR implements the recommends from [this Percy Audit](https://github.com/cypress-io/cypress-internal/issues/587). The goal is to decrease current number of Percy snapshots. We are currently recording 50K-60K snapshots a month. This targets snapshots that are any of the following:

- A subset of another snapshot
- A pixel perfect duplicate of another snapshot
- Would be better written as a text based assertion
- Covered in an E2E test
- Does not provide much value

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

There isn't really any - just take a look at the snapshots, you'll see a lot of duplicates were removed. I'm confident we are losing a negligible amount of coverage at best, and this number of snapshots is far more easy to review and maintain.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
