### PR TITLE
chore: use setWindowOpenHandler over 'new-window' event as it has bee…

### DIFF
--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -158,7 +158,7 @@ export = {
           return menu.set({ withInternalDevTools: true })
         }
       },
-      async onNewWindow (this: BrowserWindow, e, url) {
+      async onNewWindow (this: BrowserWindow, { url }) {
         let _win: BrowserWindow | null = this
 
         _win.on('closed', () => {
@@ -168,7 +168,7 @@ export = {
         })
 
         try {
-          const child = await _this._launchChild(e, url, _win, projectRoot, state, options, automation)
+          const child = await _this._launchChild(url, _win, projectRoot, state, options, automation)
 
           // close child on parent close
           _win.on('close', () => {
@@ -218,9 +218,7 @@ export = {
     return await this._launch(win, url, automation, preferences, options.videoApi)
   },
 
-  _launchChild (e, url, parent, projectRoot, state, options, automation) {
-    e.preventDefault()
-
+  _launchChild (url, parent, projectRoot, state, options, automation) {
     const [parentX, parentY] = parent.getPosition()
 
     const electronOptions = this._defaultOptions(projectRoot, state, options, automation)
@@ -236,10 +234,6 @@ export = {
     })
 
     const win = Windows.create(projectRoot, electronOptions)
-
-    // needed by electron since we prevented default and are creating
-    // our own BrowserWindow (https://electron.atom.io/docs/api/web-contents/#event-new-window)
-    e.newGuest = win
 
     return this._launch(win, url, automation, electronOptions)
   },

--- a/packages/server/test/unit/browsers/electron_spec.js
+++ b/packages/server/test/unit/browsers/electron_spec.js
@@ -797,19 +797,16 @@ describe('lib/browsers/electron', () => {
         return sinon.stub(electron, '_launchChild').resolves(this.win)
       })
 
-      it('passes along event, url, parent window and options', function () {
+      it('passes along url, parent window and options', function () {
         const opts = electron._defaultOptions(this.options.projectRoot, this.state, this.options, this.automation)
 
-        const event = {}
         const parentWindow = {
           on: sinon.stub(),
         }
 
-        opts.onNewWindow.call(parentWindow, event, this.url)
+        opts.onNewWindow.call(parentWindow, { url: this.url })
 
-        expect(electron._launchChild).to.be.calledWith(
-          event, this.url, parentWindow, this.options.projectRoot, this.state, this.options, this.automation,
-        )
+        expect(electron._launchChild).to.be.calledWith(this.url, parentWindow, this.options.projectRoot, this.state, this.options, this.automation)
       })
 
       it('adds pid of new BrowserWindow to allPids list', function () {

--- a/packages/server/test/unit/gui/windows_spec.ts
+++ b/packages/server/test/unit/gui/windows_spec.ts
@@ -23,6 +23,7 @@ describe('lib/gui/windows', () => {
     this.win.getPosition = sinon.stub().returns([3, 4])
     this.win.webContents = new EventEmitter()
     this.win.webContents.openDevTools = sinon.stub()
+    this.win.webContents.setWindowOpenHandler = sinon.stub()
     this.win.webContents.userAgent = DEFAULT_USER_AGENT
     this.win.isDestroyed = sinon.stub().returns(false)
   })


### PR DESCRIPTION
…n deprecated in Electron v13 and removed in Electron v22

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24775

### Additional details
In order to upgrade Electron past v21, Cypress needs to replace the deprecated `new-window` event handler for the preferred `setWindowOpenHandler`. The `new-window` event was deprecated in Electron `v13` and was removed in `v22`. This PR maintains that functionality with the new preferred method.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

https://github.com/cypress-io/cypress/assets/3980464/4f11978d-9036-4226-adcc-54bb7cc8fae2

UX should not change here, as windows can still be opened (in this case with `modifyObstructiveCode: false`). Cypress, when receiving the window open event wishes to create the child window off the parent in order to decorate the window with necessary events. Because of this, we want to deny opening the new window. We were previously doing this by leveraging `e.preventDefault()` and setting `newGuest` on the event. The same functionality is now accomplished with `action: 'deny'`.

Please see Electron PRs and Documentation for more info: 
* https://github.com/electron/electron/blob/v21.0.0/docs/api/web-contents.md#event-new-window-deprecated
* https://github.com/electron/electron/blob/v21.0.0/docs/api/web-contents.md#contentssetwindowopenhandlerhandler
* https://github.com/electron/electron/pull/34526

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
