### PR TITLE
test: fix firefox default size system test

### DIFF
--- a/system-tests/projects/screen-size/cypress/e2e/default_size.cy.js
+++ b/system-tests/projects/screen-size/cypress/e2e/default_size.cy.js
@@ -2,7 +2,6 @@ describe('windowSize', () => {
   it('spawns with correct default size', () => {
     // assert the browser was spawned at 1280x720 and is full size
     // normally e2e tests spawn at fixed size, but this spec should be spawned without passing any width/height arguments in plugins file.
-    // TODO: look into fixing screen/available height and width
     if (Cypress.browser.name === 'chrome') {
       // NOTE: there is a bug in chrome headless=new where height is not spawned correctly
       // the issue is marked as fixed, but others are still running into it in Chrome 116
@@ -13,14 +12,6 @@ describe('windowSize', () => {
       }).deep.eq({
         innerWidth: 1280,
         innerHeight: 581, // chrome 128 decreased the size here from 633 to 581
-      })
-    } else if (Cypress.browser.name === 'firefox') {
-      expect({
-        innerWidth: top.window.innerWidth,
-        innerHeight: top.window.innerHeight,
-      }).deep.eq({
-        innerWidth: 1280,
-        innerHeight: Cypress.env('CI') ? 676 : 677, // firefox 133 decreased the size here from 720 to 676/677
       })
     } else {
       expect({


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
After merging in the firefox size fix from develop, the `default_size.cy.js` spec started failing since it was not assuming the size fix. To resolve the failure, the firefox size workaround was removed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
