### PR TITLE
chore: fix updating v8 snapshot cache when pr already exists

### DIFF
--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -118,11 +118,14 @@ jobs:
           echo "BRANCH_NAME=update-v8-snapshot-cache-on-${{ env.BASE_BRANCH }}-${{ env.PLATFORM }}" >> $GITHUB_ENV
           echo "BRANCH_EXISTS=$(git show-ref --verify --quiet refs/remotes/origin/update-v8-snapshot-cache-on-${{ env.BASE_BRANCH }}-${{ env.PLATFORM }} && echo 'true')" >> $GITHUB_ENV
         shell: bash
+      - name: Check number of existing prs
+        id: check-number-of-existing-prs
+        run: |
+          echo "number_of_prs_for_branch=$(gh api '/repos/cypress-io/cypress/pulls?head=cypress-io:${{ env.BRANCH_NAME }}' --jq length)" >> $GITHUB_OUTPUT
       - name: Check need for PR or branch update
         id: check-need-for-pr
         run: |
-          echo "number_of_prs_for_branch=$(gh api '/repos/cypress-io/cypress/pulls?head=cypress-io:${{ env.BRANCH_NAME }}' --jq length)" >> $GITHUB_OUTPUT
-          echo "needs_pr=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_NAME != env.BASE_BRANCH && steps.check-need-for-pr.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
+          echo "needs_pr=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_NAME != env.BASE_BRANCH && steps.check-number-of-existing-prs.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
           echo "needs_branch_update=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_EXISTS == 'true' }}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Apparently, github output can't be used within the step that it is set, so I need to split up the logic that detects the number of PRs from the logic that uses that number.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
