### PR TITLE
fix: Allow option values containing quotation marks to be selected

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 4/2/2024 (PENDING)_
 
 - Fixed an issue where Cypress was not executing beyond the first spec in `cypress run` for versions of Firefox 124 and up when a custom user agent was provided. Fixes [#29190](https://github.com/cypress-io/cypress/issues/29190).
 - Fixed a bug where fields using arrays in `cypress.config` are not correctly processed. Fixes [#27103](https://github.com/cypress-io/cypress/issues/27103). Fixed in [#27312](https://github.com/cypress-io/cypress/pull/27312).
+- Fixed a bug where option values containing quotation marks could not be selected. Fixes [#29213](https://github.com/cypress-io/cypress/issues/29213)
 
 ## 13.7.1
 

--- a/packages/driver/cypress/e2e/commands/actions/select.cy.js
+++ b/packages/driver/cypress/e2e/commands/actions/select.cy.js
@@ -51,6 +51,22 @@ describe('src/cy/commands/actions/select', () => {
       })
     })
 
+    it('can select by value when value contains a quotation mark', () => {
+      cy.$$('select[name=maps] option:nth-child(3)').attr('value', '"test"')
+
+      cy.get('select[name=maps]').select('"test"').then(($select) => {
+        expect($select[0].selectedOptions[0].text).to.eq('nuke')
+      })
+    })
+
+    it('can select by index when value contains a quotation mark', () => {
+      cy.$$('select[name=maps] option:nth-child(3)').attr('value', '"test"')
+
+      cy.get('select[name=maps]').select(2).then(($select) => {
+        expect($select[0].selectedOptions[0].text).to.eq('nuke')
+      })
+    })
+
     it('can handle index when all values are identical', () => {
       cy.$$('select[name=maps] option').attr('value', 'foo')
 

--- a/packages/driver/src/cy/commands/actions/select.ts
+++ b/packages/driver/src/cy/commands/actions/select.ts
@@ -128,7 +128,7 @@ export default (Commands, Cypress, cy) => {
             values.push(value)
 
             // https://github.com/cypress-io/cypress/issues/24739
-            if (options.$el.find(`option[value="${value}"]`).length > 1) {
+            if (options.$el.find(`option[value="${value.replace(/"/g, '\\\"')}"]`).length > 1) {
               notAllUniqueValues = true
             }
           }


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/29213

### Additional details

I believe this issue was introduced by https://github.com/cypress-io/cypress/pull/25016

### PR Tasks
<!--
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
