### PR TITLE
chore: skip flaky component test for selector playground

### DIFF
--- a/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
+++ b/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
@@ -180,7 +180,8 @@ describe('SelectorPlayground', () => {
     })
   })
 
-  it('shows tooltips when buttons are focused', () => {
+  // TODO: fix this flaky test
+  it.skip('shows tooltips when buttons are focused', () => {
     mountSelectorPlayground()
 
     cy.get('[data-cy="playground-toggle"]').focus()


### PR DESCRIPTION
This PR disables a flaky component test around selector playground

Flake example: https://app.circleci.com/pipelines/github/cypress-io/cypress/55919/workflows/47c157fc-70a4-44d6-bd0c-ce10106cca9e/jobs/2317227/tests#failed-test-0