### PR TITLE
Shallow Clone Cypress Repository in CI

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -147,6 +147,15 @@ executors:
       DISABLE_SNAPSHOT_REQUIRE: 1
 
 commands:
+  shallow_checkout:
+    description: Checkout the current branch with a shallow clone
+    steps:
+      - run:
+          name: Checkout current branch with a shallow clone
+          command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" . --depth 1
   # This command inserts SHOULD_PERSIST_ARTIFACTS into BASH_ENV. This way, we can define the variable in one place and use it in multiple steps.
   # Run this command in a job before you want to use the SHOULD_PERSIST_ARTIFACTS variable.
   setup_should_persist_artifacts:
@@ -1343,7 +1352,7 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - update_known_hosts
-      - checkout
+      - shallow_checkout
       - install-required-node
       - verify-build-setup:
           executor: << parameters.executor >>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
Workspaces are unique per workflow per commit. In this example the workspace paths are different for the same job and branch:

https://app.circleci.com/pipelines/github/cypress-io/cypress/58352/workflows/0756ee6f-133f-4f70-86cd-8105c65844f6/jobs/2422136/parallel-runs/0/steps/0-101

https://app.circleci.com/pipelines/github/cypress-io/cypress/58333/workflows/bb132359-8160-48cd-88aa-ff1b6d9954fd/jobs/2421644/parallel-runs/0/steps/0-101

The total workspace size for those two commits is not 1.7GB, but 3.4GB.

This now does a shallow clone with `--depth 1`, which clones only the last commit and not the entire commit history. This reduces the size of the workspace by 630MB (see first layer). Since the clone is done at the beginning of the workflow and attached to the workspace for future jobs: though it has a negligible effect on overall pipeline execution time, it should be a noticible improvement in cost for workspace persistence.

Compare the size of the above workspaces to the one for this PR:

https://app.circleci.com/pipelines/github/cypress-io/cypress/58355/workflows/561d55a6-101d-470c-9b83-b137672dbc3b/jobs/2422279/parallel-runs/0/steps/0-101

<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->



<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
See difference in size and download time in the above links.

