### PR TITLE
fix: regression fix for trashAssetsBeforeRuns=false not working when video=false

### DIFF
--- a/system-tests/test/downloads_spec.ts
+++ b/system-tests/test/downloads_spec.ts
@@ -58,12 +58,20 @@ describe('e2e downloads', () => {
   })
 
   it('does not trash downloads between runs if trashAssetsBeforeRuns: false', async function () {
+    // Run the spec that downloads the file
     await systemTests.exec(this, {
       project: 'downloads',
       spec: 'download_csv.cy.ts',
     })
 
-    // this run should _not_ trash the downloads from the above run
+    // Get the absolute path to the downloaded file
+    const filePath = path.join(downloadsProject, 'cypress', 'downloads', 'records.csv')
+
+    // Check if the file exists after the first run
+    let exists = await fs.pathExists(filePath)
+    expect(exists, `Expected ${filePath} to exist after the first run, but it does not`).to.be.true
+
+    // Run the spec without trashing assets before runs
     await systemTests.exec(this, {
       project: 'downloads',
       spec: 'simple_passing.cy.ts',
@@ -72,9 +80,8 @@ describe('e2e downloads', () => {
       },
     })
 
-    const filePath = path.join(downloadsProject, 'cypress', 'downloads', 'records.csv')
-    const exists = await fs.pathExists(filePath)
-
-    expect(exists, `Expected ${filePath} to exist, but it does not`).to.be.true
+    // Check if the file still exists after the second run
+    exists = await fs.pathExists(filePath)
+    expect(exists, `Expected ${filePath} to exist after the second run, but it does not`).to.be.true
   })
 })


### PR DESCRIPTION
- Closes #27007 

### Additional details

#### Why was this change necessary?
The change was necessary to fix a regression where trashAssetsBeforeRuns=false was not working when video=false. This regression was impacting the behaviour of Cypress when running tests with specific configurations.

#### What is affected by this change?
This change affects the behaviour of Cypress when the trashAssetsBeforeRuns configuration is set to false and the video configuration is set to false. It ensures that assets are not trashed between test runs, regardless of the video configuration.

#### Any implementation details to explain?
The fix involves modifying the code in the downloads_spec.ts file to separate the test into two steps. First, the spec that downloads the file is run, and then the existence of the file is checked. Next, the spec is run again with the trashAssetsBeforeRuns configuration set to false, and the existence of the file is checked again. This verifies that the file is retained between test runs when trashAssetsBeforeRuns=false.

### Steps to test

1. Run the spec that downloads the file.
2. Check if the file exists after the first run.
3. Run the spec again with trashAssetsBeforeRuns: false.
4. Check if the file still exists after the second run.

### PR Tasks

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
