### PR TITLE
docs: Python 3.11 is highest compatible version for yarn install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ You must have the following installed on your system to contribute locally:
 
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
-- [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
+- [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements. Use Python `3.11` or lower.)
   - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make cmake` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
 
 ### Getting Started


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/28695

### Additional details

When rebuilding Cypress from source, at the stage where dependencies are installed, the following two npm modules require rebuilding, and this in turn requires that Python be installed.:

- [registry-js](https://www.npmjs.com/package/registry-js)
- [cpu-features](https://www.npmjs.com/package/cpu-features)

If the current version of [Python](https://www.python.org/) `3.12.1` is installed then the rebuild fails with the following error message:

> ModuleNotFoundError: No module named 'distutils'

This PR changes [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) to document that [Python](https://www.python.org/) `3.11` or lower be used, so that the problem does not occur.

On local Windows systems, for instance, there is no pre-installed or default version of Python installed, so the version to be installed must be chosen. [node-gyp](https://github.com/nodejs/node-gyp/blob/main/README.md) recommends for Windows:

> Install the current [version of Python](https://devguide.python.org/versions/) from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation).

On macOS GitHub runners `macos-11`, `macos-12` and `macos-13` these have Python `3.12.x` installed by default.

### Steps to test

Install / set up the Node.js version specified by [.node-version](https://github.com/cypress-io/cypress/blob/develop/.node-version) - currently `18.15.0`

- on Ubuntu 22.04 use the default Python version, for example `3.10.11`
- on Windows 11
  - install [Python 3.11](https://devguide.python.org/versions/) from the [Microsoft Store](https://apps.microsoft.com/detail/9NRWMJP3717K?hl=en-us&gl=US). Check the version with `python3 --version`.
  - install [Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) version 2022 (`17.18.4`), using the workload "Desktop development with C++" with its default selections. Select (or use Visual Studio Installer > Modify) to add Optional component Windows 10 SDK (for example `10.0.20348.0`).

then execute the following:

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
npm install yarn -g
yarn
```

Examine the logs and ensure that there are no errors recorded between the steps

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

### How has the user experience changed?

This documentation change avoids the build error

> ModuleNotFoundError: No module named 'distutils'

and concerns developers only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
