### PR TITLE
chore: exclude null highlight elements from protocol snapshot

### DIFF
--- a/packages/driver/cypress/e2e/cy/snapshot.cy.js
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.js
@@ -198,6 +198,23 @@ describe('driver/src/cy/snapshots', () => {
         expect(name).to.equal('snapshot')
         expect(timestamp).to.be.a('number')
       })
+
+      it('captures a protocol snapshot and excludes a null element', {
+        protocolEnabled: true,
+      }, function () {
+        // set to 0 to ensure protocol snapshots are taken
+        // since the driver support file sets the value to 1
+        Cypress.config('numTestsKeptInMemory', 0)
+
+        // create an element but don't append it to the DOM
+        const element = $('<div id=\'foo\' />')
+
+        const { elementsToHighlight, name, timestamp } = cy.createSnapshot('snapshot', element)
+
+        expect(elementsToHighlight?.length).to.equal(0)
+        expect(name).to.equal('snapshot')
+        expect(timestamp).to.be.a('number')
+      })
     })
   })
 

--- a/packages/driver/src/cy/snapshots.ts
+++ b/packages/driver/src/cy/snapshots.ts
@@ -5,6 +5,9 @@ import type { $Cy } from '../cypress/cy'
 import type { StateFunc } from '../cypress/state'
 import $dom from '../dom'
 import { create as createSnapshotsCSS } from './snapshots_css'
+import { debug as Debug } from 'debug'
+
+const debug = Debug('cypress:driver:snapshots')
 
 export const HIGHLIGHT_ATTR = 'data-cypress-el'
 
@@ -270,6 +273,13 @@ export const create = ($$: $Cy['$$'], state: StateFunc) => {
             }
 
             const selector = uniqueSelector(el)
+
+            if (!selector) {
+              debug('could not find a unique selector for element %o', el)
+
+              return []
+            }
+
             const frameId = elWindow['__cypressProtocolMetadata']?.frameId
 
             return [{ selector, frameId }]

--- a/system-tests/projects/plugins-async-error/cypress.config.js
+++ b/system-tests/projects/plugins-async-error/cypress.config.js
@@ -6,7 +6,7 @@ module.exports = {
         return new Promise(() => {
           setTimeout(() => {
             throw new Error('Async error from plugins file')
-          }, 50)
+          }, 250)
         })
       })
 

--- a/system-tests/test/plugins_spec.js
+++ b/system-tests/test/plugins_spec.js
@@ -27,9 +27,6 @@ describe('e2e plugins', function () {
   })
 
   it('fails when there is an async error inside an event handler', function () {
-    // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23493
-    this.retries(30)
-
     return systemTests.exec(this, {
       spec: 'app.cy.js',
       project: 'plugins-async-error',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updated the protocol snapshots to exclude any highlight elements that returned null.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
