### PR TITLE
chore: fix debugEmpty flaky test

### DIFF
--- a/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
+++ b/packages/app/src/debug/empty/DebugEmptyStates.cy.tsx
@@ -64,6 +64,12 @@ describe('Debug page empty states', { defaultCommandTimeout: 250 }, () => {
             cy.percySnapshot(`slideshow step ${step}`)
           }
 
+          // ensure the promos are done transitioning before clicking on the control
+          // since 2 buttons could display if both promos are easing in and out
+          cy.findByTestId('promo-action')
+          .should('not.have.class', 'ease-in')
+          .and('not.have.class', 'ease-out')
+
           cy.findByTestId('promo-action-control').click()
         }
       }


### PR DESCRIPTION
### Additional details

[Example of flaky failure in CircleCI](https://app.circleci.com/pipelines/github/cypress-io/cypress/59414/workflows/e75f1757-1919-4545-8282-c6429b6eaabd/jobs/2470241)

You can see in the [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/53649/overview/9a59ec45-94a2-4f14-8095-f98cbe661f27/replay?att=1&roarHideRunsWithDiffGroupsAndTags=1&ts=1705934377534.5) of a failure, that the test was finding more than one button that matched the `promo-action-control` testId, when looking at why there were 2 buttons, you could see one promo was transitioning out of view with `ease-in` class and one was transitioning out with `ease-out` class. We don't want to try to click on the button if it's transitioning.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
