### PR TITLE
docs: add contributor instructions for Python 3.11 on Ubuntu 24.04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,8 +206,28 @@ You must have the following installed on your system to contribute locally:
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements. Use Python `3.11` or lower.)
-  - Note for Debian-based systems: `python` is pre-installed.<br>`sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
-  - Note for Windows systems: when installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.
+
+#### Debian/Ubuntu
+
+`sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
+`python` is pre-installed on Debian-based systems including Ubuntu.
+The Python versions shipped with Ubuntu versions `20.04`, `23.10` and `22.04` are compatible with Cypress requirements.
+
+Only on Ubuntu `24.04` install Python `3.11` by executing the following command:
+
+```shell
+ sudo apt install python3.11
+```
+
+Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:
+
+```shell
+export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
+```
+
+#### Windows
+
+When installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.
 
 ### Getting Started
 


### PR DESCRIPTION
### Additional details

Ubuntu `24.04` ships with Python `3.12`, which is not compatible with the Cypress `yarn` build process. Ubuntu `24.04` is currently available as a beta version and the [planned release date](https://wiki.ubuntu.com/Releases) is April 2024.

If the pre-installed Python `3.12` version of Ubuntu `24.04` is used by `yarn install` then the build encounters the errors described in https://github.com/cypress-io/cypress/issues/28695 when it attempts to install the npm modules:

- [registry-js](https://www.npmjs.com/package/registry-js)
- [cpu-features](https://www.npmjs.com/package/cpu-features)

The error messages include the following line caused by a breaking change in Python `3.12` which is incompatible with the version of `node-gyp` currently used by Cypress:

> ModuleNotFoundError: No module named 'distutils'

This PR adds instructions to the [CONTRIBUTING](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md) document to install Python `3.11` on Ubuntu `24.04` in addition to the pre-installed Python `3.12` version. Python `3.11` is the highest version compatible with the Cypress Yarn build process.

Note: Cypress will build using the default pre-installed versions of Python on earlier versions of Ubuntu (`20.04`, `23.10` and `22.04`). These Ubuntu versions have Python versions `3.8`, `3.10` and `3.11` respectively pre-installed and so no changes in instructions are necessary for these Ubuntu versions.

### Installation instructions

These instructions are intended for Ubuntu `24.04` only:

Execute

```shell
sudo apt install python3.11
```

Add the following to `~/.bashrc`

```shell
export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
```

### Steps to test

On Ubuntu `24.04` apply the above installation instructions, then execute:

```bash
sudo apt install git g++ make curl
curl -L https://bit.ly/n-install | bash
. ~/.bashrc
cd ~
git clone https://github.com/cypress-io/cypress
cd cypress
n auto
npm install yarn -g
yarn
```

The build log should contain the following steps with no errors recorded between these two lines:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

### How has the user experience changed?

This is a documentation change which affects only contributors to Cypress. There is no change to the user experience of end-users.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
