### PR TITLE
chore: implement remote executable signing for windows binary builds

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-01-02-24
+01-04-24

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -79,7 +79,10 @@ windowsWorkflowFilters: &windows-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'feature/experimental-retries', << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/service-worker-capture', << pipeline.git.branch >> ]
+    - equal: [ 'chore/update_windows_signing', << pipeline.git.branch >> ]
+    - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
+    - equal: [ 'em/shallow-checkout', << pipeline.git.branch >> ]
+    - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -149,7 +152,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "ryanm/fix/service-worker-capture" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "chore/update_windows_signing" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command
@@ -1150,8 +1153,10 @@ commands:
           # set variable CSC_FOR_PULL_REQUEST=true
           command: |
             set -e
-            NEEDS_CODE_SIGNING=`node -p 'process.platform === "win32" || process.platform === "darwin"'`
-            if [[ "$NEEDS_CODE_SIGNING" == "true" ]]; then
+            NEEDS_CODE_SIGNING_WINDOWS=`node -p 'process.platform === "win32"'`
+            NEEDS_CODE_SIGNING_MAC=`node -p 'process.platform === "darwin"'`
+
+            if [[ "$NEEDS_CODE_SIGNING_MAC" == "true" ]]; then
               echo "Checking for required environment variables..."
               if [ -z "$CSC_LINK" ]; then
                 echo "Need to provide environment variable CSC_LINK"
@@ -1161,6 +1166,29 @@ commands:
               if [ -z "$CSC_KEY_PASSWORD" ]; then
                 echo "Need to provide environment variable CSC_KEY_PASSWORD"
                 echo "with password for unlocking certificate .p12 file"
+                exit 1
+              fi
+              echo "Succeeded."
+            elif [[ "$NEEDS_CODE_SIGNING_WINDOWS" == "true" ]]; then
+              echo "Checking for required environment variables..."
+              if [ -z "$WINDOWS_SIGN_USER_NAME" ]; then
+                echo "Need to provide environment variable WINDOWS_SIGN_USER_NAME"
+                echo "with password for fetching and signing certificate"
+                exit 1
+              fi
+              if [ -z "$WINDOWS_SIGN_USER_PASSWORD" ]; then
+                echo "Need to provide environment variable WINDOWS_SIGN_USER_PASSWORD"
+                echo "for fetching and signing certificate"
+                exit 1
+              fi
+              if [ -z "$WINDOWS_SIGN_CREDENTIAL_ID" ]; then
+                echo "Need to provide environment variable WINDOWS_SIGN_CREDENTIAL_ID"
+                echo "for identifying certificate"
+                exit 1
+              fi
+              if [ -z "$WINDOWS_SIGN_USER_TOTP" ]; then
+                echo "Need to provide environment variable WINDOWS_SIGN_USER_TOTP"
+                echo "for signing certificate"
                 exit 1
               fi
               echo "Succeeded."

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,6 +16,10 @@
     "executableName": "Cypress"
   },
   "win": {
+    "signingHashAlgorithms": [
+      "sha256"
+    ],
+    "sign": "./scripts/windows-sign.js",
     "target": "dir"
   },
   "afterPack": "./scripts/after-pack-hook.js",

--- a/scripts/windows-sign.js
+++ b/scripts/windows-sign.js
@@ -1,0 +1,72 @@
+// This signing procedure only runs on windows binary builds to leverage remote signing in order to
+// fullfil new requirements around OV and IV code signing.
+// @see https://www.ssl.com/article/code-signing-key-storage-requirements-will-change-on-june-1-2023/ for more details.
+
+// Signing delegation happens inside the electron-builder.json, which can be seen in the configuration:
+// "sign": "./scripts/windows-sign.js"
+// @see https://www.electron.build/configuration/win#how-do-delegate-code-signing for configuration reference.
+
+// sampled from https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-899798533
+const path = require('path')
+const fs = require('fs')
+const childProcess = require('child_process')
+
+const TEMP_DIR = path.join(__dirname, 'release', 'temp')
+
+// create the temp directory we need for CodeSignTool in order to avoid manual confirmations
+try {
+  fs.statSync(TEMP_DIR).isDirectory()
+} catch (e) {
+  if (e.message.includes('no such file or directory')) {
+    fs.mkdirSync(TEMP_DIR, { recursive: true })
+  }
+
+  if (!fs.statSync(TEMP_DIR).isDirectory()) {
+    throw e
+  }
+}
+
+function sign (configuration) {
+  // credentials from ssl.com
+  const USER_NAME = process.env.WINDOWS_SIGN_USER_NAME
+  const USER_PASSWORD = process.env.WINDOWS_SIGN_USER_PASSWORD
+  const CREDENTIAL_ID = process.env.WINDOWS_SIGN_CREDENTIAL_ID
+  const USER_TOTP = process.env.WINDOWS_SIGN_USER_TOTP
+
+  if (USER_NAME && USER_PASSWORD && USER_TOTP && CREDENTIAL_ID) {
+    console.log(`Signing ${configuration.path}`)
+    const { name, dir } = path.parse(configuration.path)
+
+    // Since the CodeSignTool can only be run in the directory it is installed, we want to
+    // download the CodeSignTool and explode it into the current directory. This isn't a repeat operation
+    // in this case since we are only signing the executable, which is one file.
+    console.log('downloading CodeSignTool for Windows from ssl.com...')
+    childProcess.execSync('curl https://www.ssl.com/download/codesigntool-for-windows/ -o codesigntool-for-windows.zip')
+    childProcess.execSync('tar -xvf codesigntool-for-windows.zip')
+    childProcess.execSync('rm ./codesigntool-for-windows.zip')
+
+    // CodeSignTool can't sign in place without verifying the overwrite with a
+    // manual interaction so we are creating a new file in a temp directory and
+    // then replacing the original file with the signed file.
+    const tempFile = path.join(TEMP_DIR, name)
+
+    console.log('executing signing...')
+    // Sign the executable with the signing tool. For CLI reference, @see https://www.ssl.com/guide/esigner-codesigntool-command-guide/.
+    childProcess.execSync(`CodeSignTool.bat sign -input_file_path="${configuration.path}" -output_dir_path="${TEMP_DIR}" -credential_id="${CREDENTIAL_ID}" -username="${USER_NAME}" -password="${USER_PASSWORD}" -totp_secret="${USER_TOTP}"`)
+
+    console.log('signing complete! Moving signed files back to package directory...')
+    childProcess.execSync(`mv "${tempFile}" "${dir}"`)
+    console.log('move completed!')
+  } else {
+    console.warn(`windows-sign.js - Can't sign file ${configuration.path}, missing value for:
+${USER_NAME ? '' : 'WINDOWS_SIGN_USER_NAME'}
+${USER_PASSWORD ? '' : 'WINDOWS_SIGN_USER_PASSWORD'}
+${CREDENTIAL_ID ? '' : 'WINDOWS_SIGN_CREDENTIAL_ID'}
+${USER_TOTP ? '' : 'WINDOWS_SIGN_USER_TOTP'}
+`)
+
+    process.exit(1)
+  }
+}
+
+exports.default = sign

--- a/scripts/windows-sign.js
+++ b/scripts/windows-sign.js
@@ -8,23 +8,14 @@
 
 // sampled from https://github.com/electron-userland/electron-builder/issues/6158#issuecomment-899798533
 const path = require('path')
-const fs = require('fs')
+const { tmpdir } = require('os')
+const fs = require('fs-extra')
 const childProcess = require('child_process')
 
-const TEMP_DIR = path.join(__dirname, 'release', 'temp')
+const TEMP_DIR = path.join(tmpdir(), 'release', 'tmp')
 
 // create the temp directory we need for CodeSignTool in order to avoid manual confirmations
-try {
-  fs.statSync(TEMP_DIR).isDirectory()
-} catch (e) {
-  if (e.message.includes('no such file or directory')) {
-    fs.mkdirSync(TEMP_DIR, { recursive: true })
-  }
-
-  if (!fs.statSync(TEMP_DIR).isDirectory()) {
-    throw e
-  }
-}
+fs.ensureDirSync(TEMP_DIR)
 
 function sign (configuration) {
   // credentials from ssl.com


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28112

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Updates the app code signing process to adhere to the changes made by [ssl.com](https://www.ssl.com/article/code-signing-key-storage-requirements-will-change-on-june-1-2023/) for newly issues certificates. Currently, we sign the app with a `.p12` cert, which is retrieved in the `electron-builder` signing step through a CSC link and password. Since this format is no longer available through ssl.com, we need to e-sign the windows executable through other means.

In this case, we need to delegate to a [custom signing process](https://www.electron.build/configuration/win#how-do-delegate-code-signing) during the electron builder step in order to e-sign the executable. For this, we use the [CodeSignTool](https://www.ssl.com/guide/esigner-codesigntool-command-guide/) CLI during the signing process for windows binary builds and sign the windows executable. Signing credentials used by the CLI live in a secure and restricted context and can be updated as needed.

<img width="1491" alt="Screenshot 2024-01-04 at 8 09 57 AM" src="https://github.com/cypress-io/cypress/assets/3980464/7c6d3923-68cc-4e42-85d2-08d4311b9e31">

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Most verification for this functionality is unfortunately quite manual. This can be verified by checking the `Package the Cypress Binary` step inside one of the [CI runs](https://app.circleci.com/pipelines/github/cypress-io/cypress/59050/workflows/b592ae93-db78-44ad-a893-853987eb98d5/jobs/2452067) for this PR, or by running the binary build with the proper credentials locally on a windows machine. 

A unit test could be added for the `windows-sign.js` custom signing script, but it doesn't seem high value as most the contents of the scripts are `execSync` commands executed by the script itself and didn't seem worth the maintenance cost.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
This change only applies to the build process and should not affect the end user.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated? (N/A)
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? (N/A) <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? (N/A)
