### PR TITLE
chore: Update renovate bot to only create PRs for electron upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,13 +31,6 @@
       "semanticCommitType": "dependency",
       "groupName": "electron",
       "dependencyDashboardApproval": false
-    },
-    {
-      "excludePackagePatterns": [
-        "^electron"
-      ],
-      "semanticCommitType": "dependency",
-      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,8 +16,8 @@
     "renovate"
   ],
   "commitMessageSuffix": "🌟",
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 5,
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 1,
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "schedule": [
@@ -35,14 +35,6 @@
     {
       "excludePackagePatterns": [
         "^electron"
-      ],
-      "semanticCommitType": "dependency",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDepTypes": [
-        "dependencies",
-        "require"
       ],
       "semanticCommitType": "dependency",
       "dependencyDashboardApproval": true


### PR DESCRIPTION
Updating Renovate Bot to only create PRs for electron upgrades.  Other dependency updates will need to triggered manually until such time as we can form a strategy around dependency upgrades more holistically.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ n/a ] Have tests been added/updated?
- [ n/a ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ n/a ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
