### PR TITLE
feat: defer protocol manager initialization to after script load

### DIFF
--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -393,7 +393,7 @@ module.exports = {
         }
       } catch (e) {
         if (CAPTURE_ERRORS) {
-          protocolManager.sendErrors([
+          await protocolManager.sendErrors([
             {
               args: [result.captureProtocolUrl],
               captureMethod: 'getCaptureProtocolScript',

--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -21,6 +21,7 @@ import getEnvInformationForProjectRoot from './environment'
 import type { OptionsWithUrl } from 'request-promise'
 import { fs } from '../util/fs'
 import ProtocolManager from './protocol'
+import type { ProjectBase } from '../project-base'
 
 const THIRTY_SECONDS = humanInterval('30 seconds')
 const SIXTY_SECONDS = humanInterval('60 seconds')
@@ -250,7 +251,7 @@ export type CreateRunOptions = {
   tags: string[]
   testingType: 'e2e' | 'component'
   timeout?: number
-  project: any
+  project: ProjectBase<any>
 }
 
 type CreateRunResponse = {

--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -388,7 +388,7 @@ module.exports = {
 
           if (script) {
             options.project.protocolManager = protocolManager
-            await protocolManager.setupProtocol(script, result.runId)
+            await options.project.protocolManager.setupProtocol(script, result.runId)
           }
         }
       } catch (e) {

--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -19,8 +19,8 @@ import * as enc from './encryption'
 import getEnvInformationForProjectRoot from './environment'
 
 import type { OptionsWithUrl } from 'request-promise'
-import type { ProtocolManagerShape } from '@packages/types'
 import { fs } from '../util/fs'
+import ProtocolManager from './protocol'
 
 const THIRTY_SECONDS = humanInterval('30 seconds')
 const SIXTY_SECONDS = humanInterval('60 seconds')
@@ -250,7 +250,7 @@ export type CreateRunOptions = {
   tags: string[]
   testingType: 'e2e' | 'component'
   timeout?: number
-  protocolManager?: ProtocolManagerShape
+  project: any
 }
 
 type CreateRunResponse = {
@@ -379,17 +379,20 @@ module.exports = {
       })
     })
     .then(async (result: CreateRunResponse) => {
+      let protocolManager = new ProtocolManager()
+
       try {
-        if (options.protocolManager && (result.captureProtocolUrl || process.env.CYPRESS_LOCAL_PROTOCOL_PATH)) {
+        if (result.captureProtocolUrl || process.env.CYPRESS_LOCAL_PROTOCOL_PATH) {
           const script = await this.getCaptureProtocolScript(result.captureProtocolUrl || process.env.CYPRESS_LOCAL_PROTOCOL_PATH)
 
           if (script) {
-            await options.protocolManager.setupProtocol(script, result.runId)
+            options.project.protocolManager = protocolManager
+            await protocolManager.setupProtocol(script, result.runId)
           }
         }
       } catch (e) {
         if (CAPTURE_ERRORS) {
-          options.protocolManager?.sendErrors([
+          protocolManager.sendErrors([
             {
               args: [result.captureProtocolUrl],
               captureMethod: 'getCaptureProtocolScript',

--- a/packages/server/lib/modes/record.js
+++ b/packages/server/lib/modes/record.js
@@ -344,7 +344,7 @@ const createRun = Promise.method((options = {}) => {
     ciBuildId: null,
   })
 
-  let { projectRoot, projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags, testingType, autoCancelAfterFailures, protocolManager } = options
+  let { projectRoot, projectId, recordKey, platform, git, specPattern, specs, parallel, ciBuildId, group, tags, testingType, autoCancelAfterFailures, project } = options
 
   if (recordKey == null) {
     recordKey = env.get('CYPRESS_RECORD_KEY')
@@ -401,7 +401,7 @@ const createRun = Promise.method((options = {}) => {
     ci,
     commit,
     autoCancelAfterFailures,
-    protocolManager,
+    project,
   })
   .tap((response) => {
     if (!(response && response.warnings && response.warnings.length)) {
@@ -675,7 +675,6 @@ const createRunAndRecordSpecs = (options = {}) => {
     testingType,
     quiet,
     autoCancelAfterFailures,
-    protocolManager,
   } = options
   const recordKey = options.key
 
@@ -711,7 +710,7 @@ const createRunAndRecordSpecs = (options = {}) => {
       testingType,
       configFile: config ? config.configFile : null,
       autoCancelAfterFailures,
-      protocolManager,
+      project,
     })
     .then((resp) => {
       if (!resp) {
@@ -806,7 +805,7 @@ const createRunAndRecordSpecs = (options = {}) => {
             screenshots,
             videoUploadUrl,
             captureUploadUrl,
-            protocolManager,
+            protocolManager: project.protocolManager,
             screenshotUploadUrls,
             quiet,
           })

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -25,7 +25,7 @@ import type { SpecWithRelativeRoot, SpecFile, TestingType, OpenProjectLaunchOpts
 import type { Cfg } from '../project-base'
 import type { Browser } from '../browsers/types'
 import * as printResults from '../util/print-run'
-import { ProtocolManager } from '../cloud/protocol'
+import type { ProtocolManager } from '../cloud/protocol'
 import { telemetry } from '@packages/telemetry'
 
 type SetScreenshotMetadata = (data: TakeScreenshotProps) => void
@@ -1067,16 +1067,8 @@ async function ready (options: { projectRoot: string, record: boolean, key: stri
     errors.throwErr('UNSUPPORTED_BROWSER_VERSION', browser.warning)
   }
 
-  let protocolManager: ProtocolManager | undefined
-
   if (browser.family === 'chromium') {
     chromePolicyCheck.run(onWarning)
-
-    if (record) {
-      protocolManager = new ProtocolManager()
-
-      project.setProtocolManager(protocolManager)
-    }
   }
 
   async function runAllSpecs ({ beforeSpecRun, afterSpecRun, runUrl, parallel }: { beforeSpecRun?: BeforeSpecRun, afterSpecRun?: AfterSpecRun, runUrl?: string, parallel?: boolean }) {
@@ -1108,7 +1100,7 @@ async function ready (options: { projectRoot: string, record: boolean, key: stri
       testingType: options.testingType,
       exit: options.exit,
       webSecurity: options.webSecurity,
-      protocolManager,
+      protocolManager: project.protocolManager,
     })
 
     if (!options.quiet) {
@@ -1142,7 +1134,6 @@ async function ready (options: { projectRoot: string, record: boolean, key: stri
       runAllSpecs,
       onError,
       quiet: options.quiet,
-      protocolManager,
     })
   }
 

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -432,7 +432,7 @@ export class ProjectBase<TServer extends Server> extends EE {
     return this._protocolManager
   }
 
-  set protocolManager (protocolManager: ProtocolManager) {
+  set protocolManager (protocolManager: ProtocolManager | undefined) {
     this._protocolManager = protocolManager
 
     this._server?.setProtocolManager(protocolManager)

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -20,9 +20,10 @@ import { SocketE2E } from './socket-e2e'
 import { ensureProp } from './util/class-helpers'
 
 import system from './util/system'
-import type { BannersState, FoundBrowser, FoundSpec, OpenProjectLaunchOptions, ReceivedCypressOptions, ResolvedConfigurationOptions, TestingType, VideoRecording, ProtocolManagerShape } from '@packages/types'
+import type { BannersState, FoundBrowser, FoundSpec, OpenProjectLaunchOptions, ReceivedCypressOptions, ResolvedConfigurationOptions, TestingType, VideoRecording } from '@packages/types'
 import { DataContext, getCtx } from '@packages/data-context'
 import { createHmac } from 'crypto'
+import type ProtocolManager from './cloud/protocol'
 
 export interface Cfg extends ReceivedCypressOptions {
   projectId?: string
@@ -59,7 +60,7 @@ export class ProjectBase<TServer extends Server> extends EE {
   protected _cfg?: Cfg
   protected _server?: TServer
   protected _automation?: Automation
-  private _protocolManager?: ProtocolManagerShape
+  private _protocolManager?: ProtocolManager
   private _recordTests?: any = null
   private _isServerOpen: boolean = false
 
@@ -427,7 +428,11 @@ export class ProjectBase<TServer extends Server> extends EE {
     this.browser = browser
   }
 
-  setProtocolManager (protocolManager: ProtocolManagerShape) {
+  get protocolManager (): ProtocolManager | undefined {
+    return this._protocolManager
+  }
+
+  set protocolManager (protocolManager: ProtocolManager) {
     this._protocolManager = protocolManager
 
     this._server?.setProtocolManager(protocolManager)

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -182,7 +182,7 @@ export abstract class ServerBase<TSocket extends SocketE2E | SocketCt> {
     return this._remoteStates
   }
 
-  setProtocolManager (protocolManager: ProtocolManagerShape) {
+  setProtocolManager (protocolManager: ProtocolManagerShape | undefined) {
     this._protocolManager = protocolManager
 
     this._socket?.setProtocolManager(protocolManager)

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -628,7 +628,7 @@ export class SocketBase {
     return this.toRunner('update:telemetry:context', context)
   }
 
-  setProtocolManager (protocolManager: ProtocolManagerShape) {
+  setProtocolManager (protocolManager: ProtocolManagerShape | undefined) {
     this._protocolManager = protocolManager
   }
 }

--- a/packages/server/test/unit/cloud/api_spec.js
+++ b/packages/server/test/unit/cloud/api_spec.js
@@ -580,9 +580,19 @@ describe('lib/cloud/api', () => {
         captureProtocolUrl: 'http://localhost:1234/capture-protocol/script/protocolStub.js',
       })
 
+      const protocolManager = this.protocolManager
+      const project = {
+        set protocolManager (val) {
+          // don't override with the setter so that the protocol manager is always the same
+        },
+        get protocolManager () {
+          return protocolManager
+        },
+      }
+
       return api.createRun({
         ...this.buildProps,
-        protocolManager: this.protocolManager,
+        project,
       })
       .then((ret) => {
         expect(ret).to.deep.eq({
@@ -627,9 +637,19 @@ describe('lib/cloud/api', () => {
         }))
       }))
 
+      const protocolManager = this.protocolManager
+      const project = {
+        set protocolManager (val) {
+          // don't override with the setter so that the protocol manager is always the same
+        },
+        get protocolManager () {
+          return protocolManager
+        },
+      }
+
       return api.createRun({
         ...this.buildProps,
-        protocolManager: this.protocolManager,
+        project,
       })
       .then((ret) => {
         expect(ret).to.deep.eq({

--- a/packages/server/test/unit/modes/record_spec.js
+++ b/packages/server/test/unit/modes/record_spec.js
@@ -285,6 +285,7 @@ describe('lib/modes/record', () => {
         const tag = 'nightly,develop'
         const testingType = 'e2e'
         const autoCancelAfterFailures = 4
+        const project = {}
 
         return recordMode.createRunAndRecordSpecs({
           key,
@@ -301,6 +302,7 @@ describe('lib/modes/record', () => {
           tag,
           testingType,
           autoCancelAfterFailures,
+          project,
         })
         .then(() => {
           expect(commitInfo.commitInfo).to.be.calledWith(projectRoot)
@@ -339,7 +341,7 @@ describe('lib/modes/record', () => {
             },
             tags: ['nightly', 'develop'],
             autoCancelAfterFailures: 4,
-            protocolManager: undefined,
+            project,
           })
         })
       })

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -226,9 +226,9 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
 
   context('#getConfig', () => {
     it('returns the enabled state of the protocol manager if it is defined', function () {
-      this.project.setProtocolManager({
+      this.project.protocolManager = {
         protocolEnabled: true,
-      })
+      }
 
       const config = this.project.getConfig()
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Defer protocol manager initialization to after script load

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

In order to ensure we don't do any initialization or protocol manager logic if it is disabled for any reason (at the project or because the wrong browser is used), we will defer initialization til after we make that determination

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [naa] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
