### PR TITLE
fix: (driver) add null check for `browserRequestId` on responses for `cy.wait`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,6 +15,7 @@ _Released 1/16/2024 (PENDING)_
 - Fixed asset capture for Test Replay for requests that are routed through service workers. This addresses an issue where styles were not being applied properly in Test Replay and `cy.intercept` was not working properly for requests in this scenario. Fixes [#28516](https://github.com/cypress-io/cypress/issues/28516).
 - Fixed an issue where visiting an `http://` site would result in an infinite reload/redirect loop in Chrome 114+. Fixes [#25891](https://github.com/cypress-io/cypress/issues/25891).
 - Fixed an issue where requests made from extra tabs do not include their original headers. Fixes [#28641](https://github.com/cypress-io/cypress/issues/28641).
+- Fixed an issue where `cy.wait()` would sometimes throw an error reading a property of undefined when returning responses. Fixes [#28233](https://github.com/cypress-io/cypress/issues/28233).
 
 **Performance:**
 

--- a/packages/driver/src/cy/commands/waiting.ts
+++ b/packages/driver/src/cy/commands/waiting.ts
@@ -259,8 +259,8 @@ export default (Commands, Cypress, cy, state) => {
           }
 
           // sort responses based on browser request ID
-          const requestIdSuffixA = a.browserRequestId?.split('.').length > 1 ? a.browserRequestId?.split('.')[1] : a.browserRequestId
-          const requestIdSuffixB = b.browserRequestId?.split('.').length > 1 ? b.browserRequestId?.split('.')[1] : b.browserRequestId
+          const requestIdSuffixA = a.browserRequestId.split('.').length > 1 ? a.browserRequestId.split('.')[1] : a.browserRequestId
+          const requestIdSuffixB = b.browserRequestId.split('.').length > 1 ? b.browserRequestId.split('.')[1] : b.browserRequestId
 
           return parseInt(requestIdSuffixA) < parseInt(requestIdSuffixB) ? -1 : 1
         }).forEach((r) => {

--- a/packages/driver/src/cy/commands/waiting.ts
+++ b/packages/driver/src/cy/commands/waiting.ts
@@ -254,9 +254,13 @@ export default (Commands, Cypress, cy, state) => {
         // responses are sorted in the order the user specified them. if there are multiples of the same
         // alias awaited, they're sorted in execution order
         resp.sort((a, b) => {
+          if (!a.browserRequestId || !b.browserRequestId) {
+            return 0
+          }
+
           // sort responses based on browser request ID
-          const requestIdSuffixA = a.browserRequestId.split('.').length > 1 ? a.browserRequestId.split('.')[1] : a.browserRequestId
-          const requestIdSuffixB = b.browserRequestId.split('.').length > 1 ? b.browserRequestId.split('.')[1] : b.browserRequestId
+          const requestIdSuffixA = a.browserRequestId?.split('.').length > 1 ? a.browserRequestId?.split('.')[1] : a.browserRequestId
+          const requestIdSuffixB = b.browserRequestId?.split('.').length > 1 ? b.browserRequestId?.split('.')[1] : b.browserRequestId
 
           return parseInt(requestIdSuffixA) < parseInt(requestIdSuffixB) ? -1 : 1
         }).forEach((r) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/28233

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In #27806, we added sorting to the list of responses that we get in the wait command. The sorting algorithm uses the `browserRequestId` attribute to sort responses with the same aliases and return them in the order in which they were received by the browser. 

Sometimes this attribute isn't defined on the responses which causes us to throw an error when we call `.split` on undefined. This PR updates the sorting logic to just return the responses with the original sort order if either of the requests that we're comparing don't have a `browserRequestId`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

I wasn't able to actually reproduce this - but adding the null check should at least make it so that we don't throw if the response doesn't have the expected properties.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
