### PR TITLE
fix: do not swallow errors on upload and handle timeouts

### DIFF
--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -15,7 +15,7 @@ const groupsOrTableRe = /^(groups|table)$/
 const parentOrChildRe = /parent|child|system/
 const SNAPSHOT_PROPS = 'id snapshots $el url coords highlightAttr scrollBy viewportWidth viewportHeight'.split(' ')
 const DISPLAY_PROPS = 'id alias aliasType callCount displayName end err event functionName groupLevel hookId instrument isStubbed group message method name numElements numResponses referencesAlias renderProps sessionInfo state testId timeout type url visible wallClockStartedAt testCurrentRetry'.split(' ')
-const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt'])
+const PROTOCOL_PROPS = DISPLAY_PROPS.concat(['snapshots', 'wallClockUpdatedAt', 'scrollBy', 'coords', 'highlightAttr', 'scrollBy'])
 const BLACKLIST_PROPS = 'snapshots'.split(' ')
 
 let counter = 0

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -7,7 +7,6 @@ import os from 'os'
 import { createGzip } from 'zlib'
 import fetch from 'cross-fetch'
 import Module from 'module'
-import humanInterval from 'human-interval'
 
 const routes = require('./routes')
 const pkg = require('@packages/root')
@@ -18,7 +17,8 @@ const debugVerbose = Debug('cypress-verbose:server:protocol')
 const CAPTURE_ERRORS = !process.env.CYPRESS_LOCAL_PROTOCOL_PATH
 const DELETE_DB = !process.env.CYPRESS_LOCAL_PROTOCOL_PATH
 
-const TWO_MINUTES = humanInterval('2 minutes')
+// Timeout for upload
+const TWO_MINUTES = 120000
 
 /**
  * requireScript, does just that, requires the passed in script as if it was a module.

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -237,26 +237,16 @@ export class ProtocolManager implements ProtocolManagerShape {
 
       debug(`error response text: %s`, err)
 
-      return {
-        fileSize: zippedFileSize,
-        success: false,
-        error: new Error(err),
-      }
+      throw new Error(err)
     } catch (e) {
       if (CAPTURE_ERRORS) {
         this._errors.push({
           error: e,
           captureMethod: 'uploadCaptureArtifact',
         })
-      } else {
-        throw e
       }
 
-      return {
-        fileSize: zippedFileSize,
-        success: false,
-        error: e,
-      }
+      throw e
     } finally {
       await Promise.all([
         this.sendErrors(),

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -209,19 +209,10 @@ const uploadArtifacts = (options = {}) => {
   }
 
   if (captureUploadUrl && protocolManager) {
-    const successCallback = success('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })
-    const failCallback = fail('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })
-
     uploads.push(
       protocolManager.uploadCaptureArtifact({ uploadUrl: captureUploadUrl })
-      .then((res) => {
-        if (res.error) {
-          return failCallback(res.error)
-        }
-
-        return successCallback(res)
-      })
-      .catch(failCallback),
+      .then(success('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false }))
+      .catch(fail('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })),
     )
   }
 

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -209,10 +209,19 @@ const uploadArtifacts = (options = {}) => {
   }
 
   if (captureUploadUrl && protocolManager) {
+    const successCallback = success('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })
+    const failCallback = fail('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })
+
     uploads.push(
-      protocolManager.uploadCaptureArtifact(captureUploadUrl)
-      .then(success('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false }))
-      .catch(fail('Test Replay', captureUploadUrl, { key: 'protocol', statFile: false })),
+      protocolManager.uploadCaptureArtifact({ uploadUrl: captureUploadUrl })
+      .then((res) => {
+        if (res.error) {
+          return failCallback(res.error)
+        }
+
+        return successCallback(res)
+      })
+      .catch(failCallback),
     )
   }
 

--- a/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
+++ b/packages/server/test/support/fixtures/cloud/protocol/test-protocol.ts
@@ -1,7 +1,6 @@
 import type { ProtocolManagerShape } from '@packages/types'
 
 export class AppCaptureProtocol implements ProtocolManagerShape {
-
   setupProtocol = (script, runId) => {
     return Promise.resolve()
   }
@@ -23,7 +22,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   sendErrors (errors) {
     return Promise.resolve()
   }
-  uploadCaptureArtifact (uploadUrl) {
+  uploadCaptureArtifact ({ uploadUrl }) {
     return Promise.resolve()
   }
   afterTest (test): void {}

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -41,5 +41,5 @@ export interface ProtocolManagerShape extends AppCaptureProtocolCommon {
   setupProtocol(script: string, runId: string): Promise<void>
   beforeSpec (spec: { instanceId: string}): void
   sendErrors (errors: ProtocolError[]): Promise<void>
-  uploadCaptureArtifact(uploadUrl: string): Promise<{ fileSize: number, success: boolean, error?: string } | void>
+  uploadCaptureArtifact(options: { uploadUrl: string, timeout: number }): Promise<{ fileSize: number, success: boolean, error?: string } | void>
 }

--- a/system-tests/lib/protocolStub.ts
+++ b/system-tests/lib/protocolStub.ts
@@ -41,7 +41,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   sendErrors (errors) {
     return Promise.resolve()
   }
-  uploadCaptureArtifact (uploadUrl) {
+  uploadCaptureArtifact ({ uploadUrl }) {
     return Promise.resolve()
   }
   afterTest (test): void {}


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Currently, we were swallowing errors on upload and not setting any kind of timeout for protocol uploads.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Record a run and ensure the upload continues to succeed

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
