### PR TITLE
test: update scaffold CT test to not have chaining that will cause detached dom flake

### DIFF
--- a/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
@@ -112,15 +112,12 @@ describe('scaffolding component testing', {
       })
 
       cy.contains('Component Testing').click()
-      cy.get(`[data-testid="select-framework"]`)
-
-      cy.get('button').should('be.visible').contains('React.js(detected)')
-
-      cy.get('button').contains('Next step').click()
+      cy.contains('button', 'React.js(detected)').should('be.visible')
+      cy.contains('button', 'Next step').click()
 
       // react-dom dependency is missing
       cy.findByTestId('dependency-react-dom').within(() => {
-        cy.get('[aria-label="pending installation"]').should('exist')
+        cy.get('[aria-label="pending installation"]')
       })
 
       // fake install


### PR DESCRIPTION
### Additional details

We had some flake in the scaffold-component-testing.cy.ts file where the `.contains` command would fail with a 'detached DOM' error essentially, saying the DOM had refreshed before getting to that chain. This rewrites those chains so that they'll query for the element once and ensure they're visible (not all buttons on the page).

- [Failing Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/54074/test-results/8043091f-c87e-473f-adc7-902a14253c13/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A5555-1135__command-logs&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1708097830284.5&utm_source=github)
- [Passing Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/54074/test-results/8043091f-c87e-473f-adc7-902a14253c13/replay?actions=%5B%5D&att=2&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A5555-1346__command-logs&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1708097838191&utm_source=github)

Failure
![Screenshot 2024-02-16 at 2 53 40 PM](https://github.com/cypress-io/cypress/assets/1271364/160e9873-c854-42e3-a1d6-8337ac7a1e61)

![Screenshot 2024-02-16 at 2 58 33 PM](https://github.com/cypress-io/cypress/assets/1271364/6578335a-c3fb-4252-a1f3-86dcd4687be3)

Now
![Screenshot 2024-02-16 at 2 59 30 PM](https://github.com/cypress-io/cypress/assets/1271364/8140a07f-f526-4f6b-bf71-97f5bce518de)


Passing

### Steps to test

Run scaffold-component-testing.cy.ts file locally 

### How has the user experience changed?
N/A
