### PR TITLE
fix: Ensure response headers are set for extra target network requests

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.5.1
+
+_Released 11/21/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where pages opened in a new tab were missing response headers, causing them not to load properly. Fixes [#28293](https://github.com/cypress-io/cypress/issues/28293) and [#28303](https://github.com/cypress-io/cypress/issues/28303).
+
 ## 13.5.0
 
 _Released 11/8/2023_

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -174,6 +174,10 @@ const FilterNonProxiedResponse: ResponseMiddleware = function () {
   if (this.req.isFromExtraTarget) {
     this.debug('response for [%s %s] is from extra target', this.req.method, this.req.proxiedUrl)
 
+    // this is normally done in the OmitProblematicHeaders middleware, but we
+    // don't want to omit any headers in this case
+    this.res.set(this.incomingRes.headers)
+
     this.onlyRunMiddleware([
       'AttachPlainTextStreamFn',
       'PatchExpressSetHeader',

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -103,22 +103,28 @@ describe('http/response-middleware', function () {
   describe('FilterNonProxiedResponse', () => {
     const { FilterNonProxiedResponse } = ResponseMiddleware
     let ctx
+    let headers
 
     beforeEach(() => {
+      headers = { 'header-name': 'header-value' }
       ctx = {
         onlyRunMiddleware: sinon.stub(),
+        incomingRes: { headers },
         req: {},
         res: {
+          set: sinon.stub(),
           off: (event, listener) => {},
         },
       }
     })
 
-    it('runs minimal subsequent middleware if request is from an extra target', () => {
+    it('sets headers on response and runs minimal subsequent middleware if request is from an extra target', () => {
       ctx.req.isFromExtraTarget = true
 
       return testMiddleware([FilterNonProxiedResponse], ctx)
       .then(() => {
+        expect(ctx.res.set).to.be.calledWith(headers)
+
         expect(ctx.onlyRunMiddleware).to.be.calledWith([
           'AttachPlainTextStreamFn',
           'PatchExpressSetHeader',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28293
- Closes #28303

### Additional details

For extra tabs/windows, we skip a lot of middleware for the sake of letting the response go through un-modified. One skipped middleware was responsible for transferring the headers from the incoming response to the response we send to the browser. We need to set those headers while skipping the other parts of that middleware.

### Steps to test

- Open any project in Cypress
- Open a new tab, put in pretty much any site (i.e. `http://example.com`)
- The site should load as normal

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
