### PR TITLE
chore: upgrade nvm on windows so we can install node 20 in kitchensink binary test

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -32,7 +32,6 @@ mainBuildFilters: &mainBuildFilters
         - 'feature/experimental-retries'
         - 'publish-binary'
         - 'em/shallow-checkout'
-        - 'cacie/chore/fix-nvm-windows-ci'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -87,7 +86,6 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
     - equal: [ 'em/shallow-checkout', << pipeline.git.branch >> ]
     - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/chore/fix-nvm-windows-ci', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -32,6 +32,7 @@ mainBuildFilters: &mainBuildFilters
         - 'feature/experimental-retries'
         - 'publish-binary'
         - 'em/shallow-checkout'
+        - 'cacie/chore/fix-nvm-windows-ci'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -86,6 +87,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
     - equal: [ 'em/shallow-checkout', << pipeline.git.branch >> ]
     - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
+    - equal: [ 'cacie/chore/fix-nvm-windows-ci', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/scripts/ensure-node.sh
+++ b/scripts/ensure-node.sh
@@ -4,7 +4,7 @@
 # The Windows executor ships with nvm-windows 1.1.7, which has compatibility issues with node 16.14.2.
 # When 1.1.7 is detected, we manually update to nvm-windows 1.1.9, which includes a fix for 16.14.2 support.
 if [[ $PLATFORM == 'windows' && $(echo `nvm version`) == '1.1.7'  ]]; then
-  curl -L -O https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip && tar -xvf nvm-noinstall.zip -C C:/ProgramData/nvm 
+  curl -L -O https://github.com/coreybutler/nvm-windows/releases/download/1.1.11/nvm-noinstall.zip && tar -xvf nvm-noinstall.zip -C C:/ProgramData/nvm 
 fi
 
 node_version=$(cat .node-version)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

Windows nvm 1.1.9 would try to install an arm64 msi for node 20, which kitchensink requires. Upgrading to windows nvm 1.1.11 fixes this.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
