### PR TITLE
chore: release version 12.17.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 12.17.4
 
-_Released 08/15/2023 (PENDING)_
+_Released 08/15/2023_
 
 **Bugfixes:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "12.17.3",
+  "version": "12.17.4",
   "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This PR bumps the package version and updates the `CHANGELOG` for release `12.17.4`
