### PR TITLE
chore: stabilize side navigation bar during loading and switching testing types

### DIFF
--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -111,11 +111,11 @@ const resetErrorAndLoadConfig = (id: string) => {
 }
 
 const renderSidebar = computed(() => {
-  if (!isRunMode) {
-    return query.data.value?.currentProject?.isLoadingConfigFile === false
+  if (currentRoute.name === 'Specs' && query.data.value) {
+    return !isRunMode && query.data.value?.currentProject?.isLoadingConfigFile === false
   }
 
-  return false
+  return !isRunMode
 })
 
 </script>

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -111,7 +111,7 @@ const resetErrorAndLoadConfig = (id: string) => {
 }
 
 const renderSidebar = computed(() => {
-  if (currentRoute.name === 'Specs') {
+  if (currentRoute.name === 'Specs' && query.data.value) {
     return !isRunMode && query.data.value?.currentProject?.isLoadingConfigFile === false
   }
 

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -110,6 +110,12 @@ const resetErrorAndLoadConfig = (id: string) => {
   }
 }
 
-const renderSidebar = !isRunMode
+const renderSidebar = computed(() => {
+  if (!isRunMode) {
+    return query.data.value?.currentProject?.isLoadingConfigFile === false
+  }
+
+  return false
+})
 
 </script>

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -111,7 +111,7 @@ const resetErrorAndLoadConfig = (id: string) => {
 }
 
 const renderSidebar = computed(() => {
-  if (currentRoute.name === 'Specs' && query.data.value) {
+  if (currentRoute.name === 'Specs') {
     return !isRunMode && query.data.value?.currentProject?.isLoadingConfigFile === false
   }
 

--- a/packages/app/src/navigation/SidebarNavigation.vue
+++ b/packages/app/src/navigation/SidebarNavigation.vue
@@ -28,7 +28,6 @@
     </button>
     <div class="flex flex-col flex-1 ">
       <SidebarNavigationHeader
-        v-if="props.gql"
         :gql="props.gql"
         :is-nav-bar-expanded="isNavBarExpanded"
       />

--- a/packages/app/src/navigation/SidebarNavigationHeader.vue
+++ b/packages/app/src/navigation/SidebarNavigationHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <Tooltip
-    v-if="testingType"
+    v-if="testingType && props.gql"
     placement="right"
     :disabled="isNavBarExpanded"
     :distance="8"
@@ -46,6 +46,17 @@
       </div>
     </template>
   </Tooltip>
+  <div
+    v-else
+    class="border-b flex shrink-0 border-gray-900 h-[64px] pl-[20px] items-center"
+  >
+    <IconLoading
+      name="loading"
+      stroke-color="indigo-700"
+      fill-color="indigo-300"
+      class="shrink-0 h-[24px] mr-[20px] w-[24px] animate-spin"
+    />
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -56,6 +67,7 @@ import Tooltip from '@packages/frontend-shared/src/components/Tooltip.vue'
 import SwitchTestingTypeModal from './SwitchTestingTypeModal.vue'
 import IconE2E from '~icons/cy/testing-type-e2e-solid-simple'
 import IconComponent from '~icons/cy/testing-type-component-solid_x24'
+import { IconLoading } from '@cypress-design/vue-icon'
 import { useI18n } from '@cy/i18n'
 import { SidebarNavigationHeaderBranchChangeDocument } from '../generated/graphql-test'
 
@@ -87,7 +99,7 @@ useSubscription({ query: SidebarNavigationHeaderBranchChangeDocument })
 const showModal = ref(false)
 
 const props = defineProps<{
-  gql: SidebarNavigationHeaderFragment
+  gql?: SidebarNavigationHeaderFragment
   isNavBarExpanded: boolean
 }>()
 
@@ -103,7 +115,7 @@ const TESTING_TYPE_MAP = {
 } as const
 
 const testingType = computed(() => {
-  return props.gql.currentProject?.currentTestingType ? TESTING_TYPE_MAP[props.gql.currentProject.currentTestingType] : null
+  return props.gql?.currentProject?.currentTestingType ? TESTING_TYPE_MAP[props.gql?.currentProject.currentTestingType] : null
 })
 
 </script>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

During the work in https://github.com/cypress-io/cypress/pull/26894, I noticed some minor flickers in our sidebar when loading and switching between testing types that I wanted to address. This PR improves the following:

1. The sidebar navigation component no longer flickers when switching testing types
2. The sidebar navigation header is always present and displays a loading icon when we don't know the testing type yet, rather than being added and removed from the navigation bar causing jumping

This should make the app look a little more clean and stable

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Make sure that everything still works as expected and all tests pass

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

**Before**
https://www.loom.com/share/760dc0ad455e49d79892a44d5c44d361

**After**
https://www.loom.com/share/287c8c637b8642b098fb47de63b8c619

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
