### PR TITLE
fix: resolve process/browser to process/browser.js to resolve correct…

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,9 +30,9 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'chore/update_webpack_deps_to_latest_webpack4_compat'
-        - 'fix/pnp_discovery'
-        - 'publish-binary'
+        - 'fix/resolve_browser_process_correctly_for_mjs'
+        - 'chore/bump_loaders_and_optimize_webpack'
+        - 'bump-circle-cache'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -43,8 +43,8 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
-    - equal: [ 'fix/pnp_discovery', << pipeline.git.branch >> ]
+    - equal: [ 'fix/resolve_browser_process_correctly_for_mjs', << pipeline.git.branch >> ]
+    - equal: [ 'bump-circle-cache', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -55,9 +55,9 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
-    - equal: [ 'fix/pnp_discovery', << pipeline.git.branch >> ]
-    - equal: [ 'publish-binary', << pipeline.git.branch >> ]
+    - equal: [ 'fix/resolve_browser_process_correctly_for_mjs', << pipeline.git.branch >> ]
+    - equal: [ 'chore/bump_loaders_and_optimize_webpack', << pipeline.git.branch >> ]
+    - equal: [ 'astone123/fix-get-published-artifacts', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -77,8 +77,8 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
-    - equal: [ 'fix/pnp_discovery', << pipeline.git.branch >> ]
+    - equal: [ 'fix/resolve_browser_process_correctly_for_mjs', << pipeline.git.branch >> ]
+    - equal: [ 'bump-circle-cache', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -148,7 +148,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "fix/pnp_discovery" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "fix/resolve_browser_process_correctly_for_mjs" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 08/29/2023 (PENDING)_
 
 - Only force CommonJS when running `ts-node` with a `TS_NODE_COMPILER` environment variable, such as when Cypress uses `ts-node` internally. This solves an issue where Cypress' internal `tsconfig` conflicts with properties set in the user's `tsconfig.json` such as `module` and `moduleResolution`. Fixes [#26308](https://github.com/cypress-io/cypress/issues/26308) and [#27448](https://github.com/cypress-io/cypress/issues/27448).
 - Clarified Svelte 4 works correctly with Component Testing and updated dependencies checks to reflect this. It was incorrectly flagged as not supported. Fixes [#27465](https://github.com/cypress-io/cypress/issues/27465).
+- Resolve the `process/browser` global inside `@cypress/webpack-batteries-included-preprocessor` to resolve to `process/browser.js` in order to explicitly provide the file extension. File resolution must include the extension for `.mjs` and `.js` files inside ESM packages in order to resolve correctly. Fixes[#27599](https://github.com/cypress-io/cypress/issues/27599).
 - Fixed an issue where the correct `pnp` process was not being discovered. Fixes [#27562](https://github.com/cypress-io/cypress/issues/27562).
 
 ## 12.17.4

--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -135,7 +135,15 @@ const getDefaultWebpackOptions = () => {
     plugins: [
       new webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
-        process: 'process/browser',
+        // As of Webpack 5, a new option called resolve.fullySpecified, was added.
+        // This option means that a full path, in particular to .mjs / .js files
+        // in ESM packages must have the full path of an import specified.
+        // Otherwise, compilation fails as this option defaults to true.
+        // This means we need to adjust our global injections to always
+        // resolve to include the full file extension if a file resolution is provided.
+        // @see https://github.com/cypress-io/cypress/issues/27599
+        // @see https://webpack.js.org/configuration/module/#resolvefullyspecified
+        process: 'process/browser.js',
       }),
     ],
     resolve: {
@@ -163,7 +171,7 @@ const getDefaultWebpackOptions = () => {
         path: require.resolve('path-browserify'),
         perf_hooks: false,
         punycode: require.resolve('punycode/'),
-        process: require.resolve('process/browser'),
+        process: require.resolve('process/browser.js'),
         querystring: require.resolve('querystring-es3'),
         readline: false,
         repl: false,

--- a/npm/webpack-batteries-included-preprocessor/test/fixtures/mjs_spec.mjs
+++ b/npm/webpack-batteries-included-preprocessor/test/fixtures/mjs_spec.mjs
@@ -1,3 +1,8 @@
 import { expect } from 'chai'
 
+// make sure built in resolves correctly in mjs through the provide plugin, including process & buffer
+process.env.foo = 'bar'
+
+const buffer = new Buffer('foo');
+
 expect(true).to.be.true

--- a/packages/web-config/webpack.config.base.ts
+++ b/packages/web-config/webpack.config.base.ts
@@ -126,7 +126,7 @@ export const getCommonConfig = () => {
         net: false,
         os: require.resolve('os-browserify/browser'),
         path: require.resolve('path-browserify'),
-        process: require.resolve('process/browser'),
+        process: require.resolve('process/browser.js'),
         stream: require.resolve('stream-browserify'),
         tls: false,
         url: require.resolve('url/'),
@@ -240,7 +240,15 @@ export const getCommonConfig = () => {
       // @see https://gist.github.com/ef4/d2cf5672a93cf241fd47c020b9b3066a#polyfilling-globals
       new webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
-        process: 'process/browser',
+        // As of Webpack 5, a new option called resolve.fullySpecified, was added.
+        // This option means that a full path, in particular to .mjs / .js files
+        // in ESM packages must have the full path of an import specified.
+        // Otherwise, compilation fails as this option defaults to true.
+        // This means we need to adjust our global injections to always
+        // resolve to include the full file extension if a file resolution is provided.
+        // @see https://github.com/cypress-io/cypress/issues/27599
+        // @see https://webpack.js.org/configuration/module/#resolvefullyspecified
+        process: 'process/browser.js',
       }),
       ...(liveReloadEnabled ? [new LiveReloadPlugin({ appendScriptTag: true, port: 0, hostname: 'localhost', protocol: 'http' })] : []),
     ],
@@ -265,7 +273,7 @@ export const getSimpleConfig = () => ({
       net: false,
       os: require.resolve('os-browserify/browser'),
       path: require.resolve('path-browserify'),
-      process: require.resolve('process/browser'),
+      process: require.resolve('process/browser.js'),
       stream: require.resolve('stream-browserify'),
       tls: false,
       url: require.resolve('url/'),


### PR DESCRIPTION
…ly in ESM packages where .mjs or .js files exist where process is being used and globally imported

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27599

### Additional details

As of Webpack 5, a new option called [resolve.fullySpecified](https://webpack.js.org/configuration/module/#resolvefullyspecified) was added. This option means that a full path, in particular to `.mjs` / `.js` files in ESM packages must have the full path of an import specified. Otherwise, compilation fails as this option defaults to `true`. This means we need to adjust our global injections to always resolve to include the full file extension if a file resolution is provided. The addition of this option was missing in the migration guide and none of our tests caught it, which is why we missed it. Regression tests have been added to the preprocessor to make sure this is resolved correctly and doesn't regress in the future

### Steps to test
run the tests inside `npm/webpack-batteries-included-preprocessor`. If you revert the changes inside `index.js` in the package, the tests should fail inside the `.mjs` extension.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
