### PR TITLE
chore: fix flaky debug progress test

### DIFF
--- a/packages/app/cypress/e2e/debug.cy.ts
+++ b/packages/app/cypress/e2e/debug.cy.ts
@@ -185,7 +185,7 @@ describe('App - Debug Page', () => {
 
       const run = options.testRun
 
-      run.totalInstanceCount = 5
+      run.totalInstanceCount = 3
       if (run.completedInstanceCount === undefined) {
         run.completedInstanceCount = 0
         run.createdAt = (new Date()).toISOString()
@@ -213,10 +213,10 @@ describe('App - Debug Page', () => {
       }
 
       if (obj.operationName === 'RelevantRunSpecsDataSource_Specs' && obj.result.data) {
-        //NOTE Figure out how to manually trigger polling instead of adjusting polling intervals
+        // NOTE Figure out how to manually trigger polling instead of adjusting polling intervals
         obj.result.data.pollingIntervals = {
           __typename: 'CloudPollingIntervals',
-          runByNumber: 1, //Increase polling interval for debugging test
+          runByNumber: 1.5, //Increase polling interval for debugging test
         }
 
         if (run.totalInstanceCount === run.completedInstanceCount) {
@@ -239,15 +239,14 @@ describe('App - Debug Page', () => {
     cy.findByTestId('sidebar-link-debug-page').click()
     cy.findByTestId('debug-container').should('be.visible')
 
-    cy.findByTestId('header-top').contains('chore: testing cypress')
+    cy.findByTestId('header-top').contains('chore: testing cypress').should('be.visible')
 
-    cy.findByTestId('debug-testing-progress').as('progress')
-
-    cy.get('@progress').contains('Testing in progress...')
     cy.get('[data-cy="debug-badge"]').contains('0').should('be.visible')
-    cy.get('@progress').contains('1 of 5 specs completed')
-    cy.get('@progress').contains('2 of 5 specs completed')
-    cy.get('@progress').contains('3 of 5 specs completed')
+
+    cy.get('[data-cy=debug-testing-progress]').contains('Testing in progress...')
+    cy.findByTestId('debug-testing-progress').contains('1 of 3 specs completed')
+    cy.findByTestId('debug-testing-progress').contains('2 of 3 specs completed')
+    cy.findByTestId('debug-testing-progress').contains('3 of 3 specs completed')
     cy.get('[data-cy="debug-badge"]').contains('1').should('be.visible')
 
     cy.findByTestId('spec-contents').within(() => {


### PR DESCRIPTION
### Additional details

We have a debug test that is testing a progress bar. This test is not actually written in a way where we are manually polling the progress bar, then asserting. It just has an interval that ticks the progress bar. Sometimes the tests wouldn't make it to the first 1/3 tests assertions until the progress bar had already gone to 2/3, causing this test to be flaky.

- Failing Test Replay
- Passing Test Replay

In this PR, I've increased the polling interval from 1 sec to 1.5 sec. I've also rearranged some of the tests and assertions to get to the 1/3 assertion more quickly. I also reduced the number of specs we're looking for from 5 to 3, otherwise we're waiting an extra 3 seconds for the progress bar to finish on things we're not even asserting on. This solution could probably be better, but hopefully this fixes most of the issues. 

Failing case
![Screenshot 2024-02-16 at 9 26 19 AM](https://github.com/cypress-io/cypress/assets/1271364/53f0bc86-07bd-4264-9fb6-bc137e1c54cb)

Passing case
![Screenshot 2024-02-16 at 9 26 12 AM](https://github.com/cypress-io/cypress/assets/1271364/a264219b-084d-4741-bd03-839d71208a38)


### Steps to test
Run the debug.cy.ts test locally. 

### How has the user experience changed?
N/A