### PR TITLE
chore: use SKIP_RELEASE_CHANGELOG_VALIDATION env var to skip release-…

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -185,7 +185,7 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
 
 23. Notify the team that `develop` is reopen, and post a message to the Releases Slack channel with a link to the changelog.
 
-24. If utilizing the `SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES` to override and skip changelog validation for this release, delete it from CircleCI so that subsequent releases and PRs will go through changelog validation.
+24. If utilizing the `SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES` to override and skip changelog validation for this release, change its value as needed or delete it from CircleCI so that subsequent releases and PRs will go through changelog validation.
 
 25. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's main branch. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)

--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -48,7 +48,7 @@ The `@cypress/`-namespaced NPM packages that live inside the [`/npm`](../npm) di
   - [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)
   - [`cypress-docker-images`](https://github.com/cypress-io/cypress-docker-images)
   - [cypress-io/release-automations][release-automations]
-  
+
 
 If you don't have access to 1Password, ask a team member who has done a deploy.
 
@@ -88,7 +88,7 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
 
 2. Ensure all changes to the links manifest to [`on.cypress.io`](https://github.com/cypress-io/cypress-services/tree/develop/packages/on) have been merged to `develop` and deployed.
 
-3. Create a Release PR - 
+3. Create a Release PR -
    Bump, submit, get approvals on, and merge a new PR. This PR should:
     - Bump the Cypress `version` in [`package.json`](package.json)
     - Bump the [`packages/example`](../packages/example) dependency if there is a new [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink/releases) version
@@ -185,7 +185,9 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
 
 23. Notify the team that `develop` is reopen, and post a message to the Releases Slack channel with a link to the changelog.
 
-24. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's main branch. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
+24. If utilizing the `SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES` to override and skip changelog validation for this release, delete it from CircleCI so that subsequent releases and PRs will go through changelog validation.
+
+25. Check all `cypress-test-*` and `cypress-example-*` repositories, and if there is a branch named `x.y.z` for testing the features or fixes from the newly published version `x.y.z`, update that branch to refer to the newly published NPM version in `package.json`. Then, get the changes approved and merged into that project's main branch. For projects without a `x.y.z` branch, you can go to the Renovate dependency issue and check the box next to `Update dependency cypress to X.Y.Z`. It will automatically create a PR. Once it passes, you can merge it. Try updating at least the following projects:
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)
     - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app/issues/41)
     - [cypress-example-recipes](https://github.com/cypress-io/cypress-example-recipes/issues/225)

--- a/scripts/semantic-commits/validate-binary-changelog.js
+++ b/scripts/semantic-commits/validate-binary-changelog.js
@@ -12,7 +12,7 @@ const changelog = async () => {
   if (process.env.CIRCLECI) {
     console.log({ checkedInBinaryVersion })
 
-    if (process.env.CIRCLE_BRANCH !== 'develop' && process.env.CIRCLE_BRANCH !== 'fix-changelog-script' && !/^release\/\d+\.\d+\.\d+$/.test(process.env.CIRCLE_BRANCH) && !hasVersionBump) {
+    if (process.env.CIRCLE_BRANCH !== 'develop' && process.env.CIRCLE_BRANCH !== 'add-skip-changelog-validation' && !/^release\/\d+\.\d+\.\d+$/.test(process.env.CIRCLE_BRANCH) && !hasVersionBump) {
       console.log('Only verify the entire changelog for develop, a release branch or any branch that bumped to the Cypress version in the package.json.')
 
       return

--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -134,7 +134,7 @@ async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, c
     const branches = process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES.split(',')
 
     if (branches.includes(process.env.CIRCLE_BRANCH)) {
-      console.log(`Skipping changelog validation because branch (${process.env.CIRCLE_BRANCH}) is included in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES (${process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_BRANCHES})`)
+      console.log(`Skipping changelog validation because branch (${process.env.CIRCLE_BRANCH}) is included in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES (${process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES})`)
 
       return []
     }

--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -134,7 +134,7 @@ async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, c
     const branches = process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES.split(',')
 
     if (branches.includes(process.env.CIRCLE_BRANCH)) {
-      console.log(`Skipping changelog validation because branch (${process.env.CIRCLE_BRANCH}) is included in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES (${process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES})`)
+      console.log(`Skipping changelog validation because branch (${process.env.CIRCLE_BRANCH}) is included in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES`)
 
       return []
     }

--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -124,8 +124,17 @@ const _handleErrors = (errors) => {
 /**
  * Determines if the Cypress changelog has the correct next version and changelog entires given the provided
  * list of commits.
+ *
+ * Can be skipped by setting the SKIP_RELEASE_CHANGELOG_VALIDATION environment
+ * variable to any value in CircleCI
  */
 async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, commits }) {
+  if (process.env.SKIP_RELEASE_CHANGELOG_VALIDATION) {
+    console.log('Skipping changelog validation because SKIP_RELEASE_CHANGELOG_VALIDATION is set')
+
+    return []
+  }
+
   const hasUserFacingCommits = commits.some(({ semanticType }) => hasUserFacingChange(semanticType))
 
   if (!hasUserFacingCommits) {

--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -125,14 +125,19 @@ const _handleErrors = (errors) => {
  * Determines if the Cypress changelog has the correct next version and changelog entires given the provided
  * list of commits.
  *
- * Can be skipped by setting the SKIP_RELEASE_CHANGELOG_VALIDATION environment
- * variable to any value in CircleCI
+ * Can be skipped by setting the SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES
+ * environment variable in CircleCI to a branch or comma-separated list of
+ * branches
  */
 async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, commits }) {
-  if (process.env.SKIP_RELEASE_CHANGELOG_VALIDATION) {
-    console.log('Skipping changelog validation because SKIP_RELEASE_CHANGELOG_VALIDATION is set')
+  if (process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES) {
+    const branches = process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES.split(',')
 
-    return []
+    if (branches.includes(process.env.CIRCLE_BRANCH)) {
+      console.log(`Skipping changelog validation because branch (${process.env.CIRCLE_BRANCH}) is included in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES (${process.env.SKIP_RELEASE_CHANGELOG_VALIDATION_BRANCHES})`)
+
+      return []
+    }
   }
 
   const hasUserFacingCommits = commits.some(({ semanticType }) => hasUserFacingChange(semanticType))


### PR DESCRIPTION
### Additional details

The `SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES` env var in CircleCI can be set to a comma-separated list of branches to skip validating the changelog for the `verify-release-readiness` workflow for those branches.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
