### PR TITLE
chore: remove prerequests on request failed events

### DIFF
--- a/packages/server/lib/automation/automation.ts
+++ b/packages/server/lib/automation/automation.ts
@@ -14,7 +14,7 @@ export class Automation {
   private cookies: Cookies
   private screenshot: { capture: (data: any, automate: any) => any }
 
-  constructor (cyNamespace?: string, cookieNamespace?: string, screenshotsFolder?: string | false, public onBrowserPreRequest?: OnBrowserPreRequest, public onRequestEvent?: OnRequestEvent, public onRequestServedFromCache?: (requestId: string) => void) {
+  constructor (cyNamespace?: string, cookieNamespace?: string, screenshotsFolder?: string | false, public onBrowserPreRequest?: OnBrowserPreRequest, public onRequestEvent?: OnRequestEvent, public onRequestServedFromCache?: (requestId: string) => void, public onRequestFailed?: (requestId: string) => void) {
     this.requests = {}
 
     // set the middleware

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -171,6 +171,7 @@ export class CdpAutomation implements CDPClient {
     onFn('Network.requestWillBeSent', this.onNetworkRequestWillBeSent)
     onFn('Network.responseReceived', this.onResponseReceived)
     onFn('Network.requestServedFromCache', this.onRequestServedFromCache)
+    onFn('Network.loadingFailed', this.onRequestFailed)
 
     this.on = onFn
     this.off = offFn
@@ -243,6 +244,10 @@ export class CdpAutomation implements CDPClient {
 
   private onRequestServedFromCache = (params: Protocol.Network.RequestServedFromCacheEvent) => {
     this.automation.onRequestServedFromCache?.(params.requestId)
+  }
+
+  private onRequestFailed = (params: Protocol.Network.LoadingFailedEvent) => {
+    this.automation.onRequestFailed?.(params.requestId)
   }
 
   private onResponseReceived = (params: Protocol.Network.ResponseReceivedEvent) => {

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -313,8 +313,8 @@ export class ProjectBase extends EE {
   }
 
   startWebsockets (options: Omit<OpenProjectLaunchOptions, 'args'>, { socketIoCookie, namespace, screenshotsFolder, report, reporter, reporterOptions, projectRoot }: StartWebsocketOptions) {
-  // if we've passed down reporter
-  // then record these via mocha reporter
+    // if we've passed down reporter
+    // then record these via mocha reporter
     const reporterInstance = this.initializeReporter({
       report,
       reporter,
@@ -334,7 +334,11 @@ export class ProjectBase extends EE {
       this.server.removeBrowserPreRequest(requestId)
     }
 
-    this._automation = new Automation(namespace, socketIoCookie, screenshotsFolder, onBrowserPreRequest, onRequestEvent, onRequestServedFromCache)
+    const onRequestFailed = (requestId: string) => {
+      this.server.removeBrowserPreRequest(requestId)
+    }
+
+    this._automation = new Automation(namespace, socketIoCookie, screenshotsFolder, onBrowserPreRequest, onRequestEvent, onRequestServedFromCache, onRequestFailed)
 
     const ios = this.server.startWebsockets(this.automation, this.cfg, {
       onReloadBrowser: options.onReloadBrowser,

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -204,7 +204,7 @@ context('lib/browsers/cdp_automation', () => {
         }
 
         this.onFn
-        .withArgs('Network.requestFailed')
+        .withArgs('Network.loadingFailed')
         .yield(browserRequestFailed)
 
         expect(this.automation.onRequestFailed).to.have.been.calledWith(browserRequestFailed.requestId)

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -71,6 +71,7 @@ context('lib/browsers/cdp_automation', () => {
         onBrowserPreRequest: sinon.stub(),
         onRequestEvent: sinon.stub(),
         onRequestServedFromCache: sinon.stub(),
+        onRequestFailed: sinon.stub(),
       }
 
       cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation)
@@ -193,6 +194,20 @@ context('lib/browsers/cdp_automation', () => {
         .yield(browserRequestServedFromCache)
 
         expect(this.automation.onRequestServedFromCache).to.have.been.calledWith(browserRequestServedFromCache.requestId)
+      })
+    })
+
+    describe('.onRequestFailed', function () {
+      it('triggers onRequestFailed', function () {
+        const browserRequestFailed = {
+          requestId: '0',
+        }
+
+        this.onFn
+        .withArgs('Network.requestFailed')
+        .yield(browserRequestFailed)
+
+        expect(this.automation.onRequestFailed).to.have.been.calledWith(browserRequestFailed.requestId)
       })
     })
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Remove prerequests on request failed events. Previously these requests were hanging around and could be potentially be incorrectly correlated with future requests to the same resource.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
