### PR TITLE
chore: only send errors if we are not in local development mode

### DIFF
--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -40,6 +40,8 @@ const runnerCapabilities = {
 
 let responseCache = {}
 
+const CAPTURE_ERRORS = !process.env.CYPRESS_LOCAL_PROTOCOL_PATH
+
 class DecryptionError extends Error {
   isDecryptionError = true
 
@@ -386,17 +388,21 @@ module.exports = {
           }
         }
       } catch (e) {
-        options.protocolManager?.sendErrors([
-          {
-            args: [result.captureProtocolUrl],
-            captureMethod: 'getCaptureProtocolScript',
-            error: {
-              message: e.message,
-              stack: e.stack,
-              name: e.name,
+        if (CAPTURE_ERRORS) {
+          options.protocolManager?.sendErrors([
+            {
+              args: [result.captureProtocolUrl],
+              captureMethod: 'getCaptureProtocolScript',
+              error: {
+                message: e.message,
+                stack: e.stack,
+                name: e.name,
+              },
             },
-          },
-        ])
+          ])
+        } else {
+          throw e
+        }
       }
 
       return result


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We should only send errors if we are not in local development mode. We are doing that in most places where we error, but we missed a spot.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
