### PR TITLE
chore: move to macstadium intel runner for circle darwinx64 [run ci]

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-12-24-macstadium-intel-m1
+04-12-24-macstadium-intel-m1-cache2

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-12-24-macstadium-intel-m1-cache4
+04-15-24

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-8-24
+04-8-24-macstadium-intel

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-8-24-macstadium-intel
+04-12-24-macstadium-intel-m1

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-12-24-macstadium-intel-m1-cache2
+04-12-24-macstadium-intel-m1-cache3

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-15-24
+04-15-24-macstadium

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-15-24-macstadium-2
+04-15-24-macstadium-3

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-12-24-macstadium-intel-m1-cache3
+04-12-24-macstadium-intel-m1-cache4

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-04-15-24-macstadium
+04-15-24-macstadium-2

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -3366,46 +3366,46 @@ darwin-x64-workflow: &darwin-x64-workflow
         resource_class: cypress-io/intel-macstadium
         only-cache-for-root-user: true
 
-    - build:
-        name: darwin-x64-build
-        context: test-runner:env-canary
-        executor: darwin-amd64
-        resource_class: cypress-io/intel-macstadium
-        requires:
-          - darwin-x64-node-modules-install
+    # - build:
+    #     name: darwin-x64-build
+    #     context: test-runner:env-canary
+    #     executor: darwin-amd64
+    #     resource_class: cypress-io/intel-macstadium
+    #     requires:
+    #       - darwin-x64-node-modules-install
 
-    - create-build-artifacts:
-        name: darwin-x64-create-build-artifacts
-        context:
-          - test-runner:sign-mac-binary
-          - test-runner:upload
-          - test-runner:commit-status-checks
-          - test-runner:build-binary
-        executor: darwin-amd64
-        resource_class: cypress-io/intel-macstadium
-        requires:
-          - darwin-x64-build
+    # - create-build-artifacts:
+    #     name: darwin-x64-create-build-artifacts
+    #     context:
+    #       - test-runner:sign-mac-binary
+    #       - test-runner:upload
+    #       - test-runner:commit-status-checks
+    #       - test-runner:build-binary
+    #     executor: darwin-amd64
+    #     resource_class: cypress-io/intel-macstadium
+    #     requires:
+    #       - darwin-x64-build
 
-    - v8-integration-tests:
-        name: darwin-x64-v8-integration-tests
-        executor: darwin-amd64
-        resource_class: cypress-io/intel-macstadium
-        requires:
-          - darwin-x64-build
+    # - v8-integration-tests:
+    #     name: darwin-x64-v8-integration-tests
+    #     executor: darwin-amd64
+    #     resource_class: cypress-io/intel-macstadium
+    #     requires:
+    #       - darwin-x64-build
 
-    - driver-integration-memory-tests:
-        name: darwin-x64-driver-integration-memory-tests
-        executor: darwin-amd64
-        resource_class: cypress-io/intel-macstadium
-        requires:
-          - darwin-x64-build
+    # - driver-integration-memory-tests:
+    #     name: darwin-x64-driver-integration-memory-tests
+    #     executor: darwin-amd64
+    #     resource_class: cypress-io/intel-macstadium
+    #     requires:
+    #       - darwin-x64-build
   
-    - server-unit-tests-cloud-environment:
-        name: darwin-x64-driver-server-unit-tests-cloud-environment
-        executor: darwin-amd64
-        resource_class: cypress-io/intel-macstadium
-        requires:
-          - darwin-x64-build
+    # - server-unit-tests-cloud-environment:
+    #     name: darwin-x64-driver-server-unit-tests-cloud-environment
+    #     executor: darwin-amd64
+    #     resource_class: cypress-io/intel-macstadium
+    #     requires:
+    #       - darwin-x64-build
 
 darwin-arm64-workflow: &darwin-arm64-workflow
   jobs:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -45,7 +45,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
     - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
-    - equal: [ 'ryanm/fix/service-worker-capture', << pipeline.git.branch >> ]
+    - equal: [ 'chore/move_off_circle_to_macstadium_amd64', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -58,7 +58,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
     - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
-    - equal: [ 'em/circle2', << pipeline.git.branch >> ]
+    - equal: [ 'chore/move_off_circle_to_macstadium_amd64', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -84,7 +84,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
     - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
     - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
-    - equal: [ 'chore/reduce_windows_flake', << pipeline.git.branch >> ]
+    - equal: [ 'chore/move_off_circle_to_macstadium_amd64', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -111,11 +111,8 @@ executors:
   # executor to run on Mac OS
   # https://circleci.com/docs/2.0/executor-types/#using-macos
   # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-  mac:
-    macos:
-      # Executor should have Node >= required version
-      xcode: "14.0.1"
-    resource_class: macos.x86.medium.gen2
+  darwin-amd64:
+    machine: true
     environment:
       PLATFORM: darwin
 
@@ -154,7 +151,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "feat/protocol_shadow_dom_support" && "$CIRCLE_BRANCH" != "cacie/dep/electron-27" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "publish-binary" && "$CIRCLE_BRANCH" != "feat/protocol_shadow_dom_support" && "$CIRCLE_BRANCH" != "chore/move_off_circle_to_macstadium_amd64" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command
@@ -2262,6 +2259,7 @@ jobs:
       resource_class:
         type: string
         default: medium+
+    resource_class: << parameters.resource_class >>
     steps:
       - restore_cached_workspace
       - clone-repo-and-checkout-branch:
@@ -3364,15 +3362,15 @@ darwin-x64-workflow: &darwin-x64-workflow
   jobs:
     - node_modules_install:
         name: darwin-x64-node-modules-install
-        executor: mac
-        resource_class: macos.x86.medium.gen2
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         only-cache-for-root-user: true
 
     - build:
         name: darwin-x64-build
         context: test-runner:env-canary
-        executor: mac
-        resource_class: macos.x86.medium.gen2
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         requires:
           - darwin-x64-node-modules-install
 
@@ -3383,33 +3381,29 @@ darwin-x64-workflow: &darwin-x64-workflow
           - test-runner:upload
           - test-runner:commit-status-checks
           - test-runner:build-binary
-        executor: mac
-        resource_class: macos.x86.medium.gen2
-        requires:
-          - darwin-x64-build
-
-    - test-kitchensink:
-        name: darwin-x64-test-kitchensink
-        executor: mac
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         requires:
           - darwin-x64-build
 
     - v8-integration-tests:
         name: darwin-x64-v8-integration-tests
-        executor: mac
-        resource_class: macos.x86.medium.gen2
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         requires:
           - darwin-x64-build
+
     - driver-integration-memory-tests:
         name: darwin-x64-driver-integration-memory-tests
-        executor: mac
-        resource_class: macos.x86.medium.gen2
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         requires:
           - darwin-x64-build
+  
     - server-unit-tests-cloud-environment:
         name: darwin-x64-driver-server-unit-tests-cloud-environment
-        executor: mac
-        resource_class: macos.x86.medium.gen2
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
         requires:
           - darwin-x64-build
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -3366,46 +3366,46 @@ darwin-x64-workflow: &darwin-x64-workflow
         resource_class: cypress-io/intel-macstadium
         only-cache-for-root-user: true
 
-    # - build:
-    #     name: darwin-x64-build
-    #     context: test-runner:env-canary
-    #     executor: darwin-amd64
-    #     resource_class: cypress-io/intel-macstadium
-    #     requires:
-    #       - darwin-x64-node-modules-install
+    - build:
+        name: darwin-x64-build
+        context: test-runner:env-canary
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
+        requires:
+          - darwin-x64-node-modules-install
 
-    # - create-build-artifacts:
-    #     name: darwin-x64-create-build-artifacts
-    #     context:
-    #       - test-runner:sign-mac-binary
-    #       - test-runner:upload
-    #       - test-runner:commit-status-checks
-    #       - test-runner:build-binary
-    #     executor: darwin-amd64
-    #     resource_class: cypress-io/intel-macstadium
-    #     requires:
-    #       - darwin-x64-build
+    - create-build-artifacts:
+        name: darwin-x64-create-build-artifacts
+        context:
+          - test-runner:sign-mac-binary
+          - test-runner:upload
+          - test-runner:commit-status-checks
+          - test-runner:build-binary
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
+        requires:
+          - darwin-x64-build
 
-    # - v8-integration-tests:
-    #     name: darwin-x64-v8-integration-tests
-    #     executor: darwin-amd64
-    #     resource_class: cypress-io/intel-macstadium
-    #     requires:
-    #       - darwin-x64-build
+    - v8-integration-tests:
+        name: darwin-x64-v8-integration-tests
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
+        requires:
+          - darwin-x64-build
 
-    # - driver-integration-memory-tests:
-    #     name: darwin-x64-driver-integration-memory-tests
-    #     executor: darwin-amd64
-    #     resource_class: cypress-io/intel-macstadium
-    #     requires:
-    #       - darwin-x64-build
+    - driver-integration-memory-tests:
+        name: darwin-x64-driver-integration-memory-tests
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
+        requires:
+          - darwin-x64-build
   
-    # - server-unit-tests-cloud-environment:
-    #     name: darwin-x64-driver-server-unit-tests-cloud-environment
-    #     executor: darwin-amd64
-    #     resource_class: cypress-io/intel-macstadium
-    #     requires:
-    #       - darwin-x64-build
+    - server-unit-tests-cloud-environment:
+        name: darwin-x64-driver-server-unit-tests-cloud-environment
+        executor: darwin-amd64
+        resource_class: cypress-io/intel-macstadium
+        requires:
+          - darwin-x64-build
 
 darwin-arm64-workflow: &darwin-arm64-workflow
   jobs:

--- a/packages/app/cypress/e2e/runner/cloud-debug-filter.cy.ts
+++ b/packages/app/cypress/e2e/runner/cloud-debug-filter.cy.ts
@@ -106,7 +106,7 @@ describe('cloud debug test filtering', () => {
 
     cy.get('.debug-dismiss').contains('2 / 4 tests').click().waitForSpecToFinish()
 
-    // suite.only is respected
+    // suite only is respected
     cy.withCtx((ctx) => {
       ctx.coreData.cloudProject.testsForRunResults = {
         'cypress/e2e/skip-and-only.cy.js': ['t3', 's1 t4'],

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -83,7 +83,7 @@ describe('http/request-middleware', () => {
 
         expect(ctx.req.headers!['x-cypress-is-from-extra-target']).not.to.exist
         expect(ctx.req.isFromExtraTarget).to.be.true
-        expect(ctx.onlyRunMiddleware).to.be.calledWith(['MaybeSetBasicAuthHeaders', 'SendRequestOutgoing'])
+        expect(ctx['onlyRunMiddleware']).to.be.calledWith(['MaybeSetBasicAuthHeaders', 'SendRequestOutgoing'])
       })
 
       it('when it does not exist, removes header and sets in on the req', async () => {

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -127,7 +127,7 @@ describe('http/response-middleware', function () {
       .then(() => {
         expect(ctx.res.set).to.be.calledWith(headers)
 
-        expect(ctx.onlyRunMiddleware).to.be.calledWith([
+        expect(ctx['onlyRunMiddleware']).to.be.calledWith([
           'AttachPlainTextStreamFn',
           'PatchExpressSetHeader',
           'MaybeSendRedirectToClient',
@@ -144,7 +144,7 @@ describe('http/response-middleware', function () {
 
       return testMiddleware([FilterNonProxiedResponse], ctx)
       .then(() => {
-        expect(ctx.onlyRunMiddleware).not.to.be.called
+        expect(ctx['onlyRunMiddleware']).not.to.be.called
       })
     })
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #28033 

### Additional details
Circle CI is removing intel based resource classes on mac os, so we have migrated to macstadium to build the intel binary. More can be seen in [their blog post](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718?mkt_tok=NDg1LVpNSC02MjYAAAGNzIE9JKs7lQUAbEHjfO1sLpj412zKrQp01dqd7m-QODPrCuvuik1z9SgHLQqqAfn2tcr9NuhoepbNGp_U4NvxkdfJysL_15ZncE_OW-OfErkjAQ).

This means we cannot build the MacOS Intel binary on CircleCI after June 28th, 2024. We could build a composite binary for M1 and Intel, but this doubles the size of the binary and is not an option for us. To work around this, we are opting for a MacStadium Intel machine in addition to our M1 MacStadium Machine. This allows us to continue to build the intel based Mac binary at a fixed cost.

For the meantime, our M1 jobs will also run on MacStadium .

We can no longer run the kitchen sink jobs on mac intel due to the working directory being in the tmp directory, which now has persisted state. The self hosted runner configuration is not sophisticated enough to clear multiple directories. It might be possible to accomplish this with a [command_prefix](https://circleci.com/docs/runner-config-reference/#runner-command-prefix), but this doesn't seem worth the headache.

This also means similar to our M1 runner, our jobs will complete serially. This means if there is heavy demand to build the Mac Intel binary, the jobs will not execute and parallel and time to complete will likely be slow. 

NOTE: this runner is also on CircleCI Machine runner 3.0

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
