### PR TITLE
misc: correct CLI help typo for cypress open --global

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,6 +21,7 @@ _Released 10/24/2024_
 - Cypress now consumes [geckodriver](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html) to help automate the Firefox browser instead of [marionette-client](https://github.com/cypress-io/marionette-client). Addresses [#30217](https://github.com/cypress-io/cypress/issues/30217).
 - Cypress now consumes [webdriver](https://github.com/webdriverio/webdriverio/tree/main/packages/webdriver) to help automate the Firefox browser and [firefox-profile](https://github.com/saadtazi/firefox-profile-js) to create a firefox profile and convert it to Base64 to save user screen preferences via `xulstore.json`. Addresses [#30300](https://github.com/cypress-io/cypress/issues/30300) and [#30301](https://github.com/cypress-io/cypress/issues/30301).
 - Pass spec information to protocol's `beforeSpec` to improve troubleshooting when reporting on errors. Addressed in [#30316](https://github.com/cypress-io/cypress/pull/30316).
+- Fixed a typo in CLI `global` option help text. Addresses [#30531](https://github.com/cypress-io/cypress/issues/30531).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 11/5/2024 (PENDING)_
 
+**Misc:**
+
+- Fixed a typo in CLI `global` option help text. Addresses [#30531](https://github.com/cypress-io/cypress/issues/30531).
+
 **Dependency Updates:**
 
 - Updated `@cypress/request` from `3.0.4` to `3.0.6`. Addressed in [#30488](https://github.com/cypress-io/cypress/pull/30488).
@@ -21,7 +25,6 @@ _Released 10/24/2024_
 - Cypress now consumes [geckodriver](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html) to help automate the Firefox browser instead of [marionette-client](https://github.com/cypress-io/marionette-client). Addresses [#30217](https://github.com/cypress-io/cypress/issues/30217).
 - Cypress now consumes [webdriver](https://github.com/webdriverio/webdriverio/tree/main/packages/webdriver) to help automate the Firefox browser and [firefox-profile](https://github.com/saadtazi/firefox-profile-js) to create a firefox profile and convert it to Base64 to save user screen preferences via `xulstore.json`. Addresses [#30300](https://github.com/cypress-io/cypress/issues/30300) and [#30301](https://github.com/cypress-io/cypress/issues/30301).
 - Pass spec information to protocol's `beforeSpec` to improve troubleshooting when reporting on errors. Addressed in [#30316](https://github.com/cypress-io/cypress/pull/30316).
-- Fixed a typo in CLI `global` option help text. Addresses [#30531](https://github.com/cypress-io/cypress/issues/30531).
 
 **Dependency Updates:**
 

--- a/cli/__snapshots__/cli_spec.js
+++ b/cli/__snapshots__/cli_spec.js
@@ -33,7 +33,7 @@ exports['shows help for open --foo 1'] = `
                                      multiple values with a comma. overrides any
                                      value in cypress.config.{js,ts,mjs,cjs} or
                                      cypress.env.json
-    --global                         force Cypress into global mode as if its
+    --global                         force Cypress into global mode as if it were
                                      globally installed
     -p, --port <port>                runs Cypress on a specific port. overrides
                                      any value in cypress.config.{js,ts,mjs,cjs}.

--- a/cli/lib/cli.js
+++ b/cli/lib/cli.js
@@ -110,7 +110,7 @@ const descriptions = {
   env: 'sets environment variables. separate multiple values with a comma. overrides any value in cypress.config.{js,ts,mjs,cjs} or cypress.env.json',
   exit: 'keep the browser open after tests finish',
   forceInstall: 'force install the Cypress binary',
-  global: 'force Cypress into global mode as if its globally installed',
+  global: 'force Cypress into global mode as if it were globally installed',
   group: 'a named group for recorded runs in Cypress Cloud',
   headed: 'displays the browser instead of running headlessly',
   headless: 'hide the browser instead of running headed (default for cypress run)',


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/30531

### Additional details

Executing the following Cypress CLI command shows a grammatical error:

```shell
$ npx cypress open -h

...

  --global                         force Cypress into global mode as if its globally installed

...
```


### Steps to test

```shell
yarn
yarn build
cd cli/build
yarn pack
```

cd to `cypress-example-kitchensink`

```shell
npm install ~/{your-dirs}/cypress/cli/build/cypress-v13.13.2.tgz --ignore-scripts
```


### How has the user experience changed?

**BEFORE**

```text
$ npx cypress open -h
Usage: cypress open [options]

Opens Cypress in the interactive GUI.

Options:
  -b, --browser <browser-path>     runs Cypress in the browser with the given name. if a filesystem path is supplied, Cypress will
                                   attempt to use the browser at that path.
  --component                      runs component tests
  -c, --config <config>            sets configuration values. separate multiple values with a comma. overrides any value in
                                   cypress.config.{js,ts,mjs,cjs}.
  -C, --config-file <config-file>  path to script file where configuration values are set. defaults to
                                   "cypress.config.{js,ts,mjs,cjs}".
  -d, --detached [bool]            runs Cypress application in detached mode
  --e2e                            runs end to end tests
  -e, --env <env>                  sets environment variables. separate multiple values with a comma. overrides any value in
                                   cypress.config.{js,ts,mjs,cjs} or cypress.env.json
  --global                         force Cypress into global mode as if its globally installed
  -p, --port <port>                runs Cypress on a specific port. overrides any value in cypress.config.{js,ts,mjs,cjs}.
  -P, --project <project-path>     path to the project
  --dev                            runs cypress in development and bypasses binary check
  -h, --help                       display help for command
```

**AFTER**

![global after](https://github.com/user-attachments/assets/41b53b43-969c-4b66-b7fc-898654a12129)



### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
