### PR TITLE
fix: ensure that requests to the same resource will be properly intercepted even if they are sent in rapid succession

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 10/1/2024 (PENDING)_
 **Bugfixes:**
 
 - Patched [find-process](https://github.com/yibn2008/find-process) to fix an issue where trying to clean up browser profiles can throw an error on Windows. Addresses [#30378](https://github.com/cypress-io/cypress/issues/30378).
-- Fixed an issue where requests to the same resource in rapid succession may not have the appropriate static response intercept applied if there are multiple intercepts that apply for that resource. 
+- Fixed an issue where requests to the same resource in rapid succession may not have the appropriate static response intercept applied if there are multiple intercepts that apply for that resource. Addresses [#30375](https://github.com/cypress-io/cypress/issues/30375).
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 10/1/2024 (PENDING)_
 **Bugfixes:**
 
 - Patched [find-process](https://github.com/yibn2008/find-process) to fix an issue where trying to clean up browser profiles can throw an error on Windows. Addresses [#30378](https://github.com/cypress-io/cypress/issues/30378).
+- Fixed an issue where requests to the same resource in rapid succession may not have the appropriate static response intercept applied if there are multiple intercepts that apply for that resource. 
 
 **Misc:**
 

--- a/packages/net-stubbing/lib/server/intercepted-request.ts
+++ b/packages/net-stubbing/lib/server/intercepted-request.ts
@@ -51,8 +51,6 @@ export class InterceptedRequest {
     this._onResponse = opts.onResponse
     this.state = opts.state
     this.socket = opts.socket
-
-    this.addDefaultSubscriptions()
   }
 
   onResponse = (incomingRes: IncomingMessage, resStream: Readable) => {
@@ -65,7 +63,7 @@ export class InterceptedRequest {
     this._onResponse(incomingRes, resStream)
   }
 
-  private addDefaultSubscriptions () {
+  addDefaultSubscriptions () {
     if (this.subscriptionsByRoute.length) {
       throw new Error('cannot add default subscriptions to non-empty array')
     }
@@ -75,6 +73,10 @@ export class InterceptedRequest {
     }
 
     for (const route of this.req.matchingRoutes) {
+      if (route.disabled) {
+        continue
+      }
+
       const subscriptionsByRoute = {
         routeId: route.id,
         immediateStaticResponse: route.staticResponse,

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -138,6 +138,9 @@ export const InterceptRequest: RequestMiddleware = async function () {
 
   await ensureBody()
 
+  // Note that this needs to happen after the `ensureBody` call to ensure that we proceed synchronously to
+  // where we update the state of the routes:
+  // https://github.com/cypress-io/cypress/blob/aafac6a6104b689a118f4c4f29f948d7d8a35aef/packages/net-stubbing/lib/server/intercepted-request.ts#L167-L169
   request.addDefaultSubscriptions()
 
   if (!_.isString(req.body) && !_.isBuffer(req.body)) {

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -138,6 +138,8 @@ export const InterceptRequest: RequestMiddleware = async function () {
 
   await ensureBody()
 
+  request.addDefaultSubscriptions()
+
   if (!_.isString(req.body) && !_.isBuffer(req.body)) {
     throw new Error('req.body must be a string or a Buffer')
   }

--- a/packages/net-stubbing/test/unit/intercepted-request-spec.ts
+++ b/packages/net-stubbing/test/unit/intercepted-request-spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai'
+import chai, { expect } from 'chai'
 import _ from 'lodash'
 import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
 import { InterceptedRequest } from '../../lib/server/intercepted-request'
 import { state as NetStubbingState } from '../../lib/server/state'
+
+chai.use(sinonChai)
 
 describe('InterceptedRequest', () => {
   context('handleSubscriptions', () => {
@@ -61,6 +64,8 @@ describe('InterceptedRequest', () => {
         data,
         mergeChanges: _.merge,
       })
+
+      expect(socket.toDriver).to.be.calledTwice
     })
 
     it('ignores disabled subscriptions', async () => {
@@ -101,7 +106,7 @@ describe('InterceptedRequest', () => {
           subscription: {
             eventName: 'before:request',
             await: true,
-            routeId: '2',
+            routeId: frame.subscription.routeId,
           },
         })
 
@@ -113,6 +118,8 @@ describe('InterceptedRequest', () => {
         data,
         mergeChanges: _.merge,
       })
+
+      expect(socket.toDriver).to.be.calledOnce
     })
   })
 })


### PR DESCRIPTION
- Closes #30375 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When requests go through the proxy, they execute the following middleware functions that affect `matchingRoutes` that get attached to the request:

- SetMatchingRoutes - determines the set of matching requests and attaches it to the `req` object
- SendToDriver - uses the matching requests to determine whether or not this particular request should be proxy logged
- InterceptRequest - does the actual interception logic (if necessary)

Today, the set of matching requests gets set and then we associate subscriptions [here](https://github.com/cypress-io/cypress/blob/develop/packages/net-stubbing/lib/server/intercepted-request.ts#L55). We then proceed synchronously until we [await the request body](https://github.com/cypress-io/cypress/blob/develop/packages/net-stubbing/lib/server/middleware/request.ts#L139). In that time we could receive other requests that get their subscriptions defined. If the first request is supposed to surpass the maximum number of requests that a given interception can handle, it is supposed to not be available for the second one. However, since they've both had their associated subscriptions defined prior to being handled, this causes the first interception to apply to both requests.

This change removes the gap that can occur when multiple requests for the same resource occur in rapid succession by moving the subscription association to after the async awaiting of the request body. We then do a sanity check when adding the subscriptions to ensure the routes we are using are not disabled. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Added some unit tests for this as it is very difficult to reliably test in a more integrated fashion

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
