### PR TITLE
fix: Ensure basic auth headers are set on extra target requests

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.1
+
+_Released 12/5/2023 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where pages or downloads opened in a new tab were missing basic auth headers. Fixes [#28350](https://github.com/cypress-io/cypress/issues/28350).
+
 ## 13.6.0
 
 _Released 11/21/2023_

--- a/packages/driver/cypress/e2e/cypress/downloads.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/downloads.cy.ts
@@ -1,4 +1,5 @@
 import $Downloads from '../../../src/cypress/downloads'
+import { authCreds } from '../../fixtures/auth_creds'
 
 describe('src/cypress/downloads', () => {
   let log
@@ -115,10 +116,7 @@ describe('download behavior', () => {
 describe('basic auth download behavior', () => {
   beforeEach(() => {
     cy.visit('/fixtures/downloads.html', {
-      auth: {
-        username: 'cypress',
-        password: 'password123',
-      },
+      auth: authCreds,
     })
   })
 

--- a/packages/driver/cypress/e2e/cypress/downloads.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/downloads.cy.ts
@@ -94,6 +94,7 @@ describe('download behavior', () => {
     .should('contain', '"Joe","Smith"')
   })
 
+  // NOTE: webkit opens a new window and doesn't download the file
   it('downloads from anchor tag without download attribute', { browser: '!webkit' }, () => {
     cy.exec(`rm -f ${Cypress.config('downloadsFolder')}/downloads_records.csv`)
     cy.readFile(`${Cypress.config('downloadsFolder')}/downloads_records.csv`).should('not.exist')
@@ -108,5 +109,26 @@ describe('download behavior', () => {
     // attempt to download
     cy.get('[data-cy=invalid-download]').click()
     cy.readFile(`${Cypress.config('downloadsFolder')}/downloads_does_not_exist.csv`).should('not.exist')
+  })
+})
+
+describe('basic auth download behavior', () => {
+  beforeEach(() => {
+    cy.visit('/fixtures/downloads.html', {
+      auth: {
+        username: 'cypress',
+        password: 'password123',
+      },
+    })
+  })
+
+  // NOTE: webkit opens a new window and doesn't download the file
+  it('downloads basic auth protected file that opens in a new tab', { browser: '!webkit' }, () => {
+    cy.exec(`rm -f ${Cypress.config('downloadsFolder')}/download-basic-auth.csv`)
+    cy.readFile(`${Cypress.config('downloadsFolder')}/download-basic-auth.csv`).should('not.exist')
+
+    cy.get('[data-cy=download-basic-auth]').click()
+    cy.readFile(`${Cypress.config('downloadsFolder')}/download-basic-auth.csv`)
+    .should('contain', '"Joe","Smith"')
   })
 })

--- a/packages/driver/cypress/e2e/e2e/origin/commands/navigation.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/navigation.cy.ts
@@ -1,3 +1,4 @@
+import { authCreds } from '../../../../fixtures/auth_creds'
 import { findCrossOriginLogs } from '../../../../support/utils'
 
 context('cy.origin navigation', { browser: '!webkit' }, () => {
@@ -309,13 +310,8 @@ context('cy.origin navigation', { browser: '!webkit' }, () => {
     })
 
     it('supports auth options and adding auth to subsequent requests', () => {
-      cy.origin('http://www.foobar.com:3500', () => {
-        cy.visit('http://www.foobar.com:3500/basic_auth', {
-          auth: {
-            username: 'cypress',
-            password: 'password123',
-          },
-        })
+      cy.origin('http://www.foobar.com:3500', { args: authCreds }, (auth) => {
+        cy.visit('http://www.foobar.com:3500/basic_auth', { auth })
 
         cy.get('body').should('have.text', 'basic auth worked')
 

--- a/packages/driver/cypress/fixtures/auth_creds.ts
+++ b/packages/driver/cypress/fixtures/auth_creds.ts
@@ -1,0 +1,4 @@
+export const authCreds = {
+  username: 'cypress',
+  password: 'password123',
+}

--- a/packages/driver/cypress/fixtures/downloads.html
+++ b/packages/driver/cypress/fixtures/downloads.html
@@ -9,6 +9,9 @@
   <h3>Download CSV</h3>
   <a data-cy="download-without-download-attr" href="downloads_records.csv">download csv from anchor tag without download attr</a>
 
+  <h3>Download Basic Auth CSV</h3>
+  <a data-cy="download-basic-auth" href="/download-basic-auth.csv" target="_blank">download csv that's basic auth protected</a>
+
   <h3>Download CSV</h3>
   <a data-cy="invalid-download" href="downloads_does_not_exist.csv" download>broken download link</a>
 </body>

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -9,6 +9,7 @@ const Promise = require('bluebird')
 const multer = require('multer')
 const upload = multer({ dest: 'cypress/_test-output/' })
 const { cors } = require('@packages/network')
+const { authCreds } = require('../fixtures/auth_creds')
 
 const PATH_TO_SERVER_PKG = path.dirname(require.resolve('@packages/server'))
 
@@ -128,7 +129,7 @@ const createApp = (port) => {
   app.get('/basic_auth', (req, res) => {
     const user = auth(req)
 
-    if (user && ((user.name === 'cypress') && (user.pass === 'password123'))) {
+    if (user?.name === authCreds.username && user?.pass === authCreds.password) {
       return res.send('<html><body>basic auth worked</body></html>')
     }
 
@@ -345,7 +346,7 @@ const createApp = (port) => {
   app.get('/download-basic-auth.csv', (req, res) => {
     const user = auth(req)
 
-    if (user && ((user.name === 'cypress') && (user.pass === 'password123'))) {
+    if (user?.name === authCreds.username && user?.pass === authCreds.password) {
       return res.sendFile(path.join(__dirname, '..', 'fixtures', 'downloads_records.csv'))
     }
 

--- a/packages/driver/cypress/plugins/server.js
+++ b/packages/driver/cypress/plugins/server.js
@@ -342,6 +342,19 @@ const createApp = (port) => {
     res.send(_var)
   })
 
+  app.get('/download-basic-auth.csv', (req, res) => {
+    const user = auth(req)
+
+    if (user && ((user.name === 'cypress') && (user.pass === 'password123'))) {
+      return res.sendFile(path.join(__dirname, '..', 'fixtures', 'downloads_records.csv'))
+    }
+
+    return res
+    .set('WWW-Authenticate', 'Basic')
+    .type('html')
+    .sendStatus(401)
+  })
+
   app.post('/upload', (req, res) => {
     res.sendStatus(200)
   })

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -52,6 +52,7 @@ const ExtractCypressMetadataHeaders: RequestMiddleware = function () {
     delete this.req.headers['x-cypress-is-from-extra-target']
 
     this.onlyRunMiddleware([
+      'MaybeSetBasicAuthHeaders',
       'SendRequestOutgoing',
     ])
   }

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -83,7 +83,7 @@ describe('http/request-middleware', () => {
 
         expect(ctx.req.headers!['x-cypress-is-from-extra-target']).not.to.exist
         expect(ctx.req.isFromExtraTarget).to.be.true
-        expect(ctx.onlyRunMiddleware).to.be.calledWith(['SendRequestOutgoing'])
+        expect(ctx.onlyRunMiddleware).to.be.calledWith(['MaybeSetBasicAuthHeaders', 'SendRequestOutgoing'])
       })
 
       it('when it does not exist, removes header and sets in on the req', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28350 

### Additional details

Fixes a regression caused by https://github.com/cypress-io/cypress/pull/28188, which cut down the request middleware a bit too much. The authorization header for basic auth set through `cy.visit()` was not being carried through for extra tabs.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
