### PR TITLE
misc: Remove 'Alternatively you can use CommonJS syntax' comment from scaffolded component supportFile

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,10 @@ _Released 12/17/2024 (PENDING)_
 - Fixed an issue where targets may hang if `Network.enable` is not implemented for the target. Addresses [#29876](https://github.com/cypress-io/cypress/issues/29876).
 - Updated Firefox `userChrome.css` to correctly hide the toolbox during headless mode. Addresses [#30721](https://github.com/cypress-io/cypress/issues/30721).
 
+**Misc:**
+
+- Removed a comment from the scaffolded `supportFile` for component tests around CommonJS syntax. Addresses [#23287](https://github.com/cypress-io/cypress/issues/23287).
+
 **Dependency Updates:**
 
 - Updated `chai` from `4.2.0` to `4.5.0`. Addressed in [#30737](https://github.com/cypress-io/cypress/pull/30737).

--- a/packages/driver/cypress/support/e2e.js
+++ b/packages/driver/cypress/support/e2e.js
@@ -1,18 +1,1 @@
-// ***********************************************************
-// This example support/e2e.js is processed and
-// loaded automatically before your other test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/guides/configuration#section-global
-// ***********************************************************
-
-// Alternatively you can use CommonJS syntax:
-// require("./commands")
 require('./defaults')

--- a/packages/scaffold-config/src/supportFile.ts
+++ b/packages/scaffold-config/src/supportFile.ts
@@ -20,9 +20,6 @@ export function supportFileE2E (language: CodeLanguage['type']) {
 
     // Import commands.js using ES2015 syntax:
     import './commands'
-
-    // Alternatively you can use CommonJS syntax:
-    // require('./commands')
   `
 }
 
@@ -45,9 +42,6 @@ export function supportFileComponent (language: CodeLanguage['type'], mountModul
 
     // Import commands.js using ES2015 syntax:
     import './commands'
-
-    // Alternatively you can use CommonJS syntax:
-    // require('./commands')
   `
 
   const exampleUse = dedent`

--- a/packages/scaffold-config/test/unit/supportFile.spec.ts
+++ b/packages/scaffold-config/test/unit/supportFile.spec.ts
@@ -27,9 +27,6 @@ describe('supportFileComponent', () => {
           // Import commands.js using ES2015 syntax:
           import './commands'
 
-          // Alternatively you can use CommonJS syntax:
-          // require('./commands')
-
           import { mount } from '${mountModule}'
 
           Cypress.Commands.add('mount', mount)
@@ -60,9 +57,6 @@ describe('supportFileComponent', () => {
 
         // Import commands.js using ES2015 syntax:
         import './commands'
-
-        // Alternatively you can use CommonJS syntax:
-        // require('./commands')
 
         import { mount } from '${mountModule}'
 
@@ -111,9 +105,6 @@ describe('supportFileComponent', () => {
           // Import commands.js using ES2015 syntax:
           import './commands'
 
-          // Alternatively you can use CommonJS syntax:
-          // require('./commands')
-
           import { mount } from '${mountModule}'
 
           Cypress.Commands.add('mount', mount)
@@ -144,9 +135,6 @@ describe('supportFileComponent', () => {
 
         // Import commands.js using ES2015 syntax:
         import './commands'
-
-        // Alternatively you can use CommonJS syntax:
-        // require('./commands')
 
         import { mount } from '${mountModule}'
 
@@ -195,9 +183,6 @@ describe('supportFileComponent', () => {
         // Import commands.js using ES2015 syntax:
         import './commands'
 
-        // Alternatively you can use CommonJS syntax:
-        // require('./commands')
-
         import { mount } from '${mountModule}'
 
         // Augment the Cypress namespace to include type definitions for
@@ -244,9 +229,6 @@ describe('supportFileComponent', () => {
           // Import commands.js using ES2015 syntax:
           import './commands'
 
-          // Alternatively you can use CommonJS syntax:
-          // require('./commands')
-
           import { mount } from 'cypress/svelte'
 
           Cypress.Commands.add('mount', mount)
@@ -277,9 +259,6 @@ describe('supportFileComponent', () => {
 
         // Import commands.js using ES2015 syntax:
         import './commands'
-
-        // Alternatively you can use CommonJS syntax:
-        // require('./commands')
 
         import { mount } from 'cypress/svelte'
 

--- a/system-tests/projects/angular-cli-configured/cypress/support/component.ts
+++ b/system-tests/projects/angular-cli-configured/cypress/support/component.ts
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/angular'
 
 // Augment the Cypress namespace to include type definitions for

--- a/system-tests/projects/config-with-invalid-browser/cypress/support/e2e.js
+++ b/system-tests/projects/config-with-invalid-browser/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/migration-e2e-custom-supportFile/src/platform/testing/e2e/cypress/support/index.js
+++ b/system-tests/projects/migration-e2e-custom-supportFile/src/platform/testing/e2e/cypress/support/index.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/no-specs-vue-2/cypress/support/component.js
+++ b/system-tests/projects/no-specs-vue-2/cypress/support/component.js
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/vue2'
 
 Cypress.Commands.add('mount', mount)

--- a/system-tests/projects/no-specs/cypress/support/component.js
+++ b/system-tests/projects/no-specs/cypress/support/component.js
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/react'
 
 Cypress.Commands.add('mount', mount)

--- a/system-tests/projects/plugin-code-coverage/cypress/support/e2e.js
+++ b/system-tests/projects/plugin-code-coverage/cypress/support/e2e.js
@@ -15,5 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import '@cypress/code-coverage/support'
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/plugin-returns-bad-config/cypress/support/e2e.js
+++ b/system-tests/projects/plugin-returns-bad-config/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/plugin-returns-empty-browsers-list/cypress/support/e2e.js
+++ b/system-tests/projects/plugin-returns-empty-browsers-list/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/plugin-returns-invalid-browser/cypress/support/e2e.js
+++ b/system-tests/projects/plugin-returns-invalid-browser/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/pristine-cjs-project/expected-cypress-js-component-vue.js-3-webpack/support/component.js
+++ b/system-tests/projects/pristine-cjs-project/expected-cypress-js-component-vue.js-3-webpack/support/component.js
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/vue'
 
 Cypress.Commands.add('mount', mount)

--- a/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress/support/e2e.js
+++ b/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/pristine/expected-cypress-js-component-create-react-app-v5/cypress/support/component.js
+++ b/system-tests/projects/pristine/expected-cypress-js-component-create-react-app-v5/cypress/support/component.js
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/react'
 
 Cypress.Commands.add('mount', mount)

--- a/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress/support/e2e.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/pristine/expected-cypress-js-e2e/cypress/support/e2e.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e/cypress/support/e2e.js
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5-without-fixtures/cypress/support/component.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5-without-fixtures/cypress/support/component.ts
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-component-create-react-app-v5/cypress/support/component.ts
@@ -16,9 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
 import { mount } from 'cypress/react'
 
 // Augment the Cypress namespace to include type definitions for

--- a/system-tests/projects/pristine/expected-cypress-ts-e2e/cypress/support/e2e.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-e2e/cypress/support/e2e.ts
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/ts-proj-4-5/cypress/support/e2e.ts
+++ b/system-tests/projects/ts-proj-4-5/cypress/support/e2e.ts
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 // import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/ts-proj-5/cypress/support/e2e.ts
+++ b/system-tests/projects/ts-proj-5/cypress/support/e2e.ts
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 // import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/system-tests/projects/ts-proj/cypress/support/e2e.ts
+++ b/system-tests/projects/ts-proj/cypress/support/e2e.ts
@@ -15,6 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/23287

### Additional details

Just saw this when reviewing CT issues to see if any could be closed for 14.

I figured I'd remove the comment from all our support files just to avoid future confusion on it.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
