### PR TITLE
docs: update contributor python 3.11 instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,10 +213,12 @@ You must have the following installed on your system to contribute locally:
 `python` is pre-installed on Debian-based systems including Ubuntu.
 The Python versions shipped with Ubuntu versions `20.04`, `23.10` and `22.04` are compatible with Cypress requirements.
 
-Only on Ubuntu `24.04` install Python `3.11` by executing the following command:
+Only on Ubuntu `24.04` install Python `3.11` by executing the following commands:
 
 ```shell
- sudo apt install python3.11
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update
+sudo apt install python3.11
 ```
 
 Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:


### PR DESCRIPTION
### Additional details
#### Issue

The instructions in [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) regarding installing Python `3.11` on Ubuntu `24.04` are incomplete. The PPA (Personal Package Archive) repository information `ppa:deadsnakes/ppa` is missing.

#### Change

Add the following to [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) for Ubuntu `24.04`:

```shell
sudo add-apt-repository ppa:deadsnakes/ppa
sudo apt update
```

### Steps to test

On Ubuntu `24.04` execute the steps:

```shell
sudo add-apt-repository ppa:deadsnakes/ppa
sudo apt update
sudo apt install python3.11
```

### How has the user experience changed?

Contributors working on Ubuntu `24.04` will now be able to successfully build Cypress completely, if they follow the instructions.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

cc: @AtofStryker 