### PR TITLE
chore: revert "breaking: the supported eslint version is 8 for @cypress/eslint-plugin-dev"

### DIFF
--- a/npm/eslint-plugin-dev/README.md
+++ b/npm/eslint-plugin-dev/README.md
@@ -33,7 +33,6 @@ eslint-plugin-json-format
 @typescript-eslint/parser
 @typescript-eslint/eslint-plugin
 eslint-plugin-mocha
-eslint-plugin-import
 
 # if you have react/jsx files
 eslint-plugin-react
@@ -95,7 +94,6 @@ _Should usually be used at the root of the package._
 
 **requires you to install the following `devDependencies`**:
 ```sh
-eslint-plugin-import
 eslint-plugin-json-format
 @typescript-eslint/parser
 @typescript-eslint/eslint-plugin
@@ -180,7 +178,11 @@ After installing, add the following to your User or Workspace (`.vscode/settings
     {
       "language": "json",
       "autoFix": true
-    }
+    },
+    {
+      "language": "coffeescript",
+      "autoFix": false
+    },
   ],
 }
 ```


### PR DESCRIPTION
Reverts cypress-io/cypress#29433

This commit doesn't have the correct messaging. going to revert and open a PR with the correct messaging