### PR TITLE
chore: remove flaky Percy snapshot from scaffolding CT 3rd party

### DIFF
--- a/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
@@ -315,7 +315,8 @@ describe('scaffolding component testing', {
         cy.contains('cy-projects/qwik-app/node_modules/cypress-ct-bad-syntax/package.json').should('be.visible')
       })
 
-      cy.percySnapshot()
+      // Skipping the Percy snapshot here because it flakes
+      // cy.percySnapshot()
     })
   })
 })


### PR DESCRIPTION
This PR removes a flaky Percy snapshot from our test suite for scaffolding CT with 3rd party framework adapters

Flake example: https://percy.io/cypress-io/cypress/builds/29590891/changed/1641365946?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=800