### PR TITLE
docs: fix anchor link to changelog 13.6.3

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ _Released 2/13/2024 (PENDING)_
 
 - Fixed an issue which caused the browser to relaunch after closing the browser from the Launchpad. Fixes [#28852](https://github.com/cypress-io/cypress/issues/28852).
 - Fixed an issue with the unzip promise never being rejected when an empty error happens. Fixed in [#28850](https://github.com/cypress-io/cypress/pull/28850).
-- Fixed a regression introduced in [`13.6.3`](https://docs.cypress.io/guides/references/changelog#13.6.3) where Cypress could crash when processing service worker requests through our proxy. Fixes [#28950](https://github.com/cypress-io/cypress/issues/28950).
+- Fixed a regression introduced in [`13.6.3`](https://docs.cypress.io/guides/references/changelog#13-6-3) where Cypress could crash when processing service worker requests through our proxy. Fixes [#28950](https://github.com/cypress-io/cypress/issues/28950).
 - Fixed incorrect type definition of `dom.getContainsSelector`. Fixed in [#28339](https://github.com/cypress-io/cypress/pull/28339).
 
 **Misc:**


### PR DESCRIPTION
### Additional details

Fixes a badly formatted anchor link to the changelog for [cypress@13.6.3](https://docs.cypress.io/guides/references/changelog#13-6-3). Docusaurus Markdown generates HTML with `id="13-6-3"` **not** `id="13.6.3"` on the Cypress documentation site.

This error has been propagated several times. The links for released versions i.e. up until Cypress `13.6.4` have been corrected through https://github.com/cypress-io/cypress-documentation/pull/5643 on the Cypress documentation site, so it would be nice not to add new wrongly formatted version links in upcoming releases!

### Steps to test

~~Open https://github.com/MikeMcC399/cypress/blob/links/changelog-13-6-3/cli/CHANGELOG.md and click on link to 13.6.3. Note that it now explicitly displays this version and doesn't just go to the top of the page.~~

### How has the user experience changed?

Once the next version of Cypress is released (currently slated as `13.6.5`) the link in the changelog will work correctly.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
