### PR TITLE
fix: do not override electron debug port if previously set

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,10 +12,11 @@ _Released 07/05/2023 (PENDING)_
 - Fixed issues where commands would fail with the error `must only be invoked from the spec file or support file`. Fixes [#27149](https://github.com/cypress-io/cypress/issues/27149) and [#27163](https://github.com/cypress-io/cypress/issues/27163).
 - Fixed an issue where chrome was not recovering from browser crashes properly. Fixes [#24650](https://github.com/cypress-io/cypress/issues/24650).
 - Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Fixed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
+- Fixed an issue to prevent the debug port for Electron that was passed in with the ELECTRON_EXTRA_LAUNCH_ARGS environment variable from getting overridden. Addresses [#26711](https://github.com/cypress-io/cypress/issues/26711).
 
 **Dependency Updates:**
 
- - Update dependency semver to ^7.5.3. Addressed in [#27151](https://github.com/cypress-io/cypress/pull/27151).
+- Update dependency semver to ^7.5.3. Addressed in [#27151](https://github.com/cypress-io/cypress/pull/27151).
 
 ## 12.16.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,7 +12,7 @@ _Released 07/05/2023 (PENDING)_
 - Fixed issues where commands would fail with the error `must only be invoked from the spec file or support file`. Fixes [#27149](https://github.com/cypress-io/cypress/issues/27149) and [#27163](https://github.com/cypress-io/cypress/issues/27163).
 - Fixed an issue where chrome was not recovering from browser crashes properly. Fixes [#24650](https://github.com/cypress-io/cypress/issues/24650).
 - Fixed a race condition that was causing a GraphQL error to appear on the [Debug page](https://docs.cypress.io/guides/cloud/runs#Debug) when viewing a running Cypress Cloud build. Fixed in [#27134](https://github.com/cypress-io/cypress/pull/27134).
-- Fixed an issue to prevent the debug port for Electron that was passed in with the ELECTRON_EXTRA_LAUNCH_ARGS environment variable from getting overridden. Addresses [#26711](https://github.com/cypress-io/cypress/issues/26711).
+- Fixed an issue where a value for the Electron debug port would not be respected if defined using the `ELECTRON_EXTRA_LAUNCH_ARGS` environment variable. Fixes [#26711](https://github.com/cypress-io/cypress/issues/26711).
 
 **Dependency Updates:**
 

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -36,8 +36,6 @@ const setRemoteDebuggingPort = async () => {
 
     // set up remote debugging port
     app.commandLine.appendSwitch('remote-debugging-port', String(port))
-
-    return app.commandLine.appendSwitch
   } catch (err) {
     // Catch errors for when we're running outside of electron in development
     return

--- a/packages/server/lib/util/electron-app.js
+++ b/packages/server/lib/util/electron-app.js
@@ -24,11 +24,20 @@ const getRemoteDebuggingPort = () => {
 
 const setRemoteDebuggingPort = async () => {
   try {
-    const port = await getPort()
     const { app } = require('electron')
+
+    // if port was already set via passing from environment variable ELECTRON_EXTRA_LAUNCH_ARGS,
+    // then just keep the supplied value
+    if (app.commandLine.getSwitchValue('remote-debugging-port')) {
+      return
+    }
+
+    const port = await getPort()
 
     // set up remote debugging port
     app.commandLine.appendSwitch('remote-debugging-port', String(port))
+
+    return app.commandLine.appendSwitch
   } catch (err) {
     // Catch errors for when we're running outside of electron in development
     return

--- a/packages/server/test/support/helpers/electron_stub.js
+++ b/packages/server/test/support/helpers/electron_stub.js
@@ -17,6 +17,7 @@ module.exports = {
     exit () {},
     commandLine: {
       appendSwitch () {},
+      getSwitchValue () {},
       appendArgument () {},
     },
     disableHardwareAcceleration () {},

--- a/packages/server/test/unit/util/electron-app_spec.js
+++ b/packages/server/test/unit/util/electron-app_spec.js
@@ -1,0 +1,36 @@
+const electronApp = require('../../../lib/util/electron-app')
+
+describe('/lib/util/electron-app', () => {
+  context('remote debugging port', () => {
+    beforeEach(() => {
+      sinon.restore()
+    })
+
+    it('should not override port if previously set', async () => {
+      const { app } = require('electron')
+
+      sinon.stub(app.commandLine, 'appendSwitch')
+      sinon.stub(app.commandLine, 'getSwitchValue').callsFake((args) => {
+        return '4567'
+      })
+
+      await electronApp.setRemoteDebuggingPort()
+
+      expect(app.commandLine.appendSwitch).to.not.have.been.called
+    })
+
+    it('should assign random port if not previously set', async () => {
+      const { app } = require('electron')
+
+      sinon.stub(app.commandLine, 'appendSwitch')
+
+      sinon.stub(app.commandLine, 'getSwitchValue').callsFake((args) => {
+        return undefined
+      })
+
+      await electronApp.setRemoteDebuggingPort()
+
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('remote-debugging-port', sinon.match.string)
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/26711

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

PR https://github.com/cypress-io/cypress/pull/26573 added logic to assign a random available port for Electron to use as the debugging port to connect to CDP.  This PR adds a check to make sure if a port has been passed in via setting an environment variable (i.e. `ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=9222`) as documented here (https://docs.cypress.io/api/plugins/browser-launch-api#Modify-Electron-app-switches) that it will not get overridden with a random port.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

* Look at unit test added
* Run test with example repo in reported issue
  * Clone [NeuraLegion/cypress-har-generator](https://github.com/NeuraLegion/cypress-har-generator)
  * cd to `example` directory
  * install Cypress `12.12.0` - `npm i -D Cypress@12.12.0`
  * install rest of dependencies - `npm i`
  * run tests - `ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=9222 npm run test`
  * view failure

```
     CypressError: `cy.task('recordHar')` failed with the following error:

> Failed to connect to Chrome Debugging Protocol

Possible reasons for failure:
  - Chrome not running in headless mode
  - Using Chrome version 58 or earlier
  - Inconsistent RDP configuration settings.
```

* View fix in this branch
  * in the example repo in the `example` directory, run `npm run start` to start the example server
  * switch to this branch in the Cypress project
  * cd `packages/app`
  * run `ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=9222 yarn cypress:run-cypress-in-cypress node ../../scripts/cypress run --project {path_to}/cypress-har-generator/example` and switch out path to the reproduction repo where it says `path_to` in this command
  * Tests should run successfully

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [-] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [-] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
