### PR TITLE
fix: issue-22732-add-check-CI-browser-value

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.7.2
 
-_Released xx/xx/xxxx (PENDING)_
+_Released 04/04/2024 (PENDING)_
 
 **Bugfixes:**
 - Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 _Released 3/21/2024_
 
 **Bugfixes:**
-
+- Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).
 - Fixed an issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox 124 and up. Fixes [#29172](https://github.com/cypress-io/cypress/issues/29172).
 - Fixed an issue blurring shadow dom elements. Fixed in [#29125](https://github.com/cypress-io/cypress/pull/29125).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.7.2
 
-_Released <RELEASE_DATE> (PENDING)_
+_Released xx/xx/xxxx (PENDING)_
 
 **Bugfixes:**
 - Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## <RELEASE_VERSION>
+## 13.7.2
 
 _Released <RELEASE_DATE> (PENDING)_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 _Released 04/04/2024 (PENDING)_
 
 **Bugfixes:**
+
 - Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).
 
 ## 13.7.1

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,10 +1,16 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## <RELEASE_VERSION>
+
+_Released <RELEASE_DATE> (PENDING)_
+
+**Bugfixes:**
+- Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).
+
 ## 13.7.1
 
 _Released 3/21/2024_
 
 **Bugfixes:**
-- Fixed launching with a null browser value. Fixes [#22732](https://github.com/cypress-io/cypress/issues/22732).
 - Fixed an issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox 124 and up. Fixes [#29172](https://github.com/cypress-io/cypress/issues/29172).
 - Fixed an issue blurring shadow dom elements. Fixed in [#29125](https://github.com/cypress-io/cypress/pull/29125).
 

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -426,8 +426,10 @@ module.exports = {
       delete options.key
     }
 
-    if (typeof browser !== 'string' || browser == null) {
-      return errors.throwErr('COULD_NOT_PARSE_ARGUMENTS', 'browser', browser, 'browser must be a string or path to executable')
+    if (browser) {
+      if (typeof browser !== 'string' || browser == null) {
+        return errors.throwErr('COULD_NOT_PARSE_ARGUMENTS', 'browser', browser, 'browser must be a string or path to executable')
+      }
     }
 
     if (spec) {

--- a/packages/server/lib/util/args.js
+++ b/packages/server/lib/util/args.js
@@ -412,7 +412,7 @@ module.exports = {
     }
 
     let { spec } = options
-    const { env, config, reporterOptions, outputPath, tag, testingType, autoCancelAfterFailures } = options
+    const { browser, env, config, reporterOptions, outputPath, tag, testingType, autoCancelAfterFailures } = options
     let project = options.project || options.runProject
 
     // only accept project if it is a string
@@ -424,6 +424,10 @@ module.exports = {
     // https://github.com/cypress-io/cypress/issues/14571
     if (typeof options.key !== 'string') {
       delete options.key
+    }
+
+    if (typeof browser !== 'string' || browser == null) {
+      return errors.throwErr('COULD_NOT_PARSE_ARGUMENTS', 'browser', browser, 'browser must be a string or path to executable')
     }
 
     if (spec) {

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -261,6 +261,15 @@ describe('lib/cypress', () => {
   })
 
   context('error handling', function () {
+    it('exits if browser cannot be parsed', function () {
+      return cypress.start(['--browser', ''])
+      .then(() => {
+        const err = this.expectExitWithErr('COULD_NOT_PARSE_ARGUMENTS')
+
+        snapshot('could not parse config error', stripAnsi(err.message))
+      })
+    })
+
     it('exits if config cannot be parsed', function () {
       return cypress.start(['--config', 'xyz'])
       .then(() => {


### PR DESCRIPTION


- Closes https://github.com/cypress-io/cypress/issues/22732

### Additional details
Resolves the issue where a user doesn't specify a browser and the check ignores the null value passed.

### Steps to test
Run the steps to reproduce on the issue, providing a CI run command with the browser tag and a null value.


### PR Tasks
- [ x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
