### PR TITLE
dependency: update tmp to 0.2.3

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,7 +14,7 @@ _Released 6/18/2024 (PENDING)_
 - When capture protocol script fails verification, an appropriate error is now displayed. Previously, an error regarding Test Replay archive location was shown. Addressed in [#29603](https://github.com/cypress-io/cypress/pull/29603).
 - Fixed an issue where receiving HTTP responses with invalid headers raised an error. Now cypress removes the invalid headers and gives a warning in the console with debug mode on. Fixes [#28865](https://github.com/cypress-io/cypress/issues/28865).
 
-**Misc:** 
+**Misc:**
 
 - Report afterSpec durations to Cloud API when running in record mode with Test Replay enabled. Addressed in [#29500](https://github.com/cypress-io/cypress/pull/29500).
 
@@ -23,6 +23,7 @@ _Released 6/18/2024 (PENDING)_
 - Updated firefox-profile from `4.3.1` to `4.6.0`. Addressed in [#29662](https://github.com/cypress-io/cypress/pull/29662).
 - Updated typescript from `4.7.4` to `5.3.3`. Addressed in [#29568](https://github.com/cypress-io/cypress/pull/29568).
 - Updated url-parse from `1.5.9` to `1.5.10`. Addressed in [#29650](https://github.com/cypress-io/cypress/pull/29650).
+- Updated tmp from `0.2.1` to `0.2.3`. Addresses [#29693](https://github.com/cypress-io/cypress/issues/29693).
 
 ## 13.11.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.12.1
+
+_Released 7/2/2024 (PENDING)_
+
+**Dependency Updates:**
+
+- Updated tmp from `0.2.1` to `0.2.3`. Addresses [#29693](https://github.com/cypress-io/cypress/issues/29693).
+
 ## 13.12.0
 
 _Released 6/18/2024_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -32,7 +32,6 @@ _Released 6/18/2024_
 - Updated firefox-profile from `4.3.1` to `4.6.0`. Addressed in [#29662](https://github.com/cypress-io/cypress/pull/29662).
 - Updated typescript from `4.7.4` to `5.3.3`. Addressed in [#29568](https://github.com/cypress-io/cypress/pull/29568).
 - Updated url-parse from `1.5.9` to `1.5.10`. Addressed in [#29650](https://github.com/cypress-io/cypress/pull/29650).
-- Updated tmp from `0.2.1` to `0.2.3`. Addresses [#29693](https://github.com/cypress-io/cypress/issues/29693).
 
 ## 13.11.0
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -59,7 +59,7 @@
     "request-progress": "^3.0.0",
     "semver": "^7.5.3",
     "supports-color": "^8.1.1",
-    "tmp": "~0.2.1",
+    "tmp": "~0.2.3",
     "untildify": "^4.0.0",
     "yauzl": "^2.10.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -30007,12 +30007,10 @@ tmp@0.0.33, tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.2.0, tmp@^0.2.1, tmp@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
-  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  dependencies:
-    rimraf "^3.0.0"
+tmp@^0.2.0, tmp@^0.2.1, tmp@~0.2.1, tmp@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/29693

### Additional details

Due to the previous dependency configuration [tmp@~0.2.1](https://www.npmjs.com/package/tmp/v/0.2.1), Cypress projects with older lockfiles could be left with deprecated dependencies installed:

https://github.com/cypress-io/cypress/blob/782765682c1a571df57e5b264bac8c2dd673493c/cli/package.json#L62

The warning from pnpm was
>  WARN  3 deprecated subdependencies found: glob@7.2.3, inflight@1.0.6, rimraf@3.0.2

The dependency is bumped to `tmp@~0.2.3` in [cli/package.json](https://github.com/cypress-io/cypress/blob/develop/cli/package.json) to allow Cypress projects to remove the deprecated dependencies when the `cypress` npm module is updated.

Newly-installed Cypress projects already use `tmp@0.2.3`

```text
$ npm show tmp dist-tags
{ latest: '0.2.3' }
```

### Steps to test

```shell
pnpm add cypress@latest --save-dev
```

should no longer show a deprecation warning. See https://github.com/cypress-io/cypress/issues/29693 for exact repro steps.

### How has the user experience changed?

pnpm should no longer show a deprecation warning when Cypress is installed:

>  WARN  3 deprecated subdependencies found: glob@7.2.3, inflight@1.0.6, rimraf@3.0.2

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
