### PR TITLE
docs: fix @cypress/grep readme links

### DIFF
--- a/npm/grep/README.md
+++ b/npm/grep/README.md
@@ -51,14 +51,10 @@ Table of Contents
   - [Debugging in the plugin](#debugging-in-the-plugin)
   - [Debugging in the browser](#debugging-in-the-browser)
 - [Examples](#examples)
-- [See also](#see-also)
 - [Migration guide](#migration-guide)
   - [from v1 to v2](#from-v1-to-v2)
   - [from v2 to v3](#from-v2-to-v3)
-- [Videos & Blog Posts](#videos--blog-posts)
-- [Blog posts](#blog-posts)
 - [Small print](#small-print)
-- [MIT License](#mit-license)
 
 <!-- /MarkdownTOC -->
 
@@ -117,7 +113,7 @@ registerCypressGrep()
 }
 ```
 
-Installing the plugin via `setupNodeEvents()` is required to enable the [grepFilterSpecs](#grepfilterspecs) feature.
+Installing the plugin via `setupNodeEvents()` is required to enable the [grepFilterSpecs](#pre-filter-specs-grepfilterspecs) feature.
 
 ## Usage Overview
 
@@ -320,7 +316,7 @@ describe('block with config tag', { tags: '@smoke' }, () => {})
 --env grepTags=-@smoke
 ```
 
-See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
+See the [cypress/e2e/describe-tags-spec.js](./cypress/e2e/describe-tags-spec.js) file.
 
 **Note:** global function `describe` and `context` are aliases and both supported by this plugin.
 
@@ -424,7 +420,7 @@ it('runs on deploy', { tags: 'smoke' }, () => {
 This package comes with [src/index.d.ts](./src/index.d.ts) definition file that adds the property `tags` to the Cypress test overrides interface. Include this file in your specs or TS config settings. For example, you can load it using a reference comment
 
 ```js
-// cypress/integration/my-spec.js
+// cypress/e2e/my-spec.js
 /// <reference types="@cypress/grep" />
 ```
 
@@ -559,11 +555,6 @@ To see how to debug this plugin, watch the video [Debug @cypress/grep Plugin](ht
 - [cypress-grep-example](https://github.com/bahmutov/cypress-grep-example)
 - [todo-graphql-example](https://github.com/bahmutov/todo-graphql-example)
 
-## See also
-
-- [cypress-select-tests](https://github.com/bahmutov/cypress-select-tests)
-- [cypress-skip-test](https://github.com/cypress-io/cypress-skip-test)
-
 ## Migration guide
 
 ### from v1 to v2
@@ -599,5 +590,5 @@ Version >= 3 of @cypress/grep _only_ supports Cypress >= 10.
 
 License: MIT - do anything with the code, but don't blame me if it does not work.
 
-Support: if you find any problems with this module, email / tweet /
-[open issue](https://github.com/cypress-io/cypress/issues) on Github.
+Support: if you find any problems with this module,
+[open issue](https://github.com/cypress-io/cypress/issues) on GitHub.


### PR DESCRIPTION
### Additional details

In the [npm/grep/README.md](https://github.com/cypress-io/cypress/blob/develop/npm/grep/README.md) for the npm module [@cypress/grep](https://www.npmjs.com/package/@cypress/grep):

1. The Table of Contents is outdated, causing several invalid section headings / bookmarks to be displayed. These are removed from the end of the TOC:
  [✖] #videos--blog-posts → Status: 404
  [✖] #blog-posts → Status: 404
  [✖] #mit-license → Status: 404
2. `#grepfilterspecs` is now `#pre-filter-specs-grepfilterspecs`. This is corrected:
  [✖] #grepfilterspecs → Status: 404
3. The "See also" section is eliminated, since the two repos in that section are now both archived and therefore de facto unsupported, although they are not explicitly deprecated in the npm registry:
   - [cypress-select-tests](https://github.com/bahmutov/cypress-select-tests) - archived May 2021
   - [cypress-skip-test](https://github.com/cypress-io/cypress-skip-test) - archived Jan 2023
4. References and links to legacy `cypress/integration/` are corrected to `cypress/e2e`
5. Support via email and tweet is removed

### Steps to test

```shell
npm install markdown-link-check -g
git clone https://github.com/cypress-io/cypress
cd cypress
markdown-link-check npm/grep/README.md
```

### How has the user experience changed?

Users viewing [npm/grep/README.md](https://github.com/cypress-io/cypress/blob/develop/npm/grep/README.md) will not encounter bad or outdated links.

This PR does not itself cause a new version of [@cypress/grep](https://www.npmjs.com/package/@cypress/grep) to be released, so the [npm registry README copy](https://www.npmjs.com/package/@cypress/grep?activeTab=readme) will continue to be outdated.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
