### PR TITLE
chore: disable Firefox in system test for screenshot timeout bugfix

### DIFF
--- a/system-tests/test/issue_5016_spec.js
+++ b/system-tests/test/issue_5016_spec.js
@@ -3,6 +3,8 @@ const systemTests = require('../lib/system-tests').default
 describe('e2e issue 5016 - screenshot times out after clicking target _blank', function () {
   systemTests.setup()
 
+  // this test originally was scoped to !webkit, but Firefox has a (non-regression) flake
+  // issue: https://github.com/cypress-io/cypress/issues/29116
   systemTests.it('fails but does not timeout taking screenshot', {
     project: 'config-screenshot-on-failure-enabled',
     sanitizeScreenshotDimensions: true,

--- a/system-tests/test/issue_5016_spec.js
+++ b/system-tests/test/issue_5016_spec.js
@@ -8,6 +8,14 @@ describe('e2e issue 5016 - screenshot times out after clicking target _blank', f
     sanitizeScreenshotDimensions: true,
     snapshot: true,
     expectedExitCode: 1,
-    browser: '!webkit',
+    browser: 'chrome',
+  })
+
+  systemTests.it('fails but does not timeout taking screenshot', {
+    project: 'config-screenshot-on-failure-enabled',
+    sanitizeScreenshotDimensions: true,
+    snapshot: true,
+    expectedExitCode: 1,
+    browser: 'electron',
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
This system test is exhibiting (non-regression) flake in Firefox. Flake reported: https://github.com/cypress-io/cypress/issues/29116

This PR disables the test in Firefox until the flake can be analyzed and fixed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
