### PR TITLE
chore: unskip some tests that were previously flaky

### DIFF
--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -1,7 +1,6 @@
 import type { FoundBrowser } from '@packages/types'
 
-// TODO: fix flaky tests https://github.com/cypress-io/cypress/issues/23418
-describe.skip('Choose a browser page', () => {
+describe('Choose a browser page', () => {
   beforeEach(() => {
     cy.scaffoldProject('launchpad')
   })
@@ -15,8 +14,7 @@ describe.skip('Choose a browser page', () => {
       })
     })
 
-    // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23158
-    it('preselects browser that is provided through the command line', { retries: 15 }, () => {
+    it('preselects browser that is provided through the command line', () => {
       cy.withCtx((ctx, o) => {
         // stub launching project since we have `--browser --testingType --project` here
         o.sinon.stub(ctx._apis.projectApi, 'launchProject').resolves()
@@ -25,6 +23,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e', '--browser', 'edge'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -40,6 +39,7 @@ describe.skip('Choose a browser page', () => {
     it('shows warning when launched with --browser name that cannot be matched to found browsers', () => {
       cy.openProject('launchpad', ['--e2e', '--browser', 'doesNotExist'])
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
       cy.get('[data-cy="alert-header"]').should('contain', 'Warning: Browser Not Found')
@@ -63,13 +63,15 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e', '--browser', path])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
       cy.get('[data-cy="alert-header"]').should('contain', 'Warning: Browser Not Found')
       cy.get('[data-cy="alert-body"]').as('AlertBody')
       .should('contain', `We could not identify a known browser at the path you provided: ${path}`)
-      .validateExternalLink({
+
+      cy.validateExternalLink({
         href: 'https://on.cypress.io/troubleshooting-launching-browsers',
       })
 
@@ -96,6 +98,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -112,6 +115,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -164,6 +168,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -188,6 +193,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -205,6 +211,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
@@ -217,11 +224,11 @@ describe.skip('Choose a browser page', () => {
       cy.wait('@closeBrowser')
     })
 
-    // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23220
     it('performs mutation to focus open browser when focus button is pressed', { retries: 15 }, () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
@@ -262,6 +269,7 @@ describe.skip('Choose a browser page', () => {
       })
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -270,11 +278,11 @@ describe.skip('Choose a browser page', () => {
       })
     })
 
-    // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23158
     it('subscribes to changes to browserStatus/activeBrowser through the browserStatusUpdated subscription', { retries: 15 }, () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -306,6 +314,7 @@ describe.skip('Choose a browser page', () => {
     it('should return to welcome screen if user modifies the config file to not include the current testing type and recover', () => {
       cy.openProject('launchpad', ['--e2e'])
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -314,7 +323,7 @@ describe.skip('Choose a browser page', () => {
       })
 
       cy.get('h1').should('contain', 'Welcome to Cypress!')
-      cy.contains('[data-cy-testingtype="e2e"]', 'Not configured')
+      cy.contains('[data-cy-testingtype="e2e"]', 'Not Configured')
 
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
@@ -327,7 +336,7 @@ describe.skip('Choose a browser page', () => {
       })
 
       cy.get('h1').should('contain', 'Welcome to Cypress!')
-      cy.get('[data-cy-testingtype="e2e"]').should('not.contain', 'Not configured')
+      cy.get('[data-cy-testingtype="e2e"]').should('not.contain', 'Not Configured')
     })
   })
 
@@ -343,6 +352,7 @@ describe.skip('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 

--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -293,17 +293,6 @@ describe('Launchpad: Global Mode', () => {
         .should('have.length', projectList.length)
       })
 
-      // FIXME: fix Search by project path logic - https://cypress-io.atlassian.net/browse/UNIFY-646
-      it.skip('filters project results when searching by project path', () => {
-        setupAndValidateProjectsList(projectList)
-        cy.get('#project-search').type('packages')
-        cy.get('[data-cy="project-card"')
-        .should('have.length', projectList.length)
-
-        cy.get('#project-search').type(`${path.sep}todos`)
-        cy.contains(defaultMessages.globalPage.noResultsMessage)
-      })
-
       it('shows "empty results" pages when searching for a non-existent name', () => {
         setupAndValidateProjectsList(projectList)
         cy.get('#project-search').type('hi')
@@ -316,17 +305,6 @@ describe('Launchpad: Global Mode', () => {
         cy.get('[data-cy="no-results-clear"]').click()
         cy.get('[data-cy="project-card"]')
         .should('have.length', projectList.length)
-      })
-
-      // FIXME: fix Search by project path logic - https://cypress-io.atlassian.net/browse/UNIFY-646
-      it.skip('shows "empty results" pages when searching for a non-existent path', () => {
-        setupAndValidateProjectsList(projectList)
-        cy.get('#project-search').type('packages')
-        cy.get('[data-cy="project-card"')
-        .should('have.length', projectList.length)
-
-        cy.get('#project-search').type(`${path.sep}random`)
-        cy.contains(defaultMessages.globalPage.noResultsMessage)
       })
     })
   })

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -1024,23 +1024,6 @@ describe('Full migration flow for each project', { retries: { openMode: 0, runMo
     checkOutcome()
   })
 
-  // TODO: Do we need to consider this case?
-  it.skip('completes journey for migration-e2e-defaults-no-specs', () => {
-    startMigrationFor('migration-e2e-defaults-no-specs')
-    // no specs, nothing to rename?
-    cy.get(renameAutoStep).should('not.exist')
-    // no CT
-    cy.get(renameManualStep).should('not.exist')
-    // supportFile is false - cannot migrate
-    cy.get(renameSupportStep).should('exist')
-    cy.get(setupComponentStep).should('not.exist')
-    cy.get(configFileStep).should('exist')
-
-    renameSupport()
-    migrateAndVerifyConfig()
-    checkOutcome()
-  })
-
   it('completes journey for migration-e2e-plugins-implicit-index-js', () => {
     startMigrationFor('migration-e2e-plugins-implicit-index-js')
     // no specs, nothing to rename?

--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -673,8 +673,7 @@ describe('Launchpad: Setup Project', () => {
       verifyScaffoldedFiles('e2e')
     })
 
-    // TODO: fix failing test https://github.com/cypress-io/cypress/issues/23418
-    it.skip('takes the user to first step of ct setup when switching from app', () => {
+    it('takes the user to first step of ct setup when switching from app', () => {
       scaffoldAndOpenProject('pristine-with-e2e-testing')
       cy.visitLaunchpad()
       verifyWelcomePage({ e2eIsConfigured: true, ctIsConfigured: false })

--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -167,7 +167,8 @@ describe('scaffolding new projects', { defaultCommandTimeout: 7000 }, () => {
     assertScaffoldedFilesAreCorrect({ language, testingType: 'component', ctFramework: 'Create React App (v5)', customDirectory: 'without-fixtures' })
   })
 
-  it('generates valid config file for pristine project without cypress installed', () => {
+  // TODO: Fix flaky test
+  it.skip('generates valid config file for pristine project without cypress installed', () => {
     cy.intercept('mutation-ScaffoldedFiles_completeSetup').as('mutationScaffoldedFiles')
     cy.intercept('query-MainLaunchpadQuery').as('mainLaunchpadQuery')
     cy.intercept('query-HeaderBar_HeaderBarQuery').as('headerBarQuery')

--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -167,8 +167,7 @@ describe('scaffolding new projects', { defaultCommandTimeout: 7000 }, () => {
     assertScaffoldedFilesAreCorrect({ language, testingType: 'component', ctFramework: 'Create React App (v5)', customDirectory: 'without-fixtures' })
   })
 
-  // NOTE: Skipping this test because it is flaky
-  it.skip('generates valid config file for pristine project without cypress installed', () => {
+  it('generates valid config file for pristine project without cypress installed', () => {
     cy.intercept('mutation-ScaffoldedFiles_completeSetup').as('mutationScaffoldedFiles')
     cy.intercept('query-MainLaunchpadQuery').as('mainLaunchpadQuery')
     cy.intercept('query-HeaderBar_HeaderBarQuery').as('headerBarQuery')


### PR DESCRIPTION
### Additional details

Unskipping some tests that were previously skipped. I noticed in our [UI Coverage scoring](https://cloud.cypress.io/projects/ypt4pf/runs/54362/ui-coverage/025590e09a6edf822a6d05538ae6d876f18ab8fb?snapshotId=97ae40657c190a7ab34124908b1984de57a3602c&itemId=519cb45ea4f8ba87e9e1867f1155b77abb39a5ba) that we had no coverage on the buttons that click to choose a browser, which led me to see that we had skipped all of these tests. There's a [bug](https://cypressio.slack.com/archives/C061K0AH030/p1709243541476409) with how we're detecting UI Coverage of this element though, so this doesn't actually increase our score atm. 

When running them, they seem to pass consistently, but I'll track if this introduces more flake. The guarding of loading the page added in previous PRs may have addressed the previous flake. 

I tried to unskip an extra one, but it was still flaky 😢 

### Steps to test

See the tests pass. 

### How has the user experience changed?

N/A
