### PR TITLE
chore: release 13.5.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.5.0
 
-_Released 11/7/2023_
+_Released 11/8/2023_
 
 **Features:**
 


### PR DESCRIPTION
This PR updates the CHANGELOG with today's date for the `13.5.0` release.
