### PR TITLE
feat: remove protocol environment variable from binary

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-07-25-23
+08-10-23

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -31,7 +31,7 @@ mainBuildFilters: &mainBuildFilters
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
         - 'publish-binary'
-        - 'chore/merge_develop_into_release_13'
+        - 'ryanm/feat/remove-protocol-environment-variable-from-binary'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -42,7 +42,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/merge_develop_into_release_13', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/feat/remove-protocol-environment-variable-from-binary', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -54,7 +54,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'publish-binary', << pipeline.git.branch >> ]
-    - equal: [ 'chore/merge_develop_into_release_13', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/feat/remove-protocol-environment-variable-from-binary', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -74,7 +74,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/merge_develop_into_release_13', << pipeline.git.branch >> ]
+    - equal: [ 'ryanm/feat/remove-protocol-environment-variable-from-binary', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -144,7 +144,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "chore/merge_develop_into_release_13" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "ryanm/feat/remove-protocol-environment-variable-from-binary" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/packages/server/lib/cloud/api.ts
+++ b/packages/server/lib/cloud/api.ts
@@ -626,7 +626,6 @@ module.exports = {
   },
 
   getCaptureProtocolScript (url: string) {
-    // TODO(protocol): Ensure this is removed in production
     if (process.env.CYPRESS_LOCAL_PROTOCOL_PATH) {
       debugProtocol(`Loading protocol via script at local path %s`, process.env.CYPRESS_LOCAL_PROTOCOL_PATH)
 

--- a/scripts/binary/binary-sources.js
+++ b/scripts/binary/binary-sources.js
@@ -89,7 +89,7 @@ const getProtocolFileSource = async (protocolFilePath) => {
     throw new Error(`Expected to find CYPRESS_ENV_PROTOCOL in protocol file`)
   }
 
-  return fileContents.replace('process.env.CYPRESS_LOCAL_PROTOCOL_PATH', 'undefined')
+  return fileContents.replaceAll('process.env.CYPRESS_LOCAL_PROTOCOL_PATH', 'undefined')
 }
 
 const validateProtocolFile = async (protocolFilePath) => {

--- a/scripts/binary/binary-sources.js
+++ b/scripts/binary/binary-sources.js
@@ -86,7 +86,7 @@ const getProtocolFileSource = async (protocolFilePath) => {
   const fileContents = await fs.readFile(protocolFilePath, 'utf8')
 
   if (!fileContents.includes('process.env.CYPRESS_LOCAL_PROTOCOL_PATH')) {
-    throw new Error(`Expected to find CYPRESS_ENV_PROTOCOL in protocol file`)
+    throw new Error(`Expected to find CYPRESS_LOCAL_PROTOCOL_PATH in protocol file`)
   }
 
   return fileContents.replaceAll('process.env.CYPRESS_LOCAL_PROTOCOL_PATH', 'undefined')

--- a/scripts/binary/binary-sources.js
+++ b/scripts/binary/binary-sources.js
@@ -58,7 +58,7 @@ const validateEncryptionFile = async (encryptionFilePath) => {
   }
 }
 
-const getCloudApiFileSource = async (cloudApiFilePath) => {
+const getCloudEnvironmentFileSource = async (cloudApiFilePath) => {
   const fileContents = await fs.readFile(cloudApiFilePath, 'utf8')
 
   if (!fileContents.includes('process.env.CYPRESS_ENV_DEPENDENCIES')) {
@@ -72,7 +72,7 @@ const getCloudApiFileSource = async (cloudApiFilePath) => {
   return fileContents
 }
 
-const validateCloudApiFile = async (cloudApiFilePath) => {
+const validateCloudEnvironmentFile = async (cloudApiFilePath) => {
   if (process.env.CYPRESS_ENV_DEPENDENCIES) {
     const afterReplaceCloudApi = await fs.readFile(cloudApiFilePath, 'utf8')
 
@@ -82,11 +82,31 @@ const validateCloudApiFile = async (cloudApiFilePath) => {
   }
 }
 
+const getProtocolFileSource = async (protocolFilePath) => {
+  const fileContents = await fs.readFile(protocolFilePath, 'utf8')
+
+  if (!fileContents.includes('process.env.CYPRESS_LOCAL_PROTOCOL_PATH')) {
+    throw new Error(`Expected to find CYPRESS_ENV_PROTOCOL in protocol file`)
+  }
+
+  return fileContents.replace('process.env.CYPRESS_LOCAL_PROTOCOL_PATH', 'undefined')
+}
+
+const validateProtocolFile = async (protocolFilePath) => {
+  const afterReplaceProtocol = await fs.readFile(protocolFilePath, 'utf8')
+
+  if (afterReplaceProtocol.includes('process.env.CYPRESS_LOCAL_PROTOCOL_PATH')) {
+    throw new Error(`Expected process.env.CYPRESS_LOCAL_PROTOCOL_PATH to be stripped from protocol file`)
+  }
+}
+
 module.exports = {
   getBinaryEntryPointSource,
   getIntegrityCheckSource,
   getEncryptionFileSource,
-  getCloudApiFileSource,
-  validateCloudApiFile,
   validateEncryptionFile,
+  getCloudEnvironmentFileSource,
+  validateCloudEnvironmentFile,
+  getProtocolFileSource,
+  validateProtocolFile,
 }


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Remove the local protocol environment variable from the binary at binary build time. This will prevent third party code from being utilized in the place of our protocol.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Run:

```
CYPRESS_LOCAL_PROTOCOL_PATH=~/protocol/cypress-services/packages/app-capture-protocol/dist/index.js CYPRESS_CONFIG_ENV=staging DEBUG=cypress:*protocol* yarn cypress run --record
```

And ensure that the protocol uses the downloaded script instead of the local script

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
