### PR TITLE
fix: force moduleResolution: 'node' when ts-node is registered in the…

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -29,7 +29,7 @@ mainBuildFilters: &mainBuildFilters
         - develop
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-        - 'chore/update_aws_sdk'
+        - 'fix/set_module_resolution_with_commonjs'
         - 'publish-binary'
         - 'em/circle2'
 
@@ -42,7 +42,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_aws_sdk', << pipeline.git.branch >> ]
+    - equal: [ 'fix/set_module_resolution_with_commonjs', << pipeline.git.branch >> ]
     - equal: [ 'ryanm/fix/service-worker-capture', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -54,8 +54,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_aws_sdk', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_webpack_deps_to_latest_webpack4_compat', << pipeline.git.branch >> ]
+    - equal: [ 'fix/set_module_resolution_with_commonjs', << pipeline.git.branch >> ]
     - equal: [ 'em/circle2', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -79,8 +78,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_aws_sdk', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_windows_signing', << pipeline.git.branch >> ]
+    - equal: [ 'fix/set_module_resolution_with_commonjs', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
     - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
     - matches:
@@ -152,7 +150,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "chore/update_aws_sdk" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "fix/set_module_resolution_with_commonjs" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 _Released 1/16/2024 (PENDING)_
 
 **Bugfixes:**
-- Force `moduleResolution` to `node` when `typescript` projects are detected to correctly run Cypress. This change should not have a large impact as `commonjs` is already forced when `ts-node` is registered. Fixes [#27731](https://github.com/cypress-io/cypress/issues/27731).
+- Force `moduleResolution` to `node` when `typescript` projects are detected to correctly run Cypress. This change should not have a large impact as `commonjs` is already forced when `ts-node` is registered. This fix does not impact the ESM Typescript configuration loader. Fixes [#27731](https://github.com/cypress-io/cypress/issues/27731).
 - No longer wait for additional frames when recording a video for a spec that was skipped by the Cloud due to Auto Cancellation. Fixes [#27898](https://github.com/cypress-io/cypress/issues/27898).
 - Now `node_modules` will not be ignored if a project path or a provided path to spec files contains it. Fixes [#23616](https://github.com/cypress-io/cypress/issues/23616).
 - Updated display of assertions and commands with a URL argument to escape markdown formatting so that values are displayed as is and assertion values display as bold. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#28100](https://github.com/cypress-io/cypress/issues/28100).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 _Released 1/16/2024 (PENDING)_
 
 **Bugfixes:**
-
+- Force `moduleResolution` to `node` when `typescript` projects are detected to correctly run Cypress. This change should not have a large impact as `commonjs` is already forced when `ts-node` is registered. Fixes [#27731](https://github.com/cypress-io/cypress/issues/27731).
 - No longer wait for additional frames when recording a video for a spec that was skipped by the Cloud due to Auto Cancellation. Fixes [#27898](https://github.com/cypress-io/cypress/issues/27898).
 - Now `node_modules` will not be ignored if a project path or a provided path to spec files contains it. Fixes [#23616](https://github.com/cypress-io/cypress/issues/23616).
 - Updated display of assertions and commands with a URL argument to escape markdown formatting so that values are displayed as is and assertion values display as bold. Fixes [#24960](https://github.com/cypress-io/cypress/issues/24960) and [#28100](https://github.com/cypress-io/cypress/issues/28100).

--- a/packages/server/lib/plugins/child/ts_node.js
+++ b/packages/server/lib/plugins/child/ts_node.js
@@ -23,6 +23,7 @@ const getTsNodeOptions = (tsPath, registeredFile) => {
    */
   const compilerOptions = {
     module: 'commonjs',
+    moduleResolution: 'node',
     ...(semver.satisfies(version, '>=4.5.0')
       // Only adding this option for TS >= 4.5.0
       ? { preserveValueImports: false }
@@ -34,9 +35,6 @@ const getTsNodeOptions = (tsPath, registeredFile) => {
 
   if (process.env.TS_NODE_COMPILER) {
     try {
-      // @ts-expect-error - compilerOptions is an object we can assign properties on.
-      // It's the 'tsconfig.compilerOptions'.
-      compilerOptions.moduleResolution = 'node'
       compiler = require.resolve(process.env.TS_NODE_COMPILER, { paths: [path.dirname(registeredFile)] })
     } catch {
       // ts-node compiler not installed in project directory

--- a/packages/server/test/unit/plugins/child/ts_node_spec.js
+++ b/packages/server/test/unit/plugins/child/ts_node_spec.js
@@ -24,6 +24,7 @@ describe('lib/plugins/child/ts_node', () => {
         dir: '/path/to/plugins',
         compilerOptions: {
           module: 'commonjs',
+          moduleResolution: 'node',
         },
         ignore: [
           '(?:^|/)node_modules/',
@@ -44,6 +45,7 @@ describe('lib/plugins/child/ts_node', () => {
         dir: '/path/to/plugins',
         compilerOptions: {
           module: 'commonjs',
+          moduleResolution: 'node',
           preserveValueImports: false,
         },
         ignore: [
@@ -53,30 +55,6 @@ describe('lib/plugins/child/ts_node', () => {
           '/packages/telemetry/dist/processors/on-start-span-processor',
         ],
       })
-    })
-
-    it('registers ts-node with commonjs and node moduleResolution when process.env.TS_NODE_COMPILER is set', () => {
-      process.env.TS_NODE_COMPILER = true
-      sinon.stub(typescriptObject, 'version').value('1.1.1')
-      tsNodeUtil.register('proj-root', '/path/to/plugins/file.js')
-
-      expect(tsnode.register).to.be.calledWith({
-        transpileOnly: true,
-        compiler: 'typescript/lib/typescript.js',
-        dir: '/path/to/plugins',
-        compilerOptions: {
-          module: 'commonjs',
-          moduleResolution: 'node',
-        },
-        ignore: [
-          '(?:^|/)node_modules/',
-          '/packages/telemetry/dist/span-exporters/ipc-span-exporter',
-          '/packages/telemetry/dist/span-exporters/console-trace-link-exporter',
-          '/packages/telemetry/dist/processors/on-start-span-processor',
-        ],
-      })
-
-      delete process.env.TS_NODE_COMPILER
     })
 
     it('does not register ts-node if typescript is not installed', () => {


### PR DESCRIPTION
… cypress process to make sure value is compatible with commonjs (which is already forced). [run ci]

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27731

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
This PR attempts to fix #27731, which was reopened when #26308 did not resolve the issue. 

Currently in Cypress, if a user has `typescript` installed and the project is NOT an ES Module (via `type: 'module'`), Cypress sets the module to `commonjs` when registering `ts-node` to load the project's config. This was to guarantee that cypress could run the transpiled config in its owned node process as node can natively run `commonjs` with ease. This however started being a problem when new `moduleResolution` properties were introduced to newer versions of typescript that are incompatible with `commonjs`. 

To avoid this issue, this PR sets the `moduleResolution` to `node` to guarantee `commonjs` as a module configuration will work. #26308 attempted to fix this in a similar way, except the `moduleResolution` setting to `node` happened behind to `TS_NODE_COMPILER` flag, which is only set when a user provides a custom compiler, which the Cypress monorepo does [here](https://github.com/cypress-io/cypress/blob/develop/scripts/gulp/tasks/gulpCypress.ts#L99), which made the issue appear to be fixed. This isn't usually set in production, hence why #27731 was opened.

This should resolve the issues with `next.js` scaffolding, but e need to figure out a more long term solution to processing the users cypress config with typescript. Right now we use the user's typescript configuration to transpile files executed by the cypress node child process, which is a gamble on compatibility (hence the forcing, but isn't really an option with `ts-node/esm` due to https://github.com/TypeStrong/ts-node/issues/1997#issue-1675909705).

To verify the issue, standalone binaries have been build on the commit in this PR https://github.com/cypress-io/cypress/commit/0481c7af5d4085004b91dd644d7a4c8d97ea1b00. From testing, it looks like the fix works.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Since reproducing this issue is difficult in the cypress monorepo due to the `TS_NODE_COMPILER` flag set, standalone binaries have been build on the commit in this PR https://github.com/cypress-io/cypress/commit/0481c7af5d4085004b91dd644d7a4c8d97ea1b00.  Follow the `next.js` reproduction steps in #27731 to create a new `next.js` project with the CLI, install cypress, and make sure a user can set up their cypress project for the first time without error and run tests.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

`next.js@14` with cypress e2e tests and typescript installed should run out of the box. This PR does NOT resolve CT support for `next.js@14`, mentioned in #28185.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> (N/A)
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? (N/A)
