### PR TITLE
fix: resolve reporters using module resolution algorithm (#4536)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@ _Released 12/19/2023 (PENDING)_
 - Cypress no longer errors during `cypress run` or `cypress open` when using Typescript 5.3.2+ with `extends` in `tsconfig.json`. Fixes [#28385](https://github.com/cypress-io/cypress/issues/28385).
 - Fixed a regression in [`13.6.1`](https://docs.cypress.io/guides/references/changelog/13.6.1) where a malformed URI would crash Cypress. Fixes [#28521](https://github.com/cypress-io/cypress/issues/28521).
 - Fixed a regression in [`12.4.0`](https://docs.cypress.io/guides/references/changelog/12.4.0) where erroneous `<br>` tags were displaying in error messages in the Command Log making them less readable. Fixes [#28452](https://github.com/cypress-io/cypress/issues/28452).
+- Resolve reporters using the module resolution algorithm starting from the project root rather than as an absolute path. Allows reporters to be loaded in workspaces. Fixes [#4536](https://github.com/cypress-io/cypress/issues/4536).
 
 **Performance:**
 

--- a/packages/server/lib/reporter.js
+++ b/packages/server/lib/reporter.js
@@ -665,8 +665,6 @@ class Reporter {
   }
 
   static loadReporter (reporterName, projectRoot) {
-    let p
-
     debug('trying to load reporter:', reporterName)
 
     // Explicitly require this here (rather than dynamically) so that it gets included in the v8 snapshot
@@ -689,41 +687,12 @@ class Reporter {
       return reporterName
     }
 
-    // it's likely a custom reporter
-    // that is local (./custom-reporter.js)
-    // or one installed by the user through npm
-    try {
-      p = path.resolve(projectRoot, reporterName)
-
-      // try local
-      debug('trying to require local reporter with path:', p)
-
-      // using path.resolve() here so we can just pass an
-      // absolute path as the reporterName which avoids
-      // joining projectRoot unnecessarily
-      return require(p)
-    } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        // bail early if the error wasn't MODULE_NOT_FOUND
-        // because that means theres something actually wrong
-        // with the found reporter
-        throw err
-      }
-
-      p = path.resolve(projectRoot, 'node_modules', reporterName)
-
-      // try npm. if this fails, we're out of options, so let it throw
-      debug('trying to require local reporter with path:', p)
-
-      return require(p)
-    }
+    return require.resolve(reporterName, { paths: Reporter.getSearchPathsForReporter(projectRoot) })
   }
 
-  static getSearchPathsForReporter (reporterName, projectRoot) {
-    return _.uniq([
-      path.resolve(projectRoot, reporterName),
-      path.resolve(projectRoot, 'node_modules', reporterName),
-    ])
+  // This seems redundant, but it ensures that if the paths ever change, that the error message will contain the correct paths.
+  static getSearchPathsForReporter (projectRoot) {
+    return [projectRoot]
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #4536 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- The explicit join to the project root meant that it effectively disabled the normal module resolution algorithm which would just work™️.
- This has been there since at least https://github.com/cypress-io/cypress/commit/98c4538ddda568a294f665600ff527a0db86b3ab.
- I kept the project root there as the starting point as I wasn't sure whether `__dirname` or the current working directory would be correct.
- https://nodejs.org/dist/latest-v18.x/docs/api/modules.html#requireresolverequest-options
- I'd like some help writing a test. What is the best way?
- Also might need to update the error. It has the correct path but it doesn't explain that it uses the module resolution algorithm.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Setup a small monorepo that uses workspaces.
2. Add cypress to the workspace project.
3. Add a reporter to the root.
4. Run cypress in the workspace project.
5. It should find the reporter.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

The behaviour should be the same except that it now searches up properly. It will also look in the global modules.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
