### PR TITLE
chore(deps): bump electron version from 27.1.3 to 27.3.10

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.8.2
+
+_Released 5/7/2024 (PENDING)_
+
+**Dependency Updates:**
+
+- Updated electron from `27.1.3` to `27.3.10`. Addressed in [#29421](https://github.com/cypress-io/cypress/pull/29421).
+
 ## 13.8.1
 
 _Released 4/23/2024_

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "dedent": "^0.7.0",
     "del": "3.0.0",
     "detect-port": "^1.3.0",
-    "electron": "^27.3.10",
+    "electron": "27.3.10",
     "electron-builder": "^23.6.0",
     "enzyme-adapter-react-16": "1.12.1",
     "eslint": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "dedent": "^0.7.0",
     "del": "3.0.0",
     "detect-port": "^1.3.0",
-    "electron": "27.1.3",
+    "electron": "^27.3.10",
     "electron-builder": "^23.6.0",
     "enzyme-adapter-react-16": "1.12.1",
     "eslint": "^8.56.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14437,10 +14437,10 @@ electron-to-chromium@^1.4.477:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.480.tgz#40e32849ca50bc23ce29c1516c5adb3fddac919d"
   integrity sha512-IXTgg+bITkQv/FLP9FjX6f9KFCs5hQWeh5uNSKxB9mqYj/JXhHDbu+ekS43LVvbkL3eW6/oZy4+r9Om6lan1Uw==
 
-electron@27.1.3:
-  version "27.1.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-27.1.3.tgz#3fd6decda95c1dd0a7e51a9ac77ee0ba37b7c5c6"
-  integrity sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==
+electron@27.3.10:
+  version "27.3.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-27.3.10.tgz#3c9a3c918a644bb3ba07e4d4744f277636a54e58"
+  integrity sha512-fwJRWVP8/U42D5rk/xLvxN94zbM8P14PisJIWkOX6wctXOLGDTUFZb4jrkZA3/Fzuo8pzwXrXJmBL9FTwXzP3Q==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
This PR bumps the electon version to fix a out-of-bounds vulnerability. 

## Sources
[Chrome releases](https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop.html)
[Synk](https://security.snyk.io/vuln/SNYK-JS-ELECTRON-6564965) 

### PR Tasks
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
