### PR TITLE
docs: remove cmake as Debian-based prerequisite for build from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,7 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements. Use Python `3.11` or lower.)
-  - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make cmake` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
+  - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
   - Note for Windows systems: when installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.
 
 ### Getting Started


### PR DESCRIPTION
### Additional details

This PR removes `cmake` from the list of recommended packages for Debian-based systems, including Ubuntu, listed under [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements).

The revised text says:

>   - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.

- PR https://github.com/cypress-io/cypress/pull/28726, which caused [cpu-features@0.0.2](https://github.com/mscdex/cpu-features/releases/tag/v0.0.2) to be updated to [cpu-features@0.0.9](https://github.com/mscdex/cpu-features/releases/tag/v0.0.9), removed the need for `cmake` on Debian-based systems. (It also removed the need on Windows systems to have `cmake` installed additionally to the `cmake` support provided by a Visual Studio "Desktop development with C++" and optional component "C++ CMake tools for Windows".)

This is also consistent with the [node-gyp > Installation](https://github.com/nodejs/node-gyp#installation) recommendations for [On Unix](https://github.com/nodejs/node-gyp#on-unix) which specify:

#### On Unix

   * [A supported version of Python](https://devguide.python.org/versions/)
   * `make`
   * A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org)

### Steps to test

Clean install Ubuntu `22.04.03` LTS [Ubuntu Desktop](https://ubuntu.com/desktop) (minimal installation) and install system updates, then execute the following.

```bash
python3 --version
sudo apt install git g++ make curl
curl -L https://bit.ly/n-install | bash
 . ~/.bashrc
cd ~
git clone https://github.com/cypress-io/cypress
cd cypress
n auto
npm install yarn -g
yarn
```

If not testing on a clean install of the operating system, then ensure that `cmake` is not installed:

```bash
sudo apt remove cmake
```

The version of Python is `3.10` (`3.10.12`).

Yarn should install with no errors. Especially the following log items should be present with no error messages between them:

> [5/6] Building fresh packages...
> [6/6] Cleaning modules...

The following message may be output. This is not related to `cmake`.

> info There appears to be trouble with your network connection. Retrying...

Repeat the test on Ubuntu `23.10` which has Python `3.11` (`3.11.6`) as default.

### How has the user experience changed?

This change affects developers and CI workflows only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
