### PR TITLE
feat: Add RequestResponseBody #22378

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 07/05/2023 (PENDING)_
 
 - Fixed an issue where some internal file locations consumed by the Cypress Angular Handler moved as a result of [this commit](https://github.com/angular/angular-cli/commit/466d86dc8d3398695055f9eced7402804848a381) from Angular. Addressed in [#27030](https://github.com/cypress-io/cypress/pull/27030).
 - Fixed an issue where certain commands would fail with the error `must only be invoked from the spec file or support file` when invoked with a large argument. Fixes [#27099](https://github.com/cypress-io/cypress/issues/27099).
+- Improves typing and structure. Fixes [#22378](https://github.com/cypress-io/cypress/issues/22378).
 
 ## 12.15.0
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -6413,9 +6413,13 @@ declare namespace Cypress {
     consoleProps(): ObjectLike
   }
 
-  interface Response<T> {
+  interface RequestResponseBody {
+    json: JSON
+  }
+
+  interface Response {
     allRequestResponses: any[]
-    body: T
+    body: RequestResponseBody 
     duration: number
     headers: { [key: string]: string | string[] }
     isOkStatusCode: boolean

--- a/cli/types/tests/kitchen-sink.ts
+++ b/cli/types/tests/kitchen-sink.ts
@@ -164,7 +164,22 @@ namespace BufferTests {
   buffer.length
 }
 
-cy.window().then(window => {
+interface RequestResponseBody {
+  json: JSON
+}
+
+// ensure json property of responseBody is of type object
+describe('RequestResponseBody', () => {
+  it('should have the correct structure', () => {
+    const responseBody: RequestResponseBody = {
+      json: {} as JSON, // Placeholder JSON object
+    };
+
+    expect(responseBody.json).to.be.an('object');
+  });
+});
+
+cy.window().then(window => { 
   window // $ExpectType AUTWindow
 
   window.eval('1')


### PR DESCRIPTION
* Closes [Generic for request/response inside .then coming from .wait #22378](https://github.com/cypress-io/cypress/issues/22378)

### Additional details
* Added RequestResponseBody interface.
* This change improves the typing and structure of the project.
* Added a test case for the added RequestResponseBody interface.

### Steps to test 
* Created a responseBody object of type RequestResponseBody with a placeholder JSON object.
* The test case to checks the basic structure of the RequestResponseBody interface.

### PR tasks
* Add interface to improve typing structure. 

### Questions for reviewers 
* Should more fields be added to the interface?