### PR TITLE
chore: update app to cypress-example-kitchensink v2.0.5

### DIFF
--- a/commands/actions.html
+++ b/commands/actions.html
@@ -74,28 +74,28 @@
         <div class="col-xs-7">
           <h4 id="type"><a href="https://on.cypress.io/type">.type()</a></h4>
           <p>To type into a DOM element, use the <a href="https://on.cypress.io/type"><code>.type()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('.action-email')
-  .type('fake@email.com').should('have.value', 'fake@email.com')
+          <pre><code class="javascript">cy.get('.action-email').type('fake@email.com')
+cy.get('.action-email').should('have.value', 'fake@email.com')
 
-  // .type() with special character sequences
-  .type('{leftarrow}{rightarrow}{uparrow}{downarrow}')
-  .type('{del}{selectall}{backspace}')
+// .type() with special character sequences
+cy.get('.action-email').type('{leftarrow}{rightarrow}{uparrow}{downarrow}')
+cy.get('.action-email').type('{del}{selectall}{backspace}')
 
-  // .type() with key modifiers
-  .type('{alt}{option}') //these are equivalent
-  .type('{ctrl}{control}') //these are equivalent
-  .type('{meta}{command}{cmd}') //these are equivalent
-  .type('{shift}')
+// .type() with key modifiers
+cy.get('.action-email').type('{alt}{option}') //these are equivalent
+cy.get('.action-email').type('{ctrl}{control}') //these are equivalent
+cy.get('.action-email').type('{meta}{command}{cmd}') //these are equivalent
+cy.get('.action-email').type('{shift}')
 
-  // Delay each keypress by 0.1 sec
-  .type('slow.typing@email.com', { delay: 100 })
-  .should('have.value', 'slow.typing@email.com')
+// Delay each keypress by 0.1 sec
+cy.get('.action-email').type('slow.typing@email.com', { delay: 100 })
+cy.get('.action-email').should('have.value', 'slow.typing@email.com')
 
 cy.get('.action-disabled')
   // Ignore error checking prior to type
   // like whether the input is visible or disabled
   .type('disabled error checking', { force: true })
-  .should('have.value', 'disabled error checking')</code></pre>
+cy.get('.action-disabled').should('have.value', 'disabled error checking')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -118,7 +118,7 @@ cy.get('.action-disabled')
           <h4 id="focus"><a href="https://on.cypress.io/focus">.focus()</a></h4>
           <p>To focus on a DOM element, use the <a href="https://on.cypress.io/focus"><code>.focus()</code></a> command.</p>
           <pre><code class="javascript">cy.get('.action-focus').focus()
-  .should('have.class', 'focus')
+cy.get('.action-focus').should('have.class', 'focus')
   .prev().should('have.attr', 'style', 'color: orange;')</code></pre>
         </div>
         <div class="col-xs-5">
@@ -137,9 +137,11 @@ cy.get('.action-disabled')
         <div class="col-xs-7">
           <h4 id="blur"><a href="https://on.cypress.io/blur">.blur()</a></h4>
           <p>To blur on a DOM element, use the <a href="https://on.cypress.io/blur"><code>.blur()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('.action-blur').type('About to blur').blur()
-  .should('have.class', 'error')
-  .prev().should('have.attr', 'style', 'color: red;')</code></pre>
+          <pre><code class="javascript">cy.get('.action-blur').type('About to blur')
+cy.get('.action-blur').blur()
+cy.get('.action-blur').should('have.class', 'error')
+  .prev().should('have.attr', 'style', 'color: red;')
+          </code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -158,9 +160,9 @@ cy.get('.action-disabled')
           <h4 id="clear"><a href="https://on.cypress.io/clear">.clear()</a></h4>
           <p>To clear on a DOM element, use the <a href="https://on.cypress.io/clear"><code>.clear()</code></a> command.</p>
           <pre><code class="javascript">cy.get('.action-clear').type('Clear this text')
-  .should('have.value', 'Clear this text')
-  .clear()
-  .should('have.value', '')</code></pre>
+cy.get('.action-clear').should('have.value', 'Clear this text')
+cy.get('.action-clear').clear()
+cy.get('.action-clear').should('have.value', '')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -180,8 +182,9 @@ cy.get('.action-disabled')
           <p>To submit a form, use the <a href="https://on.cypress.io/submit"><code>cy.submit()</code></a> command.</p>
           <pre><code class="javascript">cy.get('.action-form')
   .find('[type="text"]').type('HALFOFF')
+      
 cy.get('.action-form').submit()
-  .next().should('contain', 'Your form has been submitted!')</code></pre>
+cy.get('.action-form').next().should('contain', 'Your form has been submitted!')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -202,6 +205,19 @@ cy.get('.action-form').submit()
           <p>To click a DOM element, use the <a href="https://on.cypress.io/click"><code>.click()</code></a> command.</p>
           <pre><code class="javascript">cy.get('.action-btn').click()
 
+// You can click on 9 specific positions of an element:
+//  -----------------------------------
+// | topLeft        top       topRight |
+// |                                   |
+// |                                   |
+// |                                   |
+// | left          center        right |
+// |                                   |
+// |                                   |
+// |                                   |
+// | bottomLeft   bottom   bottomRight |
+//  -----------------------------------
+
 // clicking in the center of the element is the default
 cy.get('#action-canvas').click()
 
@@ -214,16 +230,17 @@ cy.get('#action-canvas').click('bottomLeft')
 cy.get('#action-canvas').click('bottom')
 cy.get('#action-canvas').click('bottomRight')
 
-// .click() accepts a an x and y coordinate
+// .click() accepts an x and y coordinate
 // that controls where the click occurs :)
+
 cy.get('#action-canvas')
-  .click(80, 75)
-  .click(170, 75)
-  .click(80, 165)
-  .click(100, 185)
-  .click(125, 190)
-  .click(150, 185)
-  .click(170, 165)
+cy.get('#action-canvas').click(80, 75) // click 80px on x coord and 75px on y coord
+cy.get('#action-canvas').click(170, 75)
+cy.get('#action-canvas').click(80, 165)
+cy.get('#action-canvas').click(100, 185)
+cy.get('#action-canvas').click(125, 190)
+cy.get('#action-canvas').click(150, 185)
+cy.get('#action-canvas').click(170, 165)
 
 // click multiple elements by passing multiple: true
 cy.get('.action-labels>.label').click({ multiple: true })
@@ -264,7 +281,10 @@ cy.get('.action-opacity>.btn').click({ force: true })</code></pre>
         <div class="col-xs-7">
           <h4 id="dblclick"><a href="https://on.cypress.io/dblclick">.dblclick()</a></h4>
           <p>To double click a DOM element, use the <a href="https://on.cypress.io/dblclick"><code>.dblclick()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('.action-div').dblclick().should('not.be.visible')
+          <pre><code class="javascript">// Our app has a listener on 'dblclick' event in our 'scripts.js'
+// that hides the div and shows an input on double click
+cy.get('.action-div').dblclick()
+cy.get('.action-div').should('not.be.visible')
 cy.get('.action-input-hidden').should('be.visible')</code></pre>
         </div>
         <div class="col-xs-5">
@@ -284,7 +304,10 @@ cy.get('.action-input-hidden').should('be.visible')</code></pre>
           <h4 id="rightclick"><a href="https://on.cypress.io/rightclick">.rightclick()</a></h4>
           <p>To right click a DOM element, use the <a href="https://on.cypress.io/rightclick"><code>.rightclick()</code></a>
             command.</p>
-          <pre><code class="javascript">cy.get('.rightclick-action-div').rightclick().should('not.be.visible')
+          <pre><code class="javascript">// Our app has a listener on 'contextmenu' event in our 'scripts.js'
+// that hides the div and shows an input on right click
+cy.get('.rightclick-action-div').rightclick()
+cy.get('.rightclick-action-div').should('not.be.visible')
 cy.get('.rightclick-action-input-hidden').should('be.visible')</code></pre>
         </div>
         <div class="col-xs-5">
@@ -307,26 +330,26 @@ cy.get('.rightclick-action-input-hidden').should('be.visible')</code></pre>
           <p>To check a checkbox or radio, use the <a href="https://on.cypress.io/check"><code>.check()</code></a> command.</p>
           <pre><code class="javascript">// By default, .check() will check all
 // matching checkbox or radio elements in succession, one after another
-cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]')
-  .check().should('be.checked')
+cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]').check()
+cy.get('.action-checkboxes [type="checkbox"]').not('[disabled]').should('be.checked')
 
-cy.get('.action-radios [type="radio"]').not('[disabled]')
-  .check().should('be.checked')
+cy.get('.action-radios [type="radio"]').not('[disabled]').check()
+cy.get('.action-radios [type="radio"]').not('[disabled]').should('be.checked')
 
 // .check() accepts a value argument
-cy.get('.action-radios [type="radio"]')
-  .check('radio1').should('be.checked')
+cy.get('.action-radios [type="radio"]').check('radio1')
+cy.get('.action-radios [type="radio"]').should('be.checked')
 
 // .check() accepts an array of values
-cy.get('.action-multiple-checkboxes [type="checkbox"]')
-  .check(['checkbox1', 'checkbox2']).should('be.checked')
+cy.get('.action-multiple-checkboxes [type="checkbox"]').check(['checkbox1', 'checkbox2'])
+cy.get('.action-multiple-checkboxes [type="checkbox"]').should('be.checked')
 
 // Ignore error checking prior to checking
-cy.get('.action-checkboxes [disabled]')
-  .check({ force: true }).should('be.checked')
+cy.get('.action-checkboxes [disabled]').check({ force: true })
+cy.get('.action-checkboxes [disabled]').should('be.checked')
 
-cy.get('.action-radios [type="radio"]')
-  .check('radio3', { force: true }).should('be.checked')</code></pre>
+cy.get('.action-radios [type="radio"]').check('radio3', { force: true })
+cy.get('.action-radios [type="radio"]').should('be.checked')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -408,21 +431,32 @@ cy.get('.action-radios [type="radio"]')
 // checkbox elements in succession, one after another
 cy.get('.action-check [type="checkbox"]')
   .not('[disabled]')
-  .uncheck().should('not.be.checked')
+  .uncheck()
+cy.get('.action-check [type="checkbox"]')
+  .not('[disabled]')
+  .should('not.be.checked')
 
 // .uncheck() accepts a value argument
 cy.get('.action-check [type="checkbox"]')
   .check('checkbox1')
-  .uncheck('checkbox1').should('not.be.checked')
+cy.get('.action-check [type="checkbox"]')
+  .uncheck('checkbox1')
+cy.get('.action-check [type="checkbox"][value="checkbox1"]')
+  .should('not.be.checked')
 
 // .uncheck() accepts an array of values
 cy.get('.action-check [type="checkbox"]')
   .check(['checkbox1', 'checkbox3'])
-  .uncheck(['checkbox1', 'checkbox3']).should('not.be.checked')
+cy.get('.action-check [type="checkbox"]')
+  .uncheck(['checkbox1', 'checkbox3'])
+cy.get('.action-check [type="checkbox"][value="checkbox1"]')
+  .should('not.be.checked')
+cy.get('.action-check [type="checkbox"][value="checkbox3"]')
+  .should('not.be.checked')
 
 // Ignore error checking prior to unchecking
-cy.get('.action-check [disabled]')
-  .uncheck({ force: true }).should('not.be.checked')</code></pre>
+cy.get('.action-check [disabled]').uncheck({ force: true })
+cy.get('.action-check [disabled]').should('not.be.checked')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -466,19 +500,23 @@ cy.get('.action-select').should('have.value', 'fr-apples')
 
 cy.get('.action-select-multiple')
   .select(['apples', 'oranges', 'bananas'])
+cy.get('.action-select-multiple')
   // when getting multiple values, invoke "val" method first
   .invoke('val')
   .should('deep.equal', ['fr-apples', 'fr-oranges', 'fr-bananas'])
 
 // Select option(s) with matching value
 cy.get('.action-select').select('fr-bananas')
+cy.get('.action-select')
   // can attach an assertion right away to the element
   .should('have.value', 'fr-bananas')
 
 cy.get('.action-select-multiple')
   .select(['fr-apples', 'fr-oranges', 'fr-bananas'])
+cy.get('.action-select-multiple')
   .invoke('val')
   .should('deep.equal', ['fr-apples', 'fr-oranges', 'fr-bananas'])
+
 // assert the selected values include oranges
 cy.get('.action-select-multiple')
   .invoke('val').should('include', 'fr-oranges')</code></pre>
@@ -507,11 +545,16 @@ cy.get('.action-select-multiple')
         <div class="col-xs-7">
           <h4 id="scrollIntoView"><a href="https://on.cypress.io/scrollintoview">.scrollIntoView()</a></h4>
           <p>To scroll an element into view, use the <a href="https://on.cypress.io/scrollintoview"><code>.scrollintoview()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('#scroll-horizontal button')
+          <pre><code class="javascript">// normally all of these buttons are hidden,
+// because they're not within
+// the viewable area of their parent
+// (we need to scroll to see them)
+cy.get('#scroll-horizontal button')
   .should('not.be.visible')
 
 // scroll the button into view, as if the user had scrolled
 cy.get('#scroll-horizontal button').scrollIntoView()
+cy.get('#scroll-horizontal button')
   .should('be.visible')
 
 cy.get('#scroll-vertical button')
@@ -519,6 +562,7 @@ cy.get('#scroll-vertical button')
 
 // Cypress handles the scroll direction needed
 cy.get('#scroll-vertical button').scrollIntoView()
+cy.get('#scroll-vertical button')
   .should('be.visible')
 
 cy.get('#scroll-both button')
@@ -526,6 +570,7 @@ cy.get('#scroll-both button')
 
 // Cypress knows to scroll to the right and down
 cy.get('#scroll-both button').scrollIntoView()
+cy.get('#scroll-both button')
   .should('be.visible')</code></pre>
         </div>
         <div class="col-xs-5">
@@ -558,7 +603,20 @@ cy.get('#scroll-both button').scrollIntoView()
         <div class="col-xs-7">
           <h4 id="scrollTo"><a href="https://on.cypress.io/scrollto">cy.scrollTo()</a></h4>
           <p>To scroll the window or a scrollable element to a specific position, use the <a href="https://on.cypress.io/scrollto"><code>cy.scrollTo()</code></a> command.</p>
-          <pre><code class="javascript">// if you chain .scrollTo() off of cy, we will
+          <pre><code class="javascript">// You can scroll to 9 specific positions of an element:
+//  -----------------------------------
+// | topLeft        top       topRight |
+// |                                   |
+// |                                   |
+// |                                   |
+// | left          center        right |
+// |                                   |
+// |                                   |
+// |                                   |
+// | bottomLeft   bottom   bottomRight |
+//  -----------------------------------
+
+// if you chain .scrollTo() off of cy, we will
 // scroll the entire window
 cy.scrollTo('bottom')
 
@@ -679,9 +737,17 @@ cy.get('#scrollable-both').scrollTo('center', { duration: 2000 })</code></pre>
         <div class="col-xs-7">
           <h4 id="trigger"><a href="https://on.cypress.io/trigger">.trigger()</a></h4>
           <p>To trigger an event on a DOM element, use the <a href="https://on.cypress.io/trigger"><code>.trigger()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('.trigger-input-range')
+          <pre><code class="javascript">// To interact with a range input (slider)
+// we need to set its value & trigger the
+// event to signal it changed
+
+// Here, we invoke jQuery's val() method to set
+// the value and trigger the 'change' event
+cy.get('.trigger-input-range')
   .invoke('val', 25)
+cy.get('.trigger-input-range')
   .trigger('change')
+cy.get('.trigger-input-range')
   .get('input[type=range]').siblings('p')
   .should('have.text', '25')</code></pre>
         </div>

--- a/commands/cookies.html
+++ b/commands/cookies.html
@@ -188,7 +188,7 @@ cy.get('#clearCookie .set-a-cookie').click()
 cy.getCookie('token').should('have.property', 'value', '123ABC')
 
 // cy.clearCookies() yields null
-cy.clearCookie('token').should('be.null')
+cy.clearCookie('token')
 
 cy.getCookie('token').should('be.null')</code></pre>
         </div>

--- a/commands/misc.html
+++ b/commands/misc.html
@@ -70,45 +70,6 @@
   <div class="container content-container">
     <div id="misc">
       <div class="row">
-
-        <div class="col-xs-7">
-          <h4 id="end"><a href="https://on.cypress.io/end">.end()</a></h4>
-          <p>To end the command chain, use the <a href="https://on.cypress.io/end"><code>.end()</code></a> command.</p>
-          <pre><code class="javascript">// cy.end is useful when you want to end a chain of commands
-// and force Cypress to re-query from the root element
-cy.get('.misc-table').within(() => {
-  // ends the current chain and yields null
-  cy.contains('Cheryl').click().end()
-
-  // queries the entire table again
-  cy.contains('Charles').click()
-})</code></pre>
-        </div>
-        <div class="col-xs-5">
-          <div class="well">
-            <table class="table table-bordered misc-table">
-              <thead>
-                <tr>
-                  <th>Table</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>User: Cheryl</td>
-                </tr>
-                <tr>
-                  <td>User: Charles</td>
-                </tr>
-                <tr>
-                  <td>User: Darryl</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="col-xs-12"><hr></div>
-
         <div class="col-xs-12">
           <h4 id="exec"><a href="https://on.cypress.io/exec">cy.exec()</a></h4>
           <p>To execute a system command, use the <a href="https://on.cypress.io/exec"><code>cy.exec()</code></a> command.</p>

--- a/commands/spies-stubs-clocks.html
+++ b/commands/spies-stubs-clocks.html
@@ -128,13 +128,14 @@ expect(stub).to.be.called</code></pre>
         <div class="col-xs-7">
           <h4 id="clock"><a href="https://on.cypress.io/clock">cy.clock()</a></h4>
           <p>To control time in the browser, use the <a href="https://on.cypress.io/clock"><code>cy.clock()</code></a> command.</p>
-          <pre><code class="javascript">// create the date in UTC so its always the same
+          <pre><code class="javascript">// create the date in UTC so it's always the same
 // no matter what local timezone the browser is running in
 const now = new Date(Date.UTC(2017, 2, 14)).getTime()
 
 cy.clock(now)
 cy.visit('https://example.cypress.io/commands/spies-stubs-clocks')
 cy.get('#clock-div').click()
+cy.get('#clock-div')
   .should('have.text', '1489449600')</code></pre>
         </div>
         <div class="col-xs-5">
@@ -150,16 +151,18 @@ cy.get('#clock-div').click()
         <div class="col-xs-7">
           <h4 id="tick"><a href="https://on.cypress.io/tick">cy.tick()</a></h4>
           <p>To move time in the browser, use the <a href="https://on.cypress.io/tick"><code>cy.tick()</code></a> command.</p>
-          <pre><code class="javascript">// create the date in UTC so its always the same
+          <pre><code class="javascript">// create the date in UTC so it's always the same
 // no matter what local timezone the browser is running in
 const now = new Date(Date.UTC(2017, 2, 14)).getTime()
 
 cy.clock(now)
 cy.visit('https://example.cypress.io/commands/spies-stubs-clocks')
 cy.get('#tick-div').click()
+cy.get('#tick-div')
   .should('have.text', '1489449600')
 cy.tick(10000) // 10 seconds passed
 cy.get('#tick-div').click()
+cy.get('#tick-div')
   .should('have.text', '1489449610')</code></pre>
         </div>
         <div class="col-xs-5">

--- a/commands/storage.html
+++ b/commands/storage.html
@@ -74,43 +74,48 @@
         <div class="col-xs-7">
           <h4><a href="https://on.cypress.io/clearlocalstorage">cy.clearLocalStorage()</a></h4>
           <p>To clear all data in localStorage for the current origin, use the <a href="https://on.cypress.io/clearlocalstorage"><code>cy.clearLocalStorage()</code></a> command.</p>
-          <pre><code class="javascript">cy.get('.ls-btn').click().should(() => {
+          <pre><code class="javascript">cy.get('.ls-btn').click()
+cy.get('.ls-btn').should(() => {
   expect(localStorage.getItem('prop1')).to.eq('red')
   expect(localStorage.getItem('prop2')).to.eq('blue')
   expect(localStorage.getItem('prop3')).to.eq('magenta')
 })
 
-// clearLocalStorage() yields the localStorage object
-cy.clearLocalStorage().should((ls) => {
-  expect(ls.getItem('prop1')).to.be.null
-  expect(ls.getItem('prop2')).to.be.null
-  expect(ls.getItem('prop3')).to.be.null
+cy.clearLocalStorage()
+cy.getAllLocalStorage().should(() => {
+  expect(localStorage.getItem('prop1')).to.be.null
+  expect(localStorage.getItem('prop2')).to.be.null
+  expect(localStorage.getItem('prop3')).to.be.null
+})
+
+cy.get('.ls-btn').click()
+cy.get('.ls-btn').should(() => {
+  expect(localStorage.getItem('prop1')).to.eq('red')
+  expect(localStorage.getItem('prop2')).to.eq('blue')
+  expect(localStorage.getItem('prop3')).to.eq('magenta')
 })
 
 // Clear key matching string in localStorage
-cy.get('.ls-btn').click().should(() => {
-  expect(localStorage.getItem('prop1')).to.eq('red')
+cy.clearLocalStorage('prop1')
+cy.getAllLocalStorage().should(() => {
+  expect(localStorage.getItem('prop1')).to.be.null
   expect(localStorage.getItem('prop2')).to.eq('blue')
   expect(localStorage.getItem('prop3')).to.eq('magenta')
 })
 
-cy.clearLocalStorage('prop1').should((ls) => {
-  expect(ls.getItem('prop1')).to.be.null
-  expect(ls.getItem('prop2')).to.eq('blue')
-  expect(ls.getItem('prop3')).to.eq('magenta')
+cy.get('.ls-btn').click()
+cy.get('.ls-btn').should(() => {
+  expect(localStorage.getItem('prop1')).to.eq('red')
+  expect(localStorage.getItem('prop2')).to.eq('blue')
+  expect(localStorage.getItem('prop3')).to.eq('magenta')
 })
 
 // Clear keys matching regex in localStorage
-cy.get('.ls-btn').click().should(() => {
-  expect(localStorage.getItem('prop1')).to.eq('red')
-  expect(localStorage.getItem('prop2')).to.eq('blue')
+cy.clearLocalStorage(/prop1|2/)
+cy.getAllLocalStorage().should(() => {
+  expect(localStorage.getItem('prop1')).to.be.null
+  expect(localStorage.getItem('prop2')).to.be.null
   expect(localStorage.getItem('prop3')).to.eq('magenta')
-})
-
-cy.clearLocalStorage(/prop1|2/).should((ls) => {
-  expect(ls.getItem('prop1')).to.be.null
-  expect(ls.getItem('prop2')).to.be.null
-  expect(ls.getItem('prop3')).to.eq('magenta')
 })</code></pre>
         </div>
         <div class="col-xs-5">
@@ -159,10 +164,11 @@ cy.getAllLocalStorage().should((storageMap) => {
           <pre><code class="javascript">cy.get('.ls-btn').click()
 
 // clearAllLocalStorage() yields null
-cy.clearAllLocalStorage().should(() => {
-  expect(sessionStorage.getItem('prop1')).to.be.null
-  expect(sessionStorage.getItem('prop2')).to.be.null
-  expect(sessionStorage.getItem('prop3')).to.be.null
+cy.clearAllLocalStorage()
+cy.getAllLocalStorage().should(() => {
+  expect(localStorage.getItem('prop1')).to.be.null
+  expect(localStorage.getItem('prop2')).to.be.null
+  expect(localStorage.getItem('prop3')).to.be.null
 })</code></pre>
         </div>
         <div class="col-xs-5">
@@ -208,7 +214,8 @@ cy.getAllSessionStorage().should((storageMap) => {
           <pre><code class="javascript">cy.get('.ls-btn').click()
 
 // clearAllSessionStorage() yields null
-cy.clearAllSessionStorage().should(() => {
+cy.clearAllSessionStorage()
+cy.getAllSessionStorage().should(() => {
   expect(sessionStorage.getItem('prop4')).to.be.null
   expect(sessionStorage.getItem('prop5')).to.be.null
   expect(sessionStorage.getItem('prop6')).to.be.null

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
   <div class="banner">
     <div class="container">
       <h1>Kitchen Sink</h1>
-      <p>This is an example app used to showcase <a href="https://www.cypress.io" target="_blank">Cypress.io</a> testing. For a full reference of our documentation, go to <a href="https://docs.cypress.io" target="_blank">docs.cypress.io</a>
+      <p>This is an example app used to showcase <a href="https://www.cypress.io" target="_blank">Cypress.io</a> End-to-End (E2E) testing. For a full reference of our documentation, go to <a href="https://docs.cypress.io" target="_blank">docs.cypress.io</a>
       </p>
     </div>
   </div>
@@ -176,7 +176,6 @@
           <li>
             <a href="/commands/misc">Misc</a>
             <ul>
-              <li><a href="/commands/misc">end</a></li>
               <li><a href="/commands/misc">exec</a></li>
               <li><a href="/commands/misc">focused</a></li>
               <li><a href="/commands/misc">screenshot</a></li>

--- a/utilities.html
+++ b/utilities.html
@@ -88,10 +88,9 @@
           <p>To call a jQuery method, use the <a href="https://on.cypress.io/$"><code>Cypress.$</code></a> command.</p>
           <pre><code class="javascript">let $li = Cypress.$('.utility-jquery li:first')
 
-cy.wrap($li)
-  .should('not.have.class', 'active')
-  .click()
-  .should('have.class', 'active')</code></pre>
+cy.wrap($li).should('not.have.class', 'active')
+cy.wrap($li).click()
+cy.wrap($li).should('have.class', 'active')</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">
@@ -115,21 +114,23 @@ cy.wrap($li)
         <div class="col-xs-7">
           <h4 id="Blob"><a href="https://on.cypress.io/blob">Cypress.Blob</a></h4>
           <p>To work with blobs, convert strings, and other utility functions, use the <a href="https://on.cypress.io/blob"><code>Cypress.Blob</code></a> library.</p>
-          <pre><code class="javascript">cy.get('.utility-blob').then(($div) =>
-// https://github.com/nolanlawson/blob-util#imgSrcToDataURL
-// get the dataUrl string for the javascript-logo
-  Cypress.Blob.imgSrcToDataURL('https://example.cypress.io/assets/img/javascript-logo.png', undefined, 'anonymous')
+          <pre><code class="javascript">cy.get('.utility-blob').then(($div) => {
+  // https://github.com/nolanlawson/blob-util#imgSrcToDataURL
+  // get the dataUrl string for the javascript-logo
+  return Cypress.Blob.imgSrcToDataURL('https://example.cypress.io/assets/img/javascript-logo.png', undefined, 'anonymous')
   .then((dataUrl) => {
     // create an <img> element and set its src to the dataUrl
     let img = Cypress.$('<img />', { src: dataUrl })
+
     // need to explicitly return cy here since we are initially returning
     // the Cypress.Blob.imgSrcToDataURL promise to our test
     // append the image
     $div.append(img)
 
     cy.get('.utility-blob img').click()
-      .should('have.attr', 'src', dataUrl)
-  }))</code></pre>
+    cy.get('.utility-blob img').should('have.attr', 'src', dataUrl)
+  })
+})</code></pre>
         </div>
         <div class="col-xs-5">
           <div class="well">


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/29156

### Additional details

Updates https://example.cypress.io/ through branch [gh-pages](https://github.com/cypress-io/cypress/tree/gh-pages) to deploy app from [cypress-example-kitchensink@2.0.5](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v2.0.5).

### Steps to test

#### Smoke test

- Open https://example.cypress.io/ . The text "This is an example app used to showcase Cypress.io End-to-End (E2E) testing." should be displayed.
- Open https://example.cypress.io/commands/misc and confirm that the `.end()` section no longer appears.

#### Scaffolded test execution

Execute:

```shell
mkdir cy-test-app
cd cy-test-app
git init
npm init -y
npm install cypress
npx cypress open --e2e --browser electron
```

Select Continue
Select "Scaffold example specs"
Select "Okay, I got it!"
Exit Cypress Runner and Launchpad

```shell
npx cypress run
```

confirm all tests run successfully.

### How has the user experience changed?

- Content on https://example.cypress.io/ is updated to align with scaffolded tests from PR https://github.com/cypress-io/cypress/pull/29229.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

