### PR TITLE
fix: pass undefined to test:before:after:run:async if there isn't a next test

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -87,6 +87,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
     - equal: [ 'ryanm/fix/better-sqlite3', << pipeline.git.branch >> ]
+    - equal: [ 'mschile/test-before-after-run-async', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 11/7/2023 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue determining visibility when an element is hidden by an ancestor with a shared edge. Fixes [#27514](https://github.com/cypress-io/cypress/issues/27514).
+- Fixed an issue where `nextTestHasTestIsolationOn` was incorrectly being set when there isn't a next test. Addressed in [#28213](https://github.com/cypress-io/cypress/pull/28213)
 
 ## 13.4.0
 

--- a/packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.snapshots.ts
+++ b/packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.snapshots.ts
@@ -21684,6 +21684,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -22129,6 +22132,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -22548,6 +22554,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -22967,6 +22976,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -23385,6 +23397,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -23860,6 +23875,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 5,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -24355,6 +24373,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -24910,6 +24931,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -25309,6 +25333,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -25677,6 +25704,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -25982,6 +26012,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -26277,6 +26310,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -26572,6 +26608,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -26866,6 +26905,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -27205,6 +27247,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 6,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -28071,6 +28116,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -28516,6 +28564,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -28935,6 +28986,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -29354,6 +29408,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -29773,6 +29830,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -30192,6 +30252,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -30611,6 +30674,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -31030,6 +31096,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -31448,6 +31517,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -31948,6 +32020,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -32454,6 +32529,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -33009,6 +33087,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -33408,6 +33489,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -33776,6 +33860,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -34081,6 +34168,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -34376,6 +34466,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -34671,6 +34764,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -34966,6 +35062,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -35261,6 +35360,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -35556,6 +35658,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -35850,6 +35955,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -36213,6 +36321,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -37091,6 +37202,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -37616,6 +37730,9 @@ export const snapshots = {
           retries: 1,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -38122,6 +38239,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -38677,6 +38797,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -39076,6 +39199,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -39397,6 +39523,9 @@ export const snapshots = {
           currentRetry: 1,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -39770,6 +39899,9 @@ export const snapshots = {
           currentRetry: 2,
           retries: 2,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -41584,6 +41716,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -41927,6 +42062,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -42237,6 +42375,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -42540,6 +42681,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -42843,6 +42987,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -43146,6 +43293,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -43448,6 +43598,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -43797,6 +43950,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 6,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -44703,6 +44859,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -45046,6 +45205,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -45356,6 +45518,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -45659,6 +45824,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -45962,6 +46130,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -46265,6 +46436,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -46568,6 +46742,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -46871,6 +47048,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -47174,6 +47354,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -47476,6 +47659,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -47849,6 +48035,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -48767,6 +48956,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -49110,6 +49302,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -49419,6 +49614,9 @@ export const snapshots = {
           currentRetry: 1,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -49792,6 +49990,9 @@ export const snapshots = {
           currentRetry: 2,
           retries: 2,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [

--- a/packages/app/cypress/e2e/runner/retries.mochaEvents.snapshots.ts
+++ b/packages/app/cypress/e2e/runner/retries.mochaEvents.snapshots.ts
@@ -3504,6 +3504,9 @@ export const snapshots = {
         retries: 2,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -4005,6 +4008,9 @@ export const snapshots = {
         retries: 1,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -4499,6 +4505,9 @@ export const snapshots = {
         currentRetry: 0,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -5054,6 +5063,9 @@ export const snapshots = {
         currentRetry: 0,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -5453,6 +5465,9 @@ export const snapshots = {
         retries: 2,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -5774,6 +5789,9 @@ export const snapshots = {
         currentRetry: 1,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -6123,6 +6141,9 @@ export const snapshots = {
         currentRetry: 2,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -7281,6 +7302,9 @@ export const snapshots = {
         retries: 2,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -7624,6 +7648,9 @@ export const snapshots = {
         retries: 2,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -7933,6 +7960,9 @@ export const snapshots = {
         currentRetry: 1,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -8282,6 +8312,9 @@ export const snapshots = {
         currentRetry: 2,
         retries: 2,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [

--- a/packages/app/cypress/e2e/runner/runner.experimentalRetries.mochaEvents.snapshots.ts
+++ b/packages/app/cypress/e2e/runner/runner.experimentalRetries.mochaEvents.snapshots.ts
@@ -1037,6 +1037,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -1289,6 +1292,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -1539,6 +1545,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -1789,6 +1798,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -2038,6 +2050,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -2294,6 +2309,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -2618,6 +2636,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -2870,6 +2891,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -3120,6 +3144,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -3370,6 +3397,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -3619,6 +3649,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -3869,6 +3902,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -4119,6 +4155,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -4369,6 +4408,9 @@ export const snapshots = {
           currentRetry: 7,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -4619,6 +4661,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -4875,6 +4920,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -5199,6 +5247,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -5451,6 +5502,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -5701,6 +5755,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -5951,6 +6008,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -6200,6 +6260,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -6450,6 +6513,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -6700,6 +6766,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -6950,6 +7019,9 @@ export const snapshots = {
           currentRetry: 7,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -7200,6 +7272,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -7456,6 +7531,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -7752,6 +7830,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -8300,6 +8381,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -8846,6 +8930,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -9427,6 +9514,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -9732,6 +9822,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -10035,6 +10128,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -10338,6 +10434,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -10640,6 +10739,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -10951,6 +11053,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -11289,6 +11394,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -11594,6 +11702,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -11897,6 +12008,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -12200,6 +12314,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -12503,6 +12620,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -12805,6 +12925,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -13108,6 +13231,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -13411,6 +13537,9 @@ export const snapshots = {
           currentRetry: 7,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -13714,6 +13843,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -13996,6 +14128,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -14346,6 +14481,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -14610,6 +14748,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -14872,6 +15013,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -15134,6 +15278,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -15395,6 +15542,9 @@ export const snapshots = {
           currentRetry: 4,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -15657,6 +15807,9 @@ export const snapshots = {
           currentRetry: 5,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -15919,6 +16072,9 @@ export const snapshots = {
           currentRetry: 6,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -16181,6 +16337,9 @@ export const snapshots = {
           currentRetry: 7,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -16443,6 +16602,9 @@ export const snapshots = {
           currentRetry: 8,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -16725,6 +16887,9 @@ export const snapshots = {
           currentRetry: 9,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -27324,6 +27489,9 @@ export const snapshots = {
         retries: 9,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -27693,6 +27861,9 @@ export const snapshots = {
         currentRetry: 0,
         retries: 9,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -28571,6 +28742,9 @@ export const snapshots = {
         retries: 9,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -28940,6 +29114,9 @@ export const snapshots = {
         currentRetry: 0,
         retries: 9,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [
@@ -29831,6 +30008,9 @@ export const snapshots = {
           retries: 9,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -30215,6 +30395,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 9,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [

--- a/packages/app/cypress/e2e/runner/runner.mochaEvents.snapshots.ts
+++ b/packages/app/cypress/e2e/runner/runner.mochaEvents.snapshots.ts
@@ -510,6 +510,9 @@ export const snapshots = {
           retries: 0,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -871,6 +874,9 @@ export const snapshots = {
           retries: 0,
           _slow: 10000,
         },
+        {
+          nextTestHasTestIsolationOn: true,
+        },
       ],
       [
         'mocha',
@@ -1196,6 +1202,9 @@ export const snapshots = {
           currentRetry: 0,
           retries: 0,
           _slow: 10000,
+        },
+        {
+          nextTestHasTestIsolationOn: true,
         },
       ],
       [
@@ -3360,6 +3369,9 @@ export const snapshots = {
         retries: 0,
         _slow: 10000,
       },
+      {
+        nextTestHasTestIsolationOn: true,
+      },
     ],
     [
       'mocha',
@@ -3739,6 +3751,9 @@ export const snapshots = {
         currentRetry: 0,
         retries: 0,
         _slow: 10000,
+      },
+      {
+        nextTestHasTestIsolationOn: true,
       },
     ],
     [

--- a/packages/driver/cypress/e2e/commands/sessions/sessions.cy.js
+++ b/packages/driver/cypress/e2e/commands/sessions/sessions.cy.js
@@ -68,6 +68,20 @@ describe('cy.session', { retries: 0 }, () => {
         .should('eq', 'about:blank')
       })
 
+      it('clears page before the end of each run when nextTestHasTestIsolationOn is undefined', () => {
+        cy.visit('/fixtures/form.html')
+        .then(async () => {
+          cy.spy(Cypress, 'action').log(false)
+
+          await Cypress.action('runner:test:before:after:run:async', {}, Cypress.state('runnable'), { nextTestHasTestIsolationOn: undefined })
+
+          expect(Cypress.action).to.be.calledWith('cy:url:changed', '')
+          expect(Cypress.action).to.be.calledWith('cy:visit:blank', { testIsolation: true })
+        })
+        .url()
+        .should('eq', 'about:blank')
+      })
+
       it('does not clear the page before the end of each run if the next test has test isolation off', () => {
         cy.visit('/fixtures/form.html')
         .then(async () => {

--- a/packages/driver/src/cy/commands/sessions/index.ts
+++ b/packages/driver/src/cy/commands/sessions/index.ts
@@ -33,7 +33,7 @@ export default function (Commands, Cypress, cy) {
     })
 
     Cypress.on('test:before:after:run:async', (test, Cypress, { nextTestHasTestIsolationOn }: {nextTestHasTestIsolationOn?: boolean} = {}) => {
-      if (nextTestHasTestIsolationOn) {
+      if (nextTestHasTestIsolationOn || nextTestHasTestIsolationOn === undefined) {
         return navigateAboutBlank({ inBetweenTestsAndNextTestHasTestIsolationOn: true })
       }
 

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -571,7 +571,7 @@ class $Cypress {
         return this.emitThen('test:before:run:async', ...args)
 
       case 'runner:test:before:after:run:async':
-        this.maybeEmitCypressInCypress('mocha', 'test:before:after:run:async', ...args)
+        this.maybeEmitCypressInCypress('mocha', 'test:before:after:run:async', args[0], args[2])
 
         return this.emitThen('test:before:after:run:async', ...args)
 

--- a/packages/driver/src/cypress.ts
+++ b/packages/driver/src/cypress.ts
@@ -571,7 +571,7 @@ class $Cypress {
         return this.emitThen('test:before:run:async', ...args)
 
       case 'runner:test:before:after:run:async':
-        this.maybeEmitCypressInCypress('mocha', 'test:before:after:run:async', args[0])
+        this.maybeEmitCypressInCypress('mocha', 'test:before:after:run:async', ...args)
 
         return this.emitThen('test:before:after:run:async', ...args)
 

--- a/system-tests/__snapshots__/protocol_spec.js
+++ b/system-tests/__snapshots__/protocol_spec.js
@@ -681,9 +681,7 @@ exports['e2e events'] = `
         "retries": 0,
         "_slow": 10000
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     },
     {
       "test": {
@@ -1385,9 +1383,7 @@ exports['e2e events'] = `
         "retries": 0,
         "_slow": 10000
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     }
   ],
   "afterTest": [
@@ -5273,9 +5269,7 @@ exports['component events - experimentalSingleTabRunMode: true'] = `
         "retries": 0,
         "_slow": 250
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     },
     {
       "test": {
@@ -5373,9 +5367,7 @@ exports['component events - experimentalSingleTabRunMode: true'] = `
         "retries": 0,
         "_slow": 250
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     }
   ],
   "afterTest": [
@@ -7016,9 +7008,7 @@ exports['component events - experimentalSingleTabRunMode: false'] = `
         "retries": 0,
         "_slow": 250
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     },
     {
       "test": {
@@ -7116,9 +7106,7 @@ exports['component events - experimentalSingleTabRunMode: false'] = `
         "retries": 0,
         "_slow": 250
       },
-      "options": {
-        "nextTestHasTestIsolationOn": true
-      }
+      "options": {}
     }
   ],
   "afterTest": [


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updated the `test:before:after:run:async` event to not pass `nextTestHasTestIsolationOn` if there isn't a next test (i.e. it's the last test).

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
