### PR TITLE
fix: Add Chromium flag to disable-component-extensions-with-background-pages

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.5.1
+
+_Released 11/21/2023_
+
+**Bugfixes:**
+
+- We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/issues/28294).
+
 ## 13.5.0
 
 _Released 11/8/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.5.1
 
-_Released 11/21/2023_
+_Released 11/21/2023 (PENDING)_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 11/21/2023 (PENDING)_
 
 **Bugfixes:**
 
-- We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/issues/28294).
+- We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/pull/28294).
 
 ## 13.5.0
 

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -73,6 +73,7 @@ const DEFAULT_ARGS = [
   '--reduce-security-for-testing',
   '--enable-automation',
   '--disable-print-preview',
+  '--disable-component-extensions-with-background-pages',
 
   '--disable-device-discovery-notifications',
 


### PR DESCRIPTION
### Additional details

Pass flag to "Disable default component extensions with background pages - useful for performance tests where these pages may interfere with perf results."

[Component Extensions doc](https://chromium.googlesource.com/chromium/src/+/main/extensions/docs/component_extensions.md)

I noticed this as a flag passed to [puppeteer](https://source.chromium.org/chromiumos/chromiumos/codesearch/+/main:gen/arm-generic/chroot/var/cache/chromeos-chrome/chrome-src/src/out_arm-generic/Release/gen/third_party/devtools-frontend/src/front_end/third_party/puppeteer/package/lib/esm/puppeteer/node/ChromeLauncher.js;l=113?q=disable-client-side-phishing-detection&sq=&ss=chromiumos%2Fchromiumos%2Fcodesearch) and also a flag recommended in the [common tooling flags for Chrome](https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md).

Perhaps it might reduce some background traffic? 

### Steps to test

See a passing test suite

### How has the user experience changed?

Unsure if this will improve performance or not

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
