### PR TITLE
fix: 29752 and 25554 baseUrl slash breaks URL when trying to append query string

### DIFF
--- a/cli/lib/tasks/download.js
+++ b/cli/lib/tasks/download.js
@@ -24,11 +24,11 @@ const getProxyForUrlWithNpmConfig = (url) => {
     null
 }
 
-const getBaseUrl = () => {
+const getBaseUrl = (urlPath = '') => {
   if (util.getEnv('CYPRESS_DOWNLOAD_MIRROR')) {
     let baseUrl = util.getEnv('CYPRESS_DOWNLOAD_MIRROR')
 
-    if (!baseUrl.endsWith('/')) {
+    if (!baseUrl.endsWith('/') && !urlPath.startsWith('?')) {
       baseUrl += '/'
     }
 
@@ -57,7 +57,7 @@ const getCA = () => {
 }
 
 const prepend = (arch, urlPath, version) => {
-  const endpoint = url.resolve(getBaseUrl(), urlPath)
+  const endpoint = url.resolve(getBaseUrl(urlPath), urlPath)
   const platform = os.platform()
   const pathTemplate = util.getEnv('CYPRESS_DOWNLOAD_PATH_TEMPLATE', true)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
#29752 and #25554

### Additional details
- Issue: The baseUrl feature is appending a slash to the baseUrl, which can cause some websites to disconnect or fail to fire their load event.
- Fix: Checking if the pathUrl is actually a querystring, if so don't append the slash

### Steps to test
as described in 29752 and 25554.

### How has the user experience changed?
if:
```js
baseUrl: "https:/example.com"
```
and used with query parameters like this:
```js
cy.visit('?id=1')
```

previous behavior:
it visits: https:/example.com/?id=1 (with additional slash)

current behavior with the changes:
it visits: https:/example.com?id=1 (without slash for querystrings)

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
