### PR TITLE
test: fix driver reruns spec while recording due to weird reloading cycle

### DIFF
--- a/packages/driver/cypress/e2e/e2e/rerun.cy.js
+++ b/packages/driver/cypress/e2e/e2e/rerun.cy.js
@@ -8,6 +8,10 @@ if (window.top.runCount == null) {
   window.top.runCount = 0
 }
 
+// The reruns spec in the driver has some weird reloading that occurs. It triggers a simulation of 
+// essentially reloading the page in run mode and that effectively wipes away some state that we 
+// need for protocol. Rather than trying to handle this edge case in a complicated one-off fashion, 
+// just ensure that the protocol events fire for this one spec.
 const getCypressProtocolElement = () => {
   let cypressProtocolElement = window.top.document.getElementById('__cypress-protocol')
 

--- a/packages/driver/cypress/e2e/e2e/rerun.cy.js
+++ b/packages/driver/cypress/e2e/e2e/rerun.cy.js
@@ -8,7 +8,7 @@ if (window.top.runCount == null) {
   window.top.runCount = 0
 }
 
-// The reruns spec in the driver has some weird reloading that occurs. It triggers a simulation of 
+// This spec in the driver has some weird reloading that occurs. It triggers a simulation of 
 // essentially reloading the page in run mode and that effectively wipes away some state that we 
 // need for protocol. Rather than trying to handle this edge case in a complicated one-off fashion, 
 // just ensure that the protocol events fire for this one spec.

--- a/packages/driver/cypress/e2e/e2e/rerun.cy.js
+++ b/packages/driver/cypress/e2e/e2e/rerun.cy.js
@@ -8,35 +8,43 @@ if (window.top.runCount == null) {
   window.top.runCount = 0
 }
 
-// This spec in the driver has some weird reloading that occurs. It triggers a simulation of 
-// essentially reloading the page in run mode and that effectively wipes away some state that we 
-// need for protocol. Rather than trying to handle this edge case in a complicated one-off fashion, 
+// This spec in the driver has some weird reloading that occurs. It triggers a simulation of
+// essentially reloading the page in run mode and that effectively wipes away some state that we
+// need for protocol. Rather than trying to handle this edge case in a complicated one-off fashion,
 // just ensure that the protocol events fire for this one spec.
-const getCypressProtocolElement = () => {
-  let cypressProtocolElement = window.top.document.getElementById('__cypress-protocol')
+if (Cypress.config('browser').family === 'chromium') {
+  // Copied from:
+  // https://github.com/cypress-io/cypress-services/blob/825abbabaaa0a8ecf78e2ad543493a85a01a939f/packages/app-capture-protocol/src/cypress-events/track-cypress-events.ts#L17-L30
+  const getCypressProtocolElement = () => {
+    let cypressProtocolElement = window.top.document.getElementById('__cypress-protocol')
 
-  // If element does not exist, create it
-  if (!cypressProtocolElement) {
-    cypressProtocolElement = document.createElement('div')
-    cypressProtocolElement.id = '__cypress-protocol'
-    cypressProtocolElement.style.display = 'none'
-    window.top.document.body.appendChild(cypressProtocolElement)
+    // If element does not exist, create it
+    if (!cypressProtocolElement) {
+      cypressProtocolElement = document.createElement('div')
+      cypressProtocolElement.id = '__cypress-protocol'
+      cypressProtocolElement.style.display = 'none'
+      window.top.document.body.appendChild(cypressProtocolElement)
+    }
+
+    return cypressProtocolElement
   }
 
-  return cypressProtocolElement
-}
+  // Copied from:
+  // https://github.com/cypress-io/cypress-services/blob/825abbabaaa0a8ecf78e2ad543493a85a01a939f/packages/app-capture-protocol/src/cypress-events/track-cypress-events.ts#L38-L44
+  const attachCypressProtocolTestAfterRun = () => {
+    const cypressProtocolElement = getCypressProtocolElement()
 
-const attachCypressProtocolTestAfterRun = () => {
-  const cypressProtocolElement = getCypressProtocolElement()
+    cypressProtocolElement.dataset.cypressProtocolTestAfterRun = JSON.stringify({
+      timestamp: performance.now() + performance.timeOrigin,
+    })
+  }
 
-  cypressProtocolElement.dataset.cypressProtocolTestAfterRun = JSON.stringify({
-    timestamp: performance.now() + performance.timeOrigin,
+  // Copied from:
+  // https://github.com/cypress-io/cypress-services/blob/825abbabaaa0a8ecf78e2ad543493a85a01a939f/packages/app-capture-protocol/src/cypress-events/track-cypress-events.ts#L110-L112
+  Cypress.prependListener('test:after:run:async', () => {
+    attachCypressProtocolTestAfterRun()
   })
 }
-
-Cypress.prependListener('test:after:run:async', () => {
-  attachCypressProtocolTestAfterRun()
-})
 
 const isTextTerminal = Cypress.config('isTextTerminal')
 

--- a/packages/driver/cypress/e2e/e2e/rerun.cy.js
+++ b/packages/driver/cypress/e2e/e2e/rerun.cy.js
@@ -8,6 +8,32 @@ if (window.top.runCount == null) {
   window.top.runCount = 0
 }
 
+const getCypressProtocolElement = () => {
+  let cypressProtocolElement = window.top.document.getElementById('__cypress-protocol')
+
+  // If element does not exist, create it
+  if (!cypressProtocolElement) {
+    cypressProtocolElement = document.createElement('div')
+    cypressProtocolElement.id = '__cypress-protocol'
+    cypressProtocolElement.style.display = 'none'
+    window.top.document.body.appendChild(cypressProtocolElement)
+  }
+
+  return cypressProtocolElement
+}
+
+const attachCypressProtocolTestAfterRun = () => {
+  const cypressProtocolElement = getCypressProtocolElement()
+
+  cypressProtocolElement.dataset.cypressProtocolTestAfterRun = JSON.stringify({
+    timestamp: performance.now() + performance.timeOrigin,
+  })
+}
+
+Cypress.prependListener('test:after:run:async', () => {
+  attachCypressProtocolTestAfterRun()
+})
+
 const isTextTerminal = Cypress.config('isTextTerminal')
 
 describe('rerun state bugs', () => {

--- a/packages/driver/cypress/e2e/e2e/rerun.cy.js
+++ b/packages/driver/cypress/e2e/e2e/rerun.cy.js
@@ -48,10 +48,7 @@ if (Cypress.config('browser').family === 'chromium') {
 
 const isTextTerminal = Cypress.config('isTextTerminal')
 
-// TODO: UNSKIP this for chromium browsers. @see https://github.com/cypress-io/cypress/issues/29181
-describe('rerun state bugs', { browser: {
-  family: '!chromium',
-} }, () => {
+describe('rerun state bugs', () => {
   // NOTE: there's probably other ways to cause a re-run
   // event more programatically (like firing it through Cypress)
   // but we get the hashchange coverage for free on this.


### PR DESCRIPTION
Close https://github.com/cypress-io/cypress/issues/29181

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The reruns spec in the driver, has some weird reloading that occurs. It triggers a simulation of essentially reloading the page in run mode and then effectively wipes away some state that we need for protocol. Rather than trying to handle this edge case in a complicated one-off fashion, I am instead just ensuring that the protocol events fire for this one spec.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
