### PR TITLE
chore: Update CI workflows path to be current branch workflows file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,11 @@ jobs:
 
             echo "Skipping CI; branch in progress - $TRIGGER_INSTRUCTIONS"
             cancel_build
-
+      - checkout
       - continuation/continue:
           configuration_path: .circleci/workflows.yml
           parameters: |
             {  "targetBranch" : "$GITHUB_PR_BASE_BRANCH" }
-          checkout: true
 
 workflows:
   # the setup-workflow workflow is always triggered.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 setup: true
 
 orbs:
-  continuation: circleci/continuation@0.3.1
+  continuation: circleci/continuation@1.0.0
 
 jobs:
   verify-ci-should-run:
@@ -55,6 +55,9 @@ jobs:
 
       - continuation/continue:
           configuration_path: .circleci/workflows.yml
+          parameters: |
+            {  "targetBranch" : "$GITHUB_PR_BASE_BRANCH" }
+          checkout: true
 
 workflows:
   # the setup-workflow workflow is always triggered.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,6 @@ jobs:
       - checkout
       - continuation/continue:
           configuration_path: .circleci/workflows.yml
-          parameters: |
-            {  "targetBranch" : "$GITHUB_PR_BASE_BRANCH" }
 
 workflows:
   # the setup-workflow workflow is always triggered.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,16 +53,8 @@ jobs:
             echo "Skipping CI; branch in progress - $TRIGGER_INSTRUCTIONS"
             cancel_build
 
-      - run:
-          name: Download .circleci/workflows.yaml
-          command: |
-            if [[ "$CIRCLE_BRANCH" == "pull/"* ]]; then
-              curl -o workflows.yml https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/develop/.circleci/workflows.yml
-            else 
-              curl -o workflows.yml https://raw.githubusercontent.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}/.circleci/workflows.yml
-            fi
       - continuation/continue:
-          configuration_path: workflows.yml
+          configuration_path: .circleci/workflows.yml
 
 workflows:
   # the setup-workflow workflow is always triggered.


### PR DESCRIPTION
### Additional details

There were some tests failing in strange ways when contributor PRs were run on our release/14 branch (see https://github.com/cypress-io/cypress/pull/29680). Some of the tests were running in the new Node version and some in the old Node version. 

It turns out that for contributor PRs, they always pull in the workflow.yml from the `develop` branch to run. We don't see any utility in doing CI this way, so I'm updating the code to checkout the code and run the `.circleci/workflows.yml` file that is in the working directory. 

### Steps to test

Test of this was conducted in this outside contributor PR: https://github.com/cypress-io/cypress/pull/30520

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
