### PR TITLE
misc: update postinstall cypress open instructions

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 13.14.0
+## 13.13.3
 
 _Released 8/13/2024 (PENDING)_
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.14.0
+
+_Released 8/13/2024 (PENDING)_
+
+**Misc:**
+
+- Updated `cypress open` hints displayed after Cypress binary install. Addresses [#29935](https://github.com/cypress-io/cypress/issues/29935).
+
 ## 13.13.2
 
 _Released 7/31/2024_

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -20,9 +20,9 @@ Installing Cypress (version: 1.2.3)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -54,9 +54,9 @@ Installing Cypress (version: 1.2.3)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -88,9 +88,9 @@ Installing Cypress (version: 1.2.3)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -108,9 +108,9 @@ Installing Cypress (version: 1.2.3)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -139,9 +139,9 @@ Installing Cypress (version: 1.2.3)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -209,9 +209,9 @@ Installing Cypress (version: 0.12.1)
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 
@@ -313,9 +313,9 @@ Installing Cypress (version: https://cdn.cypress.io/beta/binary/0.0.0-developmen
 
 You can now open Cypress by running one of the following, depending on your package manager:
 
-npx cypress open
-yarn cypress open
-pnpm cypress open
+- npx cypress open
+- yarn cypress open
+- pnpm cypress open
 
 https://on.cypress.io/opening-the-app
 

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -18,9 +18,12 @@ Installing Cypress (version: 1.2.3)
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -48,9 +51,12 @@ Installing Cypress (version: 1.2.3)
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -78,9 +84,12 @@ Installing Cypress (version: 1.2.3)
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -94,9 +103,12 @@ Installing Cypress (version: 1.2.3)
 
 
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -121,9 +133,12 @@ Installing Cypress (version: 1.2.3)
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -187,9 +202,12 @@ Installing Cypress (version: 0.12.1)
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `
@@ -287,9 +305,12 @@ Installing Cypress (version: https://cdn.cypress.io/beta/binary/0.0.0-developmen
 ✔  Unzipped Cypress
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
-You can now open Cypress by running: node_modules/.bin/cypress open
+You can now open Cypress by running one of the following, depending on your package manager:
+npx cypress open
+yarn cypress open
+pnpm cypress open
 
-https://on.cypress.io/installing-cypress
+https://on.cypress.io/opening-the-app
 
 
 `

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -19,6 +19,7 @@ Installing Cypress (version: 1.2.3)
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -52,6 +53,7 @@ Installing Cypress (version: 1.2.3)
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -85,6 +87,7 @@ Installing Cypress (version: 1.2.3)
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -104,6 +107,7 @@ Installing Cypress (version: 1.2.3)
 
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -134,6 +138,7 @@ Installing Cypress (version: 1.2.3)
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -203,6 +208,7 @@ Installing Cypress (version: 0.12.1)
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open
@@ -306,6 +312,7 @@ Installing Cypress (version: https://cdn.cypress.io/beta/binary/0.0.0-developmen
 ✔  Finished Installation   /cache/Cypress/1.2.3
 
 You can now open Cypress by running one of the following, depending on your package manager:
+
 npx cypress open
 yarn cypress open
 pnpm cypress open

--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -55,12 +55,15 @@ const displayCompletionMsg = () => {
 
   logger.log()
   logger.log(
-    'You can now open Cypress by running:',
-    chalk.cyan(path.join('node_modules', '.bin', 'cypress'), 'open'),
+    'You can now open Cypress by running one of the following, depending on your package manager:',
   )
 
+  logger.log(chalk.cyan('npx cypress open'))
+  logger.log(chalk.cyan('yarn cypress open'))
+  logger.log(chalk.cyan('pnpm cypress open'))
+
   logger.log()
-  logger.log(chalk.grey('https://on.cypress.io/installing-cypress'))
+  logger.log(chalk.grey('https://on.cypress.io/opening-the-app'))
   logger.log()
 }
 

--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -58,6 +58,7 @@ const displayCompletionMsg = () => {
     'You can now open Cypress by running one of the following, depending on your package manager:',
   )
 
+  logger.log()
   logger.log(chalk.cyan('npx cypress open'))
   logger.log(chalk.cyan('yarn cypress open'))
   logger.log(chalk.cyan('pnpm cypress open'))

--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -59,9 +59,9 @@ const displayCompletionMsg = () => {
   )
 
   logger.log()
-  logger.log(chalk.cyan('npx cypress open'))
-  logger.log(chalk.cyan('yarn cypress open'))
-  logger.log(chalk.cyan('pnpm cypress open'))
+  logger.log(chalk.cyan('- npx cypress open'))
+  logger.log(chalk.cyan('- yarn cypress open'))
+  logger.log(chalk.cyan('- pnpm cypress open'))
 
   logger.log()
   logger.log(chalk.grey('https://on.cypress.io/opening-the-app'))


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/29935

### Additional details

The Cypress binary installation previously output the following instructions after completion:

```text
You can now open Cypress by running: node_modules/.bin/cypress open

https://on.cypress.io/installing-cypress
```

1. This instruction does not work on a default installation of Yarn Modern
2. The link https://on.cypress.io/installing-cypress is about installing Cypress, not about running it.

The text is changed to provide the following information:

| Package Manager | Command                  |
| --------------- | ------------------------ |
| npm             | `npx cypress open`       |
| Yarn            | `yarn cypress open`      |
| pnpm            | `pnpm exec cypress open` |

https://on.cypress.io/opening-the-app

### Steps to test

See https://github.com/cypress-io/cypress/blob/develop/cli/README.md#manual

### How has the user experience changed?

**BEFORE**

![install before](https://github.com/user-attachments/assets/fe987580-c3b8-4074-a195-26047ff8c215)

**AFTER**

![install after](https://github.com/user-attachments/assets/847fc01d-57ed-42cc-a8eb-4eb4bb532390)

### PR Tasks

- [x] Have tests been added/updated?
  - snapshots updated
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
  - https://github.com/cypress-io/cypress-documentation/pull/5390 already provided this update in July 2023
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
