### PR TITLE
fix: undo timeout change to fix performance regression

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.3.2
+
+_Released 10/18/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed a performance regression where proxy correlation timeouts for requests in service workers were always hit causing slow downs. Fixes [#28054](https://github.com/cypress-io/cypress/issues/28054)
+
 ## 13.3.1
 
 _Released 10/11/2023_

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -51,12 +51,12 @@ class QueueMap<T> {
 
     this.queues[queueKey].push(value)
   }
-  shift (queueKey: string): T | undefined {
+  pop (queueKey: string): T | undefined {
     const queue = this.queues[queueKey]
 
     if (!queue) return
 
-    const item = queue.shift()
+    const item = queue.pop()
 
     if (queue.length === 0) delete this.queues[queueKey]
 
@@ -95,7 +95,7 @@ export class PreRequests {
   protocolManager?: ProtocolManagerShape
 
   constructor (
-    requestTimeout = 2000,
+    requestTimeout = 500,
     // 10 seconds
     sweepInterval = 10000,
   ) {
@@ -134,7 +134,7 @@ export class PreRequests {
   addPending (browserPreRequest: BrowserPreRequest) {
     metrics.browserPreRequestsReceived++
     const key = `${browserPreRequest.method}-${browserPreRequest.url}`
-    const pendingRequest = this.pendingRequests.shift(key)
+    const pendingRequest = this.pendingRequests.pop(key)
 
     if (pendingRequest) {
       const timings = {
@@ -174,7 +174,7 @@ export class PreRequests {
 
   addPendingUrlWithoutPreRequest (url: string) {
     const key = `GET-${url}`
-    const pendingRequest = this.pendingRequests.shift(key)
+    const pendingRequest = this.pendingRequests.pop(key)
 
     if (pendingRequest) {
       debugVerbose('Handling %s without a CDP prerequest', key)
@@ -200,7 +200,7 @@ export class PreRequests {
 
     metrics.proxyRequestsReceived++
     const key = `${req.method}-${req.proxiedUrl}`
-    const pendingPreRequest = this.pendingPreRequests.shift(key)
+    const pendingPreRequest = this.pendingPreRequests.pop(key)
 
     if (pendingPreRequest) {
       metrics.immediatelyMatchedRequests++
@@ -217,7 +217,7 @@ export class PreRequests {
       return
     }
 
-    const pendingUrlWithoutPreRequests = this.pendingUrlsWithoutPreRequests.shift(key)
+    const pendingUrlWithoutPreRequests = this.pendingUrlsWithoutPreRequests.pop(key)
 
     if (pendingUrlWithoutPreRequests) {
       metrics.immediatelyMatchedRequests++

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -41,18 +41,6 @@ describe('http/util/prerequests', () => {
       cdpRequestWillBeSentReceivedTimestamp: 2,
     })
 
-    const secondPreRequest: BrowserPreRequest = {
-      requestId: '1234',
-      url: 'foo',
-      method: 'GET',
-      headers: {},
-      resourceType: 'xhr',
-      originalResourceType: undefined,
-      cdpRequestWillBeSentTimestamp: 1,
-      cdpRequestWillBeSentReceivedTimestamp: performance.now() + performance.timeOrigin + 10000,
-    }
-
-    preRequests.addPending(secondPreRequest)
     preRequests.addPending({
       requestId: '1234',
       url: 'foo',
@@ -64,6 +52,19 @@ describe('http/util/prerequests', () => {
       cdpRequestWillBeSentReceivedTimestamp: 2,
     })
 
+    const thirdRequest: BrowserPreRequest = {
+      requestId: '1234',
+      url: 'foo',
+      method: 'GET',
+      headers: {},
+      resourceType: 'xhr',
+      originalResourceType: undefined,
+      cdpRequestWillBeSentTimestamp: 1,
+      cdpRequestWillBeSentReceivedTimestamp: performance.now() + performance.timeOrigin + 10000,
+    }
+
+    preRequests.addPending(thirdRequest)
+
     expectPendingCounts(0, 3)
 
     const cb = sinon.stub()
@@ -73,17 +74,17 @@ describe('http/util/prerequests', () => {
     const { args } = cb.getCall(0)
     const arg = args[0]
 
-    expect(arg.requestId).to.eq(secondPreRequest.requestId)
-    expect(arg.url).to.eq(secondPreRequest.url)
-    expect(arg.method).to.eq(secondPreRequest.method)
-    expect(arg.headers).to.deep.eq(secondPreRequest.headers)
-    expect(arg.resourceType).to.eq(secondPreRequest.resourceType)
-    expect(arg.originalResourceType).to.eq(secondPreRequest.originalResourceType)
-    expect(arg.cdpRequestWillBeSentTimestamp).to.eq(secondPreRequest.cdpRequestWillBeSentTimestamp)
-    expect(arg.cdpRequestWillBeSentReceivedTimestamp).to.eq(secondPreRequest.cdpRequestWillBeSentReceivedTimestamp)
+    expect(arg.requestId).to.eq(thirdRequest.requestId)
+    expect(arg.url).to.eq(thirdRequest.url)
+    expect(arg.method).to.eq(thirdRequest.method)
+    expect(arg.headers).to.deep.eq(thirdRequest.headers)
+    expect(arg.resourceType).to.eq(thirdRequest.resourceType)
+    expect(arg.originalResourceType).to.eq(thirdRequest.originalResourceType)
+    expect(arg.cdpRequestWillBeSentTimestamp).to.eq(thirdRequest.cdpRequestWillBeSentTimestamp)
+    expect(arg.cdpRequestWillBeSentReceivedTimestamp).to.eq(thirdRequest.cdpRequestWillBeSentReceivedTimestamp)
     expect(arg.proxyRequestReceivedTimestamp).to.be.a('number')
-    expect(arg.cdpLagDuration).to.eq(secondPreRequest.cdpRequestWillBeSentReceivedTimestamp - secondPreRequest.cdpRequestWillBeSentTimestamp)
-    expect(arg.proxyRequestCorrelationDuration).to.eq(secondPreRequest.cdpRequestWillBeSentReceivedTimestamp - arg.proxyRequestReceivedTimestamp)
+    expect(arg.cdpLagDuration).to.eq(thirdRequest.cdpRequestWillBeSentReceivedTimestamp - thirdRequest.cdpRequestWillBeSentTimestamp)
+    expect(arg.proxyRequestCorrelationDuration).to.eq(thirdRequest.cdpRequestWillBeSentReceivedTimestamp - arg.proxyRequestReceivedTimestamp)
 
     expectPendingCounts(0, 2)
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes [#28054 ](https://github.com/cypress-io/cypress/issues/28054)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We [introduced a regression](https://github.com/cypress-io/cypress/pull/27976) by bumping up the timeout on proxy correlation. The thought was that the majority of requests should be correlated quickly and for the occasional ones that take a while, it is more important to actually correlate for things like assets in test replay and intercepts. Unfortunately, there are still bugs in the proxy correlation logic that cause some requests to never be able to be correlated. [Specifically](https://github.com/cypress-io/cypress/issues/28056) requests that come from service workers. We originally thought this would be a fairly fast fix to this problem; however it ended up being more nuanced than we thought so we are backing out the change that caused the regression while we work on a more robust solution.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
