### PR TITLE
chore: remove Typescript dependency from app node_modules in binary

### DIFF
--- a/scripts/binary/binary-cleanup.js
+++ b/scripts/binary/binary-cleanup.js
@@ -242,8 +242,8 @@ const buildEntryPointAndCleanup = async (buildAppDir) => {
     path.join(buildAppDir, '**', 'plist', 'dist'),
     // Remove yarn locks
     path.join(buildAppDir, '**', 'yarn.lock'),
-    // Remove Nx cache
-    path.join(buildAppDir, 'node_modules', '.cache'),
+    // Remove Typescript dependency
+    path.join(buildAppDir, '**', 'node_modules', 'typescript'),
   ], { force: true })
 
   // 7. Remove any empty directories as a result of the rest of the cleanup

--- a/scripts/binary/binary-cleanup.js
+++ b/scripts/binary/binary-cleanup.js
@@ -242,6 +242,8 @@ const buildEntryPointAndCleanup = async (buildAppDir) => {
     path.join(buildAppDir, '**', 'plist', 'dist'),
     // Remove yarn locks
     path.join(buildAppDir, '**', 'yarn.lock'),
+    // Remove Nx cache
+    path.join(buildAppDir, 'node_modules', '.cache'),
   ], { force: true })
 
   // 7. Remove any empty directories as a result of the rest of the cleanup


### PR DESCRIPTION
For some reason, the [Lerna 6 upgrade commit](https://github.com/cypress-io/cypress/commit/9e60aeba8fd9691568e82e0ff1adf6afb4f9aaa0) added Typescript into production dependencies that made it into the binary. This increased the size of the zip by ~11MB (compressed).

This PR adds a line to the binary cleanup script to remove this dependency before shipping the binary. This will bring the size back down to what it was before the commit was merged. We should investigate more to determine why the Typescript dependency is in `packages/app/node_modules`, but for now this is a quick fix to allow us to move forward with the v13 release.