### PR TITLE
fix: Hanging indefinitely when unzip fails with an empty error

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,11 +1,15 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 13.6.5 
+## 13.6.5
 
 _Released 2/13/2024 (PENDING)_
 
 **Misc:**
 
 - Improved accessibility of the Cypress App in some areas. Addressed in [#28774](https://github.com/cypress-io/cypress/pull/28774).
+
+**Bugfixes:**
+
+- Fixed an issue with the unzip promise never being rejected when an empty error happens. Fixed in [#28850](https://github.com/cypress-io/cypress/pull/28850).
 
 ## 13.6.4
 

--- a/cli/lib/tasks/unzip.js
+++ b/cli/lib/tasks/unzip.js
@@ -84,11 +84,11 @@ const unzip = ({ zipFilePath, installDir, progress }) => {
             return resolve()
           })
           .catch((err) => {
-            if (err) {
-              debug('error %s', err.message)
+            const error = err || new Error('Unknown error with Node extract tool')
 
-              return reject(err)
-            }
+            debug('error %s', error.message)
+
+            return reject(error)
           })
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

It seems the promise for trying to unzip with Node extract was not always either resolved or rejected. There shouldn't be a case where this shouldn't be done once the fallback has been tried.

### Additional details

Sometimes on my CI, I see the following log: 

```
2024-02-02T05:07:52.724Z cypress:cli expected file size 183022418
2024-02-02T05:07:54.537Z cypress:cli downloading finished
2024-02-02T05:07:54.537Z cypress:cli only checking expected file size 183022418
2024-02-02T05:07:54.538Z cypress:cli downloaded file has the expected size ✅
2024-02-02T05:07:54.538Z cypress:cli verified
2024-02-02T05:07:54.538Z cypress:cli finished downloading file: /tmp/cypress-262.zip
[SUCCESS] Task without title.
[STARTED] Task without title.
2024-02-02T05:07:54.539Z cypress:cli:unzip unzipping from /tmp/cypress-262.zip
2024-02-02T05:07:54.539Z cypress:cli:unzip into /root/.cache/Cypress/13.6.2
2024-02-02T05:07:54.541Z cypress:cli:unzip zipFile entries count 21852
2024-02-02T05:07:54.541Z cypress:cli:unzip unzipping via `unzip`
2024-02-02T05:07:54.544Z cypress:cli:unzip unzip tool error: spawn unzip ENOENT
2024-02-02T05:07:54.544Z cypress:cli:unzip unzipping with node.js (slow)
2024-02-02T05:07:54.544Z cypress:cli:unzip calling Node extract tool /tmp/cypress-262.zip { dir: '/root/.cache/Cypress/13.6.2', onEntry: [Function: tick] }
2024-02-02T05:07:54.545Z cypress:cli:unzip unzip tool close with code -2
2024-02-02T05:07:54.545Z cypress:cli:unzip `unzip` failed { code: -2 }

```

In those cases, the CI stays stuck until a timeout is reached, but there shouldn't be any reason to not reject the unzip promise when no more recovery is possible.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
