### PR TITLE
test: fix flaky https-proxy test 'closes outgoing connections when client disconnects'

### DIFF
--- a/packages/https-proxy/test/integration/proxy_spec.js
+++ b/packages/https-proxy/test/integration/proxy_spec.js
@@ -320,29 +320,32 @@ describe('Proxy', () => {
       })
     })
 
-    it('closes outgoing connections when client disconnects', function () {
+    it('closes outgoing connections when client disconnects', async function () {
       this.sandbox.spy(net, 'connect')
 
-      return request({
+      await request({
         strictSSL: false,
         url: 'https://localhost:8444/replace',
         proxy: 'http://localhost:3333',
         resolveWithFullResponse: true,
         forever: false,
       })
-      .then(() => {
-        // ensure the outgoing socket created for this connection was destroyed
-        expect(net.connect).calledOnce
-        const socket = net.connect.getCalls()[0].returnValue
 
+      // ensure the outgoing socket created for this connection was destroyed
+      expect(net.connect).calledOnce
+      const socket = net.connect.getCalls()[0].returnValue
+
+      // sometimes the close event happens before we can attach the listener,
+      // causing this test to flake
+      if (!socket.destroyed || !socket.readyState === 'closed') {
         return new Promise((resolve) => {
-          return socket.on('close', () => {
+          socket.on('close', () => {
             expect(socket.destroyed).to.be.true
 
             resolve()
           })
         })
-      })
+      }
     })
 
     // https://github.com/cypress-io/cypress/issues/4257


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
Sometimes the socket in this test has already fired its close event by the time we register the close listener. To fix, check to see if the socket is not already closed before adding the close listener.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
