### PR TITLE
chore: fix passing the correct attributes to getProtocolPropsForLog

### DIFF
--- a/packages/app/src/runner/events/capture-protocol.ts
+++ b/packages/app/src/runner/events/capture-protocol.ts
@@ -20,13 +20,13 @@ export const addCaptureProtocolListeners = (Cypress: Cypress.Cypress) => {
     })
   })
 
-  Cypress.on('log:added', (_, log) => {
+  Cypress.on('log:added', (attributes) => {
     // TODO: UNIFY-1318 - Race condition in unified runner - we should not need this null check
     if (!Cypress.runner) {
       return
     }
 
-    const protocolProps = Cypress.runner.getProtocolPropsForLog(log.attributes)
+    const protocolProps = Cypress.runner.getProtocolPropsForLog(attributes)
 
     attachCypressProtocolInfo({
       type: 'log:added',
@@ -36,13 +36,13 @@ export const addCaptureProtocolListeners = (Cypress: Cypress.Cypress) => {
     Cypress.backend('protocol:command:log:added', protocolProps)
   })
 
-  Cypress.on('log:changed', (_, log) => {
+  Cypress.on('log:changed', (attributes) => {
     // TODO: UNIFY-1318 - Race condition in unified runner - we should not need this null check
     if (!Cypress.runner) {
       return
     }
 
-    const protocolProps = Cypress.runner.getProtocolPropsForLog(log.attributes)
+    const protocolProps = Cypress.runner.getProtocolPropsForLog(attributes)
 
     attachCypressProtocolInfo({
       type: 'log:changed',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
The `log.attributes` instead of the `attributes` were being passed to the `getProtocolPropsForLog` function which was causing `renderProps` to not be populated. The [attributes](https://github.com/cypress-io/cypress/blob/17ed1c9831054c5875e21d29c588a5ecb50edcbc/packages/app/src/runner/event-manager.ts#L510) is what is passed to the reporter for display so we should be using the same value for the protocol.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Run a test that contains a log that has `renderProps` and verify the props are added to the DB.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
<img width="382" alt="Screenshot 2023-07-10 at 11 18 01 AM" src="https://github.com/cypress-io/cypress/assets/2002044/6aa40361-3217-4050-b54e-5efbfbdbd809">

After:
<img width="378" alt="Screenshot 2023-07-10 at 11 16 13 AM" src="https://github.com/cypress-io/cypress/assets/2002044/9b7a8738-a2a5-4e25-ae2a-52aabb1934b6">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
