### PR TITLE
fix: add yarn pnp support for reporters (#18922)

### DIFF
--- a/packages/server/lib/util/search-utils.js
+++ b/packages/server/lib/util/search-utils.js
@@ -1,0 +1,65 @@
+const findUp = require('find-up')
+const path = require('path')
+const fs = require('fs-extra')
+const Debug = require('debug')
+
+const debug = Debug('cypress:scaffold-config:searchUtils')
+
+const ROOT_PATHS = [
+  '.git',
+  'pnpm-workspace.yaml',
+  'rush.json',
+  'workspace.json',
+  'nx.json',
+  'lerna.json',
+]
+
+function hasWorkspacePackageJson (directory) {
+  try {
+    const pkg = require(path.join(directory, 'package.json'))
+
+    debug('package file for %s: %o', directory, pkg)
+
+    return !!pkg.workspaces
+  } catch (e) {
+    debug('error reading package.json in %s. this is not the repository root', directory)
+
+    return false
+  }
+}
+
+function isRepositoryRoot (directory) {
+  if (ROOT_PATHS.some((rootPath) => fs.existsSync(path.join(directory, rootPath)))) {
+    return true
+  }
+
+  return hasWorkspacePackageJson(directory)
+}
+
+function tryToFindPnpFile (projectPath) {
+  return findUp((directory) => {
+    const isCurrentRepositoryRoot = isRepositoryRoot(directory)
+
+    const file = path.join(directory, '.pnp.cjs')
+    const hasPnpCjs = fs.existsSync(file)
+
+    if (hasPnpCjs) {
+      return file
+    }
+
+    if (isCurrentRepositoryRoot) {
+      debug('stopping search at %s because it is believed to be the repository root', directory)
+
+      return findUp.stop
+    }
+
+    // Return undefined to keep searching
+    return undefined
+  }, { cwd: projectPath })
+}
+
+module.exports = {
+  hasWorkspacePackageJson,
+  isRepositoryRoot,
+  tryToFindPnpFile,
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/18922

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
As better explained here: https://github.com/cypress-io/cypress/issues/18922#issuecomment-1515473969, since the loading of external reporters occur in a separate process from the one loading the Cypress configuration, Node is not able to locate/load external packages when Yarn PnP is enabled.

This PR should register Yarn PnP API before the resolvers are requested and should fix the issue.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
TODO.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
TODO.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
