### PR TITLE
chore: ensure that beforeTest awaits

### DIFF
--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -142,7 +142,7 @@ export class ProtocolManager implements ProtocolManagerShape {
   }
 
   async beforeTest (test: Record<string, any>) {
-    this.invokeAsync('beforeTest', test)
+    await this.invokeAsync('beforeTest', test)
   }
 
   async afterTest (test: Record<string, any>) {

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -141,8 +141,8 @@ export class ProtocolManager implements ProtocolManagerShape {
     await this.invokeAsync('afterSpec')
   }
 
-  beforeTest (test: Record<string, any>) {
-    this.invokeSync('beforeTest', test)
+  async beforeTest (test: Record<string, any>) {
+    this.invokeAsync('beforeTest', test)
   }
 
   async afterTest (test: Record<string, any>) {

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -94,10 +94,10 @@ describe('lib/cloud/protocol', () => {
     })
   })
 
-  it('should be able to initialize a new test', () => {
+  it('should be able to initialize a new test', async () => {
     sinon.stub(protocol, 'beforeTest')
 
-    protocolManager.beforeTest({
+    await protocolManager.beforeTest({
       id: 'id',
       title: 'test',
       wallClockStartedAt: 1234,

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -19,7 +19,7 @@ export interface AppCaptureProtocolCommon {
   commandLogChanged (log: any): void
   viewportChanged (input: any): void
   urlChanged (input: any): void
-  beforeTest(test: Record<string, any>): void
+  beforeTest(test: Record<string, any>): Promise<void>
   afterTest(test: Record<string, any>): Promise<void>
   afterSpec (): Promise<void>
   connectToBrowser (cdpClient: CDPClient): Promise<void>

--- a/system-tests/lib/protocolStub.ts
+++ b/system-tests/lib/protocolStub.ts
@@ -20,6 +20,8 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
     this.createHash = createHash
   }
 
+  protocolEnabled: boolean
+
   setupProtocol = (script, runId) => {
     return Promise.resolve()
   }
@@ -31,7 +33,9 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   afterSpec = () => {
     return Promise.resolve()
   }
-  beforeTest = (test) => {}
+  beforeTest = (test) => {
+    return Promise.resolve()
+  }
   commandLogAdded = (log) => {}
   commandLogChanged = (log) => {}
   viewportChanged = (input) => {}
@@ -44,5 +48,7 @@ export class AppCaptureProtocol implements ProtocolManagerShape {
   uploadCaptureArtifact ({ uploadUrl }) {
     return Promise.resolve()
   }
-  afterTest (test): void {}
+  afterTest = (test) => {
+    return Promise.resolve()
+  }
 }


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR makes sure that we await beforeTest calls in protocolManager. It's already using the right event, we just didn't need to wait til now.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
