### PR TITLE
chore: revert circle M1 runners for MacStadium VM

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-06-07-23
+07-19-23

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'fix/chrome_crash_recovery'
+        - 'revert-runner'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -41,7 +41,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
+    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -52,7 +52,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
+    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -72,7 +72,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
+    - equal: [ 'revert-runner', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -139,7 +139,7 @@ commands:
       - run:
           name: Check current branch to persist artifacts
           command: |
-            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "jordanpowell88/angular-tsconfig" ]]; then
+            if [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "revert-runner" ]]; then
               echo "Not uploading artifacts or posting install comment for this branch."
               circleci-agent step halt
             fi
@@ -429,7 +429,7 @@ commands:
             node_version=$(cat .node-version)
             source ./scripts/ensure-node.sh
             echo "Installing Yarn"
-            npm install yarn -g # ensure yarn is installed with the correct node engine
+            npm install yarn --location=global # ensure yarn is installed with the correct node engine
             yarn check-node-version
       - run:
           name: Check Node
@@ -2865,13 +2865,13 @@ darwin-arm64-workflow: &darwin-arm64-workflow
     - node_modules_install:
         name: darwin-arm64-node-modules-install
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         only-cache-for-root-user: true
 
     - build:
         name: darwin-arm64-build
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         requires:
           - darwin-arm64-node-modules-install
 
@@ -2883,26 +2883,26 @@ darwin-arm64-workflow: &darwin-arm64-workflow
           - test-runner:commit-status-checks
           - test-runner:build-binary
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         requires:
           - darwin-arm64-build
 
     - v8-integration-tests:
         name: darwin-arm64-v8-integration-tests
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         requires:
           - darwin-arm64-build
     - driver-integration-memory-tests:
         name: darwin-arm64-driver-integration-memory-tests
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         requires:
           - darwin-arm64-build
     - server-unit-tests-cloud-environment:
         name: darwin-arm64-server-unit-tests-cloud-environment
         executor: darwin-arm64
-        resource_class: cypress-io/latest_m1
+        resource_class: cypress-io/m1-macstadium
         requires:
           - darwin-arm64-build
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,6 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'jordanpowell88/angular-tsconfig'
         - 'fix/chrome_crash_recovery'
 
 # usually we don't build Mac app - it takes a long time
@@ -42,7 +41,6 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: ['jordanpowell88/angular-tsconfig', << pipeline.git.branch >> ]
     - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -54,7 +52,6 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'jordanpowell88/angular-tsconfig', << pipeline.git.branch >> ]
     - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -75,7 +72,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/use_cloud_m1_runners', << pipeline.git.branch >> ]
+    - equal: [ 'mschile/issue-26900_browserCriClient', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -122,11 +119,8 @@ executors:
     environment:
       PLATFORM: windows
 
-  # see https://circleci.com/docs/configuration-reference/#macos-execution-environment  
   darwin-arm64: &darwin-arm64-executor
-    macos:
-      xcode: "14.2.0"
-    resource_class: macos.m1.large.gen1
+    machine: true
     environment:
       PLATFORM: darwin
 
@@ -1361,18 +1355,12 @@ jobs:
     steps:
       - restore_cached_workspace
       - restore_cached_system_tests_deps
+      # TODO: Remove this once we switch off self-hosted M1 runners
       - when:
           condition:
-            or:
-              - equal: [ *linux-arm64-executor, << parameters.executor >> ] # TODO: Figure out how to support linux-arm64 when we get to linux arm64 build: https://github.com/cypress-io/cypress/issues/23557
+            equal: [ *darwin-arm64-executor, << parameters.executor >> ]
           steps:
-            - run:
-                name: Run v8 integration tests
-                command: |
-                  source ./scripts/ensure-node.sh
-                  yarn test-integration --scope "'@tooling/packherd'"
-            - verify-mocha-results:
-                expectedResultCount: 1
+            - run: rm -f /tmp/cypress/junit/*
       - unless:
           condition:
             or:
@@ -1385,6 +1373,18 @@ jobs:
                   yarn test-integration --scope "'@tooling/{packherd,v8-snapshot,electron-mksnapshot}'"
             - verify-mocha-results:
                 expectedResultCount: 3
+      - when:
+          condition:
+            or:
+              - equal: [ *linux-arm64-executor, << parameters.executor >> ]
+          steps:
+            - run:
+                name: Run v8 integration tests
+                command: |
+                  source ./scripts/ensure-node.sh
+                  yarn test-integration --scope "'@tooling/packherd'"
+            - verify-mocha-results:
+                expectedResultCount: 1
       - store_test_results:
           path: /tmp/cypress
       - store-npm-logs
@@ -1520,6 +1520,12 @@ jobs:
     parallelism: 1
     steps:
       - restore_cached_workspace
+      # TODO: Remove this once we switch off self-hosted M1 runners
+      - when:
+          condition:
+            equal: [ *darwin-arm64-executor, << parameters.executor >> ]
+          steps:
+            - run: rm -f /tmp/cypress/junit/*
       - run: yarn workspace @packages/server test-unit cloud/environment_spec.ts
       - verify-mocha-results:
           expectedResultCount: 1
@@ -2859,11 +2865,13 @@ darwin-arm64-workflow: &darwin-arm64-workflow
     - node_modules_install:
         name: darwin-arm64-node-modules-install
         executor: darwin-arm64
+        resource_class: cypress-io/latest_m1
         only-cache-for-root-user: true
 
     - build:
         name: darwin-arm64-build
         executor: darwin-arm64
+        resource_class: cypress-io/latest_m1
         requires:
           - darwin-arm64-node-modules-install
 
@@ -2875,23 +2883,26 @@ darwin-arm64-workflow: &darwin-arm64-workflow
           - test-runner:commit-status-checks
           - test-runner:build-binary
         executor: darwin-arm64
-        resource_class: large
+        resource_class: cypress-io/latest_m1
         requires:
           - darwin-arm64-build
 
     - v8-integration-tests:
         name: darwin-arm64-v8-integration-tests
         executor: darwin-arm64
+        resource_class: cypress-io/latest_m1
         requires:
           - darwin-arm64-build
     - driver-integration-memory-tests:
         name: darwin-arm64-driver-integration-memory-tests
         executor: darwin-arm64
+        resource_class: cypress-io/latest_m1
         requires:
           - darwin-arm64-build
     - server-unit-tests-cloud-environment:
         name: darwin-arm64-server-unit-tests-cloud-environment
         executor: darwin-arm64
+        resource_class: cypress-io/latest_m1
         requires:
           - darwin-arm64-build
 

--- a/scripts/circle-cache.js
+++ b/scripts/circle-cache.js
@@ -69,6 +69,8 @@ async function prepareCircleCache () {
       .replace(/(.*?)\/node_modules/, '$1_node_modules')
       .replace(BASE_DIR, CACHE_DIR)
 
+      // self-hosted M1 doesn't always clear this directory between runs, so remove it
+      await fsExtra.remove(dest)
       await fsExtra.move(src, dest)
     }),
   )


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
Corrects the missed implementation of Circle M1 cloud runners and opts for the newly upgraded/reimaged macstadium mini runner so we can correctly build the `darwin-arm64` binary

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
