### PR TITLE
chore: skip flaky scaffold-project test

### DIFF
--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -167,7 +167,8 @@ describe('scaffolding new projects', { defaultCommandTimeout: 7000 }, () => {
     assertScaffoldedFilesAreCorrect({ language, testingType: 'component', ctFramework: 'Create React App (v5)', customDirectory: 'without-fixtures' })
   })
 
-  it('generates valid config file for pristine project without cypress installed', () => {
+  // NOTE: Skipping this test because it is flaky
+  it.skip('generates valid config file for pristine project without cypress installed', () => {
     cy.intercept('mutation-ScaffoldedFiles_completeSetup').as('mutationScaffoldedFiles')
     cy.intercept('query-MainLaunchpadQuery').as('mainLaunchpadQuery')
     cy.intercept('query-HeaderBar_HeaderBarQuery').as('headerBarQuery')


### PR DESCRIPTION
This test skips a scaffold-project integration test that flaked in [this CI run](https://app.circleci.com/pipelines/github/cypress-io/cypress/55408/workflows/54372cd3-ae8d-43ce-8c1b-d5d85dc86d97/jobs/2293663/tests).

We don't have the resources to actually fix the test so let's skip it for now so that our CI is more deterministic and reliable.