### PR TITLE
fix: Handle large payloads sent with privileged commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 07/05/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where some internal file locations consumed by the Cypress Angular Handler moved as a result of [this commit](https://github.com/angular/angular-cli/commit/466d86dc8d3398695055f9eced7402804848a381) from Angular. Addressed in [#27030](https://github.com/cypress-io/cypress/pull/27030).
+- Fixed an issue where certain commands would fail with the error `must only be invoked from the spec file or support file` when invoked with a large argument. Fixes [#27099](https://github.com/cypress-io/cypress/pull/27099).
 
 ## 12.15.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 07/05/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where some internal file locations consumed by the Cypress Angular Handler moved as a result of [this commit](https://github.com/angular/angular-cli/commit/466d86dc8d3398695055f9eced7402804848a381) from Angular. Addressed in [#27030](https://github.com/cypress-io/cypress/pull/27030).
-- Fixed an issue where certain commands would fail with the error `must only be invoked from the spec file or support file` when invoked with a large argument. Fixes [#27099](https://github.com/cypress-io/cypress/pull/27099).
+- Fixed an issue where certain commands would fail with the error `must only be invoked from the spec file or support file` when invoked with a large argument. Fixes [#27099](https://github.com/cypress-io/cypress/issues/27099).
 
 ## 12.15.0
 

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -73,11 +73,14 @@ describe('privileged commands', () => {
       cy.task('arg:is:undefined')
       cy.task('arg:is:undefined', undefined)
       cy.task('arg:is:undefined', undefined, undefined)
+      cy.task('arg:is:undefined', undefined, { timeout: 9999 })
     })
 
     it('handles null argument(s)', () => {
       cy.task('return:arg', null)
+      // @ts-ignore
       cy.task('return:arg', null, null)
+      cy.task('return:arg', null, { timeout: 9999 })
     })
 
     it('passes in test body .then() callback', () => {

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -69,6 +69,17 @@ describe('privileged commands', () => {
       cy.writeFile('cypress/_test-output/huge-out.json', hugeJson)
     })
 
+    it('handles undefined argument(s)', () => {
+      cy.task('arg:is:undefined')
+      cy.task('arg:is:undefined', undefined)
+      cy.task('arg:is:undefined', undefined, undefined)
+    })
+
+    it('handles null argument(s)', () => {
+      cy.task('return:arg', null)
+      cy.task('return:arg', null, null)
+    })
+
     it('passes in test body .then() callback', () => {
       cy.then(() => {
         cy.exec('echo "hello"')

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -51,6 +51,24 @@ describe('privileged commands', () => {
       cy.task('return:arg', 'arg')
     })
 
+    // https://github.com/cypress-io/cypress/issues/27099
+    it('passes with large payloads', () => {
+      const hugeJson = Cypress._.times(3000).map(() => {
+        return {
+          key1: 'value 1',
+          key2: {
+            key3: 'value 3',
+            key4: {
+              key5: 'value 5',
+            },
+          },
+        }
+      })
+
+      cy.task('return:arg', hugeJson)
+      cy.writeFile('cypress/_test-output/huge-out.json', hugeJson)
+    })
+
     it('passes in test body .then() callback', () => {
       cy.then(() => {
         cy.exec('echo "hello"')

--- a/packages/server/lib/privileged-commands/privileged-channel.js
+++ b/packages/server/lib/privileged-commands/privileged-channel.js
@@ -159,8 +159,9 @@
     // see https://github.com/cypress-io/cypress/issues/27099 and
     // https://github.com/cypress-io/cypress/issues/27097
     const args = dropRightUndefined(map.call([...command.args], (arg) => {
+      // undefined can't be JSON-stringified
       if (arg === undefined) {
-        return undefined
+        arg = null
       }
 
       if (typeof arg === 'function') {

--- a/packages/server/lib/privileged-commands/privileged-commands-manager.ts
+++ b/packages/server/lib/privileged-commands/privileged-commands-manager.ts
@@ -95,17 +95,13 @@ class PrivilegedCommandsManager {
   // also removes that command from the verified commands array
   hasVerifiedCommand (command) {
     const matchingCommand = _.find(this.verifiedCommands, ({ name, args }) => {
-      // undefined values can end up at the end of the args array due to the
-      // way it's sent over websockets. need to trim them so that they properly
-      // match the original invocation
-      const trimmedArgs = _.dropRightWhile(args, _.isUndefined)
       // the args added to `this.verifiedCommands` come hashed (see
       // server/lib/privileged-commands/privileged-channel.js for more info)
       // hash the ones sent with the command we're running for an
       // apples-to-apples comparison
       const hashedArgs = command.args.map((arg) => hash(JSON.stringify(arg)))
 
-      return command.name === name && _.isEqual(trimmedArgs, hashedArgs)
+      return command.name === name && _.isEqual(args, hashedArgs)
     })
 
     return !!matchingCommand

--- a/packages/server/lib/privileged-commands/privileged-commands-manager.ts
+++ b/packages/server/lib/privileged-commands/privileged-commands-manager.ts
@@ -16,7 +16,7 @@ export interface SpecChannelOptions {
 
 interface SpecOriginatedCommand {
   name: string
-  args: string
+  args: string[]
 }
 
 type NonSpecError = Error & { isNonSpec: boolean | undefined }

--- a/packages/server/test/unit/browsers/privileged-channel_spec.js
+++ b/packages/server/test/unit/browsers/privileged-channel_spec.js
@@ -19,11 +19,15 @@ describe('privileged channel', () => {
     // in the tests, they don't mess up the actual globals since the test
     // runner itself relies on them
     win = {
-      Array: { prototype: {
-        filter: Array.prototype.filter,
-        includes: Array.prototype.includes,
-        map: Array.prototype.map,
-      } },
+      Array: {
+        isArray: Array.isArray,
+        prototype: {
+          filter: Array.prototype.filter,
+          includes: Array.prototype.includes,
+          map: Array.prototype.map,
+          slice: Array.prototype.slice,
+        },
+      },
       Error: ErrorStub,
       Cypress: {
         on () {},
@@ -32,11 +36,15 @@ describe('privileged channel', () => {
       Function: { prototype: {
         toString: Function.prototype.toString,
       } },
+      Math: {
+        imul: Math.imul,
+      },
       JSON: {
         parse: JSON.parse,
         stringify: JSON.stringify,
       },
       String: { prototype: {
+        charCodeAt: String.prototype.charCodeAt,
         includes: String.prototype.includes,
         replace: String.prototype.replace,
         split: String.prototype.split,
@@ -175,6 +183,38 @@ describe('privileged channel', () => {
       onCommandInvocation({ name: 'task', args: [] })
 
       expect(win.JSON.parse).not.to.be.called
+    })
+  })
+
+  describe('#dropRightUndefined', () => {
+    it('removes undefined values from the right side of the array', () => {
+      const { dropRightUndefined } = runPrivilegedChannel()
+
+      expect(dropRightUndefined(['one', 'two'])).to.deep.equal(['one', 'two'])
+      expect(dropRightUndefined(['one', 'two', undefined])).to.deep.equal(['one', 'two'])
+      expect(dropRightUndefined(['one', 'two', undefined, undefined])).to.deep.equal(['one', 'two'])
+      expect(dropRightUndefined(['one', 'two', undefined, null])).to.deep.equal(['one', 'two', undefined, null])
+      expect(dropRightUndefined(['one', 'two', null, undefined])).to.deep.equal(['one', 'two', null])
+    })
+
+    it('does not remove undefined values from the beginning or middle of the array', () => {
+      const { dropRightUndefined } = runPrivilegedChannel()
+
+      expect(dropRightUndefined([undefined, 'one', 'two'])).to.deep.equal([undefined, 'one', 'two'])
+      expect(dropRightUndefined([undefined, 'one', undefined, 'two'])).to.deep.equal([undefined, 'one', undefined, 'two'])
+      expect(dropRightUndefined([undefined, 'one', undefined, 'two', undefined])).to.deep.equal([undefined, 'one', undefined, 'two'])
+      expect(dropRightUndefined(['one', undefined, 'two'])).to.deep.equal(['one', undefined, 'two'])
+      expect(dropRightUndefined(['one', undefined, 'two', undefined])).to.deep.equal(['one', undefined, 'two'])
+    })
+
+    it('returns empty array if not passed an array', () => {
+      const { dropRightUndefined } = runPrivilegedChannel()
+
+      expect(dropRightUndefined()).to.deep.equal([])
+      expect(dropRightUndefined({})).to.deep.equal([])
+      expect(dropRightUndefined(true)).to.deep.equal([])
+      expect(dropRightUndefined(123)).to.deep.equal([])
+      expect(dropRightUndefined('string')).to.deep.equal([])
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27099 

### Additional details

Running a privileged command with a large payload can cause a `413 Request Entity Too Large` error in express/body-parser when on the `POST /__cypress/add-verified-command` request. 

This is experienced with the code coverage plugin since it sends the entire coverage payload through `cy.task()`.

The crux of the issue is that privileged commands send their args to the server via a POST request when the command is invoked (i.e. enqueued, before being run), which triggers the 413 error in express/body-parser. Those args are compared later when the command is actually run. The fix is to send a hashed version of each arg instead of sending the entire arg in order to reduce the payload size. Then when the command is run, hashes are compared instead of full values.

### Steps to test

1. Set up a simple `someTask` implementation in `cypress.config.js`. Doesn't actually need to do anything besides `return null`.
2. Run this test

```js
it('privileged command can handle a large json payload', () => {
    const hugeJson = Cypress._.times(3000).map(() => {
      return {
        key1: 'value 1',
        key2: {
          key3: 'value 3',
          key4: {
            key5: 'value 5',
          },
        },
      }
    })

    cy.task('someTask', hugeJson)
})
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
