### PR TITLE
chore: move frontend-shared from a dev dependency to a runtime dependency in launchpad package.json

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-06-07-24
+07-01-24

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,7 +30,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'ignore-chrom-prefs'
+        - 'investigate/darwin-ci-build-order'
         - 'publish-binary'
         - 'angular-signals-ct-harness'
 
@@ -44,6 +44,7 @@ macWorkflowFilters: &darwin-workflow-filters
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - equal: [ 'angular-signals-ct-harness', << pipeline.git.branch >> ]
+    - equal: [ 'investigate/darwin-ci-build-order', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -18,13 +18,14 @@
     "test": "yarn cypress:run:ct && yarn types",
     "watch": "echo 'run yarn dev from the root' && exit 1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@packages/frontend-shared": "0.0.0-development"
+  },
   "devDependencies": {
     "@cypress-design/vue-button": "^0.11.6",
     "@graphql-typed-document-node/core": "^3.1.0",
     "@headlessui/vue": "1.4.0",
     "@intlify/unplugin-vue-i18n": "4.0.0",
-    "@packages/frontend-shared": "0.0.0-development",
     "@packages/scaffold-config": "0.0.0-development",
     "@percy/cypress": "^3.1.2",
     "@purge-icons/generated": "0.8.1",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -18,14 +18,13 @@
     "test": "yarn cypress:run:ct && yarn types",
     "watch": "echo 'run yarn dev from the root' && exit 1"
   },
-  "dependencies": {
-    "@packages/frontend-shared": "0.0.0-development"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@cypress-design/vue-button": "^0.11.6",
     "@graphql-typed-document-node/core": "^3.1.0",
     "@headlessui/vue": "1.4.0",
     "@intlify/unplugin-vue-i18n": "4.0.0",
+    "@packages/frontend-shared": "0.0.0-development",
     "@packages/scaffold-config": "0.0.0-development",
     "@percy/cypress": "^3.1.2",
     "@purge-icons/generated": "0.8.1",
@@ -76,7 +75,8 @@
   ],
   "nx": {
     "implicitDependencies": [
-      "@packages/graphql"
+      "@packages/graphql",
+      "@packages/frontend-shared"
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
`darwin-arm64` is building packages in a different order than other jobs; declaring frontend-shared as an nx implicit dependency of `launchpad` seems to fix it.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
