### PR TITLE
fix: 29798 : DevServerPublicPathRoute cause intercept not being called

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.13.2
+
+_Released <RELEASE_DATE> (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where intercept could not be called when DevServerPublicPathRoute is used. Addressed in [#29798](
+
 ## 13.13.1
 
 _Released 7/16/2024_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.13.2
 
-_Released <RELEASE_DATE> (PENDING)_
+_Released xx/xx/xxxx (PENDING)_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.13.2
 
-_Released 00/00/0000 (PENDING)_
+_Released 7/30/2024 (PENDING)_
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 00/00/0000 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue where intercept could not be called when DevServerPublicPathRoute is used. Addressed in [#29798](
+- Fixed an issue where intercept could not be called when DevServerPublicPathRoute is used. Fixed in [#29874](https://github.com/cypress-io/cypress/pull/29874)
 
 ## 13.13.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.13.2
 
-_Released xx/xx/xxxx (PENDING)_
+_Released 00/00/0000 (PENDING)_
 
 **Bugfixes:**
 

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -28,6 +28,16 @@ const debug = null
 export const SetMatchingRoutes: RequestMiddleware = async function () {
   const span = telemetry.startSpan({ name: 'set:matching:routes', parentSpan: this.reqMiddlewareSpan, isVerbose: true })
 
+  const url = new URL(this.req.proxiedUrl)
+
+  // if this is a request to the dev server, do not match any routes as
+  // we do not want to allow the user to intercept requests to the dev server
+  if (url.pathname.startsWith('/__cypress/src')) {
+    span?.end()
+
+    return this.next()
+  }
+
   if (matchesRoutePreflight(this.netStubbingState.routes, this.req)) {
     // send positive CORS preflight response
     return sendStaticResponse(this, {

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -28,16 +28,6 @@ const debug = null
 export const SetMatchingRoutes: RequestMiddleware = async function () {
   const span = telemetry.startSpan({ name: 'set:matching:routes', parentSpan: this.reqMiddlewareSpan, isVerbose: true })
 
-  const url = new URL(this.req.proxiedUrl)
-
-  // if this is a request to the dev server, do not match any routes as
-  // we do not want to allow the user to intercept requests to the dev server
-  if (url.pathname.startsWith(this.config.devServerPublicPathRoute)) {
-    span?.end()
-
-    return this.next()
-  }
-
   if (matchesRoutePreflight(this.netStubbingState.routes, this.req)) {
     // send positive CORS preflight response
     return sendStaticResponse(this, {

--- a/system-tests/project-fixtures/.eslintrc.json
+++ b/system-tests/project-fixtures/.eslintrc.json
@@ -7,5 +7,8 @@
   },
   "rules": {
     "mocha/no-global-tests": "off"
-  }
+  },
+  "extends": [
+    "plugin:vue/vue3-recommended"
+  ]
 }

--- a/system-tests/project-fixtures/.eslintrc.json
+++ b/system-tests/project-fixtures/.eslintrc.json
@@ -7,8 +7,5 @@
   },
   "rules": {
     "mocha/no-global-tests": "off"
-  },
-  "extends": [
-    "plugin:vue/vue3-recommended"
-  ]
+  }
 }

--- a/system-tests/project-fixtures/vue/cypress.config.js
+++ b/system-tests/project-fixtures/vue/cypress.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
       framework: 'vue',
       bundler: 'vite',
     },
+    devServerPublicPathRoute: '',
   },
 })

--- a/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
+++ b/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
@@ -1,17 +1,17 @@
 <script setup>
-import { ref } from "vue"
+import { ref } from "vue";
 
 defineProps({
   msg: String,
-})
+});
 
-const count = ref(0)
+const count = ref(0);
 
 function handleClick () {
-  count.value++
+  count.value++;
   fetch("http://localhost:3000/hello", {
     method: "GET",
-  })
+  });
 }
 </script>
 

--- a/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
+++ b/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
@@ -1,17 +1,30 @@
 <script setup>
-import { ref } from "vue";
+import { ref } from 'vue'
 
 defineProps({
   msg: String,
-});
+})
 
-const count = ref(0);
+const count = ref(0)
+
+function handleClick () {
+  count.value++
+  fetch('http://localhost:3000/hello', {
+    method: 'GET',
+  })
+}
 </script>
 
 <template>
   <div>
     <h1>{{ msg }}</h1>
-    <button type="button" @click="count++">count is {{ count }}</button>
+    <button
+      id="button"
+      type="button"
+      @click="handleClick"
+    >
+      count is {{ count }}
+    </button>
   </div>
 </template>
 

--- a/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
+++ b/system-tests/project-fixtures/vue/src/components/HelloWorld.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref } from "vue"
 
 defineProps({
   msg: String,
@@ -9,8 +9,8 @@ const count = ref(0)
 
 function handleClick () {
   count.value++
-  fetch('http://localhost:3000/hello', {
-    method: 'GET',
+  fetch("http://localhost:3000/hello", {
+    method: "GET",
   })
 }
 </script>

--- a/system-tests/project-fixtures/vue/src/mount.cy.js
+++ b/system-tests/project-fixtures/vue/src/mount.cy.js
@@ -23,4 +23,18 @@ describe('mount', () => {
       cy.get('[data-cy-root]').children().should('have.length', 1)
     })
   })
+
+  it('should succeed to intercept with devServerPublicPathRoute', () => {
+    cy.intercept('GET', 'http://localhost:3000/hello', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: { hello: 'world' },
+      })
+    }).as('helloRequest')
+
+    cy.mount(HelloWorld)
+
+    cy.get('#button').click()
+    cy.wait('@helloRequest')
+  })
 })


### PR DESCRIPTION
- Closes [https://github.com/cypress-io/cypress/issues/29798](https://github.com/cypress-io/cypress/issues/29798)

### Additional details
Bug fixed - a test was added to check its fix

### Steps to test
Adding a cy.intercept with devServerPublicPathRoute: '' in component config

### How has the user experience changed?
No change

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [y] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
