### PR TITLE
chore(deps): add type-fest devDep

### DIFF
--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -69,6 +69,7 @@
     "postcss": "^8.4.22",
     "shiki": "^0.9.12",
     "tailwindcss": "^3.3.1",
+    "type-fest": "^2.3.4",
     "unplugin-icons": "0.19.0",
     "unplugin-vue-components": "^0.27.0",
     "vite": "5.2.11",


### PR DESCRIPTION
### Additional details

This was pulled out of https://github.com/cypress-io/cypress/pull/29672. That PR gets weird with the semver if we're touching more than the grep package. 

[Slack thread for reference](https://cypressio.slack.com/archives/C06G5D5KFCJ/p1718993079923339), but that other PR caused some yarn hoisting that was not right. This will add type-fest as it's own devDep so that it always uses the correct version. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
