### PR TITLE
fix: Use setInput for component properties in Angular component tests

### DIFF
--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -8,7 +8,7 @@ window.Mocha['__zone_patch__'] = false
 import 'zone.js/testing'
 
 import { CommonModule } from '@angular/common'
-import { Component, ErrorHandler, EventEmitter, Injectable, SimpleChange, SimpleChanges, Type, OnChanges } from '@angular/core'
+import { Component, ErrorHandler, EventEmitter, Injectable, Type, OnChanges } from '@angular/core'
 import {
   ComponentFixture,
   getTestBed,
@@ -268,8 +268,8 @@ function setupComponent<T> (
 ): void {
   let component = fixture.componentInstance as unknown as { [key: string]: any } & Partial<OnChanges>
 
-  if (config?.componentProperties) {
-    component = Object.assign(component, config.componentProperties)
+  for (const [key, value] of Object.entries(config?.componentProperties ?? {})) {
+    fixture.componentRef.setInput(key, value)
   }
 
   if (config.autoSpyOutputs) {
@@ -280,23 +280,6 @@ function setupComponent<T> (
         component[key] = createOutputSpy(`${key}Spy`)
       }
     })
-  }
-
-  // Manually call ngOnChanges when mounting components using the class syntax.
-  // This is necessary because we are assigning input values to the class directly
-  // on mount and therefore the ngOnChanges() lifecycle is not triggered.
-  if (component.ngOnChanges && config.componentProperties) {
-    const { componentProperties } = config
-
-    const simpleChanges: SimpleChanges = Object.entries(componentProperties).reduce((acc, [key, value]) => {
-      acc[key] = new SimpleChange(null, value, true)
-
-      return acc
-    }, {} as {[key: string]: SimpleChange})
-
-    if (Object.keys(componentProperties).length > 0) {
-      component.ngOnChanges(simpleChanges)
-    }
   }
 }
 


### PR DESCRIPTION
This is an alternative fix for #23591, where `ngOnChanges` is not being called when mounting a component using the Class syntax.

ComponentRef.setInput [was introduced in Angular 14.1](https://netbasal.com/a-new-way-to-set-inputs-on-angular-componentrefs-6214f95db63d).

The original fix (#23596) calls `ngOnChanges` manually to make up for the fact that properties are assigned directly to the component, bypassing Angular change detection.

That fix, however, causes an issue where subsequent calls to `componentRef.setInput` in the test will be considered the first change, and will not include `previousValue`.

Instead, if we use `setInput` to set component properties when mounting, ngOnChanges is called automatically by Angular, and future calls to `setInput` track changes properly.

Note: I didn't figure out how to run the tests modified in the original bug. They should still pass. It also might be worth adding a test for the ngOnChanges behavior. If someone could let me know how to run those tests, I would be happy to add it!