### PR TITLE
chore: Assert using cy.window property so that assertion retries to reduce flaky in test

### DIFF
--- a/packages/driver/cypress/e2e/cy/timers.cy.js
+++ b/packages/driver/cypress/e2e/cy/timers.cy.js
@@ -187,9 +187,9 @@ describe('driver/src/cy/timers', () => {
           // now go ahead and run all the queued timers
           return cy.pauseTimers(false)
         })
-        .then(() => {
-          expect(win.bar).to.eq('bar')
 
+        cy.window().its('bar').should('eq', 'bar')
+        .and(() => {
           // requestAnimationFrame should have passed through
           // its high res timestamp from performance.now()
           expect(rafStub).to.be.calledWithMatch(Number)


### PR DESCRIPTION
### Additional details

I noticed this test fail in this [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/53971/overview/c9cd475f-03c3-4378-8893-fa8039aad1c4/replay?att=2&roarHideRunsWithDiffGroupsAndTags=1&ts=1707504003177.2002) where the `bar` property on `window` seems to sometimes not be resolved in time to the correct property 'bar'. 

![Screenshot 2024-02-09 at 2 38 01 PM](https://github.com/cypress-io/cypress/assets/1271364/a8ccddff-7ca7-43d3-9c37-196bb8deaf04)


I switched this assertion to use `cy.window().its()` to utilize Cypress' retries to check the value instead of instantly assertion on the value via `then`. Hopefully this resolves the flake. 

![](http://g.recordit.co/emTG4TImJV.gif)

### Steps to test

Run the timers.cy.js test.

### How has the user experience changed?
N/A

### PR Tasks
N/A
