### PR TITLE
misc: removed spaces in screenshot filename

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,10 @@ _Released 06/20/2023 (PENDING)_
 
 - Fixed an issue where video output was not being logged to the console when `videoCompression` was turned off. Videos will now log to the terminal regardless of the compression value. Addresses [#25945](https://github.com/cypress-io/cypress/issues/25945).
 
+**Misc:**
+
+ - Replaced spaces in screenshot name with `_` and also replaced `(failed)` with `<failed>` to allow CMD+Click to work on screenshot names. Addressed in [#26992](https://github.com/cypress-io/cypress/pull/26992).
+
 **Dependency Updates:**
 
 - Removed [`@cypress/mocha-teamcity-reporter`](https://www.npmjs.com/package/@cypress/mocha-teamcity-reporter) as this package was no longer being referenced. Addressed in [#26938](https://github.com/cypress-io/cypress/pull/26938).

--- a/packages/server/lib/screenshots.js
+++ b/packages/server/lib/screenshots.js
@@ -11,7 +11,7 @@ let debug = require('debug')('cypress:server:screenshot')
 const plugins = require('./plugins')
 const { fs } = require('./util/fs')
 
-const RUNNABLE_SEPARATOR = ' -- '
+const RUNNABLE_SEPARATOR = '_--_'
 const pathSeparatorRe = /[\\\/]/g
 
 // internal id incrementor
@@ -342,17 +342,25 @@ const sanitizeToString = (title) => {
   return sanitize(_.toString(title))
 }
 
+const makeTerminalFriendly = (title) => {
+  return title.split(' ').join('_')
+}
+
 const getPath = function (data, ext, screenshotsFolder, overwrite) {
   let names
   const specNames = (data.specName || '')
   .split(pathSeparatorRe)
 
   if (data.name) {
-    names = data.name.split(pathSeparatorRe).map(sanitize)
+    names = data.name
+    .split(pathSeparatorRe)
+    .map(sanitize)
+    .map(makeTerminalFriendly)
   } else {
     names = _
     .chain(data.titles)
     .map(sanitizeToString)
+    .map(makeTerminalFriendly)
     .join(RUNNABLE_SEPARATOR)
     .concat([])
     .value()
@@ -362,11 +370,11 @@ const getPath = function (data, ext, screenshotsFolder, overwrite) {
 
   // append (failed) to the last name
   if (data.testFailure) {
-    names[index] = `${names[index]} (failed)`
+    names[index] = `${names[index]}_<failed>`
   }
 
   if (data.testAttemptIndex > 0) {
-    names[index] = `${names[index]} (attempt ${data.testAttemptIndex + 1})`
+    names[index] = `${names[index]}_<attempt_${data.testAttemptIndex + 1}>`
   }
 
   const withoutExt = path.join(screenshotsFolder, ...specNames, ...names)

--- a/packages/server/test/unit/screenshots_spec.js
+++ b/packages/server/test/unit/screenshots_spec.js
@@ -12,6 +12,7 @@ const { fs } = require(`../../lib/util/fs`)
 const plugins = require(`../../lib/plugins`)
 const { Screenshot } = require(`../../lib/automation/screenshot`)
 const { getCtx } = require(`../../lib/makeDataContext`)
+const sanitize = require('sanitize-filename')
 
 const image = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAALlJREFUeNpi1F3xYAIDA4MBA35wgQWqyB5dRoaVmeHJ779wPhOM0aQtyBAoyglmOwmwM6z1lWY44CMDFgcBFmRTGp3EGGJe/WIQ5mZm4GRlBGJmhlm3PqGaeODpNzCtKsbGIARUCALvvv6FWw9XeOvrH4bbQNOQwfabnzHdGK3AwyAjyAqX2HPzC0Pn7Y9wPtyNIMGlD74wmAqwMZz+8AvFxzATVZAFQIqwABWQiWtgAY5uCnKAAwQYAPr8OZysiz4PAAAAAElFTkSuQmCC'
 const iso8601Regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.?\d*Z?$/
@@ -505,7 +506,7 @@ describe('lib/screenshots', () => {
         )
         .then((result) => {
           const expectedPath = path.join(
-            this.config.screenshotsFolder, 'foo.spec.js', 'foo bar', 'baz', 'my-screenshot.png',
+            this.config.screenshotsFolder, 'foo.spec.js', 'foo_bar', 'baz', 'my-screenshot.png',
           )
 
           const actualPath = path.normalize(result.path)
@@ -597,7 +598,7 @@ describe('lib/screenshots', () => {
       }, 'png', 'path/to/screenshots')
       .then((p) => {
         expect(p).to.eq(
-          'path/to/screenshots/examples/user/list.js/bar -- baz (failed).png',
+          'path/to/screenshots/examples/user/list.js/bar_--_baz_<failed>.png',
         )
       })
     })
@@ -611,7 +612,7 @@ describe('lib/screenshots', () => {
       }, 'png', 'path/to/screenshots')
       .then((p) => {
         expect(p).to.eq(
-          'path/to/screenshots/examples$/user/list.js/bar -- baz -- 語言 (failed).png',
+          'path/to/screenshots/examples$/user/list.js/bar_--_baz_--_語言_<failed>.png',
         )
       })
     })
@@ -663,6 +664,8 @@ describe('lib/screenshots', () => {
     })
 
     _.each([Infinity, 0 / 0, [], {}, 1, false], (value) => {
+      let stringifiedValue = sanitize(_.toString(value)).split(' ').join('_')
+
       it(`doesn't err and stringifies non-string test title: ${value}`, () => {
         return screenshots.getPath({
           specName: 'examples$/user/list.js',
@@ -671,7 +674,7 @@ describe('lib/screenshots', () => {
           testFailure: true,
         }, 'png', 'path/to/screenshots')
         .then((p) => {
-          expect(p).to.eq(`path/to/screenshots/examples$/user/list.js/bar -- 語言 -- ${value} (failed).png`)
+          expect(p).to.eq(`path/to/screenshots/examples$/user/list.js/bar_--_語言_--_${stringifiedValue}_<failed>.png`)
         })
       })
     })
@@ -685,7 +688,7 @@ describe('lib/screenshots', () => {
           testFailure: true,
         }, 'png', 'path/to/screenshots')
         .then((p) => {
-          expect(p).to.eq('path/to/screenshots/examples$/user/list.js/bar -- 語言 --  (failed).png')
+          expect(p).to.eq('path/to/screenshots/examples$/user/list.js/bar_--_語言_--__<failed>.png')
         })
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes  #23510

### Additional details

The most noticeable change is that screenshots of failed tests are now named with `<failed>` instead of `(failed)` as the parenthesis broke cmd+click when trying to access the screenshots quickly

Other than that, this PR simply adds `_` instead of spaces for screenshot names.
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The testing environment has been modified to accept these changes, so simply running the test sweet will test everything. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

**Before**
Screenshot names would be something like: `path/to/screenshot number 1.png`

**After**
Screenshot names are now something like: `path/to/screenshot_number_1.png`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
