### PR TITLE
chore: skip running ct mount hover test against angular-14 project

### DIFF
--- a/packages/app/cypress/e2e/runner/reporter-ct-mount-hover.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter-ct-mount-hover.cy.ts
@@ -3,7 +3,7 @@ import type { fixtureDirs } from '@tooling/system-tests'
 type ProjectDirs = typeof fixtureDirs
 
 const PROJECTS: {projectName: ProjectDirs[number], test: string}[] = [
-  { projectName: 'angular-14', test: 'app.component' },
+  // TODO: Flaky { projectName: 'angular-14', test: 'app.component' },
   // TODO: Flaky. { projectName: 'vueclivue2-configured', test: 'HelloWorld.cy' },
   { projectName: 'react-vite-ts-configured', test: 'App.cy' },
   { projectName: 'react18', test: 'App.cy' },


### PR DESCRIPTION
This PR skips a project that is particularly flaky in the CT mount hover tests, the angular-14 project.

Flake example: https://app.circleci.com/pipelines/github/cypress-io/cypress/55775/workflows/e54c104c-9c96-43b2-992d-fb747454fc43/jobs/2311376/tests#failed-test-0