### PR TITLE
docs: add pnpm to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
       <source media="(prefers-color-scheme: dark)"  srcset="./assets/cypress-logo-dark.png">
       <source media="(prefers-color-scheme: light)" srcset="./assets/cypress-logo-light.png">
       <img alt="Cypress Logo" src="./assets/cypress-logo-light.png">
-    </picture>    
+    </picture>
   </a>
 </p>
 <p align="center">
@@ -56,6 +56,10 @@ npm install cypress --save-dev
 or
 ```bash
 yarn add cypress --dev
+```
+or
+```bash
+pnpm add cypress --save-dev
 ```
 
 ![installing-cli e1693232](https://user-images.githubusercontent.com/1271364/31740846-7bf607f0-b420-11e7-855f-41c996040d31.gif)


### PR DESCRIPTION
### Additional details

Although pnpm is listed in the Cypress documentation [Installing Cypress](https://docs.cypress.io/guides/getting-started/installing-cypress), it was not listed in [README > Installing](https://github.com/cypress-io/cypress/blob/develop/README.md#installing).

This PR adds

```shell
pnpm add cypress --save-dev
```

to [README > Installing](https://github.com/cypress-io/cypress/blob/develop/README.md#installing) alongside commands to install Cypress using npm and Yarn.

For consistency with the npm and Yarn commands, the pnpm command uses the long form `--save-dev`, not the short-form `-D` to specify "Install the specified packages as `devDependencies`."

### Steps to test

```shell
mkdir pnpm-test
cd pnpm-test
npm install pnpm --global
pnpm init
pnpm add cypress --save-dev
pnpm list cypress
```

should show output similar to

```text
$ pnpm list cypress
Legend: production dependency, optional only, dev only

devDependencies:
cypress 13.6.3

```
### How has the user experience changed?

Documentation enhancement only.

### PR Tasks

- [na ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
