### PR TITLE
chore: remove the electron extension API and opt for CDP methods to leverage Fetch.Enable/Paused

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -12,6 +12,7 @@ import type { ResourceType, BrowserPreRequest, BrowserResponseReceived } from '@
 import type { WriteVideoFrame } from '@packages/types'
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
+import type { CriClient } from './cri-client'
 
 export type CdpCommand = keyof ProtocolMapping.Commands
 
@@ -141,6 +142,9 @@ export const normalizeResourceType = (resourceType: string | undefined): Resourc
 type SendDebuggerCommand = <T extends CdpCommand>(message: T, data?: any) => Promise<ProtocolMapping.Commands[T]['returnType']>
 type SendCloseCommand = (shouldKeepTabOpen: boolean) => Promise<any> | void
 type OnFn = <T extends CdpEvent>(eventName: T, cb: (data: ProtocolMapping.Events[T][0]) => void) => void
+interface HasFrame {
+  frame: Protocol.Page.Frame
+}
 
 // the intersection of what's valid in CDP and what's valid in FFCDP
 // Firefox: https://searchfox.org/mozilla-central/rev/98a9257ca2847fad9a19631ac76199474516b31e/remote/cdp/domains/parent/Network.jsm#22
@@ -153,6 +157,9 @@ const ffToStandardResourceTypeMap: { [ff: string]: ResourceType } = {
 }
 
 export class CdpAutomation {
+  private frameTree: any
+  private gettingFrameTree: any
+
   private constructor (private sendDebuggerCommandFn: SendDebuggerCommand, private onFn: OnFn, private sendCloseCommandFn: SendCloseCommand, private automation: Automation) {
     onFn('Network.requestWillBeSent', this.onNetworkRequestWillBeSent)
     onFn('Network.responseReceived', this.onResponseReceived)
@@ -266,6 +273,130 @@ export class CdpAutomation {
     .then((cookies) => {
       return _.get(cookies, 0, null)
     })
+  }
+
+  // eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
+  private _updateFrameTree = (client: CriClient, eventName) => async () => {
+    debugVerbose(`update frame tree for ${eventName}`)
+
+    this.gettingFrameTree = new Promise<void>(async (resolve) => {
+      try {
+        this.frameTree = (await client.send('Page.getFrameTree')).frameTree
+        debugVerbose('frame tree updated')
+      } catch (err) {
+        debugVerbose('failed to update frame tree:', err.stack)
+      } finally {
+        this.gettingFrameTree = null
+
+        resolve()
+      }
+    })
+  }
+
+  private _continueRequest = (client, params, headers?) => {
+    const details: Protocol.Fetch.ContinueRequestRequest = {
+      requestId: params.requestId,
+    }
+
+    if (headers && headers.length) {
+    // headers are received as an object but need to be an array
+    // to modify them
+      const currentHeaders = _.map(params.request.headers, (value, name) => ({ name, value }))
+
+      details.headers = [
+        ...currentHeaders,
+        ...headers,
+      ]
+    }
+
+    debugVerbose('continueRequest: %o', details)
+
+    client.send('Fetch.continueRequest', details).catch((err) => {
+    // swallow this error so it doesn't crash Cypress.
+    // an "Invalid InterceptionId" error can randomly happen in the driver tests
+    // when testing the redirection loop limit, when a redirect request happens
+    // to be sent after the test has moved on. this shouldn't crash Cypress, in
+    // any case, and likely wouldn't happen for standard user tests, since they
+    // will properly fail and not move on like the driver tests
+      debugVerbose('continueRequest failed, url: %s, error: %s', params.request.url, err?.stack || err)
+    })
+  }
+
+  private _isAUTFrame = async (frameId: string) => {
+    debugVerbose('need frame tree')
+
+    // the request could come in while in the middle of getting the frame tree,
+    // which is asynchronous, so wait for it to be fetched
+    if (this.gettingFrameTree) {
+      debugVerbose('awaiting frame tree')
+
+      await this.gettingFrameTree
+    }
+
+    const frame = _.find(this.frameTree?.childFrames || [], ({ frame }) => {
+      return frame?.name?.startsWith('Your project:')
+    }) as HasFrame | undefined
+
+    if (frame) {
+      return frame.frame.id === frameId
+    }
+
+    return false
+  }
+
+  _handlePausedRequests = async (client) => {
+    // NOTE: only supported in chromium based browsers
+    await client.send('Fetch.enable')
+
+    // adds a header to the request to mark it as a request for the AUT frame
+    // itself, so the proxy can utilize that for injection purposes
+    client.on('Fetch.requestPaused', async (params: Protocol.Fetch.RequestPausedEvent) => {
+      const addedHeaders: {
+        name: string
+        value: string
+      }[] = []
+
+      /**
+     * Unlike the the web extension or Electrons's onBeforeSendHeaders, CDP can discern the difference
+     * between fetch or xhr resource types. Because of this, we set X-Cypress-Is-XHR-Or-Fetch to either
+     * 'xhr' or 'fetch' with CDP so the middleware can assume correct defaults in case credential/resourceTypes
+     * are not sent to the server.
+     * @see https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
+     */
+      if (params.resourceType === 'XHR' || params.resourceType === 'Fetch') {
+        debugVerbose('add X-Cypress-Is-XHR-Or-Fetch header to: %s', params.request.url)
+        addedHeaders.push({
+          name: 'X-Cypress-Is-XHR-Or-Fetch',
+          value: params.resourceType.toLowerCase(),
+        })
+      }
+
+      if (
+      // is a script, stylesheet, image, etc
+        params.resourceType !== 'Document'
+      || !(await this._isAUTFrame(params.frameId))
+      ) {
+        return this._continueRequest(client, params, addedHeaders)
+      }
+
+      debugVerbose('add X-Cypress-Is-AUT-Frame header to: %s', params.request.url)
+      addedHeaders.push({
+        name: 'X-Cypress-Is-AUT-Frame',
+        value: 'true',
+      })
+
+      return this._continueRequest(client, params, addedHeaders)
+    })
+  }
+
+  // we can't get the frame tree during the Fetch.requestPaused event, because
+  // the CDP is tied up during that event and can't be utilized. so we maintain
+  // a reference to it that's updated when it's likely to have been changed
+  _listenForFrameTreeChanges = (client) => {
+    debugVerbose('listen for frame tree changes')
+
+    client.on('Page.frameAttached', this._updateFrameTree(client, 'Page.frameAttached'))
+    client.on('Page.frameDetached', this._updateFrameTree(client, 'Page.frameDetached'))
   }
 
   onRequest = (message, data) => {

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -8,7 +8,6 @@ import path from 'path'
 import extension from '@packages/extension'
 import mime from 'mime'
 import { launch } from '@packages/launcher'
-import type { Protocol } from 'devtools-protocol'
 
 import appData from '../util/app_data'
 import { fs } from '../util/fs'
@@ -310,142 +309,7 @@ const _handleDownloads = async function (client, downloadsFolder: string, automa
   })
 }
 
-let frameTree
-let gettingFrameTree
-
-const onReconnect = (client: CriClient) => {
-  // if the client disconnects (e.g. due to a computer sleeping), update
-  // the frame tree on reconnect in cases there were changes while
-  // the client was disconnected
-  return _updateFrameTree(client, 'onReconnect')()
-}
-
-// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
-const _updateFrameTree = (client: CriClient, eventName) => async () => {
-  debug(`update frame tree for ${eventName}`)
-
-  gettingFrameTree = new Promise<void>(async (resolve) => {
-    try {
-      frameTree = (await client.send('Page.getFrameTree')).frameTree
-      debug('frame tree updated')
-    } catch (err) {
-      debug('failed to update frame tree:', err.stack)
-    } finally {
-      gettingFrameTree = null
-
-      resolve()
-    }
-  })
-}
-
-// we can't get the frame tree during the Fetch.requestPaused event, because
-// the CDP is tied up during that event and can't be utilized. so we maintain
-// a reference to it that's updated when it's likely to have been changed
-const _listenForFrameTreeChanges = (client) => {
-  debug('listen for frame tree changes')
-
-  client.on('Page.frameAttached', _updateFrameTree(client, 'Page.frameAttached'))
-  client.on('Page.frameDetached', _updateFrameTree(client, 'Page.frameDetached'))
-}
-
-const _continueRequest = (client, params, headers?) => {
-  const details: Protocol.Fetch.ContinueRequestRequest = {
-    requestId: params.requestId,
-  }
-
-  if (headers && headers.length) {
-    // headers are received as an object but need to be an array
-    // to modify them
-    const currentHeaders = _.map(params.request.headers, (value, name) => ({ name, value }))
-
-    details.headers = [
-      ...currentHeaders,
-      ...headers,
-    ]
-  }
-
-  debug('continueRequest: %o', details)
-
-  client.send('Fetch.continueRequest', details).catch((err) => {
-    // swallow this error so it doesn't crash Cypress.
-    // an "Invalid InterceptionId" error can randomly happen in the driver tests
-    // when testing the redirection loop limit, when a redirect request happens
-    // to be sent after the test has moved on. this shouldn't crash Cypress, in
-    // any case, and likely wouldn't happen for standard user tests, since they
-    // will properly fail and not move on like the driver tests
-    debug('continueRequest failed, url: %s, error: %s', params.request.url, err?.stack || err)
-  })
-}
-
-interface HasFrame {
-  frame: Protocol.Page.Frame
-}
-
-const _isAUTFrame = async (frameId: string) => {
-  debug('need frame tree')
-
-  // the request could come in while in the middle of getting the frame tree,
-  // which is asynchronous, so wait for it to be fetched
-  if (gettingFrameTree) {
-    debug('awaiting frame tree')
-
-    await gettingFrameTree
-  }
-
-  const frame = _.find(frameTree?.childFrames || [], ({ frame }) => {
-    return frame?.name?.startsWith('Your project:')
-  }) as HasFrame | undefined
-
-  if (frame) {
-    return frame.frame.id === frameId
-  }
-
-  return false
-}
-
-const _handlePausedRequests = async (client) => {
-  await client.send('Fetch.enable')
-
-  // adds a header to the request to mark it as a request for the AUT frame
-  // itself, so the proxy can utilize that for injection purposes
-  client.on('Fetch.requestPaused', async (params: Protocol.Fetch.RequestPausedEvent) => {
-    const addedHeaders: {
-      name: string
-      value: string
-    }[] = []
-
-    /**
-     * Unlike the the web extension or Electrons's onBeforeSendHeaders, CDP can discern the difference
-     * between fetch or xhr resource types. Because of this, we set X-Cypress-Is-XHR-Or-Fetch to either
-     * 'xhr' or 'fetch' with CDP so the middleware can assume correct defaults in case credential/resourceTypes
-     * are not sent to the server.
-     * @see https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
-     */
-    if (params.resourceType === 'XHR' || params.resourceType === 'Fetch') {
-      debug('add X-Cypress-Is-XHR-Or-Fetch header to: %s', params.request.url)
-      addedHeaders.push({
-        name: 'X-Cypress-Is-XHR-Or-Fetch',
-        value: params.resourceType.toLowerCase(),
-      })
-    }
-
-    if (
-      // is a script, stylesheet, image, etc
-      params.resourceType !== 'Document'
-      || !(await _isAUTFrame(params.frameId))
-    ) {
-      return _continueRequest(client, params, addedHeaders)
-    }
-
-    debug('add X-Cypress-Is-AUT-Frame header to: %s', params.request.url)
-    addedHeaders.push({
-      name: 'X-Cypress-Is-AUT-Frame',
-      value: 'true',
-    })
-
-    return _continueRequest(client, params, addedHeaders)
-  })
-}
+let onReconnect: (client: CriClient) => Promise<void> = async () => undefined
 
 const _setAutomation = async (client: CriClient, automation: Automation, resetBrowserTargets: (shouldKeepTabOpen: boolean) => Promise<void>, options: BrowserLaunchOpts) => {
   const cdpAutomation = await CdpAutomation.create(client.send, client.on, resetBrowserTargets, automation)
@@ -471,8 +335,6 @@ export = {
   _navigateUsingCRI,
 
   _handleDownloads,
-
-  _handlePausedRequests,
 
   _setAutomation,
 
@@ -636,6 +498,14 @@ export = {
 
     const cdpAutomation = await this._setAutomation(pageCriClient, automation, browserCriClient.resetBrowserTargets, options)
 
+    onReconnect = (client: CriClient) => {
+      // if the client disconnects (e.g. due to a computer sleeping), update
+      // the frame tree on reconnect in cases there were changes while
+      // the client was disconnected
+      // @ts-expect-error
+      return cdpAutomation._updateFrameTree(client, 'onReconnect')()
+    }
+
     await pageCriClient.send('Page.enable')
 
     await options['onInitializeNewBrowserTab']?.()
@@ -647,8 +517,8 @@ export = {
 
     await this._navigateUsingCRI(pageCriClient, url)
 
-    await this._handlePausedRequests(pageCriClient)
-    _listenForFrameTreeChanges(pageCriClient)
+    await cdpAutomation._handlePausedRequests(pageCriClient)
+    cdpAutomation._listenForFrameTreeChanges(pageCriClient)
 
     return cdpAutomation
   },

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -15,8 +15,6 @@ import type { BrowserLaunchOpts, Preferences, RunModeVideoApi } from '@packages/
 import memory from './memory'
 import { BrowserCriClient } from './browser-cri-client'
 import { getRemoteDebuggingPort } from '../util/electron-app'
-import type Protocol from 'devtools-protocol'
-import type { CriClient } from './cri-client'
 
 // TODO: unmix these two types
 type ElectronOpts = Windows.WindowOptions & BrowserLaunchOpts
@@ -113,136 +111,6 @@ async function recordVideo (cdpAutomation: CdpAutomation, videoApi: RunModeVideo
   const { writeVideoFrame } = await videoApi.useFfmpegVideoController()
 
   await cdpAutomation.startVideoRecording(writeVideoFrame, screencastOpts())
-}
-
-let frameTree
-let gettingFrameTree
-
-// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
-const _updateFrameTree = (client: CriClient, eventName) => async () => {
-  debug(`update frame tree for ${eventName}`)
-
-  gettingFrameTree = new Promise<void>(async (resolve) => {
-    try {
-      frameTree = (await client.send('Page.getFrameTree')).frameTree
-      debug('frame tree updated')
-    } catch (err) {
-      debug('failed to update frame tree:', err.stack)
-    } finally {
-      gettingFrameTree = null
-
-      resolve()
-    }
-  })
-}
-
-// we can't get the frame tree during the Fetch.requestPaused event, because
-// the CDP is tied up during that event and can't be utilized. so we maintain
-// a reference to it that's updated when it's likely to have been changed
-const _listenForFrameTreeChanges = (client) => {
-  debug('listen for frame tree changes')
-
-  client.on('Page.frameAttached', _updateFrameTree(client, 'Page.frameAttached'))
-  client.on('Page.frameDetached', _updateFrameTree(client, 'Page.frameDetached'))
-}
-
-const _continueRequest = (client, params, headers?) => {
-  const details: Protocol.Fetch.ContinueRequestRequest = {
-    requestId: params.requestId,
-  }
-
-  if (headers && headers.length) {
-    // headers are received as an object but need to be an array
-    // to modify them
-    const currentHeaders = _.map(params.request.headers, (value, name) => ({ name, value }))
-
-    details.headers = [
-      ...currentHeaders,
-      ...headers,
-    ]
-  }
-
-  debug('continueRequest: %o', details)
-
-  client.send('Fetch.continueRequest', details).catch((err) => {
-    // swallow this error so it doesn't crash Cypress.
-    // an "Invalid InterceptionId" error can randomly happen in the driver tests
-    // when testing the redirection loop limit, when a redirect request happens
-    // to be sent after the test has moved on. this shouldn't crash Cypress, in
-    // any case, and likely wouldn't happen for standard user tests, since they
-    // will properly fail and not move on like the driver tests
-    debug('continueRequest failed, url: %s, error: %s', params.request.url, err?.stack || err)
-  })
-}
-
-interface HasFrame {
-  frame: Protocol.Page.Frame
-}
-
-const _isAUTFrame = async (frameId: string) => {
-  debug('need frame tree')
-
-  // the request could come in while in the middle of getting the frame tree,
-  // which is asynchronous, so wait for it to be fetched
-  if (gettingFrameTree) {
-    debug('awaiting frame tree')
-
-    await gettingFrameTree
-  }
-
-  const frame = _.find(frameTree?.childFrames || [], ({ frame }) => {
-    return frame?.name?.startsWith('Your project:')
-  }) as HasFrame | undefined
-
-  if (frame) {
-    return frame.frame.id === frameId
-  }
-
-  return false
-}
-
-const _handlePausedRequests = async (client) => {
-  await client.send('Fetch.enable')
-
-  // adds a header to the request to mark it as a request for the AUT frame
-  // itself, so the proxy can utilize that for injection purposes
-  client.on('Fetch.requestPaused', async (params: Protocol.Fetch.RequestPausedEvent) => {
-    const addedHeaders: {
-      name: string
-      value: string
-    }[] = []
-
-    /**
-     * Unlike the the web extension or Electrons's onBeforeSendHeaders, CDP can discern the difference
-     * between fetch or xhr resource types. Because of this, we set X-Cypress-Is-XHR-Or-Fetch to either
-     * 'xhr' or 'fetch' with CDP so the middleware can assume correct defaults in case credential/resourceTypes
-     * are not sent to the server.
-     * @see https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
-     */
-    if (params.resourceType === 'XHR' || params.resourceType === 'Fetch') {
-      debug('add X-Cypress-Is-XHR-Or-Fetch header to: %s', params.request.url)
-      addedHeaders.push({
-        name: 'X-Cypress-Is-XHR-Or-Fetch',
-        value: params.resourceType.toLowerCase(),
-      })
-    }
-
-    if (
-      // is a script, stylesheet, image, etc
-      params.resourceType !== 'Document'
-      || !(await _isAUTFrame(params.frameId))
-    ) {
-      return _continueRequest(client, params, addedHeaders)
-    }
-
-    debug('add X-Cypress-Is-AUT-Frame header to: %s', params.request.url)
-    addedHeaders.push({
-      name: 'X-Cypress-Is-AUT-Frame',
-      value: 'true',
-    })
-
-    return _continueRequest(client, params, addedHeaders)
-  })
 }
 
 export = {
@@ -433,10 +301,8 @@ export = {
 
     await win.loadURL(url)
 
-    await this._handlePausedRequests(browserCriClient?.currentlyAttachedTarget)
-    _listenForFrameTreeChanges(browserCriClient?.currentlyAttachedTarget)
-
-    // this._listenToOnBeforeHeaders(win)
+    await cdpAutomation._handlePausedRequests(browserCriClient?.currentlyAttachedTarget)
+    cdpAutomation._listenForFrameTreeChanges(browserCriClient?.currentlyAttachedTarget)
 
     return win
   },
@@ -477,8 +343,6 @@ export = {
       downloadPath: dir,
     })
   },
-
-  _handlePausedRequests,
 
   _getPartition (options) {
     if (options.isTextTerminal) {

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -1059,6 +1059,7 @@ describe('lib/cypress', () => {
           const browserCriClient = {
             ensureMinimumProtocolVersion: sinon.stub().resolves(),
             attachToTargetUrl: sinon.stub().resolves(criClient),
+            currentlyAttachedTarget: criClient,
             close: sinon.stub().resolves(),
           }
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -1004,6 +1004,11 @@ describe('lib/cypress', () => {
             close: sinon.stub().resolves(),
           }
 
+          const cdpAutomation = {
+            _handlePausedRequests: sinon.stub().resolves(),
+            _listenForFrameTreeChanges: sinon.stub().returns(),
+          }
+
           sinon.stub(chromeBrowser, '_writeExtension').resolves()
 
           sinon.stub(BrowserCriClient, 'create').resolves(browserCriClient)
@@ -1014,7 +1019,7 @@ describe('lib/cypress', () => {
           sinon.stub(chromeBrowser, '_handleDownloads').resolves()
           sinon.stub(chromeBrowser, '_recordVideo').resolves()
 
-          sinon.stub(chromeBrowser, '_setAutomation').returns()
+          sinon.stub(chromeBrowser, '_setAutomation').returns(cdpAutomation)
 
           return cypress.start([
             `--run-project=${this.pluginBrowser}`,
@@ -1046,6 +1051,9 @@ describe('lib/cypress', () => {
 
             expect(BrowserCriClient.create).to.have.been.calledOnce
             expect(browserCriClient.attachToTargetUrl).to.have.been.calledOnce
+
+            expect(cdpAutomation._handlePausedRequests).to.have.been.calledOnce
+            expect(cdpAutomation._listenForFrameTreeChanges).to.have.been.calledOnce
           })
         })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
Allows electron to use the CDP methods for determining the Cypress metadata headers such as `X-Cypress-Is-AUT-Frame` and `X-Cypress-is-XHR-Or-Fetch`. 

These methods are consolidated to the CDP automation client, but are only called/instantiated inside electron/chromium based browsers. Because the methods are called in the actual browser files, I elected to keep the tests separate for determining `X-Cypress-Is-AUT-Frame` and `X-Cypress-is-XHR-Or-Fetch`, which now function more as an integration test. I can move these into single tests inside `cdp_automation` if we think that is the right move, though the way we would test is seems like it might be disjointed, which is why I held off moving it. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
