### PR TITLE
fix: #29171 set correct host header with fetch

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ _Released 5/7/2024 (PENDING)_
 
 - Fixed a bug where promises rejected with `undefined` were failing inside `cy.origin()`. Addresses [#23937](https://github.com/cypress-io/cypress/issues/23937).
 - We now pass the same default Chromium flags to Electron as we do to Chrome. As a result of this change, the application under test's `navigator.webdriver` property will now correctly be `true` when testing in Electron. Fixes [#27939](https://github.com/cypress-io/cypress/issues/27939).
+- Fixed network issues in requests using fetch for users where Cypress is run behind a proxy that performs HTTPS decryption (common among corporate proxies). Fixes [#29171](https://github.com/cypress-io/cypress/issues/29171)
 
 **Misc:**
 

--- a/packages/network/test/unit/agent_spec.ts
+++ b/packages/network/test/unit/agent_spec.ts
@@ -227,6 +227,15 @@ describe('lib/agent', function () {
           })
         })
 
+        it('HTTP pages are requested with correct host header when loaded via fetch', function () {
+          return this.fetch(`http://localhost:${HTTP_PORT}/get`)
+          .then(() => {
+            expect(this.servers.lastRequestHeaders).to.include({
+              host: `localhost:${HTTP_PORT}`,
+            })
+          })
+        })
+
         it('HTTPS pages can be loaded', function () {
           return this.request({
             url: `https://localhost:${HTTPS_PORT}/get`,
@@ -255,6 +264,15 @@ describe('lib/agent', function () {
           })
         })
 
+        it('HTTPS pages are requested with correct host header when loaded via fetch', function () {
+          return this.fetch(`https://localhost:${HTTPS_PORT}/get`)
+          .then(() => {
+            expect(this.servers.lastRequestHeaders).to.include({
+              host: 'localhost',
+            })
+          })
+        })
+
         it('HTTPS pages can be loaded via fetch with no explicit port', function () {
           return this.fetch(`https://localhost/get`)
           .then((response) => response.text())
@@ -266,6 +284,15 @@ describe('lib/agent', function () {
                 url: `localhost:${HTTPS_PORT}`,
               })
             }
+          })
+        })
+
+        it('HTTPS pages requested with correct host header when loaded via fetch with no explicit port', function () {
+          return this.fetch(`https://localhost/get`)
+          .then(() => {
+            expect(this.servers.lastRequestHeaders).to.include({
+              host: 'localhost',
+            })
           })
         })
 

--- a/patches/node-fetch+2.7.0.patch
+++ b/patches/node-fetch+2.7.0.patch
@@ -8,7 +8,7 @@ index 567ff5d..c7e2bd9 100644
  
 -		const send = (options.protocol === 'https:' ? https : http).request;
 +		const isHttps = options.protocol === 'https:';
-+		options.defaultPort = opts.defaultPort || (isHttps ? 443 : 80);
++		options.defaultPort = (isHttps ? 443 : 80);
 +		const send = (isHttps ? https : http).request;
  		const signal = request.signal;
  

--- a/patches/node-fetch+2.7.0.patch
+++ b/patches/node-fetch+2.7.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/node-fetch/lib/index.js b/node_modules/node-fetch/lib/index.js
+index 567ff5d..c7e2bd9 100644
+--- a/node_modules/node-fetch/lib/index.js
++++ b/node_modules/node-fetch/lib/index.js
+@@ -1449,7 +1449,9 @@ function fetch(url, opts) {
+ 		const request = new Request(url, opts);
+ 		const options = getNodeRequestOptions(request);
+ 
+-		const send = (options.protocol === 'https:' ? https : http).request;
++		const isHttps = options.protocol === 'https:';
++		options.defaultPort = opts.defaultPort || (isHttps ? 443 : 80);
++		const send = (isHttps ? https : http).request;
+ 		const signal = request.signal;
+ 
+ 		let response = null;


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/29171

### Additional details

Use of node-fetch, in particular during launch of the Cypress UI when started with `cypress open`, did not pass the correct host header to the proxy when accessing HTTPS sites. This affected many corporate proxies that perform HTTPS decryption, resulting in that the requests did not reach their target servers. In addition it caused the launcher to hang.

The implementation is a patch of the node-patch library to set the defaultPort option based on the protocol of the URL. If a specific port is set in the URL, this will still override the defaultPort.

### Steps to test

Place cypress behind a proxy that performs HTTPS decryption and launch cypress with `npx cypress open`. 

One such proxy is the `ntlm-proxy` part of https://github.com/bjowes/cypress-ntlm-auth :
1. Open a terminal, create a testing folder, initiate npm and install cypress-ntlm-auth. Run `npx ntlm-proxy`. Note the ports used for configApiUrl and ntlmProxyUrl.
2. Open another terminal, configure ntlm-proxy with (make sure to replace `xxx` with the port from configApiUrl)
```curl -d '{ "ntlmHosts": ["download.cypress.io", "registry.npmjs.org", "on.cypress.io"], "username": "dummy", "password": "dummy", "ntlmVersion": 2 }' -H 'Content-Type: application/json' http://127.0.0.1:xxx/ntlm-config``` 
The call should return OK.
4. Start cypress with the proxy: `HTTP_PROXY=http://127.0.0.1:yyy npx cypress open`, make sure to replace `yyy` with the port from ntlmProxyUrl. The launcher will stall and requests to download.cypress.io, registry.npmjs.org and on.cypress.io will fail.

Repeat step 3 with this PR applied, then the launcher shall work as intended. To test the proxy without HTTPS decryption, simply skip step 2.

<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

The launcher now works as expected behind proxies that perform HTTPS decryption - for other users no change.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? NA - No documentation needs updating
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? NA - No APIs have been changed
