### PR TITLE
docs: clarify cli manual build instructions

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -43,22 +43,25 @@ When testing with `dtslint`, you may need to remove existing typescript installa
 
 ### Manual
 
-To build and test an NPM package:
+To build and test an npm package, execute the following from the repo's root directory:
 
-- `yarn`
-- `yarn build`
+```shell
+yarn
+yarn build
+```
 
-This creates `build` folder.
+This creates the `cli/build` folder.
 
-- `cd build; yarn pack`
+```shell
+cd cli/build
+yarn pack
+```
 
 This creates an archive, usually named `cypress-v<version>.tgz`. You can install this archive from other projects, but because there is no corresponding binary yet (probably), skip binary download. For example from inside `cypress-example-kitchensink` folder
 
 ```shell
-yarn add ~/{your-dirs}/cypress/cli/build/cypress-3.3.1.tgz --ignore-scripts
+yarn add ~/{your-dirs}/cypress/cli/build/cypress-v13.13.2.tgz --ignore-scripts
 ```
-
-Which installs the `tgz` file we have just built from folder `Users/jane-lane/{your-dirs}/cypress/cli/build`.
 
 #### Sub-package API
 


### PR DESCRIPTION
### Additional details

The [CLI manual build](https://github.com/cypress-io/cypress/blob/develop/cli/README.md#manual) instructions are unclear / inconsistent about the working directory.

As stated in [CONTRIBUTING > Getting Started](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#getting-started)

> ... it is *important* to note that running scripts or installing new dependencies should always happen from the repo's root directory.

The instructions are updated and made consistent.

### Steps to test

Follow the updated steps in [CLI manual build](https://github.com/cypress-io/cypress/blob/develop/cli/README.md#manual) and ensure they are successful.

### How has the user experience changed?

Developer usage only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?