### PR TITLE
chore(deps): remove deprecated @types/chalk

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -28,7 +28,6 @@
     "@packages/telemetry": "0.0.0-development",
     "@packages/ts": "0.0.0-development",
     "@sinonjs/fake-timers": "8.1.0",
-    "@types/chalk": "^2.2.0",
     "@types/common-tags": "^1.8.0",
     "@types/crypto-js": "4.1.1",
     "@types/jquery.scrollto": "1.4.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7473,13 +7473,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.15.tgz#b7a6d263c2cecf44b6de9a051cf496249b154553"
   integrity sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  integrity sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==
-  dependencies:
-    chalk "*"
-
 "@types/cheerio@*", "@types/cheerio@0.22.21":
   version "0.22.21"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.21.tgz#5e37887de309ba11b2e19a6e14cad7874b31a8a3"
@@ -11687,11 +11680,6 @@ chalk-template@0.4.0:
   dependencies:
     chalk "^4.1.2"
 
-chalk@*, chalk@^5.0.0, chalk@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
-
 chalk@1.x.x, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -11740,6 +11728,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.0.0, chalk@^5.0.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
 change-case-all@1.0.14:
   version "1.0.14"


### PR DESCRIPTION
### Additional details

- Currently as listed as deprecated on https://github.com/cypress-io/cypress/issues/3777

The deprecated `@types/chalk` npm module is removed:

https://github.com/cypress-io/cypress/blob/d79c99e324e9d9588679d9d79402f9f528ba4c27/packages/driver/package.json#L31

npm modules [@types/chalk](https://www.npmjs.com/package/@types/chalk) is deprecated with the note:
> This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!

npm module [chalk](https://www.npmjs.com/package/chalk) includes type definitions.

### Steps to test

```shell
yarn
yarn workspace @packages/runner watch
```

in a separate terminal

```shell
yarn workspace @packages/driver cypress:run
```

### How has the user experience changed?

No change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?