### PR TITLE
fix: make CDP errors non fatal

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ _Released 09/12/2023 (PENDING)_
 
  - Introduce a status icon representing the `latest` test run in the Sidebar for the Runs Page. Addresses [#27206](https://github.com/cypress-io/cypress/issues/27206).
 
+**Bugfixes:**
+
+- Individual CDP errors that occur while capturing data for test replay will no longer prevent the entire run from being available. Addressed in [#27709](https://github.com/cypress-io/cypress/pull/27709).
+
 ## 13.0.0
 
 _Released 08/29/2023_

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -141,7 +141,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       this._protocol = undefined
 
       if (CAPTURE_ERRORS) {
-        this._errors.push({ captureMethod: 'beforeSpec', error, args: [spec], runnableId: this._runnableId })
+        this._errors.push({ captureMethod: 'beforeSpec', fatal: true, error, args: [spec], runnableId: this._runnableId })
       } else {
         throw error
       }

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -112,7 +112,7 @@ export class ProtocolManager implements ProtocolManagerShape {
             await listener(message)
           } catch (error) {
             if (CAPTURE_ERRORS) {
-              this._errors.push({ captureMethod: 'cdpClient.on', fatal: true, error, args: [event, message] })
+              this._errors.push({ captureMethod: 'cdpClient.on', fatal: false, error, args: [event, message] })
             } else {
               debug('error in cdpClient.on %O', { error, event, message })
               throw error

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -137,6 +137,9 @@ export class ProtocolManager implements ProtocolManagerShape {
     try {
       this._beforeSpec(spec)
     } catch (error) {
+      // Clear out protocol since we will not have a valid state when spec has failed
+      this._protocol = undefined
+
       if (CAPTURE_ERRORS) {
         this._errors.push({ captureMethod: 'beforeSpec', error, args: [spec], runnableId: this._runnableId })
       } else {


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We want to ensure that CDP errors don't get treated as fatal with respect to protocol. Most CDP errors aren't critical and this will ensure that the databases get uploaded even when these errors happen.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The DB will upload even when there are CDP errors

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
