### PR TITLE
chore: use ISO 8601 format in cli test timestamps

### DIFF
--- a/cli/test/lib/exec/info_spec.js
+++ b/cli/test/lib/exec/info_spec.js
@@ -78,7 +78,7 @@ describe('exec info', function () {
       stable: false,
       commitSha: 'abc123',
       commitBranch: 'someBranchName',
-      commitDate: new Date('02-02-2022').toISOString(),
+      commitDate: new Date('2022-02-02').toISOString(),
     })
 
     await startInfoAndSnapshot('logs additional info about pre-releases')

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -78,7 +78,7 @@ describe('/lib/tasks/install', function () {
         stable: false,
         commitSha: '3b7f0b5c59def1e9b5f385bd585c9b2836706c29',
         commitBranch: 'aBranchName',
-        commitDate: new Date('11-27-1996').toISOString(),
+        commitDate: new Date('1996-11-27').toISOString(),
       }
 
       function runInstall () {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/29961

### Additional details

Running the following command was failing for timezones east of Greenwich

```shell
yarn test-unit --scope cypress
```

Timestamp settings in test specs below are changed to use ISO 8601 format `YYYY-MM-DD` for unambiguous interpretation. This affects:

- [cli/test/lib/exec/info_spec.js](https://github.com/cypress-io/cypress/blob/develop/cli/test/lib/exec/info_spec.js)
- [cli/test/lib/tasks/install_spec.js](https://github.com/cypress-io/cypress/blob/develop/cli/test/lib/tasks/install_spec.js)

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format

### Steps to test

```shell
yarn
```

Reconfigure timezone for tests with:

```shell
sudo dpkg-reconfigure tzdata
```

then repeat

```shell
yarn test-unit --scope cypress
```

| Timezone                    | Before | After |
| --------------------------- | ------ | ----- |
| US/Eastern (EDT, -0400)     | pass   | pass  |
| Europe/London (BST, +0100)  | pass   | pass  |
| Europe/Berlin (CEST, +0200) | fail   | pass  |
| Europe/Athens (EEST, +0300) | fail   | pass  |
| Etc/UTC (UTC, +0000)        | pass   | pass  |


### How has the user experience changed?

Developer and CI usage only.

### PR Tasks

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
