### PR TITLE
chore: remove obsolete docker compose v1 file format version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   dev:
     image: cypress/browsers:latest


### PR DESCRIPTION
### Additional details

The obsolete `version` definition is removed from [docker-compose.yml](https://github.com/cypress-io/cypress/blob/develop/docker-compose.yml).

The `version` definition belongs to the Compose V1 specification and is no longer supported. Compose V1 is no longer included in current releases of Docker Desktop and the final release was in May 2021.

Compose V2, the current version, released in 2020, ignores the `version` top-level element in a `compose.yml` file. See [Compose history](https://docs.docker.com/compose/intro/history/#introduction) and [Version top-level element (obsolete)](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete).

### Steps to test

Follow the instructions in [CONTRIBUTING > Docker](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#docker) and run the following from the root of the repo, after having started Desktop Docker:

```shell
yarn docker
```

There should be no warning about the attribute `version`.

### How has the user experience changed?

Developers will no longer see the following warning message when running `yarn docker`:

```text
WARN[0000] /<user-directory>/cypress/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
