### PR TITLE
chore(deps): remove deprecated @types/classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@types/better-sqlite3": "^7.6.3",
     "@types/bluebird": "3.5.29",
     "@types/chai-enzyme": "0.6.7",
-    "@types/classnames": "2.2.9",
     "@types/debug": "4.1.7",
     "@types/detect-port": "^1.3.5",
     "@types/enzyme-adapter-react-16": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7501,11 +7501,6 @@
   dependencies:
     "@types/filesystem" "*"
 
-"@types/classnames@2.2.9":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
-  integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
-
 "@types/common-tags@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.0.tgz#79d55e748d730b997be5b7fce4b74488d8b26a6b"


### PR DESCRIPTION
### Additional details

- Currently listed as deprecated without replacement on https://github.com/cypress-io/cypress/issues/3777

The deprecated `@types/classnames` npm module is removed:

https://github.com/cypress-io/cypress/blob/d79c99e324e9d9588679d9d79402f9f528ba4c27/package.json#L102

npm modules [@types/classnames](https://www.npmjs.com/package/@types/classnames) is deprecated with the note:
> This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.

npm module [classnames](https://www.npmjs.com/package/classnames) includes type definitions.

### Steps to test

```shell
git clean -xfd
yarn
```

### How has the user experience changed?

No change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?