### PR TITLE
fix: fix failures and correlation in proxy

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 13.3.2
+## 13.3.3
 
 _Released 10/24/2023 (PENDING)_
 
@@ -8,6 +8,8 @@ _Released 10/24/2023 (PENDING)_
 - Fixed a performance problem with proxy correlation when requests get aborted and then get miscorrelated with follow up requests. Fixed in [#28094](https://github.com/cypress-io/cypress/pull/28094).
 
 _Released 10/18/2023_
+
+## 13.3.2
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,9 +7,9 @@ _Released 10/24/2023 (PENDING)_
 
 - Fixed a performance problem with proxy correlation when requests get aborted and then get miscorrelated with follow up requests. Fixed in [#28094](https://github.com/cypress-io/cypress/pull/28094).
 
-_Released 10/18/2023_
-
 ## 13.3.2
+
+_Released 10/18/2023_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 10/24/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed a performance problem with proxy correlation when requests get aborted and then get miscorrelated with follow up requests. Addressed in [#28094](https://github.com/cypress-io/cypress/pull/28094).
+- Fixed a performance problem with proxy correlation when requests get aborted and then get miscorrelated with follow up requests. Fixed in [#28094](https://github.com/cypress-io/cypress/pull/28094).
 
 _Released 10/18/2023_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.3.2
 
+_Released 10/24/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed a performance problem with proxy correlation when requests get aborted and then get miscorrelated with follow up requests. Addressed in [#28094](https://github.com/cypress-io/cypress/pull/28094).
+
 _Released 10/18/2023_
 
 **Bugfixes:**

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -128,7 +128,7 @@ const CorrelateBrowserPreRequest: RequestMiddleware = async function () {
   }
 
   this.debug('waiting for prerequest')
-  this.getPreRequest((({ browserPreRequest, noPreRequestExpected }) => {
+  this.pendingRequest = this.getPreRequest((({ browserPreRequest, noPreRequestExpected }) => {
     this.req.browserPreRequest = browserPreRequest
     this.req.noPreRequestExpected = noPreRequestExpected
     copyResourceTypeAndNext()

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -455,6 +455,13 @@ const SendRequestOutgoing: RequestMiddleware = function () {
     this.debug('request aborted')
     // if the request is aborted, close out the middleware span and http span. the response middleware did not run
 
+    const pendingRequest = this.pendingRequest
+
+    if (pendingRequest) {
+      delete this.pendingRequest
+      this.removePendingRequest(pendingRequest)
+    }
+
     this.reqMiddlewareSpan?.setAttributes({
       requestAborted: true,
     })

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -28,7 +28,7 @@ export type CorrelationInformation = {
 
 export type GetPreRequestCb = (correlationInformation: CorrelationInformation) => void
 
-type PendingRequest = {
+export type PendingRequest = {
   ctxDebug
   callback?: GetPreRequestCb
   timeout: NodeJS.Timeout
@@ -283,6 +283,8 @@ export class PreRequests {
     }
 
     this.pendingRequests.push(key, pendingRequest)
+
+    return pendingRequest
   }
 
   setProtocolManager (protocolManager: ProtocolManagerShape) {

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -75,11 +75,9 @@ class QueueMap<T> {
     })
   }
   removeExact (queueKey: string, value: T) {
-    const queue = this.queues[queueKey]
+    const i = this.queues[queueKey]?.findIndex((v) => v === value)
 
-    if (queue) {
-      const i = queue.findIndex((v) => v === value)
-
+    if (i > -1) {
       this.queues[queueKey].splice(i, 1)
       if (this.queues[queueKey].length === 0) delete this.queues[queueKey]
     }

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -207,7 +207,7 @@ describe('http/util/prerequests', () => {
 
     expectPendingCounts(0, 3)
 
-    preRequests.removePending('1235')
+    preRequests.removePendingPreRequest('1235')
 
     expectPendingCounts(0, 2)
   })
@@ -222,7 +222,7 @@ describe('http/util/prerequests', () => {
 
     expectPendingCounts(0, 6)
 
-    preRequests.removePending('1235')
+    preRequests.removePendingPreRequest('1235')
 
     expectPendingCounts(0, 2)
   })

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -239,11 +239,20 @@ describe('http/util/prerequests', () => {
   it('removes a pending request', () => {
     const cb = sinon.stub()
 
-    const preRequest = preRequests.get({ proxiedUrl: 'foo', method: 'GET', headers: {} } as CypressIncomingRequest, () => {}, cb)
+    const firstPreRequest = preRequests.get({ proxiedUrl: 'foo', method: 'GET', headers: {} } as CypressIncomingRequest, () => {}, cb)
+    const secondPreRequest = preRequests.get({ proxiedUrl: 'foo', method: 'GET', headers: {} } as CypressIncomingRequest, () => {}, cb)
+
+    expectPendingCounts(2, 0)
+
+    preRequests.removePendingRequest(firstPreRequest!)
 
     expectPendingCounts(1, 0)
 
-    preRequests.removePendingRequest(preRequest!)
+    preRequests.removePendingRequest(firstPreRequest!)
+
+    expectPendingCounts(1, 0)
+
+    preRequests.removePendingRequest(secondPreRequest!)
 
     expectPendingCounts(0, 0)
   })

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -236,6 +236,18 @@ describe('http/util/prerequests', () => {
     expect(cbServiceWorker).to.be.calledWith()
   })
 
+  it('removes a pending request', () => {
+    const cb = sinon.stub()
+
+    const preRequest = preRequests.get({ proxiedUrl: 'foo', method: 'GET', headers: {} } as CypressIncomingRequest, () => {}, cb)
+
+    expectPendingCounts(1, 0)
+
+    preRequests.removePendingRequest(preRequest!)
+
+    expectPendingCounts(0, 0)
+  })
+
   it('resets the queues', () => {
     let callbackCalled = false
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We recently made a change to clean up browser prerequests when requests are aborted, but we don't do the same thing with proxy prerequests. This PR ensures that we clean things up on both sides.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

I added some integration tests to cover if CDP failures come in first vs. proxy failures.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
