### PR TITLE
chore: exit successfully when test report directory doesn't exist

### DIFF
--- a/scripts/unit/verify-mocha-results-spec.js
+++ b/scripts/unit/verify-mocha-results-spec.js
@@ -7,6 +7,8 @@ if (process.platform !== 'win32') {
   describe('verify-mocha-results', () => {
     let cachedEnv = { ...process.env }
 
+    let fsAccessStub
+
     afterEach(() => {
       sinon.restore()
       Object.assign(process.env, cachedEnv)
@@ -19,9 +21,17 @@ if (process.platform !== 'win32') {
         Dispatched: { TaskInfo: { Environment: { somekey: 'someval' } } },
       }))
 
+      fsAccessStub = sinon.stub(fs, 'access').withArgs('/tmp/cypress/junit').resolves()
+
       sinon.stub(fs, 'readdir').withArgs('/tmp/cypress/junit').resolves([
         'report.xml',
       ])
+    })
+
+    it('exits normally when report directory does not exist', async () => {
+      fsAccessStub.rejects()
+
+      await verifyMochaResults()
     })
 
     it('does not fail with normal report', async () => {

--- a/scripts/verify-mocha-results.js
+++ b/scripts/verify-mocha-results.js
@@ -94,6 +94,14 @@ async function checkReportFiles (filenames) {
 
 async function verifyMochaResults () {
   try {
+    try {
+      await fs.access(REPORTS_PATH)
+    } catch {
+      console.log('Reports directory does not exist - assuming no tests ran')
+
+      return
+    }
+
     const filenames = await fs.readdir(REPORTS_PATH)
 
     const resultCount = filenames.length


### PR DESCRIPTION
Sometimes when we use Cypress Cloud parallelization for our tests (most often the driver tests have this problem), Cypress Cloud will only recognize some of the CI machines. The result is that one or more of our CI machines won't actually run any of our tests. This is fine, because the other machines _do_ run them.

However, when we run our "Verify mocha results" step, we check the test reports directory. If no tests have run on the machine, then this directory won't exist. [This causes our CI run to fail](https://app.circleci.com/pipelines/github/cypress-io/cypress/57295/workflows/7eb99ecb-3f61-4ffb-beec-6b9a7873cfda/jobs/2377382/parallel-runs/3?filterBy=ALL&invite=true#step-112-437_111). If this happens, we shouldn't fail the CI job. All of our tests still ran and passed, just on other CI machines.

This PR adds a check to make sure that the test report directory exists. If it doesn't exist, then we can assume that no tests ran, and we can exit the script.