### PR TITLE
docs: Install Windows 10 SDK for yarn install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,7 @@ You must have the following installed on your system to contribute locally:
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
   - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make cmake` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
+  - Note for Windows systems: when installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.
 
 ### Getting Started
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/28703

### Additional details

When rebuilding Cypress from source on local Windows systems, and at the stage where dependencies are installed, the following two npm modules require rebuilding, and this in turn requires that a Visual Studio C++ environment be installed:

- [registry-js](https://www.npmjs.com/package/registry-js)
- [cpu-features](https://www.npmjs.com/package/cpu-features)

If only the default Windows 11 SDK is installed then the rebuild fails with the following error message:

> stack Error: Could not find any Visual Studio installation to use

This PR changes [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) to document that Windows systems require the installation of a Windows 10 SDK, so that the problem does not occur.

[node-gyp](https://github.com/nodejs/node-gyp/blob/main/README.md) recommends for Windows:

> * Install Visual C++ Build Environment: [Visual Studio Build Tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools) (using "Visual C++ build tools" if using a version older than VS2019, otherwise use "Desktop development with C++" workload) or [Visual Studio Community](https://vis ualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) (using the "Desktop development with C++" workload)

### Steps to test

Install / set up the Node.js version specified by [.node-version](https://github.com/cypress-io/cypress/blob/develop/.node-version) - currently `18.15.0`

- on Windows 11
  - install [Python 3.11](https://devguide.python.org/versions/) from the [Microsoft Store](https://apps.microsoft.com/detail/9NRWMJP3717K?hl=en-us&gl=US). Check the version with `python3 --version`.
  - install [Visual Studio Community](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) version 2022 (`17.18.x`), using the workload "Desktop development with C++" with its default selections. Select (or use Visual Studio Installer > Modify) to add Optional component Windows 10 SDK (for example `10.0.20348.0`).

then execute the following:

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
npm install yarn -g
yarn
```

Examine the logs and ensure that there are no errors recorded between the steps

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

### How has the user experience changed?

This documentation change avoids the build error

> stack Error: Could not find any Visual Studio installation to use

for local Windows systems and concerns developers only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
