### PR TITLE
chore: added dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+# Prepare apt
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get upgrade -y
+
+# Install dependencies
+RUN apt-get install -y python3 g++ make cmake libglib2.0-dev libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xvfb
+
+# Install Node
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
+
+# Install Yarn
+RUN npm install --global yarn

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "cypress",
+  "dockerFile": "Dockerfile",
+  "runArgs": [
+    "--cap-add=SYS_ADMIN"
+  ],
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=8192"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "eamodio.gitlens"
+      ]
+    }
+  },
+  
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
As someone who works/contributes to dozens of projects, I dislike installing all dev-tools needed for all projects on a single machine. Fortunately, there are [Dev Containers](https://containers.dev/), which allow to build a whole dev-environment inside containers and with correct X11 forwarding (eg. by default with WSL2), even allows to use UI apps in the container and display them.

This PR adds initial support for a dev-container, which allows building, testing and even running Cypress from inside the container. It will not affect anyone not using dev-containers at all but allows those who want to use it.

It probably needs some fine-tuning and adjustments (eg. I had to set chrome-sandbox to root and chmod 4755) which might be fixed in other ways, but it is a start and works and allows improving it further if people use it and give feedback.