### PR TITLE
chore: explicit fs promises to not drop support for NodeJS 12

### DIFF
--- a/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
+++ b/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
@@ -1,8 +1,8 @@
-import fs from 'fs'
+import { promises as fs } from 'fs'
 import path from 'path'
 
 export async function uninstallDependenciesInScaffoldedProject ({ currentProject }) {
-  await fs.promises.rm(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
+  await fs.rm(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
 
   return null
 }

--- a/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
+++ b/packages/launchpad/cypress/tasks/uninstallDependenciesInScaffoldedProject.ts
@@ -1,8 +1,8 @@
-import fs from 'fs/promises'
+import fs from 'fs'
 import path from 'path'
 
 export async function uninstallDependenciesInScaffoldedProject ({ currentProject }) {
-  await fs.rm(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
+  await fs.promises.rm(path.resolve(currentProject, '../node_modules'), { recursive: true, force: true })
 
   return null
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- ```import fs from 'fs/promises'``` does not work in NodeJS 12
- ```import { promises as fs } from 'fs'``` does work in NodeJS 12

- I understand support for NodeJS 12 was dropped

### Steps to test
Try to launch Cypress 12.17.4 on NodeJS 12
```
Error: Webpack Compilation Error
Module build failed (from ../../AppData/Local/Cypress/Cache/12.17.4/Cypress/resources/app/node_modules/babel-loader/lib/index.js):
Error: Cannot find module 'fs/promises'
```

Try to launch this version on NodeJS 12
```
[Test will be able to run]
```

### How has the user experience changed?
Cypress will be able to run on NodeJS 12

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
