### PR TITLE
misc: allow HiDPI Screen running wayland to use cypress window/browser

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -30,9 +30,8 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'jquery-patch-remove-unload'
         - 'publish-binary'
-        - 'fix/8599'
+        - 'chore/support_hidpi_wayland'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -43,6 +42,7 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
+    - equal: [ 'chore/support_hidpi_wayland', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -53,7 +53,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'jquery-patch-remove-unload', << pipeline.git.branch >> ]
+    - equal: [ 'chore/support_hidpi_wayland', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -76,7 +76,7 @@ windowsWorkflowFilters: &windows-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/29880/unload-in-chromium', << pipeline.git.branch >> ]
+    - equal: [ 'chore/support_hidpi_wayland', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
         value: << pipeline.git.branch >>
@@ -152,7 +152,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "fix/8599" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "chore/support_hidpi_wayland" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,6 +24,10 @@ _Released 8/27/2024 (PENDING)_
 
 - Correctly determines current browser family when choosing between `unload` and `pagehide` options in App Runner. Fixes [#29880](https://github.com/cypress-io/cypress/issues/29880).
 
+**Misc:**
+
+- Allow HiDPI Screen running wayland to use cypress window/browser by adding `--ozone-platform-hint=auto` flag to the electron's runtime argument. Addresses [#20891](https://github.com/cypress-io/cypress/issues/20891).
+
 **Dependency Updates:**
 
 - Updated `detect-port` from `1.3.0` to `1.6.1`. Addressed in [#30038](https://github.com/cypress-io/cypress/pull/30038).

--- a/cli/lib/exec/spawn.js
+++ b/cli/lib/exec/spawn.js
@@ -155,7 +155,7 @@ module.exports = {
 
         const { onStderrData } = overrides
         const envOverrides = util.getEnvOverrides(options)
-        const electronArgs = []
+        const electronArgs = ['--ozone-platform-hint=auto']
         const node11WindowsFix = isPlatform('win32')
 
         let startScriptPath

--- a/cli/test/lib/exec/spawn_spec.js
+++ b/cli/test/lib/exec/spawn_spec.js
@@ -121,6 +121,7 @@ describe('lib/exec/spawn', function () {
       return spawn.start('--foo', { foo: 'bar' })
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('/path/to/cypress', [
+          '--ozone-platform-hint=auto',
           '--',
           '--foo',
           '--cwd',
@@ -148,6 +149,7 @@ describe('lib/exec/spawn', function () {
         const args = cp.spawn.firstCall.args.slice(0, 2)
         // it is important for "--no-sandbox" to appear before "--" separator
         const expectedCliArgs = [
+          '--ozone-platform-hint=auto',
           '--no-sandbox',
           '--',
           '--foo',
@@ -173,6 +175,7 @@ describe('lib/exec/spawn', function () {
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('node', [
           p,
+          '--ozone-platform-hint=auto',
           '--',
           '--foo',
           '--cwd',
@@ -198,6 +201,7 @@ describe('lib/exec/spawn', function () {
       .then(() => {
         expect(cp.spawn).to.be.calledWithMatch('node', [
           p,
+          '--ozone-platform-hint=auto',
           '--',
           '--foo',
           '--cwd',


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #20891

### Additional details
A revisit of #29366. When merging in #29366, there were issues detecting the `--ozone-platform=auto` in older versions of linux distributions, the `--ozone-platform-hint` argument is in place to not make this a critical error when testing the binary 
![](https://github.com/user-attachments/assets/c56a44f5-0f54-4156-8bf8-4bb279b0c58e)

From original PR #29366: 

1. High demand of HiDPI Screen and multi monitor setups make people tend to use fractional scaling for each their own monitor differently. Problem happens when using chromium based app that can lead to blurriness of the UI. By providing simple flag to the electron arguments `--ozone-platform=auto` which literally can backwards compatible will help Wayland users to use chromium/electron without blurry texts, the flag also compatible with x11 window system if it's the only available option.

2. Just small change to add the flag to the spawn.js file

### Steps to test
It's already tested [here](https://github.com/cypress-io/cypress/issues/20891#issuecomment-1998122717)
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
