### PR TITLE
chore: skip flaky system tests

### DIFF
--- a/system-tests/test/cdp_spec.ts
+++ b/system-tests/test/cdp_spec.ts
@@ -20,5 +20,6 @@ describe('e2e cdp', function () {
     project: 'remote-debugging-disconnect',
     spec: 'spec.cy.ts',
     browser: 'chrome',
+    skip: true, // TODO: Investigate and unskip flaky test
   })
 })

--- a/system-tests/test/screenshot_fullpage_capture_spec.js
+++ b/system-tests/test/screenshot_fullpage_capture_spec.js
@@ -24,5 +24,6 @@ describe('e2e screenshot fullPage capture', () => {
   systemTests.it('passes', {
     spec: 'screenshot_fullpage_capture.cy.js',
     snapshot: true,
+    browser: '!firefox', // This test is flaky on Firefox
   })
 })


### PR DESCRIPTION
This PR skips and restricts browsers for a couple of flaky system tests

Flake example: https://app.circleci.com/pipelines/github/cypress-io/cypress/55474/workflows/9b03aa8b-1965-45c9-b989-0d07daf9a0e9