### PR TITLE
fix: Fix web worker creation within spec frame

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 07/18/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where `cy.writeFile()` would erroneously fail with the error `cy.writeFile() must only be invoked from the spec file or support file`. Fixes [#27097](https://github.com/cypress-io/cypress/issues/27097).
+- Fixed an issue where web workers could not be created within a spec. Fixes [#27298](https://github.com/cypress-io/cypress/issues/27298).
 
 ## 12.17.1
 

--- a/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/privileged_commands.cy.ts
@@ -132,6 +132,21 @@ describe('privileged commands', () => {
       `)
     })
 
+    it('allows web workers in spec frame', () => {
+      const workerScript = `postMessage('hello from worker')`
+      const blob = new Blob([workerScript], { type: 'application/javascript' })
+      const workerURL = URL.createObjectURL(blob)
+      const worker = new Worker(workerURL)
+
+      return new Promise<void>((resolve) => {
+        worker.onmessage = ({ data }) => {
+          expect(data).to.equal('hello from worker')
+
+          resolve()
+        }
+      })
+    })
+
     it('passes in test body .then() callback', () => {
       cy.then(() => {
         cy.exec('echo "hello"')

--- a/packages/driver/src/util/privileged_channel.ts
+++ b/packages/driver/src/util/privileged_channel.ts
@@ -10,7 +10,7 @@ export function setSpecContentSecurityPolicy (specWindow) {
   const metaEl = specWindow.document.createElement('meta')
 
   metaEl.setAttribute('http-equiv', 'Content-Security-Policy')
-  metaEl.setAttribute('content', `script-src 'unsafe-eval'`)
+  metaEl.setAttribute('content', `script-src 'unsafe-eval'; worker-src * data: blob: 'unsafe-eval' 'unsafe-inline'`)
   specWindow.document.querySelector('head')!.appendChild(metaEl)
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27298

### Additional details

The content security policy set for the spec frame is primarily intended to prevent additional scripts from being added to it. Disallowing web workers was an unintended consequence of adding the policy, so this loosens up the restriction and allows web workers to be created and used within the spec frame.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
