### PR TITLE
chore: patch cli @types/sinon to fix issue with TS 4.3 linting

### DIFF
--- a/cli/patches/@types+sinon+9.0.9.patch
+++ b/cli/patches/@types+sinon+9.0.9.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@types/sinon/index.d.ts b/node_modules/@types/sinon/index.d.ts
+index 07ba706..fd32cbe 100644
+--- a/node_modules/@types/sinon/index.d.ts
++++ b/node_modules/@types/sinon/index.d.ts
+@@ -45,7 +45,7 @@ declare namespace Sinon {
+          * so a call that received the provided arguments (in the same spots) and possibly others as well will return true.
+          * @param args
+          */
+-        calledWith(...args: Partial<MatchArguments<TArgs>>): boolean;
++        calledWith(...args: Partial<MatchArguments<TArgs>>[]): boolean;
+         /**
+          * Returns true if spy was called at least once with the provided arguments and no others.
+          */


### PR DESCRIPTION
Fixes an issue with sinon types hitting a linting error when checking them with TypeScript 4.3: https://app.circleci.com/pipelines/github/cypress-io/cypress/59181/workflows/ae5dfe43-7dde-4236-a6a4-722e4436c48b/jobs/2458030