### PR TITLE
chore: redirect and scroll to device settings when enabling notifications

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -407,7 +407,7 @@ describe('App: Settings', () => {
 
       itSkipIfWindows('redirects to settings page and focuses notifications when enabling via banner', () => {
       // Make it really vertically narrow to ensure the "scrollTo" behavior is working as expected.
-        cy.viewport(1000, 200)
+        cy.viewport(1000, 500)
         cy.startAppServer('e2e')
         cy.loginUser()
         cy.visitApp()

--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -413,7 +413,7 @@ describe('App: Settings', () => {
         cy.visitApp()
         cy.get('button').contains('Enable desktop notifications').click()
         // We specifically scroll this anchor into view when clicking the "Enable desktop notifications" button.
-        cy.get('h2#notifications').should('be.visible')
+        cy.get('section#notifications').should('be.visible')
       })
     })
 

--- a/packages/app/src/settings/SettingsCard.vue
+++ b/packages/app/src/settings/SettingsCard.vue
@@ -1,8 +1,10 @@
 <template>
   <Collapsible
+    ref="root"
     class="border rounded bg-light-50 border-gray-100 w-full block
   overflow-hidden hocus-default"
     :max-height="maxHeight"
+    :initially-open="initiallyOpen"
     lazy
     :data-cy="title"
   >
@@ -43,20 +45,79 @@
 
 <script lang="ts" setup>
 import type { FunctionalComponent, SVGAttributes } from 'vue'
+import { ref, ComponentPublicInstance, computed, watchEffect, nextTick } from 'vue'
 import Collapsible from '@cy/components/Collapsible.vue'
 import ListRowHeader from '@cy/components/ListRowHeader.vue'
+import { useRoute } from 'vue-router'
 
-defineProps<{
+const props = defineProps<{
   title: string
+  name: string
   description: string
   icon: FunctionalComponent<SVGAttributes, {}>
   maxHeight: string
 }>()
 
-</script>
+const route = useRoute()
+const initiallyOpen = computed(() => route.query.section === props.name)
+const root = ref<ComponentPublicInstance>()
 
-<style lang="scss" scoped>
-.settings-card-header {
-  grid-template-columns: auto auto 1fr auto;
+/**
+ * This feature is used for opening and scrolling to a specific
+ * setting, often as a result of doing something else
+ * somewhere in the App.
+ *
+ * One example use case is enabling Desktop Notifications.
+ * When a user selects "Enable desktop notifications" on the
+ * Specs page, the desired behavior is:
+ *
+ * 1. Redirect to the /settings page
+ * 2. Open the relevant settings card (Device Settings, in this case)
+ * 3. Scroll to the #notifications anchor
+ *
+ * Example usage:
+ *
+ *
+ * router.push({
+ *   path: '/settings',         // page to redirect to
+ *   query: {
+ *     section: 'device',       // section to open by default
+ *     anchor: 'notifications'  // anchor to scroll to
+ *   }
+ * })
+ *
+ * @see https://github.com/cypress-io/cypress/issues/27090
+ */
+function maybeScrollToAnchor () {
+  if (!initiallyOpen.value) {
+    return
+  }
+
+  if (!route.query.anchor) {
+    // Do nothing - no anchor query parameter.
+  }
+
+  if (!root.value?.$el) {
+    // Component will always have an underlying HTML element,
+    // but better to be defensive, and appease TypeScript.
+    return
+  }
+
+  // Get the root HTML element, then query for the desired anchor element.
+  // Finally, if we found it, scroll into into view!
+  const $el = root.value.$el as HTMLDivElement
+  const $anchor = $el.querySelector(`#${route.query.anchor}`)
+
+  $anchor?.scrollIntoView({ behavior: 'smooth' })
 }
-</style>
+
+watchEffect(() => {
+  if (initiallyOpen.value) {
+    // Wait for the next tick to ensure the target section
+    // has had time to transition from closed to open.
+    // This only occurs when clicking "Enable desktop notifications"
+    // when the user is already on the /settings route.
+    nextTick(maybeScrollToAnchor)
+  }
+})
+</script>

--- a/packages/app/src/settings/SettingsCard.vue
+++ b/packages/app/src/settings/SettingsCard.vue
@@ -52,14 +52,22 @@ import { useRoute } from 'vue-router'
 
 const props = defineProps<{
   title: string
-  name: string
+  name?: string
   description: string
   icon: FunctionalComponent<SVGAttributes, {}>
   maxHeight: string
 }>()
 
 const route = useRoute()
-const initiallyOpen = computed(() => route.query.section === props.name)
+
+const initiallyOpen = computed(() => {
+  if (!props.name || !route.query.section) {
+    return false
+  }
+
+  return route.query.section === props.name
+})
+
 const root = ref<ComponentPublicInstance>()
 
 /**

--- a/packages/app/src/settings/SettingsContainer.vue
+++ b/packages/app/src/settings/SettingsContainer.vue
@@ -6,6 +6,7 @@
     <div class="space-y-[24px]">
       <SettingsCard
         :title="t('settingsPage.project.title')"
+        name="project"
         :description="t('settingsPage.project.description')"
         :icon="IconFolder"
         max-height="10000px"
@@ -18,6 +19,7 @@
       <SettingsCard
         :title="t('settingsPage.device.title')"
         :description="t('settingsPage.device.description')"
+        name="device"
         :icon="IconLaptop"
         max-height="800px"
       >
@@ -33,6 +35,7 @@
         :title="t('settingsPage.cloud.title')"
         :description="t('settingsPage.cloud.description')"
         :icon="IconOdometer"
+        name="cloud"
         max-height="10000px"
       >
         <CloudSettings :gql="props.gql" />

--- a/packages/app/src/settings/SettingsSection.vue
+++ b/packages/app/src/settings/SettingsSection.vue
@@ -1,6 +1,9 @@
 <template>
   <section>
-    <h2 class="font-medium text-[16px] text-gray-900 leading-[24px] inline-flex items-baseline align-middle">
+    <h2
+      :id="anchor"
+      class="font-medium text-[16px] text-gray-900 leading-[24px] inline-flex items-baseline align-middle"
+    >
       <slot name="title" />
       <code
         v-if="code"
@@ -19,5 +22,6 @@
 <script lang="ts" setup>
 defineProps<{
   code?: string
+  anchor?: string
 }>()
 </script>

--- a/packages/app/src/settings/SettingsSection.vue
+++ b/packages/app/src/settings/SettingsSection.vue
@@ -1,7 +1,6 @@
 <template>
-  <section>
+  <section :id="anchor">
     <h2
-      :id="anchor"
       class="font-medium text-[16px] text-gray-900 leading-[24px] inline-flex items-baseline align-middle"
     >
       <slot name="title" />

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <SettingsSection>
+  <SettingsSection anchor="notifications">
     <template #title>
       {{ t('settingsPage.notifications.title') }}
     </template>

--- a/packages/app/src/specs/banners/EnableNotificationsBanner.vue
+++ b/packages/app/src/specs/banners/EnableNotificationsBanner.vue
@@ -43,6 +43,7 @@ import Button from '@cypress-design/vue-button'
 import { IconActionDeleteMedium } from '@cypress-design/vue-icon'
 import { dayjs } from '../../runs/utils/day.js'
 import { EnableNotificationsBanner_ShowNotificationDocument, EnableNotificationsBanner_SetPreferencesDocument } from '../../generated/graphql'
+import { useRouter } from 'vue-router'
 
 const { t } = useI18n()
 
@@ -66,10 +67,19 @@ mutation EnableNotificationsBanner_SetPreferences ($value: String!) {
 const showNotification = useMutation(EnableNotificationsBanner_ShowNotificationDocument)
 const setPreferences = useMutation(EnableNotificationsBanner_SetPreferencesDocument)
 
+const router = useRouter()
+
 const enableNotifications = async () => {
   await showNotification.executeMutation({ title: t('specPage.banners.enableNotifications.notificationsEnabledTitle'), body: t('specPage.banners.enableNotifications.notificationsEnabledBody') })
 
-  await setPreferences.executeMutation({ value: JSON.stringify({ desktopNotificationsEnabled: true }) })
+  // await setPreferences.executeMutation({ value: JSON.stringify({ desktopNotificationsEnabled: true }) })
+  router.push({
+    path: '/settings',
+    query: {
+      section: 'device',
+      anchor: 'notifications',
+    },
+  })
 }
 
 const remindLater = async () => {

--- a/packages/app/src/specs/banners/EnableNotificationsBanner.vue
+++ b/packages/app/src/specs/banners/EnableNotificationsBanner.vue
@@ -72,7 +72,9 @@ const router = useRouter()
 const enableNotifications = async () => {
   await showNotification.executeMutation({ title: t('specPage.banners.enableNotifications.notificationsEnabledTitle'), body: t('specPage.banners.enableNotifications.notificationsEnabledBody') })
 
-  // await setPreferences.executeMutation({ value: JSON.stringify({ desktopNotificationsEnabled: true }) })
+  await setPreferences.executeMutation({ value: JSON.stringify({ desktopNotificationsEnabled: true }) })
+
+  // Redirect to the /settings page, expand the Device Settings and scroll to the #notifications anchor.
   router.push({
     path: '/settings',
     query: {

--- a/packages/frontend-shared/src/components/Collapsible.vue
+++ b/packages/frontend-shared/src/components/Collapsible.vue
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { useToggle } from '@vueuse/core'
+import { watch } from 'vue'
 
 const props = withDefaults(defineProps<{
   maxHeight?: string
@@ -59,4 +60,11 @@ const props = withDefaults(defineProps<{
 
 const [isOpen, toggle] = useToggle(props.initiallyOpen)
 
+watch(() => props.initiallyOpen, (val, oldVal) => {
+  // It was toggled from false to true by the parent to
+  // force the collapsible to open.
+  if (oldVal === false && val === true) {
+    isOpen.value = true
+  }
+})
 </script>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/27090

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I documented this feature and the code heavily since I think reverse engineering this in the future would be difficult. Basically, we use the query params to orchestrate the redirecting. Changing the route from `http://localhost:4455/__app/#/specs` to `http://localhost:4455/__app/#/settings?section=device&anchor=notifications` will

- ensure the `section` with `name="device"` is expanded
- scroll to an element `#notifications` if it is found

I wrote a neat End to End test, video included.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Ensure desktop notifications are not enabled
2. Open App
3. Enable desktop notifications by clicking the banner
4. It should redirect you to `/settings`, expand "Device Settings" and scroll the "Notifications" to the top.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

## 1. Redirect + Scroll from non Settings page

https://github.com/cypress-io/cypress/assets/19196536/ddc60eea-ab25-4035-a7c5-66705d34a81e

## 2. Redirect + Scroll while already on Settings page


https://github.com/cypress-io/cypress/assets/19196536/bc6a0c46-9287-46ef-92b7-fa3e5622cc0e


## 3. End to End test

The neat trick to ensure the scrolling works is make the viewport vertically very compact.


https://github.com/cypress-io/cypress/assets/19196536/1d874dda-fd4b-4c2a-af02-d2126ab76ba4



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
