### PR TITLE
chore: update homepage field to point to marketing site

### DIFF
--- a/cli/__snapshots__/build_spec.js
+++ b/cli/__snapshots__/build_spec.js
@@ -4,7 +4,7 @@ exports['package.json build outputs expected properties 1'] = {
   'version': 'x.y.z',
   'buildInfo': 'replaced by normalizePackageJson',
   'description': 'Cypress is a next generation front end testing tool built for the modern web',
-  'homepage': 'https://github.com/cypress-io/cypress',
+  'homepage': 'https://cypress.io',
   'license': 'MIT',
   'bugs': {
     'url': 'https://github.com/cypress-io/cypress/issues',

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "type": "git",
     "url": "https://github.com/cypress-io/cypress.git"
   },
-  "homepage": "https://github.com/cypress-io/cypress",
+  "homepage": "https://cypress.io",
   "bugs": {
     "url": "https://github.com/cypress-io/cypress/issues"
   },


### PR DESCRIPTION
NPM uses this field to display a link on our package overview page

![Screenshot 2023-10-24 at 2 30 05 PM](https://github.com/cypress-io/cypress/assets/14275198/e2c555e4-173e-4991-822a-646e70c7acf9)

Right now our "repository" and "homepage" links both point to the Github repository. Instead, the homepage link should point to our marketing site, https://cypress.io