### PR TITLE
fix: WebSocket Connection Closed crashing from BrowserCriClient

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,8 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.14.2
+
 _Released 9/10/2024 (PENDING)_
 
-- Fixed an issue where Cypress could crash with a `WebSocket Connection Closed` error. Addresses [30174](https://github.com/cypress-io/cypress/pull/30174).
+**Bugfixes:**
+
+- Fixed an issue where Cypress could crash with a `WebSocket Connection Closed` error. Fixes [#30100](https://github.com/cypress-io/cypress/issues/30100).
 
 ## 13.14.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 8/29/2024_
 
 **Bugfixes:**
 
+- Fixed an issue where Cypress could crash with a `WebSocket Connection Closed` error. Addresses [30174](https://github.com/cypress-io/cypress/pull/30174).
 - Fixed an issue where no description was available for the `experimentalJustInTimeCompile` feature inside the Cypress application settings page. Addresses [#30126](https://github.com/cypress-io/cypress/issues/30126).
 
 ## 13.14.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,11 +1,15 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.14.2
+_Released 9/10/2024 (PENDING)_
+
+- Fixed an issue where Cypress could crash with a `WebSocket Connection Closed` error. Addresses [30174](https://github.com/cypress-io/cypress/pull/30174).
+
 ## 13.14.1
 
 _Released 8/29/2024_
 
 **Bugfixes:**
 
-- Fixed an issue where Cypress could crash with a `WebSocket Connection Closed` error. Addresses [30174](https://github.com/cypress-io/cypress/pull/30174).
 - Fixed an issue where no description was available for the `experimentalJustInTimeCompile` feature inside the Cypress application settings page. Addresses [#30126](https://github.com/cypress-io/cypress/issues/30126).
 
 ## 13.14.0

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -403,7 +403,10 @@ export class BrowserCriClient {
 
     browserCriClient.addExtraTargetClient(targetInfo, extraTargetCriClient)
 
-    await extraTargetCriClient.send('Fetch.enable')
+    await extraTargetCriClient.send('Fetch.enable').catch((err) => {
+      // swallow this error so it doesn't crash Cypress
+      debug('Fetch.enable failed on extra target#%s: %s', targetId, err)
+    })
 
     // we mark extra targets with this header, so that the proxy can recognize
     // where they came from and run only the minimal middleware necessary

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -403,10 +403,12 @@ export class BrowserCriClient {
 
     browserCriClient.addExtraTargetClient(targetInfo, extraTargetCriClient)
 
-    await extraTargetCriClient.send('Fetch.enable').catch((err) => {
+    try {
+      await extraTargetCriClient.send('Fetch.enable')
+    } catch (err) {
       // swallow this error so it doesn't crash Cypress
       debug('Fetch.enable failed on extra target#%s: %s', targetId, err)
-    })
+    }
 
     // we mark extra targets with this header, so that the proxy can recognize
     // where they came from and run only the minimal middleware necessary

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -278,6 +278,20 @@ describe('lib/browsers/browser-cri-client', function () {
       expect(options.browserClient.send).to.be.calledWith('Runtime.runIfWaitingForDebugger', undefined, 'session-id')
     })
 
+    it('does not throw if Fetch.enable on extra target throws', async () => {
+      const extraTargetCriClient = {
+        send: sinon.stub().withArgs('Fetch.enable').rejects('Fetch.enable failed'),
+        on: sinon.stub(),
+      }
+
+      options.CriConstructor.resolves(extraTargetCriClient)
+
+      options.browserClient.send.withArgs('Fetch.enable').resolves()
+      options.browserClient.send.withArgs('Runtime.runIfWaitingForDebugger').resolves()
+
+      expect(BrowserCriClient._onAttachToTarget(options as any)).to.be.fulfilled
+    })
+
     it('adds the service worker fetch event binding', async () => {
       options.event.targetInfo.type = 'service_worker'
 

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -278,7 +278,7 @@ describe('lib/browsers/browser-cri-client', function () {
       expect(options.browserClient.send).to.be.calledWith('Runtime.runIfWaitingForDebugger', undefined, 'session-id')
     })
 
-    it('does not throw if Fetch.enable on extra target throws', async () => {
+    it('does not throw if Fetch.enable on extra target throws', () => {
       const extraTargetCriClient = {
         send: sinon.stub().withArgs('Fetch.enable').rejects('Fetch.enable failed'),
         on: sinon.stub(),


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/30100

### Additional details
When the BrowserCRIClient attaches to a target, it determines if the new target is an "extra target" or not. As a part of this process, it creates a raw CDPClient instance and sends a `Fetch.enable` command. If this extra target is closed before that command can resolve, CDPClient will throw a `WebSocket Connection Closed` error. If this error is uncaught, it will crash Cypress.

To fix this, the command is wrapped in try/catch, and logs a debug entry for the error if an error is encountered.

This could have been fixed by using the more resilient `CRIClient` class, but `BrowserCRIClient` is fairly complex, and this approach has a smaller change footprint. `BrowserCRIClient` is a candidate for similar refactors that were made to `CRIClient`, recently.

### Steps to test
As this error is very difficult to reproduce intentionally, the only test available is a unit test.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
