### PR TITLE
fix: patch new tab creation for firefox 124 and up to fix issue where…

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 3/26/2024 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed and issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox `124` and up. Fixes [#29172](https://github.com/cypress-io/cypress/issues/29172).
+- Fixed an issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox 124 and up. Fixes [#29172](https://github.com/cypress-io/cypress/issues/29172).
 - Fixed an issue blurring shadow dom elements. Fixed in [#29125](https://github.com/cypress-io/cypress/pull/29125).
 
 **Dependency Updates:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 3/26/2024 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed and issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox `124` and up. Fixes [#29172](https://github.com/cypress-io/cypress/issues/29172).
 - Fixed an issue blurring shadow dom elements. Fixed in [#29125](https://github.com/cypress-io/cypress/pull/29125).
 
 **Dependency Updates:**

--- a/packages/extension/app/v2/background.js
+++ b/packages/extension/app/v2/background.js
@@ -1,3 +1,4 @@
+/* global window */
 const get = require('lodash/get')
 const map = require('lodash/map')
 const pick = require('lodash/pick')
@@ -292,7 +293,6 @@ const automation = {
 
       try {
         // credit to https://stackoverflow.com/questions/7000190/detect-all-firefox-versions-in-js
-        // eslint-disable-next-line no-undef
         const match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./)
         const version = match ? parseInt(match[1]) : 0
 

--- a/packages/server/lib/browsers/firefox-util.ts
+++ b/packages/server/lib/browsers/firefox-util.ts
@@ -105,8 +105,10 @@ const attachToTabMemory = Bluebird.method((tab) => {
 })
 
 async function connectMarionetteToNewTab () {
-  // When firefox closes its last tab, it keeps a blank tab open. This will be the only handle
-  // So we will connect to it and navigate it to about:blank to set it up for CDP connection
+  // Firefox keeps a blank tab open in versions of Firefox 123 and lower when the last tab is closed.
+  // For versions 124 and above, a new tab is not created, so @packages/extension creates one for us.
+  // Since the tab is always available on our behalf,
+  // we can connect to it here and navigate it to about:blank to set it up for CDP connection
   const handles = await sendMarionette({
     name: 'WebDriver:GetWindowHandles',
   })


### PR DESCRIPTION
… cypress was not executing beyond the first spec in cypress run (specific to firefox).

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #29172

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR addresses an issue with Firefox versions `124` and up where the `browsers.tabs` [extension API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/remove) behavior changed.
Previously, in versions of Firefox `123` and below, removing all tabs in the browser would result in a new tab being created. Now, in Firefox versions `124` (and beta `125` as well), this behavior no longer happens. Instead, the browser closes, but the process is still running. Cypress cannot find a tab to connect to, and therefor browser connection times out when running the second spec in run mode with `npx cypress run -b firefox`.

To fix this, this PR creates an `about:blank` tab (but does not active it) before all the other tabs are removed. This tab is the only remaining tab, which is fairly consistent with the behavior we saw previously in Firefox `123` and lower. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
