### PR TITLE
fix: Fix Issue 27103. Retain original array after defaultsDeep

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 07/18/2023_
 
 - Fixed invalid stored preference when enabling in-app notifications that could cause the application to crash.  Fixes [#27228](https://github.com/cypress-io/cypress/issues/27228).
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
+ - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 07/18/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
+ - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
 
 ## 12.17.1
 
@@ -15,7 +16,6 @@ _Released 07/10/2023_
 
 - Fixed invalid stored preference when enabling in-app notifications that could cause the application to crash.  Fixes [#27228](https://github.com/cypress-io/cypress/issues/27228).
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
- - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 07/18/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
- - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
+ - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixes [#27103](https://github.com/cypress-io/cypress/issues/27103). Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
 
 ## 12.17.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 07/18/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
- - Fixes a bug where fields using arrays in `cypress.config` are not correctly processed. Fixes [#27103](https://github.com/cypress-io/cypress/issues/27103). Fixed in [#27240](https://github.com/cypress-io/cypress/issues/27240).
+ - Fixed a bug where fields using arrays in `cypress.config` are not correctly processed. Fixes [#27103](https://github.com/cypress-io/cypress/issues/27103). Fixed in [#27240](https://github.com/cypress-io/cypress/pull/27240).
 
 ## 12.17.1
 

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -435,6 +435,40 @@ e2e: {
 
       cy.get('[data-cy="file-match-indicator"]', { timeout: 7500 })
       .should('contain', '3 matches')
+
+      // Regession for https://github.com/cypress-io/cypress/issues/27103
+      cy.withCtx(async (ctx) => {
+        await ctx.actions.file.writeFileInProject('cypress.config.js',
+`   
+module.exports = {
+  projectId: 'abc123',
+  experimentalInteractiveRunEvents: true,
+  component: {
+    specPattern: 'src/**/*.{spec,cy}.{js,jsx,ts,tsx}',
+    supportFile: false,
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack',
+    }
+  },
+  e2e: {
+    specPattern: ['cypress/e2e/**/dom-cont*.spec.{js,ts}'],
+    supportFile: false,
+    setupNodeEvents(on, config) {
+      /**
+       * This should make Cypress yield a "no specs found" error.
+       *
+       * This stops being the case if 'specPattern' is an array.
+       */
+      config.specPattern = [];
+      return config;
+    },
+  },
+}`)
+      })
+
+      cy.get('[data-cy="create-spec-page-title"]')
+      .should('contain', defaultMessages.createSpec.page.customPatternNoSpecs.title)
     })
   })
 })

--- a/packages/config/src/project/index.ts
+++ b/packages/config/src/project/index.ts
@@ -110,9 +110,9 @@ export function updateWithPluginValues (cfg: FullConfig, modifiedConfig: any, te
   // merge cfg into overrides
   const merged = _.defaultsDeep(diffs, cfg)
 
-  for (const key in diffsClone) {
-    if (Array.isArray(diffsClone[key])) {
-      merged[key] = _.cloneDeep(diffsClone[key])
+  for (const [key, value] of Object.entries(diffsClone)) {
+    if (Array.isArray(value)) {
+      merged[key] = _.cloneDeep(value)
     }
   }
 

--- a/packages/config/src/project/index.ts
+++ b/packages/config/src/project/index.ts
@@ -105,10 +105,10 @@ export function updateWithPluginValues (cfg: FullConfig, modifiedConfig: any, te
     debug('resolved config object %o', cfg.resolved)
   }
 
-  const diffsClone = _.cloneDeep(diffs)
+  const diffsClone = _.cloneDeep(diffs) ?? {}
 
   // merge cfg into overrides
-  const merged = _.defaultsDeep(diffs, cfg)
+  const merged = _.defaultsDeep(diffs, cfg) ?? {}
 
   for (const [key, value] of Object.entries(diffsClone)) {
     if (Array.isArray(value)) {

--- a/packages/config/src/project/index.ts
+++ b/packages/config/src/project/index.ts
@@ -105,8 +105,16 @@ export function updateWithPluginValues (cfg: FullConfig, modifiedConfig: any, te
     debug('resolved config object %o', cfg.resolved)
   }
 
+  const diffsClone = _.cloneDeep(diffs)
+
   // merge cfg into overrides
   const merged = _.defaultsDeep(diffs, cfg)
+
+  for (const key in diffsClone) {
+    if (Array.isArray(diffsClone[key])) {
+      merged[key] = _.cloneDeep(diffsClone[key])
+    }
+  }
 
   debug('merged config object %o', merged)
 


### PR DESCRIPTION
- Closes [issue-27103](https://github.com/cypress-io/cypress/issues/27103)

### Additional details
`What is affected by this change?`
Previously the defaultsDeep function was merging/combining arrays. This PR will fix that issue and restore any arrays modified by the `setupNodeEvents` function.

### Steps to test
To test, copy the cypress.config.js from the `reproduction` section of the issue and configure for e2e testing. Then run cypress using `yarn cypress open --dev --config-file cypress.config.js`. After setting any key within the config object to any array value (within the setupNodeEvents function), it should reflect as is in the final config.

### How has the user experience changed?
User will get the exact config they supply in the `setupNodeEvents` function.

### PR Tasks

- [doubt] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
