### PR TITLE
chore: fix windows regression

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -53,6 +53,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
+    - equal: [ 'lmiller/fix-windows-regressions', << pipeline.git.branch >> ]
     - equal: [ 'matth/feat/chrome-headless', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/

--- a/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
@@ -403,8 +403,10 @@ describe('Cypress in Cypress', { viewportWidth: 1500, defaultCommandTimeout: 100
       cy.contains('E2E specs').should('be.visible')
 
       cy.withCtx(async (ctx) => {
+        const currentProject = ctx.currentProject?.replaceAll('\\', '/')
+        const specPath = `${currentProject}/cypress/e2e/dom-content.spec.js`
         const url = `http://127.0.0.1:${ctx.gqlServerPort}/__launchpad/graphql?`
-        const payload = `{"query":"mutation{\\nrunSpec(specPath:\\"${ctx.currentProject}/cypress/e2e/dom-content.spec.js\\"){\\n__typename\\n... on RunSpecResponse{\\ntestingType\\nbrowser{\\nid\\nname\\n}\\nspec{\\nid\\nname\\n}\\n}\\n}\\n}","variables":null}`
+        const payload = `{"query":"mutation{\\nrunSpec(specPath:\\"${specPath}\\"){\\n__typename\\n... on RunSpecResponse{\\ntestingType\\nbrowser{\\nid\\nname\\n}\\nspec{\\nid\\nname\\n}\\n}\\n}\\n}","variables":null}`
 
         ctx.coreData.app.browserStatus = 'open'
 

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -1754,7 +1754,7 @@ type Mutation {
   """
   runSpec(
     """
-    Relative path of spec to run from Cypress project root - must match e2e or component specPattern
+    Absolute path of the spec to run - must match e2e or component specPattern
     """
     specPath: String!
   ): RunSpecResult

--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -1,5 +1,6 @@
 import defaultMessages from '@packages/frontend-shared/src/locales/en-US.json'
 import pkg from '../../../../package.json'
+import { getPathForPlatform } from './support/getPathForPlatform'
 
 const expectStackToBe = (mode: 'open' | 'closed') => {
   cy.get(`[data-cy="stack-open-${mode === 'open' ? 'true' : 'false'}"]`)
@@ -161,7 +162,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.findAllByTestId('collapsible').should('be.visible')
     cy.contains('h3', 'TSError')
     cy.contains('p', 'Your configFile is invalid:')
-    cy.contains('p', 'cy-projects/config-with-ts-syntax-error/cypress.config.ts')
+    cy.contains('p', getPathForPlatform('cy-projects/config-with-ts-syntax-error/cypress.config.ts'))
     cy.contains('p', 'It threw an error when required, check the stack trace below:')
 
     cy.withCtx(async (ctx) => {
@@ -207,7 +208,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.findAllByTestId('collapsible').should('be.visible')
     cy.contains('h3', 'Error')
     cy.contains('p', 'Your configFile is invalid:')
-    cy.contains('p', 'cy-projects/config-with-import-error/cypress.config.js')
+    cy.contains('p', getPathForPlatform('cy-projects/config-with-import-error/cypress.config.js'))
     cy.contains('p', 'It threw an error when required, check the stack trace below:')
 
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.js:3:23')
@@ -222,7 +223,7 @@ describe('Launchpad: Error System Tests', () => {
     cy.findAllByTestId('collapsible').should('be.visible')
     cy.contains('h3', 'TSError')
     cy.contains('p', 'Your configFile is invalid:')
-    cy.contains('p', 'cy-projects/config-with-ts-module-error/cypress.config.ts')
+    cy.contains('p', getPathForPlatform('cy-projects/config-with-ts-module-error/cypress.config.ts'))
     cy.contains('p', 'It threw an error when required, check the stack trace below:')
     cy.get('[data-testid="error-code-frame"]').should('contain', 'cypress.config.ts:6:10')
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fix regression in Windows CI introduced in https://github.com/cypress-io/cypress/pull/26973/files. CI: https://app.circleci.com/pipelines/github/cypress-io/cypress/53618/workflows/4bfd1c4d-14ae-43fd-9e25-08a78f7b5d99/jobs/2212016/tests#failed-test-0

There are two failures. One is a real regression, one is flake.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Ensure Windows CI is passing.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
