### PR TITLE
fix: runIfWaitingForDebugger when targets are reloaded after crashing

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@ _Released 11/7/2023 (PENDING)_
 - Fixed an issue with 'other' targets (e.g. pdf documents embedded in an object tag) not fully loading. Fixes [#28228](https://github.com/cypress-io/cypress/issues/28228) and [#28162](https://github.com/cypress-io/cypress/issues/28162).
 - Fixed an issue where network requests made from tabs/windows other than the main Cypress tab would be delayed. Fixes [#28113](https://github.com/cypress-io/cypress/issues/28113).
 - Stopped processing CDP events at the end of a spec when Test Isolation is off and Test Replay is enabled. Addressed in [#28213](https://github.com/cypress-io/cypress/pull/28213).
+- Fixed a regression in [`13.3.3`](https://docs.cypress.io/guides/references/changelog/13.3.3) where Cypress would hang on loading shared workers when using `cy.reload` to reload the page. Fixes [#28248](https://github.com/cypress-io/cypress/issues/28248).
 
 ## 13.4.0
 

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -264,9 +264,14 @@ export class BrowserCriClient {
     })
 
     browserClient.on('Inspector.targetReloadedAfterCrash', async (event, sessionId) => {
-      // Things like service workers will effectively crash in terms of CDP when the page is reloaded in the middle of things
-      // We will still auto attach in this case, but we need to runIfWaitingForDebugger to get the page back to a running state
-      await browserClient.send('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      try {
+        // Things like service workers will effectively crash in terms of CDP when the page is reloaded in the middle of things
+        // We will still auto attach in this case, but we need to runIfWaitingForDebugger to get the page back to a running state
+        await browserClient.send('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      } catch (error) {
+      // it's possible that the target was closed before we can run. If so, just ignore
+        debug('error running Runtime.runIfWaitingForDebugger:', error)
+      }
     })
 
     await Promise.all(promises)

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -263,6 +263,12 @@ export class BrowserCriClient {
       this._onTargetDestroyed({ browserClient, browserCriClient, browserName, event, onAsynchronousError })
     })
 
+    browserClient.on('Inspector.targetReloadedAfterCrash', async (event, sessionId) => {
+      // Things like service workers will effectively crash in terms of CDP when the page is reloaded in the middle of things
+      // We will still auto attach in this case, but we need to runIfWaitingForDebugger to get the page back to a running state
+      await browserClient.send('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+    })
+
     await Promise.all(promises)
   }
 

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -142,7 +142,7 @@ export const normalizeResourceType = (resourceType: string | undefined): Resourc
 
 export type SendDebuggerCommand = <T extends CdpCommand>(message: T, data?: ProtocolMapping.Commands[T]['paramsType'][0], sessionId?: string) => Promise<ProtocolMapping.Commands[T]['returnType']>
 
-export type OnFn = <T extends CdpEvent>(eventName: T, cb: (data: ProtocolMapping.Events[T][0]) => void) => void
+export type OnFn = <T extends CdpEvent>(eventName: T, cb: (data: ProtocolMapping.Events[T][0], sessionId?: string) => void) => void
 
 export type OffFn = (eventName: string, cb: (data: any) => void) => void
 

--- a/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/web_worker.cy.js
@@ -32,3 +32,12 @@ it('loads web workers', { defaultCommandTimeout: 1900 }, () => {
   .then(webWorker)
   .then(sharedWorker)
 })
+
+// Timeout of 1900 will ensure that the proxy correlation timeout is not hit
+it('reloads web workers', { defaultCommandTimeout: 1900 }, () => {
+  cy.visit('https://localhost:1515/web_worker.html')
+
+  cy.reload()
+  .then(webWorker)
+  .then(sharedWorker)
+})

--- a/system-tests/test/web_worker_spec.js
+++ b/system-tests/test/web_worker_spec.js
@@ -46,8 +46,8 @@ describe('e2e web worker', () => {
     spec: 'web_worker.cy.js',
     onRun: async (exec, browser) => {
       await exec()
-      expect(requestsForWebWorker).to.eq(1)
-      expect(requestsForSharedWorker).to.eq(1)
+      expect(requestsForWebWorker).to.eq(2)
+      expect(requestsForSharedWorker).to.eq(2)
     },
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28248 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In terms of CDP events, shared workers effectively crash when the page is reloaded. When that crash happens, we don't get any new Target events, but instead get a `Target.targetReloadedAfterCrash` event. However, since we are attaching to targets in a paused state, we need to make sure and `runIfWaitingForDebugger` when this happens.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The change to the system test on this PR shows tests the problem

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Shared workers will no longer hang on `cy.reload`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
