### PR TITLE
fix: studio generated assertions now use proper past tense for assertions

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.3
+
+_Released 1/2/2024 (PENDING)_
+
+**Bugfixes:**
+
+- When generating assertions via Cypress Studio, the preview of the generated assertions now correctly displays the past tense of 'expected' instead of 'expect'. Fixed in [#28593](https://github.com/cypress-io/cypress/pull/28593).
+
 ## 13.6.2
 
 _Released 12/26/2023_

--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -138,19 +138,19 @@ it('visits a basic html page', () => {
       cy.get('.command-name-assert').should('have.length', 5)
 
       // (1) Assert Enabled
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be enabled')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be enabled')
 
       // (2) Assert Visible
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to be visible')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to be visible')
 
       // (3) Assert Text
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have text Increment')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have text Increment')
 
       // (4) Assert Id
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have id increment')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have id increment')
 
       // (5) Assert Attr
-      cy.get('.command-name-assert').should('contain.text', 'expect <button#increment> to have attr onclick with the value increment()')
+      cy.get('.command-name-assert').should('contain.text', 'expected <button#increment> to have attr onclick with the value increment()')
     })
 
     cy.get('button').contains('Save Commands').click()

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -734,7 +734,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       const elementString = stringifyActual($el)
       const assertionString = args[0].replace(/\./g, ' ')
 
-      let message = `expect **${elementString}** to ${assertionString}`
+      let message = `expected **${elementString}** to ${assertionString}`
 
       if (args[1]) {
         message = `${message} **${args[1]}**`


### PR DESCRIPTION
### Additional details

When you generate assertions within Cypress Studio, we insert a little preview of the assertions right away while the assertions are being written to your code. It doesn't refresh and run what is in your codebase right away - it generates a fake preview. 

Previously this preview was showing the text 'expect....' for assertions, but in reality assertions always show in the past tense as 'expected...'. You can see this behavior after saving the commands - when they run, it switches from 'expect' to 'expected'

![](http://g.recordit.co/Fm1wjAreU5.gif)

I found this while working on [this PR](https://github.com/cypress-io/cypress/pull/28583) because I created a regex to capture all assertion text and this was the one test that failed and borked up when going through the regex. Baffling! 

Well the hard written generated assertion is incorrect and the test was written to verify the incorrect behavior. This updates both.

### Steps to test

Not sure I would bother with a true test to prevent this in the future. 🤔 But you can run cypress with studio, add an assertion - see that it writes 'expected' and then the same thing after saving the file should display as 'expected'.

### How has the user experience changed?

#### Before

![Screen Shot 2023-12-27 at 3 22 26 PM](https://github.com/cypress-io/cypress/assets/1271364/cb11dff1-a09d-4d1f-afa9-ad2d0948dc55)

#### After

![Screen Shot 2023-12-27 at 3 22 42 PM](https://github.com/cypress-io/cypress/assets/1271364/0b3c65d2-50b6-4105-b46c-ddf90874f01e)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
