### PR TITLE
chore:updating styles

### DIFF
--- a/packages/app/src/runs/RunCard.vue
+++ b/packages/app/src/runs/RunCard.vue
@@ -3,16 +3,16 @@
     :data-cy="`runCard-${run.id}`"
   >
     <div
-      class="flex justify-between gap-[8px] text-sm text-gray-700 items-center whitespace-nowrap children:flex children:py-[16px]"
+      class="flex justify-between p-[16px] gap-[8px] text-sm text-gray-700 items-center"
       :data-cy="`runCard-status-${run.status}`"
     >
       <div
-        class="children:flex items-center gap-[8px] pl-[16px]"
+        class="flex items-center gap-[8px] min-w-0"
       >
         <div>
           <ExternalLink
             :data-cy="`runNumberLink-${run.id}`"
-            class="overflow-hidden border border-transparent hocus-default"
+            class="group focus-visible:outline-none hover:underline-transparent"
             :href="runUrl"
             :use-default-hocus="false"
           >
@@ -20,11 +20,12 @@
               v-if="props.gql.status && props.gql.runNumber"
               :status="props.gql.status"
               :value="props.gql.runNumber"
+              :is-actionable="true"
             />
           </ExternalLink>
         </div>
         <div
-          class="gap-[8px]"
+          class="flex gap-[8px] min-w-0"
         >
           <RunResults
             :gql="props.gql"
@@ -36,7 +37,7 @@
             :title="run.commitInfo?.branch"
             :icon="IconTechnologyBranchH"
             :icon-label="t('runs.card.branchName')"
-            class="hidden xl:inline-flex"
+            class="hidden xl:inline-flex min-w-0"
             data-cy="runCard-branchName"
           />
           <RunTag
@@ -44,7 +45,7 @@
             :key="tag"
             :label="tag"
             :title="tag"
-            class="hidden 2xl:inline-flex"
+            class="hidden 2xl:inline-flex max-w-[100px]"
           />
           <RunTagCount
             v-for="tagCount in tagData?.tagCounts"
@@ -60,26 +61,23 @@
         </div>
       </div>
       <div
-        class="flex children:flex items-center pr-[16px]"
+        class="flex gap-[16px] items-center"
       >
         <ul
-          class="w-[80px] lg:w-auto lg:max-w-[160px] 2xl:max-w-none mr-[16px]  justify-end text-sm text-gray-700 items-center whitespace-nowrap children:flex children:items-center"
+          class="flex gap-2 2xl:gap-4 w-[80px] lg:w-auto lg:max-w-[160px] 2xl:max-w-none justify-end text-sm text-gray-700 items-center whitespace-nowrap children:flex children:items-center"
         >
           <li
             v-if="run.commitInfo?.authorName"
             data-cy="runCard-author"
-            class="shrink-0 2xl:shrink-1 xl:max-w-[160px] pr-[8px] 2xl:pr-[16px] overflow-hidden"
+            class="gap-2 shrink-0 xl:max-w-[160px] overflow-hidden"
             :title="run.commitInfo.authorName"
           >
-            <span
+            <UserAvatar
+              aria-hidden="true"
               data-cy="runCard-avatar"
-            >
-              <UserAvatar
-                aria-hidden="true"
-                class="h-[16px] w-[16px] 2xl:mr-1 icon-dark-gray-500 icon-light-gray-100 icon-secondary-light-gray-200"
-                :email="run.commitInfo?.authorEmail"
-              />
-            </span>
+              class="h-[16px] w-[16px] shrink-0 icon-dark-gray-500 icon-light-gray-100 icon-secondary-light-gray-200"
+              :email="run.commitInfo?.authorEmail"
+            />
             <span class="sr-only">{{ t('runs.card.commitAuthor') }}</span>
             <div
               class="hidden 2xl:block truncate"
@@ -91,12 +89,12 @@
           <li
             v-if="run.createdAt"
             data-cy="runCard-createdAt"
-            class="2xl:w-[160px] overflow-hidden"
+            class="gap-2 2xl:w-[200px] overflow-hidden"
             :title="`${totalDuration} ${relativeCreatedAt}`"
           >
             <IconTimeClock
               size="16"
-              class="hidden 2xl:inline-block mr-2 shrink-0"
+              class="hidden 2xl:inline-block shrink-0"
               stroke-color="gray-500"
               fill-color="gray-50"
               aria-hidden="true"
@@ -126,7 +124,7 @@
           >
             <IconTechnologyDebugger
               aria-hidden="true"
-              class="h-[16px] w-[16px] mr-2"
+              class="h-[16px] w-[16px] mr-2 shrink-0"
             />
             {{ t('runs.card.debugLabel') }}
           </Button>

--- a/packages/app/src/runs/RunNumber.cy.tsx
+++ b/packages/app/src/runs/RunNumber.cy.tsx
@@ -7,7 +7,27 @@ describe('<RunNumber />', () => {
   describe('playground', () => {
     STATUSES.forEach((status) => {
       it(`status = '${status}'`, () => {
-        cy.mount(<RunNumber status={status} value={123} />)
+        cy.mount(() => (
+          <div class="flex m-2">
+            <RunNumber status={status} value={123} />
+          </div>
+        ))
+
+        cy.findByTestId(`runNumber-status-${status}`).should('be.visible').should('not.have.class', 'group-focus-visible:outline')
+      })
+    })
+  })
+
+  describe('with hover', () => {
+    STATUSES.forEach((status) => {
+      it(`status = '${status}'`, () => {
+        cy.mount(() => (
+          <div class="flex m-2 group">
+            <RunNumber status={status} value={123} is-actionable={true} />
+          </div>
+        ))
+
+        cy.findByTestId(`runNumber-status-${status}`).should('be.visible').should('have.class', 'group-focus-visible:outline')
       })
     })
   })

--- a/packages/app/src/runs/RunNumber.vue
+++ b/packages/app/src/runs/RunNumber.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="border rounded flex flex-row font-semibold bg-gray-50 border-gray-200 h-6 text-sm px-2 gap-x-1 items-center justify-center"
+    :class="hocusStyles"
     :data-cy="`runNumber-status-${props.status}`"
   >
     <SolidStatusIcon
@@ -21,25 +22,37 @@ import { SolidStatusIcon, StatusType } from '@cypress-design/vue-statusicon'
 const props = defineProps<{
   status: CloudRunStatus
   value: number
+  isActionable?: boolean
 }>()
 
-const ICON_MAP: Record<CloudRunStatus, { textColor: string, type: StatusType }> = {
-  PASSED: { textColor: 'text-jade-400', type: 'passed' },
-  FAILED: { textColor: 'text-red-400', type: 'failed' },
-  CANCELLED: { textColor: 'text-gray-500', type: 'cancelled' },
-  ERRORED: { textColor: 'text-orange-400', type: 'errored' },
-  RUNNING: { textColor: 'text-indigo-500', type: 'running' },
-  NOTESTS: { textColor: 'text-indigo-500', type: 'noTests' },
-  OVERLIMIT: { textColor: 'text-indigo-500', type: 'overLimit' },
-  TIMEDOUT: { textColor: 'text-indigo-500', type: 'timedOut' },
+const ICON_MAP: Record<CloudRunStatus, { textColor: string, type: StatusType, hocusStyles: readonly string[] }> = {
+  PASSED: { textColor: 'text-jade-400', type: 'passed', hocusStyles: ['group-hover:border-jade-400', 'group-focus-visible:border-jade-400', 'group-focus-visible:outline-jade-400'] },
+  FAILED: { textColor: 'text-red-400', type: 'failed', hocusStyles: ['group-hover:border-red-400', 'group-focus-visible:border-red-400', 'group-focus-visible:outline-red-400'] },
+  CANCELLED: { textColor: 'text-gray-500', type: 'cancelled', hocusStyles: ['group-hover:border-gray-500', 'group-focus-visible:border-gray-500', 'group-focus-visible:outline-gray-500'] },
+  ERRORED: { textColor: 'text-orange-400', type: 'errored', hocusStyles: ['group-hover:border-orange-400', 'group-focus-visible:border-orange-400', 'group-focus-visible:outline-orange-400'] },
+  RUNNING: { textColor: 'text-indigo-500', type: 'running', hocusStyles: ['group-hover:border-indigo-500', 'group-focus-visible:border-indigo-500', 'group-focus-visible:outline-indigo-500'] },
+  NOTESTS: { textColor: 'text-indigo-500', type: 'noTests', hocusStyles: ['group-hover:border-indigo-500', 'group-focus-visible:border-indigo-500', 'group-focus-visible:outline-indigo-500'] },
+  OVERLIMIT: { textColor: 'text-indigo-500', type: 'overLimit', hocusStyles: ['group-hover:border-indigo-500', 'group-focus-visible:border-indigo-500', 'group-focus-visible:outline-indigo-500'] },
+  TIMEDOUT: { textColor: 'text-indigo-500', type: 'timedOut', hocusStyles: ['group-hover:border-indigo-500', 'group-focus-visible:border-indigo-500', 'group-focus-visible:outline-indigo-500'] },
 } as const
 
+const icon = computed(() => {
+  return ICON_MAP[props.status]
+})
+
 const runNumberColor = computed(() => {
-  if (props.status) {
-    return ICON_MAP[props.status].textColor
+  return icon.value.textColor
+})
+
+const hocusStyles = computed(() => {
+  if (!props.isActionable) {
+    return
   }
 
-  return ''
+  return [
+    'group-focus-visible:outline',
+    ...icon.value.hocusStyles,
+  ]
 })
 
 </script>

--- a/packages/app/src/runs/RunResults.vue
+++ b/packages/app/src/runs/RunResults.vue
@@ -9,7 +9,6 @@
       :total-skipped="results.totalSkipped"
       :total-pending="results.totalPending"
       :order="['PASSED', 'FAILED', 'SKIPPED', 'PENDING']"
-      :class="{'relative overflow-hidden fade-out max-w-[240px]': useBreakpointDisplay}"
     />
     <div
       v-if="results?.totalFlakyTests"
@@ -60,17 +59,3 @@ const results = computed(() => {
   return props.gql
 })
 </script>
-
-<style scoped>
-.fade-out::after {
-  background: linear-gradient(90deg, transparent, #fff);
-  content: '';
-  height: 100%;
-  left: 176px;
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: 64px;
-  z-index: 1;
-}
-</style>

--- a/packages/app/src/runs/RunTag.vue
+++ b/packages/app/src/runs/RunTag.vue
@@ -2,7 +2,6 @@
   <div
     v-if="label"
     class="inline-flex rounded-md bg-gray-50 border-gray-200 border-[1px] text-sm px-[8px] text-gray-700 items-center py-[2px]"
-    :class="icon ? 'max-w-[160px]' : 'max-w-[100px]'"
     data-cy="runTag"
   >
     <component


### PR DESCRIPTION
Taking a pass at making the RunCard data more visible at wider breakpoints
* Being consistent when using `flex` to rely on `gap` versus having to make sure each child has the correct margin on the correct side
* Adding `min-w-0` to some flex children to allow them to shrink if needed
* Allowing branch tag to be as wide as needed but truncating if there is not enough space
* Moved max widths out of RunTag to allow it to be more flexible. Applied them as an attribute on an instance of the component when needed
* Increased width of `created-at` div at largest breakpoint to allow it to show the entire string for almost all times and duration
* Updated style for `RunNumber` component when used as an external link.  Best approach would be to move the ExternalLink into the component and conditionally render it depending on its usage, but did not do that refactor.  The issue is with fighting default styles on the `a` tag rendered by the `ExternalLink` component and the internal styles of the `RunNumber` component.  Made use of the `group` utility class in Tailwind
* Removed "fade-out` from RunResults and removed the max-width.  With the original implementation, there was always a "fade-out" shown, even when the entire text was visible.  The times when the number values will be so large and the viewport so small to cause overflow are very minimal.  Not worth the trade off.
* Refactored `RunCard` test.  
  * Added more examples of various states of data in the first loop of tests.  It could use more examples to show off more permutations of data.
  * Changed the wrapping styles to make the component more visible
* Added to the `RunNumber` test to assert component was visible when rendered and that hover styles were applied when appropriate