### PR TITLE
fix: Open app urls externally instead of in Cypress-launched browser

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ _Released 11/21/2023 (PENDING)_
 
 **Bugfixes:**
 
-- The URL of the app-under-test and command error "Learn more" links now open externally instead of in the Cypress-launched browser. Fixes [#24572](https://github.com/cypress-io/cypress/issues/24572).
+- The URL of the application under test and command error "Learn more" links now open externally instead of in the Cypress-launched browser. Fixes [#24572](https://github.com/cypress-io/cypress/issues/24572).
 
 ## 13.5.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.5.2
+
+_Released 11/21/2023 (PENDING)_
+
+**Bugfixes:**
+
+- The URL of the app-under-test and command error "Learn more" links now open externally instead of in the Cypress-launched browser. Fixes [#24572](https://github.com/cypress-io/cypress/issues/24572).
+
 ## 13.5.1
 
 _Released 11/14/2023_

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
@@ -25,12 +25,11 @@
         </Button>
         <input
           ref="autUrlInputRef"
-          target="_blank"
           :value="studioStore.needsUrl ? urlInProgress : autUrl"
           data-cy="aut-url-input"
           class="flex grow mr-[12px] leading-normal max-w-full text-indigo-500 z-51 self-center hocus-link-default truncate"
           @input="setStudioUrl"
-          @click="openInNewTab"
+          @click="openExternally"
           @keyup.enter="visitUrl"
         >
         <StudioUrlPrompt
@@ -186,6 +185,7 @@ import SpecRunnerDropdown from './SpecRunnerDropdown.vue'
 import { allBrowsersIcons } from '@packages/frontend-shared/src/assets/browserLogos'
 import BookIcon from '~icons/cy/book_x16'
 import { useStudioStore } from '../store/studio-store'
+import { useExternalLink } from '@cy/gql-components/useExternalLink'
 
 gql`
 fragment SpecRunnerHeader on CurrentProject {
@@ -255,6 +255,8 @@ const activeSpecPath = specStore.activeSpec?.absolute
 
 const isDisabled = computed(() => autStore.isRunning || autStore.isLoading)
 
+const openExternal = useExternalLink()
+
 function setStudioUrl (event: Event) {
   const url = (event.currentTarget as HTMLInputElement).value
 
@@ -265,11 +267,11 @@ function visitUrl () {
   studioStore.visitUrl(urlInProgress.value)
 }
 
-function openInNewTab () {
+function openExternally () {
   if (!autStore.url || studioStore.isActive) {
     return
   }
 
-  window.open(autStore.url, '_blank')?.focus()
+  openExternal(autStore.url)
 }
 </script>

--- a/packages/reporter/cypress/e2e/test_errors.cy.ts
+++ b/packages/reporter/cypress/e2e/test_errors.cy.ts
@@ -225,6 +225,15 @@ describe('test errors', () => {
       cy.percySnapshot()
     })
 
+    it('opens "Learn more" link externally', () => {
+      setError(commandErr)
+
+      cy.spy(runner, 'emit')
+
+      cy.get('.runnable-err-message').contains('Learn more').click()
+      cy.wrap(runner.emit).should('be.calledWith', 'external:open', 'https://on.cypress.io/type')
+    })
+
     // NOTE: still needs to be implemented
     it.skip('renders and escapes markdown with leading/trailing whitespace', () => {
       setError(commandErr)

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -24,10 +24,16 @@ interface DocsUrlProps {
 const DocsUrl = ({ url }: DocsUrlProps) => {
   if (!url) return null
 
+  const openUrl = (url: string) => (e: React.MouseEvent) => {
+    e.preventDefault()
+
+    events.emit('external:open', url)
+  }
+
   const urlArray = _.castArray(url)
 
   return _.map(urlArray, (url) => (
-    <a className='runnable-err-docs-url' href={url} target='_blank' key={url}>
+    <a className='runnable-err-docs-url' href={url} key={url} onClick={openUrl(url)}>
       Learn more
     </a>
   ))


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #24572

### Additional details

Updates the AUT URL and "Learn more" command error links to open externally.

Links within the Cypress-launched browser should launch externally, especially since we don't recommend users browser within the Cypress browser and we will be [closing extra tabs between tests](https://github.com/cypress-io/cypress/pull/28204) and [moving focus to the Cypress tab before commands](https://github.com/cypress-io/cypress/pull/28334).

### Steps to test

AUT URL

- Run a test with a visit
- Click the AUT URL in the runner
- It should open in your default browser

Learn more links

- Run a test with a command failure like `cy.viewport('foo')`
- Click the "Learn more" link
- It should open in your default browser 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
