### PR TITLE
fix: avoid ANSI character output when running the binary smoke test f…

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'cacie/dep/electron-27'
-        - 'chore/update_octokit'
+        - 'fix/force_colors_on_verify'
         - 'publish-binary'
         - 'em/circle2'
 
@@ -44,7 +44,7 @@ macWorkflowFilters: &darwin-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_octokit', << pipeline.git.branch >> ]
+    - equal: [ 'fix/force_colors_on_verify', << pipeline.git.branch >> ]
     - equal: [ 'ryanm/fix/service-worker-capture', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -57,7 +57,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_octokit', << pipeline.git.branch >> ]
+    - equal: [ 'fix/force_colors_on_verify', << pipeline.git.branch >> ]
     - equal: [ 'em/circle2', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -82,7 +82,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'chore/update_octokit', << pipeline.git.branch >> ]
+    - equal: [ 'fix/force_colors_on_verify', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
     - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
     - matches:
@@ -154,7 +154,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "chore/update_octokit" && "$CIRCLE_BRANCH" != "cacie/dep/electron-27" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "fix/force_colors_on_verify" && "$CIRCLE_BRANCH" != "cacie/dep/electron-27" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.6.6
+
+_Released 2/22/2024 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where `cypress verify` was failing for `nx` users. Fixes [#28982](https://github.com/cypress-io/cypress/issues/28982).
+
 ## 13.6.5
 
 _Released 2/20/2024_

--- a/cli/lib/tasks/verify.js
+++ b/cli/lib/tasks/verify.js
@@ -102,7 +102,10 @@ const runSmokeTest = (binaryDir, options) => {
     debug('smoke test timeout %d ms', options.smokeTestTimeout)
 
     const stdioOptions = _.extend({}, {
-      env: process.env,
+      env: {
+        ...process.env,
+        FORCE_COLOR: 0,
+      },
       timeout: options.smokeTestTimeout,
     })
 


### PR DESCRIPTION
…or eecution environments that set FORCE_COLOR [run ci]

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28982

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Fixes an issue with env pollution inside the `cypress verify` step of the binary. After the electron update, something under the hood changed with how environment variables are hydrated into the process where not all options before were being respected inside the process. In particular, this causes issues with the `FORCE_COLOR` option that can live inside the node process.  Previously, `FORCE_COLOR` on the previous version of electron was not respected inside the `execa` process, but now it is. This causes the `ping` number to be colored yellow via our error templating, causing an unexpected mismatch on the lines contained in the verify check. This is only an issue if `FORCE_COLOR` is set inside the process, which happens to be the case for `nx` users. Here is a sample diff of the `process.env` differences between invoking cypress via the `nx` plugin vs invoking cypress directly.
 
```
// nx process.env (from cypress-test-tiny)
{
  env: {
    NX_CLI_SET: 'true',
    NX_LOAD_DOT_ENV_FILES: 'true',
    NX_TASK_TARGET_TARGET: 'e2e',
    npm_config_inspect_brk: 'true',
    NX_TASK_HASH: '18267722001484630910',
    NX_TASK_TARGET_PROJECT: 'cypress-test-tiny',
    NX_WORKSPACE_ROOT: '/Users/$NAME/cypress-test-tiny',
    npm_command: 'run-script',
    FORCE_COLOR: 'true',
    npm_lifecycle_script: 'nx e2e',
    LERNA_PACKAGE_NAME: 'cypress-test-tiny',
  }
}
```

```
// cypress process.env (from cypress-test-tiny)
{
  env: {
    npm_command: 'exec',
    npm_lifecycle_script: 'cypress',
  }
}
```

Since the verify job does not need knowledge of ANSI coloring and we mainly want to make sure the verify passes, we are opting to set `FORCE_COLOR` to `0` in order for the verify messaging to pass and make the logic less dependent on user environments

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Likely the best way to test is setting up `cypress-test-tiny` and installing the prebuild binary mentioned in this [commit](https://github.com/cypress-io/cypress/commit/fef0204e7b2b4d385f94b8995bb20572484d25e3). once installed, run `yarn nx init` and install `@nx/cypress`. Then install via `yarn` and execute `yarn cypress:run`. The binary verification should pass.

I have also added a unit test to verify `FORCE_COLOR` is off. We could add a system test that leverages a binary test against an nx project, but the time to set that up locally is a bit tedious at the moment and think we get the coverage we need from this plus some of our internal repos.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
