### PR TITLE
fix: update userChrome.css to correctly hide the toolbox

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 13.16.2
+
+_Released 12/17/2024 (PENDING)_
+
+**Bugfixes:**
+
+- Updated Firefox `userChrome.css` file to correctly hide the toolbox during headless mode. Addresses [#30721](https://github.com/cypress-io/cypress/issues/30721).
+
 ## 13.16.1
 
 _Released 12/03/2024_

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -370,7 +370,12 @@ toolbar {
   overflow: hidden !important;
   display: none;
 }
-
+toolbox {
+  height: 0px !important;
+  min-height: 0px !important;
+  overflow: hidden !important;
+  border: none !important;
+}
 `
 
 let browserCriClient: BrowserCriClient | undefined
@@ -560,11 +565,10 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
   }
 
   // resolution of exactly 1280x720
-  // (height must account for firefox url bar, which we can only shrink to 2px)
   const BROWSER_ENVS = {
     MOZ_REMOTE_SETTINGS_DEVTOOLS: '1',
     MOZ_HEADLESS_WIDTH: '1280',
-    MOZ_HEADLESS_HEIGHT: '722',
+    MOZ_HEADLESS_HEIGHT: '720',
     ...launchOptions.env,
   }
 

--- a/packages/server/test/unit/browsers/firefox_spec.ts
+++ b/packages/server/test/unit/browsers/firefox_spec.ts
@@ -274,7 +274,7 @@ describe('lib/browsers/firefox', () => {
                 env: {
                   MOZ_REMOTE_SETTINGS_DEVTOOLS: '1',
                   MOZ_HEADLESS_WIDTH: '1280',
-                  MOZ_HEADLESS_HEIGHT: '722',
+                  MOZ_HEADLESS_HEIGHT: '720',
                 },
               }),
               jsdebugger: false,
@@ -339,7 +339,7 @@ describe('lib/browsers/firefox', () => {
                   env: {
                     MOZ_REMOTE_SETTINGS_DEVTOOLS: '1',
                     MOZ_HEADLESS_WIDTH: '1280',
-                    MOZ_HEADLESS_HEIGHT: '722',
+                    MOZ_HEADLESS_HEIGHT: '720',
                   },
                 }),
                 jsdebugger: true,

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -180,25 +180,6 @@ export const normalizeStdout = function (str: string, options: any = {}) {
     str = str.split('\n').filter((line) => !line.includes(wdsFailedMsg)).join('\n')
   }
 
-  // in Firefox 130, height dimensions are off by 1 pixel in CI, so we need to fix the offset to match common snapshots
-  if (options.browser === 'firefox' && process.env.CI) {
-    const dimensionRegex = new RegExp(/(\((?<width>\d+)x(?<height>\d+)\))/g)
-
-    const matches = dimensionRegex.exec(str)
-
-    if (matches?.groups?.height && matches?.groups?.width) {
-      const height = parseInt(matches?.groups?.height)
-
-      // only happens on default height for whatever reason in firefox 130...
-      if (height === 719) {
-        const expectedHeight = height + 1
-        const expectedWidth = matches?.groups?.width
-
-        str = str.replaceAll(`(${expectedWidth}x${height})`, `(${expectedWidth}x${expectedHeight})`)
-      }
-    }
-  }
-
   if (options.sanitizeScreenshotDimensions) {
     // screenshot dimensions
     str = str.replace(/(\(\d+x\d+\))/g, replaceScreenshotDims)

--- a/system-tests/lib/pluginUtils.js
+++ b/system-tests/lib/pluginUtils.js
@@ -3,12 +3,7 @@ module.exports = {
     if (config.env['NO_RESIZE']) return
 
     if (browser.family === 'firefox') {
-      // this is needed to ensure correct error screenshot / video recording
-      // resolution of exactly 1280x720
-      // (height must account for firefox url bar, which we can only shrink to 2px)
-      options.args.push(
-        '-width', '1280', '-height', '722',
-      )
+      options.args.push('-width', '1280', '-height', '720')
     } else if (browser.name === 'electron') {
       options.preferences.width = 1280
       options.preferences.height = 720


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/30721

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updated the `userChrome.css` to correctly hide the toolbox which also removed the need for the `722px` workaround.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Tested with firefox 100, 130, and 133.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
