### PR TITLE
feat: expose Chrome Devtools Protocol "on" and "off" methods

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 6/4/2024 (PENDING)_
 
 **Features:**
 
+- Added support for using Chrome DevTools Protocol's `on` and `off` functions for event listening. Addresses [#29598](https://github.com/cypress-io/cypress/issues/29598)
 - Added support for [Next.js 14](https://nextjs.org/blog/next-14) for component testing. Addresses [#28185](https://github.com/cypress-io/cypress/issues/28185).
 
 **Bugfixes:**

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -555,6 +555,10 @@ export class CdpAutomation implements CDPClient {
         return true
       case 'remote:debugger:protocol':
         return this.sendDebuggerCommandFn(data.command, data.params, data.sessionId)
+      case 'remote:debugger:protocol:off':
+        return this.off(data.event, data.callback)
+      case 'remote:debugger:protocol:on':
+        return this.on(data.event, data.callback)
       case 'take:screenshot':
         debugVerbose('capturing screenshot')
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/29598

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
1) Use this code snippet in your `before` hook:
```js
Cypress.automation('remote:debugger:protocol', { command: 'Tracing.start' , { transferMode: 'ReturnAsStream', traceConfig: { includedCategories: ['latencyInfo'] } } })
```
2) use this code snippet in your `after` hook:
```js
Cypress.automation('remote:debugger:protocol', { command: 'Tracing.end' })
Cypress.automation('remote:debugger:protocol:on', { event: 'Tracing.tracingComplete', callback: ({ stream }) => {
  // do your logic with the callback stream
})
```
3) Load a page in the test

### How has the user experience changed?
It has not, other than that consumers will now be able to listen for events on the CDP instance.

### PR Tasks

I have not added tests for these, I am fine to add them if requested, though I'm not sure they're necessary, given that the functionality that's being extended also is not tested AFAICT. 

Re: documentation, again, there's no direct documentation of the `remote:debugger:protocol`, only an example or two. I am fine to add documentation if you can point out where that should be done.

Re: type definitions, the type of the `message` variable that is used in the function that contains the message switch is `any`, so no type changes should be required here.

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
