### PR TITLE
chore: fix CI pipeline issues with deduped tar package

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,6 +267,7 @@
     "**/@types/enzyme": "3.10.5",
     "**/@types/react": "16.9.50",
     "**/jquery": "3.4.1",
+    "**/nx-cloud/**/tar": "6.1.15",
     "**/pretty-format": "26.4.0",
     "**/sharp": "0.29.3",
     "**/socket.io-parser": "4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29405,22 +29405,10 @@ tar@6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@6.1.15, tar@^6.0.2, tar@^6.0.5, tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
+tar@6.1.15, tar@6.2.1, tar@^6.0.2, tar@^6.0.5, tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
   version "6.1.15"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
   integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
-  dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
-
-tar@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #30058

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

After introducing our [yarn dedupe strategy to highest](https://github.com/cypress-io/cypress/commit/f666aecc691605ece8daa2c0667aef91baa8b5a6) after our [@nrwl/nx-cloud](91f862ad72fd236381ad8b81124202a4c9abf0c3) upgrade, the `yarn.lock` file became out of sync.

deduping the `tar` package for semver packages to point to `6.2.1`  (introduced in the  [@nrwl/nx-cloud](91f862ad72fd236381ad8b81124202a4c9abf0c3) update) instead of `6.1.15` causes the issue:

```bash
TypeError: Class extends value #<Object> is not a constructor or null
```

inside our [ci pipeline](https://app.circleci.com/pipelines/github/cypress-io/cypress/63585/workflows/8cf9f748-532e-4ded-a36d-344449081910/jobs/2634951). This issue is hard to reproduce locally as well as in the used docker container. I was also unable to find a root cause of this issue.

To remedy this, I am introducing a yarn [resolution](https://yarnpkg.com/cli/set/resolution) to resolve `tar` in the `nx-cloud` package from `6.2.1` to `6.1.15`, which removes the reference to `6.2.1` and gets our CI pipeline working again. However, this may creep up again in the future if a semver compatible package of `tar` gets updated to `6.2.1` and other `tar` versions are deduped.

I would rather solve this issue by telling the `nx-cloud` package to not hoist any dependencies and install them all  inside the `nx-cloud` package to prevent cross pollination, but I have not been able to figure that out.  

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
