### PR TITLE
fix: no longer use capture script url as default upload url for test replay recordings

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 5/21/2024 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where Cypress was unable to search in the Specs list for files or folders containing numbers. Fixes [#29034](https://github.com/cypress-io/cypress/issues/29034).
+- Fixed an issue where Cypress would use the wrong URL to upload Test Replay recordings when it wasn't able to determine the upload URL. It now displays an error when the upload URL cannot be determined, rather than a "Request Entity Too Large" error. Addressed in [#29512](https://github.com/cypress-io/cypress/pull/29512).
 
 **Dependency Updates:**
 

--- a/packages/errors/__snapshot-html__/CLOUD_PROTOCOL_CANNOT_UPLOAD_ARTIFACT.html
+++ b/packages/errors/__snapshot-html__/CLOUD_PROTOCOL_CANNOT_UPLOAD_ARTIFACT.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8" />
+      
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Courier+Prime&display=swap" rel="stylesheet">
+    <style>
+  
+        body {
+          font-family: "Courier Prime", Courier, monospace;
+          padding: 0 1em;
+          line-height: 1.4;
+          color: #eee;
+          background-color: #111;
+        }
+        pre {
+          padding: 0 0;
+          margin: 0 0;
+          font-family: "Courier Prime", Courier, monospace;
+        }
+      
+    body {
+      margin: 5px;
+      padding: 0;
+      overflow: hidden;
+    }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+      -webkit-font-smoothing: antialiased;
+    }
+    </style>
+  
+    </head>
+    <body><pre><span style="color:#e05561">Warning: We are unable to upload the Test Replay recording of this spec due to a missing or invalid upload URL.<span style="color:#e6e6e6">
+<span style="color:#e05561"><span style="color:#e6e6e6">
+<span style="color:#e05561">These results will not display Test Replay recordings.<span style="color:#e6e6e6">
+<span style="color:#e05561"><span style="color:#e6e6e6">
+<span style="color:#e05561">This error will not affect or change the exit code.<span style="color:#e6e6e6">
+<span style="color:#e05561"><span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span>
+</pre></body></html>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -565,6 +565,15 @@ export const AllCypressErrors = {
         
         ${fmt.highlightSecondary(error)}`
   },
+  CLOUD_PROTOCOL_CANNOT_UPLOAD_ARTIFACT: (error: Error) => {
+    return errTemplate`\
+        Warning: We are unable to upload the Test Replay recording of this spec due to a missing or invalid upload URL.
+
+        These results will not display Test Replay recordings.
+
+        This error will not affect or change the exit code.
+    `
+  },
   CLOUD_PROTOCOL_UPLOAD_HTTP_FAILURE: (error: Error & { url: string, status: number, statusText: string }) => {
     return errTemplate`\
         Warning: We encountered an HTTP error while uploading the Test Replay recording for this spec.

--- a/packages/errors/test/unit/visualSnapshotErrors_spec.ts
+++ b/packages/errors/test/unit/visualSnapshotErrors_spec.ts
@@ -651,6 +651,13 @@ describe('visual error templates', () => {
         default: [err],
       }
     },
+    CLOUD_PROTOCOL_CANNOT_UPLOAD_ARTIFACT: () => {
+      const err = makeErr()
+
+      return {
+        default: [err],
+      }
+    },
     CLOUD_PROTOCOL_INITIALIZATION_FAILURE: () => {
       const err = makeErr()
 

--- a/packages/types/src/protocol.ts
+++ b/packages/types/src/protocol.ts
@@ -41,7 +41,7 @@ export interface AppCaptureProtocolInterface extends AppCaptureProtocolCommon {
   beforeSpec ({ workingDirectory, archivePath, dbPath, db }: { workingDirectory: string, archivePath: string, dbPath: string, db: Database }): void
 }
 
-export type ProtocolCaptureMethod = keyof AppCaptureProtocolInterface | 'setupProtocol' | 'uploadCaptureArtifact' | 'getCaptureProtocolScript' | 'cdpClient.on' | 'getZippedDb' | 'UNKNOWN' | 'createProtocolArtifact'
+export type ProtocolCaptureMethod = keyof AppCaptureProtocolInterface | 'setupProtocol' | 'uploadCaptureArtifact' | 'getCaptureProtocolScript' | 'cdpClient.on' | 'getZippedDb' | 'UNKNOWN' | 'createProtocolArtifact' | 'protocolUploadUrl'
 
 export interface ProtocolError {
   args?: any

--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -4248,3 +4248,86 @@ StatusCodeError: 500 - "Internal Server Error"
 
 
 `
+
+exports['e2e record capture-protocol enabled but missing upload url Does not try to upload the protocol artifact to the capture protocol script url 1'] = `
+
+====================================================================================================
+
+  (Run Starting)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Cypress:    1.2.3                                                                              │
+  │ Browser:    FooBrowser 88                                                                      │
+  │ Specs:      1 found (record_pass.cy.js)                                                        │
+  │ Searched:   cypress/e2e/record_pass*                                                           │
+  │ Params:     Tag: false, Group: false, Parallel: false                                          │
+  │ Run URL:    https://dashboard.cypress.io/projects/cjvoj7/runs/12                               │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  record_pass.cy.js                                                               (1 of 1)
+  Estimated: X second(s)
+
+
+  record pass
+    ✓ passes
+    - is pending
+
+
+  1 passing
+  1 pending
+
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        2                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      1                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Estimated:    X second(s)                                                                      │
+  │ Spec Ran:     record_pass.cy.js                                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png                 (400x1022)
+
+Warning: We are unable to upload the Test Replay recording of this spec due to a missing or invalid upload URL.
+
+These results will not display Test Replay recordings.
+
+This error will not affect or change the exit code.
+
+
+  (Uploading Cloud Artifacts)
+
+  - Video - Nothing to upload 
+  - Screenshot - Nothing to upload 
+  - Test Replay - Failed Capturing - Invalid or missing Test Replay upload URL
+
+====================================================================================================
+
+  (Run Finished)
+
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ ✔  record_pass.cy.js                        XX:XX        2        1        -        1        - │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        2        1        -        1        -  
+
+
+───────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                       
+  Recorded Run: https://dashboard.cypress.io/projects/cjvoj7/runs/12
+
+
+`

--- a/system-tests/lib/serverStub.ts
+++ b/system-tests/lib/serverStub.ts
@@ -243,6 +243,13 @@ export const routeHandlers: Record<string, RouteHandler> = {
       }
     },
   },
+  putCaptureScript: {
+    method: 'put',
+    url: '/capture-protocol/script/*',
+    res: async (_, res) => {
+      res.status(413).send('')
+    },
+  },
   putCaptureProtocolUpload: {
     method: 'put',
     url: '/capture-protocol/upload',

--- a/system-tests/test/record_spec.js
+++ b/system-tests/test/record_spec.js
@@ -2584,6 +2584,35 @@ describe('e2e record', () => {
       })
     })
   })
+
+  describe('capture-protocol enabled but missing upload url', () => {
+    enableCaptureProtocol()
+    setupStubbedServer(createRoutes({
+      postInstanceResults: {
+        res: (req, res) => {
+          res.status(200).json({
+            screenshotUploadUrls: [],
+            videoUploadUrl: undefined,
+            captureUloadUrl: undefined,
+          })
+        },
+      },
+    }))
+
+    it('Does not try to upload the protocol artifact to the capture protocol script url', function () {
+      return systemTests.exec(this, {
+        key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
+        configFile: 'cypress-with-project-id.config.js',
+        spec: 'record_pass*',
+        record: true,
+        snapshot: true,
+      }).then(() => {
+        const requestUrls = getRequestUrls()
+
+        expect(requestUrls.find((url) => url.includes('PUT /capture-protocol/script/'))).to.be.undefined
+      })
+    })
+  })
 })
 
 describe('capture-protocol api errors', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

When Cloud responds to the instance results POST with an empty protocol upload url, the artifact upload logic was defaulting to using the URL of the capture protocol script. This URL does not accept uploads, and was causing HTTP errors similar to `Failed to upload after 1 attempts. Errors: Request Entity Too Large`. Instead of attempting to upload to this URL, Cypress will now report to stdout that the upload URL for Test Replay was missing or invalid, and it cannot upload the recording. Further investigation is necessary into why Cypress Cloud is returning an undefined upload url for runs that have Test Replay enabled.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
