### PR TITLE
chore: bring contributor PR approval check earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
 workflows:
   # the setup-workflow workflow is always triggered.
-  setup-workflow:
+  setup-workflow-contributor:
     jobs:
       # This job will allow for a Cypress member to approve and run the code changes from contributors after being reviewed.
       - contributor-pr:
@@ -74,3 +74,10 @@ workflows:
       - verify-ci-should-run:
           requires:
             - contributor-pr
+    when:
+      matches:
+        pattern: /^pull\/[0-9]+/
+        value: << pipeline.git.branch >>
+  setup-workflow:
+    jobs:
+      - verify-ci-should-run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,4 +68,9 @@ workflows:
   # the setup-workflow workflow is always triggered.
   setup-workflow:
     jobs:
-      - verify-ci-should-run
+      # This job will allow for a Cypress member to approve and run the code changes from contributors after being reviewed.
+      - contributor-pr:
+          type: approval
+      - verify-ci-should-run:
+          requires:
+            - contributor-pr

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -3111,12 +3111,6 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
     - build:
         requires:
           - node_modules_install
-    # In subsequent jobs, we use some contexts that are restricted to members of the Cypress organization.
-    # This job will allow for a Cypress member to approve and run the rest of the restricted jobs in the pipeline after the contributor code has been reviewed.
-    - contributor-pr:
-        type: approval
-        requires:
-          - build
     # verify-accessibility-results is required for status checks, however, it will be skipped for contributors so it
     # can run in any order
     - verify-accessibility-results
@@ -3147,15 +3141,11 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
     # unit, integration and e2e tests
     - cli-visual-tests:
         context: test-runner:percy
-        requires:
-          - contributor-pr
     - unit-tests:
         requires:
           - build
     - verify-release-readiness:
         context: test-runner:npm-release
-        requires:
-          - contributor-pr
     - server-unit-tests:
         requires:
           - build
@@ -3167,8 +3157,6 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
           - build
     - system-tests-node-modules-install:
         context: test-runner:performance-tracking
-        requires:
-          - contributor-pr
     - system-tests-chrome:
         context: test-runner:performance-tracking
         requires:
@@ -3192,47 +3180,29 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
           - system-tests-node-modules-install
     - driver-integration-tests-chrome:
         context: test-runner:cypress-record-key
-        requires:
-          - contributor-pr
     - driver-integration-tests-chrome-beta:
         context: test-runner:cypress-record-key
-        requires:
-          - contributor-pr
     - driver-integration-tests-firefox:
         context: test-runner:cypress-record-key
-        requires:
-          - contributor-pr
     - driver-integration-tests-electron:
         context: test-runner:cypress-record-key
-        requires:
-          - contributor-pr
     - driver-integration-tests-webkit:
         context: test-runner:cypress-record-key
-        requires:
-          - contributor-pr
     - driver-integration-memory-tests:
         requires:
           - build
     - run-frontend-shared-component-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - run-launchpad-integration-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - run-launchpad-component-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - run-app-integration-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - run-webpack-dev-server-integration-tests:
         context: [test-runner:cypress-record-key, test-runner:percy]
         requires:
@@ -3244,17 +3214,11 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
     - run-app-component-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:launchpad-tests, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - run-reporter-component-tests-chrome:
         context: [test-runner:cypress-record-key, test-runner:percy]
         percy: true
-        requires:
-          - contributor-pr
     - reporter-integration-tests:
         context: [test-runner:cypress-record-key, test-runner:percy]
-        requires:
-          - contributor-pr
     - npm-webpack-dev-server:
         requires:
           - system-tests-node-modules-install
@@ -3354,8 +3318,6 @@ linux-x64-contributor-workflow: &linux-x64-contributor-workflow
 
     - create-and-trigger-packaging-artifacts:
         context: [test-runner:upload, test-runner:build-binary, publish-binary]
-        requires:
-          - contributor-pr
     - get-published-artifacts:
         context: [publish-binary, test-runner:commit-status-checks]
         requires:


### PR DESCRIPTION
### Additional details

It would be easier to quickly approve contributor PRs to run at the start of CI than at an arbitrary time after node modules install - as we often forget to recheck and approve the contributor PR at that point.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
