### PR TITLE
fix:Make sure file server folder path characters are parsed correctly to fix[ERR_INVALID_CHAR]: Invalid character in header content ["x-cypress-file-path"] #25839

### DIFF
--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -2343,7 +2343,7 @@ export default {
 
         We failed looking for this file at the path:
 
-        ${obj.path}
+        ${decodeURIComponent(obj.path)}
 
         The internal Cypress web server responded with:
 

--- a/packages/server/lib/file_server.js
+++ b/packages/server/lib/file_server.js
@@ -54,7 +54,7 @@ module.exports = {
       const token = random.id(64)
 
       const srv = http.createServer(httpUtils.lenientOptions, (req, res) => {
-        return onRequest(req, res, token, fileServerFolder)
+        return onRequest(req, res, token, encodeURIComponent(fileServerFolder))
       })
 
       allowDestroy(srv)


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/25839

### Additional details
When there are special characters in our test folder path, (such as Chinese characters) and under the ubuntu system, the folder path is not parsed correctly, causing Cypress to crash and throw a stack error "Invalid character in header content ["x- cypress-file-path"]".
This PR will encode the test folder path to solve the issue and decode it in the error_messages.ts file to prevent the error log from being expressed intuitively.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?