### PR TITLE
chore: add @packages/example as a dependency of create-cypress-tests

### DIFF
--- a/npm/create-cypress-tests/package.json
+++ b/npm/create-cypress-tests/package.json
@@ -50,5 +50,10 @@
   },
   "license": "MIT",
   "repository": "https://github.com/cypress-io/cypress.git",
-  "homepage": "https://github.com/cypress-io/cypress/blob/develop/npm/create-cypress-tests/#readme"
+  "homepage": "https://github.com/cypress-io/cypress/blob/develop/npm/create-cypress-tests/#readme",
+  "nx": {
+    "implicitDependencies": [
+      "@packages/example"
+    ]
+  }
 }


### PR DESCRIPTION
The build step for `create-cypress-tests` relies on build output from `packages/example`. This is an implicit dependency since create-cypress-tests doesn't import anything from `packages/example` in its source. 

This PR tells Nx that create-cypress-tests depends on `packages/example`.

[Example CI failure](https://app.circleci.com/pipelines/github/cypress-io/cypress/57269/workflows/211e6e96-d52a-4627-ac71-8d1cff867971/jobs/2376506?invite=true#step-114-33972_113)