### PR TITLE
chore: increase protocol enabled postDataSize

### DIFF
--- a/packages/driver/cypress/e2e/cy/timers.cy.js
+++ b/packages/driver/cypress/e2e/cy/timers.cy.js
@@ -187,9 +187,8 @@ describe('driver/src/cy/timers', () => {
           // now go ahead and run all the queued timers
           return cy.pauseTimers(false)
         })
+        .window().its('bar').should('eq', 'bar')
         .then(() => {
-          expect(win.bar).to.eq('bar')
-
           // requestAnimationFrame should have passed through
           // its high res timestamp from performance.now()
           expect(rafStub).to.be.calledWithMatch(Number)

--- a/packages/driver/cypress/e2e/cy/timers.cy.js
+++ b/packages/driver/cypress/e2e/cy/timers.cy.js
@@ -187,8 +187,9 @@ describe('driver/src/cy/timers', () => {
           // now go ahead and run all the queued timers
           return cy.pauseTimers(false)
         })
-        .window().its('bar').should('eq', 'bar')
         .then(() => {
+          expect(win.bar).to.eq('bar')
+
           // requestAnimationFrame should have passed through
           // its high res timestamp from performance.now()
           expect(rafStub).to.be.calledWithMatch(Number)

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -185,7 +185,8 @@ export class CdpAutomation implements CDPClient {
   static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, protocolManager?: ProtocolManagerShape): Promise<CdpAutomation> {
     const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, sendCloseCommandFn, automation)
 
-    const networkEnabledOPtions = protocolManager?.protocolEnabled ? {
+    const networkEnabledOptions = protocolManager?.protocolEnabled ? {
+      // omit maxTotalBufferSize and maxResourceBufferSize, use defaults
       maxPostDataSize: 64 * 1024,
     } : {
       maxTotalBufferSize: 0,
@@ -193,7 +194,7 @@ export class CdpAutomation implements CDPClient {
       maxPostDataSize: 0,
     }
 
-    await sendDebuggerCommandFn('Network.enable', networkEnabledOPtions)
+    await sendDebuggerCommandFn('Network.enable', networkEnabledOptions)
 
     return cdpAutomation
   }

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -9,7 +9,7 @@ import debugModule from 'debug'
 import { URL } from 'url'
 
 import type { ResourceType, BrowserPreRequest, BrowserResponseReceived } from '@packages/proxy'
-import type { CDPClient, WriteVideoFrame } from '@packages/types'
+import type { CDPClient, ProtocolManagerShape, WriteVideoFrame } from '@packages/types'
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
 
@@ -182,14 +182,18 @@ export class CdpAutomation implements CDPClient {
     await this.sendDebuggerCommandFn('Page.startScreencast', screencastOpts)
   }
 
-  static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, sendCloseCommandFn: SendCloseCommand, automation: Automation): Promise<CdpAutomation> {
+  static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, protocolManager?: ProtocolManagerShape): Promise<CdpAutomation> {
     const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, sendCloseCommandFn, automation)
 
-    await sendDebuggerCommandFn('Network.enable', {
+    const networkEnabledOPtions = protocolManager?.protocolEnabled ? {
+      maxPostDataSize: 64 * 1024,
+    } : {
       maxTotalBufferSize: 0,
       maxResourceBufferSize: 0,
       maxPostDataSize: 0,
-    })
+    }
+
+    await sendDebuggerCommandFn('Network.enable', networkEnabledOPtions)
 
     return cdpAutomation
   }

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -448,7 +448,7 @@ const _handlePausedRequests = async (client) => {
 }
 
 const _setAutomation = async (client: CriClient, automation: Automation, resetBrowserTargets: (shouldKeepTabOpen: boolean) => Promise<void>, options: BrowserLaunchOpts) => {
-  const cdpAutomation = await CdpAutomation.create(client.send, client.on, resetBrowserTargets, automation)
+  const cdpAutomation = await CdpAutomation.create(client.send, client.on, resetBrowserTargets, automation, options.protocolManager)
 
   automation.use(cdpAutomation)
 

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -1,10 +1,61 @@
 const { expect, sinon } = require('../../spec_helper')
 
+import { ProtocolManagerShape } from '@packages/types'
 import { CdpAutomation } from '../../../lib/browsers/cdp_automation'
 
 context('lib/browsers/cdp_automation', () => {
   context('.CdpAutomation', () => {
     let cdpAutomation: CdpAutomation
+
+    describe('create', function () {
+      it('networkEnabledOptions - protocol enabled', async function () {
+        const enabledObject = {
+          maxPostDataSize: 64 * 1024,
+        }
+        const localCommand = sinon.stub()
+        const localOnFn = sinon.stub()
+        const localSendCloseTargetCommand = sinon.stub()
+        const localAutomation = {
+          onBrowserPreRequest: sinon.stub(),
+          onRequestEvent: sinon.stub(),
+        }
+        const localManager = {
+          protocolEnabled: true,
+        } as ProtocolManagerShape
+
+        const localCommmandStub = localCommand.withArgs('Network.enable', enabledObject).resolves()
+
+        await CdpAutomation.create(localCommand, localOnFn, localSendCloseTargetCommand, localAutomation as any, localManager)
+
+        expect(localCommmandStub).to.have.been.calledWith('Network.enable', enabledObject)
+      })
+
+      it('networkEnabledOptions - protocol disabled', async function () {
+        const disabledObject = {
+          maxTotalBufferSize: 0,
+          maxResourceBufferSize: 0,
+          maxPostDataSize: 0,
+        }
+        const localCommand = sinon.stub()
+        const localOnFn = sinon.stub()
+        const localSendCloseTargetCommand = sinon.stub()
+        const localAutomation = {
+          onBrowserPreRequest: sinon.stub(),
+          onRequestEvent: sinon.stub(),
+        }
+        const localManager = {
+          protocolEnabled: false,
+        } as ProtocolManagerShape
+
+        const localCommmandStub = localCommand.withArgs('Network.enable', disabledObject).resolves()
+
+        await CdpAutomation.create(localCommand, localOnFn, localSendCloseTargetCommand, localAutomation as any, localManager)
+        await CdpAutomation.create(localCommand, localOnFn, localSendCloseTargetCommand, localAutomation as any)
+
+        expect(localCommmandStub).to.have.been.calledTwice
+        expect(localCommmandStub).to.have.been.calledWithExactly('Network.enable', disabledObject)
+      })
+    })
 
     beforeEach(async function () {
       this.sendDebuggerCommand = sinon.stub()


### PR DESCRIPTION

### Additional details
- Protocols capture of data calls was failing to return a `responseBody` as a result of a `Failed to load response data: Request content was evicted from inspector cache` error caused by out size limit being set to zero.
- Selectively increase the `postDataSize` limit to allow for `responseBody` capture. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
