### PR TITLE
chore: modify highlight selector to include frameId

### DIFF
--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -181,11 +181,11 @@ describe('driver/src/cy/snapshots', () => {
         numTestsKeptInMemory: 0,
       }, function () {
         const element = $('<iframe id=\'frame-foo-bar\' src=\'generic.html\' />').appendTo(cy.$$('body'))
-        const { elToHighlightSelectors } = cy.createSnapshot(null, element)
+        const { elementsToHighlight } = cy.createSnapshot(null, element)
 
-        expect(elToHighlightSelectors.length).to.equal(1)
-        expect(elToHighlightSelectors[0].selector).to.equal('#frame-foo-bar')
-        expect(elToHighlightSelectors[0].frameId).to.equal(undefined)
+        expect(elementsToHighlight.length).to.equal(1)
+        expect(elementsToHighlight[0].selector).to.equal('#frame-foo-bar')
+        expect(elementsToHighlight[0].frameId).to.equal(undefined)
       })
     })
   })

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -183,7 +183,7 @@ describe('driver/src/cy/snapshots', () => {
         const ownerDoc = element[0].ownerDocument
         const elWindow = ownerDoc.defaultView
 
-        elWindow['__cypressProtocolMetadata'] = { frameId: 'test-frame-id' }
+        elWindow.__cypressProtocolMetadata = { frameId: 'test-frame-id' }
 
         const { elementsToHighlight } = cy.createSnapshot(null, element)
 

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -174,6 +174,26 @@ describe('driver/src/cy/snapshots', () => {
 
         expect(body.get().find('iframe').css('height')).to.equal('70px')
       })
+
+      // TODO-KASPER: add frame test here stubbing context
+      it('captures highlight elements with frameId', {
+        protocolEnabled: true,
+        numTestsKeptInMemory: 0,
+      }, function () {
+        // this.setup({ protocolEnabled: true, numTestsKeptInMemory: 0 })
+        // // this.setup({ animationDistanceThreshold: 10 })
+        // // cy.stub(Cypress.config, 'protocolEnabled').returns(true)
+        // // cy.stub(Cypress.config, 'numTestsKeptInMemory').returns(0)
+
+        //  $('<button type=\'button\' id=\'button-foo-bar\' />')
+
+        const element = $('<iframe id=\'frame-foo-bar\' src=\'generic.html\' />').appendTo(cy.$$('body'))
+        // element.appendTo(cy.$$('body'))
+
+        const snapshot = cy.createSnapshot(null, element)
+
+        expect(snapshot).to.equal({ selector: 'button-foo-bar', frameId: 'frame-foo-bar' })
+      })
     })
   })
 

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -180,19 +180,12 @@ describe('driver/src/cy/snapshots', () => {
         protocolEnabled: true,
         numTestsKeptInMemory: 0,
       }, function () {
-        // this.setup({ protocolEnabled: true, numTestsKeptInMemory: 0 })
-        // // this.setup({ animationDistanceThreshold: 10 })
-        // // cy.stub(Cypress.config, 'protocolEnabled').returns(true)
-        // // cy.stub(Cypress.config, 'numTestsKeptInMemory').returns(0)
-
-        //  $('<button type=\'button\' id=\'button-foo-bar\' />')
-
         const element = $('<iframe id=\'frame-foo-bar\' src=\'generic.html\' />').appendTo(cy.$$('body'))
-        // element.appendTo(cy.$$('body'))
+        const { elToHighlightSelectors } = cy.createSnapshot(null, element)
 
-        const snapshot = cy.createSnapshot(null, element)
-
-        expect(snapshot).to.equal({ selector: 'button-foo-bar', frameId: 'frame-foo-bar' })
+        expect(elToHighlightSelectors.length).to.equal(1)
+        expect(elToHighlightSelectors[0].selector).to.equal('#frame-foo-bar')
+        expect(elToHighlightSelectors[0].frameId).to.equal(undefined)
       })
     })
   })

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -175,17 +175,23 @@ describe('driver/src/cy/snapshots', () => {
         expect(body.get().find('iframe').css('height')).to.equal('70px')
       })
 
-      // TODO-KASPER: add frame test here stubbing context
       it('captures highlight elements with frameId', {
         protocolEnabled: true,
         numTestsKeptInMemory: 0,
       }, function () {
         const element = $('<iframe id=\'frame-foo-bar\' src=\'generic.html\' />').appendTo(cy.$$('body'))
+        const ownerDoc = element[0].ownerDocument
+        const elWindow = ownerDoc.defaultView
+
+        elWindow['__cypressProtocolMetadata'] = { frameId: 'test-frame-id' }
+
         const { elementsToHighlight } = cy.createSnapshot(null, element)
+
+        delete elWindow.__cypressProtocolMetadata
 
         expect(elementsToHighlight.length).to.equal(1)
         expect(elementsToHighlight[0].selector).to.equal('#frame-foo-bar')
-        expect(elementsToHighlight[0].frameId).to.equal(undefined)
+        expect(elementsToHighlight[0].frameId).to.equal('test-frame-id')
       })
     })
   })

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -177,8 +177,12 @@ describe('driver/src/cy/snapshots', () => {
 
       it('captures highlight elements with frameId', {
         protocolEnabled: true,
-        numTestsKeptInMemory: 0,
       }, function () {
+        const previousKept = Cypress.config('numTestsKeptInMemory')
+
+        // set value internal to test, headless default overrides the value
+        Cypress.config('numTestsKeptInMemory', 0)
+
         const element = $('<iframe id=\'frame-foo-bar\' src=\'generic.html\' />').appendTo(cy.$$('body'))
         const ownerDoc = element[0].ownerDocument
         const elWindow = ownerDoc.defaultView
@@ -190,8 +194,10 @@ describe('driver/src/cy/snapshots', () => {
         delete elWindow.__cypressProtocolMetadata
 
         expect(elementsToHighlight?.length).to.equal(1)
-        expect(elementsToHighlight[0].selector).to.equal('#frame-foo-bar')
-        expect(elementsToHighlight[0].frameId).to.equal('test-frame-id')
+        expect(elementsToHighlight?.[0].selector).to.equal('#frame-foo-bar')
+        expect(elementsToHighlight?.[0].frameId).to.equal('test-frame-id')
+
+        Cypress.config('numTestsKeptInMemory', previousKept)
       })
     })
   })

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -189,7 +189,7 @@ describe('driver/src/cy/snapshots', () => {
 
         delete elWindow.__cypressProtocolMetadata
 
-        expect(elementsToHighlight.length).to.equal(1)
+        expect(elementsToHighlight?.length).to.equal(1)
         expect(elementsToHighlight[0].selector).to.equal('#frame-foo-bar')
         expect(elementsToHighlight[0].frameId).to.equal('test-frame-id')
       })

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -253,14 +253,14 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
       const snapshot: {
         name: string
         timestamp: number
-        elToHighlightSelectors?: {
+        elementsToHighlight?: {
           selector: string
           frameId: string
         }[]
       } = { name, timestamp }
 
       if (isJqueryElement($elToHighlight)) {
-        snapshot.elToHighlightSelectors = $dom.unwrap($elToHighlight).flatMap((el: HTMLElement) => {
+        snapshot.elementsToHighlight = $dom.unwrap($elToHighlight).flatMap((el: HTMLElement) => {
           try {
             const ownerDoc = el.ownerDocument
             const elWindow = ownerDoc.defaultView
@@ -270,8 +270,7 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             }
 
             const selector = uniqueSelector(el)
-            const meta = elWindow['__cypressProtocolMetadata']
-            const frameId = meta ? JSON.parse(meta)?.frameId : undefined
+            const frameId = elWindow['__cypressProtocolMetadata']?.frameId
 
             return [{ selector, frameId }]
           } catch (e) {

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -266,17 +266,17 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             const elWindow = ownerDoc.defaultView
 
             if (elWindow === null) {
-              // TODO-KASPER: revert this
-              return ['test-window']
+              return []
             }
 
             const selector = uniqueSelector(el)
             const frameId = elWindow['__cypressProtocolMetadata']?.frameId
 
             return [{ selector, frameId }]
-          } catch {
+          } catch (e) {
             // the element may not always be found since it's possible for the element to be removed from the DOM
-            return []
+            // TODO-KASPER: revert this
+            return [e.message]
           }
         })
       }

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -279,6 +279,9 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             return [e.message]
           }
         })
+      } else {
+        // TODO-KASPER: revert this
+        snapshot.elementsToHighlight = ['aardvark']
       }
 
       Cypress.action('cy:protocol-snapshot')

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -265,36 +265,16 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             const ownerDoc = el.ownerDocument
             const elWindow = ownerDoc.defaultView
 
-            if (!elWindow) {
+            if (elWindow === null) {
               return []
             }
 
-            const stateDoc = Cypress.state('document')
-            const frameId = elWindow.frameElement?.id
-            let shouldAdd = false
+            const selector = uniqueSelector(el)
+            const meta = elWindow['__cypressProtocolMetadata']
+            const frameId = meta ? JSON.parse(meta)?.frameId : undefined
 
-            if (ownerDoc === stateDoc) {
-              shouldAdd = true
-            } else {
-              if (!elWindow.top) {
-                let currWindow = elWindow.parent
-
-                while (!currWindow.top) {
-                  if (currWindow.document === stateDoc) {
-                    shouldAdd = true
-                    break
-                  } else {
-                    currWindow = currWindow.parent
-                  }
-                }
-              }
-            }
-
-            // TODO-KASPER: could also check for frameId as it's part of the unique selector
-            if (shouldAdd) {
-              return [{ selector: uniqueSelector(el), frameId }]
-            }
-          } catch {
+            return [{ selector, frameId }]
+          } catch (e) {
             // the element may not always be found since it's possible for the element to be removed from the DOM
           }
 

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -266,7 +266,8 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             const elWindow = ownerDoc.defaultView
 
             if (elWindow === null) {
-              return []
+              // TODO-KASPER: revert this
+              return ['test-window']
             }
 
             const selector = uniqueSelector(el)

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -273,11 +273,10 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             const frameId = elWindow['__cypressProtocolMetadata']?.frameId
 
             return [{ selector, frameId }]
-          } catch (e) {
+          } catch {
             // the element may not always be found since it's possible for the element to be removed from the DOM
+            return []
           }
-
-          return []
         })
       }
 

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -273,15 +273,11 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             const frameId = elWindow['__cypressProtocolMetadata']?.frameId
 
             return [{ selector, frameId }]
-          } catch (e) {
+          } catch {
             // the element may not always be found since it's possible for the element to be removed from the DOM
-            // TODO-KASPER: revert this
-            return [e.message]
+            return []
           }
         })
-      } else {
-        // TODO-KASPER: revert this
-        snapshot.elementsToHighlight = [{ selector: 'aardvark', frameId: 'aardvark' }]
       }
 
       Cypress.action('cy:protocol-snapshot')

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -281,7 +281,7 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
         })
       } else {
         // TODO-KASPER: revert this
-        snapshot.elementsToHighlight = ['aardvark']
+        snapshot.elementsToHighlight = [{ selector: 'aardvark', frameId: 'aardvark' }]
       }
 
       Cypress.action('cy:protocol-snapshot')


### PR DESCRIPTION
Update snapshot API to return `elementsToHighlight`, an array of objects containing the a `selector` and `frameId`.

### Additional details
Test replay needs the ability to handle actions/highlights within nested iframes. Currently we are only capturing the selector which is only relative to the AUT frame.

### Steps to test
- set `protocolEnabled: true` and `numTestsKeptInMemory: 0` either within cypress config or on a individual test run
- in test execute action within iframe
        

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
