### PR TITLE
chore: fix flaky navigation test where done is called multiple times …

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -764,9 +764,14 @@ describe('src/cy/commands/navigation', () => {
     // https://github.com/cypress-io/cypress/issues/14445
     // FIXME: fix flaky test (webkit): https://github.com/cypress-io/cypress/issues/24600
     it('should eventually fail on assertion despite redirects', { browser: '!webkit' }, (done) => {
+      let hasDoneBeenCalled = false
+
       cy.on('fail', (err) => {
         expect(err.message).to.contain('The application redirected to')
-        done()
+        if (!hasDoneBeenCalled) {
+          hasDoneBeenCalled = true
+          done()
+        }
       })
 
       // One time, set the amount of times we want the page to perform it's redirect loop.


### PR DESCRIPTION
…almsot always, but sometimes throws an error

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
Currently, the `should eventually fail on assertion despite redirects` inside `navigation.cy.js` somtimes failes with `done() has been called multiple times`. This has been more relevant on the `release/13.0.0` branch with video off for whatever reason, but the behavior looks to be correct in `release/13.0.0` because done does look to be called multiple times, but does not throw an error on `develop` 

I figure the use case here of testing/throwing an error on multiple redirects is rare, hence why fixing the test to only call done once at most seems to be a good solution to work around the issue

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
