### PR TITLE
chore: Update querying of element to not chain actions/assertions so many levels to address test flake

### DIFF
--- a/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
@@ -198,10 +198,9 @@ describe('Cypress in Cypress', { viewportWidth: 1500, defaultCommandTimeout: 100
       cy.get('[data-cy="select-browser"]').as('selectBrowser')
 
       cy.viewport(500, 600)
-      cy.get('@selectBrowser')
-      .should('not.be.visible')
-      .scrollIntoView()
-      .should('be.visible') // with no specs list open, we should see this by scrolling
+      cy.get('@selectBrowser').should('not.be.visible')
+      cy.get('@selectBrowser').scrollIntoView()
+      cy.get('@selectBrowser').should('be.visible') // with no specs list open, we should see this by scrolling
 
       dragHandleToClientX('panel2', 200).then(() => {
         cy.contains('Chrome 1').should('be.visible')
@@ -210,10 +209,9 @@ describe('Cypress in Cypress', { viewportWidth: 1500, defaultCommandTimeout: 100
       cy.contains('[aria-controls=reporter-inline-specs-list]', 'Specs')
       .click({ force: true })
 
-      cy.get('@selectBrowser')
-      .should('not.be.visible')
-      .scrollIntoView()
-      .should('not.be.visible') // with specs list open, scrolling is not enough to see this
+      cy.get('@selectBrowser').should('not.be.visible')
+      cy.get('@selectBrowser').scrollIntoView()
+      cy.get('@selectBrowser').should('not.be.visible') // with specs list open, scrolling is not enough to see this
 
       dragHandleToClientX('panel1', 130)
       cy.get('@selectBrowser')

--- a/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
@@ -198,7 +198,6 @@ describe('Cypress in Cypress', { viewportWidth: 1500, defaultCommandTimeout: 100
       cy.get('[data-cy="select-browser"]').as('selectBrowser')
 
       cy.viewport(500, 600)
-      cy.get('@selectBrowser').should('not.be.visible')
       cy.get('@selectBrowser').scrollIntoView()
       cy.get('@selectBrowser').should('be.visible') // with no specs list open, we should see this by scrolling
 


### PR DESCRIPTION
### Additional details

#### Chaining of commands

I noticed a flaky test, where the test was failing sometimes with the message below. See [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/53898/overview/83f16ad6-1aff-407d-ae52-128d1bf8c28c/replay?att=1&pc=log-http%3A%2F%2Flocalhost%3A4455-948__command-logs&roarHideRunsWithDiffGroupsAndTags=1&ts=1707240744504.8). 

![Screenshot 2024-02-06 at 2 28 29 PM](https://github.com/cypress-io/cypress/assets/1271364/3dd64447-1307-432b-8a36-00e0b21b6a60)


We have a few actions and assertions chained together and apparently the element is being re-rendered at some point. I've updated our test to requery the element for each assertion/action to hopefully prevent us seeing this flake again.

![Screenshot 2024-02-06 at 12 58 17 PM](https://github.com/cypress-io/cypress/assets/1271364/26398abb-2467-47e8-956d-6d3c3feea039)

#### Browser button visibility in smaller screens

When the viewport is made smaller, there's an assertion about the browser button not being visible before scrolling. Sometimes this assertion passes, sometimes it fails. (You can run locally and see this pass and fail very often). I've included a passing and failing example below with the browser button highlighted. The button is basically visible on each, but one is technically visible and the other is not. I don't really understand the value of this assertion, so I removed it.

Passing
![Screenshot 2024-02-06 at 1 34 51 PM](https://github.com/cypress-io/cypress/assets/1271364/3e02deca-01bd-46b9-9c2a-703ecce50140)

Failing
![Screenshot 2024-02-06 at 1 20 29 PM](https://github.com/cypress-io/cypress/assets/1271364/f41419cd-97bd-4b24-8d85-57fb02b782f1)



### Steps to test

Tests should pass and not have as many retries, can run the `cypress-in-cypress` test locally.

### How has the user experience changed?

N/A

### PR Tasks

N/A

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
