### PR TITLE
fix: adds a description for the JIT experiment

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.14.1
+
+_Released 8/29/2024 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where no description was available for the `experimentalJustInTimeCompile` feature inside the Cypress application settings page. Addresses [#30126](https://github.com/cypress-io/cypress/issues/30126).
+
 ## 13.14.0
 
 _Released 8/27/2024_

--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -219,6 +219,13 @@ describe('App: Settings', () => {
           })
         })
       })
+
+      // makes sure all experiments have an i18n header and description available.
+      // @see https://github.com/cypress-io/cypress/issues/30126.
+      cy.get('[data-cy="settings-experiments"] [role="row"][data-cy^="experiment-"]').each((experimentRow) => {
+        cy.wrap(experimentRow[0]).get('[data-cy="experimentName"]').should('not.contain.text', 'settingsPage.')
+        cy.wrap(experimentRow[0]).get('[data-cy="experimentDescription"]').should('not.contain.text', 'settingsPage.')
+      })
     })
 
     it('shows the Resolved Configuration section', () => {

--- a/packages/app/src/settings/project/ExperimentRow.vue
+++ b/packages/app/src/settings/project/ExperimentRow.vue
@@ -7,6 +7,7 @@
       <h3
         class="inline text-indigo-500 text-md"
         role="rowheader"
+        data-cy="experimentName"
       >
         {{ experiment.name }}
       </h3>
@@ -22,6 +23,7 @@
       <span
         ref="descriptionRef"
         class="description children:text-sm children:leading-[24px]"
+        data-cy="experimentDescription"
         v-html="markdown"
       />
     </span>

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -609,6 +609,10 @@
         "name": "Single tab run mode",
         "description": "Runs all component specs in a single tab, trading spec isolation for faster run mode execution."
       },
+      "experimentalJustInTimeCompile": {
+        "name": "Just-In-Time compiling",
+        "description": "Enables Just-In-Time (JIT) compiling for component testing, which will only compile assets related to the spec before the spec is run. Currently supported for Vite and Webpack."
+      },
       "experimentalSourceRewriting": {
         "name": "Source rewriting",
         "description": "Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm. See [#5273](https://github.com/cypress-io/cypress/issues/5273) for details."

--- a/packages/server/lib/experiments.ts
+++ b/packages/server/lib/experiments.ts
@@ -53,6 +53,7 @@ interface StringValues {
 const _summaries: StringValues = {
   experimentalFetchPolyfill: 'Polyfills `window.fetch` to enable Network spying and stubbing.',
   experimentalInteractiveRunEvents: 'Allows listening to the `before:run`, `after:run`, `before:spec`, and `after:spec` events in the plugins file during interactive mode.',
+  experimentalJustInTimeCompile: 'Just-In-Time compiling',
   experimentalModifyObstructiveThirdPartyCode: 'Applies `modifyObstructiveCode` to third party `.html` and `.js`, removes subresource integrity, and modifies the user agent in Electron.',
   experimentalSkipDomainInjection: 'Disables setting document.domain to the document\'s super domain on injection.',
   experimentalSourceRewriting: 'Enables AST-based JS/HTML rewriting. This may fix issues caused by the existing regex-based JS/HTML replacement algorithm.',
@@ -77,6 +78,7 @@ const _summaries: StringValues = {
 const _names: StringValues = {
   experimentalFetchPolyfill: 'Fetch Polyfill',
   experimentalInteractiveRunEvents: 'Interactive Mode Run Events',
+  experimentalJustInTimeCompile: 'Enables Just-In-Time (JIT) compiling for component testing, which will only compile assets related to the spec before the spec is run. Currently supported for Vite and Webpack.',
   experimentalModifyObstructiveThirdPartyCode: 'Modify Obstructive Third Party Code',
   experimentalSkipDomainInjection: 'Use Default document.domain',
   experimentalSingleTabRunMode: 'Single Tab Run Mode',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #30126

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Adds a header and description for the JIT experiment that was released yesterday. I accidentally overlooked this on the initial implementation. Since I believe I have done this twice now with two separate experiments, I have added a regression test in `settings.cy.ts` that checks the settings page in the app to make sure all experiments have an i18n value and will fail otherwise. I am hoping this test catches this problem in the future. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
