### PR TITLE
chore: skip flaky go test in driver commands

### DIFF
--- a/packages/driver/cypress/e2e/e2e/origin/commands/navigation.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/navigation.cy.ts
@@ -424,7 +424,7 @@ context('cy.origin navigation', { browser: '!webkit' }, () => {
     })
 
     // TODO: Investigate this flaky test.
-    it('.go()', { retries: 15 }, () => {
+    it.skip('.go()', { retries: 15 }, () => {
       cy.visit('/fixtures/primary-origin.html')
       cy.get('a[data-cy="cross-origin-secondary-link"]').click()
 


### PR DESCRIPTION
This PR skips a flaky test in the driver integration tests. We left a comment on this test 10 months ago to investigate why it is flaky

Flake example: https://app.circleci.com/pipelines/github/cypress-io/cypress/55429/workflows/e092081a-a6da-42eb-9227-da35ca4c4aee/jobs/2294543/tests