### PR TITLE
chore: fix net_stubbing flake

### DIFF
--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -1619,7 +1619,7 @@ describe('network stubbing', { retries: 15 }, function () {
       })
     })
 
-    it('can modify the request body', function () {
+    it('can modify the request body', function (done) {
       const body = '{"foo":"bar"}'
 
       cy.intercept('/post-only', function (req) {
@@ -1630,12 +1630,14 @@ describe('network stubbing', { retries: 15 }, function () {
       }).then(function () {
         $.post('/post-only', 'quuz').done((responseText) => {
           expect(responseText).to.contain(body)
+
+          done()
         })
       })
     })
 
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23422
-    it('can add a body to a request that does not have one', { retries: 15 }, function () {
+    it('can add a body to a request that does not have one', { retries: 15 }, function (done) {
       const body = '{"foo":"bar"}'
 
       cy.intercept('/post-only', function (req) {
@@ -1648,6 +1650,7 @@ describe('network stubbing', { retries: 15 }, function () {
       }).then(function () {
         $.get('/post-only').done((responseText) => {
           expect(responseText).to.contain(body)
+          done()
         })
       })
     })
@@ -1672,7 +1675,7 @@ describe('network stubbing', { retries: 15 }, function () {
       const delay = 250
       const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
-      cy.intercept('/timeout*', { times: 1 }, (req) => {
+      cy.intercept('/timeout*', (req) => {
         this.start = Date.now()
 
         req.reply({

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -1640,7 +1640,7 @@ describe('network stubbing', { retries: 15 }, function () {
     it('can add a body to a request that does not have one', { retries: 15 }, function (done) {
       const body = '{"foo":"bar"}'
 
-      cy.intercept('/post-only', function (req) {
+      cy.intercept('/post-only*', function (req) {
         expect(req.body).to.eq('')
         expect(req.method).to.eq('GET')
         req.method = 'POST'
@@ -1648,7 +1648,7 @@ describe('network stubbing', { retries: 15 }, function () {
 
         req.body = body
       }).then(function () {
-        $.get('/post-only').done((responseText) => {
+        $.get('/post-only').then((responseText) => {
           expect(responseText).to.contain(body)
           done()
         })

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -1672,7 +1672,7 @@ describe('network stubbing', { retries: 15 }, function () {
       const delay = 250
       const expectedSeconds = payload.length / (1024 * throttleKbps) + delay / 1000
 
-      cy.intercept('/timeout*', (req) => {
+      cy.intercept('/timeout*', { times: 1 }, (req) => {
         this.start = Date.now()
 
         req.reply({


### PR DESCRIPTION
Fixes: #30273

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We are seeing sporadic failures in `net_stubbing.cy.ts` for the test `can delay and throttle a StaticResponse` caused by `done` getting called multiple times.

In looking at the [various times](https://cloud.cypress.io/projects/ypt4pf/runs/56924/test-results/defe0d79-001a-47a9-8de6-45a36f38daf3) this has failed, I noticed that they all had this failure:

![image](https://github.com/user-attachments/assets/a689cbb5-8988-44ff-80e0-c26a97975bcb)

I noticed that an earlier test doesn't actually utilize `done` properly, and so my theory is that the callback for one test is being executed in the middle of another test and that is messing a ton of stuff up with respect to the intercepts on `can delay and throttle a StaticResponse` especially since it's retrying it potentially 15 times. The fix on this PR makes sure that we utilize `done` properly. I tested it a bunch in CI and didn't see the error any longer.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

N/A

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
