### PR TITLE
chore: fixes darwin arm64 builds

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-11-20-23
+12-20-2024

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -32,6 +32,7 @@ mainBuildFilters: &mainBuildFilters
         - 'feature/experimental-retries'
         - 'publish-binary'
         - 'em/shallow-checkout'
+        - 'cacie/investigate-darwin-failure'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -45,6 +46,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ 'feature/experimental-retries', << pipeline.git.branch >> ]
     - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
+    - equal: [ 'cacie/investigate-darwin-failure', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -45,6 +45,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ 'feature/experimental-retries', << pipeline.git.branch >> ]
     - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
+    - equal: [ 'cacie/chore/fix-darwin-arm64-builds', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -32,7 +32,6 @@ mainBuildFilters: &mainBuildFilters
         - 'feature/experimental-retries'
         - 'publish-binary'
         - 'em/shallow-checkout'
-        - 'cacie/investigate-darwin-failure'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -46,7 +45,6 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ 'feature/experimental-retries', << pipeline.git.branch >> ]
     - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/investigate-darwin-failure', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/scripts/binary/meta.ts
+++ b/scripts/binary/meta.ts
@@ -82,7 +82,7 @@ export const zipDir = function () {
 export const buildAppDir = function (...args: string[]) {
   switch (PLATFORM) {
     case 'darwin':
-      return buildDir('Cypress.app', 'Contents', 'resources', 'app', ...args)
+      return buildDir('Cypress.app', 'Contents', 'Resources', 'app', ...args)
     case 'linux':
     case 'win32':
       return buildDir('resources', 'app', ...args)

--- a/scripts/binary/smoke.js
+++ b/scripts/binary/smoke.js
@@ -254,6 +254,14 @@ const checkAccess = async (path) => {
   } catch (e) {
     console.error(`cannot access ${path}. UserInfo: `, os.userInfo())
 
+    try {
+      const stat = await fso.lstat(path)
+
+      console.log('stat', stat)
+    } catch (e) {
+      console.error(`cannot stat ${path}: `, e)
+    }
+
     return
   }
   console.log(`can access ${path} as user`, os.userInfo())

--- a/scripts/binary/smoke.js
+++ b/scripts/binary/smoke.js
@@ -309,7 +309,7 @@ const runIntegrityTest = async function (buildAppExecutable, buildAppDir, e2e) {
     const contents = await fs.readFile(file)
 
     // Backup state
-    await fs.move(file, backupFile)
+    await fs.move(file, backupFile, { overwrite: true })
 
     // Modify app
     await fs.writeFile(file, `console.log("rewritten code");const fs=require('fs');const { join } = require('path');fs.writeFileSync(join(__dirname,'index.js'),fs.readFileSync(join(__dirname,'index.js.bak')));${contents}`)

--- a/scripts/binary/smoke.js
+++ b/scripts/binary/smoke.js
@@ -252,7 +252,7 @@ const runIntegrityTest = async function (buildAppExecutable, buildAppDir, e2e) {
     const contents = await fs.readFile(file)
 
     // Backup state
-    await fs.move(file, `${file}.bak`)
+    await fs.move(file, `${file}.bak`, { overwrite: true })
 
     // Modify app
     await fs.writeFile(file, Buffer.concat([contents, Buffer.from(`\nconsole.log('modified code')`)]))

--- a/scripts/binary/smoke.js
+++ b/scripts/binary/smoke.js
@@ -248,9 +248,22 @@ const runErroringProjectTest = function (buildAppExecutable, e2e, testName, erro
   })
 }
 
+const checkAccess = async (path) => {
+  try {
+    await fso.access(path, fso.constants.W_OK | fso.constants.R_OK)
+  } catch (e) {
+    console.error(`cannot access ${path}. UserInfo: `, os.userInfo())
+
+    return
+  }
+  console.log(`can access ${path} as user`, os.userInfo())
+}
+
 const runIntegrityTest = async function (buildAppExecutable, buildAppDir, e2e) {
   const testCorruptingFile = async (file, errorMessage) => {
     const contents = await fs.readFile(file)
+
+    ;[file, `${file}.bak`, path.dirname(file)].forEach(checkAccess)
 
     // Backup state
     await fso.rename(file, `${file}.bak`)

--- a/scripts/binary/smoke.js
+++ b/scripts/binary/smoke.js
@@ -263,7 +263,7 @@ const runIntegrityTest = async function (buildAppExecutable, buildAppDir, e2e) {
   const testCorruptingFile = async (file, errorMessage) => {
     const contents = await fs.readFile(file)
 
-    ;[file, `${file}.bak`, path.dirname(file)].forEach(checkAccess)
+    await Promise.all([file, `${file}.bak`, path.dirname(file)].map(checkAccess))
 
     // Backup state
     await fso.rename(file, `${file}.bak`)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

Core fix: `darwin-arm64` build CI was failing with a permissions error during post-build smoke tests. Using the build-in `fs.rename` instead of `fs-extra`'s `move` method resolves it. Renaming `resources`->`Resources` in `scripts/binary/meta.js` did not fix anything, but it is now aligned with the path for `darwin` in various other places.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
