### PR TITLE
chore: remove flaky Percy snapshot from ConfigCode spec

### DIFF
--- a/packages/app/src/settings/project/ConfigCode.cy.tsx
+++ b/packages/app/src/settings/project/ConfigCode.cy.tsx
@@ -119,9 +119,6 @@ describe('<ConfigCode />', () => {
         .should('be.visible')
         .should('contain.text', 'env')
       })
-
-      // Take a snapshot of the last case
-      cy.percySnapshot()
     })
   })
 

--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -117,6 +117,8 @@ describe('Launchpad: Global Mode', () => {
       const projectList = ['todos', 'ids', 'cookies', 'plugin-empty']
 
       setupAndValidateProjectsList(projectList)
+
+      cy.percySnapshot()
     })
 
     it('takes user to the next step when clicking on a project card', () => {

--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -117,8 +117,6 @@ describe('Launchpad: Global Mode', () => {
       const projectList = ['todos', 'ids', 'cookies', 'plugin-empty']
 
       setupAndValidateProjectsList(projectList)
-
-      cy.percySnapshot()
     })
 
     it('takes user to the next step when clicking on a project card', () => {


### PR DESCRIPTION
This PR removes a flaky Percy snapshot from the CodeConfig spec.

Flake example: https://percy.io/cypress-io/cypress/builds/29576061/changed/1640726573?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=800&widths=800