### PR TITLE
docs: remove ubuntu 23.10 from contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ You must have the following installed on your system to contribute locally:
 
 `sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
 `python` is pre-installed on Debian-based systems including Ubuntu.
-The Python versions shipped with Ubuntu versions `20.04`, `23.10` and `22.04` are compatible with Cypress requirements.
+The Python versions shipped with Ubuntu versions `20.04` and `22.04` are compatible with Cypress requirements.
 
 Only on Ubuntu `24.04` install Python `3.11` by executing the following commands:
 


### PR DESCRIPTION
### Additional details

- The reference to Ubuntu `23.10` is removed from the [CONTRIBUTING > Debian/Ubuntu](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#debianubuntu) documentation section.
- As shown on [Ubuntu release cycle](https://ubuntu.com/about/release-cycle) and [Ubuntu Releases](https://wiki.ubuntu.com/Releases) the interim release `23.10` (Mantic Minotaur) reached end-of-life on July 11, 2024. It therefore no longer needs consideration in the Contributor's documentation.

### Steps to test

Preview

https://github.com/MikeMcC399/cypress/blob/ubuntu-23.10-eol/CONTRIBUTING.md#debianubuntu

### How has the user experience changed?

Contributor documentation change only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?