### PR TITLE
fix(driver): add support for alias.all when using dynamic alias

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,10 +7,14 @@ _Released 11/21/2023 (PENDING)_
 
 - When artifacts are uploaded to the Cypress Cloud, the duration of each upload will be displayed in the console. Addresses [#28237](https://github.com/cypress-io/cypress/issues/28237).
 
+**Bugfixes:**
+
+- Fixed an issue getting a dynamic route alias using .all. Addresses [#25448](https://github.com/cypress-io/cypress/issues/25448)
+
 **Misc:**
 
 - Browser tabs and windows other than the Cypress tab are now closed between tests in Chromium-based browsers. Addressed in [#28204](https://github.com/cypress-io/cypress/pull/28204).
-- Cypress now ensures the main browser tab is active before running eaech command in Chromium-based browsers. Addressed in [#28334](https://github.com/cypress-io/cypress/pull/28334).
+- Cypress now ensures the main browser tab is active before running each command in Chromium-based browsers. Addressed in [#28334](https://github.com/cypress-io/cypress/pull/28334).
 
 ## 13.5.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ _Released 11/21/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue getting a dynamic route alias using `@alias.all`. Addresses [#25448](https://github.com/cypress-io/cypress/issues/25448)
+- Fixed an issue where [aliasing individual requests](https://docs.cypress.io/api/commands/intercept#Aliasing-individual-requests) with `cy.intercept()` led to an error when retrieving all of the aliases with `cy.get(@alias.all)` . Addresses [#25448](https://github.com/cypress-io/cypress/issues/25448)
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ _Released 11/21/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue getting a dynamic route alias using .all. Addresses [#25448](https://github.com/cypress-io/cypress/issues/25448)
+- Fixed an issue getting a dynamic route alias using `@alias.all`. Addresses [#25448](https://github.com/cypress-io/cypress/issues/25448)
 
 **Misc:**
 

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -3699,6 +3699,25 @@ describe('network stubbing', { retries: 15 }, function () {
       .wait('@a').its('response.body').should('eq', 'bar')
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/25448
+    it('gets all aliased Interceptions by alias.all when assigning an alias using req.alias', function () {
+      const url = uniqueRoute('/foo')
+
+      cy.intercept(`${url}*`, (req) => {
+        req.alias = 'alias'
+        req.reply({ bar: 'baz' })
+      })
+      .then(() => {
+        $.get(url)
+        $.get(url)
+      })
+      .wait('@alias').wait('@alias')
+
+      cy.get('@alias.all').then((interceptions) => {
+        expect(interceptions).to.have.length(2)
+      })
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/9306
     context('cy.get(alias)', function () {
       it('gets the latest Interception by alias', function () {

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -3699,25 +3699,6 @@ describe('network stubbing', { retries: 15 }, function () {
       .wait('@a').its('response.body').should('eq', 'bar')
     })
 
-    // @see https://github.com/cypress-io/cypress/issues/25448
-    it('gets all aliased Interceptions by alias.all when assigning an alias using req.alias', function () {
-      const url = uniqueRoute('/foo')
-
-      cy.intercept(`${url}*`, (req) => {
-        req.alias = 'alias'
-        req.reply({ bar: 'baz' })
-      })
-      .then(() => {
-        $.get(url)
-        $.get(url)
-      })
-      .wait('@alias').wait('@alias')
-
-      cy.get('@alias.all').then((interceptions) => {
-        expect(interceptions).to.have.length(2)
-      })
-    })
-
     // @see https://github.com/cypress-io/cypress/issues/9306
     context('cy.get(alias)', function () {
       it('gets the latest Interception by alias', function () {
@@ -3740,6 +3721,25 @@ describe('network stubbing', { retries: 15 }, function () {
         const url = uniqueRoute('/foo')
 
         cy.intercept(`${url}*`, { bar: 'baz' }).as('alias')
+        .then(() => {
+          $.get(url)
+          $.get(url)
+        })
+        .wait('@alias').wait('@alias')
+
+        cy.get('@alias.all').then((interceptions) => {
+          expect(interceptions).to.have.length(2)
+        })
+      })
+
+      // @see https://github.com/cypress-io/cypress/issues/25448
+      it('gets all aliased Interceptions by alias.all when assigning an alias using req.alias', function () {
+        const url = uniqueRoute('/foo')
+
+        cy.intercept(`${url}*`, (req) => {
+          req.alias = 'alias'
+          req.reply({ bar: 'baz' })
+        })
         .then(() => {
           $.get(url)
           $.get(url)

--- a/packages/driver/src/cy/aliases.ts
+++ b/packages/driver/src/cy/aliases.ts
@@ -12,7 +12,7 @@ const requestXhrRe = /\.request$/
 
 const reserved = ['test', 'runnable', 'timeout', 'slow', 'skip', 'inspect']
 
-const aliasDisplayName = (name) => {
+export const aliasDisplayName = (name) => {
   return name.replace(aliasDisplayRe, '')
 }
 

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -7,7 +7,7 @@ import $utils from '../../../cypress/utils'
 import type { Log } from '../../../cypress/log'
 import { resolveShadowDomInclusion } from '../../../cypress/shadow_dom_utils'
 import { getAliasedRequests, isDynamicAliasingPossible } from '../../net-stubbing/aliasing'
-import { aliasRe, aliasIndexRe } from '../../aliases'
+import { aliasRe, aliasIndexRe, aliasDisplayName } from '../../aliases'
 
 type GetOptions = Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withinable & Cypress.Shadow & {
   _log?: Log
@@ -38,7 +38,9 @@ function getAlias (selector, log, cy) {
       aliasObj = cy.getAlias(toSelect)
     } catch (err) {
       // possibly this is a dynamic alias, check to see if there is a request
-      const requests = getAliasedRequests(alias, cy.state)
+      // We need to use the stripped alias
+      const strippedAlias = aliasDisplayName(toSelect)
+      const requests = getAliasedRequests(strippedAlias, cy.state)
 
       if (!isDynamicAliasingPossible(cy.state) || !requests.length) {
         err.retry = false
@@ -46,7 +48,7 @@ function getAlias (selector, log, cy) {
       }
 
       aliasObj = {
-        alias,
+        alias: strippedAlias,
         command: cy.state('routes')[requests[0].routeId].command,
       }
     }


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/25448

### Additional details
Their is a bug in our driver where you can't `get` an alias using `.all` with dynamically assigned route aliases. 
```
cy.intercept(`/foo*`, (req) => {
    req.alias = 'alias'
})
```

You will get an error when attempting to get this alias with a `.all` like:
`cy.get('@dyanamicRouteAlias.all')`

This PR resolves this issue.

### Steps to test
Run the following test in the `packages/driver/cypress/e2e/commands/net_stubbing.cy.ts` => `gets all aliased Interceptions by alias.all when assigning an alias using req.alias`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
