### PR TITLE
docs: update installation requirements in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
-- [`cmake`](https://cmake.org/), [`g++`](https://gcc.gnu.org/), and [`make`](https://www.gnu.org/software/make/) (command: `sudo apt install cmake g++ make` on Debian-based systems)
+- [`cmake`](https://cmake.org/), [`g++`](https://gcc.gnu.org/onlinedocs/libstdc++/), and [`make`](https://www.gnu.org/software/make/) (command: `sudo apt install cmake g++ make` on Debian-based systems)
 
 ### Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
-- `g++` and `make` (command: `sudo apt install g++ make` on Debian-based systems)
+- `cmake`, `g++` and `make` (command: `sudo apt install cmake g++ make` on Debian-based systems)
 
 ### Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,7 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
+- `g++` and `make` (command: `sudo apt install g++ make` on Debian-based systems)
 
 ### Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
-- `cmake`, `g++` and `make` (command: `sudo apt install cmake g++ make` on Debian-based systems)
+- [`cmake`](https://cmake.org/), [`g++`](https://gcc.gnu.org/), and [`make`](https://www.gnu.org/software/make/) (command: `sudo apt install cmake g++ make` on Debian-based systems)
 
 ### Getting Started
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/27846

- Supersedes https://github.com/cypress-io/cypress/pull/27878

### Additional details
```cmake```, ```g++``` and ```make``` are required to build Cypress

---

> A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)

**GCC** is not enough for Cypress to build successfully

---

#### Without ```cmake``` installed
```
/bin/sh: 1: cmake: not found
```

#### Without ```g++``` installed
```
make: g++: No such file or directory
```

#### Without ```make``` installed
```
Error: not found: make
```

### PR Tasks
- [no] Have tests been added/updated?
- [no] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [no] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
