### PR TITLE
chore: Do not add issues with feature/enhancement labels to triage board

### DIFF
--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -28,6 +28,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
     steps:
       - name: is-collaborator
+        # Checks if the user that created the issue/PR has write access to the cypress repo
+        # We ignore these PRs and issues since review of those is handled by internal team processes
         run: |
           gh api graphql -f query='
             query($org: String!, $repo: String!, $user: String!) {
@@ -40,11 +42,12 @@ jobs:
 
           echo 'IS_COLLABORATOR='$(jq -r '.data.repository.collaborators.totalCount' collaborators.json) >> $GITHUB_ENV
       - uses: actions/add-to-project@v0.4.1
-        # only add issues/prs from outside contributors to the project
         if: ${{ env.IS_COLLABORATOR == 0 || github.event.repository.name == 'cypress-support-internal' || github.event.pull_request.user.login == 'github-actions[bot]' || github.event.issue.user.login == 'github-actions[bot]' }}
         with:
           project-url: https://github.com/orgs/${{github.repository_owner}}/projects/${{env.PROJECT_NUMBER}}
           github-token: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}
+          labeled: "type: feature", "type: enhancement"          
+          label-operator: NOT
   add-contributor-pr-comment:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Additional details

The intention of this PR is to exclude issues labeled with `type: feature` and `type: enhancement` from the triage board. 

The engineering triage board should be focused primarily on bugs and comments on those issues. While the product team can use its own processes for evaluating and reading comments on features/enhancement. This should reduce some of the noise of having all comments from features/enhancements added to the board for triage.

### Steps to test

Well, good question. I guess we'll see if this works. Mostly the quotes around the labels since they have spaces.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
