### PR TITLE
feat(webpack-dev-server): update the generated tsconfig path for angular CT

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -29,9 +29,8 @@ mainBuildFilters: &mainBuildFilters
         - develop
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-        - 'update-v8-snapshot-cache-on-develop'
         - 'publish-binary'
-        - 'cacie/chore/capture-metadata'
+        - 'jordanpowell88/update-angular-tsconfig-path'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -41,8 +40,7 @@ macWorkflowFilters: &darwin-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-    - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ cacie/chore/capture-metadata', << pipeline.git.branch >> ]
+    - equal: [ 'jordanpowell88/update-angular-tsconfig-path', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -52,9 +50,8 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-    - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
+    - equal: [ 'jordanpowell88/update-angular-tsconfig-path', << pipeline.git.branch >> ]
     - equal: [ 'publish-binary', << pipeline.git.branch >> ]
-    - equal: [ cacie/chore/capture-metadata', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -73,8 +70,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     or:
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-    - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ cacie/chore/capture-metadata', << pipeline.git.branch >> ]
+    - equal: [ 'jordanpowell88/update-angular-tsconfig-path', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -144,7 +140,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "update-v8-snapshot-cache-on-develop" && "$CIRCLE_BRANCH" != "ryanm/feat/handle-304s" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "jordanpowell88/update-angular-tsconfig-path" && "$CIRCLE_BRANCH" != "ryanm/feat/handle-304s" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.2.0
+
+_Released 09/12/2023 (PENDING)_
+
+**Features:**
+
+ - Adds support for Nx users who want to run Angular Component Testing in parallel. Addresses [#27723](https://github.com/cypress-io/cypress/pull/27723).
+
 ## 13.1.0
 
 _Released 09/12/2023 (PENDING)_

--- a/npm/webpack-dev-server/src/helpers/angularHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/angularHandler.ts
@@ -154,15 +154,15 @@ export async function generateTsConfig (devServerConfig: AngularWebpackDevServer
     include: includePaths,
   }, null, 2)
 
-  const tsConfigPath = path.join(await getTempDir(), 'tsconfig.json')
+  const tsConfigPath = path.join(await getTempDir(path.basename(projectRoot)), 'tsconfig.json')
 
   await fs.writeFile(tsConfigPath, tsConfigContent)
 
   return tsConfigPath
 }
 
-export async function getTempDir (): Promise<string> {
-  const cypressTempDir = path.join(tmpdir(), 'cypress-angular-ct')
+export async function getTempDir (projectName: string): Promise<string> {
+  const cypressTempDir = path.join(tmpdir(), 'cypress-angular-ct', projectName)
 
   await fs.ensureDir(cypressTempDir)
 

--- a/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
@@ -194,7 +194,7 @@ const expectLoadsAngularBuildOptions = (buildOptions: BuildOptions) => {
 const expectGeneratesTsConfig = async (devServerConfig: AngularWebpackDevServerConfig, buildOptions: any) => {
   const { projectRoot } = devServerConfig.cypressConfig
   let tsConfigPath = await generateTsConfig(devServerConfig, buildOptions)
-  const tempDir = await getTempDir()
+  const tempDir = await getTempDir(path.basename(projectRoot))
 
   expect(tsConfigPath).to.eq(path.join(tempDir, 'tsconfig.json'))
 


### PR DESCRIPTION

- Closes https://github.com/nrwl/nx/issues/14382

### Additional details
This changes is needed so that Nx users can execute `component-test` tasks in `parallel`.  This is a Huge performance blocker at the moment. [This PR](https://github.com/cypress-io/cypress/issues/27675) in version 13 unblocked users from doing this for `React`. However, this PR is needed to support this behavior for Angular (in addition to the other PR).

Essentially when Component Testing for Angular is launched we generate a `tsconfig` file on the fly in a temp directory that gets passed to the Angular builder. The builder returns a `webpack` config which we use in our `webpack-dev-server`. The issue is that when Nx users try to run in `parallel` the generated `tsconfig` file gets overwritten in the same path. This PR generates the temporarily `tsconfig` in a unique path based upon the `projectRoot` name.

 
### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
No changes are made to the current UX. The change is that it now allows users with Nx to run in CT tests in parallel. 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
