### PR TITLE
fix: issue with describe level test isolation and navigating to about:blank

### DIFF
--- a/packages/app/cypress/e2e/reporter_header.cy.ts
+++ b/packages/app/cypress/e2e/reporter_header.cy.ts
@@ -13,7 +13,7 @@ describe('Reporter Header', () => {
       cy.get('body').type('f')
 
       cy.get('[data-selected-spec="true"]').should('contain', 'dom-content').should('have.length', '1')
-      cy.get('[data-selected-spec="false"]').should('have.length', '29')
+      cy.get('[data-selected-spec="false"]').should('have.length', '30')
     })
 
     // TODO: Reenable as part of https://github.com/cypress-io/cypress/issues/23902

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -152,7 +152,7 @@ describe('App: Spec List (E2E)', () => {
 
       it('displays only matching spec', function () {
         cy.get('button')
-        .contains('25 matches')
+        .contains('26 matches')
         .should('not.contain.text', 'of')
 
         clearSearchAndType('content')
@@ -160,13 +160,13 @@ describe('App: Spec List (E2E)', () => {
         .should('have.length', 3)
         .and('contain', 'dom-content.spec.js')
 
-        cy.get('button').contains('3 of 25 matches')
+        cy.get('button').contains('3 of 26 matches')
 
         cy.findByLabelText('Search specs').clear().type('asdf')
         cy.findAllByTestId('spec-item')
         .should('have.length', 0)
 
-        cy.get('button').contains('0 of 25 matches')
+        cy.get('button').contains('0 of 26 matches')
       })
 
       it('only shows matching folders', () => {
@@ -217,7 +217,7 @@ describe('App: Spec List (E2E)', () => {
         cy.findByLabelText('Search specs')
         .should('have.value', '')
 
-        cy.get('button').contains('25 matches')
+        cy.get('button').contains('26 matches')
       })
 
       it('clears the filter if the user presses ESC key', function () {
@@ -226,7 +226,7 @@ describe('App: Spec List (E2E)', () => {
 
         cy.get('@searchField').should('have.value', '')
 
-        cy.get('button').contains('25 matches')
+        cy.get('button').contains('26 matches')
       })
 
       it('shows empty message if no results', function () {
@@ -242,7 +242,7 @@ describe('App: Spec List (E2E)', () => {
         cy.findByText('Clear search').click()
         cy.focused().should('have.id', 'spec-filter')
 
-        cy.get('button').contains('25 matches')
+        cy.get('button').contains('26 matches')
       })
 
       it('normalizes directory path separators for Windows', function () {

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -76,6 +76,7 @@ describe('specChange subscription', () => {
           getPathForPlatform('cypress/e2e/admin_users/admin_users_list.spec.js'),
           getPathForPlatform('cypress/e2e/admin_users/admin.user/foo_list.spec.js'),
           getPathForPlatform('cypress/e2e/test-isolation.spec.js'),
+          getPathForPlatform('cypress/e2e/test-isolation-describe-config.spec.js'),
           getPathForPlatform('cypress/e2e/z001.spec.js'),
           getPathForPlatform('cypress/e2e/z002.spec.js'),
           getPathForPlatform('cypress/e2e/z003.spec.js'),
@@ -120,6 +121,7 @@ describe('specChange subscription', () => {
           getPathForPlatform('cypress/e2e/admin_users/admin_users_list.spec.js'),
           getPathForPlatform('cypress/e2e/admin_users/admin.user/foo_list.spec.js'),
           getPathForPlatform('cypress/e2e/test-isolation.spec.js'),
+          getPathForPlatform('cypress/e2e/test-isolation-describe-config.spec.js'),
           getPathForPlatform('cypress/e2e/z001.spec.js'),
           getPathForPlatform('cypress/e2e/z002.spec.js'),
           getPathForPlatform('cypress/e2e/z003.spec.js'),
@@ -190,7 +192,7 @@ e2e: {
 
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
-      .should('have.length', 25)
+      .should('have.length', 26)
       .should('contain', 'blank-contents.spec.js')
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -201,7 +203,7 @@ e2e: {
       }, { path: getPathForPlatform('cypress/e2e/new-file.spec.js') })
 
       cy.get('[data-cy="spec-file-item"]')
-      .should('have.length', 26)
+      .should('have.length', 27)
       .should('contain', 'blank-contents.spec.js')
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -216,7 +218,7 @@ e2e: {
 
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
-      .should('have.length', 25)
+      .should('have.length', 26)
       .should('contain', 'blank-contents.spec.js')
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -227,7 +229,7 @@ e2e: {
       }, { path: getPathForPlatform('cypress/e2e/dom-list.spec.js') })
 
       cy.get('[data-cy="spec-file-item"]')
-      .should('have.length', 24)
+      .should('have.length', 25)
       .should('contain', 'blank-contents.spec.js')
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -258,6 +260,7 @@ e2e: {
           getPathForPlatform('cypress/e2e/admin_users/admin_users_list.spec.js'),
           getPathForPlatform('cypress/e2e/admin_users/admin.user/foo_list.spec.js'),
           getPathForPlatform('cypress/e2e/test-isolation.spec.js'),
+          getPathForPlatform('cypress/e2e/test-isolation-describe-config.spec.js'),
           getPathForPlatform('cypress/e2e/z001.spec.js'),
           getPathForPlatform('cypress/e2e/z002.spec.js'),
           getPathForPlatform('cypress/e2e/z003.spec.js'),
@@ -289,7 +292,7 @@ e2e: {
 
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
-      .should('have.length', 25)
+      .should('have.length', 26)
       .should('contain', 'blank-contents.spec.js')
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -332,14 +335,14 @@ e2e: {
       cy.get('[data-cy="spec-pattern"]').contains('cypress/e2e/**/*.spec.{js,ts}')
 
       cy.get('[data-cy="file-match-indicator"]')
-      .should('contain', '25 matches')
+      .should('contain', '26 matches')
 
       cy.withCtx(async (ctx, o) => {
         await ctx.actions.file.writeFileInProject(o.path, '')
       }, { path: getPathForPlatform('cypress/e2e/new-file.spec.js') })
 
       cy.get('[data-cy="file-match-indicator"]')
-      .should('contain', '26 matches')
+      .should('contain', '27 matches')
     })
 
     it('responds to specChange event for a removed file', () => {
@@ -349,14 +352,14 @@ e2e: {
       cy.get('[data-cy="spec-pattern"]').contains('cypress/e2e/**/*.spec.{js,ts}')
 
       cy.get('[data-cy="file-match-indicator"]')
-      .should('contain', '25 matches')
+      .should('contain', '26 matches')
 
       cy.withCtx(async (ctx, o) => {
         await ctx.actions.file.removeFileInProject(o.path)
       }, { path: getPathForPlatform('cypress/e2e/dom-list.spec.js') })
 
       cy.get('[data-cy="file-match-indicator"]')
-      .should('contain', '24 matches')
+      .should('contain', '25 matches')
     })
 
     it('handles removing the last file', () => {
@@ -384,6 +387,7 @@ e2e: {
           getPathForPlatform('cypress/e2e/admin_users/admin_users_list.spec.js'),
           getPathForPlatform('cypress/e2e/admin_users/admin.user/foo_list.spec.js'),
           getPathForPlatform('cypress/e2e/test-isolation.spec.js'),
+          getPathForPlatform('cypress/e2e/test-isolation-describe-config.spec.js'),
           getPathForPlatform('cypress/e2e/z001.spec.js'),
           getPathForPlatform('cypress/e2e/z002.spec.js'),
           getPathForPlatform('cypress/e2e/z003.spec.js'),
@@ -414,7 +418,7 @@ e2e: {
       cy.get('[data-cy="spec-pattern"]').contains('cypress/e2e/**/*.spec.{js,ts}')
 
       cy.get('[data-cy="file-match-indicator"]')
-      .should('contain', '25 matches')
+      .should('contain', '26 matches')
 
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject('cypress.config.js',

--- a/packages/driver/src/cy/commands/sessions/index.ts
+++ b/packages/driver/src/cy/commands/sessions/index.ts
@@ -32,12 +32,12 @@ export default function (Commands, Cypress, cy) {
       }
     })
 
-    Cypress.on('test:before:after:run:async', () => {
-      if (!Cypress.config('testIsolation')) {
-        return
+    Cypress.on('test:before:after:run:async', (test, Cypress, { nextTestHasTestIsolationOn }) => {
+      if (nextTestHasTestIsolationOn) {
+        return navigateAboutBlank(true)
       }
 
-      return navigateAboutBlank()
+      return
     })
 
     Cypress.on('test:before:run:async', async () => {

--- a/packages/driver/src/cy/commands/sessions/index.ts
+++ b/packages/driver/src/cy/commands/sessions/index.ts
@@ -32,7 +32,7 @@ export default function (Commands, Cypress, cy) {
       }
     })
 
-    Cypress.on('test:before:after:run:async', (test, Cypress, { nextTestHasTestIsolationOn }) => {
+    Cypress.on('test:before:after:run:async', (test, Cypress, { nextTestHasTestIsolationOn }: {nextTestHasTestIsolationOn?: boolean} = {}) => {
       if (nextTestHasTestIsolationOn) {
         return navigateAboutBlank(true)
       }

--- a/packages/driver/src/cy/commands/sessions/index.ts
+++ b/packages/driver/src/cy/commands/sessions/index.ts
@@ -34,7 +34,7 @@ export default function (Commands, Cypress, cy) {
 
     Cypress.on('test:before:after:run:async', (test, Cypress, { nextTestHasTestIsolationOn }: {nextTestHasTestIsolationOn?: boolean} = {}) => {
       if (nextTestHasTestIsolationOn) {
-        return navigateAboutBlank(true)
+        return navigateAboutBlank({ inBetweenTestsAndNextTestHasTestIsolationOn: true })
       }
 
       return

--- a/packages/driver/src/cy/commands/sessions/utils.ts
+++ b/packages/driver/src/cy/commands/sessions/utils.ts
@@ -191,9 +191,11 @@ const getPostMessageLocalStorage = (specWindow, origins): Promise<any[]> => {
   })
 }
 
-function navigateAboutBlank () {
-  // Component testing does not support navigation and handles clearing the page via mount utils
-  if (Cypress.testingType === 'component' || !Cypress.config('testIsolation')) {
+function navigateAboutBlank (inBetweenTestsAndNextTestHasTestIsolationOn?: boolean) {
+  // Component testing never supports navigating to about:blank as that is handled by its unmount mechanism
+  // When test isolation is off we typically don't navigate to about blank; however if we are in between tests and the next
+  // test has test isolation on, we need to navigate to about blank to ensure the next test is not affected by the previous test
+  if (Cypress.testingType === 'component' || (!Cypress.config('testIsolation') && !inBetweenTestsAndNextTestHasTestIsolationOn)) {
     return Promise.resolve()
   }
 

--- a/packages/driver/src/cy/commands/sessions/utils.ts
+++ b/packages/driver/src/cy/commands/sessions/utils.ts
@@ -191,7 +191,7 @@ const getPostMessageLocalStorage = (specWindow, origins): Promise<any[]> => {
   })
 }
 
-function navigateAboutBlank (inBetweenTestsAndNextTestHasTestIsolationOn?: boolean) {
+function navigateAboutBlank ({ inBetweenTestsAndNextTestHasTestIsolationOn }: { inBetweenTestsAndNextTestHasTestIsolationOn?: boolean } = {}) {
   // Component testing never supports navigating to about:blank as that is handled by its unmount mechanism
   // When test isolation is off we typically don't navigate to about blank; however if we are in between tests and the next
   // test has test isolation on, we need to navigate to about blank to ensure the next test is not affected by the previous test

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -46,7 +46,7 @@ const duration = (before: Date, after: Date) => {
   return Number(before) - Number(after)
 }
 
-const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, additionalInfo?) => {
+const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, ...args) => {
   debug('fire: %o', { event })
   if (runnable._fired == null) {
     runnable._fired = {}
@@ -59,7 +59,7 @@ const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, additional
     return
   }
 
-  return Cypress.action(event, wrap(runnable), runnable, additionalInfo)
+  return Cypress.action(event, wrap(runnable), runnable, ...args)
 }
 
 const fired = (event: typeof RUNNER_EVENTS[number], runnable) => {
@@ -74,10 +74,10 @@ const testBeforeRunAsync = (test, Cypress) => {
   })
 }
 
-const testBeforeAfterRunAsync = (test, Cypress, additionalInfo) => {
+const testBeforeAfterRunAsync = (test, Cypress, ...args) => {
   return Promise.try(() => {
     if (!fired(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test)) {
-      return fire(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test, Cypress, additionalInfo)
+      return fire(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test, Cypress, ...args)
     }
   })
 }

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation-describe-config.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation-describe-config.spec.js
@@ -1,0 +1,132 @@
+const shouldAlwaysResetPage = (config) => {
+  const isRunMode = !config('isInteractive')
+  const isHeadedNoExit = config('browser').isHeaded && !config('exit')
+
+  return isRunMode && !isHeadedNoExit
+}
+
+const TEST_METADATA = {
+  'passes 1': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: 'about:blank',
+  },
+  'passes 2': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: '/cypress/e2e/dom-content.html',
+  },
+  'passes 3': {
+    start: '/cypress/e2e/dom-content.html',
+    firesTestBeforeAfterRunAsync: true,
+    end: '/cypress/e2e/dom-content.html',
+  },
+  'passes 4': {
+    start: '/cypress/e2e/dom-content.html',
+    firesTestBeforeAfterRunAsync: true,
+    end: 'about:blank',
+  },
+  'passes 5': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: 'about:blank',
+  },
+  'passes 6': {
+    start: 'about:blank',
+    firesTestBeforeAfterRunAsync: true,
+    end: shouldAlwaysResetPage(Cypress.config) ? 'about:blank' : '/cypress/e2e/dom-content.html',
+  },
+}
+
+let cypressEventsHandled = 0
+
+const testBeforeRun = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].start)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const testBeforeRunAsync = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].start)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const testBeforeAfterRunAsync = (Cypress, ...args) => {
+  expect(TEST_METADATA[args[1].title].firesTestBeforeAfterRunAsync).to.be.true
+  cypressEventsHandled += 1
+}
+
+const testAfterRun = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].end)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const testAfterRunAsync = (Cypress, ...args) => {
+  expect(Cypress.state('window').location.href.endsWith(TEST_METADATA[args[1].title].end)).to.equal(true)
+  cypressEventsHandled += 1
+}
+
+const cypressEvents = [
+  ['test:before:run', testBeforeRun],
+  ['test:before:run:async', testBeforeRunAsync],
+  ['test:before:after:run:async', testBeforeAfterRunAsync],
+  ['test:after:run', testAfterRun],
+  ['test:after:run:async', testAfterRunAsync],
+]
+
+cypressEvents.forEach(([event, handler]) => {
+  Cypress.prependListener(event, (...args) => {
+    handler(Cypress, ...args)
+  })
+})
+
+Cypress.on('test:after:run:async', async (test) => {
+  if (test.title === 'passes 1') {
+    expect(cypressEventsHandled).to.equal(5)
+  } else if (test.title === 'passes 2') {
+    expect(cypressEventsHandled).to.equal(10)
+  } else if (test.title === 'passes 3') {
+    expect(cypressEventsHandled).to.equal(15)
+  } else if (test.title === 'passes 4') {
+    expect(cypressEventsHandled).to.equal(20)
+  } else if (test.title === 'passes 5') {
+    expect(cypressEventsHandled).to.equal(25)
+  } else if (test.title === 'passes 6') {
+    expect(cypressEventsHandled).to.equal(!shouldAlwaysResetPage(Cypress.config) ? 29 : 30)
+  }
+})
+
+describe('test isolation', () => {
+  beforeEach(() => {
+    cy.visit('cypress/e2e/dom-content.html')
+  })
+
+  describe('suite 1', { testIsolation: true }, () => {
+    it('passes 1', () => {
+      expect(true).to.equal(true)
+    })
+
+    it('passes 2', () => {
+      expect(true).to.equal(true)
+    })
+  })
+
+  describe('suite 2', { testIsolation: false }, () => {
+    it('passes 3', () => {
+      expect(true).to.equal(true)
+    })
+
+    it('passes 4', () => {
+      expect(true).to.equal(true)
+    })
+  })
+
+  describe('suite 3', { testIsolation: true }, () => {
+    it('passes 5', () => {
+      expect(true).to.equal(true)
+    })
+
+    it('passes 6', () => {
+      expect(true).to.equal(true)
+    })
+  })
+})

--- a/system-tests/test/test_isolation_spec.ts
+++ b/system-tests/test/test_isolation_spec.ts
@@ -12,6 +12,14 @@ describe('Test Isolation', () => {
     browser: 'chrome',
   })
 
+  systemTests.it('fires events in the right order with the right arguments when overridden within the spec - run mode', {
+    project: 'cypress-in-cypress',
+    spec: 'test-isolation-describe-config.spec.js',
+    expectedExitCode: 0,
+    timeout: 20000,
+    browser: 'chrome',
+  })
+
   systemTests.it('fires events in the right order with the right arguments - headed: true - noExit: true', {
     config: {
       env: {


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fix issue with describe-level test isolation and navigating to about:blank. We need to ensure that we honor the *next* test's config when determining whether or not to navigate to about:blank at the end of the current test. This will allow an individual test to be isolated or not from previous tests

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The new system test specifies the scenario.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
