### PR TITLE
fix: Properly handle formatting and escaping markdown for commands and assertions in Command Log

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 1/2/2024 (PENDING)_
 **Bugfixes:**
 
 - Now 'node_modules' will not be ignored if a project path or a provided path to spec files contains it. Fixes [#23616](https://github.com/cypress-io/cypress/issues/23616).
-- Updated display of assertions to escape markdown formatting and properly render bold styles for assertion values. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#5679](https://github.com/cypress-io/cypress/issues/5679).
+- Updated display of assertions and commands with a URL argument to escape markdown formatting so that values are displayed as is and assertion values display as bold. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#28100](https://github.com/cypress-io/cypress/issues/28100).
 - When generating assertions via Cypress Studio, the preview of the generated assertions now correctly displays the past tense of 'expected' instead of 'expect'. Fixed in [#28593](https://github.com/cypress-io/cypress/pull/28593).
 
 **Dependency Updates:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.6.3
 
-_Released 01/02/2024  (PENDING)_
+_Released 01/02/2024 (PENDING)_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.3
+
+_Released 1/2/2024  (PENDING)_
+
+**Bugfixes:**
+
+- Updated display of assertions to escape markdown formatting and properly render bold styles for assertion values. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#5679](https://github.com/cypress-io/cypress/issues/5679).
+
 ## 13.6.2
 
 _Released 12/26/2023_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.6.3
 
-_Released 1/2/2024  (PENDING)_
+_Released 01/02/2024  (PENDING)_
 
 **Bugfixes:**
 

--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -137,19 +137,19 @@ it('visits a basic html page', () => {
       cy.get('.command-name-assert').should('have.length', 5)
 
       // (1) Assert Enabled
-      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be enabled')
+      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be enabled')
 
       // (2) Assert Visible
-      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be visible')
+      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be visible')
 
       // (3) Assert Text
-      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have text Increment')
+      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have text Increment')
 
       // (4) Assert Id
-      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have id increment')
+      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have id increment')
 
       // (5) Assert Attr
-      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have attr onclick with the value increment()')
+      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have attr onclick with the value increment()')
     })
 
     cy.get('button').contains('Save Commands').click()

--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -91,7 +91,6 @@ it('visits a basic html page', () => {
     })
 
     assertStudioHookCount(2)
-
     cy.getAutIframe().within(() => {
       cy.get('#increment').rightclick().then(() => {
         cy.get('.__cypress-studio-assertions-menu').shadow().contains('be visible').realClick()
@@ -138,19 +137,19 @@ it('visits a basic html page', () => {
       cy.get('.command-name-assert').should('have.length', 5)
 
       // (1) Assert Enabled
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be enabled')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be enabled')
 
       // (2) Assert Visible
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be visible')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be visible')
 
       // (3) Assert Text
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have text Increment')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have text Increment')
 
       // (4) Assert Id
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have id increment')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have id increment')
 
       // (5) Assert Attr
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have attr onclick with the value increment()')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have attr onclick with the value increment()')
     })
 
     cy.get('button').contains('Save Commands').click()

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -734,7 +734,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       const elementString = stringifyActual($el)
       const assertionString = args[0].replace(/\./g, ' ')
 
-      let message = `expect **${elementString}** to ${assertionString}`
+      let message = `expected **${elementString}** to ${assertionString}`
 
       if (args[1]) {
         message = `${message} **${args[1]}**`

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -734,7 +734,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       const elementString = stringifyActual($el)
       const assertionString = args[0].replace(/\./g, ' ')
 
-      let message = `expected **${elementString}** to ${assertionString}`
+      let message = `expect **${elementString}** to ${assertionString}`
 
       if (args[1]) {
         message = `${message} **${args[1]}**`

--- a/packages/reporter/cypress/e2e/commands.cy.ts
+++ b/packages/reporter/cypress/e2e/commands.cy.ts
@@ -185,6 +185,56 @@ describe('commands', { viewportHeight: 1000 }, () => {
     cy.percySnapshot()
   })
 
+  it('displays assertions formatted', () => {
+    addCommand(runner, {
+      id: 1291,
+      name: 'assert',
+      type: 'child',
+      message: 'expected **value** to equal **value**',
+      state: 'passed',
+      timeout: 4000,
+      group: 1229,
+      groupLevel: 2,
+      wallClockStartedAt: inProgressStartedAt,
+    })
+
+    addCommand(runner, {
+      id: 1292,
+      name: 'assert',
+      type: 'child',
+      message: 'expected **value** to match **value**',
+      state: 'passed',
+      timeout: 4000,
+      group: 1229,
+      groupLevel: 2,
+      wallClockStartedAt: inProgressStartedAt,
+    })
+
+    addCommand(runner, {
+      id: 1293,
+      name: 'assert',
+      type: 'child',
+      message: 'expected **_value_** to contain **_value_**',
+      state: 'passed',
+      timeout: 4000,
+      group: 1229,
+      groupLevel: 2,
+      wallClockStartedAt: inProgressStartedAt,
+    })
+
+    cy.contains('.command-message-text', 'to equal')
+    .find('strong').should('have.length', 2)
+    .and('contain', 'value')
+    .and('not.contain', '*')
+
+    cy.contains('.command-message-text', 'to match')
+    .find('strong').should('have.length', 2)
+    .and('contain', 'value')
+    .and('not.contain', '*')
+
+    cy.percySnapshot()
+  })
+
   it('includes the type class', () => {
     cy.contains('#exists').closest('.command-wrapper')
     .should('have.class', 'command-type-parent')

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -87,12 +87,35 @@ describe('formattedMessage', () => {
     })
   })
 
+  describe('when command that accepts url', () => {
+    it('cy.visit does not do markdown formatting', () => {
+      const specialMessage = 'http://www.test.com/__Path__99~~path~~'
+      const result = formattedMessage(specialMessage, 'visit')
+
+      expect(result).to.equal('http://www.test.com/__Path__99~~path~~')
+    })
+
+    it('cy.request does not do markdown formatting', () => {
+      const specialMessage = 'http://www.test.com/__Path__99~~path~~'
+      const result = formattedMessage(specialMessage, 'request')
+
+      expect(result).to.equal('http://www.test.com/__Path__99~~path~~')
+    })
+
+    it('cy.origin does not do markdown formatting', () => {
+      const specialMessage = 'http://www.test.com/__Path__99~~path~~'
+      const result = formattedMessage(specialMessage, 'origin')
+
+      expect(result).to.equal('http://www.test.com/__Path__99~~path~~')
+    })
+  })
+
   describe('when not an assertion', () => {
     it('displays special characters as markdown when not assertion', () => {
-      const specialMessage = 'expected **__*abcdef*__** to contain **/__.*abcdef.*__/**'
+      const specialMessage = 'message\n here `code block` with *formatting*'
       const result = formattedMessage(specialMessage)
 
-      expect(result).to.equal('expected <strong><strong><em>abcdef</em></strong></strong> to contain <strong>/<strong>.<em>abcdef.</em></strong>/</strong>')
+      expect(result).to.equal(`message\nhere <code>code block</code> with <em>formatting</em>`)
     })
   })
 })

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -63,6 +63,13 @@ describe('formattedMessage', () => {
 
       expect(result).to.equal('expected <strong>glob*glob</strong> to contain <strong>*</strong>')
     })
+
+    it('bolds asterisks with complex assertions', () => {
+      const specialMessage = 'expected **span** to have CSS property **background-color** with the value **rgb(0, 0, 0)**, but the value was **rgba(0, 0, 0, 0)**'
+      const result = formattedMessage(specialMessage)
+
+      expect(result).to.equal('expected <strong>span</strong> to have CSS property <strong>background-color</strong> with the value <strong>rgb(0, 0, 0)</strong>, but the value was <strong>rgba(0, 0, 0, 0)</strong>')
+    })
   })
 
   describe('when not an assertion', () => {

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -30,10 +30,10 @@ describe('formattedMessage', () => {
     })
 
     it('maintains special characters when using "to not match"', () => {
-      const specialMessage = 'expected **__*abcdef*__** to not match **/__.*abcde.*__/**'
+      const specialMessage = 'expected **__*abcdef*__** not to match **/__.*abcde.*__/**'
       const result = formattedMessage(specialMessage, 'assert')
 
-      expect(result).to.equal('expected <strong>__*abcdef*__</strong> to not match <strong>/__.*abcde.*__/</strong>')
+      expect(result).to.equal('expected <strong>__*abcdef*__</strong> not to match <strong>/__.*abcde.*__/</strong>')
     })
 
     it('maintains special characters when using "to equal"', () => {

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -70,6 +70,21 @@ describe('formattedMessage', () => {
 
       expect(result).to.equal('expected <strong>span</strong> to have CSS property <strong>background-color</strong> with the value <strong>rgb(0, 0, 0)</strong>, but the value was <strong>rgba(0, 0, 0, 0)</strong>')
     })
+
+    it('bolds asterisks with simple assertions', () => {
+      const specialMessage = 'expected **dom** to be visible'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>dom</strong> to be visible')
+    })
+
+    it('bolds assertions and displays html correctly', () => {
+      // expected <button#increment> to be enabled
+      const specialMessage = 'expected **<button#increment>** to be enabled'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>&lt;button#increment&gt;</strong> to be enabled')
+    })
   })
 
   describe('when not an assertion', () => {

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -7,38 +7,66 @@ describe('formattedMessage', () => {
     expect(result).to.equal('')
   })
 
-  describe('when to equal or to match assertions are used', () => {
+  describe('when assertion', () => {
     it('does not display extraneous "*" for to equal assertions', () => {
       const specialMessage = 'expected **abcdef** to equal **abcdef**'
-      const result = formattedMessage(specialMessage)
+      const result = formattedMessage(specialMessage, 'assert')
 
       expect(result).to.equal('expected <strong>abcdef</strong> to equal <strong>abcdef</strong>')
     })
 
+    it('does not display extraneous "*" for to not equal assertions', () => {
+      const specialMessage = 'expected **abcdef** to not equal **abcde**'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>abcdef</strong> to not equal <strong>abcde</strong>')
+    })
+
     it('maintains special characters when using "to match"', () => {
       const specialMessage = 'expected **__*abcdef*__** to match **/__.*abcdef.*__/**'
-      const result = formattedMessage(specialMessage)
+      const result = formattedMessage(specialMessage, 'assert')
 
       expect(result).to.equal('expected <strong>__*abcdef*__</strong> to match <strong>/__.*abcdef.*__/</strong>')
     })
 
+    it('maintains special characters when using "to not match"', () => {
+      const specialMessage = 'expected **__*abcdef*__** to not match **/__.*abcde.*__/**'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>__*abcdef*__</strong> to not match <strong>/__.*abcde.*__/</strong>')
+    })
+
     it('maintains special characters when using "to equal"', () => {
       const specialMessage = 'expected *****abcdef***** to equal *****abcdef*****'
-      const result = formattedMessage(specialMessage)
+      const result = formattedMessage(specialMessage, 'assert')
 
       expect(result).to.equal('expected <strong>***abcdef***</strong> to equal <strong>***abcdef***</strong>')
     })
 
+    it('maintains special characters when using "to not equal"', () => {
+      const specialMessage = 'expected *****abcdef***** to not equal *****abcde*****'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>***abcdef***</strong> to not equal <strong>***abcde***</strong>')
+    })
+
     it('maintains initial spaces on new lines', () => {
       const specialMessage = 'expected **hello\n world `code block`** to equal **hello\n world `code block`**'
-      const result = formattedMessage(specialMessage)
+      const result = formattedMessage(specialMessage, 'assert')
 
       expect(result).to.equal('expected <strong>hello\n world `code block`</strong> to equal <strong>hello\n world `code block`</strong>')
     })
+
+    it('bolds asterisks using "to contain"', () => {
+      const specialMessage = 'expected **glob*glob** to contain *****'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>glob*glob</strong> to contain <strong>*</strong>')
+    })
   })
 
-  describe('when to equal or to match assertions are not used', () => {
-    it('displays special characters as markdown using "to match"', () => {
+  describe('when not an assertion', () => {
+    it('displays special characters as markdown when not assertion', () => {
       const specialMessage = 'expected **__*abcdef*__** to contain **/__.*abcdef.*__/**'
       const result = formattedMessage(specialMessage)
 

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -7,31 +7,42 @@ describe('formattedMessage', () => {
     expect(result).to.equal('')
   })
 
-  it('maintains special characters when using "to match"', () => {
-    const specialMessage = 'expected **__*abcdef*__** to match /__.*abcdef.*__/'
-    const result = formattedMessage(specialMessage)
+  describe('when to equal or to match assertions are used', () => {
+    it('does not display extraneous "*" for to equal assertions', () => {
+      const specialMessage = 'expected **abcdef** to equal **abcdef**'
+      const result = formattedMessage(specialMessage)
 
-    expect(result).to.equal('expected <strong><strong><em>abcdef</em></strong></strong> to match <strong>/__.*abcdef.*__/</strong>')
+      expect(result).to.equal('expected <strong>abcdef</strong> to equal <strong>abcdef</strong>')
+    })
+
+    it('maintains special characters when using "to match"', () => {
+      const specialMessage = 'expected **__*abcdef*__** to match **/__.*abcdef.*__/**'
+      const result = formattedMessage(specialMessage)
+
+      expect(result).to.equal('expected <strong>__*abcdef*__</strong> to match <strong>/__.*abcdef.*__/</strong>')
+    })
+
+    it('maintains special characters when using "to equal"', () => {
+      const specialMessage = 'expected *****abcdef***** to equal *****abcdef*****'
+      const result = formattedMessage(specialMessage)
+
+      expect(result).to.equal('expected <strong>***abcdef***</strong> to equal <strong>***abcdef***</strong>')
+    })
+
+    it('maintains initial spaces on new lines', () => {
+      const specialMessage = 'expected **hello\n world `code block`** to equal **hello\n world `code block`**'
+      const result = formattedMessage(specialMessage)
+
+      expect(result).to.equal('expected <strong>hello\n world `code block`</strong> to equal <strong>hello\n world `code block`</strong>')
+    })
   })
 
-  it('maintains special characters when using "to contain"', () => {
-    const specialMessage = 'expected ***abcdef*** to equal ***abcdef***'
-    const result = formattedMessage(specialMessage)
+  describe('when to equal or to match assertions are not used', () => {
+    it('displays special characters as markdown using "to match"', () => {
+      const specialMessage = 'expected **__*abcdef*__** to contain **/__.*abcdef.*__/**'
+      const result = formattedMessage(specialMessage)
 
-    expect(result).to.equal('expected <em><strong>abcdef</strong></em> to equal <strong>***abcdef***</strong>')
-  })
-
-  it('does NOT maintain special characters when "to equal" or "to match" are not in assertion', () => {
-    const specialMessage = 'expected ***abcdef*** to contain ***abcdef***'
-    const result = formattedMessage(specialMessage)
-
-    expect(result).to.equal('expected <em><strong>abcdef</strong></em> to contain <em><strong>abcdef</strong></em>')
-  })
-
-  it('maintains initial spaces on new lines', () => {
-    const specialMessage = 'hello\n world `code block`'
-    const result = formattedMessage(specialMessage)
-
-    expect(result).to.equal('hello<br>\n world <code>code block</code>')
+      expect(result).to.equal('expected <strong><strong><em>abcdef</em></strong></strong> to contain <strong>/<strong>.<em>abcdef.</em></strong>/</strong>')
+    })
   })
 })

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -26,7 +26,7 @@
     "cypress-multi-reporters": "1.4.0",
     "cypress-real-events": "1.6.0",
     "lodash": "^4.17.21",
-    "markdown-it": "11.0.1",
+    "markdown-it": "^14.0.0",
     "mobx": "5.15.4",
     "mobx-react": "6.1.8",
     "prismjs": "1.21.0",

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -35,7 +35,7 @@ const asterisksRegex = /^\*\*(.+?)\*\*$/gs
 // 'expected **<span>** to exist in the DOM'
 // `expected **glob*glob** to contain *****`
 // `expected **<span>** to have CSS property **background-color** with the value **rgb(0, 0, 0)**, but the value was **rgba(0, 0, 0, 0)**`
-const assertionRegex = /expected | to([^\*])+| with([^\*])+|, but([^\*])+/g
+const assertionRegex = /expected | to[^\*]+| with[^\*]+|, but[^\*]+/g
 
 // used to format the display of command messages and error messages
 // we use markdown syntax within our error messages (code ticks, urls, etc)
@@ -48,16 +48,15 @@ export const formattedMessage = (message: string, name?: string) => {
 
   const expectedActualArray = () => {
     // get the expected and actual values of assertions
-    const split = message.split(assertionRegex).filter(Boolean)
-    const trimSplit = split.map((s) => s.trim()).filter(Boolean)
+    const splitTrim = message.split(assertionRegex).filter(Boolean).map((s) => s.trim())
 
     // replace outside double asterisks with strong tags
-    return trimSplit.map((s) => {
+    return splitTrim.map((s) => {
       // we want to escape HTML chars so that they display
       // correctly in the command log: <p> -> &lt;p&gt;
-      const HTMLFormattedString = mdOnlyHTML.renderInline(s)
+      const HTMLEscapedString = mdOnlyHTML.renderInline(s)
 
-      return HTMLFormattedString.replace(asterisksRegex, `<strong>$1</strong>`)
+      return HTMLEscapedString.replace(asterisksRegex, `<strong>$1</strong>`)
     })
   }
 

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -60,17 +60,21 @@ export const formattedMessage = (message: string, name?: string) => {
     })
   }
 
-  // if the command name is not an assertion or the format of the assertion is
-  // not something that matched our regex, we want to render the markdown formatting
-  if (name !== 'assert' || !assertionArray) {
-    return md.renderInline(message)
+  if (name === 'assert' && assertionArray) {
+    // for assertions print the exact text so that characters like _ and *
+    // are not escaped in the assertion display when comparing values
+    const result = assertionArray.flatMap((s, index) => [s, expectedActualArray()[index]])
+
+    return result.join('')
   }
 
-  // for assertions print the exact text so that characters like _ and *
-  // are not escaped in the assertion display when comparing values
-  const result = assertionArray.flatMap((s, index) => [s, expectedActualArray()[index]])
+  // if the command has url args, don't format those chars like __ and ~~
+  if (name === 'visit' || name === 'request' || name === 'origin') {
+    return message
+  }
 
-  return result.join('')
+  // format markdown for everything else
+  return md.renderInline(message)
 }
 
 const invisibleMessage = (model: CommandModel) => {

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -30,7 +30,7 @@ const nameClassName = (name: string) => name.replace(/(\s+)/g, '-')
 const md = new Markdown()
 
 const asterisksRegex = /^\*\*(.+?)\*\*$/gs
-const assertionRegex = /expected | to([^\*])+/g
+const assertionRegex = /expected | to([^\*])+| with([^\*])+|, but([^\*])+/g
 
 // used to format the display of command messages and error messages
 // we use markdown syntax within our error messages (code ticks, urls, etc)
@@ -41,14 +41,6 @@ export const formattedMessage = (message: string, name?: string) => {
   // the command message is formatted as 'expected <actual> to {assertion} <expected>'
   const assertionArray = message.match(assertionRegex)
 
-  // if the command name is not an assertion or the format of the assertion is
-  // not something that matched our regex, we want to render the markdown formatting
-  if (name !== 'assert' || !assertionArray) {
-    return md.renderInline(message)
-  }
-
-  // for assertions print the exact text so that characters like _ and *
-  // are not escaped in the assertion display when comparing values
   const expectedActualArray = () => {
     // get the expected and actual values
     const split = message.split(assertionRegex).filter(Boolean)
@@ -58,7 +50,14 @@ export const formattedMessage = (message: string, name?: string) => {
     return trimSplit.map((s) => s.replace(asterisksRegex, '<strong>$1</strong>'))
   }
 
-  // put the message back together
+  // if the command name is not an assertion or the format of the assertion is
+  // not something that matched our regex, we want to render the markdown formatting
+  if (name !== 'assert' || !assertionArray) {
+    return md.renderInline(message)
+  }
+
+  // for assertions print the exact text so that characters like _ and *
+  // are not escaped in the assertion display when comparing values
   const result = assertionArray.flatMap((s, index) => [s, expectedActualArray()[index]])
 
   return result.join('')

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -35,7 +35,7 @@ const asterisksRegex = /^\*\*(.+?)\*\*$/gs
 // 'expected **<span>** to exist in the DOM'
 // `expected **glob*glob** to contain *****`
 // `expected **<span>** to have CSS property **background-color** with the value **rgb(0, 0, 0)**, but the value was **rgba(0, 0, 0, 0)**`
-const assertionRegex = /expected | to[^\*]+| with[^\*]+|, but[^\*]+/g
+const assertionRegex = /expected | to[^\*]+| not[^\*]+| with[^\*]+|, but[^\*]+/g
 
 // used to format the display of command messages and error messages
 // we use markdown syntax within our error messages (code ticks, urls, etc)

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -90,7 +90,7 @@ const TestError = (props: TestErrorProps) => {
         {groupPlaceholder}
         <div className='runnable-err-content'>
           <div className='runnable-err-message'>
-            <span dangerouslySetInnerHTML={{ __html: formattedMessage(err.message, 'error') }} />
+            <span dangerouslySetInnerHTML={{ __html: formattedMessage(err.message) }} />
             <DocsUrl url={err.docsUrl} />
           </div>
           {codeFrame && <ErrorCodeFrame codeFrame={codeFrame} />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13485,11 +13485,6 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
-entities@~2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
-  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
-
 entities@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
@@ -19361,19 +19356,19 @@ lines-and-columns@~2.0.3:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
   integrity sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==
 
-linkify-it@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
-  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
-  dependencies:
-    uc.micro "^1.0.1"
-
 linkify-it@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
   integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
   dependencies:
     uc.micro "^1.0.1"
+
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
 
 lint-staged@11.1.2:
   version "11.1.2"
@@ -20161,17 +20156,6 @@ map-visit@^1.0.0:
     promise "7.0.4"
     socket-retry-connect "0.0.1"
 
-markdown-it@11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-11.0.1.tgz#b54f15ec2a2193efa66dda1eb4173baea08993d6"
-  integrity sha512-aU1TzmBKcWNNYvH9pjq6u92BML+Hz3h5S/QpfTFwiQF852pLT+9qHsrhM9JYipkOXZxGn+sGH8oyJE9FD9WezQ==
-  dependencies:
-    argparse "^1.0.7"
-    entities "~2.0.0"
-    linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
-
 markdown-it@13.0.1:
   version "13.0.1"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
@@ -20182,6 +20166,18 @@ markdown-it@13.0.1:
     linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
+
+markdown-it@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.0.0.tgz#b4b2ddeb0f925e88d981f84c183b59bac9e3741b"
+  integrity sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.0.0"
 
 marked-terminal@^5.0.0:
   version "5.1.1"
@@ -20257,6 +20253,11 @@ mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -24331,6 +24332,11 @@ pumpify@1.5.1, pumpify@^1.3.3, pumpify@^1.3.5:
     duplexify "^3.6.0"
     inherits "^2.0.3"
     pump "^2.0.0"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@1.3.2:
   version "1.3.2"
@@ -28945,6 +28951,11 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uc.micro@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.0.0.tgz#84b3c335c12b1497fd9e80fcd3bfa7634c363ff1"
+  integrity sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/24960
- Closes https://github.com/cypress-io/cypress/issues/28100
- Closes https://github.com/cypress-io/cypress/pull/28245

### Additional details

~THIS PR NEEDS TO BE MERGED FIRST FOR THE TESTS TO PASS: https://github.com/cypress-io/cypress/pull/28593~

This PR mainly addresses issues that were originally introduced in this PR: https://github.com/cypress-io/cypress/pull/22537

The original PRs intent was to not have markdown formatting display in situations where you want to assert that exact value. https://github.com/cypress-io/cypress/issues/5679 So if you want to write:

```js
expect(glob).to.contain('**/*')
expect(url).to.equal('https://test.com/__/path')
```
Cypress would actually translate the asterisks or underscores to markdown formatting. Not great. You can't see the actual values.

The way this code was written ended up introducing an issue where the assertions actual values were sometimes showing the asterisks instead of the bold text as described in: https://github.com/cypress-io/cypress/issues/24960

The original PR only had instances of 'to.equal' and 'to.match' where this was a problem reported, so the code naively looked for only messages containing 'to.equal' or 'to.match', not 'to.not.equal' or 'to.not.match'. Additionally, as shown above, the 'to.contain' seems like a good case where it also shouldn't do markdown formatting. 

We want some situations to do markdown formatting:
- We want our own error messages to format markdown for code ticks and docs urls
- We want to provide users the ability to markdown format their custom commands.
- We want HTML to be escaped so that `<p>` formats as `&lt;p&gt;` so that it doesn't render an actual element in the command log

In this PR, I've updated to logic to exclude normal markdown formatting when the command being displayed is an assertion.

Additionally I added logic for escaping markdown formatting for urls (`__path__` should be displayed as is, not with markdown bold).

The test coverage was also lacking in covering many of the cases that could be encountered and we had NO visual tests to cover assertion commands with realistic formatting. I've added a percy snapshot for that case. 

*(As an aside: For my sanity I made sure chainable getters are not rendered in the final assertion)*

<img width="1015" alt="Screen Shot 2023-12-28 at 3 36 13 PM" src="https://github.com/cypress-io/cypress/assets/1271364/a63a33b5-3d47-4e00-a3a2-28fdcc989a0b">

![Screen Shot 2023-12-28 at 3 36 20 PM](https://github.com/cypress-io/cypress/assets/1271364/2a36e349-fb51-4b09-9e8d-f727f818512c)



### Steps to test

Most of the use cases are covered in the formattes_message.cy.ts file. But anything that runs assertions through cypress should show the updated highlighting.

### How has the user experience changed?

Given the following assertions:

```js
  it('Test', () => {
    expect('abc').to.equal('abc')
    expect('abc').to.not.equal('bcd')
    expect('__*abcdef*__').to.match(/\*abcdef\*/)
    expect('__*abcdef*__').to.not.match(/\*fed\*/)
    expect('***abcdef***').to.equal('***abcdef***')
    expect('hello\n world `code block`').to.equal('hello\n world `code block`')
    expect('glob*glob').to.contain('*')
    cy.get('div').should('have.css', 'color', 'rgb(0, 0, 255)')
    cy.get('div').should('be.visible')
  })
```

#### Before

![Screen Shot 2023-12-27 at 2 05 55 PM](https://github.com/cypress-io/cypress/assets/1271364/0a05c6a1-5127-4ffb-9625-3fc2e60986c0)


#### After

![Screen Shot 2023-12-27 at 2 17 38 PM](https://github.com/cypress-io/cypress/assets/1271364/cad5a679-ecd5-403e-ac87-8c08f409c467)



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
