### PR TITLE
test: increase timeout of cy.readFile to address flaky WebKit test

### DIFF
--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -5,7 +5,7 @@ This package contains Cypress's suite of system tests.
 
 These tests launch the [Cypress server](../packages/server) process for each test and run different specs and projects under specific environment conditions, to get tests that can be as close to "real world" as possible.
 
-These tests run in CI in Electron, Chrome, and Firefox under the `system-tests` job family.
+These tests run in CI in Electron, Chrome, Firefox, and WebKit under the `system-tests` job family.
 
 ## Running System Tests
 
@@ -106,7 +106,7 @@ Running `yarn test node-versions` would spin up a local Docker container for `cy
 
 These tests run in the `binary-system-tests` CI job.
 
-### Updating Snaphots
+### Updating Snapshots
 
 Prepend `SNAPSHOT_UPDATE=1` to any test command. See [`snap-shot-it` instructions](https://github.com/bahmutov/snap-shot-it#advanced-use) for more info.
 

--- a/system-tests/projects/e2e/cypress/e2e/form_submission_multipart.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/form_submission_multipart.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 const { Blob, _ } = Cypress
 
-Cypress.Commands.add('setFile', { prevSubject: 'element' }, (element, filePath) => {
+Cypress.Commands.add('setFile', { prevSubject: 'element' }, (element, filePath, commandTimeoutOpts) => {
   const mimeTypes = {
     jpeg: 'image/jpeg',
     jpg: 'image/jpeg',
@@ -14,10 +14,10 @@ Cypress.Commands.add('setFile', { prevSubject: 'element' }, (element, filePath) 
 
   const fixtureOrReadFile = function (filePath) {
     if (_.startsWith(filePath, '/')) {
-      return cy.readFile(filePath, 'base64')
+      return cy.readFile(filePath, 'base64', commandTimeoutOpts)
     }
 
-    return cy.fixture(filePath, 'base64')
+    return cy.fixture(filePath, 'base64', commandTimeoutOpts)
   }
 
   return fixtureOrReadFile(filePath).then((image) => {
@@ -62,16 +62,16 @@ describe('<form> submissions', () => {
   })
 
   context('can submit a multipart/form-data form with attachments', () => {
-    const testUpload = (fixturePath, containsOpts = {}) => {
+    const testUpload = (fixturePath, commandTimeoutOpts = {}) => {
       cy.visit(`/multipart-with-attachment?fixturePath=${fixturePath}`)
       cy.get('input[type=file]')
-      .setFile(fixturePath)
+      .setFile(fixturePath, commandTimeoutOpts)
 
       cy.get('input[type=submit]')
       .click()
 
       cy.document()
-      .contains('files match', containsOpts)
+      .contains('files match', commandTimeoutOpts)
     }
 
     it('image/png', () => {


### PR DESCRIPTION
### Additional details

Increase the readFile timeout for a system test around submitting multiple/form-data with attachments for a large jpeg.

![Screen Shot 2023-06-09 at 11 27 12 AM](https://github.com/cypress-io/cypress/assets/1271364/0eac9dd4-fbd9-48d6-82f9-aec3bdf1c2bf)

![Screen Shot 2023-06-09 at 11 27 29 AM](https://github.com/cypress-io/cypress/assets/1271364/8ddb88ee-2a7b-48fd-b165-ddfe9539caf2)


This test is shown as the [2nd most flaky tes](https://app.circleci.com/insights/github/cypress-io/cypress/workflows/linux-arm64/tests?branch=develop)t within CircleCI on our develop branch. [Example failure in CircleCI.](https://app.circleci.com/pipelines/github/cypress-io/cypress/53487/workflows/2c139e49-8cec-49b6-944c-d5d13d4d10d1/jobs/2206229)

![Screen Shot 2023-06-09 at 11 31 23 AM](https://github.com/cypress-io/cypress/assets/1271364/0fbd6fb2-345a-4a0f-ae99-469ec3a89cec)


### Steps to test

Well, the test didn't fail this time, but hard to tell if it will flake in the future. Let me know if the logic seems ok. It seems like it shouldn't hurt anything to increase this timeout if it's not fixing the flake.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
