### PR TITLE
fix: ensure that each js file served up by vite dev server has an inline sourcemap

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.15.3
+
+_Released 11/19/2024 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where some JS assets were not properly getting sourcemaps included with the vite dev server if they had a cache busting query parameter in the URL. Fixed some scenarios to ensure that the sourcemaps that were included by the vite dev server were inlined. Addressed in [#30606](https://github.com/cypress-io/cypress/pull/30606).
+
 ## 13.15.2
 
 _Released 11/5/2024_

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -19,6 +19,7 @@ export const CypressSourcemap = (
         // have a cache buster query parameter (e.g. `?v=12345`)
         const queryParameterLessId = id.split('?')[0]
 
+        // Check if the file has a JavaScript extension and does not have an inlined sourcemap
         if (/\.(js|jsx|ts|tsx|vue|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
           /*
           The Vite dev server and plugins automatically generate sourcemaps for most files, but there are

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -34,8 +34,11 @@ export const CypressSourcemap = (
           const sourcemapUrl = sourcemap.toUrl()
 
           if (/\/\/# sourceMappingURL=/i.test(code)) {
+            // If the code already has a sourceMappingURL, it is not an inlined sourcemap
+            // and we should replace it with the new sourcemap
             code = code.replace(/\/\/# sourceMappingURL=(.*)$/m, `//# sourceMappingURL=${sourcemapUrl}`)
           } else {
+            // If the code does not have a sourceMappingURL, we should append the new sourcemap
             code += `\n//# sourceMappingURL=${sourcemapUrl}`
           }
 

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -20,7 +20,7 @@ export const CypressSourcemap = (
         const queryParameterLessId = id.split('?')[0]
 
         // Check if the file has a JavaScript extension and does not have an inlined sourcemap
-        if (/\.(js|jsx|ts|tsx|vue|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
+        if (/\.(js|jsx|ts|tsx|vue|svelte|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
           /*
           The Vite dev server and plugins automatically generate sourcemaps for most files, but there are
           some files that don't have sourcemaps generated for them or are not inlined. We utilize a 'post' plugin

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -15,9 +15,11 @@ export const CypressSourcemap = (
     enforce: 'post',
     transform (code, id, options?) {
       try {
+        // Remove query parameters from the id. This is necessary because some files
+        // have a cache buster query parameter (e.g. `?v=12345`)
         const queryParameterLessId = id.split('?')[0]
 
-        if (/\.(js|jsx|ts|tsx|vue|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
+        if (/\.js$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
           /*
           The Vite dev server and plugins automatically generate sourcemaps for most files, but they are
           only included in the served files if any transpilation actually occurred (JSX, TS, etc). This

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -37,11 +37,12 @@ export const CypressSourcemap = (
           */
 
           const sourcemap = this.getCombinedSourcemap()
+          const sourcemapUrl = sourcemap.toUrl()
 
           if (/\/\/# sourceMappingURL=/i.test(code)) {
-            code = code.replace(/\/\/# sourceMappingURL=(.*)$/m, `//# sourceMappingURL=${sourcemap.toUrl()}`)
+            code = code.replace(/\/\/# sourceMappingURL=(.*)$/m, `//# sourceMappingURL=${sourcemapUrl}`)
           } else {
-            code += `\n//# sourceMappingURL=${sourcemap.toUrl()}`
+            code += `\n//# sourceMappingURL=${sourcemapUrl}`
           }
 
           return {

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -15,7 +15,9 @@ export const CypressSourcemap = (
     enforce: 'post',
     transform (code, id, options?) {
       try {
-        if (/\.js$/i.test(id) && !/\/\/# sourceMappingURL=/i.test(code)) {
+        const queryParameterLessId = id.split('?')[0]
+
+        if (/\.(js|jsx|ts|tsx|vue|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
           /*
           The Vite dev server and plugins automatically generate sourcemaps for most files, but they are
           only included in the served files if any transpilation actually occurred (JSX, TS, etc). This
@@ -36,7 +38,11 @@ export const CypressSourcemap = (
 
           const sourcemap = this.getCombinedSourcemap()
 
-          code += `\n//# sourceMappingURL=${sourcemap.toUrl()}`
+          if (/\/\/# sourceMappingURL=/i.test(code)) {
+            code = code.replace(/\/\/# sourceMappingURL=(.*)$/m, `//# sourceMappingURL=${sourcemap.toUrl()}`)
+          } else {
+            code += `\n//# sourceMappingURL=${sourcemap.toUrl()}`
+          }
 
           return {
             code,

--- a/npm/vite-dev-server/src/plugins/sourcemap.ts
+++ b/npm/vite-dev-server/src/plugins/sourcemap.ts
@@ -19,19 +19,11 @@ export const CypressSourcemap = (
         // have a cache buster query parameter (e.g. `?v=12345`)
         const queryParameterLessId = id.split('?')[0]
 
-        if (/\.js$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
+        if (/\.(js|jsx|ts|tsx|vue|mjs|cjs)$/i.test(queryParameterLessId) && !/\/\/# sourceMappingURL=data/i.test(code)) {
           /*
-          The Vite dev server and plugins automatically generate sourcemaps for most files, but they are
-          only included in the served files if any transpilation actually occurred (JSX, TS, etc). This
-          means that files that are "pure" JS won't include sourcemaps, so JS spec files that don't require
-          transpilation won't get code frames in the runner.
-
-          A sourcemap for these files is generated (just not served) which is in effect an "identity"
-          sourcemap mapping 1-to-1 to the output file. We can grab this and pass it along as a sourcemap
-          we want Vite to embed into the output, giving Cypress a sourcemap to use for codeFrame lookups.
-          @see https://rollupjs.org/guide/en/#thisgetcombinedsourcemap
-
-          We utilize a 'post' plugin here and manually append the sourcemap content to the code. We *should*
+          The Vite dev server and plugins automatically generate sourcemaps for most files, but there are
+          some files that don't have sourcemaps generated for them or are not inlined. We utilize a 'post' plugin
+          here and manually append the sourcemap content to the code in these cases. We *should*
           be able to pass the sourcemap along using the `map` attribute in the return value, but Babel-based
           plugins don't work with this which causes sourcemaps to break for files that go through common
           plugins like `@vitejs/plugin-react`. By manually appending the sourcemap at this point in time

--- a/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
+++ b/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
@@ -9,7 +9,7 @@ import sinon from 'sinon'
 Chai.use(SinonChai)
 
 describe('sourcemap plugin', () => {
-  ['js', 'jsx', 'ts', 'tsx', 'vue', 'mjs', 'cjs'].forEach((ext) => {
+  ['js', 'jsx', 'ts', 'tsx', 'vue', 'svelte', 'mjs', 'cjs'].forEach((ext) => {
     it(`should append sourcemap to the code if sourceMappingURL is not present for files with extension ${ext}`, () => {
       const code = 'console.log("hello world")'
       const id = `test.js`

--- a/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
+++ b/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
@@ -1,0 +1,62 @@
+import { Plugin } from 'vite-5'
+import { ViteDevServerConfig } from '../../src/devServer'
+import { Vite } from '../../src/getVite'
+import { CypressSourcemap } from '../../src/plugins'
+import Chai, { expect } from 'chai'
+import SinonChai from 'sinon-chai'
+
+Chai.use(SinonChai)
+
+describe('sourcemap plugin', () => {
+  ['js', 'jsx', 'ts', 'tsx', 'vue', 'mjs', 'cjs'].forEach((ext) => {
+    it('should append sourcemap to the code if sourceMappingURL is not present', () => {
+      const code = 'console.log("hello world")'
+      const id = `test.${ext}`
+      const options = {} as ViteDevServerConfig
+      const vite = {} as Vite
+      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+
+      plugin.getCombinedSourcemap = () => {
+        return {
+          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
+        }
+      }
+
+      expect(plugin.name).to.equal('cypress:sourcemap')
+      expect(plugin.enforce).to.equal('post')
+
+      if (plugin.transform instanceof Function) {
+        const result = plugin.transform.call(plugin, code, id)
+
+        expect(result.code).to.include('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      } else {
+        throw new Error('transform is not a function')
+      }
+    })
+
+    it('should replace sourceMappingURL with sourcemap', () => {
+      const code = 'console.log("hello world")\n//# sourceMappingURL=old-url'
+      const id = `test.${ext}`
+      const options = {} as ViteDevServerConfig
+      const vite = {} as Vite
+      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+
+      plugin.getCombinedSourcemap = () => {
+        return {
+          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
+        }
+      }
+
+      expect(plugin.name).to.equal('cypress:sourcemap')
+      expect(plugin.enforce).to.equal('post')
+
+      if (plugin.transform instanceof Function) {
+        const result = plugin.transform.call(plugin, code, id)
+
+        expect(result.code).to.include('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      } else {
+        throw new Error('transform is not a function')
+      }
+    })
+  })
+})

--- a/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
+++ b/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
@@ -4,22 +4,71 @@ import { Vite } from '../../src/getVite'
 import { CypressSourcemap } from '../../src/plugins'
 import Chai, { expect } from 'chai'
 import SinonChai from 'sinon-chai'
+import sinon from 'sinon'
 
 Chai.use(SinonChai)
 
 describe('sourcemap plugin', () => {
-  it('should append sourcemap to the code if sourceMappingURL is not present', () => {
-    const code = 'console.log("hello world")'
+  ['js', 'jsx', 'ts', 'tsx', 'vue', 'mjs', 'cjs'].forEach((ext) => {
+    it(`should append sourcemap to the code if sourceMappingURL is not present for files with extension ${ext}`, () => {
+      const code = 'console.log("hello world")'
+      const id = `test.js`
+      const options = {} as ViteDevServerConfig
+      const vite = {} as Vite
+      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+
+      plugin.getCombinedSourcemap = () => {
+        return {
+          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
+        }
+      }
+
+      expect(plugin.name).to.equal('cypress:sourcemap')
+      expect(plugin.enforce).to.equal('post')
+
+      if (plugin.transform instanceof Function) {
+        const result = plugin.transform.call(plugin, code, id)
+
+        expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      } else {
+        throw new Error('transform is not a function')
+      }
+    })
+
+    it(`should replace sourceMappingURL with sourcemap and handle query parameters for files with extension ${ext}`, () => {
+      const code = 'console.log("hello world")\n//# sourceMappingURL=old-url'
+      const id = `test.js?v=12345`
+      const options = {} as ViteDevServerConfig
+      const vite = {} as Vite
+      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+
+      plugin.getCombinedSourcemap = () => {
+        return {
+          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
+        }
+      }
+
+      expect(plugin.name).to.equal('cypress:sourcemap')
+      expect(plugin.enforce).to.equal('post')
+
+      if (plugin.transform instanceof Function) {
+        const result = plugin.transform.call(plugin, code, id)
+
+        expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      } else {
+        throw new Error('transform is not a function')
+      }
+    })
+  })
+
+  it('should not append sourcemap to the code if sourceMappingURL is already present', () => {
+    const code = 'console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ=='
     const id = `test.js`
     const options = {} as ViteDevServerConfig
     const vite = {} as Vite
     const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
 
-    plugin.getCombinedSourcemap = () => {
-      return {
-        toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
-      }
-    }
+    plugin.getCombinedSourcemap = sinon.stub()
 
     expect(plugin.name).to.equal('cypress:sourcemap')
     expect(plugin.enforce).to.equal('post')
@@ -27,24 +76,21 @@ describe('sourcemap plugin', () => {
     if (plugin.transform instanceof Function) {
       const result = plugin.transform.call(plugin, code, id)
 
-      expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      expect(result).to.be.undefined
+      expect(plugin.getCombinedSourcemap).not.to.have.been.called
     } else {
       throw new Error('transform is not a function')
     }
   })
 
-  it('should replace sourceMappingURL with sourcemap and handle query parameters', () => {
-    const code = 'console.log("hello world")\n//# sourceMappingURL=old-url'
-    const id = `test.js?v=12345`
+  it('should not append sourcemap to the code if the file is not a js, jsx, ts, tsx, vue, mjs, or cjs file', () => {
+    const code = 'console.log("hello world")'
+    const id = `test.css`
     const options = {} as ViteDevServerConfig
     const vite = {} as Vite
     const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
 
-    plugin.getCombinedSourcemap = () => {
-      return {
-        toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
-      }
-    }
+    plugin.getCombinedSourcemap = sinon.stub()
 
     expect(plugin.name).to.equal('cypress:sourcemap')
     expect(plugin.enforce).to.equal('post')
@@ -52,7 +98,8 @@ describe('sourcemap plugin', () => {
     if (plugin.transform instanceof Function) {
       const result = plugin.transform.call(plugin, code, id)
 
-      expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+      expect(result).to.be.undefined
+      expect(plugin.getCombinedSourcemap).not.to.have.been.called
     } else {
       throw new Error('transform is not a function')
     }

--- a/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
+++ b/npm/vite-dev-server/test/plugins/sourcemap.spec.ts
@@ -8,55 +8,53 @@ import SinonChai from 'sinon-chai'
 Chai.use(SinonChai)
 
 describe('sourcemap plugin', () => {
-  ['js', 'jsx', 'ts', 'tsx', 'vue', 'mjs', 'cjs'].forEach((ext) => {
-    it('should append sourcemap to the code if sourceMappingURL is not present', () => {
-      const code = 'console.log("hello world")'
-      const id = `test.${ext}`
-      const options = {} as ViteDevServerConfig
-      const vite = {} as Vite
-      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+  it('should append sourcemap to the code if sourceMappingURL is not present', () => {
+    const code = 'console.log("hello world")'
+    const id = `test.js`
+    const options = {} as ViteDevServerConfig
+    const vite = {} as Vite
+    const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
 
-      plugin.getCombinedSourcemap = () => {
-        return {
-          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
-        }
+    plugin.getCombinedSourcemap = () => {
+      return {
+        toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
       }
+    }
 
-      expect(plugin.name).to.equal('cypress:sourcemap')
-      expect(plugin.enforce).to.equal('post')
+    expect(plugin.name).to.equal('cypress:sourcemap')
+    expect(plugin.enforce).to.equal('post')
 
-      if (plugin.transform instanceof Function) {
-        const result = plugin.transform.call(plugin, code, id)
+    if (plugin.transform instanceof Function) {
+      const result = plugin.transform.call(plugin, code, id)
 
-        expect(result.code).to.include('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
-      } else {
-        throw new Error('transform is not a function')
+      expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+    } else {
+      throw new Error('transform is not a function')
+    }
+  })
+
+  it('should replace sourceMappingURL with sourcemap and handle query parameters', () => {
+    const code = 'console.log("hello world")\n//# sourceMappingURL=old-url'
+    const id = `test.js?v=12345`
+    const options = {} as ViteDevServerConfig
+    const vite = {} as Vite
+    const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+
+    plugin.getCombinedSourcemap = () => {
+      return {
+        toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
       }
-    })
+    }
 
-    it('should replace sourceMappingURL with sourcemap', () => {
-      const code = 'console.log("hello world")\n//# sourceMappingURL=old-url'
-      const id = `test.${ext}`
-      const options = {} as ViteDevServerConfig
-      const vite = {} as Vite
-      const plugin = CypressSourcemap(options, vite) as Plugin & { getCombinedSourcemap: () => { toUrl: () => string } }
+    expect(plugin.name).to.equal('cypress:sourcemap')
+    expect(plugin.enforce).to.equal('post')
 
-      plugin.getCombinedSourcemap = () => {
-        return {
-          toUrl: () => 'data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==',
-        }
-      }
+    if (plugin.transform instanceof Function) {
+      const result = plugin.transform.call(plugin, code, id)
 
-      expect(plugin.name).to.equal('cypress:sourcemap')
-      expect(plugin.enforce).to.equal('post')
-
-      if (plugin.transform instanceof Function) {
-        const result = plugin.transform.call(plugin, code, id)
-
-        expect(result.code).to.include('//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
-      } else {
-        throw new Error('transform is not a function')
-      }
-    })
+      expect(result.code).to.eq('console.log("hello world")\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==')
+    } else {
+      throw new Error('transform is not a function')
+    }
   })
 })


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We have a custom vite dev server plugin that transforms JS files to include inlined source maps but there were two scenarios that were missed with this plugin:

- files that include a cache busting query parameter (e.g. ?v=12345)
- files that include a sourcemap but one that is not inline

This PR resolves both of these scenarios.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
