### PR TITLE
breaking: Remove `run-ct`and `open-ct` CLI commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@ _Released 12/3/2024 (PENDING)_
 
 - Removed support for Node.js 16 and Node.js 21. Addresses [#29930](https://github.com/cypress-io/cypress/issues/29930).
 - Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc <2.28, for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](https://github.com/cypress-io/cypress/issues/29601).
+- The `cypress open-ct` and `cypress run-ct` commands were removed. Please use `cypress open --component` or `cypress run --component` respectively instead. Addressed in [#30456](https://github.com/cypress-io/cypress/pull/30456)
 - The undocumented methods `Cypress.backend('firefox:force:gc')` and `Cypress.backend('log:memory:pressure')` were removed. Addresses [#30222](https://github.com/cypress-io/cypress/issues/30222).
 
 ## 13.15.1

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ _Released 12/3/2024 (PENDING)_
 
 - Removed support for Node.js 16 and Node.js 21. Addresses [#29930](https://github.com/cypress-io/cypress/issues/29930).
 - Prebuilt binaries for Linux are no longer compatible with Linux distributions based on glibc <2.28, for example: Ubuntu 14-18, RHEL 7, CentOS 7, Amazon Linux 2. Addresses [#29601](https://github.com/cypress-io/cypress/issues/29601).
-- The `cypress open-ct` and `cypress run-ct` commands were removed. Please use `cypress open --component` or `cypress run --component` respectively instead. Addressed in [#30456](https://github.com/cypress-io/cypress/pull/30456)
+- The `cypress open-ct` and `cypress run-ct` CLI commands were removed. Please use `cypress open --component` or `cypress run --component` respectively instead. Addressed in [#30456](https://github.com/cypress-io/cypress/pull/30456)
 - The undocumented methods `Cypress.backend('firefox:force:gc')` and `Cypress.backend('log:memory:pressure')` were removed. Addresses [#30222](https://github.com/cypress-io/cypress/issues/30222).
 
 ## 13.15.1

--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -223,10 +223,6 @@ exports['cli help command shows help 1'] = `
     version [options]  prints Cypress version
     open [options]     Opens Cypress in the interactive GUI.
     run [options]      Runs Cypress tests from the CLI without the GUI
-    open-ct [options]  Opens Cypress component testing interactive mode.
-                       Deprecated: use "open --component"
-    run-ct [options]   Runs all Cypress component testing suites. Deprecated:
-                       use "run --component"
     install [options]  Installs the Cypress executable matching this package's
                        version
     verify [options]   Verifies that Cypress is installed correctly and
@@ -263,10 +259,6 @@ exports['cli help command shows help for -h 1'] = `
     version [options]  prints Cypress version
     open [options]     Opens Cypress in the interactive GUI.
     run [options]      Runs Cypress tests from the CLI without the GUI
-    open-ct [options]  Opens Cypress component testing interactive mode.
-                       Deprecated: use "open --component"
-    run-ct [options]   Runs all Cypress component testing suites. Deprecated:
-                       use "run --component"
     install [options]  Installs the Cypress executable matching this package's
                        version
     verify [options]   Verifies that Cypress is installed correctly and
@@ -303,10 +295,6 @@ exports['cli help command shows help for --help 1'] = `
     version [options]  prints Cypress version
     open [options]     Opens Cypress in the interactive GUI.
     run [options]      Runs Cypress tests from the CLI without the GUI
-    open-ct [options]  Opens Cypress component testing interactive mode.
-                       Deprecated: use "open --component"
-    run-ct [options]   Runs all Cypress component testing suites. Deprecated:
-                       use "run --component"
     install [options]  Installs the Cypress executable matching this package's
                        version
     verify [options]   Verifies that Cypress is installed correctly and
@@ -344,10 +332,6 @@ exports['cli unknown command shows usage and exits 1'] = `
     version [options]  prints Cypress version
     open [options]     Opens Cypress in the interactive GUI.
     run [options]      Runs Cypress tests from the CLI without the GUI
-    open-ct [options]  Opens Cypress component testing interactive mode.
-                       Deprecated: use "open --component"
-    run-ct [options]   Runs all Cypress component testing suites. Deprecated:
-                       use "run --component"
     install [options]  Installs the Cypress executable matching this package's
                        version
     verify [options]   Verifies that Cypress is installed correctly and
@@ -457,10 +441,6 @@ exports['cli CYPRESS_INTERNAL_ENV allows and warns when staging environment 1'] 
     version [options]  prints Cypress version
     open [options]     Opens Cypress in the interactive GUI.
     run [options]      Runs Cypress tests from the CLI without the GUI
-    open-ct [options]  Opens Cypress component testing interactive mode.
-                       Deprecated: use "open --component"
-    run-ct [options]   Runs all Cypress component testing suites. Deprecated:
-                       use "run --component"
     install [options]  Installs the Cypress executable matching this package's
                        version
     verify [options]   Verifies that Cypress is installed correctly and

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -137,8 +137,6 @@ const knownCommands = [
   'install',
   'open',
   'run',
-  'open-ct',
-  'run-ct',
   'verify',
   '-v',
   '--version',
@@ -478,80 +476,6 @@ module.exports = {
       debug('running Cypress with args %o', fnArgs)
       require('./exec/run')
       .start(parseVariableOpts(fnArgs, args))
-      .then(util.exit)
-      .catch(util.logErrorExit1)
-    })
-
-    program
-    .command('open-ct')
-    .usage('[options]')
-    .description('Opens Cypress component testing interactive mode. Deprecated: use "open --component"')
-    .option('-b, --browser <browser-path>', text('browser'))
-    .option('-c, --config <config>', text('config'))
-    .option('-C, --config-file <config-file>', text('configFile'))
-    .option('-d, --detached [bool]', text('detached'), coerceFalse)
-    .option('-e, --env <env>', text('env'))
-    .option('--global', text('global'))
-    .option('-p, --port <port>', text('port'))
-    .option('-P, --project <project-path>', text('project'))
-    .option('--dev', text('dev'), coerceFalse)
-    .action((opts) => {
-      debug('opening Cypress')
-
-      const msg = `
-      ${logSymbols.warning} Warning: open-ct is deprecated and will be removed in a future release.
-
-      Use \`cypress open --component\` instead.
-      `
-
-      logger.warn()
-      logger.warn(stripIndent(msg))
-      logger.warn()
-
-      require('./exec/open')
-      .start({ ...util.parseOpts(opts), testingType: 'component' })
-      .then(util.exit)
-      .catch(util.logErrorExit1)
-    })
-
-    program
-    .command('run-ct')
-    .usage('[options]')
-    .description('Runs all Cypress component testing suites. Deprecated: use "run --component"')
-    .option('-b, --browser <browser-name-or-path>', text('browser'))
-    .option('--ci-build-id <id>', text('ciBuildId'))
-    .option('-c, --config <config>', text('config'))
-    .option('-C, --config-file <config-file>', text('configFile'))
-    .option('-e, --env <env>', text('env'))
-    .option('--group <name>', text('group'))
-    .option('-k, --key <record-key>', text('key'))
-    .option('--headed', text('headed'))
-    .option('--headless', text('headless'))
-    .option('--no-exit', text('exit'))
-    .option('--parallel', text('parallel'))
-    .option('-p, --port <port>', text('port'))
-    .option('-P, --project <project-path>', text('project'))
-    .option('-q, --quiet', text('quiet'))
-    .option('--record [bool]', text('record'), coerceFalse)
-    .option('-r, --reporter <reporter>', text('reporter'))
-    .option('-o, --reporter-options <reporter-options>', text('reporterOptions'))
-    .option('-s, --spec <spec>', text('spec'))
-    .option('-t, --tag <tag>', text('tag'))
-    .option('--dev', text('dev'), coerceFalse)
-    .action((opts) => {
-      debug('running Cypress run-ct')
-
-      const msg = `
-      ${logSymbols.warning} Warning: run-ct is deprecated and will be removed in a future release.
-      Use \`cypress run --component\` instead.
-      `
-
-      logger.warn()
-      logger.warn(stripIndent(msg))
-      logger.warn()
-
-      require('./exec/run')
-      .start({ ...util.parseOpts(opts), testingType: 'component' })
       .then(util.exit)
       .catch(util.logErrorExit1)
     })

--- a/cli/test/lib/cli_spec.js
+++ b/cli/test/lib/cli_spec.js
@@ -635,34 +635,10 @@ describe('cli', () => {
       expect(spawn.start.firstCall.args[0]).to.include('component')
     })
 
-    it('spawns server with correct args for deprecated component-testing command', () => {
-      this.exec('open-ct --dev')
-      expect(spawn.start.firstCall.args[0]).to.include('--testing-type')
-      expect(spawn.start.firstCall.args[0]).to.include('component')
-    })
-
     it('runs server with correct args for component-testing', () => {
       this.exec('run --component --dev')
       expect(spawn.start.firstCall.args[0]).to.include('--testing-type')
       expect(spawn.start.firstCall.args[0]).to.include('component')
-    })
-
-    it('runs server with correct args for deprecated component-testing command', () => {
-      this.exec('run-ct --dev')
-      expect(spawn.start.firstCall.args[0]).to.include('--testing-type')
-      expect(spawn.start.firstCall.args[0]).to.include('component')
-    })
-
-    it('does display open-ct command in the help', () => {
-      return execa('bin/cypress', ['help']).then((result) => {
-        expect(result).to.include('open-ct')
-      })
-    })
-
-    it('does display run-ct command in the help', () => {
-      return execa('bin/cypress', ['help']).then((result) => {
-        expect(result).to.include('run-ct')
-      })
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cypress:open:debug": "node ./scripts/debug.js cypress:open",
     "precypress:run": "yarn ensure-deps",
     "cypress:run": "cypress run --dev",
-    "cypress:run:ct": "cypress run-ct --dev",
+    "cypress:run:ct": "cypress run --component --dev",
     "precypress:run:debug": "yarn ensure-deps",
     "cypress:run:debug": "node ./scripts/debug.js cypress:run",
     "cypress:verify": "cypress verify --dev",

--- a/packages/errors/__snapshot-html__/EXPERIMENTAL_COMPONENT_TESTING_REMOVED.html
+++ b/packages/errors/__snapshot-html__/EXPERIMENTAL_COMPONENT_TESTING_REMOVED.html
@@ -38,9 +38,9 @@
 <span style="color:#e05561"><span style="color:#e6e6e6">
 <span style="color:#e05561">Please remove this flag from: <span style="color:#4ec4ff">/path/to/cypress.config.js<span style="color:#e05561"><span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">Component Testing is now a standalone command. You can now run your component tests with:<span style="color:#e6e6e6">
+<span style="color:#e05561">Component Testing is now a supported testing type. You can run your component tests with:<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">  <span style="color:#4f5666">$<span style="color:#e05561"> <span style="color:#4ec4ff">cypress open-ct<span style="color:#e05561"><span style="color:#e6e6e6">
+<span style="color:#e05561">  <span style="color:#4f5666">$<span style="color:#e05561"> <span style="color:#4ec4ff">cypress open --component<span style="color:#e05561"><span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
 <span style="color:#e05561">https://on.cypress.io/migration-guide<span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1257,9 +1257,9 @@ export const AllCypressErrors = {
 
         Please remove this flag from: ${fmt.path(arg1.configFile)}
 
-        Component Testing is now a standalone command. You can now run your component tests with:
+        Component Testing is now a supported testing type. You can run your component tests with:
 
-          ${fmt.terminal(`cypress open-ct`)}
+          ${fmt.terminal(`cypress open --component`)}
 
         https://on.cypress.io/migration-guide`
   },

--- a/system-tests/test/run_ct_spec.js
+++ b/system-tests/test/run_ct_spec.js
@@ -1,6 +1,6 @@
 const systemTests = require('../lib/system-tests').default
 
-describe('run-ct', () => {
+describe('run ct', () => {
   systemTests.setup()
 
   systemTests.it('reports correct exit code when failing', {


### PR DESCRIPTION
### Additional details

Just noticed this marked as deprecated - signalling it would be removed in a future version. This will be 4 major versions since the `--component` flag was introduced, so seems to be a good time to remove it.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
