### PR TITLE
docs: fix broken CONTRIBUTING.md links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,6 @@ Thanks for taking the time to contribute! :smile:
 
 - [Report bugs](https://github.com/cypress-io/cypress/issues/new) by opening an issue.
 - [Request features](https://github.com/cypress-io/cypress/issues/new) by opening an issue.
-- [Help triage existing issues](#triaging-issues).
 - Write code to address an issue. We have some issues labeled as [`good first issue`](https://github.com/cypress-io/cypress/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) that are a good place to start. Please thoroughly read our [Writing Code guide](#writing-code).
 
 ## Table of Contents
@@ -26,7 +25,7 @@ Thanks for taking the time to contribute! :smile:
   - [Requirements](#requirements)
   - [Getting Started](#getting-started)
   - [Coding Style](#coding-style)
-  - [Adding links within code](#Adding-links-within-code)
+  - [Adding links within code](#adding-links-within-code)
   - [Tests](#tests)
   - [Packages](#packages)
 - [Committing Code](#committing-code)
@@ -34,11 +33,11 @@ Thanks for taking the time to contribute! :smile:
   - [Pull Requests](#pull-requests)
   - [Dependencies](#dependencies)
 - [Reviewing Code](#reviewing-code)
-  - [Some rules about Code Review](#Some-rules-about-Code-Review)
-  - [Steps to take during Code Review](#Steps-to-take-during-Code-Review)
-  - [Code Review Checklist](#Code-Review-Checklist)
-  - [Code Review of Dependency Updates](#Code-Review-of-Dependency-Updates)
-- [Deployment](#deployment)
+  - [Some rules about Code Review](#some-rules-about-code-review)
+  - [Steps to take during Code Review](#steps-to-take-during-code-review)
+  - [Code Review Checklist](#code-review-checklist)
+  - [Code Review of Dependency Updates](#code-review-of-dependency-updates)
+- [Releases](#releases)
 
 ## Code of Conduct
 
@@ -172,7 +171,7 @@ Here is a list of the packages in this repository with a short description, loca
 
  | Folder Name                           | Package Name            | Purpose                                                                      |
  | :------------------------------------ | :---------------------- | :--------------------------------------------------------------------------- |
- | [electron-mksnapshot](./electron-mksnapshot) | `electron-mksnapshot` | A rewrite of [electron/mksnapshot](https://github.com/electron/mksnapshot) to support multiple versions. |
+ | [electron-mksnapshot](./tooling/electron-mksnapshot) | `electron-mksnapshot` | A rewrite of [electron/mksnapshot](https://github.com/electron/mksnapshot) to support multiple versions. |
  | [packherd](./tooling/packherd)        | `packherd`              | Herds all dependencies reachable from an entry and packs them.               |
  | [v8-snapshot](./tooling/v8-snapshot)  | `v8-snapshot`           | Tool to create a snapshot for Electron applications.                         |
 


### PR DESCRIPTION
### Additional details

Fix some failing links in [CONTRIBUTING.md](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md)

```text
  [✖] #triaging-issues → Status: 404
  [✖] #Adding-links-within-code → Status: 404
  [✖] #Some-rules-about-Code-Review → Status: 404
  [✖] #Steps-to-take-during-Code-Review → Status: 404
  [✖] #Code-Review-Checklist → Status: 404
  [✖] #Code-Review-of-Dependency-Updates → Status: 404
  [✖] #deployment → Status: 404
  [✖] ./electron-mksnapshot → Status: 400
```

- The section `Triaging Issues` was moved in https://github.com/cypress-io/cypress/pull/23722 to `cypress-prioritization-and-triage.md` and deleted in PR https://github.com/cypress-io/cypress/pull/28876.

- Incorrect case in bookmarks affects viewing the file locally (for instance in VSCode). GitHub ignores bookmark case errors when reading the page online.

- The `Deployment` section was renamed to [Releases](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#releases) in PR https://github.com/cypress-io/cypress/pull/23899

- `./electron-mksnapshot` is missing the parent directory `./tooling`

- HTTP 429 (Too Many Requests) from https://github.com seem to be spurious and can be ignored
- HTTP 404 (Not Found) concerns links accessing the private repo https://github.com/cypress-io/cypress-services/. The text explains that it is a private repo, so the errors can be ignored.

### Steps to test

```shell
npm install markdown-link-check@latest -g
npx markdown-link-check CONTRIBUTING.md
```

Confirm no errors except:

- HTTP 429
- HTTP 404 accessing the private repo https://github.com/cypress-io/cypress-services/

### How has the user experience changed?

Readers of [CONTRIBUTING.md](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md) should not encounter any avoidable bad hyperlinks.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
