### PR TITLE
chore: remove deprecated system test execOptions

### DIFF
--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -80,16 +80,6 @@ type ExecOptions = {
    */
   withBinary?: boolean
   /**
-   * Deprecated. Use `--cypress-inspect-brk` from command line instead.
-   * @deprecated
-   */
-  inspectBrk?: null
-  /**
-   * Deprecated. Use `--no-exit` from command line instead.
-   * @deprecated
-   */
-  exit?: null
-  /**
    * Don't exit when tests are finished. You can also pass `--no-exit` via the command line.
    */
   noExit?: boolean
@@ -629,14 +619,6 @@ const systemTests = {
   },
 
   options (ctx, options: ExecOptions) {
-    if (options.inspectBrk != null) {
-      throw new Error(`
-      passing { inspectBrk: true } to system test options is no longer supported
-      Please pass the --cypress-inspect-brk flag to the test command instead
-      e.g. "yarn test async_timeouts_spec.js --cypress-inspect-brk"
-      `)
-    }
-
     _.defaults(options, {
       browser: process.env.SNAPSHOT_BROWSER || 'electron',
       headed: process.env.HEADED || false,
@@ -648,18 +630,9 @@ const systemTests = {
       sanitizeScreenshotDimensions: false,
       normalizeStdoutAvailableBrowsers: true,
       noExit: process.env.NO_EXIT,
-      inspectBrk: process.env.CYPRESS_INSPECT_BRK,
     })
 
     const projectPath = Fixtures.projectPath(options.project)
-
-    if (options.exit != null) {
-      throw new Error(`
-      passing { exit: false } to system test options is no longer supported
-      Please pass the --no-exit flag to the test command instead
-      e.g. "yarn test async_timeouts_spec.js --no-exit"
-      `)
-    }
 
     if (options.noExit && options.timeout < 3000000) {
       options.timeout = 3000000
@@ -768,10 +741,6 @@ const systemTests = {
 
     if (options.noExit) {
       args.push('--no-exit')
-    }
-
-    if (options.inspectBrk) {
-      args.push('--inspect-brk')
     }
 
     if (options.tag) {


### PR DESCRIPTION
Noticed these old exec options in system tests that have been deprecated for...some time. Removing. This will have no effect on users, it's internal to our system tests.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
