### PR TITLE
fix: change how tsconfig is aliased in webpack-batteries-included-preprocessor

### DIFF
--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -38,6 +38,6 @@ jobs:
       - name: Perform SCA Scan
         continue-on-error: false
         run: |
-          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical--target-reference="$(git branch --show-current)"
+          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical --target-reference="$(git branch --show-current)"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -1,15 +1,15 @@
 name: Snyk Software Composition Analysis Scan
-# This git workflow leverages Snyk actions to perform a Software Composition 
+# This git workflow leverages Snyk actions to perform a Software Composition
 # Analysis scan on our Opensource libraries upon Pull Requests to the
-# "develop" branch. We use this as a control to prevent vulnerable packages 
-# from being introduced into the codebase. 
+# "develop" branch. We use this as a control to prevent vulnerable packages
+# from being introduced into the codebase.
 # Enhancements were made to this action to build the yarn packages to reduce
-# Snyk scan errors that were complaining about the yarn.locks etc.  Also 
+# Snyk scan errors that were complaining about the yarn.locks etc.  Also
 # implemented PAT token for actions to resolve an issue with the action not
 # running and reporting back to the PR status checks
 on:
   pull_request_target:
-    branches: 
+    branches:
       - develop
 jobs:
   Snyk_SCA_Scan:
@@ -38,6 +38,6 @@ jobs:
       - name: Perform SCA Scan
         continue-on-error: false
         run: |
-          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical
+          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical--target-reference="$(git branch --show-current)"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -8,7 +8,7 @@ name: Snyk Software Composition Analysis Scan
 # implemented PAT token for actions to resolve an issue with the action not
 # running and reporting back to the PR status checks
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - develop
 jobs:
@@ -38,6 +38,6 @@ jobs:
       - name: Perform SCA Scan
         continue-on-error: false
         run: |
-          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical --target-reference="$(git branch --show-current)"
+          snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=system-tests,tooling,docker,Dockerfile --severity-threshold=critical
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -1,11 +1,11 @@
 name: Snyk Static Analysis Scan
-# This git workflow leverages Snyk actions to perform a Static Application 
+# This git workflow leverages Snyk actions to perform a Static Application
 # Testing scan (SAST) on our first-party code upon Pull Requests to the
-# "develop" branch. We use this as a control to prevent vulnerabilities 
-# from being introduced into the codebase. 
+# "develop" branch. We use this as a control to prevent vulnerabilities
+# from being introduced into the codebase.
 on:
-  pull_request_target:
-    branches: 
+  pull_request:
+    branches:
       - develop
 jobs:
   Snyk_SAST_Scan :

--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -27,8 +27,8 @@ const addTypeScriptConfig = (file, options) => {
 
   const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
   // node will try to load a projects tsconfig.json instead of the node
-  // package using require('tsconfig'), so we alias it as 'tsconfig-package'
-  const configFile = require('tsconfig-package').findSync(path.dirname(file.filePath))
+  // package using require('tsconfig'), so we alias it as 'tsconfig-aliased-for-wbip'
+  const configFile = require('tsconfig-aliased-for-wbip').findSync(path.dirname(file.filePath))
 
   webpackOptions.module.rules.push({
     test: /\.tsx?$/,

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -37,7 +37,7 @@
     "stream-http": "^3.2.0",
     "timers-browserify": "^2.0.12",
     "ts-loader": "9.4.4",
-    "tsconfig-package": "npm:tsconfig@^7.0.0",
+    "tsconfig-aliased-for-wbip": "npm:tsconfig@^7.0.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tty-browserify": "^0.0.1",
     "url": "^0.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28700,7 +28700,7 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
-"tsconfig-package@npm:tsconfig@^7.0.0":
+"tsconfig-aliased-for-wbip@npm:tsconfig@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-7.0.0.tgz#84538875a4dc216e5c4a5432b3a4dec3d54e91b7"
   integrity sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->


### Additional details

Addresses this [snyk vulnerability](https://security.snyk.io/vuln/SNYK-JS-TSCONFIGPACKAGE-5869851). It's not an actual vulnerability in this repo because we aren't using the actual `tsconfig-package` package, but aliasing the `tsconfig` package as `tsconfig-package` to get around a path resolution issue with Node.

My solution is to use a name less likely to end up as a real package name: `tsconfig-aliased-for-wbip` (wbip === webpack-batteries-included-preprocessor).

### Steps to test

Should see a passing snyk check.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [N/A] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
