### PR TITLE
chore: attempt to not cache electron build

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,12 +28,12 @@
   },
   "namedInputs": {
     "sharedGlobals": [
-      "{workspaceRoot}/scripts",
-      "{workspaceRoot}/.circleci/cache-version.txt"
+      "{workspaceRoot}/scripts"
     ],
     "default": [
       "{projectRoot}/**/*",
-      "sharedGlobals"
+      "sharedGlobals",
+      "{workspaceRoot}/.circleci/cache-version.txt"
     ],
     "production": [
       "default",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run build --stream && yarn workspace @packages/electron build && lerna run build-cli --stream",
+    "build": "lerna run build --stream && yarn workspace @packages/electron build-binary && lerna run build-cli --stream",
     "build-prod": "lerna run build-prod --stream && node ./cli/scripts/post-build.js && lerna run build-prod --stream --scope",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run build --stream --ignore=@packages/electron && yarn workspace @packages/electron build && lerna run build-cli --stream",
+    "build": "lerna run --ignore=@packages/electron build --stream && yarn workspace @packages/electron build && lerna run build-cli --stream",
     "build-prod": "lerna run build-prod --stream && node ./cli/scripts/post-build.js && lerna run build-prod --stream --scope",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run --ignore=@packages/electron build --stream && yarn workspace @packages/electron build && lerna run build-cli --stream",
+    "build": "lerna run build --stream && yarn workspace @packages/electron build && lerna run build-cli --stream",
     "build-prod": "lerna run build-prod --stream && node ./cli/scripts/post-build.js && lerna run build-prod --stream --scope",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run build --stream && lerna run build-cli --stream",
+    "build": "lerna run build --stream --ignore=@packages/electron && yarn workspace @packages/electron build && lerna run build-cli --stream",
     "build-prod": "lerna run build-prod --stream && node ./cli/scripts/post-build.js && lerna run build-prod --stream --scope",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "build": "node ./bin/cypress-electron --install",
+    "build-binary": "node ./bin/cypress-electron --install",
     "clean-deps": "rimraf node_modules",
     "postinstall": "echo '@packages/electron needs: yarn build'",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, .",


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The nx caching of electron seems to be corrupting the Electron binary. This PR will ensure that we always build the electron package to avoid that.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
