### PR TITLE
dependency: Bump ts-node to 10.9.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ _Released 12/19/2023 (PENDING)_
 
 - Fixed a regression in [`12.4.0`](https://docs.cypress.io/guides/references/changelog/12.4.0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
 
-**Dependency Upgrades:**
+**Dependency Updates:**
 
 - Updated ts-node from `10.9.1` to `10.9.2`.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ _Released 12/19/2023 (PENDING)_
 
 - Fixed a regression in [`12.4.0`](https://docs.cypress.io/guides/references/changelog/12.4.0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
 
+**Dependency Upgrades:**
+
+- Updated ts-node from `10.9.1` to `10.9.2`.
+
 ## 13.6.1
 
 _Released 12/5/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@ _Released 12/19/2023 (PENDING)_
 
 **Dependency Updates:**
 
-- Updated ts-node from `10.9.1` to `10.9.2`.
+- Updated ts-node from `10.9.1` to `10.9.2`. Fixed in [#28528](https://github.com/cypress-io/cypress/pull/28528).
 
 ## 13.6.1
 

--- a/npm/puppeteer/package.json
+++ b/npm/puppeteer/package.json
@@ -29,7 +29,7 @@
     "semantic-release": "19.0.3",
     "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "typescript": "4.7.4"
   },
   "peerDependencies": {

--- a/npm/vite-dev-server/package.json
+++ b/npm/vite-dev-server/package.json
@@ -25,7 +25,7 @@
     "dedent": "^0.7.0",
     "mocha": "^9.2.2",
     "sinon": "^13.0.1",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "vite": "4.3.2",
     "vite-plugin-inspect": "0.7.24"
   },

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -39,7 +39,7 @@
     "proxyquire": "2.1.3",
     "sinon": "^13.0.1",
     "snap-shot-it": "^7.9.6",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "webpack": "npm:webpack@^5",
     "webpack-4": "npm:webpack@^4",
     "webpack-dev-server-3": "npm:webpack-dev-server@^3"

--- a/npm/webpack-preprocessor/package.json
+++ b/npm/webpack-preprocessor/package.json
@@ -46,7 +46,7 @@
     "sinon": "^9.0.0",
     "sinon-chai": "^3.5.0",
     "snap-shot-it": "7.9.2",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "webpack": "^5.88.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "through": "2.3.8",
     "through2": "^4.0.2",
     "tree-kill": "1.2.2",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "typescript": "4.7.4",
     "yarn-deduplicate": "3.1.0"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -125,7 +125,7 @@
     "tough-cookie": "4.1.3",
     "trash": "5.2.0",
     "tree-kill": "1.2.2",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "tslib": "2.3.1",
     "underscore.string": "3.3.6",
     "url-parse": "1.5.9",

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
     "tslib": "2.3.1",
     "typescript-cached-transpile": "^0.0.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -28604,10 +28604,10 @@ ts-log@^2.2.3:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.3.tgz#4da5640fe25a9fb52642cd32391c886721318efb"
   integrity sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==
 
-ts-node@^10.9.1:
-  version "10.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
-  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/28385 

### Additional details

ts-node had a critical error that many people encountered with Typescrit 5.3.2+. https://github.com/TypeStrong/ts-node/pull/2091 

Given that many of our users have encountered TS errors with TS 5.3.2+,I thought this may address some of those issues. Probably good to get in regardless.

- https://github.com/cypress-io/cypress/issues/27731 [NOT FIXED]
- https://github.com/cypress-io/cypress/issues/28483

### Steps to test
(verified here: https://github.com/cypress-io/cypress/issues/28385#issuecomment-1856442943)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
