### PR TITLE
chore: parallelize test-binary-against-recipes CI step

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2383,10 +2383,12 @@ jobs:
 
   test-binary-against-recipes:
     <<: *defaults
+    parallelism: 4
     steps:
       - test-binary-against-repo:
           repo: cypress-example-recipes
-          command: npm run test:ci
+          # Split the specs up across 4 different machines to run in parallel
+          command: npm run test:ci -- --chunk $CIRCLE_NODE_INDEX --total-chunks $CIRCLE_NODE_TOTAL
 
   # This is a special job. It allows you to test the current
   # built test runner against a pull request in the repo

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "internal-scripts",
+  "version": "0.0.0-development",
   "scripts": {
     "lint": "eslint --ext .js,.ts,.json, ."
   }

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn clean && gulp postinstall && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'patch-package && yarn clean && gulp postinstall',
+  ci: 'patch-package && gulp postinstall && yarn build',
 }
 
 execSync(postInstallCommands[executionEnv], {

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn clean && gulp postinstall && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'patch-package && yarn clean && gulp postinstall && yarn build',
+  ci: 'patch-package && yarn clean && gulp postinstall && yarn build && V8_SNAPSHOT_DISABLE_MINIFY=1 yarn build-v8-snapshot-prod',
 }
 
 execSync(postInstallCommands[executionEnv], {

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn clean && gulp postinstall && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'patch-package && gulp postinstall && yarn build',
+  ci: 'patch-package && yarn clean && gulp postinstall && yarn build',
 }
 
 execSync(postInstallCommands[executionEnv], {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/27521

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

According to CircleCI insights, `test-binary-against-recipes` is the longest-running job that we have in our CI pipeline (it only runs on `develop` and other branches specified in `mainBuildFilters`). It's p95 runtime for the past 30 days is 25m 14s. Because it runs in parallel with the rest of the binary tasks, we need to wait for it to complete to release Cypress, re-run the workflow from failed, etc. This adds a lot of time to our development cycle.

This PR uses the existing [chunking logic](https://github.com/cypress-io/cypress-example-recipes/blob/master/test-examples.js#L24) in the `test-examples.js` script in cypress-example-recipes to split these tests across 4 machines. This brings the runtime in line with the rest of the binary steps, so we're not over-optimizing, just optimizing enough so that the runtime for all of the binary steps are within 1 minute or so of eachother.

This should significantly decrease the average runtime for our `linux-x64` workflow on `develop`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Look at the CI runs for this branch and specifically the `test-binary-against-recipes` job.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
