### PR TITLE
docs: update link to debug-js/debug repo

### DIFF
--- a/guides/debug-logs.md
+++ b/guides/debug-logs.md
@@ -39,4 +39,4 @@ localStorage.DEBUG = 'cypress:driver,cypress:driver:*'
 
 For more info, see the [public documentation for printing debug logs](https://docs.cypress.io/guides/references/troubleshooting#Print-DEBUG-logs) and the [`debug` module docs][debug]
 
-[debug]: https://github.com/visionmedia/debug#readme
+[debug]: https://github.com/debug-js/debug#readme

--- a/npm/grep/README.md
+++ b/npm/grep/README.md
@@ -525,7 +525,7 @@ Then I expect to see the grep string and the "filter tests" flag in the `env` ob
 
 ### Log messages
 
-This module uses [debug](https://github.com/visionmedia/debug#readme) to log verbose messages. You can enable the debug messages in the plugin file (runs when discovering specs to filter), and inside the browser to see how it determines which tests to run and to skip. When opening a new issue, please provide the debug logs from the plugin (if any) and from the browser.
+This module uses [debug](https://github.com/debug-js/debug#readme) to log verbose messages. You can enable the debug messages in the plugin file (runs when discovering specs to filter), and inside the browser to see how it determines which tests to run and to skip. When opening a new issue, please provide the debug logs from the plugin (if any) and from the browser.
 
 ### Debugging in the plugin
 

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -26,7 +26,7 @@ yarn workspace @packages/launcher test
 
 ## Debugging
 
-Uses [debug](https://github.com/visionmedia/debug#readme)
+Uses [debug](https://github.com/debug-js/debug#readme)
 to output debug log messages. To turn on, use
 
 ```sh


### PR DESCRIPTION
### Additional details

The npm [debug](https://www.npmjs.com/package/debug) module's source repo moved:

- from https://github.com/visionmedia/debug
- to https://github.com/debug-js/debug

See release notes [debug@4.3.3](https://github.com/debug-js/debug/releases/tag/4.3.3).

### Steps to test

View links in the following and ensure they point to https://github.com/debug-js/debug:

- https://github.com/cypress-io/cypress/blob/develop/guides/debug-logs.md#debug-logs
- https://github.com/cypress-io/cypress/tree/develop/npm/grep#log-messages
- https://github.com/cypress-io/cypress/tree/develop/packages/launcher#debugging

### How has the user experience changed?

Clicking on `debug` links will open the current repo https://github.com/debug-js/debug directly instead of being redirected from https://github.com/visionmedia/debug.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?