### PR TITLE
fix: hang when Network.enable is not implemented for a target

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 12/17/2024 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed and issue where targets may hang if `Network.enable` is not implemented for the target. Addresses [#29876](https://github.com/cypress-io/cypress/issues/29876).
+- Fixed an issue where targets may hang if `Network.enable` is not implemented for the target. Addresses [#29876](https://github.com/cypress-io/cypress/issues/29876).
 
 ## 13.16.1
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.16.2
+
+_Released 12/17/2024_
+
+**Bugfixes:**
+
+- Fixed and issue where targets may hang if `Network.enable` is not implemented for the target. Addresses [#29876](https://github.com/cypress-io/cypress/issues/29876).
+
 ## 13.16.1
 
 _Released 12/03/2024_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 13.16.2
 
-_Released 12/17/2024_
+_Released 12/17/2024 (PENDING)_
 
 **Bugfixes:**
 

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -342,9 +342,8 @@ export class BrowserCriClient {
       try {
         await browserClient.send('Runtime.runIfWaitingForDebugger', undefined, sessionId)
       } catch (error) {
-        // it's possible that the target was closed before we could enable
-        // network and continue, in that case, just ignore
-        debug('error running Runtime.runIfWaitingForDebugger:', error)
+        // it's possible that the target was closed before we could tell it to run, in that case, just ignore
+        debug('error running Runtime.runIfWaitingForDebugger: %o', error)
       }
     }
 

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events'
 import { ProtocolManagerShape } from '@packages/types'
 import type { CriClient } from '../../../lib/browsers/cri-client'
 import pDefer from 'p-defer'
+import type Protocol from 'devtools-protocol'
 const { expect, proxyquire, sinon } = require('../../spec_helper')
 
 const DEBUGGER_URL = 'http://foo'
@@ -108,11 +109,9 @@ describe('lib/browsers/cri-client', function () {
         it('does not enable network', async () => {
           await Promise.all(['service_worker', 'page', 'other'].map((type) => {
             return fireCDPEvent('Target.attachedToTarget', {
-              // do not need entire event payload for this test
-              // @ts-ignore
               targetInfo: {
                 type,
-              },
+              } as Protocol.Target.TargetInfo,
             })
           }))
 
@@ -123,11 +122,9 @@ describe('lib/browsers/cri-client', function () {
       describe('target type is something other than service worker, page, or other', () => {
         it('enables network', async () => {
           await fireCDPEvent('Target.attachedToTarget', {
-          // do not need entire event payload for this test
-          // @ts-ignore
             targetInfo: {
-              type: 'somethin else',
-            },
+              type: 'iframe',
+            } as Protocol.Target.TargetInfo,
           })
 
           expect(criStub.send).to.have.been.calledWith('Network.enable')
@@ -135,14 +132,13 @@ describe('lib/browsers/cri-client', function () {
       })
 
       describe('target is waiting for debugger', () => {
-        it('sends Runtime.runIfWaitingForDebugger', async () => {
-          const sessionId = 'abc123'
+        const sessionId = 'abc123'
 
+        it('sends Runtime.runIfWaitingForDebugger', async () => {
           await fireCDPEvent('Target.attachedToTarget', {
             waitingForDebugger: true,
             sessionId,
-            // @ts-ignore
-            targetInfo: { type: 'service_worker' },
+            targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
           })
 
           expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
@@ -151,8 +147,8 @@ describe('lib/browsers/cri-client', function () {
         it('does not send Runtime.runIfWaitingForDebugger if not waiting for debugger', async () => {
           await fireCDPEvent('Target.attachedToTarget', {
             waitingForDebugger: false,
-            // @ts-ignore
-            targetInfo: { type: 'service_worker' },
+            sessionId,
+            targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
           })
 
           expect(criStub.send).not.to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
@@ -162,11 +158,25 @@ describe('lib/browsers/cri-client', function () {
           criStub.send.withArgs('Network.enable').throws(new Error('ProtocolError: Inspected target closed'))
 
           await fireCDPEvent('Target.attachedToTarget', {
-            // @ts-ignore
-            targetInfo: { type: 'service_worker' },
+            waitingForDebugger: true,
+            sessionId,
+            targetInfo: { type: 'iframe' } as Protocol.Target.TargetInfo,
           })
 
-          expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
+          expect(criStub.send).to.have.been.calledWith('Network.enable').and.to.have.thrown()
+          expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+        })
+
+        it('continues even if Runtime.runIfWaitingForDebugger throws', async () => {
+          criStub.send.withArgs('Runtime.runIfWaitingForDebugger').throws(new Error('ProtocolError: Inspected target closed'))
+
+          await fireCDPEvent('Target.attachedToTarget', {
+            waitingForDebugger: true,
+            sessionId,
+            targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
+          })
+
+          expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId).and.to.have.thrown()
         })
       })
     })

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -147,6 +147,27 @@ describe('lib/browsers/cri-client', function () {
 
           expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
         })
+
+        it('does not send Runtime.runIfWaitingForDebugger if not waiting for debugger', async () => {
+          await fireCDPEvent('Target.attachedToTarget', {
+            waitingForDebugger: false,
+            // @ts-ignore
+            targetInfo: { type: 'service_worker' },
+          })
+
+          expect(criStub.send).not.to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
+        })
+
+        it('sends Runtime.runIfWaitingForDebugger even if Network.enable throws', async () => {
+          criStub.send.withArgs('Network.enable').throws(new Error('ProtocolError: Inspected target closed'))
+
+          await fireCDPEvent('Target.attachedToTarget', {
+            // @ts-ignore
+            targetInfo: { type: 'service_worker' },
+          })
+
+          expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
+        })
       })
     })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/29876

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
When attaching to a target, we try to call `Network.enable` and then `Runtime.runIfWaitingForDebugger`. However, since both of these calls are in the same `try/catch`, if the `Network.enable` call throws an error, we never call `Runtime.runIfWaitingForDebugger` which causes the target to hang. 

In order to fix the issue, the two calls are now split into their own `try/catch` blocks.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
<img width="1529" alt="Screenshot 2024-12-06 at 3 54 19 PM" src="https://github.com/user-attachments/assets/4eecf3d8-86a2-46e3-89bc-e03e4e99f569">

After:
<img width="1525" alt="Screenshot 2024-12-06 at 3 52 54 PM" src="https://github.com/user-attachments/assets/dd5fea9d-d947-49d1-8104-b859fe79e743">

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
