### PR TITLE
chore: skip flaky tests

### DIFF
--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -199,7 +199,8 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
     })
   })
 
-  context('when no runs are recorded', () => {
+  // TODO: Flaky test: Sometimes this test renders the empty view instead of the placeholder
+  context.skip('when no runs are recorded', () => {
     it('shows placeholders for all visible specs', { defaultCommandTimeout: 6000 }, () => {
       cy.loginUser()
 

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -2199,7 +2199,7 @@ describe('network stubbing', { retries: 15 }, function () {
 
       context('with `times`', function () {
         // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23434
-        it('only uses each handler N times', { retries: 15 }, function () {
+        it('only uses each handler N times', { browser: '!webkit', retries: 15 }, function () {
           const url = uniqueRoute('/foo')
           const third = sinon.stub()
 


### PR DESCRIPTION
### Additional details

#### 1. First Flaky Test

[Test Replay](https://cloud.cypress.io/projects/ypt4pf/analytics/flaky-tests?att=1&branches=%5B%7B%22value%22%3A%22develop%22%2C%22label%22%3A%22develop%22%7D%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&replayTestId=f3cdb1bf-b199-423c-9c0c-067910c26c80&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222024-03-07%22%2C%22endDate%22%3A%222024-03-14%22%7D&ts=1710431553593.8027&viewBy=TEST_CASE)

![Screenshot 2024-03-14 at 4 14 15 PM](https://github.com/cypress-io/cypress/assets/1271364/bc932284-e232-4293-a632-3532a2c0eade)


This test is our flakiest test right now. I've looked into it, and I can't figure out why it's flaking, maybe it's a slight timing difference and could be a bug in how we're rendering. What's happening:

In this case where there are no runs recorded, the view renders this loading styles instead of the --- placeholder text. Since this is very low impact even if this is a bug, I think we should just skip this test and save ourselves the time of rerunning our whole suite when this fails. 

Passing
![Screenshot 2024-03-14 at 4 06 45 PM](https://github.com/cypress-io/cypress/assets/1271364/d5615576-65fb-4682-83fe-34fa3fac8d82)


Failing
![Screenshot 2024-03-14 at 4 06 27 PM](https://github.com/cypress-io/cypress/assets/1271364/6d0c9c39-8e6a-49cd-bd44-78e405b24656)

#### 2. Second flaky test

This test only seems to be flaky when run in Webkit, so I think we should skip webkit. There are some other tests in that file that are not run in webkit. 

![Screenshot 2024-03-14 at 4 21 14 PM](https://github.com/cypress-io/cypress/assets/1271364/e4b1125b-1a32-4e2e-b250-8eec87b88dd1)


### How has the user experience changed?
N/A

### PR Tasks
N/A