### PR TITLE
docs: remove contributing "Docker for built binary"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,24 +406,6 @@ There is a script [scripts/run-docker-local.sh](scripts/run-docker-local.sh) tha
 
 The image will start and will map the root of the repository to `/cypress` inside the image. Now you can modify the files using your favorite environment and rerun tests inside the docker environment.
 
-#### Docker for built binary
-
-You can also use Docker to simulate and debug the built binary. In a temporary folder (for example from the folder `/tmp/test-folder/`) start a Docker image:
-
-```shell
-$ docker run -it -w /app -v $PWD:/app cypress/base:8 /bin/bash
-```
-
-Point the installation at a specific beta binary and NPM package archive (if needed) and _set local cache folder_ to unzip the downloaded binary into a subfolder.
-
-```shell
-$ export CYPRESS_INSTALL_BINARY=https://cdn.cypress.io/beta/.../cypress.zip
-$ export CYPRESS_CACHE_FOLDER=./cypress-cache
-$ yarn add https://cdn.cypress.io/beta/npm/.../cypress.tgz
-```
-
-Note that unzipping the Linux binary inside a Docker container onto a mapped volume drive is *slow*. But once this is done you can modify the application resource folder in the local folder `/tmp/test-folder/node_modules/cypress/cypress-cache/3.3.0/Cypress/resources/app` to debug issues.
-
 #### Docker as a performance constrained environment
 
 Sometimes performance issues are easier to reproduce in performance constrained environments. A docker container can be a good way to simulate this locally and allow for quick iteration.


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/30071

### Additional details

The section is removed:

[CONTRIBUTING > Docker for built binary](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#docker-for-built-binary)

- As described in #30071 the section [CONTRIBUTING > Docker for built binary](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#docker-for-built-binary) which refers to using Cypress Docker image `cypress/base:8` from Jan 2019 is outdated.
- Pre-release versions as described in https://on.cypress.io/advanced-installation#Install-pre-release-version are installed the same as released versions so there is no need for additional instructions.
- https://github.com/cypress-io/cypress-docker-images provides information about running Cypress in Cypress Docker images. The documentation has been considerably expanded in the Cypress Docker repo since the contributor section in this repo was written.
- The fact that there has been no feedback about this outdated section in the last 5 years indicates that it is not being used.

### Steps to test

N/A

### How has the user experience changed?

Developer documentation change only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
