### PR TITLE
chore: remove flaky Percy snapshot from global-mode spec

### DIFF
--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -117,8 +117,6 @@ describe('Launchpad: Global Mode', () => {
       const projectList = ['todos', 'ids', 'cookies', 'plugin-empty']
 
       setupAndValidateProjectsList(projectList)
-
-      cy.percySnapshot()
     })
 
     it('takes user to the next step when clicking on a project card', () => {


### PR DESCRIPTION
This PR removes a Percy snapshot from the `global-mode` spec because it flakes on showing the version number. We already make a bunch of assertions on the content here.

Flake example: https://percy.io/cypress-io/cypress/builds/29594711/changed/1641650644?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=400%2C800