### PR TITLE
fix: stop subscription race condition error on debug page

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,11 +1,15 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 12.15.1
+## 12.16.1
 
 _Released 07/05/2023 (PENDING)_
 
 **Bugfixes:**
 
 - Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Fixed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
+
+## 12.16.0
+
+_Released 06/26/2023_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 _Released 07/05/2023 (PENDING)_
 
 **Bugfixes:**
+
 - Fixed an issue where chrome was not recovering from browser crashes properly. Fixes [#24650](https://github.com/cypress-io/cypress/issues/24650).
 - Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Fixed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,10 @@ _Released 07/05/2023 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Addressed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
+
+**Bugfixes:**
+
 - Fixed an issue where some internal file locations consumed by the Cypress Angular Handler moved as a result of [this commit](https://github.com/angular/angular-cli/commit/466d86dc8d3398695055f9eced7402804848a381) from Angular. Addressed in [#27030](https://github.com/cypress-io/cypress/pull/27030).
 - Fixed an issue where certain commands would fail with the error `must only be invoked from the spec file or support file` when invoked with a large argument. Fixes [#27099](https://github.com/cypress-io/cypress/issues/27099).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 07/05/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Addressed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
+- Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Fixed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
 
 **Bugfixes:**
 

--- a/packages/app/src/debug/DebugTestingProgress.vue
+++ b/packages/app/src/debug/DebugTestingProgress.vue
@@ -49,7 +49,7 @@ subscription DebugTestingProgress_Specs($id: ID!) {
   relevantRunSpecChange(runId: $id) {
     id
     ...DebugPendingRunCounts
-      scheduledToCompleteAt
+    scheduledToCompleteAt
   }
 }
 `

--- a/packages/data-context/src/polling/poller.ts
+++ b/packages/data-context/src/polling/poller.ts
@@ -30,7 +30,7 @@ export class Poller<E extends EventType, T = never, M = never> {
 
     debug(`subscribing to ${this.event} with initial value %o and meta %o`, config?.initialValue, config?.meta)
     this.#subscriptions[subscriptionId] = { meta: config.meta }
-    debug('subscriptions before subscribe', this.#subscriptions)
+    debug('subscriptions after subscribe', this.#subscriptions)
 
     if (!this.#isPolling) {
       this.#isPolling = true
@@ -57,13 +57,14 @@ export class Poller<E extends EventType, T = never, M = never> {
   }
 
   async #poll () {
+    debug(`polling for ${this.event}`)
     if (!this.#isPolling) {
       debug('terminating poll after being stopped')
 
       return
     }
 
-    debug(`polling for ${this.event} with interval of ${this.pollingInterval} seconds`)
+    debug(`calling poll callback for ${this.event}`)
 
     await this.callback(this.subscriptions)
 
@@ -73,6 +74,7 @@ export class Poller<E extends EventType, T = never, M = never> {
       return
     }
 
+    debug(`setting timeout with interval of ${this.pollingInterval} second`)
     this.#timeout = setTimeout(async () => {
       this.#timeout = undefined
       await this.#poll()

--- a/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
+++ b/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
@@ -129,6 +129,8 @@ export class RelevantRunSpecsDataSource {
             this.ctx.emitter.relevantRunSpecChange(run)
           }
         })
+
+        debug('processed runs')
       })
     }
 
@@ -148,7 +150,7 @@ export class RelevantRunSpecsDataSource {
       const runFields = Object.keys(run)
       const hasAllFields = fields.every((field) => runFields.includes(field))
 
-      debug('Calling filter %o', { runId, runIdsMatch, hasAllFields })
+      debug('Calling filter %o', { runId, runIdsMatch, hasAllFields }, runFields, fields)
 
       return runIdsMatch && hasAllFields
     }

--- a/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
+++ b/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts
@@ -88,7 +88,8 @@ export class RelevantRunSpecsDataSource {
     //TODO Get spec counts before poll starts
     if (!this.#poller) {
       this.#poller = new Poller(this.ctx, 'relevantRunSpecChange', this.#pollingInterval, async (subscriptions) => {
-        debug('subscriptions', subscriptions)
+        debug('subscriptions', subscriptions.length)
+
         const runIds = uniq(compact(subscriptions?.map((sub) => sub.meta?.runId)))
 
         debug('Polling for specs for runs: %o', runIds)
@@ -131,10 +132,25 @@ export class RelevantRunSpecsDataSource {
       })
     }
 
-    const filter = (run: PartialCloudRunWithId) => {
-      debug('calling filter', run.id, runId)
+    const fields = getFields(info)
 
-      return run.id === runId
+    /**
+     * Checks runs as they are emitted for the subscription to make sure they match what is
+     * expected by the subscription they are attached to. First, verifies it is for the run
+     * being watched by comparing IDs. Then also verifies that the fields match.  The field validation
+     * was needed to prevent a race condition when attaching different subscriptions for the same
+     * run that expect different fields.
+     *
+     * @param run check to see if it should be filtered out
+     */
+    const filter = (run: PartialCloudRunWithId) => {
+      const runIdsMatch = run.id === runId
+      const runFields = Object.keys(run)
+      const hasAllFields = fields.every((field) => runFields.includes(field))
+
+      debug('Calling filter %o', { runId, runIdsMatch, hasAllFields })
+
+      return runIdsMatch && hasAllFields
     }
 
     return this.#poller.start({ meta: { runId, info }, filter })
@@ -278,4 +294,16 @@ const createCombinedFragment = (name: string, fragmentNames: string[], type: Gra
       }),
     },
   }
+}
+
+/**
+ * Get the field names for a given GraphQLResolveInfo
+ * @param info to extract field names from
+ */
+const getFields = (info: GraphQLResolveInfo) => {
+  const selections = info.fieldNodes[0]!.selectionSet?.selections!
+
+  const fields = selections.map((selection) => selection.kind === 'Field' && selection.name.value).filter((field): field is string => typeof field === 'string')
+
+  return fields
 }

--- a/packages/data-context/test/unit/sources/RelevantRunSpecsDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/RelevantRunSpecsDataSource.spec.ts
@@ -2,7 +2,7 @@ import chai from 'chai'
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import debugLib from 'debug'
-import { GraphQLString } from 'graphql'
+import { GraphQLInt, GraphQLString } from 'graphql'
 
 import { DataContext } from '../../../src'
 import { createTestDataContext } from '../helper'
@@ -47,7 +47,7 @@ describe('RelevantRunSpecsDataSource', () => {
   })
 
   describe('polling', () => {
-    let clock
+    let clock: sinon.SinonFakeTimers
 
     beforeEach(() => {
       clock = sinon.useFakeTimers()
@@ -56,34 +56,6 @@ describe('RelevantRunSpecsDataSource', () => {
     afterEach(() => {
       clock.restore()
     })
-
-    const configureGraphQL = (cb: (info: Parameters<typeof dataSource.pollForSpecs>[1]) => any) => {
-      const query = `
-        query Test {
-          test {
-            value
-            value2
-          }
-        }
-      `
-
-      const fields = {
-        value: {
-          type: GraphQLString,
-        },
-        value2: {
-          type: GraphQLString,
-        },
-      }
-
-      return createGraphQL(
-        query,
-        fields,
-        (source, args, context, info) => {
-          return cb(info)
-        },
-      )
-    }
 
     it('polls and emits changes', async () => {
       const testData = FAKE_PROJECT_ONE_RUNNING_RUN_ONE_SPEC
@@ -95,7 +67,41 @@ describe('RelevantRunSpecsDataSource', () => {
 
       sinon.stub(ctx.cloud, 'executeRemoteGraphQL').resolves(FAKE_PROJECT)
 
-      return configureGraphQL(async (info) => {
+      const query = `
+        query Test {
+          test {
+            id
+            runNumber
+            completedInstanceCount
+            totalInstanceCount
+            totalTests
+            status
+          }
+        }
+      `
+
+      const fields = {
+        id: {
+          type: GraphQLString,
+        },
+        runNumber: {
+          type: GraphQLString,
+        },
+        completedInstanceCount: {
+          type: GraphQLInt,
+        },
+        totalInstanceCount: {
+          type: GraphQLInt,
+        },
+        totalTests: {
+          type: GraphQLInt,
+        },
+        status: {
+          type: GraphQLString,
+        },
+      }
+
+      return createGraphQL(query, fields, async (source, args, context, info) => {
         const subscriptionIterator = dataSource.pollForSpecs(runId, info)
 
         const firstEmit = await subscriptionIterator.next()
@@ -145,8 +151,12 @@ describe('RelevantRunSpecsDataSource', () => {
         const expected = {
           data: {
             test: {
-              value: null,
-              value2: null,
+              completedInstanceCount: null,
+              id: null,
+              runNumber: null,
+              status: null,
+              totalInstanceCount: null,
+              totalTests: null,
             },
           },
         }
@@ -155,14 +165,46 @@ describe('RelevantRunSpecsDataSource', () => {
       })
     })
 
-    it('should create query', () => {
-      const gqlStub = sinon.stub(ctx.cloud, 'executeRemoteGraphQL')
+    it('should create query', async () => {
+      const gqlStub = sinon.stub(ctx.cloud, 'executeRemoteGraphQL').resolves({ data: {} })
 
-      return configureGraphQL(async (info) => {
-        const subscriptionIterator = dataSource.pollForSpecs('runId', info)
+      const fields = {
+        value: {
+          type: GraphQLString,
+        },
+        value2: {
+          type: GraphQLString,
+        },
+        value3: {
+          type: GraphQLString,
+        },
+      }
 
-        subscriptionIterator.return(undefined)
-      }).then((result) => {
+      const query = `
+        query Test {
+          test {
+            value
+            value2
+          }
+        }
+      `
+
+      const query2 = `
+        query Test {
+          test {
+            value2
+            value3
+          }
+        }
+      `
+
+      let iterator1: ReturnType<RelevantRunSpecsDataSource['pollForSpecs']>
+      let iterator2: ReturnType<RelevantRunSpecsDataSource['pollForSpecs']>
+
+      return createGraphQL(query, fields, async (source, args, context, info) => {
+        iterator1 = dataSource.pollForSpecs('runId', info)
+      })
+      .then(() => {
         const expected =
           dedent`query RelevantRunSpecsDataSource_Specs($ids: [ID!]!) {
                 cloudNodesByIds(ids: $ids) {
@@ -187,7 +229,51 @@ describe('RelevantRunSpecsDataSource', () => {
 
         expect(gqlStub).to.have.been.called
         expect(gqlStub.firstCall.args[0]).to.haveOwnProperty('operation')
-        expect(gqlStub.firstCall.args[0].operation).to.eql(`${expected }\n`)
+        expect(gqlStub.firstCall.args[0].operation, 'should match initial query with one fragment').to.eql(`${expected }\n`)
+      })
+      .then(() => {
+        return createGraphQL(query2, fields, async (source, args, context, info) => {
+          iterator2 = dataSource.pollForSpecs('runId', info)
+
+          await clock.nextAsync()
+        })
+      })
+      .then(() => {
+        const expected =
+          dedent`query RelevantRunSpecsDataSource_Specs($ids: [ID!]!) {
+                cloudNodesByIds(ids: $ids) {
+                  id
+                  ... on CloudRun {
+                    ...Subscriptions
+                  }
+                }
+                pollingIntervals {
+                  runByNumber
+                }
+              }
+
+              fragment Subscriptions on Test {
+                ...Fragment0
+                ...Fragment1
+              }
+              
+              fragment Fragment0 on Test {
+                value
+                value2
+              }
+              
+              fragment Fragment1 on Test {
+                value2
+                value3
+              }`
+
+        expect(gqlStub).to.have.been.calledTwice
+        expect(gqlStub.secondCall.args[0]).to.haveOwnProperty('operation')
+        expect(gqlStub.secondCall.args[0].operation, 'should match second query with two fragments').to.eql(`${expected }\n`)
+      })
+      .then(() => {
+        iterator1.return(undefined)
+        iterator2.return(undefined)
       })
     })
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

_Summary_
A race condition between two different subscriptions used on the Debug page was causing a GraphQL error to be shown to the user when viewing a running Cypress Cloud build.  The error would have no effect on the results being shown on the page and resolve itself after the next polling cycle for the running build.  

_Issue_
The error occurred because the `RevelentRunSpecsDataSource` allows the front end to pass different GraphQL fields to be returned for the `relevantRunSpecChange` subscription on the `CloudRun` type.  These fields get combined into one query that is sent to Cypress Cloud.  

The race condition was occurring when the following steps occurred: 
* The subscription in `DebugTestingProgress` would run first and kick off the underlying poller in the data source and cause the [first cloud query](https://github.com/cypress-io/cypress/blob/f5815b776f71ff9d5de9465fa00384030ce78425/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts#L102-L103) to start.  
* When awaiting the return of this query, the subscription in `useDebugRunSummary` would be mounted and register itself to watch for emitted results.  The second subscription asked for the `createdAt` field which is a non-nullable field as defined in the GraphQL type.  The first subscription did not ask for this field.  
* When the initial query returned, the value would be emitted and checked by the [filter](https://github.com/cypress-io/cypress/blob/f5815b776f71ff9d5de9465fa00384030ce78425/packages/data-context/src/sources/RelevantRunSpecsDataSource.ts#L134-L135) function which would only check to see if the run ids matched. 
* Urql would try to resolve those initial values for the second subscription, it would show the error in the `before` video below due to the missing `createdAt`.  
* Finally, the second polling cycle would run and now have both `GraphQLResolveInfo` objects, it would generate a GraphQL query that correctly satisfy both subscriptions.

_Solution_
The fix was to add an additional check to the `filter` function to also validate that the object being emitted had the fields asked for that particular subscription.  The trade off for this solution is that the second subscription will not have accurate results for one additional polling cycle (currently 15 seconds).  

_Before_

https://github.com/cypress-io/cypress/assets/1702361/453f3bcf-5e77-4fb4-b547-62da518c4e2a

_After_

https://github.com/cypress-io/cypress/assets/1702361/fab07877-1fae-4cd7-b4f2-7d2bcc2a7db7



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

* Visit debug page for a RUNNING build. 
* No GraphQL error should be shown and page should update as expected

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No error toast is shown when viewing a running build on the Debug page.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [-] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
