### PR TITLE
chore: Fix puppeteer plugin publishing

### DIFF
--- a/npm/puppeteer/CHANGELOG.md
+++ b/npm/puppeteer/CHANGELOG.md
@@ -1,6 +1,0 @@
-# @cypress/puppeteer-v1.0.0 (2023-11-22)
-
-
-### Features
-
-* Add @cypress/puppeteer plugin ([#28370](https://github.com/cypress-io/cypress/issues/28370)) ([b34d145](https://github.com/cypress-io/cypress/commit/b34d14571689a9b36efc707a3a48f27edcb98113))

--- a/npm/puppeteer/README.md
+++ b/npm/puppeteer/README.md
@@ -1,6 +1,8 @@
-# @cypress/puppeteer
+# @cypress/puppeteer [beta]
 
 Utilize [Puppeteer's browser API](https://pptr.dev/api) within Cypress with a single command.
+
+> This plugin is in public beta, so we'd love to get your feedback to improve it. Please leave any feedback you have in [this discussion](https://github.com/cypress-io/cypress/discussions/28410).
 
 # Table of Contents
 

--- a/npm/puppeteer/package.json
+++ b/npm/puppeteer/package.json
@@ -39,5 +39,16 @@
     "dist",
     "index.d.ts"
   ],
-  "types": "index.d.ts"
+  "types": "index.d.ts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cypress-io/cypress.git"
+  },
+  "homepage": "https://github.com/cypress-io/cypress/blob/develop/npm/puppeteer/#readme",
+  "author": "Cypress App Team",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fangular&template=1-bug-report.md&title=",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/npm/puppeteer/package.json
+++ b/npm/puppeteer/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/cypress-io/cypress/blob/develop/npm/puppeteer/#readme",
   "author": "Cypress App Team",
-  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fangular&template=1-bug-report.md&title=",
+  "bugs": "https://github.com/cypress-io/cypress/issues/new?assignees=&labels=npm%3A%20%40cypress%2Fpuppeteer&template=1-bug-report.md&title=",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details

Scoped npm packages [need `--access public` specified for their initial release](https://app.circleci.com/pipelines/github/cypress-io/cypress/58351/workflows/c79b08c5-a414-4d4c-9f90-56d1940d14d9/jobs/2422294). Adding the `publishConfig` to `package.json` fixes that for semantic-release.

Also added some missing package.json fields.

Also removed the 1.0.0 changelog since it wasn't successfully published yet.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [N/A] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
