### PR TITLE
fix: no longer swallow stderr logs on linux

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 12/05/2023 (PENDING)_
 
 **Bugfixes:**
 
-- Cypress will now correctly log errors and debug logs on Linux machines. Fixes [#5051](https://github.com/cypress-io/cypress/issue/5051) and [#24713](https://github.com/cypress-io/cypress/issue/24713).
+- Cypress will now correctly log errors and debug logs on Linux machines. Fixes [#5051](https://github.com/cypress-io/cypress/issues/5051) and [#24713](https://github.com/cypress-io/cypress/issues/24713).
 
 ## 13.6.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.1
+
+_Released 12/05/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Cypress will now correctly log errors and debug logs on Linux machines. Fixes [#5051](https://github.com/cypress-io/cypress/issue/5051) and [#24713](https://github.com/cypress-io/cypress/issue/24713).
+
 ## 13.6.0
 
 _Released 11/21/2023 (PENDING)_

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -4,7 +4,6 @@ const cp = require('child_process')
 const path = require('path')
 const Promise = require('bluebird')
 const debug = require('debug')('cypress:cli')
-const debugElectron = require('debug')('cypress:electron')
 
 const util = require('../util')
 const state = require('../tasks/state')
@@ -122,10 +121,9 @@ module.exports = {
       return new Promise((resolve, reject) => {
         _.defaults(overrides, {
           onStderrData: false,
-          electronLogging: false,
         })
 
-        const { onStderrData, electronLogging } = overrides
+        const { onStderrData } = overrides
         const envOverrides = util.getEnvOverrides(options)
         const electronArgs = []
         const node11WindowsFix = isPlatform('win32')
@@ -158,10 +156,6 @@ module.exports = {
 
         if (node11WindowsFix) {
           stdioOptions = _.extend({}, stdioOptions, { windowsHide: false })
-        }
-
-        if (electronLogging) {
-          stdioOptions.env.ELECTRON_ENABLE_LOGGING = true
         }
 
         if (util.isPossibleLinuxWithIncorrectDisplay()) {
@@ -241,7 +235,7 @@ module.exports = {
 
             // if we have a callback and this explicitly returns
             // false then bail
-            if (onStderrData && onStderrData(str) === false) {
+            if (onStderrData && onStderrData(str)) {
               return
             }
 
@@ -293,13 +287,6 @@ module.exports = {
             // then we know that's why cypress exited early
             if (util.isBrokenGtkDisplay(str)) {
               brokenGtkDisplay = true
-            }
-
-            // we should attempt to always slurp up
-            // the stderr logs unless we've explicitly
-            // enabled the electron debug logging
-            if (!debugElectron.enabled) {
-              return false
             }
           },
         })

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -101,12 +101,8 @@ const runSmokeTest = (binaryDir, options) => {
     debug('smoke test command:', smokeTestCommand)
     debug('smoke test timeout %d ms', options.smokeTestTimeout)
 
-    const env = _.extend({}, process.env, {
-      ELECTRON_ENABLE_LOGGING: true,
-    })
-
     const stdioOptions = _.extend({}, {
-      env,
+      env: process.env,
       timeout: options.smokeTestTimeout,
     })
 

--- a/cli/test/lib/tasks/verify_spec.js
+++ b/cli/test/lib/tasks/verify_spec.js
@@ -278,35 +278,6 @@ context('lib/tasks/verify', () => {
     })
   })
 
-  it('sets ELECTRON_ENABLE_LOGGING without mutating process.env', () => {
-    createfs({
-      alreadyVerified: false,
-      executable: mockfs.file({ mode: 0o777 }),
-      packageVersion,
-    })
-
-    expect(process.env.ELECTRON_ENABLE_LOGGING).to.be.undefined
-
-    util.exec.resolves()
-    sinon.stub(util, 'stdoutLineMatches').returns(true)
-
-    return verify
-    .start()
-    .then(() => {
-      expect(process.env.ELECTRON_ENABLE_LOGGING).to.be.undefined
-
-      const stdioOptions = util.exec.firstCall.args[2]
-
-      expect(stdioOptions).to.include({
-        timeout: verify.VERIFY_TEST_RUNNER_TIMEOUT_MS,
-      })
-
-      expect(stdioOptions.env).to.include({
-        ELECTRON_ENABLE_LOGGING: true,
-      })
-    })
-  })
-
   describe('with force: true', () => {
     beforeEach(() => {
       createfs({


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Fixes https://github.com/cypress-io/cypress/issues/5051
- Closes #24713

On Linux we were swallowing stderr logs (see #24713) and consequently also unintentionally swallowing any cypress app debug logs that weren't defined as `cypress:*` + `cypress:electron`. (i.e. not including `cypress:electron` meant no debug logs from the app).
