### PR TITLE
chore: bump number of machines for binary-system-tests

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-08-19-23
+08-21-23

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -215,6 +215,11 @@ commands:
     description: Save entire folder as artifact for other jobs to run without reinstalling
     steps:
       - run:
+          name: Patch packages
+          command: |
+            source ./scripts/ensure-node.sh
+            yarn patch-package
+      - run:
           name: Build all codegen
           command: |
             source ./scripts/ensure-node.sh

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -368,7 +368,7 @@ commands:
             # avoid installing Percy's Chromium every time we use @percy/cli
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
-            yarn --prefer-offline --frozen-lockfile --ignore-scripts --cache-folder ~/.yarn
+            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1638,7 +1638,7 @@ jobs:
       - update_cached_system_tests_deps
 
   binary-system-tests:
-    parallelism: 2
+    parallelism: 3
     working_directory: ~/cypress
     environment:
       <<: *defaultsEnvironment

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -363,7 +363,7 @@ commands:
             # avoid installing Percy's Chromium every time we use @percy/cli
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
-            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
+            yarn --prefer-offline --frozen-lockfile --ignore-scripts --cache-folder ~/.yarn
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1643,7 +1643,7 @@ jobs:
       - update_cached_system_tests_deps
 
   binary-system-tests:
-    parallelism: 3
+    parallelism: 4
     working_directory: ~/cypress
     environment:
       <<: *defaultsEnvironment


### PR DESCRIPTION
This PR bumps the number of parallel machines for the binary-system-tests job from 2 to 3 in order to speed up PR feedback time. This job is about 5 minutes longer on average than all of the other jobs that run in parallel with it, so it increases the overall runtime of the workflow by that much.

By decreasing the runtime of this job by running a 3rd machine in parallel, we can decrease the overall runtime of the workflow.