### PR TITLE
fix: support multiple imports of one module with multiple lines

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,13 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+
+## 13.16.1
+
+_Released 11/26/2024 (PENDING)_
+
+**Bugfixes:**
+
+- Support multiple imports of one module with multiple lines. Addressed in [#30314](https://github.com/cypress-io/cypress/pull/30314).
+
 ## 13.16.0
 
 _Released 11/19/2024_

--- a/npm/vite-plugin-cypress-esm/cypress/component/fixtures/kitchenSink.ts
+++ b/npm/vite-plugin-cypress-esm/cypress/component/fixtures/kitchenSink.ts
@@ -2,6 +2,12 @@ export const export1 = 'export1'
 
 export const export2 = 'export2'
 
+export const export3 = 'export3'
+
+export const export4 = 'export4'
+
+export const export5 = 'export5'
+
 // @ts-expect-error
 window.sideEffect = 'Side Effect'
 

--- a/npm/vite-plugin-cypress-esm/cypress/component/importSyntax.cy.ts
+++ b/npm/vite-plugin-cypress-esm/cypress/component/importSyntax.cy.ts
@@ -9,6 +9,17 @@ import { default as alias } from './fixtures/kitchenSink'
 import defaultExport2, { export2 } from './fixtures/kitchenSink'
 import defaultExport3, * as name2 from './fixtures/kitchenSink'
 import { export1 as e1, export2 as e2 } from './fixtures/kitchenSink'
+import {
+  export3,
+  export4,
+} from './fixtures/kitchenSink'
+import {
+  export3 as alias3,
+  export4 as alias4,
+} from './fixtures/kitchenSink'
+import defaultExport4, {
+  export5,
+} from './fixtures/kitchenSink'
 import './fixtures/kitchenSink'
 
 // Examples for all syntax
@@ -19,6 +30,9 @@ describe('supports every combination of import syntax in a single file', () => {
     expect(defaultExport1).to.deep.eq({
       export1: 'export1',
       export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
       default: {
         export1: 'export1',
         export2: 'export2',
@@ -30,6 +44,9 @@ describe('supports every combination of import syntax in a single file', () => {
     expect(name1).to.deep.eq({
       export1: 'export1',
       export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
       default: {
         export1: 'export1',
         export2: 'export2',
@@ -38,7 +55,7 @@ describe('supports every combination of import syntax in a single file', () => {
   })
 
   it('Import { export1 } from "./kitchenSink"', () => {
-    expect(export1).to.deep.eq(export1)
+    expect(export1).to.eq('export1')
   })
 
   it('Import { export1 as alias1 } from "./kitchenSink"', () => {
@@ -56,19 +73,25 @@ describe('supports every combination of import syntax in a single file', () => {
     expect(defaultExport2).to.deep.eq({
       export1: 'export1',
       export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
       default: {
         export1: 'export1',
         export2: 'export2',
       },
     })
 
-    expect(export2).to.eq(export2)
+    expect(export2).to.eq('export2')
   })
 
   it('Import defaultExport3, * as name2 from "./kitchenSink"', () => {
     expect(defaultExport3).to.deep.eq({
       export1: 'export1',
       export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
       default: {
         export1: 'export1',
         export2: 'export2',
@@ -80,6 +103,9 @@ describe('supports every combination of import syntax in a single file', () => {
     expect(name2).to.deep.eq({
       export1: 'export1',
       export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
       default: {
         export1: 'export1',
         export2: 'export2',
@@ -90,6 +116,41 @@ describe('supports every combination of import syntax in a single file', () => {
   it('Import { export1 as e1, export2 as e2 } from "./kitchenSink"', () => {
     expect(e1).to.deep.eq(export1)
     expect(e2).to.deep.eq(export2)
+  })
+
+  it(`import {
+  export3,
+  export4,
+} from './fixtures/kitchenSink'`, () => {
+    expect(export3).to.deep.eq('export3')
+    expect(export4).to.deep.eq('export4')
+  })
+
+  it(`import {
+  export3 as alias3,
+  export4 as alias4,
+} from './fixtures/kitchenSink'`, () => {
+    expect(alias3).to.deep.eq(export3)
+    expect(alias4).to.deep.eq(export4)
+  })
+
+  it(`import defaultExport4, {
+  export5,
+} from './fixtures/kitchenSink'`, () => {
+    console.log(defaultExport4)
+    expect(defaultExport4).to.deep.eq({
+      export1: 'export1',
+      export2: 'export2',
+      export3: 'export3',
+      export4: 'export4',
+      export5: 'export5',
+      default: {
+        export1: 'export1',
+        export2: 'export2',
+      },
+    })
+
+    expect(export5).to.eq('export5')
   })
 
   it('Import "./kitchenSink"', () => {

--- a/npm/vite-plugin-cypress-esm/src/index.ts
+++ b/npm/vite-plugin-cypress-esm/src/index.ts
@@ -120,7 +120,7 @@ export const CypressEsm = (options?: CypressEsmOptions): Plugin => {
 
     // Ensure import comes at start of line *or* is prefixed by a space so we don't capture things like
     // `Refresh.__hmr_import('')
-    const importRegex = /(?<=^|\s)import (.+?) from ['"](.*?)['"]/g
+    const importRegex = /(?<=^|\s)import ([^;'"]+?) from ['"](.*?)['"]/g
 
     return code.replace(
       importRegex,


### PR DESCRIPTION
The [`.`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Wildcard) in RegExp matches all characters except line terminators, so the following won't match:

```javascript
import {
  a,
  b,
  c,
} from 'x';
```

Changing it to `[^;'"]` allows it to match all characters, including `\n`, except for `;'"`, which resolves the issue.

Using the current regular expression `/(?<=^|\s)import (.+?) from ['"](.*?)['"]/g` will cause the new test cases to fail.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
