### PR TITLE
chore: revert "misc: allow HiDPI Screen running wayland to use cypress window/browser"

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,7 +11,6 @@ _Released 8/13/2024 (PENDING)_
 **Misc:**
 
 - Updated `cypress open` hints displayed after Cypress binary install. Addresses [#29935](https://github.com/cypress-io/cypress/issues/29935).
-- Allow HiDPI Screen running wayland to use cypress window/browser by adding `--ozone-platform=auto` flag to the electron's runtime argument. Addresses [#20891](https://github.com/cypress-io/cypress/issues/20891).
 
 ## 13.13.2
 

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -155,7 +155,7 @@ module.exports = {
 
         const { onStderrData } = overrides
         const envOverrides = util.getEnvOverrides(options)
-        const electronArgs = ['--ozone-platform=auto']
+        const electronArgs = []
         const node11WindowsFix = isPlatform('win32')
 
         let startScriptPath

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -121,7 +121,6 @@ describe('lib/exec/spawn', function () {
       return spawn.start('--foo', { foo: 'bar' })
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('/path/to/cypress', [
-          '--ozone-platform=auto',
           '--',
           '--foo',
           '--cwd',
@@ -149,7 +148,6 @@ describe('lib/exec/spawn', function () {
         const args = cp.spawn.firstCall.args.slice(0, 2)
         // it is important for "--no-sandbox" to appear before "--" separator
         const expectedCliArgs = [
-          '--ozone-platform=auto',
           '--no-sandbox',
           '--',
           '--foo',
@@ -175,7 +173,6 @@ describe('lib/exec/spawn', function () {
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('node', [
           p,
-          '--ozone-platform=auto',
           '--',
           '--foo',
           '--cwd',
@@ -201,7 +198,6 @@ describe('lib/exec/spawn', function () {
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('node', [
           p,
-          '--ozone-platform=auto',
           '--',
           '--foo',
           '--cwd',


### PR DESCRIPTION
Reverts cypress-io/cypress#29366

It looks like upon merge, there are some issues with setting `ozone-platform=auto` with the built linux binary. We will need to revert until another solution can be assessed. It looks like in the meantime we might be able to try out `ozone-platform-hint`, but that is outside the scope of this PR