### PR TITLE
fix: allow users to pass in custom useragent for firefox 124 and up w…

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 4/2/2024 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed an issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox 124 and up when a custom user agent was provided. Fixes [#29190](https://github.com/cypress-io/cypress/issues/29190).
 - Fixed a bug where fields using arrays in `cypress.config` are not correctly processed. Fixes [#27103](https://github.com/cypress-io/cypress/issues/27103). Fixed in [#27312](https://github.com/cypress-io/cypress/pull/27312).
 
 ## 13.7.1

--- a/packages/extension/app/v2/background.js
+++ b/packages/extension/app/v2/background.js
@@ -1,4 +1,3 @@
-/* global window */
 const get = require('lodash/get')
 const map = require('lodash/map')
 const pick = require('lodash/pick')
@@ -292,17 +291,12 @@ const automation = {
       let newTabId = null
 
       try {
-        // credit to https://stackoverflow.com/questions/7000190/detect-all-firefox-versions-in-js
-        const match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./)
-        const version = match ? parseInt(match[1]) : 0
-
         // in versions of Firefox 124 and up, firefox no longer creates a new tab for us when we close all tabs in the browser.
         // to keep change minimal and backwards compatible, we are creating an 'about:blank' tab here to keep the behavior consistent.
-        if (version >= 124) {
-          const newAboutBlankTab = await browser.tabs.create({ url: 'about:blank', active: false })
+        // this works in previous versions as well since one tab is left, hence one will not be created for us in Firefox 123 and below
+        const newAboutBlankTab = await browser.tabs.create({ url: 'about:blank', active: false })
 
-          newTabId = newAboutBlankTab.id
-        }
+        newTabId = newAboutBlankTab.id
       // eslint-disable-next-line no-empty
       } catch (e) {}
 

--- a/packages/extension/test/integration/v2/background_spec.js
+++ b/packages/extension/test/integration/v2/background_spec.js
@@ -853,42 +853,20 @@ describe('app/background', () => {
         })
       })
 
-      it('closes the tabs in the current browser window', function (done) {
+      // @see https://github.com/cypress-io/cypress/issues/29172 for Firefox versions 124 and up
+      it('closes the tabs in the current browser window and creates a new "about:blank" tab', function (done) {
         this.socket.on('automation:response', (id, obj) => {
           expect(id).to.eq(123)
           expect(obj.response).to.be.undefined
 
           expect(browser.windows.getCurrent).to.be.called
-          expect(browser.tabs.remove).to.be.called
-          expect(browser.tabs.create).not.to.be.called
+          expect(browser.tabs.remove).to.be.calledWith(['1', '2', '3'])
+          expect(browser.tabs.create).to.be.calledWith({ url: 'about:blank', active: false })
 
           done()
         })
 
         this.server.emit('automation:request', 123, 'reset:browser:tabs:for:next:test')
-      })
-
-      // @see https://github.com/cypress-io/cypress/issues/29172
-      describe('firefox 124 and up', () => {
-        beforeEach(() => {
-          global.window.navigator = {
-            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0',
-          }
-        })
-
-        it('creates a new "about:blank" tab and closes the other tabs in the current browser window', function (done) {
-          this.socket.on('automation:response', (id, obj) => {
-            expect(id).to.eq(123)
-            expect(obj.response).to.be.undefined
-
-            expect(browser.windows.getCurrent).to.be.called
-            expect(browser.tabs.remove).to.be.calledWith(['1', '2', '3'])
-            expect(browser.tabs.create).to.be.calledWith({ url: 'about:blank', active: false })
-            done()
-          })
-
-          this.server.emit('automation:request', 123, 'reset:browser:tabs:for:next:test')
-        })
       })
     })
   })


### PR DESCRIPTION
…ithout changes to behavior

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #29190

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This fix applies the new tab behavior implemented in #29179 to all versions of firefox. Since a tab is now preserved in versions of Firefox 123 and below, one does not need to be created. This makes the fix backwards compatible for all version of firefox, including those that specify a custom user agent.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
