### PR TITLE
docs: fix link to moved changelog docs source

### DIFF
--- a/guides/writing-the-cypress-changelog.md
+++ b/guides/writing-the-cypress-changelog.md
@@ -57,4 +57,4 @@ At the time of the release, the releaser will:
 - ensure the change sections are in the correct order
 - ensure that the entries are ordered by impact
 
-Each Cypress release results in an update to the [changelog.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/guides/references/changelog.mdx) file in the [cypress-documentation](https://github.com/cypress-io/cypress-documentation) repository to be published on the [doc site](https://docs.cypress.io/guides/references/changelog). See [Example pull request](https://github.com/cypress-io/cypress-documentation/pull/5874) adding a new changelog section to the repository.
+Each Cypress release results in an update to the [changelog.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/references/changelog.mdx) file in the [cypress-documentation](https://github.com/cypress-io/cypress-documentation) repository to be published on the [doc site](https://docs.cypress.io/guides/references/changelog). See [Example pull request](https://github.com/cypress-io/cypress-documentation/pull/5965) adding a new changelog section to the repository.


### PR DESCRIPTION
### Additional details

The document [Cypress App - Managing the Release Changelog](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md), in the section [Release](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#release), contains an outdated link to the `changelog.mdx` file in the [cypress-documentation](https://github.com/cypress-io/cypress-documentation) repository, which was reorganized in October 2024.

1. Change the `changelog.mdx` link to https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/references/changelog.mdx
2. Update the example PR to https://github.com/cypress-io/cypress-documentation/pull/5965

### Steps to test

Open the document [Release](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#release) section and click on the link [changelog.mdx](https://github.com/cypress-io/cypress-documentation/blob/main/docs/app/references/changelog.mdx). Confirm it references an existing file. (Note: GitHub may display the error "This blob took too long to generate".)

### How has the user experience changed?

Maintainer (release function) issue only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
