### PR TITLE
chore: Add check to ensure input has record text before trying to copy to fix flaky test

### DIFF
--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -662,7 +662,7 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       cy.get('[data-cy="terminal-prompt-input').should('have.value', 'npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
       cy.get('[data-cy="copy-button"]').click()
       cy.contains('Copied!')
-      cy.withRetryableCtx(function (ctx) {
+      cy.withRetryableCtx((ctx) => {
         expect(ctx.config.electronApi.copyTextToClipboard as SinonStub).to.have.been.calledWith('npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
       })
     })

--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -652,15 +652,18 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
     })
 
     it('displays a copy button and copies correct command in E2E', () => {
+      const recordE2EText = 'npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
       scaffoldTestingTypeAndVisitRunsPage('e2e')
       cy.withCtx(async (ctx, o) => {
         o.sinon.stub(ctx.config.electronApi, 'copyTextToClipboard')
       })
 
+      cy.get('[data-cy="terminal-prompt-input').should('have.value', recordE2EText)
       cy.get('[data-cy="copy-button"]').click()
       cy.contains('Copied!')
       cy.withRetryableCtx((ctx) => {
-        expect(ctx.config.electronApi.copyTextToClipboard as SinonStub).to.have.been.calledWith('npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+        expect(ctx.config.electronApi.copyTextToClipboard as SinonStub).to.have.been.calledWith(recordE2EText)
       })
     })
   })

--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -644,6 +644,7 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         o.sinon.stub(ctx.config.electronApi, 'copyTextToClipboard')
       })
 
+      cy.get('[data-cy="terminal-prompt-input').should('have.value', 'npx cypress run --component --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
       cy.get('[data-cy="copy-button"]').click()
       cy.contains('Copied!')
       cy.withRetryableCtx((ctx) => {
@@ -652,18 +653,17 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
     })
 
     it('displays a copy button and copies correct command in E2E', () => {
-      const recordE2EText = 'npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-
       scaffoldTestingTypeAndVisitRunsPage('e2e')
+
       cy.withCtx(async (ctx, o) => {
         o.sinon.stub(ctx.config.electronApi, 'copyTextToClipboard')
       })
 
-      cy.get('[data-cy="terminal-prompt-input').should('have.value', recordE2EText)
+      cy.get('[data-cy="terminal-prompt-input').should('have.value', 'npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
       cy.get('[data-cy="copy-button"]').click()
       cy.contains('Copied!')
-      cy.withRetryableCtx((ctx) => {
-        expect(ctx.config.electronApi.copyTextToClipboard as SinonStub).to.have.been.calledWith(recordE2EText)
+      cy.withRetryableCtx(function (ctx) {
+        expect(ctx.config.electronApi.copyTextToClipboard as SinonStub).to.have.been.calledWith('npx cypress run --record --key 2aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
       })
     })
   })


### PR DESCRIPTION
### Additional details

I noticed a flaky/failing test where we are clicking the 'Copy' button to copy an input value and this is failing sometimes due to the input value not having the value yet. See [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/53887/overview/42542511-0629-4ba7-806f-6e813922c89f/replay?att=1&pc=log-http%3A%2F%2Flocalhost%3A4455-2001__command-logs&roarHideRunsWithDiffGroupsAndTags=1&ts=1707232238583.2). 

This change adds an assertion to verify the input has the value before clicking the copy button on 2 tests where this could cause flake or failures.

![Screenshot 2024-02-06 at 11 39 47 AM](https://github.com/cypress-io/cypress/assets/1271364/d9d5ce16-8876-4cfa-b3bd-c35124d8047f)


### Steps to test

I ran the runs.cy.ts file locally in the app tests.

### How has the user experience changed?

N/A

### PR Tasks

N/A

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
