### PR TITLE
chore(webkit): update playwright-webkit to 1.45.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "mock-fs": "5.2.0",
     "p-defer": "^3.0.0",
     "patch-package": "6.4.7",
-    "playwright-webkit": "1.24.2",
+    "playwright-webkit": "1.45.3",
     "pluralize": "8.0.0",
     "print-arch": "1.0.0",
     "proxyquire": "2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25024,17 +25024,17 @@ platform@1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
   integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
-playwright-core@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.2.tgz#47bc5adf3dcfcc297a5a7a332449c9009987db26"
-  integrity sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==
+playwright-core@1.45.3:
+  version "1.45.3"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.45.3.tgz#e77bc4c78a621b96c3e629027534ee1d25faac93"
+  integrity sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==
 
-playwright-webkit@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.24.2.tgz#a81c59c75538172cadd2efcf2ec955dd9b2d9666"
-  integrity sha512-o0JJUWkQ228rNU+a14FVEPf7uUnA+cOrpKM4vsHqLew42sn4Q9ns0rl8pZwekv4u6054OMki4LbKDpvY5ulPgg==
+playwright-webkit@1.45.3:
+  version "1.45.3"
+  resolved "https://registry.yarnpkg.com/playwright-webkit/-/playwright-webkit-1.45.3.tgz#1eea2cb77afdb08e0c0a8f1daa08a95edcd3daf1"
+  integrity sha512-2oR/6nEgqMn1Eb3/rpLt+4wBwXHxvVXfZFLq/5FYyOOkLlhHuW5T1yzo569X0LNUG/j1BaYiCwsrGYqDIc4tWQ==
   dependencies:
-    playwright-core "1.24.2"
+    playwright-core "1.45.3"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/29954

### Additional details

Updates WebKit testing from browser version `16.0` to `17.4`.

`playwright-webkit` is updated from `1.24.2` to `1.45.3`

### Steps to test

TBD

The following does not test WebKit:

```shell
yarn test
```

### How has the user experience changed?

Affects internal CircleCI tests only.

### PR Tasks

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
