### PR TITLE
chore: fix cypress-example-kitchensink deployments

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -14,6 +14,9 @@ images
 assets
 !mochawesome-report-generator/dist/assets
 
+# Do NOT clean out assets from cypress-example-kitchensink to avoid broken deployments
+!cypress-example-kitchensink/**/assets/*
+
 # examples
 example
 !@packages/example


### PR DESCRIPTION
Do NOT clean out example-kitchensink assets. This breaks the example-kitchensink deployment.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #29135

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

With the lerna work in [27848](https://github.com/cypress-io/cypress/pull/27848) , we introduced yarn autoclean (see [autoclean docs](https://classic.yarnpkg.com/lang/en/docs/cli/autoclean/)) with a `.yarnclean` file to reduce files in `node_modules` for cache size in CI. Inside this file we [remove assets directories](https://github.com/cypress-io/cypress/blob/v13.7.0/.yarnclean#L14) everywhere in `node_modules`. Removing assets keeps the directory and won't break the deploy next time.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

run a `yarn` in the root after running `yarn clean-deps` with the configuration in `develop`. Notice `node_modules/cypress-example-kitchensink/app/assets` directory is cleaned out after `yarn` when `cleaning modules...` is run by `yarn`. 

![](https://github.com/cypress-io/cypress/assets/3980464/1d3f1dc2-635a-495a-851d-cdcbbe868d5b)

Then, run a `yarn` in the root after running `yarn clean-deps` with the configuration on this branch `chore/fix_kitchen_sink_deploy`. Notice `node_modules/cypress-example-kitchensink/app/assets` directory exists after `yarn` when `cleaning modules...` is run by `yarn`. This means the assets will be available when we deploy the app from the `@packages/example`.

![](https://github.com/cypress-io/cypress/assets/3980464/b5595b6d-e9df-4a0a-b7dd-7ef4ba10b9d5)

I currently do NOT have tests to verify if the assets are present, but considering the root cause of the issue I think documenting in the `.yarnclean` why we are preserving the assets should be enough. If others feel different, we can of course add a small test to verify.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
