### PR TITLE
chore: use CircleCI M1 runner over Macstadium

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-07-19-23
+07-20-214-23

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'revert-runner'
+        - 'fix/circle_ci_m1'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -41,7 +41,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
+    - equal: [ 'fix/circle_ci_m1', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -52,7 +52,6 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -72,7 +71,6 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -119,8 +117,11 @@ executors:
     environment:
       PLATFORM: windows
 
+  # see https://circleci.com/docs/configuration-reference/#macos-execution-environment
   darwin-arm64: &darwin-arm64-executor
-    machine: true
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.m1.medium.gen1	
     environment:
       PLATFORM: darwin
 
@@ -139,7 +140,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "revert-runner" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "fix/circle_ci_m1" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi
@@ -159,7 +160,16 @@ commands:
       - attach_workspace:
           at: ~/
       - install-required-node
+      - install_rosetta_2_if_applicable
       - unpack-dependencies
+
+  install_rosetta_2_if_applicable:
+    steps:
+      - run:
+          # We need Rosetta 2 to build/run the V8 snapshot on darwin-arm64
+          # see https://github.com/CircleCI-Public/macos-orb/pull/46/files for reference
+          name: Installing Rosetta 2 if darwin-arm64
+          command: source ./scripts/install-rosetta.sh
 
   restore_cached_binary:
     steps:
@@ -2865,13 +2875,13 @@ darwin-arm64-workflow: &darwin-arm64-workflow
     - node_modules_install:
         name: darwin-arm64-node-modules-install
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         only-cache-for-root-user: true
 
     - build:
         name: darwin-arm64-build
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         requires:
           - darwin-arm64-node-modules-install
 
@@ -2883,26 +2893,26 @@ darwin-arm64-workflow: &darwin-arm64-workflow
           - test-runner:commit-status-checks
           - test-runner:build-binary
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         requires:
           - darwin-arm64-build
 
     - v8-integration-tests:
         name: darwin-arm64-v8-integration-tests
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         requires:
           - darwin-arm64-build
     - driver-integration-memory-tests:
         name: darwin-arm64-driver-integration-memory-tests
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         requires:
           - darwin-arm64-build
     - server-unit-tests-cloud-environment:
         name: darwin-arm64-server-unit-tests-cloud-environment
         executor: darwin-arm64
-        resource_class: cypress-io/m1-macstadium
+        resource_class: macos.m1.large.gen1
         requires:
           - darwin-arm64-build
 

--- a/scripts/install-rosetta.sh
+++ b/scripts/install-rosetta.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [ "$(uname -m)" == "arm64" ] && [ "$(uname -s)" == "Darwin" ]; then
+    echo "Detected darwin-arm64. Installing Rosetta 2"
+    /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+else
+    echo "Not running on darwin-arm64. Skipping Rosetta 2 installation"
+fi


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
Moves M1 MacOS runners off of Macstadium and over to Circle CI Cloud Runners.

~Right now, the issue with this migration is that the S3 artifact jobs time out after building the binary. It is believed to be related to virtualization as per https://github.com/aws/aws-sdk/issues/469, but further investigation is needed. Until then, this PR will remain in draft~ ~Seems to now be working. see comment below~ this is an intermittent issue that needs investigating



### Steps to test
Check for passing build in darwin-arm64 and that the binary is pinned to the recent commit.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
