### PR TITLE
docs: add contributing restriction for ubuntu 24.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,9 @@ Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:
 export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
 ```
 
+> [!IMPORTANT]
+> The above steps to install an earlier version of Python are currently not available for the interim release Ubuntu `24.10`. The highest compatible Ubuntu version for rebuilding Cypress from source error-free is currently Ubuntu `24.04`.
+
 For Ubuntu `24.04` refer also to the [Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` when you try to run Cypress on this version of Ubuntu after building Cypress from source.
 
 #### Windows


### PR DESCRIPTION
### Additional details

The [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) section refers to additional steps for a Ubuntu `24.04` environment. In the meantime [Ubuntu 24.10 (Oracular Oriole)](https://fridge.ubuntu.com/2024/10/10/ubuntu-24-10-oracular-oriole-released/) was released on Oct 10, 2024, as an interim release, and this needs to be added to the instructions.

To allow building Cypress from source with Python `3.12` requires a minimum of [node-gyp@10.0.0](https://github.com/nodejs/node-gyp/releases/tag/v10.0.0). Cypress has not yet reached this state and Python `3.11` is currently the highest compatible version usable to build Cypress from source.

The workaround involving [deadsnakes](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa) is available for `Ubuntu 24.04 (noble)`. Attempting to use it for `Ubuntu 24.10 (oracular)` results in an error

> E: The repository 'https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu oracular Release' does not have a Release file.

Due to the Python restrictions, Ubuntu `24.10` is currently not suitable to rebuild Cypress from source error-free.

Add this statement to the [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) section:

![image](https://github.com/user-attachments/assets/701a7dd9-60ec-4e27-b10a-e3f3c5caa6e6)


### Steps to test

Clean install [Ubuntu `24.10`](https://releases.ubuntu.com/oracular/) Desktop.

Attempt to use `deadsnakes` to install an earlier version of Python by executing the following command:

```shell
sudo add-apt-repository ppa:deadsnakes/ppa
```

Note the failure.

### How has the user experience changed?

Affects contributors only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
