### PR TITLE
chore: improve logging on retried upload failures

### DIFF
--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -1277,8 +1277,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r3',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 1440,
-        'width': 2560,
+        'height': 720,
+        'width': 1280,
       },
     ],
     'reporterStats': {
@@ -1357,8 +1357,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r3',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 2044,
-        'width': 800,
+        'height': 1022,
+        'width': 400,
       },
     ],
     'reporterStats': {
@@ -1434,8 +1434,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r2',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 1440,
-        'width': 2560,
+        'height': 720,
+        'width': 1280,
       },
     ],
     'reporterStats': {

--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -1277,8 +1277,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r3',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 720,
-        'width': 1280,
+        'height': 1440,
+        'width': 2560,
       },
     ],
     'reporterStats': {
@@ -1357,8 +1357,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r3',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 1022,
-        'width': 400,
+        'height': 2044,
+        'width': 800,
       },
     ],
     'reporterStats': {
@@ -1434,8 +1434,8 @@ exports['e2e record passing passes 2'] = [
         'testId': 'r2',
         'testAttemptIndex': 0,
         'takenAt': '2018-02-01T20:14:19.323Z',
-        'height': 720,
-        'width': 1280,
+        'height': 1440,
+        'width': 2560,
       },
     ],
     'reporterStats': {
@@ -3387,7 +3387,88 @@ exports['e2e record capture-protocol enabled protocol runtime errors error in pr
 
 `
 
-exports['capture-protocol api errors upload 500 - retries 6 times continues 1'] = `
+exports['e2e record capture-protocol enabled protocol runtime errors error in protocol beforeTest displays the error and reports the fatal error to the cloud via artifacts 1'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (record_pass.cy.js)                                                        │
+  │ Searched:   cypress/e2e/record_pass*                                                           │
+  │ Params:     Tag: false, Group: false, Parallel: false                                          │
+  │ Run URL:    https://dashboard.cypress.io/projects/cjvoj7/runs/12                               │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  record_pass.cy.js                                                               (1 of 1)
+  Estimated: X second(s)
+
+
+  record pass
+    ✓ passes
+    - is pending
+
+
+  1 passing
+  1 pending
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        2                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      1                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Estimated:    X second(s)                                                                      │
+  │ Spec Ran:     record_pass.cy.js                                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png                 (400x1022)
+
+
+  (Uploading Cloud Artifacts)
+
+  - Video - Nothing to upload 
+  - Screenshot - 1 kB /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
+  - Test Replay - Failed Capturing - error in beforeTest
+
+  (Uploaded Cloud Artifacts)
+
+  - Screenshot - Done Uploading 1 kB 1/1 /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  record_pass.cy.js                        XX:XX        2        1        -        1        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        2        1        -        1        -  
+
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                       
+  Recorded Run: https://dashboard.cypress.io/projects/cjvoj7/runs/12
+
+
+`
+
+exports['capture-protocol api errors upload 500 - retries 8 times continues 1'] = `
 
 ====================================================================================================
 
@@ -3469,7 +3550,7 @@ exports['capture-protocol api errors upload 500 - retries 6 times continues 1'] 
 
 `
 
-exports['capture-protocol api errors upload 500 - retries 5 times and succeeds on the last call continues 1'] = `
+exports['capture-protocol api errors upload 500 - retries 7 times and succeeds on the last call continues 1'] = `
 
 ====================================================================================================
 
@@ -3551,7 +3632,7 @@ exports['capture-protocol api errors upload 500 - retries 5 times and succeeds o
 
 `
 
-exports['e2e record capture-protocol enabled protocol runtime errors error in protocol beforeTest displays the error and reports the fatal error to the cloud via artifacts 1'] = `
+exports['capture-protocol api errors upload 500 - retries 8 times and fails continues 1'] = `
 
 ====================================================================================================
 
@@ -3607,11 +3688,12 @@ exports['e2e record capture-protocol enabled protocol runtime errors error in pr
 
   - Video - Nothing to upload 
   - Screenshot - 1 kB /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
-  - Test Replay - Failed Capturing - error in beforeTest
+  - Test Replay 
 
   (Uploaded Cloud Artifacts)
 
-  - Screenshot - Done Uploading 1 kB 1/1 /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
+  - Screenshot - Done Uploading 1 kB 1/2 /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
+  - Test Replay - Failed Uploading 2/2 - Internal Server Error
 
 ====================================================================================================
 

--- a/system-tests/test/record_spec.js
+++ b/system-tests/test/record_spec.js
@@ -2322,7 +2322,6 @@ describe('e2e record', () => {
           })
 
           it('displays error and does not upload if db size is too large', function () {
-          // have to write the db to fs here instead of in the t
             return systemTests.exec(this, {
               key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
               configFile: 'cypress-with-project-id.config.js',
@@ -2477,7 +2476,7 @@ describe('capture-protocol api errors', () => {
     }))
   }
 
-  describe('upload 500 - retries 6 times', () => {
+  describe('upload 500 - retries 8 times and fails', () => {
     stubbedServerWithErrorOn('putCaptureProtocolUpload')
     it('continues', function () {
       process.env.API_RETRY_INTERVALS = '1000'
@@ -2488,12 +2487,21 @@ describe('capture-protocol api errors', () => {
         spec: 'record_pass*',
         record: true,
         snapshot: true,
+      }).then(() => {
+        const urls = getRequestUrls()
+
+        expect(urls).to.include.members([`PUT /instances/${instanceId}/artifacts`])
+
+        const artifactReport = getRequests().find(({ url }) => url === `PUT /instances/${instanceId}/artifacts`)?.body
+
+        expect(artifactReport?.protocol).to.exist()
+        expect(artifactReport?.protocol?.error).to.equal('Failed to upload after 8 attempts. Errors: Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error, Internal Server Error')
       })
     })
   })
 
-  describe('upload 500 - retries 5 times and succeeds on the last call', () => {
-    stubbedServerWithErrorOn('putCaptureProtocolUpload', 5)
+  describe('upload 500 - retries 7 times and succeeds on the last call', () => {
+    stubbedServerWithErrorOn('putCaptureProtocolUpload', 7)
 
     let archiveFile = ''
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Improve logging on retried upload failures. We will start capturing all of the errors and send a message with the full context up to the cloud on upload failure

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
