### PR TITLE
refactor: in the frontend-shared package use the design system button

### DIFF
--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -324,7 +324,7 @@ describe('App: Spec List (E2E)', () => {
 
         cy.contains('input', targetSpecFile).should('not.exist')
 
-        cy.get('button[aria-controls="reporter-inline-specs-list"]').click({ force: true })
+        cy.contains('header button', 'Specs').click({ force: true })
 
         cy.get('@searchField').should('be.visible').and('have.value', targetSpecFile)
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@cypress-design/vue-button": "^0.10.2",
+    "@cypress-design/vue-button": "^0.11.6",
     "@cypress-design/vue-icon": "^0.26.0",
     "@cypress-design/vue-statusicon": "^0.5.0",
     "@cypress-design/vue-tabs": "^0.5.1",

--- a/packages/app/src/settings/project/ProjectId.vue
+++ b/packages/app/src/settings/project/ProjectId.vue
@@ -28,7 +28,7 @@
       />
       <CopyButton
         :text="props.gql.currentProject?.projectId"
-        variant="outline"
+        variant="outline-light"
       />
     </div>
   </SettingsSection>

--- a/packages/app/src/settings/project/RecordKey.vue
+++ b/packages/app/src/settings/project/RecordKey.vue
@@ -28,7 +28,7 @@
       />
       <CopyButton
         :text="recordKey"
-        variant="outline"
+        variant="outline-light"
       />
       <Button
         variant="outline"

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "@antfu/utils": "^0.7.0",
     "@cypress-design/css": "^0.13.3",
+    "@cypress-design/vue-button": "^0.10.2",
+    "@cypress-design/vue-icon": "^0.31.2",
     "@graphql-typed-document-node/core": "^3.1.0",
     "@headlessui/vue": "1.4.0",
     "@iconify-json/logos": "1.1.42",
@@ -69,7 +71,7 @@
     "tailwindcss": "^3.3.1",
     "unplugin-icons": "0.13.2",
     "unplugin-vue-components": "^0.24.1",
-    "vite": "4.5.2",
+    "vite": "4.3.2",
     "vite-plugin-components": "0.11.3",
     "vite-svg-loader": "4.0.0",
     "vue": "3.2.47",

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -20,7 +20,7 @@
   "dependencies": {},
   "devDependencies": {
     "@antfu/utils": "^0.7.0",
-    "@cypress-design/css": "^0.13.3",
+    "@cypress-design/css": "^0.17.1",
     "@cypress-design/vue-button": "^0.10.2",
     "@cypress-design/vue-icon": "^0.31.2",
     "@graphql-typed-document-node/core": "^3.1.0",

--- a/packages/frontend-shared/src/components/NoResults.vue
+++ b/packages/frontend-shared/src/components/NoResults.vue
@@ -18,20 +18,23 @@
     <Button
       data-cy="no-results-clear"
       class="mx-auto mt-[20px]"
-      size="lg"
-      variant="outline"
+      size="40"
+      variant="outline-light"
       @click="emit('clear')"
     >
-      <template #prefix>
-        <i-cy-delete_x12 class="w-[12px] icon-dark-gray-400" />
-      </template>
+      <IconActionDelete
+        stroke-color="gray-400"
+        class="w-[12px] mr-[8px]"
+      />
+
       {{ t('noResults.clearSearch') }}
     </Button>
   </div>
 </template>
 
 <script setup lang="ts">
-import Button from './Button.vue'
+import Button from '@cypress-design/vue-button'
+import { IconActionDelete } from '@cypress-design/vue-icon'
 import { useI18n } from '@cy/i18n'
 import NoResultsIllustration from '../assets/illustrations/no-results.svg'
 

--- a/packages/frontend-shared/src/components/ShikiHighlight.vue
+++ b/packages/frontend-shared/src/components/ShikiHighlight.vue
@@ -60,7 +60,7 @@ shikiWrapperClasses computed property.
     >{{ trimmedCode }}</pre>
     <CopyButton
       v-if="copyButton"
-      variant="outline"
+      variant="outline-light"
       tabindex="-1"
       class="bg-white ml-auto mt-[-32px] sticky"
       :class="numberOfLines === 1 ? 'bottom-[5px] right-[5px]' : 'bottom-[8px] right-[8px]'"

--- a/packages/frontend-shared/src/components/Tooltip.cy.tsx
+++ b/packages/frontend-shared/src/components/Tooltip.cy.tsx
@@ -1,5 +1,5 @@
 import Tooltip from './Tooltip.vue'
-import Button from './Button.vue'
+import Button from '@cypress-design/vue-button'
 
 const slotContents = (x: number) => ({
   popper: () => <span>Tooltip {x}</span>,

--- a/packages/frontend-shared/src/gql-components/Auth.vue
+++ b/packages/frontend-shared/src/gql-components/Auth.vue
@@ -4,7 +4,7 @@
     class="flex gap-[16px]"
   >
     <Button
-      size="lg"
+      size="40"
       @click="handleTryAgain"
     >
       <template
@@ -17,8 +17,8 @@
       {{ t('topNav.login.actionTryAgain') }}
     </Button>
     <Button
-      variant="outline"
-      size="lg"
+      variant="outline-light"
+      size="40"
       @click="handleCancel"
     >
       {{ t('topNav.login.actionCancel') }}
@@ -35,30 +35,27 @@
   <div v-else>
     <Button
       v-if="loginMutationIsPending"
-      size="lg"
-      variant="pending"
+      size="40"
+      variant="disabled"
       aria-live="polite"
-      :disabled="true"
+      disabled
     >
-      <template
-        #prefix
-      >
-        <i-cy-loading_x16
-          class="animate-spin icon-dark-white icon-light-gray-400"
-        />
-      </template>
+      <IconLoading
+        stroke-color="white"
+        fill-color="gray-400"
+        class="animate-spin mr-[8px]"
+      />
       {{ browserOpened ? t('topNav.login.actionWaiting') : t('topNav.login.actionOpening') }}
     </Button>
     <Button
       v-else
       ref="loginButtonRef"
-      size="lg"
-      variant="primary"
+      size="40"
       aria-live="polite"
       :disabled="!cloudViewer && !isOnline"
-      :prefix-icon="buttonPrefixIcon"
       @click="handleLoginOrContinue"
     >
+      <IconObjectChainLink class="mr-[8px]" />
       {{ buttonText }}
     </Button>
   </div>
@@ -66,12 +63,12 @@
 
 <script lang="ts" setup>
 import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
+import { IconObjectChainLink, IconLoading } from '@cypress-design/vue-icon'
+import Button from '@cypress-design/vue-button'
 import { gql } from '@urql/core'
 import { useMutation } from '@urql/vue'
 import { useOnline } from '@vueuse/core'
 import { getUtmSource } from '@packages/frontend-shared/src/utils/getUtmSource'
-import ChainIcon from '~icons/cy/chain-link_x16.svg'
-
 import {
   Auth_LoginDocument,
   Auth_LogoutDocument,
@@ -80,7 +77,7 @@ import {
 import type {
   AuthFragment,
 } from '../generated/graphql'
-import Button from '@cy/components/Button.vue'
+
 import { useI18n } from '@cy/i18n'
 import { useUserProjectStatusStore } from '@packages/frontend-shared/src/store/user-project-status-store'
 
@@ -249,10 +246,6 @@ const buttonText = computed(() => {
   }
 
   return strings.login
-})
-
-const buttonPrefixIcon = computed(() => {
-  return showConnectButton.value ? ChainIcon : undefined
 })
 
 </script>

--- a/packages/frontend-shared/src/gql-components/ChooseExternalEditorModal.vue
+++ b/packages/frontend-shared/src/gql-components/ChooseExternalEditorModal.vue
@@ -52,13 +52,15 @@
       <div class="flex space-x-4">
         <Button
           :disabled="!preferredEditor?.length"
+          size="32"
           @click="selectEditor"
         >
           {{ t("globalPage.saveChanges") }}
         </Button>
 
         <Button
-          variant="outline"
+          variant="outline-light"
+          size="32"
           @click="close"
         >
           {{ t("globalPage.cancel") }}
@@ -71,11 +73,11 @@
 <script lang="ts" setup>
 import { useI18n } from '@cy/i18n'
 import { gql } from '@urql/core'
+import Button from '@cypress-design/vue-button'
 import { ref } from 'vue'
 import { useMutation } from '@urql/vue'
 import ChooseExternalEditor from './ChooseExternalEditor.vue'
 import StandardModal from '../components/StandardModal.vue'
-import Button from '../components/Button.vue'
 import type { ChooseExternalEditorModalFragment } from '../generated/graphql'
 import { ChooseExternalEditorModal_SetPreferredEditorBinaryDocument } from '../generated/graphql'
 

--- a/packages/frontend-shared/src/gql-components/CopyButton.vue
+++ b/packages/frontend-shared/src/gql-components/CopyButton.vue
@@ -5,18 +5,11 @@
     data-cy="copy-button"
     @click="copyToClipboard"
   >
-    <template
+    <IconGeneralClipboard
       v-if="!noIcon"
-      #prefix
-    >
-      <i-cy-copy-clipboard_x16
-        class="h-[16px] w-[16px]"
-        :class="{
-          'icon-dark-indigo-500': variant === 'tertiary',
-          'icon-dark-gray-500': variant === 'outline'
-        }"
-      />
-    </template>
+      class="mr-[8px]"
+      :stroke-color="copyIconColor"
+    />
     <TransitionQuickFade mode="out-in">
       <span v-if="!copied">{{ t('clipboard.copy') }}</span>
       <span v-else>{{ t('clipboard.copied') }}</span>
@@ -25,21 +18,32 @@
 </template>
 
 <script setup lang="ts">
-import { useClipboard } from './useClipboard'
 import { useI18n } from '@cy/i18n'
-import type { ButtonSizes, ButtonVariants } from '@cy/components/Button.vue'
-import Button from '@cy/components/Button.vue'
+import Button, { type SizeClassesTable, type VariantClassesTable } from '@cypress-design/vue-button'
 import TransitionQuickFade from '@cy/components/transitions/TransitionQuickFade.vue'
+import { useClipboard } from './useClipboard'
+import { IconGeneralClipboard } from '@cypress-design/vue-icon'
+import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
   text: string
   noIcon?: boolean
-  variant?: ButtonVariants
-  size?: ButtonSizes
+  variant?: keyof typeof VariantClassesTable
+  size?: keyof typeof SizeClassesTable
 }>(), {
   noIcon: false,
-  variant: 'tertiary',
-  size: 'md',
+  variant: 'indigo-light',
+  size: '32',
+})
+
+const copyIconColor = computed(() => {
+  /**
+   * <wind-keep stroke-color="indigo-500" stroke-color="gray-500" />
+   */
+  return props.variant === 'indigo-light'
+    ? 'indigo-500' :
+    props.variant === 'outline-light'
+      ? 'gray-500' : undefined
 })
 
 const { copy, copied } = useClipboard({ copiedDuring: 2000 })

--- a/packages/frontend-shared/src/gql-components/error/BaseError.vue
+++ b/packages/frontend-shared/src/gql-components/error/BaseError.vue
@@ -20,22 +20,26 @@
           class="font-medium w-full pt-[12px] gap-4 inline-flex justify-center "
         >
           <Button
-            variant="outline"
+            size="32"
+            variant="outline-light"
             data-testid="error-retry-button"
-            :prefix-icon="RestartIcon"
-            prefix-icon-class="icon-dark-indigo-500"
             @click="emit('retry', baseError.id)"
           >
+            <IconActionRestart stroke-color="indigo-500" />
             {{ t('launchpadErrors.generic.retryButton') }}
           </Button>
 
           <Button
-            variant="outline"
+            size="32"
+            variant="outline-light"
             data-testid="error-docs-button"
-            :prefix-icon="BookIcon"
-            prefix-icon-class="icon-dark-indigo-500 group-hocus:icon-dark-indigo-500 group-hocus:icon-light-indigo-50"
             :href="t(`launchpadErrors.generic.docsButton.${docsType}.link`)"
           >
+            <IconObjectBook
+              stroke-color="indigo-500"
+              hocus-stroke-color="indigo-500"
+              hocus-fill-color="indigo-50"
+            />
             {{ t(`launchpadErrors.generic.docsButton.${docsType}.text`) }}
           </Button>
         </div>
@@ -111,16 +115,15 @@
 <script lang="ts" setup>
 import { ref, computed } from 'vue'
 import { gql } from '@urql/vue'
-import Button from '@cy/components/Button.vue'
+import Button from '@cypress-design/vue-button'
+import { IconObjectBook, IconActionRestart } from '@cypress-design/vue-icon'
 import { useI18n } from '@cy/i18n'
 import type { BaseErrorFragment } from '../../generated/graphql'
 import Alert from '@cy/components/Alert.vue'
 import Collapsible from '@cy/components/Collapsible.vue'
 import { useMarkdown } from '../../composables/useMarkdown'
-import RestartIcon from '~icons/cy/restart_x16.svg'
 import ErrorOutlineIcon from '~icons/cy/status-errored-outline_x16.svg'
 import ErrorCodeFrame from './ErrorCodeFrame.vue'
-import BookIcon from '~icons/cy/book_x16'
 
 gql`
 fragment BaseError on ErrorWrapper {

--- a/packages/frontend-shared/src/gql-components/modals/CreateCloudOrgModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/CreateCloudOrgModal.vue
@@ -36,26 +36,26 @@
       <div class="flex gap-[16px]">
         <Button
           v-if="waitingOrgToBeCreated"
-          size="lg"
+          size="40"
           variant="pending"
         >
-          <template #prefix>
-            <i-cy-loading_x16
-              class="animate-spin icon-dark-white icon-light-gray-400"
-            />
-          </template>
+          <IconLoading
+            class="animate-spin mr-[8px]"
+            stroke-color="white"
+            fill-color="gray-400"
+          />
           {{ t('runs.connect.modal.createOrg.waitingButton') }}
         </Button>
         <Button
           v-else
-          size="lg"
+          size="40"
           @click="refetch()"
         >
           {{ t('runs.connect.modal.createOrg.refreshButton') }}
         </Button>
         <Button
-          variant="outline"
-          size="lg"
+          variant="outline-light"
+          size="40"
           @click="emit('cancel')"
         >
           {{ t('runs.connect.modal.cancel') }}
@@ -67,9 +67,10 @@
 
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, ref } from 'vue'
+import Button from '@cypress-design/vue-button'
+import { IconLoading } from '@cypress-design/vue-icon'
 import { gql, useMutation } from '@urql/vue'
 import StandardModal from '@cy/components/StandardModal.vue'
-import Button from '@cy/components/Button.vue'
 import ExternalLink from '../ExternalLink.vue'
 import NoInternetConnection from '@cy/components/NoInternetConnection.vue'
 

--- a/packages/frontend-shared/src/gql-components/modals/NeedManualUpdateModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/NeedManualUpdateModal.vue
@@ -33,19 +33,19 @@
     <template #footer>
       <div class="flex gap-[16px]">
         <Button
-          size="lg"
-          variant="pending"
+          size="40"
+          variant="disabled"
         >
-          <template #prefix>
-            <i-cy-loading_x16
-              class="animate-spin icon-dark-white icon-light-gray-400"
-            />
-          </template>
+          <IconLoading
+            class="animate-spin mr-[8px]"
+            stroke-color="white"
+            fill-color="gray-400"
+          />
           {{ t('runs.connect.modal.connectManually.waitingButton') }}
         </Button>
         <Button
-          variant="outline"
-          size="lg"
+          variant="outline-light"
+          size="40"
           @click="emit('cancel')"
         >
           {{ t('runs.connect.modal.cancel') }}
@@ -58,8 +58,9 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { gql } from '@urql/vue'
+import Button from '@cypress-design/vue-button'
+import { IconLoading } from '@cypress-design/vue-icon'
 import StandardModal from '@cy/components/StandardModal.vue'
-import Button from '@cy/components/Button.vue'
 import Alert from '@cy/components/Alert.vue'
 import ShikiHighlight from '@cy/components/ShikiHighlight.vue'
 import WarningIcon from '~icons/cy/warning_x16.svg'

--- a/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/SelectCloudProjectModal.vue
@@ -158,20 +158,28 @@
     >
       <div class="flex gap-[16px]">
         <Button
-          size="lg"
-          :prefix-icon="newProject ? CreateIcon : ConnectIcon"
-          prefix-icon-class="icon-dark-white"
+          size="40"
           :disabled="disableButton"
           data-cy="connect-project"
           @click="createOrConnectProject"
         >
+          <IconActionAddLarge
+            v-if="newProject"
+            class="mr-[8px]"
+            stroke-color="white"
+          />
+          <IconObjectChainLink
+            v-else
+            class="mr-[8px]"
+            stroke-color="white"
+          />
           {{ newProject
             ? t('runs.connect.modal.selectProject.createProject')
             : t('runs.connect.modal.selectProject.connectProject') }}
         </Button>
         <Button
-          variant="outline"
-          size="lg"
+          variant="outline-light"
+          size="40"
           @click="emit('cancel')"
         >
           {{ t('runs.connect.modal.cancel') }}
@@ -184,16 +192,15 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from 'vue'
 import { gql, useMutation } from '@urql/vue'
+import Button from '@cypress-design/vue-button'
+import { IconActionAddLarge, IconObjectChainLink } from '@cypress-design/vue-icon'
 import StandardModal from '@cy/components/StandardModal.vue'
-import Button from '@cy/components/Button.vue'
 import ExternalLink from '../ExternalLink.vue'
 import Select from '@cy/components/Select.vue'
 import Input from '@cy/components/Input.vue'
 import Radio from '@cy/components/Radio.vue'
 import NoInternetConnection from '@cy/components/NoInternetConnection.vue'
 import Alert from '@cy/components/Alert.vue'
-import ConnectIcon from '~icons/cy/chain-link_x16.svg'
-import CreateIcon from '~icons/cy/add-large_x16.svg'
 import FolderIcon from '~icons/cy/folder-outline_x16.svg'
 import OrganizationIcon from '~icons/cy/office-building_x16.svg'
 import { SelectCloudProjectModal_CreateCloudProjectDocument, SelectCloudProjectModal_SetProjectIdDocument } from '../../generated/graphql'

--- a/packages/frontend-shared/src/gql-components/topnav/PromptContent.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/PromptContent.vue
@@ -16,29 +16,30 @@
           <Button
             :href="getUrl(provider.link)"
             class="!w-[210px]"
-            size="lg"
-            variant="outline"
+            size="40"
+            variant="outline-light"
           >
-            <template #prefix>
-              <img
-                :src="provider.icon"
-                width="14"
-                :alt="`${provider.name} logo`"
-              >
-            </template>
+            <img
+              :src="provider.icon"
+              width="14"
+              :alt="`${provider.name} logo`"
+              class="mr-[8px]"
+            >
             {{ provider.name }}
           </Button>
         </li>
         <li>
           <Button
             :href="getUrl(seeOtherGuidesInfo)"
-            variant="outline"
-            size="lg"
+            variant="outline-light"
+            size="40"
             class="!w-[210px]"
           >
-            <template #prefix>
-              <i-cy-book class="h-[16px] w-[16px] icon-dark-gray-500 icon-light-gray-50" />
-            </template>
+            <IconObjectBook
+              stroke-color="gray-500"
+              fill-color="gray-50"
+              class="mr-[8px]"
+            />
             {{ t('topNav.docsMenu.prompts.ci1.seeOtherGuides') }}
           </Button>
         </li>
@@ -122,7 +123,7 @@
             utm_campaign: 'Learn More',
           },
         })"
-      size="lg"
+      size="40"
       class="mt-[12px]"
     >
       {{ t('topNav.docsMenu.prompts.orchestration1.learnMore') }}
@@ -134,8 +135,8 @@
 </template>
 
 <script setup lang="ts">
-import Button from '@cy/components/Button.vue'
 import { useI18n } from '@cy/i18n'
+import Button from '@cypress-design/vue-button'
 const { t } = useI18n()
 import type { LinkWithParams } from '@packages/frontend-shared/src/utils/getUrlWithParams'
 import { getUrlWithParams } from '@packages/frontend-shared/src/utils/getUrlWithParams'
@@ -148,6 +149,7 @@ import Bitbucket from '@packages/frontend-shared/src/assets/logos/bitbucket.svg?
 import Gitlab from '@packages/frontend-shared/src/assets/logos/gitlab.svg?url'
 import AwsCodeBuild from '@packages/frontend-shared/src/assets/logos/aws-codebuild.svg?url'
 import ExternalLink from '../ExternalLink.vue'
+import { IconObjectBook } from '@cypress-design/vue-icon'
 
 const props = defineProps<{
   type: DocsMenuVariant

--- a/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
+++ b/packages/frontend-shared/src/gql-components/topnav/TopNav.vue
@@ -46,6 +46,7 @@
       </p>
       <Button
         class="!w-full"
+        size="32"
         @click="showUpdateModal = true"
       >
         Update to {{ versions.latest.version }}
@@ -194,21 +195,21 @@
 </template>
 
 <script setup lang="ts">
+import type { ComponentPublicInstance } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
+import { onClickOutside, onKeyStroke, useTimeAgo } from '@vueuse/core'
+import { useI18n } from '@cy/i18n'
+import { gql, useMutation } from '@urql/vue'
+import Button from '@cypress-design/vue-button'
 import TopNavListItem from './TopNavListItem.vue'
 import TopNavList from './TopNavList.vue'
 import PromptContent from './PromptContent.vue'
 import { allBrowsersIcons } from '@packages/frontend-shared/src/assets/browserLogos'
-import { gql, useMutation } from '@urql/vue'
 import { TopNav_SetPromptShownDocument } from '../../generated/graphql'
 import type { TopNavFragment } from '../../generated/graphql'
-import { useI18n } from '@cy/i18n'
-import { computed, ref, watch, watchEffect } from 'vue'
-import type { ComponentPublicInstance } from 'vue'
-import { onClickOutside, onKeyStroke, useTimeAgo } from '@vueuse/core'
 import type { DocsMenuVariant } from './DocsMenuContent.vue'
 import DocsMenuContent from './DocsMenuContent.vue'
 import ExternalLink from '../ExternalLink.vue'
-import Button from '../../components/Button.vue'
 import UpdateCypressModal from './UpdateCypressModal.vue'
 import VerticalBrowserListItems from './VerticalBrowserListItems.vue'
 

--- a/packages/frontend-shared/src/warning/Warning.vue
+++ b/packages/frontend-shared/src/warning/Warning.vue
@@ -15,22 +15,24 @@
     />
     <Button
       v-if="retryable"
-      size="md"
-      :prefix-icon="RefreshIcon"
-      prefix-icon-class="icon-dark-white"
+      size="32"
       @click="emits('retry')"
     >
+      <IconActionRefresh
+        stroke-color="white"
+        class="mr-[8px]"
+      />
       {{ t('warnings.retry') }}
     </Button>
   </Alert>
 </template>
 
 <script lang="ts" setup>
+import Button from '@cypress-design/vue-button'
+import { IconActionRefresh } from '@cypress-design/vue-icon'
 import ErrorOutlineIcon from '~icons/cy/status-errored-outline_x16.svg'
 import { useMarkdown } from '@packages/frontend-shared/src/composables/useMarkdown'
 import Alert from '@cy/components/Alert.vue'
-import Button from '@cy/components/Button.vue'
-import RefreshIcon from '~icons/cy/refresh_x16'
 import { computed, ref } from 'vue'
 import { useVModels } from '@vueuse/core'
 import { useI18n } from '@cy/i18n'

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@cypress-design/vue-button": "^0.11.0",
+    "@cypress-design/vue-button": "^0.11.6",
     "@graphql-typed-document-node/core": "^3.1.0",
     "@headlessui/vue": "1.4.0",
     "@intlify/unplugin-vue-i18n": "0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2844,17 +2844,34 @@
     resolve-pkg "^2.0.0"
     tailwindcss "^3.3.3"
 
-"@cypress-design/icon-registry@*", "@cypress-design/icon-registry@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@cypress-design/icon-registry/-/icon-registry-0.28.0.tgz#a3c5336f7b544d8be82b6a941b8915ba7084d5c9"
-  integrity sha512-xJvE1u3KBQz6Hc0Ea3ia9xUDKxTj5MdKrgYrlE9t321qKxStxVN34VB595TfWzluHZzUb6Qu7QqgqdCTFTccgw==
+"@cypress-design/css@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@cypress-design/css/-/css-0.16.0.tgz#2d8cc7ccf57b03db9019ab9ae553f535a2211dca"
+  integrity sha512-rzYpX/y4f+nXrwFYAApkS+ih5eLDl8XIaZ7f/12b0wzv7Q/Bwa8BVdEXLzDbFQ7DrMnqOHVsdhkFi7OQRAd0QQ==
   dependencies:
-    "@cypress-design/css" "^0.15.1"
+    "@windicss/plugin-interaction-variants" "^1.0.0"
+    lodash "^4.17.21"
+    resolve-pkg "^2.0.0"
+    tailwindcss "^3.3.3"
+
+"@cypress-design/icon-registry@*", "@cypress-design/icon-registry@^0.33.1":
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/@cypress-design/icon-registry/-/icon-registry-0.33.1.tgz#3665b95b48368553cf25b51dd29809d87c26f774"
+  integrity sha512-11AQjAzBiEuStdVDl4UKjdcvvapI4W8nyuweEc29ptRYByZVr8nqcA4jdueOHueuyT6cRMnAbilbWwdH1I3Mag==
+  dependencies:
+    "@cypress-design/css" "^0.16.0"
 
 "@cypress-design/icon-registry@^0.27.0":
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/@cypress-design/icon-registry/-/icon-registry-0.27.0.tgz#3feedb6bad82c7a461a348f72e62225fe912c49b"
   integrity sha512-2tiH0YklKLYQ59pduni9aAsCu5uMKf/ZVHFjoP5xZW8em3FP5NZtmIAZzdIWLXjqihz/Q4TcOAL77qi8T11UJQ==
+  dependencies:
+    "@cypress-design/css" "^0.15.1"
+
+"@cypress-design/icon-registry@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@cypress-design/icon-registry/-/icon-registry-0.28.0.tgz#a3c5336f7b544d8be82b6a941b8915ba7084d5c9"
+  integrity sha512-xJvE1u3KBQz6Hc0Ea3ia9xUDKxTj5MdKrgYrlE9t321qKxStxVN34VB595TfWzluHZzUb6Qu7QqgqdCTFTccgw==
   dependencies:
     "@cypress-design/css" "^0.15.1"
 
@@ -2885,6 +2902,13 @@
   integrity sha512-ZiMpIvjNWX/x6OJDyhb9VrXXlwPQTgSx87PA4VMVC9JVARXja4UZ950KVTZVEdDuCG8MGYu3N4/hWOrNxCKXCQ==
   dependencies:
     "@cypress-design/icon-registry" "^0.28.0"
+
+"@cypress-design/vue-icon@^0.31.2":
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/@cypress-design/vue-icon/-/vue-icon-0.31.2.tgz#5a0c2ae3581dcfa609b58ee86bee7eb4406847a4"
+  integrity sha512-xOA5MSHrUBazfjibz9bC37PwYagzLXeDLrcWs7awGQZqOA72ZHpHkliB861J+NIA/hfVk3RixBKHcYxYkMhSJw==
+  dependencies:
+    "@cypress-design/icon-registry" "^0.33.1"
 
 "@cypress-design/vue-statusicon@^0.5.0":
   version "0.5.0"
@@ -3263,50 +3287,100 @@
     ts-node "^9"
     tslib "^2"
 
+"@esbuild/android-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz#bafb75234a5d3d1b690e7c2956a599345e84a2fd"
+  integrity sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
   integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+
+"@esbuild/android-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.19.tgz#5898f7832c2298bc7d0ab53701c57beb74d78b4d"
+  integrity sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==
 
 "@esbuild/android-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
   integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
 
+"@esbuild/android-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.19.tgz#658368ef92067866d95fb268719f98f363d13ae1"
+  integrity sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==
+
 "@esbuild/android-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
   integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+
+"@esbuild/darwin-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz#584c34c5991b95d4d48d333300b1a4e2ff7be276"
+  integrity sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==
 
 "@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
   integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
+"@esbuild/darwin-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz#7751d236dfe6ce136cce343dce69f52d76b7f6cb"
+  integrity sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==
+
 "@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
   integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+
+"@esbuild/freebsd-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz#cacd171665dd1d500f45c167d50c6b7e539d5fd2"
+  integrity sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==
 
 "@esbuild/freebsd-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
   integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
 
+"@esbuild/freebsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz#0769456eee2a08b8d925d7c00b79e861cb3162e4"
+  integrity sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==
+
 "@esbuild/freebsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
   integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+
+"@esbuild/linux-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz#38e162ecb723862c6be1c27d6389f48960b68edb"
+  integrity sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==
 
 "@esbuild/linux-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
   integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
 
+"@esbuild/linux-arm@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz#1a2cd399c50040184a805174a6d89097d9d1559a"
+  integrity sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==
+
 "@esbuild/linux-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
   integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+
+"@esbuild/linux-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz#e28c25266b036ce1cabca3c30155222841dc035a"
+  integrity sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==
 
 "@esbuild/linux-ia32@0.18.20":
   version "0.18.20"
@@ -3318,60 +3392,120 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.7.tgz#1ec4af4a16c554cbd402cc557ccdd874e3f7be53"
   integrity sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==
 
+"@esbuild/linux-loong64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz#0f887b8bb3f90658d1a0117283e55dbd4c9dcf72"
+  integrity sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==
+
 "@esbuild/linux-loong64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
   integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+
+"@esbuild/linux-mips64el@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz#f5d2a0b8047ea9a5d9f592a178ea054053a70289"
+  integrity sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==
 
 "@esbuild/linux-mips64el@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
   integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
 
+"@esbuild/linux-ppc64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz#876590e3acbd9fa7f57a2c7d86f83717dbbac8c7"
+  integrity sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==
+
 "@esbuild/linux-ppc64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
   integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+
+"@esbuild/linux-riscv64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz#7f49373df463cd9f41dc34f9b2262d771688bf09"
+  integrity sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==
 
 "@esbuild/linux-riscv64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
   integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
 
+"@esbuild/linux-s390x@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz#e2afd1afcaf63afe2c7d9ceacd28ec57c77f8829"
+  integrity sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==
+
 "@esbuild/linux-s390x@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
   integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+
+"@esbuild/linux-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz#8a0e9738b1635f0c53389e515ae83826dec22aa4"
+  integrity sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==
 
 "@esbuild/linux-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
   integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
+"@esbuild/netbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz#c29fb2453c6b7ddef9a35e2c18b37bda1ae5c462"
+  integrity sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==
+
 "@esbuild/netbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
   integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+
+"@esbuild/openbsd-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz#95e75a391403cb10297280d524d66ce04c920691"
+  integrity sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==
 
 "@esbuild/openbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
   integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
 
+"@esbuild/sunos-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz#722eaf057b83c2575937d3ffe5aeb16540da7273"
+  integrity sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==
+
 "@esbuild/sunos-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
   integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+
+"@esbuild/win32-arm64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz#9aa9dc074399288bdcdd283443e9aeb6b9552b6f"
+  integrity sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==
 
 "@esbuild/win32-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
   integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
 
+"@esbuild/win32-ia32@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz#95ad43c62ad62485e210f6299c7b2571e48d2b03"
+  integrity sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==
+
 "@esbuild/win32-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
   integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
+
+"@esbuild/win32-x64@0.17.19":
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
+  integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
 "@esbuild/win32-x64@0.18.20":
   version "0.18.20"
@@ -14833,6 +14967,34 @@ esbuild@^0.15.3:
     esbuild-windows-32 "0.15.7"
     esbuild-windows-64 "0.15.7"
     esbuild-windows-arm64 "0.15.7"
+
+esbuild@^0.17.5:
+  version "0.17.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.19.tgz#087a727e98299f0462a3d0bcdd9cd7ff100bd955"
+  integrity sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.17.19"
+    "@esbuild/android-arm64" "0.17.19"
+    "@esbuild/android-x64" "0.17.19"
+    "@esbuild/darwin-arm64" "0.17.19"
+    "@esbuild/darwin-x64" "0.17.19"
+    "@esbuild/freebsd-arm64" "0.17.19"
+    "@esbuild/freebsd-x64" "0.17.19"
+    "@esbuild/linux-arm" "0.17.19"
+    "@esbuild/linux-arm64" "0.17.19"
+    "@esbuild/linux-ia32" "0.17.19"
+    "@esbuild/linux-loong64" "0.17.19"
+    "@esbuild/linux-mips64el" "0.17.19"
+    "@esbuild/linux-ppc64" "0.17.19"
+    "@esbuild/linux-riscv64" "0.17.19"
+    "@esbuild/linux-s390x" "0.17.19"
+    "@esbuild/linux-x64" "0.17.19"
+    "@esbuild/netbsd-x64" "0.17.19"
+    "@esbuild/openbsd-x64" "0.17.19"
+    "@esbuild/sunos-x64" "0.17.19"
+    "@esbuild/win32-arm64" "0.17.19"
+    "@esbuild/win32-ia32" "0.17.19"
+    "@esbuild/win32-x64" "0.17.19"
 
 esbuild@^0.18.10:
   version "0.18.20"
@@ -26743,7 +26905,7 @@ rollup@3.7.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^3.27.1:
+rollup@^3.21.0, rollup@^3.27.1:
   version "3.29.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
   integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
@@ -30764,6 +30926,17 @@ vite-svg-loader@4.0.0:
   dependencies:
     "@vue/compiler-sfc" "^3.2.20"
     svgo "^3.0.2"
+
+vite@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.3.2.tgz#95a5e0ebee80ae218849312019318aa9e3a05c26"
+  integrity sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==
+  dependencies:
+    esbuild "^0.17.5"
+    postcss "^8.4.21"
+    rollup "^3.21.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 vite@4.5.2:
   version "4.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,10 +2807,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@cypress-design/constants-button@*", "@cypress-design/constants-button@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@cypress-design/constants-button/-/constants-button-0.1.0.tgz#d32788484eda0a05ce72a53d9529ec7284174e77"
-  integrity sha512-HE5QQT6T8GDSgBDUBywOdnTvRXErrvGHm8YQuvj2iqzCTv9B0RhNQUVKSoyN9/LKyVcIXoa/ZaJLeTMVTlf+pg==
+"@cypress-design/constants-button@*", "@cypress-design/constants-button@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@cypress-design/constants-button/-/constants-button-0.1.3.tgz#6a3e14bbd0cf6d6c51763f3cc3b286dadc407a77"
+  integrity sha512-0ZBn1DvctrlypkXmclp9L8jwtaXKKBs2goPh43TgYoDNcX/IrNnmn1K/ivRcEN3Zq00qlz7Jgwv7fIxD/w8beg==
 
 "@cypress-design/constants-statusicon@^0.2.0":
   version "0.2.0"
@@ -2823,16 +2823,6 @@
   integrity sha512-2ndtAO0ycA0kgpAaCho9T4Y18a9XUbAL/S06hvwSKR7PuEmmpVx9ndGY2STaWcx5qKLRoBfMQWuPwDrN82dk5A==
   dependencies:
     "@cypress-design/icon-registry" "*"
-
-"@cypress-design/css@^0.13.3":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@cypress-design/css/-/css-0.13.3.tgz#3501e2cdbf671d75f75c8f081030fb0b27bf1714"
-  integrity sha512-+Jj/7K5gkFUOVScssUc39UOEeZiPEtiSjo+/UfxtrpN2or1c8z+56GQqDwgrdf5z5CBSicnWky+LjBS3kREglQ==
-  dependencies:
-    "@windicss/plugin-interaction-variants" "^1.0.0"
-    lodash "^4.17.21"
-    resolve-pkg "^2.0.0"
-    tailwindcss "^3.3.2"
 
 "@cypress-design/css@^0.15.1":
   version "0.15.1"
@@ -2853,6 +2843,16 @@
     lodash "^4.17.21"
     resolve-pkg "^2.0.0"
     tailwindcss "^3.3.3"
+
+"@cypress-design/css@^0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@cypress-design/css/-/css-0.17.1.tgz#ff1863d2bce196394f55e6da6077e595b3e5ebfb"
+  integrity sha512-eQlCwbifrTTU8qApJv+c4rS5u1sI06yaGZAYeA4J47mOe3Goxadq7P3lVVW0n3WZrcHEZvkAh5qj0AN2Hpsakg==
+  dependencies:
+    "@tailwindcss/container-queries" "^0.1.1"
+    lodash "^4.17.21"
+    resolve-pkg "^2.0.0"
+    tailwindcss "^3.4.1"
 
 "@cypress-design/icon-registry@*", "@cypress-design/icon-registry@^0.33.1":
   version "0.33.1"
@@ -2882,12 +2882,12 @@
   dependencies:
     "@cypress-design/constants-button" "*"
 
-"@cypress-design/vue-button@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@cypress-design/vue-button/-/vue-button-0.11.0.tgz#d324e658e60a38bd57f8761b2a7dfc76430e41cf"
-  integrity sha512-ro44uCyadSOyK/4bHnPZUvXjdBpZ89kpNjZ/mmrI9TQTjTrN+Za3PU99zYowNzijkLK5AEwqJfMtAjN/ojUZnQ==
+"@cypress-design/vue-button@^0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@cypress-design/vue-button/-/vue-button-0.11.6.tgz#57f6a9f03034e1c84f311a1fef2ecb5cf3f50c80"
+  integrity sha512-tERjqnX07SV9haaq83eOJ35wJ9bW8c1xv6arVxT+mJIPqDAMeob60uUrXDY3m7xRTKNr7PjP1/gcKuuPELR/NQ==
   dependencies:
-    "@cypress-design/constants-button" "^0.1.0"
+    "@cypress-design/constants-button" "^0.1.3"
 
 "@cypress-design/vue-icon@^0.25.0":
   version "0.25.0"
@@ -7179,6 +7179,11 @@
   integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
   dependencies:
     defer-to-connect "^2.0.0"
+
+"@tailwindcss/container-queries@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz#9a759ce2cb8736a4c6a0cb93aeb740573a731974"
+  integrity sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==
 
 "@testing-library/cypress@9.0.0":
   version "9.0.0"
@@ -19601,10 +19606,10 @@ jimp@^0.2.21:
     tinycolor2 "^1.1.2"
     url-regex "^3.0.0"
 
-jiti@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.18.2.tgz#80c3ef3d486ebf2450d9335122b32d121f2a83cd"
-  integrity sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==
+jiti@^1.18.2, jiti@^1.19.1:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
+  integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
 jose@^4.11.2:
   version "4.11.2"
@@ -29117,20 +29122,20 @@ tailwindcss@1.1.4:
     pretty-hrtime "^1.0.3"
     reduce-css-calc "^2.1.6"
 
-tailwindcss@^3.3.1, tailwindcss@^3.3.2, tailwindcss@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.3.tgz#90da807393a2859189e48e9e7000e6880a736daf"
-  integrity sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==
+tailwindcss@^3.3.1, tailwindcss@^3.3.3, tailwindcss@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.4.1.tgz#f512ca5d1dd4c9503c7d3d28a968f1ad8f5c839d"
+  integrity sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
     chokidar "^3.5.3"
     didyoumean "^1.2.2"
     dlv "^1.1.3"
-    fast-glob "^3.2.12"
+    fast-glob "^3.3.0"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
-    jiti "^1.18.2"
+    jiti "^1.19.1"
     lilconfig "^2.1.0"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"


### PR DESCRIPTION
Related to https://github.com/cypress-io/cypress-design/issues/189

### Assumptions

- `pending` is always `disabled` so the variants are merged
- size `sm` is 24 px tall, set the size accordingly
- size `lg` is 40 px tall, set the size accordingly
- the default size is different so I added `size="32"` when there is none
- instead of using prefix and suffix icons, I use declarative html, the way it is described in [the documentation](https://design.cypress.io/components/vue/Button.html#usage)
- The `CopyButton` needed to be changed a little to avoid mixups: `outline` => `outline-light`