### PR TITLE
fix: chrome missing CRI client after browser relaunch

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,12 +9,13 @@ _Released 6/18/2024 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed an issue where Chrome launch instances would not recreate the browser CRI client correctly after recovering from an unexpected browser closure. Fixes [#27657](https://github.com/cypress-io/cypress/issues/27657). Fixed in [#29663](https://github.com/cypress-io/cypress/pull/29663).
 - Fixed an issue where auto scrolling the reporter would sometimes be disabled without the user's intent. Fixes [#25084](https://github.com/cypress-io/cypress/issues/25084).
 - Fixed an issue where `inlineSourceMaps` was still being used when `sourceMaps` was provided in a users typescript config for typescript version 5. Fixes [#26203](https://github.com/cypress-io/cypress/issues/26203).
 - When capture protocol script fails verification, an appropriate error is now displayed. Previously, an error regarding Test Replay archive location was shown. Addressed in [#29603](https://github.com/cypress-io/cypress/pull/29603).
 - Fixed an issue where receiving HTTP responses with invalid headers raised an error. Now cypress removes the invalid headers and gives a warning in the console with debug mode on. Fixes [#28865](https://github.com/cypress-io/cypress/issues/28865).
 
-**Misc:** 
+**Misc:**
 
 - Report afterSpec durations to Cloud API when running in record mode with Test Replay enabled. Addressed in [#29500](https://github.com/cypress-io/cypress/pull/29500).
 

--- a/packages/data-context/src/data/coreDataShape.ts
+++ b/packages/data-context/src/data/coreDataShape.ts
@@ -171,6 +171,7 @@ export interface CoreDataShape {
   } | null
   cloudProject: CloudDataShape
   eventCollectorSource: EventCollectorSource | null
+  didBrowserPreviouslyHaveUnexpectedExit: boolean
 }
 
 /**
@@ -251,6 +252,7 @@ export function makeCoreData (modeOptions: Partial<AllModeOptions> = {}): CoreDa
       testsForRunResults: {},
     },
     eventCollectorSource: null,
+    didBrowserPreviouslyHaveUnexpectedExit: false,
   }
 
   async function machineId (): Promise<string | null> {

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -49,11 +49,5 @@ export function launch (
     debug('%s exited: %o', browser.name, { code, signal })
   })
 
-  // kill the browser
-  setTimeout(() => {
-    console.log('killing the browser after 5 seconds to mock crash...')
-    proc.kill()
-  }, 5000)
-
   return proc
 }

--- a/packages/launcher/lib/browsers.ts
+++ b/packages/launcher/lib/browsers.ts
@@ -49,5 +49,11 @@ export function launch (
     debug('%s exited: %o', browser.name, { code, signal })
   })
 
+  // kill the browser
+  setTimeout(() => {
+    console.log('killing the browser after 5 seconds to mock crash...')
+    proc.kill()
+  }, 5000)
+
   return proc
 }

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -222,6 +222,11 @@ export = {
     // so that there is a default for each browser but
     // enable the browser to configure the interface
     instance.once('exit', async (code, signal) => {
+      // When the browser has unexpectedly exited, we need to send a signal to the attempt launcher to recreate the browser CRI clients.
+      // We do NOT want to attempt to use existing CRI clients as the previous instance of the browser was terminated.
+      // @see https://github.com/cypress-io/cypress/issues/27657
+      ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit = true
+
       debug('browser instance exit event received %o', { code, signal })
 
       ctx.actions.app.setBrowserStatus('closed')

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -438,7 +438,8 @@ async function waitForBrowserToConnect (options: { project: Project, socketId: s
   if (globalThis.CY_TEST_MOCK?.waitForBrowserToConnect) return Promise.resolve()
 
   const { project, socketId, onError, spec, browser, protocolManager } = options
-  const browserTimeout = Number(process.env.CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT || 60000)
+  // HARDCODE timeout to 10 seconds to speed up loop
+  const browserTimeout = Number(10000)
   let browserLaunchAttempt = 1
 
   // without this the run mode is only setting new spec

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -438,8 +438,7 @@ async function waitForBrowserToConnect (options: { project: Project, socketId: s
   if (globalThis.CY_TEST_MOCK?.waitForBrowserToConnect) return Promise.resolve()
 
   const { project, socketId, onError, spec, browser, protocolManager } = options
-  // HARDCODE timeout to 10 seconds to speed up loop
-  const browserTimeout = Number(10000)
+  const browserTimeout = Number(process.env.CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT || 60000)
   let browserLaunchAttempt = 1
 
   // without this the run mode is only setting new spec

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -483,6 +483,14 @@ async function waitForBrowserToConnect (options: { project: Project, socketId: s
 
     debug('waiting for socket to connect and browser to launch...')
 
+    const coreData = require('@packages/data-context').getCtx().coreData
+
+    if (coreData.didBrowserPreviouslyHaveUnexpectedExit) {
+      debug(`browser previously exited. Setting shouldLaunchNewTab=false to recreate the correct browser automation clients.`)
+      options.shouldLaunchNewTab = false
+      coreData.didBrowserPreviouslyHaveUnexpectedExit = false
+    }
+
     return Bluebird.all([
       waitForSocketConnection(project, socketId),
       // TODO: remove the need to extend options and coerce this type

--- a/packages/server/test/integration/run_spec.ts
+++ b/packages/server/test/integration/run_spec.ts
@@ -1,0 +1,163 @@
+import fs from 'fs'
+import fsExtra from 'fs-extra'
+import { run } from '../../lib/modes/run'
+import { ProjectConfigIpc } from '@packages/data-context/src/data/ProjectConfigIpc'
+import { FileDataSource } from '@packages/data-context/src/sources/FileDataSource'
+import browserUtils from '../../lib/browsers'
+import { fs as fsUtil } from '../../lib/util/fs'
+import { getCtx } from '../../lib/makeDataContext'
+import { OpenProject } from '../../lib/open_project'
+
+describe('lib/modes/run', () => {
+  let browserConnectTimeoutPlaceholder
+  let ctx
+  let specs = ['foo.cy.ts', 'bar.cy.ts', 'baz.cy.ts']
+  let options = {
+    autoCancelAfterFailures: undefined,
+    browser: 'chrome',
+    ciBuildId: undefined,
+    exit: false,
+    group: undefined,
+    headed: false,
+    key: undefined,
+    outputPath: '',
+    parallel: undefined,
+    projectRoot: '/path/to/project/root',
+    quiet: false,
+    record: false,
+    socketId: 'foobarbaz',
+    spec: specs,
+    tag: undefined,
+    testingType: 'e2e',
+    webSecurity: true,
+  }
+
+  beforeEach(() => {
+    browserConnectTimeoutPlaceholder = process.env.CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT
+    process.env.CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT = '2000'
+    specs = ['foo.cy.ts', 'bar.cy.ts', 'baz.cy.ts']
+
+    options = {
+      autoCancelAfterFailures: undefined,
+      browser: 'chrome',
+      ciBuildId: undefined,
+      exit: false,
+      group: undefined,
+      headed: false,
+      key: undefined,
+      onError: (err: Error) => undefined,
+      outputPath: '',
+      parallel: undefined,
+      projectRoot: '/path/to/project/root',
+      quiet: false,
+      record: false,
+      socketId: 'foobarbaz',
+      spec: specs,
+      tag: undefined,
+      testingType: 'e2e',
+      webSecurity: true,
+    }
+
+    const mockedRelativeSupportFilePath = 'cypress/support/e2e.js'
+
+    const chromeStable = {
+      displayName: 'Chrome',
+      name: 'chrome',
+      channel: 'stable',
+      version: '12.34.56',
+      majorVersion: '12',
+      family: 'chromium',
+      path: '/path/to/google-chrome',
+    }
+
+    const foundBrowsers = [
+      chromeStable,
+    ]
+
+    sinon.stub(browserUtils, 'get').resolves(foundBrowsers)
+    sinon.stub(browserUtils, 'removeOldProfiles').resolves()
+
+    sinon.stub(fsUtil, 'access').withArgs(options.projectRoot).resolves()
+    sinon.stub(process, 'chdir').withArgs(options.projectRoot).returns()
+    // @ts-expect-error
+    sinon.stub(fs, 'statSync').withArgs(options.projectRoot).returns({
+      isDirectory: () => true,
+    })
+
+    // @ts-expect-error
+    sinon.stub(fsExtra, 'pathExists').withArgs(`${options.projectRoot}/${mockedRelativeSupportFilePath}`).resolves(true)
+    /// mock the project config IPC loadConfig to avoid communicating over sub processes, which will not work here since we are mocking the directory
+    // @ts-expect-error
+    sinon.stub(ProjectConfigIpc.prototype, 'loadConfig').callsFake(() => {
+      return Promise.resolve({
+        requires: [],
+        initialConfig: '{}',
+      })
+    })
+
+    sinon.stub(FileDataSource.prototype, 'getFilesByGlob').withArgs(options.projectRoot, 'cypress/support/e2e.{js,jsx,ts,tsx}').resolves([`${options.projectRoot}/${mockedRelativeSupportFilePath}`])
+
+    ctx = getCtx()
+
+    ctx.coreData.machineBrowsers = Promise.resolve(foundBrowsers)
+    ctx.project._specs = specs
+
+    // mock the websocket connection
+    globalThis.CY_TEST_MOCK = {
+      waitForSocketConnection: true,
+      listenForProjectEnd: { stats: { failures: 0 } },
+    }
+  })
+
+  afterEach(() => {
+    delete globalThis['CY_TEST_MOCK']
+    process.env.CYPRESS_INTERNAL_BROWSER_CONNECT_TIMEOUT = browserConnectTimeoutPlaceholder
+  })
+
+  it('recovers when the browser is closed unexpectedly by not sending "shouldLaunchNewTab" on newly created browser instances (creates the CRI client in the actual implementation)', async () => {
+    let launchAttemptOfBarSpec = 0
+
+    // @ts-expect-error
+    sinon.stub(OpenProject.prototype, 'launch').callsFake((_browser, spec, browserOpts) => {
+      switch (spec as unknown as string) {
+        case 'foo.cy.ts':
+          // should be a fresh launch of the browser, so shouldLaunchNewTab should be false
+          expect(browserOpts.shouldLaunchNewTab).to.equal(false)
+          // pass the first spec
+
+          return Promise.resolve()
+        case 'bar.cy.ts':
+          launchAttemptOfBarSpec++
+          if (launchAttemptOfBarSpec === 1) {
+            // we are on our first launch of the browser. We are going to mock
+            // the browser unexpectedly closing out of our control
+            expect(ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit).to.equal(false)
+            // since this is not the first spec launched in the browser, we should launch with a new tab and NOT a new browser instance
+            expect(browserOpts.shouldLaunchNewTab).to.equal(true)
+
+            // mock unexpected close of browser in second spec
+            // return nothing as this promise should never resolve
+            ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit = true
+
+            return new Promise(((resolve) => {
+              // never resolves as we are mocking the browser unexpectedly closing
+            }))
+          }
+
+          // assume we are second launch attempt or later. We should have detected that the browser
+          // previously exited and that we need to recreate everything related to the instance, so
+          // shouldLaunchNewTab should be false
+          expect(ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit).to.equal(false)
+          expect(browserOpts.shouldLaunchNewTab).to.equal(false)
+
+          return Promise.resolve()
+        case 'baz.cy.ts':
+          return Promise.resolve()
+        default:
+          return Promise.resolve()
+      }
+    })
+
+    await run(options, Promise.resolve())
+  })
+})

--- a/packages/server/test/unit/browsers/browsers_spec.js
+++ b/packages/server/test/unit/browsers/browsers_spec.js
@@ -399,6 +399,31 @@ describe('lib/browsers/index', () => {
       })
     })
   })
+
+  context('didBrowserPreviouslyHaveUnexpectedExit', () => {
+    it('sets didBrowserPreviouslyHaveUnexpectedExit when the browser unexpectedly closes', () => {
+      const url = 'http://localhost:3000'
+      const ee = new EventEmitter()
+
+      ee.kill = () => {
+        ee.emit('exit')
+      }
+
+      const instance = ee
+
+      browsers._setInstance(instance)
+
+      sinon.stub(electron, 'open').resolves(instance)
+      sinon.spy(ctx.actions.app, 'setBrowserStatus')
+
+      // Stub to speed up test, we don't care about the delay
+      sinon.stub(Promise, 'delay').resolves()
+
+      return browsers.open({ name: 'electron', family: 'chromium' }, { url }, null, ctx).then(browsers.close).then(() => {
+        expect(ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit).eq(true)
+      })
+    })
+  })
 })
 
 // Ooo, browser clean up tests are disabled?!!


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #27657

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR addresses the missing CRI client issue when chrome unexpectedly closes. When this would happen, we wait for the browser to reconnect up to [3 attempts](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/modes/run.ts#L502). In this case though, since the browser closed, we closed the CRI client as well and we are able to successfully relaunch the browser, expecting the CRI client to be there, but its not so we get this error. 

To fix this, we need to make sure we detect when the browser unexpectedly closes and let the launcher know that the instance is no longer active. This way, we can set `shouldLaunchNewTab` to `false`  which will prompt the recreation of the CRI client as the browser instance is new.

That being said, I am unable to create a system test where the browser closes in the manner I need it to. I was only able to recreate the issue on this [branch](https://github.com/cypress-io/cypress/compare/develop...reprod_browser_cri_crash_chrome) against this test [suite](https://github.com/AtofStryker/cypress_issue_27657). In the actual repo, I have added a brief assertion to the launcher unit test and added a new integration test for the run mode in the server, which integrates most the aspects of the server while stubbing out the config loader child process and a few other directory specific things since we are mocking the file system.


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

run the integration tests in the server for the monorepo, or try the specified branch (which is the reprod [branch](https://github.com/cypress-io/cypress/compare/develop...reprod_browser_cri_crash_chrome) but with the [fix](https://github.com/cypress-io/cypress/compare/missing_cri_client_fix_with_mock_failure?expand=1)) against the test repo to see the crash in action. You should see the log which indicates we recovered and rehydrate the CRI client correctly.
![](https://github.com/cypress-io/cypress/assets/3980464/e964d0e4-5a15-4fdd-a1c4-e8726f15cf7b)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
