### PR TITLE
chore: fix incorrect description of `cy.clear` command

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -910,7 +910,7 @@ declare namespace Cypress {
 
     /**
      * Clear the value of an `input` or `textarea`.
-     * An alias for `.type({selectall}{backspace})`
+     * An alias for `.type({selectall}{del})`
      *
      * @see https://on.cypress.io/clear
      */


### PR DESCRIPTION
https://github.com/cypress-io/cypress/blob/5a8618fad108a981ff8cdfe5f83072c4ab36a02e/packages/driver/src/cy/commands/actions/type.ts#L638

___

Create a simple component test:

```ts
import {Component} from '@angular/core';
import {mount} from 'cypress/angular';

@Component({
    standalone: true,
    template: `
        <input
            (beforeinput)="log('beforeinput', $event)"
            (input)="log('input', $event)"
        />
    `,
})
export class TestInput {
    protected log(eventName: string, event: any): void {
        console.log(`=[${eventName}]=`, {inputType: event.inputType});
    }
}

describe('Demonstration of incorrect documentation for cy.clear()', () => {
    it('Open dev tools and see console logs', () => {
        mount(TestInput);

        cy.get('input').type('1').clear();
    });
});
```

Run it and check console logs:
```shell
=[beforeinput]= {inputType: 'insertText'}
=[input]= {inputType: ''}
=[beforeinput]= {inputType: 'deleteContentForward'}
=[input]= {inputType: ''}
```

Backspace key produces `deleteContentBackward` (not forward!).