### PR TITLE
feat(angular): Add a `setup` callback for `mount`

### DIFF
--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -79,6 +79,7 @@ export interface MountConfig<T> extends TestModuleMetadata {
    *   configured with the component instance as argument.
    * @example
    * import { ButtonComponent } from 'button/button.component'
+   * import { ButtonService } from 'button/button.service'
    * it('renders a button with Save text', () => {
    *  cy.mount(ButtonComponent, { setup: (component) => {
    *    component.label = TestBed.inject(ButtonService).getLabel()

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -289,7 +289,7 @@ function setupComponent<T> (
   }
 
   if (config?.setup) {
-    config.setup(component)
+    config.setup(fixture.componentInstance)
   }
 
   if (config.autoSpyOutputs) {

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -72,6 +72,21 @@ export interface MountConfig<T> extends TestModuleMetadata {
    * })
    */
   componentProperties?: Partial<{ [P in keyof T]: T[P] }>
+  
+  /**
+   * @memberof MountConfig
+   * @description late evaluation setup callback. Called after the TestBed has been
+   *   configured with the component instance as argument.
+   * @example
+   * import { ButtonComponent } from 'button/button.component'
+   * it('renders a button with Save text', () => {
+   *  cy.mount(ButtonComponent, { setup: (component) => {
+   *    component.label = TestBed.inject(ButtonService).getLabel()
+   *  }})
+   *  cy.get('button').contains('Save')
+   * })
+   */
+  setup?: (componentInstance: T) => void
 }
 
 let activeFixture: ComponentFixture<any> | null = null
@@ -270,6 +285,10 @@ function setupComponent<T> (
 
   if (config?.componentProperties) {
     component = Object.assign(component, config.componentProperties)
+  }
+
+  if (config?.setup) {
+    config.setup(component)
   }
 
   if (config.autoSpyOutputs) {


### PR DESCRIPTION
The `MountConfig` only accepts eagerly evaluated `componentProperties`, but this doesn't cover all use cases.

I read through the Contribution Guidelines and PR checklist and I think (also due to its small changeset and limited scope) that it ticks all the boxes.

### Additional details

Not every codebase is squeaky clean enough, or simple enough, for all of a `componentProperties` to be known before the testing module is ready. Currently I can't use `TestBed.inject` before `.mount` (because that initializes/finishes the TestBed module, and then `.mount` fails) and so I can't pass any `componentProperties` that require DI.

In my use case the application sets a bit of global state that is required to inejct outside of any injection context, so I need to call `Test.inject(Injector)` before I can create the component properties.

### How has the user experience changed?

Some users will benefit from being able to tinker a bit with the component/test suite between `TestBed` initialization and component startup.

### PR Tasks

Once a maintainer/code owner conceptually greenlights this proposed changeset, I will invest the time to complete the PR checklist.

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? (Didn't see the `MountConfig` or anything related to `mount` appear there)