### PR TITLE
fix: chrome crash when CRI client is disconnected

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,8 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'matth/feat/chrome-headless'
-        - 'lmiller/fix-windows-regressions'
+        - 'fix/chrome_crash_recovery'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -42,7 +41,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'matth/feat/chrome-headless', << pipeline.git.branch >> ]
+    - equal: [ 'fix/chrome_crash_recovery', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -53,8 +52,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'lmiller/fix-windows-regressions', << pipeline.git.branch >> ]
-    - equal: [ 'matth/feat/chrome-headless', << pipeline.git.branch >> ]
+    - equal: [ 'fix/chrome_crash_recovery', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -74,7 +72,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'privileged-commands-refactor', << pipeline.git.branch >> ]
+    - equal: [ 'fix/chrome_crash_recovery', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -141,7 +139,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "lmiller/fix-windows-regressions" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "fix/chrome_crash_recovery" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 07/05/2023 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed an issue where chrome was not recovering from browser crashes properly. Fixes [#24650](https://github.com/cypress-io/cypress/issues/24650).
 - Fixed an issue where some internal file locations consumed by the Cypress Angular Handler moved as a result of [this commit](https://github.com/angular/angular-cli/commit/466d86dc8d3398695055f9eced7402804848a381) from Angular. Addressed in [#27030](https://github.com/cypress-io/cypress/pull/27030).
 
 ## 12.15.0

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -161,7 +161,14 @@ export class CdpAutomation {
   async startVideoRecording (writeVideoFrame: WriteVideoFrame, screencastOpts) {
     this.onFn('Page.screencastFrame', async (e) => {
       writeVideoFrame(Buffer.from(e.data, 'base64'))
-      await this.sendDebuggerCommandFn('Page.screencastFrameAck', { sessionId: e.sessionId })
+      try {
+        await this.sendDebuggerCommandFn('Page.screencastFrameAck', { sessionId: e.sessionId })
+      } catch (e) {
+        // swallow this error if the CRI connection was reset
+        if (!e.message.includes('browser CRI connection was reset')) {
+          throw e
+        }
+      }
     })
 
     await this.sendDebuggerCommandFn('Page.startScreencast', screencastOpts)

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -188,6 +188,11 @@ export const create = async (target: string, onAsynchronousError: Function, host
 
           await reconnect()
 
+          // if enqueued commands were wiped out from the reconnect and the socket is already closed, reject the command as it will never be run
+          if (enqueuedCommands.length === 0 && closed) {
+            return Promise.reject(new Error(`${command} will not run as browser CRI connection was reset`))
+          }
+
           return p
         }
       }

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -241,8 +241,6 @@ export = {
         }
 
         await options.onError(err)
-
-        await options.relaunchBrowser!()
       }
     })
 

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -458,7 +458,7 @@ function listenForProjectEnd (project, exit): Bluebird<any> {
   })
 }
 
-async function waitForBrowserToConnect (options: { project: Project, socketId: string, onError: (err: Error) => void, spec: SpecWithRelativeRoot, isFirstSpec: boolean, testingType: string, experimentalSingleTabRunMode: boolean, browser: Browser, screenshots: ScreenshotMetadata[], projectRoot: string, shouldLaunchNewTab: boolean, webSecurity: boolean, videoRecording?: VideoRecording }) {
+async function waitForBrowserToConnect (options: { project: Project, socketId: string, onError: (err: Error) => void, spec: SpecWithRelativeRoot, isFirstSpecInBrowser: boolean, testingType: string, experimentalSingleTabRunMode: boolean, browser: Browser, screenshots: ScreenshotMetadata[], projectRoot: string, shouldLaunchNewTab: boolean, webSecurity: boolean, videoRecording?: VideoRecording }) {
   if (globalThis.CY_TEST_MOCK?.waitForBrowserToConnect) return Promise.resolve()
 
   const { project, socketId, onError, spec } = options
@@ -480,7 +480,7 @@ async function waitForBrowserToConnect (options: { project: Project, socketId: s
     return currentSetScreenshotMetadata(data)
   }
 
-  if (options.experimentalSingleTabRunMode && options.testingType === 'component' && !options.isFirstSpec) {
+  if (options.experimentalSingleTabRunMode && options.testingType === 'component' && !options.isFirstSpecInBrowser) {
     // reset browser state to match default behavior when opening/closing a new tab
     await openProject.resetBrowserState()
 
@@ -768,7 +768,7 @@ async function runSpecs (options: { config: Cfg, browser: Browser, sys: any, hea
     })
   }
 
-  let isFirstSpec = true
+  let isFirstSpecInBrowser = true
 
   async function runEachSpec (spec: SpecWithRelativeRoot, index: number, length: number, estimated: number) {
     const span = telemetry.startSpan({
@@ -779,16 +779,21 @@ async function runSpecs (options: { config: Cfg, browser: Browser, sys: any, hea
     span?.setAttributes({
       specName: spec.name,
       type: spec.specType,
-      firstSpec: isFirstSpec,
+      firstSpec: isFirstSpecInBrowser,
     })
 
     if (!options.quiet) {
       printResults.displaySpecHeader(spec.relativeToCommonRoot, index + 1, length, estimated)
     }
 
-    const { results } = await runSpec(config, spec, options, estimated, isFirstSpec, index === length - 1)
+    const { results } = await runSpec(config, spec, options, estimated, isFirstSpecInBrowser, index === length - 1)
 
-    isFirstSpec = false
+    if (results?.error?.includes('We detected that the Chrome process just crashed with code')) {
+      // If the browser has crashed, make sure isFirstSpecInBrowser is set to true as the browser will be relaunching
+      isFirstSpecInBrowser = true
+    } else {
+      isFirstSpecInBrowser = false
+    }
 
     debug('spec results %o', results)
 
@@ -910,7 +915,7 @@ async function runSpecs (options: { config: Cfg, browser: Browser, sys: any, hea
   return results
 }
 
-async function runSpec (config, spec: SpecWithRelativeRoot, options: { project: Project, browser: Browser, onError: (err: Error) => void, config: Cfg, quiet: boolean, exit: boolean, testingType: TestingType, socketId: string, webSecurity: boolean, projectRoot: string } & Pick<Cfg, 'video' | 'videosFolder' | 'videoCompression' | 'videoUploadOnPasses'>, estimated, isFirstSpec, isLastSpec) {
+async function runSpec (config, spec: SpecWithRelativeRoot, options: { project: Project, browser: Browser, onError: (err: Error) => void, config: Cfg, quiet: boolean, exit: boolean, testingType: TestingType, socketId: string, webSecurity: boolean, projectRoot: string } & Pick<Cfg, 'video' | 'videosFolder' | 'videoCompression' | 'videoUploadOnPasses'>, estimated, isFirstSpecInBrowser, isLastSpec) {
   const { project, browser, onError } = options
 
   const { isHeadless } = browser
@@ -935,7 +940,7 @@ async function runSpec (config, spec: SpecWithRelativeRoot, options: { project: 
 
     telemetry.startSpan({ name: 'video:capture' })
 
-    if (config.experimentalSingleTabRunMode && !isFirstSpec && project.videoRecording) {
+    if (config.experimentalSingleTabRunMode && !isFirstSpecInBrowser && project.videoRecording) {
       // in single-tab mode, only the first spec needs to create a videoRecording object
       // which is then re-used between specs
       return await startVideoRecording({ ...opts, previous: project.videoRecording })
@@ -976,9 +981,9 @@ async function runSpec (config, spec: SpecWithRelativeRoot, options: { project: 
       webSecurity: options.webSecurity,
       projectRoot: options.projectRoot,
       testingType: options.testingType,
-      isFirstSpec,
+      isFirstSpecInBrowser,
       experimentalSingleTabRunMode: config.experimentalSingleTabRunMode,
-      shouldLaunchNewTab: !isFirstSpec,
+      shouldLaunchNewTab: !isFirstSpecInBrowser,
     }),
   ])
 

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -198,7 +198,13 @@ export class OpenProject {
   }
 
   async resetBrowserTabsForNextTest (shouldKeepTabOpen: boolean) {
-    return this.projectBase?.resetBrowserTabsForNextTest(shouldKeepTabOpen)
+    try {
+      await this.projectBase?.resetBrowserTabsForNextTest(shouldKeepTabOpen)
+    } catch (e) {
+      // If the CRI client disconnected or crashed, we want to no-op here so that anything
+      // depending on resetting the browser tabs can continue with further operations
+      return
+    }
   }
 
   async resetBrowserState () {

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -96,6 +96,20 @@ describe('lib/browsers/cri-client', function () {
           })
         })
       })
+
+      context('closed', () => {
+        it(`when socket is closed mid send'`, async function () {
+          const err = new Error('WebSocket is not open: readyState 3 (CLOSED)')
+
+          send.onFirstCall().rejects(err)
+
+          const client = await getClient()
+
+          await client.close()
+
+          expect(client.send('Browser.getVersion', { baz: 'quux' })).to.be.rejectedWith('Browser.getVersion will not run as browser CRI connection was reset')
+        })
+      })
     })
   })
 

--- a/system-tests/__snapshots__/browser_crash_handling_spec.js
+++ b/system-tests/__snapshots__/browser_crash_handling_spec.js
@@ -196,7 +196,117 @@ https://on.cypress.io/renderer-process-crashed
 
 `
 
-exports['Browser Crash Handling / when the browser process crashes in chrome / fails'] = `
+exports['Browser Crash Handling / when the browser process crashes in chrome / fails w/ video off'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_process_crash.cy.js, simple.cy.js)                                 │
+  │ Searched:   cypress/e2e/chrome_process_crash.cy.js, cypress/e2e/simple.cy.js                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_process_crash.cy.js                                                      (1 of 2)
+
+
+
+We detected that the Chrome process just crashed with code 'null' and signal 'SIGTRAP'.
+
+We have failed the current test and have relaunched Chrome.
+
+This can happen for many different reasons:
+
+- You wrote an endless loop and you must fix your own code
+- You are running lots of tests on a memory intense application
+- You are running in a memory starved VM environment
+- There are problems with your GPU / GPU drivers
+- There are browser bugs
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        0                                                                                │
+  │ Passing:      0                                                                                │
+  │ Failing:      1                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     chrome_process_crash.cy.js                                                       │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  simple.cy.js                                                                    (2 of 2)
+
+
+  ✓ is true
+
+  1 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        1                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     simple.cy.js                                                                     │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✖  chrome_process_crash.cy.js               XX:XX        -        -        1        -        - │
+  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ ✔  simple.cy.js                             XX:XX        1        1        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✖  1 of 2 failed (50%)                      XX:XX        1        1        1        -        -  
+
+
+`
+
+exports['Browser Crash Handling / when the browser process crashes in electron / fails'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      2 found (chrome_process_crash.cy.js, simple.cy.js)                                 │
+  │ Searched:   cypress/e2e/chrome_process_crash.cy.js, cypress/e2e/simple.cy.js                   │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  chrome_process_crash.cy.js                                                      (1 of 2)
+
+
+
+`
+
+exports['Browser Crash Handling / when the browser process crashes in chrome / fails w/ video on'] = `
 
 ====================================================================================================
 
@@ -290,28 +400,6 @@ This can happen for many different reasons:
   │ ✔  simple.cy.js                             XX:XX        1        1        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
     ✖  1 of 2 failed (50%)                      XX:XX        1        1        1        -        -  
-
-
-`
-
-exports['Browser Crash Handling / when the browser process crashes in electron / fails'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      2 found (chrome_process_crash.cy.js, simple.cy.js)                                 │
-  │ Searched:   cypress/e2e/chrome_process_crash.cy.js, cypress/e2e/simple.cy.js                   │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  chrome_process_crash.cy.js                                                      (1 of 2)
-
 
 
 `

--- a/system-tests/test/browser_crash_handling_spec.js
+++ b/system-tests/test/browser_crash_handling_spec.js
@@ -29,11 +29,32 @@ describe('Browser Crash Handling', () => {
 
   // It should fail the chrome_tab_crash spec, but the simple spec should run and succeed
   context('when the browser process crashes in chrome', () => {
-    systemTests.it('fails', {
+    systemTests.it('fails w/ video off', {
       browser: 'chrome',
       spec: 'chrome_process_crash.cy.js,simple.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: {
+        video: false,
+      },
+      onStdout: (stdout) => {
+        // the location of this warning is non-deterministic
+        return stdout.replace('The automation client disconnected. Cannot continue running tests.\n', '')
+      },
+    })
+
+    systemTests.it('fails w/ video on', {
+      browser: 'chrome',
+      spec: 'chrome_process_crash.cy.js,simple.cy.js',
+      snapshot: true,
+      expectedExitCode: 1,
+      config: {
+        video: true,
+      },
+      onStdout: (stdout) => {
+        // the location of this warning is non-deterministic
+        return stdout.replace('The automation client disconnected. Cannot continue running tests.\n', '')
+      },
     })
   })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24650 

### Additional details
When running the [browser_crash_handling_spec.js -> when the browser process crashes in chrome](https://github.com/cypress-io/cypress/blob/develop/system-tests/test/browser_crash_handling_spec.js#L31) spec with `video: false`, Cypress enters an infinite test loop where it keeps trying to run `chrome_process_crash.cy.js`. 

The reason this is happening is when the `chrome_process_crash.cy.js` fails and crashes the browser, the CRI client becomes disconnected. However, the `browser-cri-client` is unaware of the disconnect. When `resetBrowserTabsForNextTest` is called at the end of the test, and [Target.createTarget](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/browser-cri-client.ts#L172) is called, the promise never resolves and hangs, meaning that the server state is [never reset](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/modes/run.ts#L678). We want `resetBrowserTabsForNextTest` to behave as a no-op, whether is succeeds or fails. Additionally, if the CRI socket is closed and a reconnect is attempted, and there are no pending commands in the queue and the socket is STILL closed, we want to reject send commands to prevent hanging promises. This doesn't seem to happen with video on I believe since the the video processing takes time, and in that time the browser CRI client is reconnected, which allows the state to be reset.

Additionally, after fixing the hanging promise and the state resetting, the [`relaunchBrowser`](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L161) method was getting called twice, once in [open_project](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L193) and again in [browsers/index.ts](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/index.ts#L245) when the browser crashes. I think this due to the run spec now actually resolving, which now hits the correct [`relaunchBrowser`](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L161), meaning the one in [browsers/index.ts](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/index.ts#L245) can be removed.

Lastly, when the browser crashes, we want [`shouldLaunchNewTab`](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L177) to be treated as `false`, which is handled by [runSpec](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/modes/run.ts#L789C34-L789C34). After crash this was being set to true, which was trying to run [connectToNewSpec](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L185) when it shouldn't, resulting in the infamous error `Missing browserCriClient in connectToNewSpec` [here](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/chrome.ts#L590) as the CRI client doesn't get instantiated yet.

 If a chrome crash is detected, we need to reset `isFirstSpec` (renamed to `isFirstSpecInBrowser`) to `false`, which in turn sets [`shouldLaunchNewTab`](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/open_project.ts#L177)  to `false`, which creates the CRI client as expected

### Steps to test
run the  [browser_crash_handling_spec.js -> when the browser process crashes in chrome](https://github.com/cypress-io/cypress/blob/develop/system-tests/test/browser_crash_handling_spec.js#L31) with video on and off (added in this PR)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
