### PR TITLE
chore: capitalize Yarn in 13.13.2 changelog

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,7 +10,7 @@ _Released 7/30/2024_
 
 **Bugfixes:**
 
-- Fixed an issue where yarn PnP was not working correctly with Cypress and `@cypress/webpack-batteries-included-preprocessor`. Fixes [#27947](https://github.com/cypress-io/cypress/issues/27947).
+- Fixed an issue where Yarn PnP was not working correctly with Cypress and `@cypress/webpack-batteries-included-preprocessor`. Fixes [#27947](https://github.com/cypress-io/cypress/issues/27947).
 
 **Dependency Updates:**
 


### PR DESCRIPTION
### Additional details

Capitalizes "Yarn" in "Yarn PnP" reference in https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md for `13.13.2`. "Yarn" is the product `yarn` is the CLI command.

- see https://yarnpkg.com/features/pnp

### Steps to test

N/A

### How has the user experience changed?

N/A

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
