### PR TITLE
fix: Allow absolute paths in indexHtmlFile

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@ _Released 11/14/2023_
 - Fixed a regression in [`13.5.0`](https://docs.cypress.io/guides/references/changelog/13.5.0) where requests cached within a given spec may take longer to load than they did previously. Addresses [#28295](https://github.com/cypress-io/cypress/issues/28295).
 - Fixed an issue where pages opened in a new tab were missing response headers, causing them not to load properly. Fixes [#28293](https://github.com/cypress-io/cypress/issues/28293) and [#28303](https://github.com/cypress-io/cypress/issues/28303).
 - We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/pull/28294).
+- We now allow absolute paths when setting `component.indexHtmlFile` in the Cypress config. Fixes [#27750](https://github.com/cypress-io/cypress/issues/27750).
 
 ## 13.5.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.5.2
+
+_Released 11/21/2023 (PENDING)_
+
+**Bugfixes:**
+
+- We now allow absolute paths when setting `component.indexHtmlFile` in the Cypress config. Fixes [#27750](https://github.com/cypress-io/cypress/issues/27750).
+
 ## 13.5.1
 
 _Released 11/14/2023_
@@ -8,7 +16,6 @@ _Released 11/14/2023_
 - Fixed a regression in [`13.5.0`](https://docs.cypress.io/guides/references/changelog/13.5.0) where requests cached within a given spec may take longer to load than they did previously. Addresses [#28295](https://github.com/cypress-io/cypress/issues/28295).
 - Fixed an issue where pages opened in a new tab were missing response headers, causing them not to load properly. Fixes [#28293](https://github.com/cypress-io/cypress/issues/28293) and [#28303](https://github.com/cypress-io/cypress/issues/28303).
 - We now pass a flag to Chromium browsers to disable default component extensions. This is a common flag passed during browser automation. Fixed in [#28294](https://github.com/cypress-io/cypress/pull/28294).
-- We now allow absolute paths when setting `component.indexHtmlFile` in the Cypress config. Fixes [#27750](https://github.com/cypress-io/cypress/issues/27750).
 
 ## 13.5.0
 

--- a/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
@@ -81,7 +81,7 @@ export function makeCypressWebpackConfig (
     },
     plugins: [
       new (HtmlWebpackPlugin as typeof import('html-webpack-plugin-5'))({
-        template: indexHtmlFile ? path.join(projectRoot, indexHtmlFile) : undefined,
+        template: indexHtmlFile ? path.isAbsolute(indexHtmlFile) ? indexHtmlFile : path.join(projectRoot, indexHtmlFile) : undefined,
         // Angular generates all of it's scripts with <script type="module">. Live-reloading breaks without this option.
         // We need to manually set the base here to `/__cypress/src/` so that static assets load with our proxy
         ...(framework === 'angular' ? { scriptLoading: 'module', base: '/__cypress/src/' } : {}),


### PR DESCRIPTION
This fixes https://github.com/cypress-io/cypress/issues/27750 which was broken in https://github.com/cypress-io/cypress/issues/26400