### PR TITLE
docs: correct eslint-plugin-dev link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ Many Cypress packages print out debugging information to console via the `debug`
 ### Coding Style
 
 We use [eslint](https://eslint.org/) to lint all JavaScript code and follow rules specified in
-[@cypress/eslint-plugin-dev](./npm/eslint-plugin-cypress) plugin.
+[@cypress/eslint-plugin-dev](./npm/eslint-plugin-dev) plugin.
 
 This project uses a Git pre-commit hook to lint staged files before committing. See the [`lint-staged` project](https://github.com/okonet/lint-staged) for details.
 `lint-staged` will try to auto-fix any lint errors with `eslint --fix`, so if it fails, you must manually fix the lint errors before committing.


### PR DESCRIPTION
### Additional details

[CONTRIBUTING > Coding Style](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#coding-style) contained a bad link in the sentence

> We use [eslint](https://eslint.org/) to lint all JavaScript code and follow rules specified in [@cypress/eslint-plugin-dev](https://github.com/cypress-io/cypress/tree/develop/npm/eslint-plugin-cypress) plugin.

- The bad link was introduced through https://github.com/cypress-io/cypress/pull/6396.

The link `@cypress/eslint-plugin-dev` is now corrected to point to https://github.com/cypress-io/cypress/tree/develop/npm/eslint-plugin-dev.

### Steps to test

Go to [CONTRIBUTING > Coding Style](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#coding-style) and click on link to `@cypress/eslint-plugin-dev`.

### How has the user experience changed?

`404 - page not found` changes to display of https://github.com/cypress-io/cypress/tree/develop/npm/eslint-plugin-dev

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
