### PR TITLE
chore: release version 12.17.3

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 12.17.2
+## 12.17.3
 
 _Released 08/01/2023 (PENDING)_
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "12.17.2",
+  "version": "12.17.3",
   "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This PR bumps the Cypress version to 12.17.3