### PR TITLE
test: Add commands to wait for config page to load before continue with test - address flaky test

### DIFF
--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -187,6 +187,12 @@ describe('Launchpad: Global Mode', () => {
         })
       }
 
+      const waitForConfigLoad = () => {
+        cy.contains('Initializing config...').should('be.visible')
+        // ensure the config is fully loaded before clicking the breadcrumb back
+        cy.contains('Initializing config...').should('not.exist')
+      }
+
       const projectList = ['todos']
 
       setupAndValidateProjectsList(projectList)
@@ -200,6 +206,7 @@ describe('Launchpad: Global Mode', () => {
       // Component testing breadcrumbs
       cy.get('[data-cy="project-card"]').contains('todos').click()
       cy.get('[data-cy-testingtype="component"]').click()
+      waitForConfigLoad()
       resetSpies()
       getBreadcrumbLink('Projects').click()
       getBreadcrumbLink('Projects', { disabled: true })
@@ -212,6 +219,7 @@ describe('Launchpad: Global Mode', () => {
       cy.get('[data-cy="project-card"]').contains('todos').click()
       cy.get('[data-cy-testingtype="e2e"]').click()
       cy.contains('li', 'e2e testing', { matchCase: false }).should('not.have.attr', 'href')
+      waitForConfigLoad()
       resetSpies()
       getBreadcrumbLink('Projects').click()
       getBreadcrumbLink('Projects', { disabled: true })


### PR DESCRIPTION
### Additional details

I saw this launchpad test recently show up as a flaky test: [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/54044/test-results/4739b2d2-1afe-4f42-a38d-8180f1ba2722/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1708017468748&utm_source=github).

A passing [Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/54044/test-results/4739b2d2-1afe-4f42-a38d-8180f1ba2722/replay?actions=%5B%5D&att=2&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1708017476275&utm_source=github)

It looks like we've clicked into a project, then clicked into the breadcrumbs to click into another project. Just as we're trying to click into the other project, the configuration file from the previous project seems jerk us back out with a configuration file error. This is my theory anyway. 

I've added some assertions to wait for the configuration page to finish loading before clicking back to projects. Is this an actual bug? Maybe....if we're not stopping loading of the previous project config file when we click into the main projects. I haven't seen this reported before though and it's likely fairly uncommon. So this attempts to just fix our own tests. 

![Screenshot 2024-02-15 at 12 56 04 PM](https://github.com/cypress-io/cypress/assets/1271364/cc4fd86c-7de4-4170-8abf-b773b2c50da8)

![Screenshot 2024-02-15 at 12 56 11 PM](https://github.com/cypress-io/cypress/assets/1271364/1fced76c-a64f-42d3-ad90-ad08f04969ad)


### Steps to test
 Run the global-mode-cy.ts test on the launchpad tests

### How has the user experience changed?

N/A
