### PR TITLE
docs: add contributor security user namespace instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:
 export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
 ```
 
-For Ubuntu `24.04` refer also to the [Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` and you try to run Cypress on this version of Ubuntu after building Cypress from source.
+For Ubuntu `24.04` refer also to the [Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` when you try to run Cypress on this version of Ubuntu after building Cypress from source.
 
 #### Windows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,8 @@ Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:
 export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
 ```
 
+For Ubuntu `24.04` refer also to the [Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` and you try to run Cypress on this version of Ubuntu after building Cypress from source.
+
 #### Windows
 
 When installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/cypress/issues/29422

### Additional details
#### Issue

Executing `yarn start` on Ubuntu `24.04` as described in the [CONTRIBUTING > Getting Started](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#getting-started) section results in an error message similar to the following:

```text
$ cypress open --dev --global
[9406:0427/165943.833191:FATAL:setuid_sandbox_host.cc(158)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /home/mike/cypress/packages/electron/dist/Cypress/chrome-sandbox is owned by root and has mode 4755.
```

The [Ubuntu 24.04 Release notes > Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) section describes the breaking change in security rules which causes this issue.

#### Change

Add a paragraph to [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) for Ubuntu `24.04` linking to [Ubuntu 24.04 Release notes > Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) describing how to disable the user namespace restrictions for the entire system as a workaround for the issue.

This may or may not be the long-term solution.

### Steps to test

Follow the instructions in [Ubuntu 24.04 Release notes > Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and run `yarn start` on Ubuntu `24.04`.

### How has the user experience changed?

Contributors will be able to run Cypress after building from source on Ubuntu `24.04`.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

cc: @AtofStryker 
