### PR TITLE
docs: remove node-gyp contributor workarounds / restrictions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,36 +202,19 @@ You must have the following installed on your system to contribute locally:
 
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
 - [`yarn`](https://yarnpkg.com/en/docs/install)
-- [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements. Use Python `3.11` or lower.)
+- [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
 
 #### Debian/Ubuntu
 
 `sudo apt install g++ make` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
 `python` is pre-installed on Debian-based systems including Ubuntu.
-The Python versions shipped with Ubuntu versions `20.04` and `22.04` are compatible with Cypress requirements.
+The Python versions shipped with Ubuntu versions `20.04`, `22.04` and `24.*` are compatible with Cypress requirements.
 
-Only on Ubuntu `24.04` install Python `3.11` by executing the following commands:
-
-```shell
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt update
-sudo apt install python3.11
-```
-
-Add the environment variable `NODE_GYP_FORCE_PYTHON` to `~/.bashrc`:
-
-```shell
-export NODE_GYP_FORCE_PYTHON=/usr/bin/python3.11
-```
-
-> [!IMPORTANT]
-> The above steps to install an earlier version of Python are currently not available for the interim release Ubuntu `24.10`. The highest compatible Ubuntu version for rebuilding Cypress from source error-free is currently Ubuntu `24.04`.
-
-For Ubuntu `24.04` refer also to the [Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section [Unprivileged user namespace restrictions](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15) and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` when you try to run Cypress on this version of Ubuntu after building Cypress from source.
+For Ubuntu `24.04` and above, refer also to the [Ubuntu 24.04 Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section "Unprivileged user namespace restrictions" and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` when you try to run Cypress on these versions of Ubuntu after building Cypress from source.
 
 #### Windows
 
-When installing the Visual Studio C++ environment recommended by [node-gyp](https://github.com/nodejs/node-gyp), install also a Windows 10 SDK. The currently used version of `node-gyp` may otherwise fail to recognise the Visual Studio installation.
+Currently no additional instructions for installation requirements.
 
 ### Getting Started
 


### PR DESCRIPTION
- Follows on from PR #30633

### Additional details

This PR addresses documentation changes following the merge of PR #30633, which updated [@electron/rebuild@3.6.2](https://github.com/electron/rebuild/releases/tag/v3.7.1) to [@electron/rebuild@3.7.1](https://github.com/electron/rebuild/releases/tag/v3.7.1) in [packages/server](https://github.com/cypress-io/cypress/blob/develop/packages/server) in the [release/14.0.0](https://github.com/cypress-io/cypress/tree/release/14.0.0) branch.

The update allows [node-gyp@10.2.0](https://github.com/nodejs/node-gyp/releases/tag/v10.2.0) to be used, with cascading restrictions relieved:

1. The default Python `3.12` version of Ubuntu `24.*` can be used.
2. On Ubuntu `24.04` no downgrading to Python `3.11` necessary.
3. Allows use of Ubuntu `24.10`. (Downgrading Python on Ubuntu `24.10` is not available)
4. On Windows no need to install a Windows 10 SDK additionally.

Building Cypress from source is then possible, without errors from `node-gyp` and without resorting to these workarounds.

Corresponding workaround instructions and restrictions are removed from [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements).

### Steps to test

Follow the modified instructions in [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) for Cypress 14 beta, including the use of Node.js `v20.18.0`.

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
git switch release/14.0.0
n auto # or set Node.js manually to 20.18.0
git clean -xfd
yarn
```

Confirm that the installation was successful and that the following log sequence shows no errors between the steps:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

Remove any workarounds previously installed, which are no longer part of the updated [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) instructions, as follows:

#### Ubuntu 24.04

If the system has been previously set up for Python `3.11`, then execute the following before running `yarn`:

```shell
unset NODE_GYP_FORCE_PYTHON
```

#### Ubuntu 24.10

Python `3.11` is not available for Ubuntu `24.10`, so no special preparatory steps are necessary.

#### Windows 11

In Visual Studio Installer remove any Windows 10 SDK installed. Install Python `3.12` through Microsoft Store.

- Ignore errors from issue https://github.com/cypress-io/cypress/issues/28739

Confirm that the error "could not find a version of Visual Studio 2017 or newer to use" no longer occurs.

### How has the user experience changed?

This issue affects contributors only. Contributor instructions are changed for Ubuntu and Windows.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
