### PR TITLE
feat: Device settings disabled state

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -398,6 +398,7 @@ describe('App: Settings', () => {
         showSystemNotificationStub = o.sinon.stub(ctx.actions.electron, 'showSystemNotification')
         ctx.coreData.localSettings.preferences.notifyWhenRunStarts = false
         ctx.coreData.localSettings.preferences.notifyWhenRunStartsFailing = true
+        ctx.coreData.localSettings.preferences.desktopNotificationsEnabled = true
       })
 
       cy.startAppServer('e2e')

--- a/packages/app/src/settings/device/NotificationSettings.cy.tsx
+++ b/packages/app/src/settings/device/NotificationSettings.cy.tsx
@@ -1,6 +1,16 @@
 import NotificationSettings from './NotificationSettings.vue'
 import { NotificationSettingsFragmentDoc } from '../../generated/graphql-test'
 
+function assertFormControls (assertion: 'be.disabled' | 'not.be.disabled') {
+  cy.findByTestId('send-test-notification').should(assertion)
+  cy.get('input#passed').should(assertion)
+  cy.get('input#failed').should(assertion)
+  cy.get('input#canceled').should(assertion)
+  cy.get('input#errored').should(assertion)
+  cy.get('button#notifyWhenRunStarts').should(assertion)
+  cy.get('button#notifyWhenRunStartsFailing').should(assertion)
+}
+
 describe('NotificationSettings', () => {
   it('renders', () => {
     cy.mountFragment(NotificationSettingsFragmentDoc, {
@@ -10,5 +20,34 @@ describe('NotificationSettings', () => {
     })
 
     cy.percySnapshot()
+  })
+
+  it('renders a banner and disables form when notifications are not enabled', () => {
+    cy.mountFragment(NotificationSettingsFragmentDoc, {
+      onResult: (gql) => {
+        gql.localSettings.preferences.desktopNotificationsEnabled = null
+      },
+      render (gql) {
+        return (<NotificationSettings gql={gql} />)
+      },
+    })
+
+    cy.findByTestId('enable-notifications').should('exist')
+    cy.findByTestId('send-test-notification').should('be.disabled')
+    assertFormControls('be.disabled')
+  })
+
+  it('does not render a banner when notifications are enabled', () => {
+    cy.mountFragment(NotificationSettingsFragmentDoc, {
+      onResult: (gql) => {
+        gql.localSettings.preferences.desktopNotificationsEnabled = true
+      },
+      render (gql) {
+        return (<NotificationSettings gql={gql} />)
+      },
+    })
+
+    cy.findByTestId('enable-notifications').should('not.exist')
+    assertFormControls('not.be.disabled')
   })
 })

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -6,25 +6,31 @@
     <template #description>
       {{ t('settingsPage.notifications.description') }}
     </template>
-    <div class="divide-y border rounded divide-gray-50 border-gray-100">
+    <div class="border rounded border-gray-100">
       <div
         v-if="!props.gql.localSettings.preferences.desktopNotificationsEnabled"
-        class="bg-indigo-100 p-[16px] flex justify-between items-center"
+        class="min-h-[56px] bg-indigo-50 px-[16px] py-[10px] flex flex-wrap justify-between items-center gap-[5px]"
         data-cy="enable-notifications"
       >
-        <div class="text-indigo-700 font-medium">
+        <div class="text-indigo-700 font-medium flex items-center">
+          <IconSecurityLockLocked
+            class="mr-[7px]"
+            fill-color="indigo-200"
+            stroke-color="indigo-500"
+          />
           {{ t('settingsPage.notifications.enableNotificationsLabel') }}
         </div>
 
         <ButtonDS
-          size="40"
+          size="32"
+          class="font-normal"
           @click="($event) => updatePref('desktopNotificationsEnabled', true)"
         >
           {{ t('specPage.banners.enableNotifications.enableDesktopNotifications') }}
         </ButtonDS>
       </div>
 
-      <div class="px-[16px]">
+      <div class="px-[16px] divide-y divide-gray-50">
         <div
           v-for="({id, title}) in switches"
           :key="id"
@@ -107,6 +113,7 @@ import Button from '@packages/frontend-shared/src/components/Button.vue'
 import ExternalLink from '@cy/gql-components/ExternalLink.vue'
 import { getUrlWithParams } from '@packages/frontend-shared/src/utils/getUrlWithParams'
 import { debouncedWatch } from '@vueuse/core'
+import { IconSecurityLockLocked } from '@cypress-design/vue-icon'
 
 const { t } = useI18n()
 

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -47,6 +47,7 @@
             {{ t('settingsPage.notifications.notifyMeWhenRunCompletes') }}
           </h4>
           <div class="pt-[5px]">
+            <!-- TODO: Use Design System Checkbox when https://github.com/cypress-io/cypress-design/issues/255 is fixed -->
             <Checkbox
               v-for="({id, label}) in statuses"
               :id="id"

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -24,7 +24,7 @@
         <ButtonDS
           size="32"
           class="font-normal"
-          @click="($event) => updatePref('desktopNotificationsEnabled', true)"
+          @click="enableNotifications"
         >
           {{ t('specPage.banners.enableNotifications.enableDesktopNotifications') }}
         </ButtonDS>
@@ -179,6 +179,12 @@ function updatePref (property: string, value: boolean) {
   setPreferences.executeMutation({
     value: JSON.stringify({ [property]: value }),
   })
+}
+
+async function enableNotifications () {
+  updatePref('desktopNotificationsEnabled', true)
+
+  await showNotification.executeMutation({ title: t('specPage.banners.enableNotifications.notificationsEnabledTitle'), body: t('specPage.banners.enableNotifications.notificationsEnabledBody') })
 }
 
 const debounce = 200

--- a/packages/frontend-shared/src/components/Checkbox.vue
+++ b/packages/frontend-shared/src/components/Checkbox.vue
@@ -42,7 +42,7 @@
 <script lang="ts" setup>
 import { useModelWrapper } from '../composables'
 
-type InputState = 'success' | 'danger' | 'default'
+type InputState = 'success' | 'danger' | 'default' | 'disabled'
 
 const props = withDefaults(defineProps<{
   id: string

--- a/packages/frontend-shared/src/components/Checkbox.vue
+++ b/packages/frontend-shared/src/components/Checkbox.vue
@@ -8,13 +8,15 @@
         :aria-describedby="`${id}-description`"
         :name="id"
         type="checkbox"
+        :disabled="disabled"
         class="border
         rounded
         border-gray-200
         bg-white h-4 w-4
         text-indigo-500
-        disabled:bg-gray-100
         checked:bg-indigo-500
+        disabled:bg-gray-100
+        hover:disabled:bg-gray-100
         "
         :class="{
           'text-indigo-500 checked:border-indigo-500 checked:bg-indigo-400 checked:text-indigo-400': state === 'default',
@@ -46,10 +48,12 @@ const props = withDefaults(defineProps<{
   id: string
   modelValue: any
   state?: InputState
+  disabled?: boolean
   label?: string
 }>(), {
   state: 'default',
   label: undefined,
+  disabled: false,
 })
 
 const emits = defineEmits<{

--- a/packages/frontend-shared/src/components/Switch.vue
+++ b/packages/frontend-shared/src/components/Switch.vue
@@ -1,10 +1,11 @@
 <template>
   <button
     :id="name"
-    class="border-transparent border rounded-[50px] relative hocus-default disabled:bg-gray-100"
+    class="border-transparent border rounded-[50px] relative hocus-default disabled:ring-0 disabled:outline-0 disabled:bg-gray-100"
     :class="[value ? 'bg-jade-400' : 'bg-gray-300', sizeClasses[size].container, {
       '!hocus:ring-0': size === 'sm'
     }]"
+    :disabled="disabled"
     role="switch"
     :aria-checked="value"
     @click="$emit('update', !value)"
@@ -22,9 +23,11 @@ withDefaults(defineProps<{
   value: boolean
   size?: 'sm' | 'md' | 'lg' | 'xl'
   name: string // required for an id so that an external <label> can be associated with the switch
+  disabled?: boolean
 }>(), {
   value: false,
   size: 'lg',
+  disabled: false,
 })
 
 const sizeClasses = {

--- a/packages/frontend-shared/src/components/Switch.vue
+++ b/packages/frontend-shared/src/components/Switch.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :id="name"
-    class="border-transparent border rounded-[50px] relative hocus-default"
+    class="border-transparent border rounded-[50px] relative hocus-default disabled:bg-gray-100"
     :class="[value ? 'bg-jade-400' : 'bg-gray-300', sizeClasses[size].container, {
       '!hocus:ring-0': size === 'sm'
     }]"

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -534,7 +534,8 @@
       "notReceivingNotifications": "Not receiving notifications? You might need to allow notifications from Cypress in your computer's system preferences. {0}",
       "testNotificationTitle": "Hello From Cypress",
       "testNotificationBody": "This is a test notification",
-      "troubleshoot": "Troubleshoot"
+      "troubleshoot": "Troubleshoot",
+      "enableNotificationsLabel": "To modify notification settings, enable desktop notifications"
     },
     "projectId": {
       "title": "Project ID",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/26789

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Disables notification controls until the user enables them.


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Wipe your App settings. I put my `state.json` like this:

![Screenshot 2023-06-12 at 5 56 59 pm](https://github.com/cypress-io/cypress/assets/19196536/6d753517-f1ce-4fb5-8594-59c055265e04)

- Open Cypress, any project
- Go to Settings
- Observe controls are disabled like so:

![Screenshot 2023-06-12 at 5 58 33 pm](https://github.com/cypress-io/cypress/assets/19196536/ec4e7daa-0530-49c5-8b61-43ec9b97070b)

- Click the purple "Enable Desktop Notifications" button
- Now they are enabled
- Change some settings, then refresh, observe they are persisted.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Controls cannot be interacted with until the user enabled settings. Shows a nice banner CTA to tell users to enable notifications.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
