### PR TITLE
docs: fix .eslintrc.json syntax in eslint-plugin-dev readme

### DIFF
--- a/npm/eslint-plugin-dev/README.md
+++ b/npm/eslint-plugin-dev/README.md
@@ -44,7 +44,7 @@ babel-eslint
     "@cypress/dev"
   ],
   "extends": [
-    "plugin:@cypress/dev/general",
+    "plugin:@cypress/dev/general"
   ]
 }
 ```


### PR DESCRIPTION
### Additional details

In [npm/eslint-plugin-dev/README.md](https://github.com/cypress-io/cypress/blob/develop/npm/eslint-plugin-dev/README.md) the instructions for creating `.eslintrc.json` included a syntax error due to an extra comma. The documentation is corrected to remove the comma.

The error message shown by ESLint contained the following text:

```text
Error: Unexpected token ']', ..."neral",
  ]
}
" is not valid JSON
```

### Steps to test

On Ubuntu `22.04.4` LTS with Node.js `20.12.2`, execute the following:

```bash
mkdir eslint-plugin-dev-test
cd eslint-plugin-dev-test
git init
npm init -y
npm install eslint@7 @cypress/eslint-plugin-dev eslint-plugin-json-format @typescript-eslint/parser@6 @typescript-eslint/eslint-plugin@6 eslint-plugin-mocha -D
```

Add the file `.eslintrc.json` with the following contents to the root of the above project:

```json
{
  "plugins": [
    "@cypress/dev"
  ],
  "extends": [
    "plugin:@cypress/dev/general"
  ]
}
```

```shell
touch index.js
npx eslint .
```

### How has the user experience changed?

There is no change to the end-user experience. This is a documentation-only change which affects Cypress developers only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
