### PR TITLE
chore: ensure banner persists between domain changes

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -495,8 +495,7 @@ describe('App: Settings', () => {
         expect(showSystemNotificationStub).to.have.been.calledWith('Hello From Cypress', 'This is a test notification')
       })
 
-      // TODO: Add documentation link https://github.com/cypress-io/cypress-documentation/issues/5280
-      cy.contains('a', 'Troubleshoot').should('have.attr', 'href', '#')
+      cy.contains('a', 'Troubleshoot').should('have.attr', 'href', 'https://docs.cypress.io/guides/cloud/cypress-app-integration#Troubleshooting')
     })
   })
 })

--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -495,7 +495,7 @@ describe('App: Settings', () => {
         expect(showSystemNotificationStub).to.have.been.calledWith('Hello From Cypress', 'This is a test notification')
       })
 
-      cy.contains('a', 'Troubleshoot').should('have.attr', 'href', 'https://docs.cypress.io/guides/cloud/cypress-app-integration#Troubleshooting')
+      cy.contains('a', 'Troubleshoot').should('have.attr', 'href', 'https://on.cypress.io/notifications-troubleshooting')
     })
   })
 })

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -146,11 +146,8 @@ const showEnableNotificationsBanner = computed(() => {
       Date.now() > new Date(query.data.value?.localSettings.preferences.dismissNotificationBannerUntil).getTime() : true)
 })
 
-const pause = computed(() => !showHeader.value)
-
 const query = useQuery({
   query: MainAppQueryDocument,
-  pause,
 })
 
 const mutation = useMutation(MainApp_ResetErrorsAndLoadConfigDocument)

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -66,7 +66,7 @@ import BaseError from '@cy/gql-components/error/BaseError.vue'
 import Spinner from '@cy/components/Spinner.vue'
 
 import { useRoute } from 'vue-router'
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 
 import { MainAppQueryDocument, MainApp_ResetErrorsAndLoadConfigDocument } from '../generated/graphql'
 import SidebarNavigationContainer from '../navigation/SidebarNavigationContainer.vue'
@@ -139,13 +139,6 @@ const query = useQuery({
 })
 
 const mutation = useMutation(MainApp_ResetErrorsAndLoadConfigDocument)
-
-// Ensure query is re-executed when `showHeader` value changes from false to true
-watch(showHeader, (show) => {
-  if (show) {
-    query.executeQuery()
-  }
-})
 
 const resetErrorAndLoadConfig = (id: string) => {
   if (!mutation.fetching.value) {

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -66,7 +66,7 @@ import BaseError from '@cy/gql-components/error/BaseError.vue'
 import Spinner from '@cy/components/Spinner.vue'
 
 import { useRoute } from 'vue-router'
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 
 import { MainAppQueryDocument, MainApp_ResetErrorsAndLoadConfigDocument } from '../generated/graphql'
 import SidebarNavigationContainer from '../navigation/SidebarNavigationContainer.vue'
@@ -137,7 +137,15 @@ const query = useQuery({
   query: MainAppQueryDocument,
   pause: !showHeader.value,
 })
+
 const mutation = useMutation(MainApp_ResetErrorsAndLoadConfigDocument)
+
+// Ensure query is re-executed when `showHeader` value changes from false to true
+watch(showHeader, (show) => {
+  if (show) {
+    query.executeQuery()
+  }
+})
 
 const resetErrorAndLoadConfig = (id: string) => {
   if (!mutation.fetching.value) {

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -148,6 +148,7 @@ const showEnableNotificationsBanner = computed(() => {
 
 const query = useQuery({
   query: MainAppQueryDocument,
+  pause: isRunMode,
 })
 
 const mutation = useMutation(MainApp_ResetErrorsAndLoadConfigDocument)

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -15,7 +15,6 @@
       :page-name="currentRoute.name?.toString()"
       data-cy="app-header-bar"
       :allow-automatic-prompt-open="true"
-      @header-loaded="handleHeaderLoaded"
     >
       <template #banner>
         <EnableNotificationsBanner
@@ -67,7 +66,7 @@ import BaseError from '@cy/gql-components/error/BaseError.vue'
 import Spinner from '@cy/components/Spinner.vue'
 
 import { useRoute } from 'vue-router'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 
 import { MainAppQueryDocument, MainApp_ResetErrorsAndLoadConfigDocument } from '../generated/graphql'
 import SidebarNavigationContainer from '../navigation/SidebarNavigationContainer.vue'
@@ -120,23 +119,11 @@ mutation MainApp_ResetErrorsAndLoadConfig($id: ID!) {
 
 const currentRoute = useRoute()
 
-const headedInitialLoad = ref(false)
-
-// Do not render the banner until the header has finished loading.
-// This helps to make the UI stable and prevent elements from jumping around.
-function handleHeaderLoaded () {
-  headedInitialLoad.value = true
-}
-
 const showHeader = computed(() => {
   return currentRoute.meta.header !== false
 })
 
 const showEnableNotificationsBanner = computed(() => {
-  if (!showHeader.value || !headedInitialLoad.value) {
-    return false
-  }
-
   // Run notifications will initially be released without support for Windows
   // https://github.com/cypress-io/cypress/issues/26786
   return !isWindows &&

--- a/packages/app/src/layouts/default.vue
+++ b/packages/app/src/layouts/default.vue
@@ -15,7 +15,7 @@
       :page-name="currentRoute.name?.toString()"
       data-cy="app-header-bar"
       :allow-automatic-prompt-open="true"
-      @header-loaded="handleHeadedLoaded"
+      @header-loaded="handleHeaderLoaded"
     >
       <template #banner>
         <EnableNotificationsBanner
@@ -124,7 +124,7 @@ const headedInitialLoad = ref(false)
 
 // Do not render the banner until the header has finished loading.
 // This helps to make the UI stable and prevent elements from jumping around.
-function handleHeadedLoaded () {
+function handleHeaderLoaded () {
   headedInitialLoad.value = true
 }
 

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -195,7 +195,6 @@ debouncedWatch(() => listRef.value, async (newVal) => {
   })
 }, { debounce })
 
-// TODO: Add documentation link https://github.com/cypress-io/cypress-documentation/issues/5280
-const troubleshootingHref = getUrlWithParams({ url: '#', params: {} })
+const troubleshootingHref = getUrlWithParams({ url: 'https://docs.cypress.io/guides/cloud/cypress-app-integration#Troubleshooting', params: {} })
 
 </script>

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -195,6 +195,6 @@ debouncedWatch(() => listRef.value, async (newVal) => {
   })
 }, { debounce })
 
-const troubleshootingHref = getUrlWithParams({ url: 'https://docs.cypress.io/guides/cloud/cypress-app-integration#Troubleshooting', params: {} })
+const troubleshootingHref = getUrlWithParams({ url: 'https://on.cypress.io/notifications-troubleshooting', params: {} })
 
 </script>

--- a/packages/frontend-shared/src/gql-components/HeaderBar.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBar.vue
@@ -16,6 +16,7 @@
 import { gql, useQuery } from '@urql/vue'
 import HeaderBarContent from './HeaderBarContent.vue'
 import { HeaderBar_HeaderBarQueryDocument } from '../generated/graphql'
+import { watchEffect } from 'vue'
 
 gql`
 query HeaderBar_HeaderBarQuery {
@@ -36,8 +37,14 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (event: 'connect-project'): void
+  (event: 'header-loaded'): void
 }>()
 
 const query = useQuery({ query: HeaderBar_HeaderBarQueryDocument })
 
+watchEffect(() => {
+  if (query.data.value) {
+    emit('header-loaded')
+  }
+})
 </script>

--- a/packages/frontend-shared/src/gql-components/HeaderBar.vue
+++ b/packages/frontend-shared/src/gql-components/HeaderBar.vue
@@ -1,7 +1,6 @@
 <template>
-  <div>
+  <div v-if="query.data.value">
     <HeaderBarContent
-      v-if="query.data.value"
       :gql="query.data.value"
       :show-browsers="props.showBrowsers"
       :page-name="props.pageName"
@@ -16,7 +15,6 @@
 import { gql, useQuery } from '@urql/vue'
 import HeaderBarContent from './HeaderBarContent.vue'
 import { HeaderBar_HeaderBarQueryDocument } from '../generated/graphql'
-import { watchEffect } from 'vue'
 
 gql`
 query HeaderBar_HeaderBarQuery {
@@ -37,14 +35,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (event: 'connect-project'): void
-  (event: 'header-loaded'): void
 }>()
 
 const query = useQuery({ query: HeaderBar_HeaderBarQueryDocument })
-
-watchEffect(() => {
-  if (query.data.value) {
-    emit('header-loaded')
-  }
-})
 </script>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/26915

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The `pause` property in the urql GraphQL client was not working as expected. You need to pass a `ref`, or it won't be reactive, and the query won't execute. It turns out we don't actually want to pause it during open mode, though -- only run mode. 

When running a spec that requires the domain to change, the page would refresh, clearing the GraphQL cache. Since we were passing a static value, not a `ref`, `pause` was not reactive, and the query would not re-fetch the data when navigating back to the specs page. I changed the condition to be correct:

- open mode we want to use GraphQL, no pausing 
- run mode, we do not

I also added a flag to ensure the banner won't render until the `<HeaderBar>` renders - it makes the UI more stable and prevents the elements from jumping around. See videos below.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Reproduction here: https://github.com/cypress-io/cypress/pull/26861#issuecomment-1570732445

I tested it like this:

0. Open `state.json` and delete all the properties relating to Notifications. This will ensure the banner shows up. 
1. Open Cypress, choose packages/app -> E2E testing
2. Click "+ New spec -> scaffold examples
3. Run "plugins" spec - it runs on localhost:4455
4. Go back to specs page. Run `todo.cy.js`. This runs on `cypress.io` domain
5. Go back to specs page. Banner still shows (previously it was gone after a spec that changes the domain).

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Banner correctly persists.

I did not write a test for this specific issue. I may come back for this after I knock out the last few bugs/issues - I'm guessing the test isn't really specific to this feature, but just ensuring the urql client is correctly re-querying.

Here is the bug fix (note domain changes, banner persists):


https://github.com/cypress-io/cypress/assets/19196536/6ff9f63f-046c-4900-bf99-5bec3713d6ea


Regarding the UI stability. See this video - the banner renders before the header (using `debugger` to show)

https://github.com/cypress-io/cypress/assets/19196536/eb830eb1-44c5-426a-b15c-16fbda8fc971

Fix:


https://github.com/cypress-io/cypress/assets/19196536/1c547b43-a011-4d3d-ad83-0a71e68c6c18

Here's how it looks, before/after, normal speed (first refresh shows buggy repaint, second shows more stable repaint):


https://github.com/cypress-io/cypress/assets/19196536/324d11b3-2c9c-4ca9-84a6-bd46e72b7146



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
