### PR TITLE
chore: fix runtime error when service worker container is unavailable

### DIFF
--- a/system-tests/lib/protocol-stubs/protocolStubServiceWorker.ts
+++ b/system-tests/lib/protocol-stubs/protocolStubServiceWorker.ts
@@ -23,6 +23,7 @@ export class AppCaptureProtocol implements AppCaptureProtocolInterface {
     numberOfResponseStreamReceivedEvents: 0,
     correlatedUrls: {},
     multipleNetworkRequestEventsForSameRequestId: false,
+    exceptionThrown: false,
   }
   private idToUrlAndFrameMap = new Map<string, URLAndFrame>()
   private currentRequestWillBeSent: (event) => void
@@ -63,6 +64,9 @@ export class AppCaptureProtocol implements AppCaptureProtocolInterface {
     }
 
     cdpClient.on('Network.requestWillBeSent', this.currentRequestWillBeSent)
+    cdpClient.on('Runtime.exceptionThrown', (event) => {
+      this.events.exceptionThrown = true
+    })
   }
 
   addRunnables = (runnables) => {

--- a/system-tests/projects/e2e/cypress/e2e/service_worker.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/service_worker.cy.js
@@ -1,6 +1,13 @@
 const swReq = (win) => {
   return new Promise((resolve) => {
-    win.addEventListener('service-worker:ready', () => {
+    win.addEventListener('service-worker:ready', (event) => {
+      expect(event.detail).to.deep.equal({
+        example: {
+          foo: 'bar',
+        },
+        cached: 'this response will be used by service worker',
+      })
+
       resolve(win)
     })
   })

--- a/system-tests/projects/e2e/service-worker-assets/scope/load.js
+++ b/system-tests/projects/e2e/service-worker-assets/scope/load.js
@@ -1,8 +1,15 @@
 navigator.serviceWorker?.register('/service-worker-assets/scope/service-worker.js')
 
 navigator.serviceWorker?.ready.then(async () => {
-  await fetch('/service-worker-assets/example.json')
-  await fetch('/service-worker-assets/scope/cached-service-worker')
+  const exampleResponse = await fetch('/service-worker-assets/example.json')
+  const example = await exampleResponse.json()
+  const cachedServiceWorkerResults = await fetch('/service-worker-assets/scope/cached-service-worker')
+  const cached = await cachedServiceWorkerResults.text()
 
-  window.dispatchEvent(new Event('service-worker:ready'))
+  window.dispatchEvent(new CustomEvent('service-worker:ready', {
+    detail: {
+      example,
+      cached,
+    },
+  }))
 })

--- a/system-tests/test/service_worker_protocol_spec.js
+++ b/system-tests/test/service_worker_protocol_spec.js
@@ -30,6 +30,9 @@ describe('capture-protocol', () => {
         return systemTests.exec(this, {
           key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
           project: 'protocol',
+          // Here we are testing that service worker and non-service worker specs can intermingle properly
+          // Also, protocol.cy.js is not secure which will cause window.ServiceWorkerContainer to not be available
+          // in the browser. We test that no exceptions are thrown when this happens.
           spec: 'protocol.cy.js,service-worker.cy.js',
           record: true,
           expectedExitCode: 0,
@@ -49,6 +52,8 @@ describe('capture-protocol', () => {
             'http://localhost:2121/cypress/fixtures/service-worker-assets/scope/load.js': ['frame id'],
             'http://localhost:2121/cypress/fixtures/service-worker-assets/scope/service_worker.html': ['frame id', 'no frame id', 'no frame id'],
           })
+
+          expect(parsedProtocolEvents.exceptionThrown).to.be.false
         })
       })
     })


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

#28517 introduced the ability to track on service worker registrations. We didn't handle the situation where service worker registration is unavailable (e.g. in insecure contexts). This fix resolves that issue. Marking it as a chore since #28517 hasn't been released yet.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

The system test changes test this scenario.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
