### PR TITLE
chore: update test to properly check for 'Configured' vs 'Not Configured' text

### DIFF
--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -220,7 +220,7 @@ describe('Launchpad: Setup Project', () => {
         scaffoldAndOpenProject('pristine-with-e2e-testing')
         cy.visitLaunchpad()
 
-        verifyWelcomePage({ e2eIsConfigured: true, ctIsConfigured: true })
+        verifyWelcomePage({ e2eIsConfigured: true, ctIsConfigured: false })
 
         cy.get('[data-cy-testingtype="e2e"]').click()
 

--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -50,8 +50,11 @@ describe('Launchpad: Setup Project', () => {
 
   const verifyWelcomePage = ({ e2eIsConfigured, ctIsConfigured }) => {
     cy.contains('Welcome to Cypress!').should('be.visible')
-    cy.contains('[data-cy-testingtype="e2e"]', e2eIsConfigured ? 'Configured' : 'Not Configured')
-    cy.contains('[data-cy-testingtype="component"]', ctIsConfigured ? 'Configured' : 'Not Configured')
+    cy.contains('[data-cy-testingtype="e2e"]', 'Not Configured')
+    .should(e2eIsConfigured ? 'not.exist' : 'exist')
+
+    cy.contains('[data-cy-testingtype="component"]', 'Not Configured')
+    .should(ctIsConfigured ? 'not.exist' : 'exist')
   }
 
   const verifyChooseABrowserPage = () => {
@@ -422,7 +425,7 @@ describe('Launchpad: Setup Project', () => {
 
         cy.visitLaunchpad()
 
-        verifyWelcomePage({ e2eIsConfigured: false, ctIsConfigured: true })
+        verifyWelcomePage({ e2eIsConfigured: false, ctIsConfigured: false })
 
         cy.get('[data-cy-testingtype="component"]').click()
 


### PR DESCRIPTION
### Additional details

I was investigating [this flaky test](https://cloud.cypress.io/projects/ypt4pf/runs/53968/overview/acc0e892-cda0-4fe8-ad82-7b6ddf5fef93/replay?att=1&pc=log-http%3A%2F%2Flocalhost%3A5555-615__command-logs&roarHideRunsWithDiffGroupsAndTags=1&ts=1707495992205.7) when I noticed that this assertion passes if the content says 'Configured' or 'Not Configured' since 'Configured' is in both of these texts, so it's not really testing anything! Unfortunately I don't think this has anything to do with the flake.

![Screenshot 2024-02-09 at 1 29 07 PM](https://github.com/cypress-io/cypress/assets/1271364/5d8508e7-0922-43d7-a629-ddd9e7281cc5)


### Steps to test

Run the project_setup test. I manually intercepted the request to change the test types and just ensure this test passes and fails when it should.

### How has the user experience changed?
N/A

### PR Tasks

N/A

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
