### PR TITLE
fix: correct invalid stored preference for in-app notifications

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 07/18/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed invalid stored preference for in-app notifications.  Addresses [#27228](https://github.com/cypress-io/cypress/issues/27228).
+- Fixed invalid stored preference when enabling in-app notifications that could cause the application to crash.  Fixes [#27228](https://github.com/cypress-io/cypress/issues/27228).
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
 
 ## 12.17.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 07/18/2023 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed invalid stored preference for in-app notifications.  Addresses [#27228](https://github.com/cypress-io/cypress/issues/27228).
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
 
 ## 12.17.0

--- a/packages/app/src/settings/device/NotificationSettings.vue
+++ b/packages/app/src/settings/device/NotificationSettings.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 import { gql, useMutation } from '@urql/vue'
 import { useI18n } from '@cy/i18n'
 import Switch from '@packages/frontend-shared/src/components/Switch.vue'
@@ -157,7 +157,14 @@ const switches = [
   },
 ]
 
-const listRef = ref(props.gql.localSettings.preferences.notifyWhenRunCompletes)
+const listRef = ref()
+
+// allow for gql value to load when navigating straight here from EnableNotificationsBanner
+watchEffect(() => {
+  if (!listRef.value) {
+    listRef.value = props.gql.localSettings.preferences.notifyWhenRunCompletes
+  }
+})
 
 const statuses = [
   { id: 'passed', label: t('settingsPage.notifications.passed') },

--- a/packages/data-context/src/sources/VersionsDataSource.ts
+++ b/packages/data-context/src/sources/VersionsDataSource.ts
@@ -129,6 +129,8 @@ export class VersionsDataSource {
       return pkg.version
     }
 
+    debug('#getLatestVersion')
+
     const preferences = await this.ctx.localSettingsApi.getPreferences()
     const notificationPreferences: ('started' | 'failing' | 'passed' | 'failed' | 'cancelled' | 'errored')[] = [
       ...preferences.notifyWhenRunCompletes ?? [],

--- a/packages/data-context/test/unit/actions/LocalSettingsActions.spec.ts
+++ b/packages/data-context/test/unit/actions/LocalSettingsActions.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { LocalSettingsActions } from '../../../src/actions/LocalSettingsActions'
+import { createTestDataContext } from '../helper'
+import type { DataContext } from '../../../src'
+import { NotifyCompletionStatuses } from '@packages/types'
+
+describe('LocalSettingsActions', () => {
+  let ctx: DataContext
+  let actions: LocalSettingsActions
+
+  beforeEach(() => {
+    sinon.restore()
+
+    ctx = createTestDataContext('open')
+
+    actions = new LocalSettingsActions(ctx)
+  })
+
+  context('refreshLocalSettings', () => {
+    context('notifyWhenRunCompletes', () => {
+      it('should fix false value', async () => {
+        ctx._apis.localSettingsApi.getPreferences = sinon.stub().resolves({
+        //@ts-ignore
+          notifyWhenRunCompletes: false,
+        })
+
+        await actions.refreshLocalSettings()
+
+        expect(ctx.coreData.localSettings.preferences.notifyWhenRunCompletes).to.eql([])
+      })
+
+      it('should fix true value', async () => {
+        ctx._apis.localSettingsApi.getPreferences = sinon.stub().resolves({
+        //@ts-ignore
+          notifyWhenRunCompletes: true,
+        })
+
+        await actions.refreshLocalSettings()
+
+        expect(ctx.coreData.localSettings.preferences.notifyWhenRunCompletes).to.eql([...NotifyCompletionStatuses])
+      })
+
+      it('should leave value alone if value is an array', async () => {
+        ctx._apis.localSettingsApi.getPreferences = sinon.stub().resolves({
+        //@ts-ignore
+          notifyWhenRunCompletes: ['errored'],
+        })
+
+        await actions.refreshLocalSettings()
+
+        expect(ctx.coreData.localSettings.preferences.notifyWhenRunCompletes).to.eql(['errored'])
+      })
+
+      it('should pass through default value if not set ', async () => {
+        ctx._apis.localSettingsApi.getPreferences = sinon.stub().resolves({})
+
+        await actions.refreshLocalSettings()
+
+        expect(ctx.coreData.localSettings.preferences.notifyWhenRunCompletes).to.eql(['failed'])
+      })
+    })
+  })
+})

--- a/packages/data-context/test/unit/helper.ts
+++ b/packages/data-context/test/unit/helper.ts
@@ -51,6 +51,8 @@ export function createTestDataContext (mode: DataContextConfig['mode'] = 'run', 
         majorVersionWelcomeDismissed: { [MAJOR_VERSION_FOR_CONTENT]: 123456 },
         notifyWhenRunCompletes: ['failed'],
       }),
+      getAvailableEditors: sinon.stub(),
+      setPreferences: sinon.stub(),
     } as unknown as LocalSettingsApiShape,
     authApi: {
       logIn: sinon.stub().throws('not stubbed'),

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -1,6 +1,8 @@
 import type { BannersState, Editor, MajorVersionWelcomeDismissed } from '.'
 
-export type NotifyWhenRunCompletes = 'passed' | 'failed' | 'cancelled' | 'errored'
+export const NotifyCompletionStatuses = ['passed', 'failed', 'cancelled', 'errored'] as const
+
+export type NotifyWhenRunCompletes = typeof NotifyCompletionStatuses[number]
 
 export const defaultPreferences: AllowedState = {
   autoScrollingEnabled: true,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/27228

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When navigating to the settings page after enabling in-app notifications with the top banner, the value for the `notifyWhenRunCompletes` setting was not given a chance to load before saving off the value in  a Vue `ref`.  The HTML expected the value to be an array and the backend was trying to default the value to `['failed']`, but it would end up `null` in this case.  If the user attempted to click one of the checkboxes to set the value, then the code would cause the value to get set as a boolean `true` instead of an array of strings.  Finally, if a notification attempted to be fired, or the app was closed and opened again, code that expected the value for `notifyWhenRunCompletes` to be an array would cause the app to crash. 

The fix was to reactively set the value for `notifyWhenRunCompletes` in the `NotifcationSettings` component once it had loaded when navigating from the top banner.  Also, a fix was added to `LocalSettingsActions.refreshLocalSettings()` to make sure to fix this preference value if it was set to a `boolean`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

_Reproduce the original issue_

* When on the `develop` branch, open the `state.json` file under `~/Library/Application Support/Cypress/cy/production/projects/__global__` and remove the following values:
  * `desktopNotificationsEnabled`
  * `notifyWhenRunCompletes`
  * `notifyWhenRunStartsFailing`
  * `notifyWhenRunStarts`
* Start Cypress in open mode and open the App from the Launchpad
* Click the "Enable desktop notifications" button
* The app will navigate to the "Desktop notifications" part of the Settings page
* Confirm that the "Notify me when a run completes" section has nothing checked
* Check one box and they will all show checked
* Open the `state.json` file from above and notice that the `notifyWhenRunCompletes` value will be `true`
* Close the Cypress app and reopen it
* When the app tries to show the page for selecting the testing type, it will crash

**Before fix**

https://github.com/cypress-io/cypress/assets/1702361/c0f42960-85c2-4556-900a-14004369f8dd

_Testing fix to repair bad value_

* Update to this branch
* Open the app again
* The app should not crash
* Open the `state.json` file from above and notice that the `notifyWhenRunCompletes` value will be an array of strings
* Navigate to the ""Desktop notifications" part of the Settings page and change the values for the "Notify me when a run completes" section
* Confirm those values are saved in the `state.json` file

_Testing new code without existing settings_

* Make sure app is closed
* While on this branch, open the `state.json` file under `~/Library/Application Support/Cypress/cy/production/projects/__global__` and remove the same values as listed above
* Open the app and a testing mode and click the "Enable desktop notifications" button
* The app will navigate to the "Desktop notifications" part of the Settings page
* Confirm that the "Notify me when a run completes" section has only `failed` checked as the default
* Change the options under this section
* Confirm those values are saved in the `state.json` file

**After fix**

https://github.com/cypress-io/cypress/assets/1702361/ab727220-69b5-441b-861f-844e51df105d

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
