### PR TITLE
test: rewrite flaky 1244 test to no longer be flaky

### DIFF
--- a/packages/driver/cypress/e2e/issues/1244.cy.js
+++ b/packages/driver/cypress/e2e/issues/1244.cy.js
@@ -4,7 +4,7 @@ describe('issue 1244', () => {
       cy.on('window:before:unload', (e) => {
         const win = cy.state('window')
 
-        // not all pages that ge unloaded during this spec have getCounters()
+        // not all pages that get unloaded during this spec have getCounters()
         if (win.location.href.includes('issue-1244.html')) {
           expect(win.getCounters()).to.deep.equal({ getCounter: 0, setCounter: 0 })
         }

--- a/packages/driver/cypress/fixtures/issue-1244.html
+++ b/packages/driver/cypress/fixtures/issue-1244.html
@@ -47,7 +47,7 @@
   <form target="_top" method="GET" action="/fixtures/dom.html">
     <button class="inline_top" type="submit">Submit inline top</button>
   </form>
-  <form target="_parent" method="GET" action="/fixtures/dom.html">
+  <form target="_parent" method="GET" action="/fixtures/empty.html">
     <button class="inline_parent" type="submit">Submit inline parent</button>
   </form>
   <form target="_self" method="GET" action="/fixtures/dom.html">
@@ -63,7 +63,7 @@
     <a class="setTarget" href="/fixtures/dom.html" onclick="handleEventTarget(event)">Link setTarget</a>
     <a class="setAttr" href="/fixtures/dom.html" onclick="handleEventAttribute(event)">Link setAttribute</a>
     <a class="inline_top" href="/fixtures/dom.html" target="_top">Link top</a>
-    <a class="inline_parent" href="/fixtures/dom.html" target="_parent">Link parent</a>
+    <a class="inline_parent" href="/fixtures/empty.html" target="_parent">Link parent</a>
     <a class="inline_self" href="/fixtures/dom.html" target="_self">Link self</a>
     <a class="inline_blank" href="/fixtures/dom.html" target="_blank">Link _blank</a>
     <a class="inline_invalid" href="/fixtures/dom.html" target="invalid">Link invalid</a>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

This spec exposed odd caching behavior in Electron open mode, exacerbated by the upgrade to Electron 27.  An issue was opened to address this bug, but this PR addresses the flaky test. The commented version of this test will reliably hang when Cypress attempts to perform a cross-origin `postMessage` handshake, because the browser caches a version of `dom.html` that does not have the cross-origin support script due to it being loaded in a new window via `target=_blank`.

### Steps to test
Run the `issues/1244.cy.js` driver spec in open mode with Electron, and verify that the final test does not hang.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
