### PR TITLE
chore: reduce flake in windows-run-app-integration-tests-chrome 

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-03-12-24
+03-25-24

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -84,7 +84,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
     - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
-    - equal: [ 'mschile/mochaEvents_win_sep', << pipeline.git.branch >> ]
+    - equal: [ 'chore/reduce_windows_flake', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -125,7 +125,7 @@ executors:
   # https://circleci.com/docs/2.0/hello-world-windows/#software-pre-installed-in-the-windows-image
   windows: &windows-executor
     machine:
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2022-gui:stable
       shell: bash.exe -eo pipefail
     resource_class: windows.large
     environment:
@@ -666,6 +666,11 @@ commands:
           browser: <<parameters.browser>>
       - run:
           command: |
+            if [[ $PLATFORM == 'windows' && '<<parameters.browser>>' == 'chrome' && '<<parameters.package>>' == 'app' && '<<parameters.type>>' == 'e2e' ]]; then
+              IS_WINDOWS_APP_INTEGRATION_TEST=true
+            else
+              IS_WINDOWS_APP_INTEGRATION_TEST=false
+            fi
             echo Current working directory is $PWD
             echo Total containers $CIRCLE_NODE_TOTAL
 
@@ -675,14 +680,23 @@ commands:
               fi
               # internal PR
               cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
-              DEBUG=<<parameters.debug>> \
-              CYPRESS_CONFIG_ENV=production \
-              CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
-              PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
-              PERCY_PARALLEL_TOTAL=-1 \
-              CYPRESS_INTERNAL_ENABLE_TELEMETRY="true" \
-              $cmd yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --record --parallel --group <<parameters.package>>-<<parameters.type>>
+
+              if [[ "$IS_WINDOWS_APP_INTEGRATION_TEST" = true ]]; then
+                echo "on windows running app-integration tests. Skipping flaky tests"
+                # if windows app integration tests, skip some very flaky tests that fail to load for undetermined reasons
+                TESTFILES=$(cd packages/<<parameters.package>> && /usr/bin/find cypress/e2e -regextype posix-extended -name '*.cy.*' -not -regex '.*(experimentalRetries|reporter.command_errors|ct-framework-errors|reporter-ct-vite|reporter-ct-webpack|reporter.errors|reporter.hooks|cypress-in-cypress|runner.ui|specs|studio).*' | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+                # Do NOT record on windows packages/app due to encryption issues
+                $cmd yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --spec $TESTFILES
+              else
+                DEBUG=<<parameters.debug>> \
+                CYPRESS_CONFIG_ENV=production \
+                CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
+                PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
+                PERCY_ENABLE=${PERCY_TOKEN:-0} \
+                PERCY_PARALLEL_TOTAL=-1 \
+                CYPRESS_INTERNAL_ENABLE_TELEMETRY="true" \
+                $cmd yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --record --parallel --group <<parameters.package>>-<<parameters.type>>
+              fi
             else
               # external PR
 
@@ -702,6 +716,12 @@ commands:
 
               # To run the `yarn` command, we need to walk out of the package folder.
               cd ../..
+
+              if [[ "$IS_WINDOWS_APP_INTEGRATION_TEST" = true ]]; then
+                echo "on windows running app-integration tests. Skipping flaky tests"
+                # if windows app integration tests, skip some very flaky tests that fail to load for undetermined reasons
+                TESTFILES=$(cd packages/<<parameters.package>> && /usr/bin/find cypress/e2e -regextype posix-extended -name '*.cy.*' -not -regex '.*(experimentalRetries|reporter.command_errors|ct-framework-errors|reporter-ct-vite|reporter-ct-webpack|reporter.errors|reporter.hooks|cypress-in-cypress|runner.ui|specs|studio).*' | circleci tests split --total=$CIRCLE_NODE_TOTAL)
+              fi
 
               DEBUG=<<parameters.debug>> \
               CYPRESS_CONFIG_ENV=production \
@@ -1010,6 +1030,10 @@ commands:
         type: string
         default: "npm start --if-present"
     steps:
+      - run:
+          name: Install yarn if not already installed
+          command: |
+            yarn --version || npm i -g yarn
       - clone-repo-and-checkout-branch:
           repo: <<parameters.repo>>
           pull_request_id: <<parameters.pull_request_id>>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28942

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Reduces flake in `windows-run-app-integration-tests-chrome` by not testing certain tests that are flaky inside the pap-integration cy-in-cy pipeline. These tests have been flaky for some time and it was difficult to determine what caused the flake since we are unable to see circleCI history that far back without performance implications.

Because there are issues recording with `--spec` specified with cy-in-cy, we will not be recording the windows app integration tests. Additionally, this fixes the `windows-test-binary-against-kitchensink-chrome` where `yarn` is not installed on the windows-server executor by making sure yarn is installed first before any action happens when checking out a repo.

The launchpad and app tests are still flaky, they are just less flaky and have the ability to pass now. Not ideal, but this is an improvement

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
