### PR TITLE
chore: disable rebuild better-sqlite3 to unblock PRs as Centos 7 has reached EOL

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2635,7 +2635,9 @@ jobs:
 linux-x64-workflow: &linux-x64-workflow
   jobs:
     - node_modules_install:
-        build-better-sqlite3: true
+        # NOTE: Centos reached EOL on July 1st, 2024. The centos7-builder.Dockerfile no longer works in the manner in which we are using to rebuild better-sqlite3, so for now to unblock
+        # develop we will not be rebuilding better-sqlite3. However, a solution to this is likely needed as it can be considered a breaking change due to centos 7 extended support.
+        build-better-sqlite3: false
     - build:
         context: test-runner:env-canary
         requires:


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Temporarily skips rebuilding better-sqlite3 as the mirrors needed to run on centos 7 are no longer working as centos 7 was EOLed earlier this month

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
