### PR TITLE
fix: don't inherit default message for request logging

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.1
+
+_Release (Pending)_
+
+**Bugfixes:**
+- Fixed an issue where request logging would default the `message` to the `message` of the currently running command even though that `message` would not apply to the request log and is not displayed. If the `message` was sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications.
+
 ## 13.6.0
 
 _Released 11/21/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.6.1
 
-_Release (Pending)_
+_Released 12/5/2023 (PENDING)_
 
 **Bugfixes:**
 - Fixed an issue where request logging would default the `message` to the `args` of the currently running command even though those `args` would not apply to the request log and are not displayed. If the `args` are sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications. Addressed in [#28411](https://github.com/cypress-io/cypress/pull/28411).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 _Release (Pending)_
 
 **Bugfixes:**
-- Fixed an issue where request logging would default the `message` to the `args` of the currently running command even though those `args` would not apply to the request log and are not displayed. If the `args` are sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications.
+- Fixed an issue where request logging would default the `message` to the `args` of the currently running command even though those `args` would not apply to the request log and are not displayed. If the `args` are sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications. Addressed in [#28411](https://github.com/cypress-io/cypress/pull/28411).
 
 ## 13.6.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 _Release (Pending)_
 
 **Bugfixes:**
-- Fixed an issue where request logging would default the `message` to the `message` of the currently running command even though that `message` would not apply to the request log and is not displayed. If the `message` was sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications.
+- Fixed an issue where request logging would default the `message` to the `args` of the currently running command even though those `args` would not apply to the request log and are not displayed. If the `args` are sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications.
 
 ## 13.6.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 _Released 12/5/2023 (PENDING)_
 
 **Bugfixes:**
+
 - Fixed an issue where request logging would default the `message` to the `args` of the currently running command even though those `args` would not apply to the request log and are not displayed. If the `args` are sufficiently large (e.g. when running the `cy.task` from the [code-coverage](https://github.com/cypress-io/code-coverage/) plugin) there could be performance/memory implications. Addressed in [#28411](https://github.com/cypress-io/cypress/pull/28411).
 
 ## 13.6.0

--- a/packages/driver/cypress/e2e/cypress/proxy-logging.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/proxy-logging.cy.ts
@@ -126,6 +126,27 @@ describe('Proxy Logging', () => {
       img.src = `/fixtures/media/cypress.png?${Date.now()}`
     })
 
+    it('does not inherit the message of the currently running command', () => {
+      const logs: any[] = []
+
+      cy.on('log:added', (log) => {
+        if (log.name !== 'request') return
+
+        logs.push(log)
+      })
+
+      // delay the fetch call by 100ms to ensure it gets
+      // triggered during the cy.wait() below
+      setTimeout(() => {
+        fetch('/some-url')
+      }, 100)
+
+      cy.wait(200).then(() => {
+        expect(logs).to.have.length(1)
+        expect(logs[0].message).to.eq('')
+      })
+    })
+
     context('with cy.intercept()', () => {
       it('shows non-xhr/fetch log if intercepted', (done) => {
         const src = `/fixtures/media/cypress.png?${Date.now()}`

--- a/packages/driver/src/cypress/proxy-logging.ts
+++ b/packages/driver/src/cypress/proxy-logging.ts
@@ -67,6 +67,7 @@ function getRequestLogConfig (req: Omit<ProxyRequest, 'log'>): Partial<Cypress.I
     url: req.preRequest.url,
     method: req.preRequest.method,
     timeout: 0,
+    message: '', // set to empty string so that we don't inherit the default message
     consoleProps: () => req.consoleProps,
     renderProps: () => {
       function getIndicator (): 'aborted' | 'pending' | 'successful' | 'bad' {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
During `fetch/xhr` request logging, we don’t set the log.message [here](https://github.com/cypress-io/cypress/blob/33496177aa70c05b90e3d258cfc8325058fa618d/packages/driver/src/cypress/proxy-logging.ts#L61) which means when we create the message, we take the [args](https://github.com/cypress-io/cypress/blob/33496177aa70c05b90e3d258cfc8325058fa618d/packages/driver/src/cypress/log.ts#L165) of the current command as the message which is incorrect for a request log since it’s not related in any way to the current command.

The message of the current command can be very large at times (e.g. when the `cy.task` of the `code-coverage` plugin is running) which may have performance and memory implications both in the app and when recording for Test Replay.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
