### PR TITLE
docs(grep): correct support filename in README

### DIFF
--- a/npm/grep/README.md
+++ b/npm/grep/README.md
@@ -80,7 +80,7 @@ yarn add -D @cypress/grep
 **required:** load this module from the [support file](https://on.cypress.io/writing-and-organizing-tests#Support-file) or at the top of the spec file if not using the support file. You import the registration function and then call it:
 
 ```js
-// cypress/support/index.js
+// cypress/support/e2e.js
 // load and register the grep feature using "require" function
 // https://github.com/cypress-io/cypress/tree/develop/npm/grep
 const registerCypressGrep = require('@cypress/grep')


### PR DESCRIPTION
- Closes #29103

### Additional details

The section [`@cypress/grep` > README > Support file](https://github.com/cypress-io/cypress/blob/develop/npm/grep/README.md#support-file) previously contained a code example comment referring to the [legacy filename](https://docs.cypress.io/guides/references/legacy-configuration#Folders--Files) `cypress/support/index.js`, although the  [`@cypress/grep` > README > Install](https://github.com/cypress-io/cypress/blob/develop/npm/grep/README.md#install) section explicitly ruled out the use of `@cypress/grep` with legacy Cypress versions.

The support filename `cypress/support/index.js` is replaced using using the filename `cypress/support/e2e.js` option for E2E JavaScript testing, referring to the list of possible support filenames on [Core Concepts > Writing and Organizing Tests > Support file](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Support-file).

### Steps to test

n/a documentation correction only

### How has the user experience changed?

n/a documentation correction only

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
