### PR TITLE
chore: snyk scan should run on default PR events

### DIFF
--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -8,8 +8,7 @@ name: Snyk Software Composition Analysis Scan
 # implemented PAT token for actions to resolve an issue with the action not
 # running and reporting back to the PR status checks
 on:
-  pull_request:
-    types: [opened, edited]
+  pull_request_target:
     branches: 
       - develop
 jobs:

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -5,8 +5,6 @@ name: Snyk Static Analysis Scan
 # from being introduced into the codebase. 
 on:
   pull_request_target:
-    types:
-      - opened
     branches: 
       - develop
 jobs:


### PR DESCRIPTION
Those events as-of this writing are: open, reopen, synchronize (viz., new commit on PR branch/head)

This should ensure it's run on follow-up commits, for example.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We found that snyk scans were not consistently being run, and in particular follow-up commits is where it was lacking. This is likely due to the events being filtered on.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

This is tricky to test since it's on github actions itself. Paraphrasing from the docs, some logic draws from what's on the `develop` branch as part of the underlying action logic. That makes this difficult to verify.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
