### PR TITLE
chore: add check for headed and no-exit to test isolation

### DIFF
--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -491,17 +491,12 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         }
 
         const isRunMode = !Cypress.config('isInteractive')
-        const isHeadlessNoExit = !Cypress.config('browser').isHeaded && !Cypress.config('exit')
-        const magicVarName = isRunMode && isHeadlessNoExit
-
-        // KASPER_TODO: add to test, test-isolation
-        // snapshot: true,
-        // headed: true,
-        // noExit: true,
+        const isHeadedNoExit = Cypress.config('browser').isHeaded && !Cypress.config('exit')
+        const shouldContinue = isRunMode && !isHeadedNoExit
 
         // If we're not in open mode or we're in open mode and not the last test we reset state.
         // The last test will needs to stay so that the user can see what the end result of the AUT was.
-        if (magicVarName || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
+        if (shouldContinue || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
           cy.state('duringUserTestExecution', false)
           Cypress.primaryOriginCommunicator.toAllSpecBridges('sync:state', { 'duringUserTestExecution': false })
           // Remove window:load and window:before:load listeners so that navigating to about:blank doesn't fire in user code.

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -492,11 +492,11 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
         const isRunMode = !Cypress.config('isInteractive')
         const isHeadedNoExit = Cypress.config('browser').isHeaded && !Cypress.config('exit')
-        const shouldContinue = isRunMode && !isHeadedNoExit
+        const shouldAlwaysResetPage = isRunMode && !isHeadedNoExit
 
         // If we're not in open mode or we're in open mode and not the last test we reset state.
         // The last test will needs to stay so that the user can see what the end result of the AUT was.
-        if (shouldContinue || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
+        if (shouldAlwaysResetPage || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
           cy.state('duringUserTestExecution', false)
           Cypress.primaryOriginCommunicator.toAllSpecBridges('sync:state', { 'duringUserTestExecution': false })
           // Remove window:load and window:before:load listeners so that navigating to about:blank doesn't fire in user code.

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -490,9 +490,18 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           topSuite = topSuite.parent
         }
 
+        const isRunMode = !Cypress.config('isInteractive')
+        const isHeadlessNoExit = !Cypress.config('browser').isHeaded && !Cypress.config('exit')
+        const magicVarName = isRunMode && isHeadlessNoExit
+
+        // KASPER_TODO: add to test, test-isolation
+        // snapshot: true,
+        // headed: true,
+        // noExit: true,
+
         // If we're not in open mode or we're in open mode and not the last test we reset state.
         // The last test will needs to stay so that the user can see what the end result of the AUT was.
-        if (!Cypress.config('isInteractive') || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
+        if (magicVarName || !lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))) {
           cy.state('duringUserTestExecution', false)
           Cypress.primaryOriginCommunicator.toAllSpecBridges('sync:state', { 'duringUserTestExecution': false })
           // Remove window:load and window:before:load listeners so that navigating to about:blank doesn't fire in user code.

--- a/system-tests/__snapshots__/test_isolation_spec.ts.js
+++ b/system-tests/__snapshots__/test_isolation_spec.ts.js
@@ -113,3 +113,67 @@ exports['Test Isolation / fires events in the right order with the right argumen
 
 
 `
+
+exports['Test Isolation / fires events in the right order with the right arguments - headed: true - noExit: true'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+not exiting due to options.exit being false
+
+`
+
+exports['Test Isolation / fires events in the right order with the right arguments - headed: false - noExit: true'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+not exiting due to options.exit being false
+
+`

--- a/system-tests/__snapshots__/test_isolation_spec.ts.js
+++ b/system-tests/__snapshots__/test_isolation_spec.ts.js
@@ -1,0 +1,44 @@
+exports['Test Isolation / makes lasagna'] = `
+Can't run because no spec files were found.
+
+We searched for specs matching this glob pattern:
+
+  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+
+`
+
+exports['Test Isolation / makes lasagna - false - true'] = `
+Can't run because no spec files were found.
+
+We searched for specs matching this glob pattern:
+
+  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+
+`
+
+exports['Test Isolation / makes lasagna - true - false'] = `
+Can't run because no spec files were found.
+
+We searched for specs matching this glob pattern:
+
+  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+
+`
+
+exports['Test Isolation / makes ravioli - false - false'] = `
+Can't run because no spec files were found.
+
+We searched for specs matching this glob pattern:
+
+  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+
+`
+
+exports['Test Isolation / makes aribiatta - true - true'] = `
+Can't run because no spec files were found.
+
+We searched for specs matching this glob pattern:
+
+  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+
+`

--- a/system-tests/__snapshots__/test_isolation_spec.ts.js
+++ b/system-tests/__snapshots__/test_isolation_spec.ts.js
@@ -1,44 +1,153 @@
-exports['Test Isolation / makes lasagna'] = `
-Can't run because no spec files were found.
+exports['Test Isolation / config - headed: false - noExit: true'] = `
 
-We searched for specs matching this glob pattern:
+====================================================================================================
 
-  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+  (Run Starting)
 
-`
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
 
-exports['Test Isolation / makes lasagna - false - true'] = `
-Can't run because no spec files were found.
 
-We searched for specs matching this glob pattern:
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
 
-  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
 
-`
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
 
-exports['Test Isolation / makes lasagna - true - false'] = `
-Can't run because no spec files were found.
 
-We searched for specs matching this glob pattern:
+  3 passing
 
-  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
-
-`
-
-exports['Test Isolation / makes ravioli - false - false'] = `
-Can't run because no spec files were found.
-
-We searched for specs matching this glob pattern:
-
-  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+not exiting due to options.exit being false
 
 `
 
-exports['Test Isolation / makes aribiatta - true - true'] = `
-Can't run because no spec files were found.
+exports['Test Isolation / config - headed: true - noExit: true'] = `
 
-We searched for specs matching this glob pattern:
+====================================================================================================
 
-  > /foo/bar/.projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+not exiting due to options.exit being false
+
+`
+
+exports['Test Isolation / fires events in the right order with the right arguments - headed: false - noExit: true'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+not exiting due to options.exit being false
+
+`
+
+exports['Test Isolation / fires events in the right order with the right arguments - headed: false - noExit: false'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     test-isolation.spec.js                                                           │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  test-isolation.spec.js                   XX:XX        3        3        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+
 
 `

--- a/system-tests/__snapshots__/test_isolation_spec.ts.js
+++ b/system-tests/__snapshots__/test_isolation_spec.ts.js
@@ -1,100 +1,62 @@
-exports['Test Isolation / config - headed: false - noExit: true'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        1 found (test-isolation.spec.js)                                                 │
-  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
-  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  test-isolation.spec.js                                                          (1 of 1)
-
-
-  test isolation
-    ✓ passes 1
-    ✓ passes 2
-    ✓ passes 3
-
-
-  3 passing
-
-not exiting due to options.exit being false
-
-`
-
-exports['Test Isolation / config - headed: true - noExit: true'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        1 found (test-isolation.spec.js)                                                 │
-  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
-  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  test-isolation.spec.js                                                          (1 of 1)
-
-
-  test isolation
-    ✓ passes 1
-    ✓ passes 2
-    ✓ passes 3
-
-
-  3 passing
-
-not exiting due to options.exit being false
-
-`
-
-exports['Test Isolation / fires events in the right order with the right arguments - headed: false - noExit: true'] = `
-
-====================================================================================================
-
-  (Run Starting)
-
-  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:      1.2.3                                                                            │
-  │ Browser:      FooBrowser 88                                                                    │
-  │ Specs:        1 found (test-isolation.spec.js)                                                 │
-  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
-  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
-  └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-────────────────────────────────────────────────────────────────────────────────────────────────────
-                                                                                                    
-  Running:  test-isolation.spec.js                                                          (1 of 1)
-
-
-  test isolation
-    ✓ passes 1
-    ✓ passes 2
-    ✓ passes 3
-
-
-  3 passing
-
-not exiting due to options.exit being false
-
-`
-
 exports['Test Isolation / fires events in the right order with the right arguments - headed: false - noExit: false'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:      1.2.3                                                                            │
+  │ Browser:      FooBrowser 88                                                                    │
+  │ Specs:        1 found (test-isolation.spec.js)                                                 │
+  │ Searched:     cypress/e2e/test-isolation.spec.js                                               │
+  │ Experiments:  experimentalInteractiveRunEvents=true                                            │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  test-isolation.spec.js                                                          (1 of 1)
+
+
+  test isolation
+    ✓ passes 1
+    ✓ passes 2
+    ✓ passes 3
+
+
+  3 passing
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      0                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  0                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Spec Ran:     test-isolation.spec.js                                                           │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  test-isolation.spec.js                   XX:XX        3        3        -        -        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
+
+
+`
+
+exports['Test Isolation / fires events in the right order with the right arguments - headed: true - noExit: false'] = `
 
 ====================================================================================================
 

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
@@ -1,0 +1,86 @@
+const TEST_METADATA = {
+  'passes 1': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: 'about:blank',
+  },
+  'passes 2': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: 'about:blank',
+  },
+  'passes 3': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: !Cypress.config('isInteractive'),
+    end: !Cypress.config('isInteractive') ? 'about:blank' : '/cypress/e2e/dom-content.html',
+  },
+}
+
+let cypressEventsHandled = 0
+
+const testBeforeRun = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href).to.eq(TEST_METADATA[args[1].title].start)
+  cypressEventsHandled += 1
+}
+
+const testBeforeRunAsync = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href).to.eq(TEST_METADATA[args[1].title].start)
+  cypressEventsHandled += 1
+}
+
+const testBeforeAfterRunAsync = (Cypress, ...args) => {
+  expect(TEST_METADATA[args[1].title].firesTestBeforeAfterRunAsync).to.be.true
+  cypressEventsHandled += 1
+}
+
+const testAfterRun = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].end)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const testAfterRunAsync = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].end)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const cypressEvents = [
+  ['test:before:run', testBeforeRun],
+  ['test:before:run:async', testBeforeRunAsync],
+  ['test:before:after:run:async', testBeforeAfterRunAsync],
+  ['test:after:run', testAfterRun],
+  ['test:after:run:async', testAfterRunAsync],
+]
+
+cypressEvents.forEach(([event, handler]) => {
+  Cypress.prependListener(event, (...args) => {
+    handler(Cypress, ...args)
+  })
+})
+
+Cypress.on('test:after:run:async', async (test) => {
+  if (test.title === 'passes 1') {
+    expect(cypressEventsHandled).to.equal(5)
+  } else if (test.title === 'passes 2') {
+    expect(cypressEventsHandled).to.equal(10)
+  } else if (test.title === 'passes 3') {
+    expect(cypressEventsHandled).to.equal(Cypress.config('isInteractive') ? 14 : 15)
+  }
+})
+
+describe('test isolation', () => {
+  beforeEach(() => {
+    cy.visit('cypress/e2e/dom-content.html')
+  })
+
+  it('passes 1', () => {
+    expect(true).to.equal(true)
+  })
+
+  it('passes 2', () => {
+    expect(true).to.equal(true)
+  })
+
+  it('passes 3', () => {
+    expect(true).to.equal(true)
+  })
+})

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
@@ -1,4 +1,4 @@
-const shouldContinue = (config) => {
+const shouldAlwaysResetPage = (config) => {
   const isRunMode = !config('isInteractive')
   const isHeadedNoExit = config('browser').isHeaded && !config('exit')
 
@@ -19,7 +19,7 @@ const TEST_METADATA = {
   'passes 3': {
     start: 'about:blank',
     firesTestBeforeAfterRunAsync: !Cypress.config('isInteractive'),
-    end: shouldContinue(Cypress.config) ? 'about:blank' : '/cypress/e2e/dom-content.html',
+    end: shouldAlwaysResetPage(Cypress.config) ? 'about:blank' : '/cypress/e2e/dom-content.html',
   },
 }
 
@@ -70,7 +70,7 @@ Cypress.on('test:after:run:async', async (test) => {
   } else if (test.title === 'passes 2') {
     expect(cypressEventsHandled).to.equal(10)
   } else if (test.title === 'passes 3') {
-    expect(cypressEventsHandled).to.equal(!shouldContinue(Cypress.config) ? 14 : 15)
+    expect(cypressEventsHandled).to.equal(!shouldAlwaysResetPage(Cypress.config) ? 14 : 15)
   }
 })
 

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
@@ -1,3 +1,10 @@
+const shouldContinue = (config) => {
+  const isRunMode = !config('isInteractive')
+  const isHeadedNoExit = config('browser').isHeaded && !config('exit')
+
+  return isRunMode && !isHeadedNoExit
+}
+
 const TEST_METADATA = {
   'passes 1': {
     start: 'about:blank',
@@ -12,7 +19,7 @@ const TEST_METADATA = {
   'passes 3': {
     start: 'about:blank',
     firesTestBeforeAfterRunAsync: !Cypress.config('isInteractive'),
-    end: !Cypress.config('isInteractive') ? 'about:blank' : '/cypress/e2e/dom-content.html',
+    end: shouldContinue(Cypress.config) ? 'about:blank' : '/cypress/e2e/dom-content.html',
   },
 }
 
@@ -63,7 +70,7 @@ Cypress.on('test:after:run:async', async (test) => {
   } else if (test.title === 'passes 2') {
     expect(cypressEventsHandled).to.equal(10)
   } else if (test.title === 'passes 3') {
-    expect(cypressEventsHandled).to.equal(Cypress.config('isInteractive') ? 14 : 15)
+    expect(cypressEventsHandled).to.equal(!shouldContinue(Cypress.config) ? 14 : 15)
   }
 })
 

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -1,0 +1,98 @@
+import systemTests from '../lib/system-tests'
+import childProcess from 'child_process'
+
+describe('Test Isolation', () => {
+  systemTests.setup()
+
+  systemTests.it('fires events in the right order with the right arguments - run mode', {
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation.spec.js',
+    expectedExitCode: 0, // expectedExitCode: 1, // should be 1?
+    timeout: 20000,
+    browser: 'chrome',
+  })
+
+  systemTests.it('makes lasagna - false - true', {
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation.spec.js',
+    expectedExitCode: null,
+    timeout: 20000,
+    browser: 'chrome',
+    snapshot: true,
+    headed: false,
+    noExit: true,
+    onSpawn: (cp) => {
+      cp.stdout.on('data', (buf) => {
+        if (buf.toString().includes('not exiting due to options.exit being false')) {
+          // systemTests.it spawns a new node process which then spawns the actual cypress process
+          // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
+          childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
+          cp.kill()
+        }
+      })
+    },
+  })
+
+  // systemTests.it('makes lasagna - true - false', {
+  //   project: 'cypress-in-cypress',
+  //   spec: 'test-isolation.spec.js',
+  //   expectedExitCode: 1,
+  //   timeout: 20000,
+  //   browser: 'chrome',
+  //   snapshot: true,
+  //   headed: true,
+  //   noExit: false,
+  //   onSpawn: (cp) => {
+  //     cp.stdout.on('data', (buf) => {
+  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
+  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
+  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
+  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
+  //         cp.kill()
+  //       }
+  //     })
+  //   },
+  // })
+
+  // systemTests.it('makes ravioli - false - false', {
+  //   project: 'cypress-in-cypress',
+  //   spec: 'test-isolation.spec.js',
+  //   expectedExitCode: 1,
+  //   timeout: 20000,
+  //   browser: 'chrome',
+  //   snapshot: true,
+  //   headed: false,
+  //   noExit: false,
+  //   onSpawn: (cp) => {
+  //     cp.stdout.on('data', (buf) => {
+  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
+  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
+  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
+  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
+  //         cp.kill()
+  //       }
+  //     })
+  //   },
+  // })
+
+  // systemTests.it('makes aribiatta - true - true', {
+  //   project: 'cypress-in-cypress',
+  //   spec: 'test-isolation.spec.js',
+  //   expectedExitCode: 1,
+  //   timeout: 20000,
+  //   browser: 'chrome',
+  //   snapshot: true,
+  //   headed: true,
+  //   noExit: true,
+  //   onSpawn: (cp) => {
+  //     cp.stdout.on('data', (buf) => {
+  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
+  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
+  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
+  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
+  //         cp.kill()
+  //       }
+  //     })
+  //   },
+  // })
+})

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -7,7 +7,7 @@ describe('Test Isolation', () => {
   systemTests.it('fires events in the right order with the right arguments - run mode', {
     project: 'cypress-in-cypress',
     spec: 'test-isolation.spec.js',
-    expectedExitCode: 0, // expectedExitCode: 1, // should be 1?
+    expectedExitCode: 0,
     timeout: 20000,
     browser: 'chrome',
   })
@@ -30,6 +30,7 @@ describe('Test Isolation', () => {
       cp.stdout.on('data', (buf) => {
         // TODO-KASPER: figure a new exit mechanism for this to pass
         if (buf.toString().includes('not exiting due to options.exit being false')) {
+        // if (buf.toString().includes('passes 3')) {
           // systemTests.it spawns a new node process which then spawns the actual cypress process
           // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
           childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
@@ -55,7 +56,8 @@ describe('Test Isolation', () => {
     noExit: true,
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
-        if (buf.toString().includes('not exiting due to options.exit being false')) {
+        if (buf.toString().includes('passes 3')) {
+        // if (buf.toString().includes('not exiting due to options.exit being false')) {
           // systemTests.it spawns a new node process which then spawns the actual cypress process
           // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
           childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -28,7 +28,6 @@ describe('Test Isolation', () => {
     noExit: true,
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
-        // TODO-KASPER: figure a new exit mechanism for this to pass
         if (buf.toString().includes('not exiting due to options.exit being false')) {
         // if (buf.toString().includes('passes 3')) {
           // systemTests.it spawns a new node process which then spawns the actual cypress process

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -29,7 +29,6 @@ describe('Test Isolation', () => {
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
         if (buf.toString().includes('not exiting due to options.exit being false')) {
-        // if (buf.toString().includes('passes 3')) {
           // systemTests.it spawns a new node process which then spawns the actual cypress process
           // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
           childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
@@ -55,8 +54,7 @@ describe('Test Isolation', () => {
     noExit: true,
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
-        if (buf.toString().includes('passes 3')) {
-        // if (buf.toString().includes('not exiting due to options.exit being false')) {
+        if (buf.toString().includes('not exiting due to options.exit being false')) {
           // systemTests.it spawns a new node process which then spawns the actual cypress process
           // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
           childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -12,7 +12,39 @@ describe('Test Isolation', () => {
     browser: 'chrome',
   })
 
-  systemTests.it('makes lasagna - false - true', {
+  systemTests.it('fires events in the right order with the right arguments - headed: true - noExit: true', {
+    config: {
+      env: {
+        'SHOULD_PAUSE': false,
+      },
+    },
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation.spec.js',
+    expectedExitCode: null,
+    timeout: 20000,
+    browser: 'chrome',
+    snapshot: true,
+    headed: true,
+    noExit: true,
+    onSpawn: (cp) => {
+      cp.stdout.on('data', (buf) => {
+        // TODO-KASPER: figure a new exit mechanism for this to pass
+        if (buf.toString().includes('not exiting due to options.exit being false')) {
+          // systemTests.it spawns a new node process which then spawns the actual cypress process
+          // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
+          childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
+          cp.kill()
+        }
+      })
+    },
+  })
+
+  systemTests.it('fires events in the right order with the right arguments - headed: false - noExit: true', {
+    config: {
+      env: {
+        'SHOULD_PAUSE': false,
+      },
+    },
     project: 'cypress-in-cypress',
     spec: 'test-isolation.spec.js',
     expectedExitCode: null,
@@ -33,66 +65,25 @@ describe('Test Isolation', () => {
     },
   })
 
-  // systemTests.it('makes lasagna - true - false', {
-  //   project: 'cypress-in-cypress',
-  //   spec: 'test-isolation.spec.js',
-  //   expectedExitCode: 1,
-  //   timeout: 20000,
-  //   browser: 'chrome',
-  //   snapshot: true,
-  //   headed: true,
-  //   noExit: false,
-  //   onSpawn: (cp) => {
-  //     cp.stdout.on('data', (buf) => {
-  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
-  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
-  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
-  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
-  //         cp.kill()
-  //       }
-  //     })
-  //   },
-  // })
+  systemTests.it('fires events in the right order with the right arguments - headed: false - noExit: false', {
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation.spec.js',
+    expectedExitCode: 0,
+    timeout: 20000,
+    browser: 'chrome',
+    snapshot: true,
+    headed: false,
+    noExit: false,
+  })
 
-  // systemTests.it('makes ravioli - false - false', {
-  //   project: 'cypress-in-cypress',
-  //   spec: 'test-isolation.spec.js',
-  //   expectedExitCode: 1,
-  //   timeout: 20000,
-  //   browser: 'chrome',
-  //   snapshot: true,
-  //   headed: false,
-  //   noExit: false,
-  //   onSpawn: (cp) => {
-  //     cp.stdout.on('data', (buf) => {
-  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
-  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
-  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
-  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
-  //         cp.kill()
-  //       }
-  //     })
-  //   },
-  // })
-
-  // systemTests.it('makes aribiatta - true - true', {
-  //   project: 'cypress-in-cypress',
-  //   spec: 'test-isolation.spec.js',
-  //   expectedExitCode: 1,
-  //   timeout: 20000,
-  //   browser: 'chrome',
-  //   snapshot: true,
-  //   headed: true,
-  //   noExit: true,
-  //   onSpawn: (cp) => {
-  //     cp.stdout.on('data', (buf) => {
-  //       if (buf.toString().includes('not exiting due to options.exit being false')) {
-  //         // systemTests.it spawns a new node process which then spawns the actual cypress process
-  //         // Killing just the new node process doesn't kill the cypress process so we find it and kill it manually
-  //         childProcess.execSync(`kill $(pgrep -P ${cp.pid} | awk '{print $1}')`)
-  //         cp.kill()
-  //       }
-  //     })
-  //   },
-  // })
+  systemTests.it('fires events in the right order with the right arguments - headed: true - noExit: false', {
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation.spec.js',
+    expectedExitCode: 0,
+    timeout: 20000,
+    browser: 'chrome',
+    snapshot: true,
+    headed: true,
+    noExit: false,
+  })
 })


### PR DESCRIPTION
### Additional details
Headed + NoExit was missed when converting the blank page navigation was moved to the end of the test execution

### Steps to test
1. Navigate to test project
2. Execute in test project `yarn cypress run --headed --no-exit`
3. Validate final test does not display blank page

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
