### PR TITLE
fix: issue with proxy correlations and web/shared workers

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.3.3
+
+_Released 10/24/2023 (PENDING)_
+
+- Fixed a performance regression in `13.3.1` with proxy correlation timeouts and requests issued from web and shared workers. Fixes [#28104](https://github.com/cypress-io/cypress/issues/28104).
+
 ## 13.3.2
 
 _Released 10/18/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 _Released 10/24/2023 (PENDING)_
 
+**Bugfixes:**
+
 - Fixed a performance regression in `13.3.1` with proxy correlation timeouts and requests issued from web and shared workers. Fixes [#28104](https://github.com/cypress-io/cypress/issues/28104).
 
 ## 13.3.2

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -125,7 +125,7 @@ export class BrowserCriClient {
   gracefulShutdown?: Boolean
   onClose: Function | null = null
 
-  private constructor (private browserClient: CriClient, private versionInfo, public host: string, public port: number, private browserName: string, private onAsynchronousError: Function, private protocolManager?: ProtocolManagerShape) { }
+  private constructor (private browserClient: CriClient, private versionInfo, public host: string, public port: number, private browserName: string, private onAsynchronousError: Function, private protocolManager?: ProtocolManagerShape, private fullyManageTabs?: boolean) { }
 
   /**
    * Factory method for the browser cri client. Connects to the browser and then returns a chrome remote interface wrapper around the
@@ -151,9 +151,10 @@ export class BrowserCriClient {
         onAsynchronousError,
         onReconnect,
         protocolManager,
+        fullyManageTabs,
       })
 
-      const browserCriClient = new BrowserCriClient(browserClient, versionInfo, host!, port, browserName, onAsynchronousError, protocolManager)
+      const browserCriClient = new BrowserCriClient(browserClient, versionInfo, host!, port, browserName, onAsynchronousError, protocolManager, fullyManageTabs)
 
       if (fullyManageTabs) {
         await browserClient.send('Target.setDiscoverTargets', { discover: true })
@@ -270,7 +271,7 @@ export class BrowserCriClient {
         throw new Error(`Could not find url target in browser ${url}. Targets were ${JSON.stringify(targets)}`)
       }
 
-      this.currentlyAttachedTarget = await create({ target: target.targetId, onAsynchronousError: this.onAsynchronousError, host: this.host, port: this.port, protocolManager: this.protocolManager })
+      this.currentlyAttachedTarget = await create({ target: target.targetId, onAsynchronousError: this.onAsynchronousError, host: this.host, port: this.port, protocolManager: this.protocolManager, fullyManageTabs: this.fullyManageTabs })
       await this.protocolManager?.connectToBrowser(this.currentlyAttachedTarget)
 
       return this.currentlyAttachedTarget
@@ -323,6 +324,7 @@ export class BrowserCriClient {
         host: this.host,
         port: this.port,
         protocolManager: this.protocolManager,
+        fullyManageTabs: this.fullyManageTabs,
       })
     } else {
       this.currentlyAttachedTarget = undefined

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -205,7 +205,7 @@ export class BrowserCriClient {
           }
 
           if (event.waitingForDebugger) {
-            await browserClient.send('Runtime.runIfWaitingForDebugger', undefined, event.sessionId)
+            browserClient.send('Runtime.runIfWaitingForDebugger', undefined, event.sessionId)
           }
         })
 

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -14,6 +14,7 @@ import type { CDPClient, ProtocolManagerShape, WriteVideoFrame } from '@packages
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
 import type { CriClient } from './cri-client'
+import utils from './utils'
 
 export type CdpCommand = keyof ProtocolMapping.Commands
 
@@ -198,17 +199,7 @@ export class CdpAutomation implements CDPClient {
   static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, offFn: OffFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, protocolManager?: ProtocolManagerShape): Promise<CdpAutomation> {
     const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, offFn, sendCloseCommandFn, automation)
 
-    const networkEnabledOptions = protocolManager?.protocolEnabled ? {
-      maxTotalBufferSize: 0,
-      maxResourceBufferSize: 0,
-      maxPostDataSize: 64 * 1024,
-    } : {
-      maxTotalBufferSize: 0,
-      maxResourceBufferSize: 0,
-      maxPostDataSize: 0,
-    }
-
-    await sendDebuggerCommandFn('Network.enable', networkEnabledOptions)
+    await sendDebuggerCommandFn('Network.enable', utils.getNetworkEnableOptions(protocolManager))
 
     return cdpAutomation
   }

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -13,7 +13,7 @@ import type { ResourceType, BrowserPreRequest, BrowserResponseReceived } from '@
 import type { CDPClient, ProtocolManagerShape, WriteVideoFrame } from '@packages/types'
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
-import { DEFAULT_NETWORK_ENABLE_OPTIONS, type CriClient } from './cri-client'
+import { DEFAULT_NETWORK_ENABLE_OPTIONS, CriClient } from './cri-client'
 
 export type CdpCommand = keyof ProtocolMapping.Commands
 

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -13,8 +13,7 @@ import type { ResourceType, BrowserPreRequest, BrowserResponseReceived } from '@
 import type { CDPClient, ProtocolManagerShape, WriteVideoFrame } from '@packages/types'
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
-import type { CriClient } from './cri-client'
-import utils from './utils'
+import { DEFAULT_NETWORK_ENABLE_OPTIONS, type CriClient } from './cri-client'
 
 export type CdpCommand = keyof ProtocolMapping.Commands
 
@@ -199,7 +198,7 @@ export class CdpAutomation implements CDPClient {
   static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, offFn: OffFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, protocolManager?: ProtocolManagerShape): Promise<CdpAutomation> {
     const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, offFn, sendCloseCommandFn, automation)
 
-    await sendDebuggerCommandFn('Network.enable', utils.getNetworkEnableOptions(protocolManager))
+    await sendDebuggerCommandFn('Network.enable', protocolManager?.networkEnableOptions ?? DEFAULT_NETWORK_ENABLE_OPTIONS)
 
     return cdpAutomation
   }

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -140,7 +140,7 @@ export const normalizeResourceType = (resourceType: string | undefined): Resourc
   return ffToStandardResourceTypeMap[resourceType] || 'other'
 }
 
-export type SendDebuggerCommand = <T extends CdpCommand>(message: T, data?: ProtocolMapping.Commands[T]['paramsType'][0]) => Promise<ProtocolMapping.Commands[T]['returnType']>
+export type SendDebuggerCommand = <T extends CdpCommand>(message: T, data?: ProtocolMapping.Commands[T]['paramsType'][0], sessionId?: string) => Promise<ProtocolMapping.Commands[T]['returnType']>
 
 export type OnFn = <T extends CdpEvent>(eventName: T, cb: (data: ProtocolMapping.Events[T][0]) => void) => void
 

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -488,7 +488,11 @@ export = {
     const browserCriClient = this._getBrowserCriClient()
 
     // Handle chrome tab crashes.
-    pageCriClient.on('Inspector.targetCrashed', async () => {
+    pageCriClient.on('Target.targetCrashed', async (event) => {
+      if (event.targetId !== browserCriClient?.currentlyAttachedTarget?.targetId) {
+        return
+      }
+
       const err = errors.get('RENDERER_CRASHED', browser.displayName)
 
       await memory.endProfiling()

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -473,7 +473,7 @@ export = {
     debug('connecting to existing chrome instance with url and debugging port', { url: options.url, port })
     if (!options.onError) throw new Error('Missing onError in connectToExisting')
 
-    const browserCriClient = await BrowserCriClient.create(['127.0.0.1'], port, browser.displayName, options.onError, onReconnect, undefined, { fullyManageTabs: false })
+    const browserCriClient = await BrowserCriClient.create({ hosts: ['127.0.0.1'], port, browserName: browser.displayName, onAsynchronousError: options.onError, onReconnect, fullyManageTabs: false })
 
     if (!options.url) throw new Error('Missing url in connectToExisting')
 
@@ -601,7 +601,7 @@ export = {
     // navigate to the actual url
     if (!options.onError) throw new Error('Missing onError in chrome#open')
 
-    browserCriClient = await BrowserCriClient.create(['127.0.0.1'], port, browser.displayName, options.onError, onReconnect, options.protocolManager, { fullyManageTabs: true })
+    browserCriClient = await BrowserCriClient.create({ hosts: ['127.0.0.1'], port, browserName: browser.displayName, onAsynchronousError: options.onError, onReconnect, protocolManager: options.protocolManager, fullyManageTabs: true })
 
     la(browserCriClient, 'expected Chrome remote interface reference', browserCriClient)
 

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -388,9 +388,11 @@ export const create = async ({
       debug('registering CDP on event %o', { eventName })
 
       cri.on(eventName, cb)
-      // This ensures that we are notified about the browser's events that have been registered (e.g. service workers)
+      // This ensures that we are notified about the browser's network events that have been registered (e.g. service workers)
       // Long term we should use flat mode entirely across all of chrome remote interface
-      browserClient?.on(eventName, cb)
+      if (eventName.startsWith('Network.')) {
+        browserClient?.on(eventName, cb)
+      }
     },
 
     off (eventName, cb) {
@@ -399,7 +401,11 @@ export const create = async ({
       }), 1)
 
       cri.off(eventName, cb)
-      browserClient?.off(eventName, cb)
+      // This ensures that we are notified about the browser's network events that have been registered (e.g. service workers)
+      // Long term we should use flat mode entirely across all of chrome remote interface
+      if (eventName.startsWith('Network.')) {
+        browserClient?.off(eventName, cb)
+      }
     },
 
     get ws () {

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -9,6 +9,7 @@ import type CDP from 'chrome-remote-interface'
 
 import type { SendDebuggerCommand, OnFn, CdpCommand, CdpEvent } from './cdp_automation'
 import type { ProtocolManagerShape } from '@packages/types'
+import utils from './utils'
 
 const debug = debugModule('cypress:server:browsers:cri-client')
 // debug using cypress-verbose:server:browsers:cri-client:send:*
@@ -258,34 +259,41 @@ export const create = async ({
       cri.on('disconnect', retryReconnect)
     }
 
-    cri.on('Inspector.targetCrashed', async () => {
+    cri.on('Target.targetCrashed', async (event) => {
+      if (event.targetId !== target) {
+        return
+      }
+
       debug('crash detected')
       crashed = true
     })
 
     // We only want to try and add service worker traffic if we have a host set. This indicates that this is the child cri client.
     if (host) {
-      cri.on('Target.targetCreated', async (event) => {
-        if (event.targetInfo.type === 'service_worker') {
-          const networkEnabledOptions = protocolManager?.protocolEnabled ? {
-            maxTotalBufferSize: 0,
-            maxResourceBufferSize: 0,
-            maxPostDataSize: 64 * 1024,
-          } : {
-            maxTotalBufferSize: 0,
-            maxResourceBufferSize: 0,
-            maxPostDataSize: 0,
-          }
+      // This is frustrating, but regular web workers work differently than any of the other target types. They are not auto detected
+      // by Target.setDiscoverTargets so we need to call setAutoAttach to detect them. For all the other types we use the target created event.
+      // Once detected we need to enable network traffic so that we can get CDP network events for the workers.
 
+      cri.on('Target.targetCreated', async (event) => {
+        if (event.targetInfo.type !== 'worker') {
           const { sessionId } = await cri.send('Target.attachToTarget', {
             targetId: event.targetInfo.targetId,
             flatten: true,
           })
 
-          await cri.send('Network.enable', networkEnabledOptions, sessionId)
+          await cri.send('Network.enable', utils.getNetworkEnableOptions(protocolManager), sessionId)
         }
       })
 
+      cri.on('Target.attachedToTarget', async (event) => {
+        if (event.targetInfo.type === 'worker') {
+          await cri.send('Network.enable', utils.getNetworkEnableOptions(protocolManager), event.sessionId)
+        }
+
+        await cri.send('Runtime.runIfWaitingForDebugger', undefined, event.sessionId)
+      })
+
+      await cri.send('Target.setAutoAttach', { autoAttach: true, waitForDebuggerOnStart: true, flatten: true })
       await cri.send('Target.setDiscoverTargets', { discover: true })
     }
   }

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -54,7 +54,7 @@ const _getAutomation = async function (win, options: BrowserLaunchOpts, parent) 
   const port = getRemoteDebuggingPort()
 
   if (!browserCriClient) {
-    browserCriClient = await BrowserCriClient.create(['127.0.0.1'], port, 'electron', options.onError, () => {}, undefined, { fullyManageTabs: true })
+    browserCriClient = await BrowserCriClient.create({ hosts: ['127.0.0.1'], port, browserName: 'electron', onAsynchronousError: options.onError, onReconnect: () => {}, fullyManageTabs: true })
   }
 
   const pageCriClient = await browserCriClient.attachToTargetUrl('about:blank')

--- a/packages/server/lib/browsers/firefox-util.ts
+++ b/packages/server/lib/browsers/firefox-util.ts
@@ -138,7 +138,7 @@ async function connectToNewSpec (options, automation: Automation, browserCriClie
 }
 
 async function setupRemote (remotePort, automation, onError): Promise<BrowserCriClient> {
-  const browserCriClient = await BrowserCriClient.create(['127.0.0.1', '::1'], remotePort, 'Firefox', onError)
+  const browserCriClient = await BrowserCriClient.create({ hosts: ['127.0.0.1', '::1'], port: remotePort, browserName: 'Firefox', onAsynchronousError: onError })
   const pageCriClient = await browserCriClient.attachToTargetUrl('about:blank')
 
   await CdpAutomation.create(pageCriClient.send, pageCriClient.on, pageCriClient.off, browserCriClient.resetBrowserTargets, automation)

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-redeclare */
 import Bluebird from 'bluebird'
 import _ from 'lodash'
-import type { BrowserLaunchOpts, FoundBrowser, ProtocolManagerShape } from '@packages/types'
+import type { BrowserLaunchOpts, FoundBrowser } from '@packages/types'
 import * as errors from '../errors'
 import * as plugins from '../plugins'
 import { getError } from '@packages/errors'
@@ -419,18 +419,6 @@ const listenForDownload = () => {
   }
 }
 
-const getNetworkEnableOptions = (protocolManager: ProtocolManagerShape | undefined) => {
-  return protocolManager?.protocolEnabled ? {
-    maxTotalBufferSize: 0,
-    maxResourceBufferSize: 0,
-    maxPostDataSize: 64 * 1024,
-  } : {
-    maxTotalBufferSize: 0,
-    maxResourceBufferSize: 0,
-    maxPostDataSize: 0,
-  }
-}
-
 export = {
 
   extendLaunchOptionsFromPlugins,
@@ -468,8 +456,6 @@ export = {
   handleDownloadLinksViaCDP,
 
   listenForDownload,
-
-  getNetworkEnableOptions,
 
   writeExtension (browser, isTextTerminal, proxyUrl, socketIoRoute) {
     debug('writing extension')

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-redeclare */
 import Bluebird from 'bluebird'
 import _ from 'lodash'
-import type { BrowserLaunchOpts, FoundBrowser } from '@packages/types'
+import type { BrowserLaunchOpts, FoundBrowser, ProtocolManagerShape } from '@packages/types'
 import * as errors from '../errors'
 import * as plugins from '../plugins'
 import { getError } from '@packages/errors'
@@ -419,6 +419,18 @@ const listenForDownload = () => {
   }
 }
 
+const getNetworkEnableOptions = (protocolManager: ProtocolManagerShape | undefined) => {
+  return protocolManager?.protocolEnabled ? {
+    maxTotalBufferSize: 0,
+    maxResourceBufferSize: 0,
+    maxPostDataSize: 64 * 1024,
+  } : {
+    maxTotalBufferSize: 0,
+    maxResourceBufferSize: 0,
+    maxPostDataSize: 0,
+  }
+}
+
 export = {
 
   extendLaunchOptionsFromPlugins,
@@ -456,6 +468,8 @@ export = {
   handleDownloadLinksViaCDP,
 
   listenForDownload,
+
+  getNetworkEnableOptions,
 
   writeExtension (browser, isTextTerminal, proxyUrl, socketIoRoute) {
     debug('writing extension')

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -14,6 +14,7 @@ import pkg from '@packages/root'
 import env from '../util/env'
 import type { Readable } from 'stream'
 import type { ProtocolManagerShape, AppCaptureProtocolInterface, CDPClient, ProtocolError, CaptureArtifact, ProtocolErrorReport, ProtocolCaptureMethod, ProtocolManagerOptions, ResponseStreamOptions, ResponseEndedWithEmptyBodyOptions, ResponseStreamTimedOutOptions } from '@packages/types'
+import { DEFAULT_NETWORK_ENABLE_OPTIONS } from '../browsers/cri-client'
 
 const routes = require('./routes')
 
@@ -70,6 +71,14 @@ export class ProtocolManager implements ProtocolManagerShape {
 
   get protocolEnabled (): boolean {
     return !!this._protocol
+  }
+
+  get networkEnableOptions () {
+    return this.protocolEnabled ? {
+      maxTotalBufferSize: 0,
+      maxResourceBufferSize: 0,
+      maxPostDataSize: 64 * 1024,
+    } : DEFAULT_NETWORK_ENABLE_OPTIONS
   }
 
   async setupProtocol (script: string, options: ProtocolManagerOptions) {

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -14,7 +14,6 @@ import pkg from '@packages/root'
 import env from '../util/env'
 import type { Readable } from 'stream'
 import type { ProtocolManagerShape, AppCaptureProtocolInterface, CDPClient, ProtocolError, CaptureArtifact, ProtocolErrorReport, ProtocolCaptureMethod, ProtocolManagerOptions, ResponseStreamOptions, ResponseEndedWithEmptyBodyOptions, ResponseStreamTimedOutOptions } from '@packages/types'
-import { DEFAULT_NETWORK_ENABLE_OPTIONS } from '../browsers/cri-client'
 
 const routes = require('./routes')
 
@@ -78,7 +77,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       maxTotalBufferSize: 0,
       maxResourceBufferSize: 0,
       maxPostDataSize: 64 * 1024,
-    } : DEFAULT_NETWORK_ENABLE_OPTIONS
+    } : undefined
   }
 
   async setupProtocol (script: string, options: ProtocolManagerOptions) {

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -10,6 +10,11 @@ const HOST = '127.0.0.1'
 const PORT = 50505
 const THROWS_PORT = 65535
 
+type GetClientParams = {
+  protocolManager?: ProtocolManagerShape
+  fullyManageTabs?: boolean
+}
+
 describe('lib/browsers/cri-client', function () {
   let browserCriClient: {
     BrowserCriClient: {
@@ -17,13 +22,14 @@ describe('lib/browsers/cri-client', function () {
     }
   }
   let send: sinon.SinonStub
+  let on: sinon.SinonStub
   let close: sinon.SinonStub
   let criClientCreateStub: sinon.SinonStub
   let criImport: sinon.SinonStub & {
     Version: sinon.SinonStub
   }
   let onError: sinon.SinonStub
-  let getClient: (protocolManager?: ProtocolManagerShape) => ReturnType<typeof BrowserCriClient.create>
+  let getClient: (options?: GetClientParams) => ReturnType<typeof BrowserCriClient.create>
 
   beforeEach(function () {
     sinon.stub(protocol, '_connectAsync')
@@ -37,10 +43,12 @@ describe('lib/browsers/cri-client', function () {
     .onSecondCall().throws()
     .onThirdCall().resolves({ webSocketDebuggerUrl: 'http://web/socket/url' })
 
+    on = sinon.stub()
     send = sinon.stub()
     close = sinon.stub()
-    criClientCreateStub = sinon.stub(CriClient, 'create').withArgs({ target: 'http://web/socket/url', onAsynchronousError: onError, onReconnect: undefined, protocolManager: undefined }).resolves({
+    criClientCreateStub = sinon.stub(CriClient, 'create').withArgs({ target: 'http://web/socket/url', onAsynchronousError: onError, onReconnect: undefined, protocolManager: undefined, fullyManageTabs: undefined }).resolves({
       send,
+      on,
       close,
     })
 
@@ -48,13 +56,14 @@ describe('lib/browsers/cri-client', function () {
       'chrome-remote-interface': criImport,
     })
 
-    getClient = (protocolManager) => {
-      criClientCreateStub = criClientCreateStub.withArgs({ target: 'http://web/socket/url', onAsynchronousError: onError, onReconnect: undefined, protocolManager }).resolves({
+    getClient = ({ protocolManager, fullyManageTabs } = {}) => {
+      criClientCreateStub = criClientCreateStub.withArgs({ target: 'http://web/socket/url', onAsynchronousError: onError, onReconnect: undefined, protocolManager, fullyManageTabs }).resolves({
         send,
+        on,
         close,
       })
 
-      return browserCriClient.BrowserCriClient.create(['127.0.0.1'], PORT, 'Chrome', onError, undefined, protocolManager)
+      return browserCriClient.BrowserCriClient.create(['127.0.0.1'], PORT, 'Chrome', onError, undefined, protocolManager, { fullyManageTabs })
     }
   })
 
@@ -150,7 +159,7 @@ describe('lib/browsers/cri-client', function () {
         const mockPageClient = {}
 
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 
@@ -159,16 +168,18 @@ describe('lib/browsers/cri-client', function () {
         expect(client).to.be.equal(mockPageClient)
       })
 
-      it('creates a page client when the passed in url is found and notifies the protocol manager', async function () {
+      it('creates a page client when the passed in url is found and notifies the protocol manager and fully managed tabs', async function () {
         const mockPageClient = {}
         const protocolManager: any = {
           connectToBrowser: sinon.stub().resolves(),
         }
 
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager }).resolves(mockPageClient)
+        send.withArgs('Target.setDiscoverTargets', { discover: true })
+        on.withArgs('Target.targetDestroyed', sinon.match.func)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager, fullyManageTabs: true }).resolves(mockPageClient)
 
-        const browserClient = await getClient(protocolManager)
+        const browserClient = await getClient({ protocolManager, fullyManageTabs: true })
 
         const client = await browserClient.attachToTargetUrl('http://foo.com')
 
@@ -187,7 +198,7 @@ describe('lib/browsers/cri-client', function () {
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }, { targetId: '3', url: 'http://baz.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 
@@ -205,7 +216,7 @@ describe('lib/browsers/cri-client', function () {
 
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 
@@ -226,7 +237,7 @@ describe('lib/browsers/cri-client', function () {
 
         send.withArgs('Target.createTarget', { url: 'about:blank' }).resolves(mockUpdatedCurrentlyAttachedTarget)
         send.withArgs('Target.closeTarget', { targetId: '100' }).resolves()
-        criClientCreateStub.withArgs({ target: '101', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined }).resolves(mockUpdatedCurrentlyAttachedTarget)
+        criClientCreateStub.withArgs({ target: '101', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockUpdatedCurrentlyAttachedTarget)
 
         const browserClient = await getClient() as any
 

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -159,7 +159,7 @@ describe('lib/browsers/cri-client', function () {
         const mockPageClient = {}
 
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined, browserClient: { on, send, close } }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 
@@ -177,7 +177,7 @@ describe('lib/browsers/cri-client', function () {
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.setDiscoverTargets', { discover: true })
         on.withArgs('Target.targetDestroyed', sinon.match.func)
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager, fullyManageTabs: true }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager, fullyManageTabs: true, browserClient: { on, send, close } }).resolves(mockPageClient)
 
         const browserClient = await getClient({ protocolManager, fullyManageTabs: true })
 
@@ -198,7 +198,7 @@ describe('lib/browsers/cri-client', function () {
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }, { targetId: '3', url: 'http://baz.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined, browserClient: { on, send, close } }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 
@@ -216,7 +216,7 @@ describe('lib/browsers/cri-client', function () {
 
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
         send.withArgs('Target.getTargets').resolves({ targetInfos: [{ targetId: '1', url: 'http://foo.com' }, { targetId: '2', url: 'http://bar.com' }] })
-        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined }).resolves(mockPageClient)
+        criClientCreateStub.withArgs({ target: '1', onAsynchronousError: onError, host: HOST, port: PORT, protocolManager: undefined, fullyManageTabs: undefined, browserClient: { on, send, close } }).resolves(mockPageClient)
 
         const browserClient = await getClient()
 

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -63,7 +63,7 @@ describe('lib/browsers/cri-client', function () {
         close,
       })
 
-      return browserCriClient.BrowserCriClient.create(['127.0.0.1'], PORT, 'Chrome', onError, undefined, protocolManager, { fullyManageTabs })
+      return browserCriClient.BrowserCriClient.create({ hosts: ['127.0.0.1'], port: PORT, browserName: 'Chrome', onAsynchronousError: onError, protocolManager, fullyManageTabs })
     }
   })
 
@@ -100,7 +100,7 @@ describe('lib/browsers/cri-client', function () {
 
       criImport.Version.withArgs({ host: '::1', port: THROWS_PORT, useHostName: true }).resolves({ webSocketDebuggerUrl: 'http://web/socket/url' })
 
-      await browserCriClient.BrowserCriClient.create(['127.0.0.1', '::1'], THROWS_PORT, 'Chrome', onError)
+      await browserCriClient.BrowserCriClient.create({ hosts: ['127.0.0.1', '::1'], port: THROWS_PORT, browserName: 'Chrome', onAsynchronousError: onError })
 
       expect(criImport.Version).to.be.calledOnce
     })
@@ -111,7 +111,7 @@ describe('lib/browsers/cri-client', function () {
       .onSecondCall().returns(100)
       .onThirdCall().returns(100)
 
-      const client = await browserCriClient.BrowserCriClient.create(['127.0.0.1'], THROWS_PORT, 'Chrome', onError)
+      const client = await browserCriClient.BrowserCriClient.create({ hosts: ['127.0.0.1'], port: THROWS_PORT, browserName: 'Chrome', onAsynchronousError: onError })
 
       expect(client.attachToTargetUrl).to.be.instanceOf(Function)
 
@@ -123,7 +123,7 @@ describe('lib/browsers/cri-client', function () {
       .onFirstCall().returns(100)
       .onSecondCall().returns(undefined)
 
-      await expect(browserCriClient.BrowserCriClient.create(['127.0.0.1'], THROWS_PORT, 'Chrome', onError)).to.be.rejected
+      await expect(browserCriClient.BrowserCriClient.create({ hosts: ['127.0.0.1'], port: THROWS_PORT, browserName: 'Chrome', onAsynchronousError: onError })).to.be.rejected
 
       expect(criImport.Version).to.be.calledTwice
     })

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -24,6 +24,7 @@ context('lib/browsers/cdp_automation', () => {
         }
         const localManager = {
           protocolEnabled: true,
+          networkEnableOptions: enabledObject,
         } as ProtocolManagerShape
 
         const localCommandStub = localCommand.withArgs('Network.enable', enabledObject).resolves()
@@ -49,6 +50,7 @@ context('lib/browsers/cdp_automation', () => {
         }
         const localManager = {
           protocolEnabled: false,
+          networkEnableOptions: disabledObject,
         } as ProtocolManagerShape
 
         const localCommandStub = localCommand.withArgs('Network.enable', disabledObject).resolves()
@@ -91,7 +93,7 @@ context('lib/browsers/cdp_automation', () => {
         const startScreencast = this.sendDebuggerCommand.withArgs('Page.startScreencast').resolves()
         const screencastFrameAck = this.sendDebuggerCommand.withArgs('Page.screencastFrameAck').resolves()
 
-        await cdpAutomation.startVideoRecording(writeVideoFrame)
+        await cdpAutomation.startVideoRecording(writeVideoFrame, {})
 
         expect(startScreencast).to.have.been.calledWith('Page.startScreencast')
         expect(writeVideoFrame).to.have.been.calledWithMatch((arg) => Buffer.isBuffer(arg) && arg.length > 0)

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -23,7 +23,7 @@ describe('lib/browsers/cri-client', function () {
     _notifier: EventEmitter
   }
   let onError: sinon.SinonStub
-  let getClient: () => ReturnType<typeof create>
+  let getClient: (options?: { fullyManageTabs?: boolean }) => ReturnType<typeof create>
 
   beforeEach(function () {
     send = sinon.stub()
@@ -49,8 +49,8 @@ describe('lib/browsers/cri-client', function () {
       'chrome-remote-interface': criImport,
     })
 
-    getClient = () => {
-      return criClient.create({ target: DEBUGGER_URL, onAsynchronousError: onError })
+    getClient = ({ fullyManageTabs } = {}) => {
+      return criClient.create({ target: DEBUGGER_URL, onAsynchronousError: onError, fullyManageTabs })
     }
   })
 
@@ -82,9 +82,9 @@ describe('lib/browsers/cri-client', function () {
 
       it('rejects if target has crashed', async function () {
         const command = 'DOM.getDocument'
-        const client = await getClient()
+        const client = await getClient({ fullyManageTabs: true })
 
-        await criStub.on.withArgs('Inspector.targetCrashed').args[0][1]()
+        await criStub.on.withArgs('Target.targetCrashed').args[0][1]({ targetId: DEBUGGER_URL })
         await expect(client.send(command, { depth: -1 })).to.be.rejectedWith(`${command} will not run as the target browser or tab CRI connection has crashed`)
       })
 

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -23,7 +23,7 @@ describe('lib/browsers/cri-client', function () {
     _notifier: EventEmitter
   }
   let onError: sinon.SinonStub
-  let getClient: (options?: { fullyManageTabs?: boolean }) => ReturnType<typeof create>
+  let getClient: (options?: { host?: string, fullyManageTabs?: boolean }) => ReturnType<typeof create>
 
   beforeEach(function () {
     send = sinon.stub()
@@ -49,8 +49,8 @@ describe('lib/browsers/cri-client', function () {
       'chrome-remote-interface': criImport,
     })
 
-    getClient = ({ fullyManageTabs } = {}) => {
-      return criClient.create({ target: DEBUGGER_URL, onAsynchronousError: onError, fullyManageTabs })
+    getClient = ({ host, fullyManageTabs } = {}) => {
+      return criClient.create({ target: DEBUGGER_URL, host, onAsynchronousError: onError, fullyManageTabs })
     }
   })
 
@@ -82,7 +82,7 @@ describe('lib/browsers/cri-client', function () {
 
       it('rejects if target has crashed', async function () {
         const command = 'DOM.getDocument'
-        const client = await getClient({ fullyManageTabs: true })
+        const client = await getClient({ host: '127.0.0.1', fullyManageTabs: true })
 
         await criStub.on.withArgs('Target.targetCrashed').args[0][1]({ targetId: DEBUGGER_URL })
         await expect(client.send(command, { depth: -1 })).to.be.rejectedWith(`${command} will not run as the target browser or tab CRI connection has crashed`)

--- a/packages/server/test/unit/browsers/firefox_spec.ts
+++ b/packages/server/test/unit/browsers/firefox_spec.ts
@@ -532,6 +532,14 @@ describe('lib/browsers/firefox', () => {
           on: sinon.stub(),
           off: sinon.stub(),
           close: sinon.stub(),
+          ws: sinon.stub() as any,
+          queue: {
+            enableCommands: [],
+            enqueuedCommands: [],
+            subscriptions: [],
+          },
+          closed: false,
+          connected: false,
         }
 
         const browserCriClient: BrowserCriClient = sinon.createStubInstance(BrowserCriClient)
@@ -545,7 +553,7 @@ describe('lib/browsers/firefox', () => {
 
         expect(actual).to.equal(browserCriClient)
         expect(browserCriClient.attachToTargetUrl).to.be.calledWith('about:blank')
-        expect(BrowserCriClient.create).to.be.calledWith(['127.0.0.1', '::1'], port, 'Firefox', null)
+        expect(BrowserCriClient.create).to.be.calledWith({ hosts: ['127.0.0.1', '::1'], port, browserName: 'Firefox', onAsynchronousError: null })
         expect(CdpAutomation.create).to.be.calledWith(
           criClientStub.send,
           criClientStub.on,

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -85,6 +85,7 @@ export type ProtocolManagerOptions = {
 
 export interface ProtocolManagerShape extends AppCaptureProtocolCommon {
   protocolEnabled: boolean
+  networkEnableOptions: { maxTotalBufferSize: number, maxResourceBufferSize: number, maxPostDataSize: number }
   setupProtocol(script: string, options: ProtocolManagerOptions): Promise<void>
   beforeSpec (spec: { instanceId: string }): void
   reportNonFatalErrors (clientMetadata: any): Promise<void>

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -85,7 +85,7 @@ export type ProtocolManagerOptions = {
 
 export interface ProtocolManagerShape extends AppCaptureProtocolCommon {
   protocolEnabled: boolean
-  networkEnableOptions: { maxTotalBufferSize: number, maxResourceBufferSize: number, maxPostDataSize: number }
+  networkEnableOptions?: { maxTotalBufferSize: number, maxResourceBufferSize: number, maxPostDataSize: number }
   setupProtocol(script: string, options: ProtocolManagerOptions): Promise<void>
   beforeSpec (spec: { instanceId: string }): void
   reportNonFatalErrors (clientMetadata: any): Promise<void>

--- a/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
@@ -1,25 +1,33 @@
 const webWorker = (win) => {
   return new Promise((resolve) => {
     win.worker.onmessage = (e) => {
-      if (e.data.foo === 'bar') {
+      if (e.data.foo === 'bar2') {
         resolve(win)
       }
     }
+
+    win.worker.postMessage({
+      foo: 'bar',
+    })
   })
 }
 
 const sharedWorker = (win) => {
   return new Promise((resolve) => {
     win.sharedWorker.port.onmessage = (e) => {
-      if (e.data.foo === 'baz') {
+      if (e.data.foo === 'baz2') {
         resolve(win)
       }
     }
+
+    win.sharedWorker.port.postMessage({
+      foo: 'baz',
+    })
   })
 }
 
-// Timeout of 1500 will ensure that the proxy correlation timeout is not hit
-it('loads web workers', { defaultCommandTimeout: 1500 }, () => {
+// Timeout of 1900 will ensure that the proxy correlation timeout is not hit
+it('loads web workers', { defaultCommandTimeout: 1900 }, () => {
   cy.visit('https://localhost:1515/web_worker.html')
   .then(webWorker)
   .then(sharedWorker)

--- a/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
@@ -1,0 +1,26 @@
+const webWorker = (win) => {
+  return new Promise((resolve) => {
+    win.worker.onmessage = (e) => {
+      if (e.data.foo === 'bar') {
+        resolve(win)
+      }
+    }
+  })
+}
+
+const sharedWorker = (win) => {
+  return new Promise((resolve) => {
+    win.sharedWorker.port.onmessage = (e) => {
+      if (e.data.foo === 'baz') {
+        resolve(win)
+      }
+    }
+  })
+}
+
+// Timeout of 1500 will ensure that the proxy correlation timeout is not hit
+it('loads web workers', { defaultCommandTimeout: 1500 }, () => {
+  cy.visit('https://localhost:1515/web_worker.html')
+  .then(webWorker)
+  .then(sharedWorker)
+})

--- a/system-tests/projects/e2e/shared-worker.js
+++ b/system-tests/projects/e2e/shared-worker.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line no-undef
+importScripts('/ww.js')
+
+self.addEventListener('connect', (event) => {
+  const port = event.ports[0]
+
+  port.postMessage({
+    foo: 'baz',
+  })
+})

--- a/system-tests/projects/e2e/shared-worker.js
+++ b/system-tests/projects/e2e/shared-worker.js
@@ -4,7 +4,11 @@ importScripts('/ww.js')
 self.addEventListener('connect', (event) => {
   const port = event.ports[0]
 
-  port.postMessage({
-    foo: 'baz',
-  })
+  port.onmessage = (e) => {
+    if (e.data.foo === 'baz') {
+      port.postMessage({
+        foo: 'baz2',
+      })
+    }
+  }
 })

--- a/system-tests/projects/e2e/shared-worker.js
+++ b/system-tests/projects/e2e/shared-worker.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-undef
-importScripts('/ww.js')
+importScripts('/sw.js')
 
 self.addEventListener('connect', (event) => {
   const port = event.ports[0]

--- a/system-tests/projects/e2e/web-worker.js
+++ b/system-tests/projects/e2e/web-worker.js
@@ -4,3 +4,11 @@ importScripts('/ww.js')
 postMessage({
   foo: 'bar',
 })
+
+onmessage = (e) => {
+  if (e.data.foo === 'bar') {
+    postMessage({
+      foo: 'bar2',
+    })
+  }
+}

--- a/system-tests/projects/e2e/web-worker.js
+++ b/system-tests/projects/e2e/web-worker.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-undef
+importScripts('/ww.js')
+
+postMessage({
+  foo: 'bar',
+})

--- a/system-tests/projects/e2e/web-worker.js
+++ b/system-tests/projects/e2e/web-worker.js
@@ -1,10 +1,6 @@
 // eslint-disable-next-line no-undef
 importScripts('/ww.js')
 
-postMessage({
-  foo: 'bar',
-})
-
 onmessage = (e) => {
   if (e.data.foo === 'bar') {
     postMessage({

--- a/system-tests/projects/e2e/web_worker.html
+++ b/system-tests/projects/e2e/web_worker.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title></title>
+  <script>
+    window.worker = new Worker('/web-worker.js')
+    window.sharedWorker = new SharedWorker('/shared-worker.js')
+  </script>
+</head>
+<body>
+  <h1>hi</h1>
+</body>
+</html>

--- a/system-tests/test/service_worker_spec.js
+++ b/system-tests/test/service_worker_spec.js
@@ -31,7 +31,7 @@ const onServer = function (app) {
   })
 }
 
-describe('e2e browser reset', () => {
+describe('e2e service worker', () => {
   systemTests.setup({
     servers: [{
       https: true,

--- a/system-tests/test/web_worker_spec.js
+++ b/system-tests/test/web_worker_spec.js
@@ -1,0 +1,42 @@
+const express = require('express')
+const Fixtures = require('../lib/fixtures')
+const systemTests = require('../lib/system-tests').default
+
+const e2ePath = Fixtures.projectPath('e2e')
+
+let requestsForWebWorker = 0
+
+const onServer = function (app) {
+  app.use(express.static(e2ePath, {
+    // force caching to happen
+    maxAge: 3600000,
+  }))
+
+  app.get('/ww.js', (req, res) => {
+    requestsForWebWorker += 1
+
+    res.set('Content-Type', 'application/javascript')
+    res.set('Mime-Type', 'application/javascript')
+
+    return res.send('const x = 1')
+  })
+}
+
+describe('e2e web worker', () => {
+  systemTests.setup({
+    servers: [{
+      https: true,
+      port: 1515,
+      onServer,
+    }],
+  })
+
+  systemTests.it('executes one spec with a cached call', {
+    project: 'e2e',
+    spec: 'web_worker.cy.js',
+    onRun: async (exec, browser) => {
+      await exec()
+      expect(requestsForWebWorker).to.eq(2)
+    },
+  })
+})

--- a/system-tests/test/web_worker_spec.js
+++ b/system-tests/test/web_worker_spec.js
@@ -5,6 +5,7 @@ const systemTests = require('../lib/system-tests').default
 const e2ePath = Fixtures.projectPath('e2e')
 
 let requestsForWebWorker = 0
+let requestsForSharedWorker = 0
 
 const onServer = function (app) {
   app.use(express.static(e2ePath, {
@@ -14,6 +15,15 @@ const onServer = function (app) {
 
   app.get('/ww.js', (req, res) => {
     requestsForWebWorker += 1
+
+    res.set('Content-Type', 'application/javascript')
+    res.set('Mime-Type', 'application/javascript')
+
+    return res.send('const x = 1')
+  })
+
+  app.get('/sw.js', (req, res) => {
+    requestsForSharedWorker += 1
 
     res.set('Content-Type', 'application/javascript')
     res.set('Mime-Type', 'application/javascript')
@@ -31,12 +41,13 @@ describe('e2e web worker', () => {
     }],
   })
 
-  systemTests.it('executes one spec with a cached call', {
+  systemTests.it('executes one spec with a web and shared worker', {
     project: 'e2e',
     spec: 'web_worker.cy.js',
     onRun: async (exec, browser) => {
       await exec()
-      expect(requestsForWebWorker).to.eq(2)
+      expect(requestsForWebWorker).to.eq(1)
+      expect(requestsForSharedWorker).to.eq(1)
     },
   })
 })


### PR DESCRIPTION
- Closes #28104

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We fixed service workers on #28060 however it appears that workers need to be handled differently in terms of target tracking (we need to use Target.setAutoAttach instead of Target.setDiscoverTargets). This PR handles web workers in that fashion and ensures that shared workers work as well.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

I added a few system tests to cover all of the scenarios.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
