### PR TITLE
docs: correct link from examples readme to pr contributing

### DIFF
--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -25,7 +25,7 @@ When a commit is merged into `master`, a new version of the [`cypress-example-ki
 
 2. Run `yarn` and `yarn workspace @packages/example build` to build the app and spec files.
 
-3. Create a new pull-request following this repo's [pull request instructions](CONTRIBUTING.md#pull-requests).
+3. Create a new pull-request following this repo's [pull request instructions](../../CONTRIBUTING.md#pull-requests).
 
 ## Building
 


### PR DESCRIPTION
### Additional details

In [packages/example/README.md](https://github.com/cypress-io/cypress/blob/develop/packages/example/README.md#using-a-new-version-of-cypress-example-kitchen-sink) the instruction

`3. Create a new pull-request following this repo's [pull request instructions](CONTRIBUTING.md#pull-requests).`

links to a non-existent file, producing a `404` error.

This PR changes the link to point to https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests instead.

### Steps to test

Open [README](https://github.com/cypress-io/cypress/blob/develop/packages/example/README.md#using-a-new-version-of-cypress-example-kitchen-sink) and click on link to [pull request instructions](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests). Confirm that corresponding content is displayed.

### How has the user experience changed?

See above.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?