### PR TITLE
chore(deps): remove deprecated @types/execa

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@types/debug": "4.1.7",
     "@types/detect-port": "^1.3.5",
     "@types/enzyme-adapter-react-16": "1.0.5",
-    "@types/execa": "0.9.0",
     "@types/fluent-ffmpeg": "^2.1.18",
     "@types/fs-extra": "^9.0.13",
     "@types/getenv": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7643,13 +7643,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/execa@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@types/execa/-/execa-0.9.0.tgz#9b025d2755f17e80beaf9368c3f4f319d8b0fb93"
-  integrity sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/expect@^1.20.4":
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/@types/expect/-/expect-1.20.4.tgz#8288e51737bf7e3ab5d7c77bfa695883745264e5"


### PR DESCRIPTION
### Additional details

- Currently listed as deprecated without replacement on https://github.com/cypress-io/cypress/issues/3777

The deprecated `@types/execa` npm module is removed:

https://github.com/cypress-io/cypress/blob/d79c99e324e9d9588679d9d79402f9f528ba4c27/package.json#L106

npm modules [@types/execa](https://www.npmjs.com/package/@types/execa) is deprecated with the note:
> This is a stub types definition. execa provides its own type definitions, so you do not need this installed.

npm module [execa](https://www.npmjs.com/package/execa) includes type definitions.

### Steps to test

```shell
git clean -xfd
yarn
```

### How has the user experience changed?

No change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?