### PR TITLE
docs: update guides/building-release-artifacts.md

### DIFF
--- a/guides/building-release-artifacts.md
+++ b/guides/building-release-artifacts.md
@@ -1,12 +1,12 @@
 # Building Release Artifacts
 
-The `cypress` NPM package consists of two main parts:
+The `cypress` npm package consists of two main parts:
 
-1. The `cypress` NPM package `.tgz` (built from [`cli`](../cli))
+1. The `cypress` npm package `.tgz` (built from [`cli`](../cli))
     * Contains the command line tool `cypress`, type definitions, and the [Module API](https://on.cypress.io/module-api).
-    * End users install this via NPM to the project's `node_modules`.
-2. The "binary" `.zip` (built from [`packages/server`](../packages/server))
-    * Contains the Electron app, `ffmpeg`, and built versions of the [`server`](../packages/server), [`desktop-gui`](../packages/desktop-gui), [`runner`](../packages/runner), [`example` project](../packages/example), and [`extension`](../packages/extension)
+    * End users install this via npm to the project's `node_modules` directory or via Yarn or pnpm similarly.
+2. The "binary" `.zip` (built from the [`packages`](../packages) directory)
+    * Contains the Electron app, `ffmpeg`, and built versions of the packages from the [`packages`](../packages) sub-directories (`frontend-shared`, `reporter` and `web-config` are not separately included).
         * Also contains all the production dependencies of the above.
     * This is installed when the `cli` is installed or when `cypress install` is run, to a system cache.
 


### PR DESCRIPTION
## Issues

The document [Guides > Building Release Artifacts](https://github.com/cypress-io/cypress/blob/develop/guides/building-release-artifacts.md) states that the Cypress binary

> Contains the Electron app, `ffmpeg`, and built versions of the `server`, `desktop-gui`, `runner`, `example`, and `extension`

There is no package `desktop-gui` and the `packages` directory in the Cypress binary contains many more packages:

```text
app
config
data-context
driver
electron
errors
example
extension
graphql
https-proxy
icons
launcher
launchpad
net-stubbing
network
packherd-require
proxy
resolve-dist
rewriter
root
runner
scaffold-config
server
socket
telemetry
ts
types
v8-snapshot-require
```

## Change

In [Guides > Building Release Artifacts](https://github.com/cypress-io/cypress/blob/develop/guides/building-release-artifacts.md)

- Instead of individually listing the packages, refer to the [packages](https://github.com/cypress-io/cypress/tree/develop/packages) source directory.

  The following are not published separately into the `Cypress/resources/app/packages` directory of the Cypress binary:

  ```text
  frontend-shared
  reporter
  web-config
  ```

- Convert "NPM" to "npm" to following [branding guidelines](https://github.com/npm/cli#faq-on-branding).

- Add Yarn and pnpm as possible package managers
