### PR TITLE
chore: Add experimentalMemoryManagement flag to our cy-in-cy App tests

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1851,7 +1851,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: large
       percy:
         type: boolean
         default: false

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -663,9 +663,6 @@ commands:
             echo Total containers $CIRCLE_NODE_TOTAL
 
             if [[ -v MAIN_RECORD_KEY ]]; then
-              if [[ <<parameters.package>> == 'app' && <<parameters.type>> == 'e2e' ]]; then
-                export DEBUG=cypress:*
-              fi
               # internal PR
               cmd=$([[ <<parameters.percy>> == 'true' ]] && echo 'yarn percy exec --parallel -- --') || true
 

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -29,10 +29,8 @@ mainBuildFilters: &mainBuildFilters
         - develop
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-        - 'cacie/dep/electron-27'
-        - 'feat/protocol_shadow_dom_support'
+        - 'app-mem-mng-flag'
         - 'publish-binary'
-        - 'em/circle2'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -43,9 +41,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
-    - equal: [ 'feat/support_wds5', << pipeline.git.branch >> ]
+    - equal: [ 'app-mem-mng-flag', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -56,9 +52,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'feat/support_wds5', << pipeline.git.branch >> ]
-    - equal: [ 'em/circle2', << pipeline.git.branch >> ]
+    - equal: [ 'app-mem-mng-flag', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -81,10 +75,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/dep/electron-27', << pipeline.git.branch >> ]
-    - equal: [ 'feat/protocol_shadow_dom_support', << pipeline.git.branch >> ]
-    - equal: [ 'lerna-optimize-tasks', << pipeline.git.branch >> ]
-    - equal: [ 'feat/support_wds5', << pipeline.git.branch >> ]
+    - equal: [ 'app-mem-mng-flag', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/packages/app/cypress.config.ts
+++ b/packages/app/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   reporterOptions: {
     configFile: '../../mocha-reporter-config.json',
   },
+  experimentalMemoryManagement: true,
   experimentalCspAllowList: false,
   experimentalInteractiveRunEvents: true,
   component: {


### PR DESCRIPTION
Close https://github.com/cypress-io/cypress/issues/29357

### Additional details

This PR sets `experimentalMemoryManagement` to `true` for our internal app tests. Our internal App tests run cypress within cypress, which is a unique situation that our users don't encounter. The memory used in Chrome was causing this job to crash Chrome frequently. 

I don't see a large increase in the time to run these tests, maybe an increase of ~20-30 secs in linux and windows. I suspect they'll be more stable though. 

Additionally, this PR upgrades the resource class used to run `run-app-integration-tests-chrome` job to large from medium. The medium resource class was always maxing out at 100% CPU. 

### Before

https://app.circleci.com/pipelines/github/cypress-io/cypress/61043/workflows/b0bfd961-3476-4450-9916-36d299560584/jobs/2538781/resources

![Screenshot 2024-04-19 at 9 52 18 AM](https://github.com/cypress-io/cypress/assets/1271364/b3fab722-d328-4e67-9286-5c9d618e54cc)


### After

https://app.circleci.com/pipelines/github/cypress-io/cypress/61054/workflows/fe25bb31-be6e-46b8-95ce-3bd72d1ea068/jobs/2538662/resources

![Screenshot 2024-04-19 at 9 52 09 AM](https://github.com/cypress-io/cypress/assets/1271364/32357978-b9f4-4ddf-ba31-dee185f7b28e)


### Steps to test

Tests should pass. I also ran this on Windows jobs. 

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
