### PR TITLE
chore: minor improvements to node_modules_install

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-08-19-23
+08-24-23

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-08-25-23
+08-23-23-2

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-08-24-23
+08-25-23

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-08-23-23-2
+08-23-23-3

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -363,7 +363,7 @@ commands:
             # avoid installing Percy's Chromium every time we use @percy/cli
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
-            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn --ignore-scripts
+            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -359,7 +359,6 @@ commands:
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
             yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
-            yarn patch-package
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -215,11 +215,6 @@ commands:
     description: Save entire folder as artifact for other jobs to run without reinstalling
     steps:
       - run:
-          name: Patch packages
-          command: |
-            source ./scripts/ensure-node.sh
-            yarn patch-package
-      - run:
           name: Build packages
           command: |
             source ./scripts/ensure-node.sh
@@ -364,6 +359,7 @@ commands:
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
             yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
+            yarn patch-package
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -215,6 +215,11 @@ commands:
     description: Save entire folder as artifact for other jobs to run without reinstalling
     steps:
       - run:
+          name: Patch packages
+          command: |
+            source ./scripts/ensure-node.sh
+            yarn patch-package
+      - run:
           name: Build packages
           command: |
             source ./scripts/ensure-node.sh
@@ -358,7 +363,7 @@ commands:
             # avoid installing Percy's Chromium every time we use @percy/cli
             # https://docs.percy.io/docs/caching-asset-discovery-browser-in-ci
             PERCY_POSTINSTALL_BROWSER=true \
-            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn
+            yarn --prefer-offline --frozen-lockfile --cache-folder ~/.yarn --ignore-scripts
           no_output_timeout: 20m
       - prepare-modules-cache:
           dont-move: <<parameters.only-cache-for-root-user>> # we don't move, so we don't hit any issues unpacking symlinks

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,48 @@
+# test directories
+__tests__
+test
+tests
+powered-test
+
+# asset directories
+docs
+doc
+# yaml package has a `doc` folder that we need
+!yaml/**/doc/*
+website
+images
+assets
+
+# examples
+example
+!@packages/example
+examples
+
+# code coverage directories
+coverage
+.nyc_output
+
+# build scripts
+Makefile
+Gulpfile.js
+Gruntfile.js
+
+# configs
+appveyor.yml
+circle.yml
+codeship-services.yml
+codeship-steps.yml
+wercker.yml
+.tern-project
+.gitattributes
+.editorconfig
+.*ignore
+.eslintrc
+.jshintrc
+.flowconfig
+.documentup.json
+.yarn-metadata.json
+.travis.yml
+
+# misc
+*.md

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'patch-package && yarn build',
+  ci: 'echo "Do not run post-install on CI"',
 }
 
 execSync(postInstallCommands[executionEnv], {

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'echo "Do not run post-install on CI"',
+  ci: 'patch-package',
 }
 
 execSync(postInstallCommands[executionEnv], {

--- a/scripts/run-postInstall.js
+++ b/scripts/run-postInstall.js
@@ -4,7 +4,7 @@ const executionEnv = process.env.CI ? 'ci' : 'local'
 
 const postInstallCommands = {
   local: 'patch-package && yarn-deduplicate --strategy=highest && yarn build && yarn build-v8-snapshot-dev',
-  ci: 'patch-package && yarn build && V8_SNAPSHOT_DISABLE_MINIFY=1 yarn build-v8-snapshot-prod',
+  ci: 'patch-package && yarn build',
 }
 
 execSync(postInstallCommands[executionEnv], {


### PR DESCRIPTION
This PR adds a `.yarnclean` file to tell `yarn` to remove some unnecessary files after installing dependencies. This reduces our node_modules cache size by ~150MB. Nothing crazy, but better.

It also removes `yarn build` from the `postinstall` script when running on CI. We already build packages in the `build` job, and we don't need to do it again when we update the node_modules cache. Taking it out of postinstall gives us more flexibility to install deps without building packages all over again.