### PR TITLE
Set 250 as an upper limit for retries

### DIFF
--- a/packages/config/__snapshots__/validation.spec.ts.js
+++ b/packages/config/__snapshots__/validation.spec.ts.js
@@ -267,7 +267,7 @@ exports['missing key "flaky"'] = {
   'value': {
     'default': 1,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['missing key "default"'] = {
@@ -275,7 +275,7 @@ exports['missing key "default"'] = {
   'value': {
     'flaky': 1,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['keys cannot be zero key'] = {
@@ -284,7 +284,7 @@ exports['keys cannot be zero key'] = {
     'default': 0,
     'flaky': 0,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['keys cannot be zero'] = {
@@ -293,7 +293,7 @@ exports['keys cannot be zero'] = {
     'default': 0,
     'flaky': 0,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['keys cannot be negative'] = {
@@ -302,7 +302,7 @@ exports['keys cannot be negative'] = {
     'default': -3,
     'flaky': -40,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['keys cannot be floating point numbers'] = {
@@ -311,7 +311,7 @@ exports['keys cannot be floating point numbers'] = {
     'default': 5.7,
     'flaky': 8.22,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['keys cannot be Infinity'] = {
@@ -320,7 +320,7 @@ exports['keys cannot be Infinity'] = {
     'default': null,
     'flaky': null,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['extraneous keys'] = {
@@ -330,7 +330,7 @@ exports['extraneous keys'] = {
     'flaky': 5,
     'notflaky': null,
   },
-  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.',
+  'type': 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with invalid strategy 1'] = {
@@ -659,6 +659,44 @@ exports['config/src/validation .isValidRetriesConfig experimental options fails 
     'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
     'experimentalOptions': {
       'maxRetries': 4,
+    },
+  },
+  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+}
+
+exports['invalid retry object 2'] = {
+  'key': 'mockConfigKey',
+  'value': {
+    'runMode': 251,
+  },
+  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+}
+
+exports['invalid retry object 3'] = {
+  'key': 'mockConfigKey',
+  'value': {
+    'openMode': 251,
+  },
+  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+}
+
+exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: maxRetries is greater than 250 1'] = {
+  'key': 'mockConfigKey',
+  'value': {
+    'experimentalStrategy': 'detect-flake-but-always-fail',
+    'experimentalOptions': {
+      'maxRetries': 251,
+    },
+  },
+  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+}
+
+exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: maxRetries is greater than 250 1'] = {
+  'key': 'mockConfigKey',
+  'value': {
+    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
+    'experimentalOptions': {
+      'maxRetries': 251,
     },
   },
   'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',

--- a/packages/config/__snapshots__/validation.spec.ts.js
+++ b/packages/config/__snapshots__/validation.spec.ts.js
@@ -36,7 +36,7 @@ exports['invalid retry object'] = {
   'value': {
     'fakeMode': 1,
   },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'type': 'an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls',
 }
 
 exports['not qualified url'] = {
@@ -334,11 +334,9 @@ exports['extraneous keys'] = {
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with invalid strategy 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'foo',
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalStrategy',
+  'value': 'foo',
+  'type': 'one of "detect-flake-but-always-fail", "detect-flake-and-pass-on-threshold"',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with invalid strategy w/ other options 1'] = {
@@ -351,229 +349,92 @@ exports['config/src/validation .isValidRetriesConfig experimental options fails 
   'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
 }
 
-exports['config/src/validation .isValidRetriesConfig experimental options fails with maxRetries is negative 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': -2,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with maxRetries is 0 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 0,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with maxRetries is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: maxRetries is negative 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': -2,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': -2,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: maxRetries is 0 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 0,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail" maxRetries is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 0,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: maxRetries is negative 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': -2,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': -2,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: maxRetries is 0 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 0,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold" maxRetries is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 0,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: maxRetries is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 3.5,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: maxRetries is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 3.5,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold passesRequired is negative 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 1,
-      'passesRequired': -4,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.passesRequired',
+  'value': -4,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold passesRequired is 0 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 1,
-      'passesRequired': 0,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.passesRequired',
+  'value': 0,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold passesRequired is floating 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 1,
-      'passesRequired': 3.5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.passesRequired',
+  'value': 3.5,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold provides passesRequired without maxRetries 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'passesRequired': 3,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold provides passesRequired that is greater than maxRetries 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 3,
-      'passesRequired': 5,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.passesRequired',
+  'value': 5,
+  'type': 'a positive whole number less than or equal to maxRetries',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold provides stopIfAnyPassed option 1'] = {
-  'key': 'mockConfigKey',
+  'key': 'mockConfigKey.experimentalOptions',
   'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 3,
-      'stopIfAnyPassed': true,
-    },
+    'maxRetries': 3,
+    'stopIfAnyPassed': true,
   },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'type': 'an object with keys maxRetries, passesRequired',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail provides passesRequired option 1'] = {
-  'key': 'mockConfigKey',
+  'key': 'mockConfigKey.experimentalOptions',
   'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 3,
-      'passesRequired': 2,
-    },
+    'maxRetries': 3,
+    'passesRequired': 2,
   },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'type': 'an object with keys maxRetries, stopIfAnyPassed',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail provides stopIfAnyPassed without maxRetries 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'stopIfAnyPassed': false,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail stopIfAnyPassed is a number (not coerced to a boolean 1'] = {
@@ -601,103 +462,49 @@ exports['config/src/validation .isValidRetriesConfig experimental options fails 
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail stopIfAnyPassed is a number (0 and 1 do not work) 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 2,
-      'stopIfAnyPassed': 1,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.stopIfAnyPassed',
+  'value': 1,
+  'type': 'null or boolean',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with invalid strategy w/ other options (valid) 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': true,
-    'openMode': false,
-    'experimentalStrategy': 'bar',
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalStrategy',
+  'value': 'bar',
+  'type': 'one of "detect-flake-but-always-fail", "detect-flake-and-pass-on-threshold"',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: valid strategy w/ other invalid options with experiment 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.runMode',
+  'value': 1,
+  'type': 'a boolean since an experimental strategy is provided',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: valid strategy w/ other invalid options with experiment 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 1,
-    'openMode': 0,
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with experimentalStrategy is "detect-flake-but-always-fail" with only "maxRetries" in "experimentalOptions" 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 4,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
-}
-
-exports['config/src/validation .isValidRetriesConfig experimental options fails with experimentalStrategy is "detect-flake-and-pass-on-threshold" with only "maxRetries" in "experimentalOptions" 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 4,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.runMode',
+  'value': 1,
+  'type': 'a boolean since an experimental strategy is provided',
 }
 
 exports['invalid retry object 2'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'runMode': 251,
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.runMode',
+  'value': 251,
+  'type': 'a positive whole number between 0 and 250 or null',
 }
 
 exports['invalid retry object 3'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'openMode': 251,
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.openMode',
+  'value': 251,
+  'type': 'a positive whole number between 0 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-but-always-fail: maxRetries is greater than 250 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-but-always-fail',
-    'experimentalOptions': {
-      'maxRetries': 251,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 251,
+  'type': 'a positive whole number between 1 and 250 or null',
 }
 
 exports['config/src/validation .isValidRetriesConfig experimental options fails with detect-flake-and-pass-on-threshold: maxRetries is greater than 250 1'] = {
-  'key': 'mockConfigKey',
-  'value': {
-    'experimentalStrategy': 'detect-flake-and-pass-on-threshold',
-    'experimentalOptions': {
-      'maxRetries': 251,
-    },
-  },
-  'type': 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy',
+  'key': 'mockConfigKey.experimentalOptions.maxRetries',
+  'value': 251,
+  'type': 'a positive whole number between 1 and 250 or null',
 }

--- a/packages/config/src/validation.ts
+++ b/packages/config/src/validation.ts
@@ -122,7 +122,7 @@ export const isValidBrowserList = (_key: string, browsers: any): ErrResult | tru
 const isValidExperimentalRetryOptionsConfig = (options: any, strategy: 'detect-flake-but-always-fail' | 'detect-flake-and-pass-on-threshold'): boolean => {
   if (options != null) {
     // retries must be an integer of 1 or greater
-    const isValidMaxRetries = _.isInteger(options.maxRetries) && options.maxRetries > 0
+    const isValidMaxRetries = _.isInteger(options.maxRetries) && options.maxRetries > 0 && options.maxRetries <= 250
 
     if (!isValidMaxRetries) {
       return false
@@ -163,7 +163,7 @@ export const isValidRetriesConfig = (key: string, value: any): ErrResult | true 
   const experimentalOptions = ['experimentalStrategy', 'experimentalOptions']
   const experimentalStrategyOptions = ['detect-flake-but-always-fail', 'detect-flake-and-pass-on-threshold']
 
-  const isValidRetryValue = (val: any) => _.isNull(val) || (Number.isInteger(val) && val >= 0)
+  const isValidRetryValue = (val: any) => _.isNull(val) || (Number.isInteger(val) && val >= 0 && val <= 250)
   const optionalKeysAreValid = (val: any, k: string) => optionalKeys.includes(k) && isValidRetryValue(val)
 
   if (isValidRetryValue(value)) {
@@ -462,8 +462,8 @@ export function isValidBurnInConfig (key: string, value: any): ErrResult | true 
     const { default: defaultKey, flaky: flakyKey, ...extraneousKeys } = value
 
     if (defaultKey !== undefined && defaultKey !== undefined && _.isEmpty(extraneousKeys)) {
-      const isDefaultKeyValid = _.isInteger(defaultKey) && _.inRange(defaultKey, 1, Infinity)
-      const isFlakyKeyValid = _.isInteger(flakyKey) && _.inRange(flakyKey, 1, Infinity)
+      const isDefaultKeyValid = _.isInteger(defaultKey) && _.inRange(defaultKey, 1, 250)
+      const isFlakyKeyValid = _.isInteger(flakyKey) && _.inRange(flakyKey, 1, 250)
 
       if (isDefaultKeyValid && isFlakyKeyValid) {
         return true

--- a/packages/config/src/validation.ts
+++ b/packages/config/src/validation.ts
@@ -471,5 +471,5 @@ export function isValidBurnInConfig (key: string, value: any): ErrResult | true 
     }
   }
 
-  return errMsg(key, value, 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers greater than 0.')
+  return errMsg(key, value, 'an object with keys `default` and `flaky`. Keys `default` and `flaky` must be integers between 0 and 250.')
 }

--- a/packages/config/src/validation.ts
+++ b/packages/config/src/validation.ts
@@ -119,43 +119,61 @@ export const isValidBrowserList = (_key: string, browsers: any): ErrResult | tru
   return true
 }
 
-const isValidExperimentalRetryOptionsConfig = (options: any, strategy: 'detect-flake-but-always-fail' | 'detect-flake-and-pass-on-threshold'): boolean => {
-  if (options != null) {
-    // retries must be an integer of 1 or greater
-    const isValidMaxRetries = _.isInteger(options.maxRetries) && options.maxRetries > 0 && options.maxRetries <= 250
+const isValidExperimentalRetryOptionsConfig = (key: string, value: any, strategy: 'detect-flake-but-always-fail' | 'detect-flake-and-pass-on-threshold') => {
+  if (value == null) return true
 
-    if (!isValidMaxRetries) {
-      return false
-    }
+  const isValidMaxRetries = isValidRetryValue(`${key}.maxRetries`, value.maxRetries, 1)
 
-    // if the strategy is 'detect-flake-but-always-fail', stopIfAnyPassed must be provided and must be a boolean
-    if (strategy === 'detect-flake-but-always-fail') {
-      if (options.passesRequired !== undefined) {
-        return false
-      }
+  if (isValidMaxRetries !== true) {
+    return isValidMaxRetries
+  }
 
-      const isValidStopIfAnyPasses = _.isBoolean(options.stopIfAnyPassed)
+  const validKeys = ['maxRetries']
+
+  // if the strategy is 'detect-flake-but-always-fail' and if stopIfAnyPassed is provided it must be a boolean
+  if (strategy === 'detect-flake-but-always-fail') {
+    validKeys.push('stopIfAnyPassed')
+    if (value.stopIfAnyPassed !== undefined) {
+      const isValidStopIfAnyPasses = _.isNull(value.stopIfAnyPassed) || _.isBoolean(value.stopIfAnyPassed)
 
       if (!isValidStopIfAnyPasses) {
-        return false
-      }
-    }
-
-    // if the strategy is 'detect-flake-and-pass-on-threshold', passesRequired must be provided and must be an integer greater than 0
-    if (strategy === 'detect-flake-and-pass-on-threshold') {
-      if (options.stopIfAnyPassed !== undefined) {
-        return false
-      }
-
-      const isValidPassesRequired = _.isInteger(options.passesRequired) && options.passesRequired > 0 && options.passesRequired <= options.maxRetries
-
-      if (!isValidPassesRequired) {
-        return false
+        return errMsg(`${key}.stopIfAnyPassed`, value.stopIfAnyPassed, 'null or boolean')
       }
     }
   }
 
+  // if the strategy is 'detect-flake-and-pass-on-threshold' and if passesRequired is provided it must be a valid retry value and less than or equal to maxRetries
+  if (strategy === 'detect-flake-and-pass-on-threshold') {
+    validKeys.push('passesRequired')
+
+    if (value.passesRequired !== undefined) {
+      const isValidPassesRequired = isValidRetryValue(`${key}.passesRequired`, value.passesRequired, 1)
+
+      if (isValidPassesRequired !== true) {
+        return isValidPassesRequired
+      }
+
+      if (value.passesRequired > value.maxRetries) {
+        return errMsg(`${key}.passesRequired`, value.passesRequired, 'a positive whole number less than or equal to maxRetries')
+      }
+    }
+  }
+
+  const extraneousKeys = _.difference(Object.keys(value), validKeys)
+
+  if (extraneousKeys.length > 0) {
+    return errMsg(key, value, `an object with keys ${validKeys.join(', ')}`)
+  }
+
   return true
+}
+
+const isValidRetryValue = (key: string, value: any, minimumValue: 0|1): ErrResult | true => {
+  if (_.isNull(value)) return true
+
+  if (Number.isInteger(value) && value >= minimumValue && value <= 250) return true
+
+  return errMsg(key, value, `a positive whole number between ${minimumValue} and 250 or null`)
 }
 
 export const isValidRetriesConfig = (key: string, value: any): ErrResult | true => {
@@ -163,22 +181,37 @@ export const isValidRetriesConfig = (key: string, value: any): ErrResult | true 
   const experimentalOptions = ['experimentalStrategy', 'experimentalOptions']
   const experimentalStrategyOptions = ['detect-flake-but-always-fail', 'detect-flake-and-pass-on-threshold']
 
-  const isValidRetryValue = (val: any) => _.isNull(val) || (Number.isInteger(val) && val >= 0 && val <= 250)
-  const optionalKeysAreValid = (val: any, k: string) => optionalKeys.includes(k) && isValidRetryValue(val)
+  const optionalKeysAreValid = (key: string) => {
+    return (parentVal: object, optionName: string) => {
+      if (!optionalKeys.includes(optionName)) {
+        return errMsg(key, parentVal, 'an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls')
+      }
 
-  if (isValidRetryValue(value)) {
-    return true
+      const optionValue = _.get(parentVal, optionName)
+
+      if (_.isBoolean(optionValue)) return true
+
+      return isValidRetryValue(`${key}.${optionName}`, _.get(parentVal, optionName), 0)
+    }
   }
 
   if (_.isObject(value)) {
     const traditionalConfigOptions = _.omit(value, experimentalOptions)
     const experimentalConfigOptions = _.pick<any>(value, experimentalOptions)
 
-    const isTraditionalConfigValid = _.every(traditionalConfigOptions, optionalKeysAreValid)
+    for (const optionKey in traditionalConfigOptions) {
+      if (Object.prototype.hasOwnProperty.call(traditionalConfigOptions, optionKey)) {
+        const optionValidation = optionalKeysAreValid(key)(value, optionKey)
+
+        if (optionValidation !== true || _.isObject(optionValidation)) {
+          return optionValidation
+        }
+      }
+    }
 
     // if optionalKeys are only present and are valid, return true.
     // The defaults for 'experimentalStrategy' and 'experimentalOptions' are undefined, but the keys exist, so we need to check for this
-    if (isTraditionalConfigValid && !Object.keys(experimentalConfigOptions).filter((key) => experimentalConfigOptions[key] !== undefined).length) {
+    if (!Object.keys(experimentalConfigOptions).filter((key) => experimentalConfigOptions[key] !== undefined).length) {
       return true
     }
 
@@ -187,20 +220,46 @@ export const isValidRetriesConfig = (key: string, value: any): ErrResult | true 
       // make sure the strategy provided is one of our valid enums
       const isValidStrategy = experimentalStrategyOptions.includes(experimentalConfigOptions.experimentalStrategy)
 
+      if (!isValidStrategy) {
+        return errMsg(`${key}.experimentalStrategy`, experimentalConfigOptions.experimentalStrategy, `one of ${experimentalStrategyOptions.map((s) => `"${s}"`).join(', ')}`)
+      }
+
       // if a strategy is provided, and traditional options are also provided, such as runMode and openMode, then these values need to be booleans
       const openAndRunModeConfigOptions = _.pick(value, optionalKeys)
-      const isValidRunAndOpenModeConfigWithStrategy = _.every(openAndRunModeConfigOptions, _.isBoolean)
 
-      // if options aren't present (either undefined or null) or are configured correctly, return true
-      if (isValidStrategy && isValidRunAndOpenModeConfigWithStrategy && (
-        experimentalConfigOptions.experimentalOptions == null ||
-        isValidExperimentalRetryOptionsConfig(experimentalConfigOptions.experimentalOptions, experimentalConfigOptions.experimentalStrategy))) {
-        return true
+      for (const optionalKey in openAndRunModeConfigOptions) {
+        if (Object.prototype.hasOwnProperty.call(openAndRunModeConfigOptions, optionalKey)) {
+          const optionalConfigVal = _.get(openAndRunModeConfigOptions, optionalKey)
+
+          if (!_.isBoolean(optionalConfigVal)) {
+            return errMsg(`${key}.${optionalKey}`, optionalConfigVal, 'a boolean since an experimental strategy is provided')
+          }
+        }
+
+        // if options aren't present (either undefined or null) or are configured correctly, return true
+        if (
+          experimentalConfigOptions.experimentalOptions == null) {
+          return true
+        }
       }
+
+      const isValidExperimentalRetryOptions = isValidExperimentalRetryOptionsConfig(`${key}.experimentalOptions`, experimentalConfigOptions.experimentalOptions, experimentalConfigOptions.experimentalStrategy)
+
+      if (isValidExperimentalRetryOptions !== true) {
+        return isValidExperimentalRetryOptions
+      }
+    } else if (experimentalConfigOptions.experimentalOptions) {
+      return errMsg(`${key}.experimentalOptions`, experimentalConfigOptions.experimentalOptions, 'provided only if an experimental strategy is provided')
+    }
+  } else {
+    const isValidValue = isValidRetryValue(key, value, 0)
+
+    if (isValidValue !== true) {
+      return errMsg(key, value, 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy')
     }
   }
 
-  return errMsg(key, value, 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy')
+  return true
 }
 
 /**

--- a/packages/config/test/validation.spec.ts
+++ b/packages/config/test/validation.spec.ts
@@ -213,6 +213,17 @@ describe('config/src/validation', () => {
 
             expect(result).to.be.true
           })
+
+          it(`experimentalStrategy is "${strategy}" with only "maxRetries" in "experimentalOptions"`, () => {
+            const result = validation.isValidRetriesConfig(mockKey, {
+              experimentalStrategy: strategy,
+              experimentalOptions: {
+                maxRetries: 4,
+              },
+            })
+
+            expect(result).to.be.true
+          })
         })
 
         it('experimentalStrategy is "detect-flake-but-always-fail" and has option "stopIfAnyPassed"', () => {
@@ -276,8 +287,8 @@ describe('config/src/validation', () => {
 
         it('invalid strategy w/ other options (valid)', () => {
           const result = validation.isValidRetriesConfig(mockKey, {
-            runMode: true,
-            openMode: false,
+            runMode: 1,
+            openMode: 2,
             experimentalStrategy: 'bar',
           })
 
@@ -338,18 +349,6 @@ describe('config/src/validation', () => {
               experimentalStrategy: strategy,
               experimentalOptions: {
                 maxRetries: 251,
-              },
-            })
-
-            expect(result).to.not.be.true
-            snapshot(result)
-          })
-
-          it(`experimentalStrategy is "${strategy}" with only "maxRetries" in "experimentalOptions"`, () => {
-            const result = validation.isValidRetriesConfig(mockKey, {
-              experimentalStrategy: strategy,
-              experimentalOptions: {
-                maxRetries: 4,
               },
             })
 

--- a/packages/config/test/validation.spec.ts
+++ b/packages/config/test/validation.spec.ts
@@ -138,6 +138,9 @@ describe('config/src/validation', () => {
 
       result = validation.isValidRetriesConfig(mockKey, 2)
       expect(result).to.be.true
+
+      result = validation.isValidRetriesConfig(mockKey, 250)
+      expect(result).to.be.true
     })
 
     it('returns true for valid retry objects', () => {
@@ -145,7 +148,13 @@ describe('config/src/validation', () => {
 
       expect(result).to.be.true
 
+      result = validation.isValidRetriesConfig(mockKey, { runMode: 250 })
+      expect(result).to.be.true
+
       result = validation.isValidRetriesConfig(mockKey, { openMode: 1 })
+      expect(result).to.be.true
+
+      result = validation.isValidRetriesConfig(mockKey, { openMode: 250 })
       expect(result).to.be.true
 
       result = validation.isValidRetriesConfig(mockKey, {
@@ -165,6 +174,14 @@ describe('config/src/validation', () => {
       result = validation.isValidRetriesConfig(mockKey, { fakeMode: 1 })
       expect(result).to.not.be.true
       snapshot('invalid retry object', result)
+
+      result = validation.isValidRetriesConfig(mockKey, { runMode: 251 })
+      expect(result).to.not.be.true
+      snapshot('invalid retry object 2', result)
+
+      result = validation.isValidRetriesConfig(mockKey, { openMode: 251 })
+      expect(result).to.not.be.true
+      snapshot('invalid retry object 3', result)
     })
 
     it('returns true for valid retry object with experimental keys (default)', () => {
@@ -309,6 +326,18 @@ describe('config/src/validation', () => {
               experimentalStrategy: strategy,
               experimentalOptions: {
                 maxRetries: 3.5,
+              },
+            })
+
+            expect(result).to.not.be.true
+            snapshot(result)
+          })
+
+          it(`${strategy}: maxRetries is greater than 250`, () => {
+            const result = validation.isValidRetriesConfig(mockKey, {
+              experimentalStrategy: strategy,
+              experimentalOptions: {
+                maxRetries: 251,
               },
             })
 
@@ -897,14 +926,13 @@ describe('config/src/validation', () => {
       expect(validate).to.be.true
     })
 
-    // TODO: revisit limit on 'default' and 'flaky' keys to set sane limits
-    it(`tests upper bound (currently no limit and is subject to change)`, () => {
+    it(`tests upper bound is 250`, () => {
       const validate = validation.isValidBurnInConfig('experimentalBurnIn', {
-        default: 100000,
-        flaky: 142342342,
+        default: 251,
+        flaky: 251,
       })
 
-      expect(validate).to.be.true
+      expect(validate).to.not.be.true
     })
   })
 })

--- a/packages/server/test/unit/config_spec.js
+++ b/packages/server/test/unit/config_spec.js
@@ -883,29 +883,29 @@ describe('lib/config', () => {
       })
 
       context('retries', () => {
-        const retriesError = 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy'
+        // const retriesError = 'a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy'
 
         // need to keep the const here or it'll get stripped by the build
         // eslint-disable-next-line no-unused-vars
         const cases = [
-          [{ retries: null }, 'with null', true],
-          [{ retries: 3 }, 'when a number', true],
-          [{ retries: 3.2 }, 'when a float', false],
-          [{ retries: -1 }, 'with a negative number', false],
-          [{ retries: true }, 'when true', false],
-          [{ retries: false }, 'when false', false],
-          [{ retries: {} }, 'with an empty object', true],
-          [{ retries: { runMode: 3 } }, 'when runMode is a positive number', true],
-          [{ retries: { runMode: -1 } }, 'when runMode is a negative number', false],
-          [{ retries: { openMode: 3 } }, 'when openMode is a positive number', true],
-          [{ retries: { openMode: -1 } }, 'when openMode is a negative number', false],
-          [{ retries: { openMode: 3, TypoRunMode: 3 } }, 'when there is an additional unknown key', false],
-          [{ retries: { openMode: 3, runMode: 3 } }, 'when both runMode and openMode are positive numbers', true],
-        ].forEach(([config, expectation, shouldPass]) => {
-          it(`${shouldPass ? 'passes' : 'fails'} ${expectation}`, function () {
+          [{ retries: null }, 'with null', null],
+          [{ retries: 3 }, 'when a number', null],
+          [{ retries: 3.2 }, 'when a float', 'Expected retries to be a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy.'],
+          [{ retries: -1 }, 'with a negative number', 'Expected retries to be a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy.'],
+          [{ retries: true }, 'when true', 'Expected retries to be a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy.'],
+          [{ retries: false }, 'when false', 'Expected retries to be a positive number or null or an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls, or experimental configuration with key "experimentalStrategy" with value "detect-flake-but-always-fail" or "detect-flake-and-pass-on-threshold" and key "experimentalOptions" to provide a valid configuration for your selected strategy.'],
+          [{ retries: {} }, 'with an empty object', null],
+          [{ retries: { runMode: 3 } }, 'when runMode is a positive number', null],
+          [{ retries: { runMode: -1 } }, 'when runMode is a negative number', 'Expected retries.runMode to be a positive whole number between 0 and 250 or null.'],
+          [{ retries: { openMode: 3 } }, 'when openMode is a positive number', null],
+          [{ retries: { openMode: -1 } }, 'when openMode is a negative number', 'Expected retries.openMode to be a positive whole number between 0 and 250 or null'],
+          [{ retries: { openMode: 3, TypoRunMode: 3 } }, 'when there is an additional unknown key', 'Expected retries to be an object with keys "openMode" and "runMode" with values of numbers, booleans, or nulls.'],
+          [{ retries: { openMode: 3, runMode: 3 } }, 'when both runMode and openMode are positive numbers', null],
+        ].forEach(([config, expectation, expectedError]) => {
+          it(`${expectedError ? 'fails' : 'passes'} ${expectation}`, function () {
             this.setup(config)
 
-            return shouldPass ? this.expectValidationPasses() : this.expectValidationFails(retriesError)
+            return expectedError ? this.expectValidationFails(expectedError) : this.expectValidationPasses()
           })
         })
       })


### PR DESCRIPTION
This PR sets an upper limit of 250 (inclusive) for all config values specifying the number of retries in the cloud, including:
- `retries` when set to a number
- `retries.runMode`
- `retries.openMode`
- `retries.experimentalOptions.maxRetries`
- `experimentalBurnIn.default`
- `experimentalBurnIn.flaky`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?