### PR TITLE
chore: Bump github actions deps

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -37,7 +37,7 @@ jobs:
         working-directory: scripts/github-actions/semantic-pull-request/
       - name: Lint PR Title and Cypress Changelog Entry
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const verifyPullRequest = require('./scripts/github-actions/semantic-pull-request')

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -21,12 +21,12 @@ jobs:
         node-version: [18.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -49,17 +49,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -12,7 +12,7 @@ jobs:
       BASE_BRANCH: develop
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
@@ -26,12 +26,12 @@ jobs:
           git fetch origin
           git checkout ${{ env.BASE_BRANCH }}
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Check for new Chrome versions
         id: get-versions
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { getVersions } = require('./scripts/github-actions/update-browser-versions.js')
@@ -56,7 +56,7 @@ jobs:
       - name: Check need for update on existing branch
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
         id: check-need-for-branch-update
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { checkNeedForBranchUpdate } = require('./scripts/github-actions/update-browser-versions.js')
@@ -73,7 +73,7 @@ jobs:
       ## Both
       - name: Update Browser Versions File
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { updateBrowserVersionsFile } = require('./scripts/github-actions/update-browser-versions.js')
@@ -92,7 +92,7 @@ jobs:
       ## Update available and a branch/PR already exists
       - name: Update PR Title
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { updatePRTitle } = require('./scripts/github-actions/update-browser-versions.js')
@@ -108,7 +108,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ matrix.platform == 'macos-latest' }}
         run: echo "SNAPSHOT_FILES='tooling/v8-snapshot/cache/darwin/snapshot-meta.json'" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           git config --local user.email "${{ env.CYPRESS_BOT_APP_ID }}+cypress-bot[bot]@users.noreply.github.com"
           git config --local user.name "cypress-bot[bot]"
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'yarn'
@@ -122,7 +122,7 @@ jobs:
       # PR needs to be created
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')

--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -15,7 +15,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Fossa binary and install
 # This step utilizes a curl of the latest install pkg from Fossa.  Using a git action from 
 # Fossa doesn't produce the SBOM artifact needed. This manual approach is the only way to 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/github-action/issues/1121

### Additional details

All of these GitHub Actions have moved off of Node.js 16 to Node.js 20. They show deprecation warnings when run. This bumps them to newer major version running on Node.js 20. 

- [add-issue-to-triage-board.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/add-issue-to-triage-board.yml)

> add-to-triage-project-board / add-contributor-pr-comment
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

- [triage_closed_issue_comment.yml](https://github.com/cypress-io/github-action/blob/master/.github/workflows/triage_closed_issue_comment.yml)

> closed-issue-comment / handle-comment-scenarios
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

### Steps to test

Need to check the GitHub workflows for errors

### How has the user experience changed?

N/A
### PR Tasks

N/A

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
