### PR TITLE
chore: update tests to skip the welcome screen on launchpad tests.

### DIFF
--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -25,7 +25,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--browser', 'edge'])
       cy.visitLaunchpad()
 
-      cy.skipWelcome()
       cy.get('[data-cy=card]').then(($buttons) => {
         $buttons[0].click()
       })
@@ -44,7 +43,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e', '--browser', 'edge'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -64,7 +62,6 @@ describe('Choose a browser page', () => {
 
       cy.openProject('launchpad', ['--e2e', '--browser', 'doesNotExist'])
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
       cy.get('[data-cy="alert-header"]').should('contain', 'Warning: Browser Not Found')
@@ -91,7 +88,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e', '--browser', path])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -126,7 +122,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -143,7 +138,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -196,7 +190,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -221,7 +214,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -239,8 +231,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
-
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
       })
@@ -256,7 +246,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
@@ -297,7 +286,6 @@ describe('Choose a browser page', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -310,7 +298,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -342,7 +329,6 @@ describe('Choose a browser page', () => {
     it('should return to welcome screen if user modifies the config file to not include the current testing type and recover', () => {
       cy.openProject('launchpad', ['--e2e'])
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -380,7 +366,6 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('h1').should('contain', 'Choose a browser')
 

--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -22,7 +22,6 @@ describe('Config files error handling', () => {
     // Reopen the project, now that we have 2 config files
     cy.openProject('pristine-with-e2e-testing')
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('body').should('contain.text', 'Could not load a Cypress configuration file because there are multiple matches')
     expectStackToBe('closed')
@@ -45,7 +44,6 @@ describe('Config files error handling', () => {
     cy.openProject('pristine-with-e2e-testing')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('body').should('contain.text', defaultMessages.migration.wizard.title.replace('{version}', pkg.version.split('.')[0]))
     cy.get('body').should('contain.text', defaultMessages.migration.wizard.description)
@@ -59,7 +57,6 @@ describe('Config files error handling', () => {
 
     cy.openProject('pristine-with-e2e-testing')
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.contains('p', 'There is both a cypress.config.js and a cypress.json file at the location below:')
     cy.contains('body', 'Cypress no longer supports cypress.json')
@@ -83,7 +80,6 @@ describe('Config files error handling', () => {
     cy.openProject('pristine')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingType=e2e]').click()
     cy.get('body', { timeout: 10000 }).should('contain.text', 'experimentalComponentTesting')
     expectStackToBe('closed')
@@ -102,7 +98,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('plugins-root-sync-error')
     cy.openProject('plugins-root-sync-error', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     expectStackToBe('open')
   })
@@ -111,7 +106,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('plugins-root-syntax-error')
     cy.openProject('plugins-root-syntax-error', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     expectStackToBe('open')
   })
@@ -120,7 +114,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('plugins-root-async-error')
     cy.openProject('plugins-root-async-error', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', 'Unexpected Error', { timeout: 10000 })
     expectStackToBe('open')
   })
@@ -129,7 +122,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('plugins-function-sync-error')
     cy.openProject('plugins-function-sync-error', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     expectStackToBe('open')
   })
@@ -138,7 +130,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('config-with-invalid-browser')
     cy.openProject('config-with-invalid-browser', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     expectStackToBe('closed')
   })
@@ -147,7 +138,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('plugins-function-sync-error')
     cy.openProject('plugins-function-sync-error', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     expectStackToBe('open')
   })
@@ -156,7 +146,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('config-with-ts-syntax-error')
     cy.openProject('config-with-ts-syntax-error')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
 
     cy.findAllByTestId('collapsible').should('be.visible')
@@ -179,7 +168,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('config-with-ts-syntax-error')
     cy.openProject('config-with-ts-syntax-error')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
 
     // Try again while the config is still invalid
@@ -203,7 +191,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('config-with-import-error')
     cy.openProject('config-with-import-error')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.findAllByTestId('collapsible').should('be.visible')
     cy.contains('h2', 'Error')
@@ -218,7 +205,6 @@ describe('Launchpad: Error System Tests', () => {
     cy.scaffoldProject('config-with-ts-module-error')
     cy.openProject('config-with-ts-module-error')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.findAllByTestId('collapsible').should('be.visible')
     cy.contains('h2', 'TSError')
@@ -234,7 +220,6 @@ describe('setupNodeEvents', () => {
     cy.scaffoldProject('config-update-non-migrated-value')
     cy.openProject('config-update-non-migrated-value')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.findAllByTestId('collapsible').should('be.visible')
@@ -247,7 +232,6 @@ describe('setupNodeEvents', () => {
     cy.scaffoldProject('config-update-non-migrated-value-clone')
     cy.openProject('config-update-non-migrated-value-clone')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.percySnapshot()
@@ -259,7 +243,6 @@ describe('setupNodeEvents', () => {
     cy.scaffoldProject('config-update-non-migrated-value-e2e')
     cy.openProject('config-update-non-migrated-value-e2e')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.findByText('E2E Testing').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.percySnapshot()
@@ -284,7 +267,6 @@ describe('setupNodeEvents', () => {
     cy.openProject('pristine')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingType=e2e]').click()
     cy.get('body', { timeout: 10000 }).should('contain.text', 'testFiles')
     cy.get('body', { timeout: 10000 }).should('contain.text', 'setupNodeEvents')
@@ -308,7 +290,6 @@ describe('setupNodeEvents', () => {
     cy.openProject('pristine')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.get('[data-cy="alert-body"]').should('contain', 'Expected baseUrl to be a fully qualified URL')
 
@@ -337,7 +318,6 @@ describe('setupNodeEvents', () => {
     cy.openProject('dev-server-invalid')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('[data-cy-testingtype=component]').click()
 

--- a/packages/launchpad/cypress/e2e/config-warning.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-warning.cy.ts
@@ -5,7 +5,6 @@ describe('baseUrl', () => {
     cy.scaffoldProject('config-with-base-url-warning')
     cy.openProject('config-with-base-url-warning')
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.get('[data-cy="alert"]').contains('Warning: Cannot Connect Base Url Warning')
@@ -22,7 +21,6 @@ describe('baseUrl', () => {
     cy.scaffoldProject('config-with-base-url-warning')
     cy.openProject('config-with-base-url-warning')
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.get('[data-cy="alert"]').contains('Warning: Cannot Connect Base Url Warning')
@@ -46,7 +44,6 @@ describe('baseUrl', () => {
     cy.scaffoldProject('config-with-js')
     cy.openProject('config-with-js')
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.get('h1').should('contain', 'Choose a browser')
@@ -78,7 +75,6 @@ describe('experimentalSingleTabRunMode', () => {
     cy.openProject('experimentalSingleTabRunMode', ['--component', '--config-file', 'cypress-component-only.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.findByTestId('launchpad-Choose a browser')
     cy.get('h1').contains('Choose a browser')
@@ -88,7 +84,6 @@ describe('experimentalSingleTabRunMode', () => {
     cy.scaffoldProject('experimentalSingleTabRunMode')
     cy.openProject('experimentalSingleTabRunMode')
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('error-header').contains('Cypress configuration error')
     cy.findByTestId('alert-body').contains('The experimentalSingleTabRunMode experiment is currently only supported for Component Testing.')
@@ -101,7 +96,6 @@ describe('experimentalStudio', () => {
     cy.openProject('experimentalSingleTabRunMode', ['--config-file', 'cypress-invalid-studio-experiment.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="component"]').click()
     cy.findByTestId('error-header')
     cy.contains('The experimentalStudio experiment is currently only supported for End to End Testing.')
@@ -124,7 +118,6 @@ describe('experimentalStudio', () => {
     })
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('launchpad-Choose a browser')
     cy.get('h1').contains('Choose a browser')
@@ -137,7 +130,6 @@ describe('experimentalRunAllSpecs', () => {
     cy.openProject('run-all-specs')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('launchpad-Choose a browser')
     cy.get('h1').contains('Choose a browser')
@@ -148,7 +140,6 @@ describe('experimentalRunAllSpecs', () => {
     cy.openProject('run-all-specs', ['--config-file', 'cypress-invalid-component.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="component"]').click()
     cy.findByTestId('error-header')
     cy.contains('The experimentalRunAllSpecs experiment is currently only supported for End to End Testing')
@@ -159,7 +150,6 @@ describe('experimentalRunAllSpecs', () => {
     cy.openProject('run-all-specs', ['--config-file', 'cypress-invalid-root.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('error-header')
     cy.contains('The experimentalRunAllSpecs experiment is currently only supported for End to End Testing')
@@ -172,7 +162,6 @@ describe('experimentalOriginDependencies', () => {
     cy.openProject('session-and-origin-e2e-specs')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('launchpad-Choose a browser')
     cy.get('h1').contains('Choose a browser')
@@ -184,7 +173,6 @@ describe('experimentalOriginDependencies', () => {
     cy.openProject('session-and-origin-e2e-specs', ['--config-file', 'cypress-invalid-component.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="component"]').click()
     cy.findByTestId('error-header')
     cy.contains('The experimentalOriginDependencies experiment is currently only supported for End to End Testing')
@@ -196,7 +184,6 @@ describe('experimentalOriginDependencies', () => {
     cy.openProject('session-and-origin-e2e-specs', ['--config-file', 'cypress-invalid-root.config.js'])
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy-testingtype="e2e"]').click()
     cy.findByTestId('error-header')
     cy.contains('The experimentalOriginDependencies experiment is currently only supported for End to End Testing')
@@ -209,7 +196,6 @@ describe('component testing dependency warnings', () => {
     cy.addProject('component-testing-outdated-dependencies')
     cy.openGlobalMode()
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('component-testing-outdated-dependencies').click()
     cy.get('[data-cy="warning-alert"]').should('not.exist')
     cy.contains('a', 'Projects').click()
@@ -228,7 +214,6 @@ describe('component testing dependency warnings', () => {
     cy.addProject('outdated-deps-vuecli3')
     cy.openGlobalMode()
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('outdated-deps-vuecli3').click()
     cy.get('[data-cy="warning-alert"]').should('not.exist')
     cy.contains('a', 'Projects').click()
@@ -246,7 +231,6 @@ describe('component testing dependency warnings', () => {
     cy.addProject('vueclivue3-configured')
     cy.openGlobalMode()
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('vueclivue3-configured').click()
     cy.get('[data-cy="warning-alert"]').should('not.exist')
     cy.get('a').contains('Projects').click()
@@ -261,7 +245,6 @@ describe('component testing dependency warnings', () => {
     cy.scaffoldProject('next-14')
     cy.openProject('next-14', ['--component'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy="warning-alert"]').should('not.exist')
     cy.contains('Choose a browser', { timeout: 12000 })
     cy.get('[data-cy="warning-alert"]').should('not.exist')

--- a/packages/launchpad/cypress/e2e/error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/error-handling.cy.ts
@@ -5,7 +5,6 @@ describe('Error handling', () => {
     cy.loginUser()
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('[data-cy-testingType=e2e]').click()
 
@@ -42,7 +41,6 @@ describe('Error handling', () => {
     cy.openProject('pristine')
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('body')
     .should('contain.text', cy.i18n.launchpadErrors.generic.configErrorTitle)
@@ -69,7 +67,6 @@ describe('Error handling', () => {
       cy.scaffoldProject('missing-vite-config')
       cy.openProject('missing-vite-config', ['--component'])
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       ;['vite.config.js', 'vite.config.ts', 'vite.config.mjs', 'vite.config.cjs', 'vite.config.mts', 'vite.config.cts'].forEach((idiomaticConfigFile) => {
         cy.contains(idiomaticConfigFile)
@@ -107,7 +104,6 @@ describe('Error handling', () => {
         cy.scaffoldProject('react-vite-ts-configured')
         cy.openProject('react-vite-ts-configured', ['--component'])
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         // should successful start dev server and move to launch screen!
         cy.contains('Choose a browser')
@@ -121,7 +117,6 @@ describe('Error handling', () => {
         cy.scaffoldProject('missing-webpack-config')
         cy.openProject('missing-webpack-config', ['--component'])
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         ;['webpack.config.js', 'webpack.config.ts', 'webpack.config.mjs', 'webpack.config.cjs'].forEach((idiomaticConfigFile) => {
           cy.contains(idiomaticConfigFile)
@@ -139,7 +134,6 @@ describe('Error handling', () => {
         cy.scaffoldProject('component-tests')
         cy.openProject('component-tests', ['--component'])
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         // should successful start dev server and move to launch screen!
         cy.contains('Choose a browser')

--- a/packages/launchpad/cypress/e2e/global-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/global-mode.cy.ts
@@ -10,14 +10,12 @@ describe('Launchpad: Global Mode', () => {
     it('shows global page when opened by --global flag', () => {
       cy.openGlobalMode()
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
     })
 
     it('shows global page when opened by global install', () => {
       cy.openGlobalMode({ byFlag: false })
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
     })
   })
@@ -26,7 +24,6 @@ describe('Launchpad: Global Mode', () => {
     it('shows "Add Project" view', () => {
       cy.openGlobalMode()
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
       cy.get('[data-cy="dropzone"]')
       .should('contain', defaultMessages.globalPage.empty.dropText.split('{0}')[0])
@@ -37,7 +34,6 @@ describe('Launchpad: Global Mode', () => {
     it('can add a project by dragging folder into project dropzone', () => {
       cy.openGlobalMode()
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
       cy.get('[data-cy="dropzone"]')
       .should('contain', defaultMessages.globalPage.empty.dropText.split('{0}')[0])
@@ -61,7 +57,6 @@ describe('Launchpad: Global Mode', () => {
     it('adds a project using electron native folder select', () => {
       cy.openGlobalMode()
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.scaffoldProject('todos')
       .then((projectPath) => {
@@ -99,7 +94,6 @@ describe('Launchpad: Global Mode', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.log('The recents list shows all projects that have been added')
       cy.contains(defaultMessages.globalPage.recentProjectsHeader)
@@ -315,7 +309,6 @@ describe('Launchpad: Global Mode', () => {
       cy.addProject('config-with-import-error')
       cy.addProject('todos')
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.contains('[data-cy="project-card"]', 'todos').should('be.visible')
       cy.contains('[data-cy="project-card"]', 'config-with-import-error').should('be.visible').click()
       cy.get('h1').contains('Cypress configuration error')

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -27,7 +27,6 @@ function scaffoldAndVisitLaunchpad (project: ProjectFixtureDir, argv?: string[])
   cy.scaffoldProject(project)
   cy.openProject(project, argv)
   cy.visitLaunchpad()
-  cy.skipWelcome()
 }
 
 function startMigrationFor (project: ProjectFixtureDir, argv?: string[]) {
@@ -133,7 +132,6 @@ describe('Opening unmigrated project', () => {
     cy.scaffoldProject('migration')
     cy.openProject('migration', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('h1').should('contain', 'Migrating')
   })
 
@@ -141,7 +139,6 @@ describe('Opening unmigrated project', () => {
     cy.scaffoldProject('migration-component-testing')
     cy.openProject('migration-component-testing', ['--component'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('h1').should('contain', 'Migrating')
   })
 

--- a/packages/launchpad/cypress/e2e/migration.cy.ts
+++ b/packages/launchpad/cypress/e2e/migration.cy.ts
@@ -90,8 +90,6 @@ describe('global mode', () => {
       o.sinon.stub(ctx.actions.migration, 'locallyInstalledCypressVersion').resolves((await ctx.versions.versionData()).current.version)
     })
 
-    cy.contains('button', cy.i18n.majorVersionWelcome.actionContinue).click()
-
     cy.contains('migration-e2e-export-default').click()
 
     // rename integration->e2e
@@ -145,7 +143,7 @@ describe('Opening unmigrated project', () => {
   it('major version welcome page appears with correct links and can be dismissed', () => {
     cy.scaffoldProject('migration')
     cy.openProject('migration')
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
 
     cy.contains(cy.i18n.majorVersionWelcome.title).should('be.visible')
 
@@ -1701,7 +1699,7 @@ describe('v13 migration welcome page with video', () => {
     cy.scaffoldProject('migration-v12-to-v13')
     cy.openProject('migration-v12-to-v13')
 
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
     cy.contains(cy.i18n.majorVersionWelcome.title).should('be.visible')
     cy.get('[data-cy="video-container"]').should('not.exist')
   })
@@ -1753,7 +1751,7 @@ describe('v13 migration welcome page with video', () => {
     cy.scaffoldProject('migration-v12-to-v13')
     cy.openProject('migration-v12-to-v13')
 
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
     cy.contains(cy.i18n.majorVersionWelcome.title, {
       timeout: 8000,
     }).should('be.visible')
@@ -1765,7 +1763,7 @@ describe('v13 migration welcome page with video', () => {
     cy.scaffoldProject('migration-v12-to-v13')
     cy.openProject('migration-v12-to-v13')
 
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
     cy.contains(cy.i18n.majorVersionWelcome.title).should('be.visible')
     cy.get('[data-cy="video-container"]').should('be.visible')
   })
@@ -1774,10 +1772,10 @@ describe('v13 migration welcome page with video', () => {
     cy.scaffoldProject('migration-v12-to-v13')
     cy.openProject('migration-v12-to-v13')
 
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
     cy.contains(cy.i18n.majorVersionWelcome.title).should('be.visible')
 
-    cy.visitLaunchpad()
+    cy.visitLaunchpad({ showWelcome: true })
     cy.contains(cy.i18n.majorVersionWelcome.title).should('be.visible')
     cy.withCtx((ctx, o) => {
       expect((ctx.util.fetch as SinonStub).args.filter((a) => String(a[0]).includes('v13-video-embed')).length).to.eq(1)

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -74,6 +74,7 @@ describe('Launchpad: Open Mode', () => {
       })
 
       cy.visitLaunchpad({ showWelcome: true })
+      cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
         expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -73,7 +73,7 @@ describe('Launchpad: Open Mode', () => {
         ctx.versions['_initialLaunch'] = true
       })
 
-      cy.visitLaunchpad()
+      cy.visitLaunchpad({ showWelcome: true })
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
         expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -24,7 +24,6 @@ describe('Launchpad: Open Mode', () => {
     it('shows Add Project when no projects have been added', () => {
       cy.openGlobalMode()
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
     })
 
@@ -32,14 +31,13 @@ describe('Launchpad: Open Mode', () => {
       cy.openGlobalMode()
       cy.addProject('todos')
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.contains(defaultMessages.globalPage.recentProjectsHeader)
     })
 
     it('does not show Welcome screen on next Launchpad visit when it has already been dismissed', () => {
-      cy.visitLaunchpad()
+      cy.visitLaunchpad({ showWelcome: true })
       cy.skipWelcome()
-      cy.visitLaunchpad()
+      cy.visitLaunchpad({ showWelcome: true })
       cy.contains('button', 'Continue').should('not.exist')
       cy.get('h1').should('contain', defaultMessages.globalPage.empty.title)
     })
@@ -49,7 +47,6 @@ describe('Launchpad: Open Mode', () => {
     cy.scaffoldProject('todos')
     cy.openProject('todos', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy=header-bar-content]').contains('e2e testing', { matchCase: false })
     // e2e testing is configured for the todo project, so we don't expect an error.
     cy.get('h1').should('contain', 'Choose a browser')
@@ -77,7 +74,6 @@ describe('Launchpad: Open Mode', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
         expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
@@ -97,7 +93,6 @@ describe('Launchpad: Open Mode', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.withCtx((ctx, o) => {
         expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
@@ -112,7 +107,6 @@ describe('Launchpad: Open Mode', () => {
     describe('logged-in state', () => {
       it(`sends 'false' when not logged in`, () => {
         cy.visitLaunchpad()
-        cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
           expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
@@ -126,7 +120,6 @@ describe('Launchpad: Open Mode', () => {
       it(`sends 'true' when logged in`, () => {
         cy.loginUser()
         cy.visitLaunchpad()
-        cy.skipWelcome()
         cy.get('h1').should('contain', 'Choose a browser')
         cy.withCtx((ctx, o) => {
           expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
@@ -147,7 +140,6 @@ describe('Launchpad: Open Mode', () => {
     it('goes to component test onboarding', () => {
       cy.openProject('react-vite-ts-unconfigured', ['--component'])
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('[data-cy=header-bar-content]').contains('component testing', { matchCase: false })
       // Component testing is not configured for the todo project
@@ -163,7 +155,6 @@ describe('Launchpad: Open Mode', () => {
 
       cy.openProject('react-vite-ts-unconfigured', ['--component'])
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.get('[data-testid="select-framework"]').as('framework')
 
@@ -207,7 +198,6 @@ describe('Launchpad: Open Mode', () => {
 
       // Need to visit after args have been configured, todo: fix in #18776
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.contains('E2E Testing').click()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.get('[data-cy-browser=firefox]').should('have.attr', 'aria-checked', 'true')
@@ -224,7 +214,6 @@ describe('Launchpad: Open Mode', () => {
       // Need to visit after args have been configured, todo: fix in #18776
       cy.visitLaunchpad()
 
-      cy.skipWelcome()
       cy.get('h1').should('contain', 'Choose a browser')
       cy.get('[data-cy-browser=firefox]').should('have.attr', 'aria-checked', 'true')
       cy.get('button[data-cy=launch-button]').invoke('text').should('include', 'Start E2E Testing in Firefox')
@@ -265,7 +254,6 @@ describe('Launchpad: Open Mode', () => {
       cy.scaffoldProject('todos')
       cy.openProject('todos')
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.withCtx(async (ctx, o) => {
         ctx.emitter.toLaunchpad()
@@ -280,7 +268,6 @@ describe('Launchpad: Open Mode', () => {
       cy.scaffoldProject('todos')
       cy.openProject('todos')
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.contains('button', 'Docs').click()
       cy.contains(defaultMessages.topNav.docsMenu.gettingStartedTitle).should('be.visible')
@@ -310,7 +297,6 @@ describe('Launchpad: Open Mode', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.findByTestId('project-card')
       cy.get('[aria-label="Project actions"]').click()
       cy.get('button').contains('Open in IDE').click()
@@ -337,7 +323,6 @@ describe('Launchpad: Open Mode', () => {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
       cy.findByTestId('project-card')
       cy.get('[aria-label="Project actions"]').click()
 
@@ -356,7 +341,6 @@ describe('Launchpad: Open Mode', () => {
     cy.scaffoldProject('no-support-file')
     cy.openProject('no-support-file', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains(cy.i18n.launchpadErrors.generic.configErrorTitle)
     cy.contains('Your project does not contain a default supportFile.')
     cy.contains('If a support file is not necessary for your project, set supportFile to false.')
@@ -369,7 +353,6 @@ describe('Launchpad: Open Mode', () => {
     cy.scaffoldProject('project-with-(glob)-[chars]')
     cy.openProject('project-with-(glob)-[chars]', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.get('body').should('not.contain.text', 'Your project does not contain a default supportFile.')
     cy.get('h1').should('contain', 'Choose a browser')
@@ -379,7 +362,6 @@ describe('Launchpad: Open Mode', () => {
     cy.scaffoldProject('simple with spaces')
     cy.openProject('simple with spaces', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('h1').should('contain', 'Choose a browser')
   })
 })

--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -85,7 +85,6 @@ describe('Launchpad: Setup Project', () => {
     cy.scaffoldProject('pristine')
     cy.openProject('pristine', ['--e2e'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
 
     cy.contains('h1', 'Configuration files')
     cy.findByText('We added the following files to your project:')
@@ -106,7 +105,6 @@ describe('Launchpad: Setup Project', () => {
     cy.scaffoldProject('pristine')
     cy.openProject('pristine', ['--component'])
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('h1').should('contain', 'Project setup')
   })
 
@@ -435,7 +433,6 @@ describe('Launchpad: Setup Project', () => {
       it('can move forward to choose browser if e2e is configured', () => {
         cy.openProject('pristine-with-e2e-testing')
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         verifyWelcomePage({ e2eIsConfigured: true, ctIsConfigured: false })
 
@@ -447,7 +444,6 @@ describe('Launchpad: Setup Project', () => {
       it('can move forward to choose browser if component is configured', () => {
         cy.openProject('pristine-with-ct-testing')
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         verifyWelcomePage({ e2eIsConfigured: false, ctIsConfigured: true })
 

--- a/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-component-testing.cy.ts
@@ -4,7 +4,6 @@ function startSetupFor (project: ProjectFixtureDir) {
   cy.scaffoldProject(project)
   cy.openProject(project)
   cy.visitLaunchpad()
-  cy.skipWelcome()
 
   cy.contains('Component Testing').click()
   cy.get(`[data-testid="select-framework"]`)
@@ -106,7 +105,6 @@ describe('scaffolding component testing', {
       cy.scaffoldProject('react-vite-ts-unconfigured')
       cy.openProject('react-vite-ts-unconfigured')
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.withCtx(async (ctx) => {
         const reactPackageFilePath = 'node_modules/react/package.json'
@@ -224,7 +222,6 @@ describe('scaffolding component testing', {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.contains('Component Testing').click()
       cy.contains('button', 'Qwik').should('be.visible')
@@ -256,7 +253,6 @@ describe('scaffolding component testing', {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.contains('Component Testing').click()
       cy.contains('button', 'Solid').should('be.visible')
@@ -291,7 +287,6 @@ describe('scaffolding component testing', {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.contains('Component Testing').click()
       cy.get(`[data-testid="select-framework"]`).click()
@@ -311,7 +306,6 @@ describe('scaffolding component testing', {
       })
 
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.contains('Component Testing').click()
 

--- a/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
+++ b/packages/launchpad/cypress/e2e/scaffold-project.cy.ts
@@ -36,7 +36,6 @@ function scaffoldAndOpenE2EProject (opts: {
   }
 
   cy.visitLaunchpad()
-  cy.skipWelcome()
 
   cy.contains('Welcome to Cypress!').should('be.visible')
   cy.contains('[data-cy-testingtype="e2e"]', 'Not Configured')
@@ -71,7 +70,6 @@ function scaffoldAndOpenCTProject (opts: {
   }
 
   cy.visitLaunchpad()
-  cy.skipWelcome()
 
   cy.contains('Welcome to Cypress!').should('be.visible')
   cy.contains('[data-cy-testingtype="e2e"]', 'Not Configured')
@@ -180,7 +178,6 @@ describe('scaffolding new projects', { defaultCommandTimeout: 7000 }, () => {
     })
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.contains('button', cy.i18n.testingType.e2e.name).click()
     cy.contains('button', cy.i18n.setupPage.step.continue).click()
     cy.wait('@mutationScaffoldedFiles')

--- a/packages/launchpad/cypress/e2e/slow-network.cy.ts
+++ b/packages/launchpad/cypress/e2e/slow-network.cy.ts
@@ -45,7 +45,6 @@ describe('slow network: launchpad', () => {
   it('loads through to the browser screen when the network is slow', () => {
     cy.loginUser()
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy=top-nav-cypress-version-current-link]').should('not.exist')
     cy.contains('E2E Testing').click()
     cy.get('h1').should('contain', 'Choose a browser')
@@ -54,7 +53,6 @@ describe('slow network: launchpad', () => {
   // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/21897
   it('shows the versions after they resolve', { retries: 15 }, () => {
     cy.visitLaunchpad()
-    cy.skipWelcome()
     cy.get('[data-cy=top-nav-cypress-version-current-link]').should('not.exist')
     cy.contains('Log in')
     cy.wait(500)

--- a/packages/launchpad/cypress/e2e/system-tests/config-spec.cy.ts
+++ b/packages/launchpad/cypress/e2e/system-tests/config-spec.cy.ts
@@ -8,7 +8,6 @@ describe('config-spec', () => {
     })
 
     cy.visitLaunchpad()
-    cy.skipWelcome()
     // Filtered down to the electron browser in the plugin
     cy.get('[data-cy="open-browser-list"]').children().should('have.length', 1)
   })

--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -29,7 +29,6 @@ describe('Launchpad Top Nav Workflows', () => {
       cy.openGlobalMode()
       cy.addProject('launchpad')
       cy.visitLaunchpad()
-      cy.skipWelcome()
 
       cy.findByTestId(headerBarId).should('be.visible').and('contain', 'Projects')
 
@@ -319,7 +318,6 @@ describe('Launchpad Top Nav Workflows', () => {
         cy.openProject('component-tests')
         cy.loginUser()
         cy.visitLaunchpad()
-        cy.skipWelcome()
 
         cy.remoteGraphQLIntercept((obj) => {
           if (obj.result.data?.cloudProjectBySlug) {
@@ -415,8 +413,6 @@ describe('Launchpad Top Nav Workflows', () => {
 
       context('with no project id', () => {
         it('shows "continue" button after login if config has not loaded', () => {
-          cy.skipWelcome()
-
           mockLogInActionsForUser(mockUser)
           logIn({ expectedNextStepText: 'Continue', displayName: mockUser.name })
           cy.withCtx((ctx, o) => {
@@ -428,7 +424,6 @@ describe('Launchpad Top Nav Workflows', () => {
         })
 
         it('shows "connect project" button after login if no project id is set', () => {
-          cy.skipWelcome()
           cy.contains('E2E Testing').click()
 
           mockLogInActionsForUser(mockUser)
@@ -450,7 +445,6 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.scaffoldProject('component-tests')
           cy.openProject('component-tests')
           cy.visitLaunchpad()
-          cy.skipWelcome()
         })
 
         it('shows log in modal workflow for user with name and email', () => {
@@ -649,7 +643,6 @@ describe('Launchpad Top Nav Workflows', () => {
         it('shows "continue" button after login if project not selected', () => {
           cy.openGlobalMode()
           cy.visitLaunchpad()
-          cy.skipWelcome()
 
           mockLogInActionsForUser(mockUser)
           logIn({ expectedNextStepText: 'Continue', displayName: mockUser.name })
@@ -665,7 +658,6 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.openGlobalMode()
           cy.addProject('component-tests')
           cy.visitLaunchpad()
-          cy.skipWelcome()
 
           cy.get('[data-cy="project-card"]').click()
 
@@ -683,7 +675,6 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.openGlobalMode()
           cy.addProject('component-tests')
           cy.visitLaunchpad()
-          cy.skipWelcome()
 
           cy.get('[data-cy="project-card"]').click()
 
@@ -703,7 +694,6 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.openGlobalMode()
           cy.addProject('launchpad')
           cy.visitLaunchpad()
-          cy.skipWelcome()
 
           cy.get('[data-cy="project-card"]').click()
 


### PR DESCRIPTION
### Additional details

I was looking at [UI Coverage](https://cloud.cypress.io/projects/ypt4pf/runs/57075/ui-coverage/tested-elements?columnHeading=Interactions&direction=descending) to find redundant tests and I noticed this `[data-cy="major-version-welcome-footer"]` element being interacted with 184 times and I thought, hmm...I know we are not wanting to test this button this many times, but it is the starting point of our flow through the App. But the display of this welcome screen is actually conditional. 

![Screenshot 2024-09-13 at 4 21 12 PM](https://github.com/user-attachments/assets/2462f31d-12ba-46bf-8548-b8781e88bc6a)

We should really write tests so the default is to NOT have the welcome screen show and instead have the welcome screen show on the few times we want to test it. I updated the e2e support code to do just that.

It doesn't look like this greatly reduces CI resources (for some specs they ran faster), but this will reduce complexity and reduce instances around flake of this page in our tests. 

**UI Coverage after:**

![Screenshot 2024-09-16 at 10 50 50 AM](https://github.com/user-attachments/assets/e61e6916-f6da-4475-ada2-30d0d8065d4b)


### Steps to test

Tests should pass. Also a review of touched tests would be nice because it's possible false positive could be introduced if the behavior tested isn't the same with the setup introduced.

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
