### PR TITLE
fix: Handle evaled privileged commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,13 +1,20 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 12.17.2
+
+_Released 07/18/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
+
 ## 12.17.1
 
-_Released 07/18/2023_
+_Released 07/10/2023_
 
 **Bugfixes:**
 
 - Fixed invalid stored preference when enabling in-app notifications that could cause the application to crash.  Fixes [#27228](https://github.com/cypress-io/cypress/issues/27228).
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
-- Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 07/18/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue with the Typescript types of [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot). Fixed in [#27130](https://github.com/cypress-io/cypress/pull/27130).
+- Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
 
 ## 12.17.0
 

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -115,6 +115,14 @@ describe('privileged commands', () => {
       cy.get('#basic').selectFile(Uint8Array.from([98, 97, 122]))
     })
 
+    it('handles evaled code', () => {
+      window.eval(`
+        cy.task('return:arg', 'eval arg').then(() => {
+          cy.task('return:arg', 'then eval arg')
+        })
+      `)
+    })
+
     it('passes in test body .then() callback', () => {
       cy.then(() => {
         cy.exec('echo "hello"')

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -117,8 +117,17 @@ describe('privileged commands', () => {
 
     it('handles evaled code', () => {
       window.eval(`
-        cy.task('return:arg', 'eval arg').then(() => {
+        cy.task('return:arg', 'eval arg')
+        .then(() => {
           cy.task('return:arg', 'then eval arg')
+        })
+
+        cy.get('body')
+        .each(() => {
+          cy.task('return:arg', 'each eval arg')
+        })
+        .within(() => {
+          cy.task('return:arg', 'within eval arg')
         })
       `)
     })

--- a/packages/server/lib/privileged-commands/privileged-channel.js
+++ b/packages/server/lib/privileged-commands/privileged-channel.js
@@ -69,6 +69,10 @@
     return filteredLines.length > 0
   }
 
+  const hasThenInsideEval = (err) => {
+    return stringIncludes.call(err.stack, 'thenFn@') && stringIncludes.call(err.stack, '> eval line')
+  }
+
   // in non-chromium browsers, the stack will include either the spec file url
   // or the support file
   const hasStackLinesFromSpecOrSupportFile = (err) => {
@@ -102,10 +106,10 @@
     }
 
     if (browserFamily === 'chromium') {
-      return hasSpecFrameStackLines(err)
+      return hasStackLinesFromSpecOrSupportFile(err) || hasSpecFrameStackLines(err)
     }
 
-    return hasStackLinesFromSpecOrSupportFile(err)
+    return hasThenInsideEval(err) || hasStackLinesFromSpecOrSupportFile(err)
   }
 
   // source: https://github.com/bryc/code/blob/d0dac1c607a005679799024ff66166e13601d397/jshash/experimental/cyrb53.js

--- a/packages/server/lib/privileged-commands/privileged-channel.js
+++ b/packages/server/lib/privileged-commands/privileged-channel.js
@@ -71,15 +71,16 @@
     return filteredLines.length > 0
   }
 
+  const isInCallback = (err) => {
+    return stringIncludes.call(err.stack, 'thenFn@') || stringIncludes.call(err.stack, 'withinFn@')
+  }
+
   const hasCallbackInsideEval = (err) => {
     if (browserFamily === 'webkit') {
-      return (
-        stringIncludes.call(err.stack, 'thenFn@')
-        || stringIncludes.call(err.stack, 'withinFn@')
-      ) && hasValidCallbackContext
+      return isInCallback(err) && hasValidCallbackContext
     }
 
-    return stringIncludes.call(err.stack, 'thenFn@') && stringIncludes.call(err.stack, '> eval line')
+    return isInCallback(err) && stringIncludes.call(err.stack, '> eval line')
   }
 
   // in non-chromium browsers, the stack will include either the spec file url


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27097 

### Additional details

The heuristics for evaluating needed to be updated to handle when spec code is evaled within the spec frame. In particular, it failed to validate a privileged command if it was within a callback (for a command like `.then`) that was within the evaled spec code.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
