### PR TITLE
chore: Move what-is-circular dep within Cypress repo

### DIFF
--- a/packages/driver/cypress/e2e/util/what-is-circular.cy.ts
+++ b/packages/driver/cypress/e2e/util/what-is-circular.cy.ts
@@ -1,0 +1,192 @@
+import { whatIsCircular } from '../../../src/util/what-is-circular'
+
+describe('what-is-circular', function () {
+  it('should return undefined if passed a non-object', function () {
+    expect(whatIsCircular(2)).to.eq(undefined)
+  })
+
+  it('should return path for circular objects', function () {
+    const x: any = {}
+
+    x.cyclic = { a: 1, x }
+    expect(whatIsCircular(x)).to.deep.eq(['cyclic', 'x'])
+  })
+
+  it('should return path for circular objects', function () {
+    const x: any = {}
+
+    x.cyclic = { a: {}, x }
+    expect(whatIsCircular(x)).to.deep.eq(['cyclic', 'x'])
+  })
+
+  it('should return path for circular objects', function () {
+    const x: any = {}
+
+    x.cyclic = { a: {}, indirect: { x } }
+    expect(whatIsCircular(x)).to.deep.eq(['cyclic', 'indirect', 'x'])
+  })
+
+  it('should return path for circular objects', function () {
+    const a = {
+      a: false,
+      b: {
+        a: false,
+        c: {
+          a: false,
+          d: {
+            e: {
+              a: false,
+            },
+          },
+        },
+      },
+    }
+
+    a.b.c.d.e = a
+
+    expect(whatIsCircular(a)).to.deep.eq(['b', 'c', 'd', 'e'])
+  })
+
+  it('should return path for circular objects', function () {
+    const x: any = {
+      a: [
+        {
+          a: 'b',
+          b: 'c',
+        },
+        {
+          a: 'b',
+          b: 'c',
+        },
+      ],
+      b: [
+        'a',
+        'b',
+      ],
+    }
+
+    x.c = {
+      x,
+    }
+
+    expect(whatIsCircular(x)).to.deep.eq(['c', 'x'])
+  })
+
+  it('should return path for circular objects in arrays', function () {
+    const x: any = {
+      a: [
+        {
+          a: 'b',
+          b: 'c',
+        },
+        {
+          a: 'b',
+          b: 'c',
+        },
+      ],
+      b: [
+        'a',
+        'b',
+      ],
+    }
+
+    x.a[2] = x
+
+    expect(whatIsCircular(x)).to.deep.eq(['a', '2'])
+  })
+
+  it('should return undefined for non-circular objects', function () {
+    const x: any = {}
+
+    x.cyclic = { a: 1, b: 2 }
+    expect(whatIsCircular(x)).to.eq(undefined)
+  })
+
+  it('should return undefined for non-circular objects', function () {
+    const x: any = {
+      a: [
+        {
+          a: 'b',
+          b: 'c',
+        },
+        {
+          a: 'b',
+          b: 'c',
+        },
+      ],
+      b: [
+        'a',
+        'b',
+      ],
+    }
+
+    expect(whatIsCircular(x)).to.eq(undefined)
+  })
+
+  it('should return undefined for non-circular objects', function () {
+    const x: any = {}
+    const y = {}
+
+    x.cyclic = { a: y, b: y }
+    expect(whatIsCircular(x)).to.eq(undefined)
+  })
+
+  it('detects circular objects and returns path', function () {
+    const obj1: any = {}
+
+    obj1.x = obj1
+    expect(whatIsCircular(obj1)).to.deep.eq(['x'])
+
+    const obj2: any = {}
+
+    obj2.x = { y: obj2 }
+    expect(whatIsCircular(obj2)).to.deep.eq(['x', 'y'])
+  })
+
+  it('detects circular arrays and returns path', function () {
+    const obj1: any = []
+
+    obj1.push(obj1)
+    expect(whatIsCircular(obj1)).to.deep.eq(['0'])
+  })
+
+  it('detects non-circular objects and returns undefined', function () {
+    const obj1: any = {}
+
+    obj1.x = { y: 4 }
+    expect(whatIsCircular(obj1)).to.be.undefined
+
+    expect(whatIsCircular({})).to.be.undefined
+  })
+
+  it('detects non-circular arrays and returns undefined', function () {
+    const obj1: any[] = []
+
+    obj1.push([])
+    expect(whatIsCircular(obj1)).to.be.undefined
+  })
+
+  it('returns undefined for non-objects', function () {
+    expect(whatIsCircular(undefined)).to.be.undefined
+    expect(whatIsCircular(null)).to.be.undefined
+    expect(whatIsCircular('hi')).to.be.undefined
+    expect(whatIsCircular(false)).to.be.undefined
+    expect(whatIsCircular(/a/)).to.be.undefined
+  })
+
+  it('returns undefined for non-circular functions', function () {
+    expect(whatIsCircular(function () {})).to.be.undefined
+  })
+
+  it('returns path for circular functions', function () {
+    const f: any = function () {}
+
+    f.x = {
+      y: {
+        f,
+      },
+    }
+
+    expect(whatIsCircular(f)).to.deep.eq(['x', 'y', 'f'])
+  })
+})

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -18,7 +18,6 @@
     "@cypress/unique-selector": "0.0.5",
     "@cypress/webpack-dev-server": "0.0.0-development",
     "@cypress/webpack-preprocessor": "0.0.0-development",
-    "@cypress/what-is-circular": "1.0.1",
     "@medv/finder": "3.1.0",
     "@packages/config": "0.0.0-development",
     "@packages/network": "0.0.0-development",

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import whatIsCircular from '@cypress/what-is-circular'
 import UrlParse from 'url-parse'
 import Promise from 'bluebird'
 
@@ -9,6 +8,7 @@ import { LogUtils, Log } from '../../cypress/log'
 import { bothUrlsMatchAndOneHasHash } from '../navigation'
 import { $Location, LocationObject } from '../../cypress/location'
 import { isRunnerAbleToCommunicateWithAut } from '../../util/commandAUTCommunication'
+import { whatIsCircular } from '../../util/what-is-circular'
 
 import type { RunState } from '@packages/types'
 

--- a/packages/driver/src/cy/commands/request.ts
+++ b/packages/driver/src/cy/commands/request.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash'
-import whatIsCircular from '@cypress/what-is-circular'
 import Promise from 'bluebird'
 
 import $utils from '../../cypress/utils'
 import $errUtils from '../../cypress/error_utils'
 import { $Location } from '../../cypress/location'
+import { whatIsCircular } from '../../util/what-is-circular'
 
 const isOptional = (memo, val, key) => {
   if (_.isNull(val)) {

--- a/packages/driver/src/util/what-is-circular.ts
+++ b/packages/driver/src/util/what-is-circular.ts
@@ -8,7 +8,7 @@ export function whatIsCircular (obj) {
   return _dfs(obj)
 }
 
-function _dfs (obj, parents = [], parentKeys = []) {
+function _dfs (obj, parents: any[] = [], parentKeys: any[] = []) {
   // recurse depth-first until we hit something we've seen before
   for (const key in obj) {
     const val = obj[key]

--- a/packages/driver/src/util/what-is-circular.ts
+++ b/packages/driver/src/util/what-is-circular.ts
@@ -1,0 +1,26 @@
+const lodash = require('lodash')
+
+export function whatIsCircular (obj) {
+  if (!lodash.isObject(obj)) {
+    return
+  }
+
+  return _dfs(obj)
+}
+
+function _dfs (obj, parents = [], parentKeys = []) {
+  // recurse depth-first until we hit something we've seen before
+  for (const key in obj) {
+    const val = obj[key]
+
+    if (lodash.isObject(val)) {
+      if (lodash.includes(parents, val)) {
+        return parentKeys
+      }
+
+      const path = _dfs(val, parents.concat([val]), parentKeys.concat([key]))
+
+      if (path) return path
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3069,14 +3069,6 @@
   dependencies:
     css.escape "^1.5.1"
 
-"@cypress/what-is-circular@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@cypress/what-is-circular/-/what-is-circular-1.0.1.tgz#c88adb7106a4e1624e403512fc87c18e9700c877"
-  integrity sha512-AZP6hxdiXhVKSdTeIb8tBkotH5sq/MEvECk4byAF44ulPL7MXvhInRthof20cK3UDAycKo0ThJvT71mhSfsOPw==
-  dependencies:
-    lodash.includes "^4.3.0"
-    lodash.isobject "^3.0.2"
-
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -20976,11 +20968,6 @@ lodash.isnumber@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
 
 lodash.isplainobject@4.0.6, lodash.isplainobject@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
### Additional details

This moves the code from the https://github.com/cypress-io/what-is-circular directly into Cypress. 

The https://github.com/cypress-io/what-is-circular repo was a fork of https://github.com/flotwig/what-is-circular which was inspired by https://github.com/tjmehta/is-circular/, but returns the path to the first circular reference found.

I think having this code directly in the repo is beneficial since it's a single file, has tests, and requires no maintenance on our part to run extra CI/release processes in a separate repo if a change is needed. It also deters outside users from including the package, creating an expectation for us to maintain it for them. 

### Steps to test

Unit tests transferred within utils that should run in the driver tests. Other tests should pass.

### How has the user experience changed?
N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
