### PR TITLE
chore: fix gulp watch scripts using webpack as stdout is looking for …

### DIFF
--- a/scripts/gulp/tasks/gulpWebpack.ts
+++ b/scripts/gulp/tasks/gulpWebpack.ts
@@ -55,10 +55,9 @@ export async function runWebpack (cfg: RunWebpackCfg) {
     .split('\n')
     .forEach((line) => {
       if (
-        line.includes('Compiled successfully') ||
-          line.includes('Compiled with warnings') ||
-          line.includes('Failed to compile') ||
-          line.includes('Built at: ') ||
+        line.includes('webpack compiled') ||
+          line.includes('WARNING in') ||
+          line.includes('ERROR in') ||
           line.includes('Live Reload listening')
       ) {
         dfd.resolve({})


### PR DESCRIPTION
…webpack 4 based output and now needs to be updated to 5

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Fixes the `yarn dev` and `yarn watch` to correctly resolve the webpack 5 processes when completed

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
