### PR TITLE
chore: revert making check-ts resource-class smaller

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -1412,7 +1412,6 @@ jobs:
 
   check-ts:
     <<: *defaults
-    resource_class: small
     steps:
       - restore_cached_workspace
       - install-required-node


### PR DESCRIPTION
### Additional details

I had previously made an attempt to rightsize circleci jobs [here](https://github.com/cypress-io/cypress/pull/29448), including reducing the resources for the `check-ts` job. This appears to be causing some cryptic failures with `check-ts` since it doesn't have enough resources: https://circleci.com/gh/cypress-io/cypress/2555779

### Steps to test

`check-ts` job passes

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
