### PR TITLE
docs: fix typos in guides

### DIFF
--- a/guides/graphql-subscriptions.md
+++ b/guides/graphql-subscriptions.md
@@ -109,7 +109,7 @@ browserStatusChange () {
 ```
 
 - [API Docs](https://github.com/enisdenjo/graphql-ws/tree/master/docs)
-- [Transport layer protcol specification](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
+- [Transport layer protocol specification](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
 
 ### Testing
 

--- a/guides/writing-cross-platform-javascript.md
+++ b/guides/writing-cross-platform-javascript.md
@@ -7,7 +7,7 @@ Cypress works on Linux, macOS and Windows. This includes both installing from np
 Throughout the code base, we access the file system in various ways, and need to be conscious of how we do so to ensure Cypress can be used and developed seamlessly on multiple platforms. One thing to keep in mind is file paths and file separators. macOS and Linux systems use `/`, and Windows uses `\`.
 
 
-As a general rule, we want to use **native paths** where possible. There are a few reasons for this. Whereever we display a file path, we want to use the native file separator, since that is what the user will expect on their platform. In general, we can use the Node.js `path` module to handle this:
+As a general rule, we want to use **native paths** where possible. There are a few reasons for this. Wherever we display a file path, we want to use the native file separator, since that is what the user will expect on their platform. In general, we can use the Node.js `path` module to handle this:
 
 ```js
 // on linux-like systems


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This pull request fixes typos in guides. Following are the fixed typos:
1. protcol -> protocol
2. Whereever -> Wherever

I kindly request the repository maintainers to review and merge it. Thanks! :heart: 