### PR TITLE
type fix for plugin function interface

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3572,7 +3572,7 @@ declare namespace Cypress {
     hosts?: null | { [key: string]: string }
   }
 
-  interface PluginConfigOptions extends ResolvedConfigOptions, RuntimeConfigOptions {
+  interface PluginConfigOptionsCommon extends Omit<ResolvedConfigOptions, 'component' | 'e2e'>, RuntimeConfigOptions {
     /**
     * Absolute path to the root of the project
     */
@@ -3586,6 +3586,16 @@ declare namespace Cypress {
      */
     version: string
   }
+
+  interface PluginConfigOptionsComponent<ComponentDevServerOpts = any> extends Pick<ComponentConfigOptions<ComponentDevServerOpts>, 'devServer'>, PluginConfigOptionsCommon{
+    testingType: 'component'
+  }
+
+  interface PluginConfigOptionsE2E extends PluginConfigOptionsCommon{
+    testingType: 'component'
+  }
+
+  type PluginConfigOptions = PluginConfigOptionsComponent | PluginConfigOptionsE2E
 
   interface DebugOptions {
     verbose: boolean


### PR DESCRIPTION
When using `setupNodeEvents` in typescript, the system seems to tell us we can use `config.component.devServer` this is actually false since this config is the resolved config. 

If we are in CT mode, the devServer will be available on the root. If not it will clearly be null.
