### PR TITLE
test: adds tests for visibilty when clipped by ancestor overflow:hidden

### DIFF
--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -246,9 +246,7 @@ describe('src/cypress/dom/visibility', () => {
 
       this.$parentNoWidth = add(`\
 <div style='width: 0; height: 100px; overflow: hidden;'>
-  <div style='height: 500px; width: 500px;'>
     <span>parent width: 0</span>
-  </div>
 </div>`)
 
       this.$parentNoHeight = add(`\
@@ -263,10 +261,27 @@ describe('src/cypress/dom/visibility', () => {
 
       this.$parentWithWidthHeightNoOverflow = add(`\
 <div style='width: 100px; height: 100px; overflow: hidden;'>
-  <div style='height: 100px; width: 100px;'>
     <span>parent with size, overflow: hidden</span>
-  </div>
 </div>`)
+
+      this.$ancestorWithWidthHeightNoOverflow = add(`\
+      <div style='width: 100px; height: 100px'>
+          <div><span>parent with size, overflow: hidden</span></div>
+      </div>`)
+
+      this.$ancestorNoWidth = add(`\
+      <div style='width: 0; height: 100px; overflow: hidden;'>
+        <div>
+          <span>ancestor width: 0</span>
+        </div>
+      </div>`)
+
+      this.$ancestorNoHeight = add(`\
+      <div style='width: 100px; height: 0px; overflow: hidden;'>
+        <div>
+          <span>ancestor width: 0</span>
+        </div>
+      </div>`)
 
       this.$childPosAbs = add(`\
 <div style='width: 0; height: 100px; overflow: hidden;'>
@@ -742,9 +757,24 @@ describe('src/cypress/dom/visibility', () => {
         expect(this.$parentNoHeight.find('span')).to.not.be.visible
       })
 
+      it('is hidden if ancestor has overflow:hidden and no width', function () {
+        expect(this.$ancestorNoWidth.find('span')).to.be.hidden
+        expect(this.$ancestorNoWidth.find('span')).to.not.be.visible
+      })
+
+      it('is hidden if ancestor has overflow:hidden and no height', () => {
+        expect(this.$ancestorNoHeight.find('span')).to.be.hidden
+        expect(this.$ancestorNoHeight.find('span')).to.not.be.visible
+      })
+
       it('is visible when parent has positive dimensions even with overflow hidden', function () {
         expect(this.$parentWithWidthHeightNoOverflow.find('span')).to.be.visible
         expect(this.$parentWithWidthHeightNoOverflow.find('span')).to.not.be.hidden
+      })
+
+      it('is visible when ancestor has positive dimensions even with overflow hidden', function () {
+        expect(this.$ancestorWithWidthHeightNoOverflow.find('span')).to.be.visible
+        expect(this.$ancestorWithWidthHeightNoOverflow.find('span')).to.not.be.hidden
       })
     })
 

--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -762,7 +762,7 @@ describe('src/cypress/dom/visibility', () => {
         expect(this.$ancestorNoWidth.find('span')).to.not.be.visible
       })
 
-      it('is hidden if ancestor has overflow:hidden and no height', () => {
+      it('is hidden if ancestor has overflow:hidden and no height', function () {
         expect(this.$ancestorNoHeight.find('span')).to.be.hidden
         expect(this.$ancestorNoHeight.find('span')).to.not.be.visible
       })

--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -279,7 +279,7 @@ describe('src/cypress/dom/visibility', () => {
       this.$ancestorNoHeight = add(`\
       <div style='width: 100px; height: 0px; overflow: hidden;'>
         <div>
-          <span>ancestor width: 0</span>
+          <span>ancestor height: 0</span>
         </div>
       </div>`)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/29791

### Additional details

Clipping visibility logic differs based on parent or ancestor, so these tests were added.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
