### PR TITLE
docs: remove cypress-example-docker-compose reference from release process docs

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -191,7 +191,6 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
     - [cypress-example-todomvc](https://github.com/cypress-io/cypress-example-todomvc/issues/99)
     - [cypress-realworld-app](https://github.com/cypress-io/cypress-realworld-app/issues/41)
     - [cypress-example-recipes](https://github.com/cypress-io/cypress-example-recipes/issues/225)
-    - [cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose/issues/71)
 
 Take a break, you deserve it! 👉😎👉
 


### PR DESCRIPTION
### Additional details

The [cypress-example-docker-compose](https://github.com/cypress-io/cypress-example-docker-compose) repo has been archived. The code on this hasn’t been touched since 2020, we’re just updating cypress dep every release on it. I don’t see it referenced in our docs. No issues opened on it since 2022. It’s using cypress/base:16, etc. We won't be maintaining it, so no need to update its deps on each release.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
