### PR TITLE
chore: fix get-published-artifact script

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -57,7 +57,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
     - equal: [ 'chore/bump_loaders_and_optimize_webpack', << pipeline.git.branch >> ]
-    - equal: [ 'bump-circle-cache', << pipeline.git.branch >> ]
+    - equal: [ 'astone123/fix-get-published-artifacts', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2119,7 +2119,7 @@ jobs:
           name: Download binary artifacts
           command: |
             source ./scripts/ensure-node.sh
-            node ./scripts/binary/get-published-artifacts.js --pipelineInfo ~/triggered_pipeline.json
+            node ./scripts/binary/get-published-artifacts.js --pipelineInfo ~/triggered_pipeline.json --platformKey $(node ./scripts/get-platform-key.js)
       - persist_to_workspace:
           root: ~/
           paths:

--- a/scripts/binary/get-published-artifacts.js
+++ b/scripts/binary/get-published-artifacts.js
@@ -7,7 +7,13 @@ const chalk = require('chalk')
 
 const execPromise = util.promisify(exec)
 
-const artifactJobName = 'publish-binary'
+const getArtifactJobName = (platformKey) => {
+  if (platformKey === 'linux-x64') {
+    return 'linux-amd-publish-binary'
+  }
+
+  return 'publish-binary'
+}
 
 const urlPaths = [
   '~/cypress/binary-url.json',
@@ -91,6 +97,8 @@ async function downloadArtifact (url, path) {
 
 async function run (args) {
   const options = minimist(args)
+
+  const artifactJobName = getArtifactJobName(options.platformKey)
 
   const pipelineInfoFilePath = options.pipelineInfo
 

--- a/scripts/unit/binary/get-published-artifacts-spec.js
+++ b/scripts/unit/binary/get-published-artifacts-spec.js
@@ -19,11 +19,11 @@ describe('get-published-artifacts', () => {
 
     const getPipelineIdStub = sinon.stub(getPublishedArtifactsModule, 'getPipelineId').returns('abc123')
     const getWorkflowsStub = sinon.stub(getPublishedArtifactsModule, 'getWorkflows').returns([{ id: 'my-workflow', name: 'linux-x64', status: 'success' }])
-    const getWorkflowJobsStub = sinon.stub(getPublishedArtifactsModule, 'getWorkflowJobs').returns([{ name: 'publish-binary', job_number: 2 }])
+    const getWorkflowJobsStub = sinon.stub(getPublishedArtifactsModule, 'getWorkflowJobs').returns([{ name: 'linux-amd-publish-binary', job_number: 2 }])
     const getJobArtifactsStub = sinon.stub(getPublishedArtifactsModule, 'getJobArtifacts').returns(mockArtifacts)
     const downloadArtifactStub = sinon.stub(getPublishedArtifactsModule, 'downloadArtifact')
 
-    await getPublishedArtifactsModule.run(['--pipelineInfo', 'foo'])
+    await getPublishedArtifactsModule.run(['--pipelineInfo', 'foo', '--platformKey', 'linux-x64'])
 
     expect(getPipelineIdStub).to.have.been.calledWith('foo')
     expect(getWorkflowsStub).to.have.been.calledWith('abc123')


### PR DESCRIPTION
I recently made some updates to the workflow names in cypress-publish-binary and didn't update the script that gets the artifacts from the job. This PR updates the script to pull the artifacts from the correct job based on the platform key.