### PR TITLE
feat: add coords, scrollBy, and highlight attribute to command log

### DIFF
--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -15,7 +15,7 @@ const groupsOrTableRe = /^(groups|table)$/
 const parentOrChildRe = /parent|child|system/
 const SNAPSHOT_PROPS = 'id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight'.split(' ')
 const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event functionName groupLevel hookId instrument isStubbed group message method name numElements numResponses referencesAlias renderProps sessionInfo state testId timeout type url visible wallClockStartedAt testCurrentRetry'.split(' ')
-const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt', 'scrollBy', 'coords', 'highlightAttr', 'scrollBy'])
+const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt', 'scrollBy', 'coords', 'highlightAttr'])
 const BLACKLIST_PROPS = 'snapshots'.split(' ')
 
 let counter = 0

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -15,7 +15,7 @@ const groupsOrTableRe = /^(groups|table)$/
 const parentOrChildRe = /parent|child|system/
 const SNAPSHOT_PROPS = 'id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight'.split(' ')
 const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event functionName groupLevel hookId instrument isStubbed group message method name numElements numResponses referencesAlias renderProps sessionInfo state testId timeout type url visible wallClockStartedAt testCurrentRetry'.split(' ')
-const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt'])
+const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt', 'scrollBy', 'coords', 'highlightAttr', 'scrollBy'])
 const BLACKLIST_PROPS = 'snapshots'.split(' ')
 
 let counter = 0


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Add coords, scrollBy, and highlight attribute to command log.

Note: scrollBy doesn't appear to actually be set anywhere, but it's in use when [highlighting](https://github.com/cypress-io/cypress/blob/develop/packages/app/src/runner/aut-iframe.ts#L296) so I included it so that it would be included if it ever gets [implemented](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/actionability.ts#L247-L254)

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Run against cypress-services with a test that uses cy.click and ensure that the new fields are added to the DB.

Use this branch in cypress-services: https://github.com/cypress-io/cypress-services/tree/ryanm/feat/add-coords-to-command-log

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
