### PR TITLE
BREAKING: add breaking changes/deprecations to cypress dependencies, …

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,8 @@ _Released 08/22/2023 (PENDING)_
 - The properties and values returned by the [Module API](https://docs.cypress.io/guides/guides/module-api) and included in the arguments of handlers for the [`after:run`](https://docs.cypress.io/api/plugins/after-run-api) and  [`after:spec`](https://docs.cypress.io/api/plugins/after-spec-api) have been changed to be more consistent. Addresses [#23805](https://github.com/cypress-io/cypress/issues/23805).
 - For Cypress Cloud runs with Test Replay enabled, the Cypress Runner UI is now hidden during the run since the Runner will be visible during Test Replay. As such, if video is recorded (which is now defaulted to `false`) during the run, the Runner will not be visible. In addition, if a runner screenshot (`cy.screenshot({ capture: runner })`) is captured, it will no longer contain the Runner.
 - Upgraded [`@cypress/request`](https://www.npmjs.com/package/@cypress/request) from `^2.88.11` to `^3.0.0`. Redirects between http and https are no longer supported by [`cy.visit()`](/api/commands/visit) and [`cy.request()`](/api/commands/request). Addresses [#27535](https://github.com/cypress-io/cypress/issues/27535). Addressed in [#27495](https://github.com/cypress-io/cypress/pull/27495).
+- Node 14 support has been removed and Node 16 support has been deprecated. Node 16 may continue to work with Cypress `v13`, but will not be supported moving forward to closer coincide with [Node 16's end-of-life](https://nodejs.org/en/blog/announcements/nodejs16-eol) schedule. It is recommended that users update to at least Node 18.
+- The minimum supported Typescript version is `4.x`.
 
 **Features:**
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -124,7 +124,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+    "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
   },
   "types": "types",
   "exports": {

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 3.9
+// TypeScript Version: 4.3
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />

--- a/system-tests/test-binary/ci_environments_spec.ts
+++ b/system-tests/test-binary/ci_environments_spec.ts
@@ -24,12 +24,6 @@ describe('e2e binary CI environments', () => {
     },
   )
 
-  // TODO: Where is this image located? Needs to be bumped to Node 16.16.0 or later
-  smokeTestDockerImage(
-    'bare xvfb image fails',
-    'cypressinternal/xvfb:12.13.0', 1,
-  )
-
   smokeTestDockerImage(
     'ubuntu 20 passes',
     'cypress/base-internal:ubuntu20-node16', 0,


### PR DESCRIPTION
…such as typescript, node, and TLS, that may affect users moving foward on v13

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
In order to get ahead of the Electron update and account for known breaking changes ahead of time, we want to remove/deprecate support for TLS, node versions, and typescript ahead of time so we don't have to publish a breaking change with the electron update, which includes an update to Node 18. These deprecations/removals include

* Removal of Node 14 from the CLI engine. We haven't support Node 14 for a while and it isn't in our documentation for official support. This change simply makes sure users are on at least Node 16 when running Cypress
* Deprecation of Node 16. Node 16 will be going EOL on 9/11/2023. To coincide with Node's EOL, we think its best to deprecate support of 16 moving forward. Cypress may still work with Node 16 (and likely will for 95% of users on this version even after the electron upgrade), but we do not want to guarantee support of a Node version no longer being actively maintained in 3-4 weeks.
* The minimum supported Typescript version is `4.x` to guarantee compatibility with Node 18 types. The `@types/node` change will take place when the electron update lands. Typescript `3.x` hasn't been updated in 3 years and isn't used by many (most are on v5)
* Pointing users to the right resolution if using `TLS` versions `1.0` and `1.1` and are on node 18. This is mainly due to the change in supported ciphers between Node 16 and Node 18, where `TLS` versions `1.0` and `1.1` require disabled ciphers. The cypress proxy server still supports these versions, but the cipher in node needs to be enabled. This can we worked around by users if they pass in `--tls-cipher-list=DEFAULT@SECLEVEL=0` into their `NODE_OPTIONS`, such as:
     NODE_OPTIONS="--tls-cipher-list=DEFAULT@SECLEVEL=0" yarn

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/5434
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
