### PR TITLE
test: fix system test firefox spawn message

### DIFF
--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -165,7 +165,7 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   // Replaces connection warning since Chrome or Firefox sometimes take longer to connect
   .replace(/Still waiting to connect to .+, retrying in 1 second \(attempt .+\/.+\)\n/g, '')
   // Replaces CDP connection error message in Firefox since Cypress will retry
-  .replace(/Failed to spawn CDP with Firefox. Retrying.*\.\.\.\n/g, '')
+  .replace(/\nFailed to spawn CDP with Firefox. Retrying.*\.\.\.\n/g, '')
 
   if (options.browser === 'webkit') {
     // WebKit throws for lookups on undefined refs with "Can't find variable: <var>"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updated the regex to account for the [newline before](https://github.com/cypress-io/cypress/blob/6d13d7d23e8fe4e31c05aaedc2afd2c34455ed21/packages/server/lib/modes/run.ts#L504) the spawn message.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before:
```
====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:    13.17.0                                                                            │
  │ Browser:    Firefox 133 (headless)                                                             │
  │ Specs:      1 found (issue_2196.cy.js)                                                         │
  │ Searched:   cypress/e2e/issue_2196.cy.js                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  issue_2196.cy.js                                                                (1 of 1)

Failed to spawn CDP with Firefox. Retrying...

Failed to spawn CDP with Firefox. Retrying again...


  issue #2196: overwriting visit
GET /index.html 200 2.604 ms - 92
GET /index.html 200 0.812 ms - 92
    ✓ fires onBeforeLoad (58ms)


  1 passing (947ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     issue_2196.cy.js                                                                 │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  issue_2196.cy.js                         945ms        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        945ms        1        1        -        -        -  

Different value of snapshot "e2e visit / low response timeout / calls onBeforeLoad when overwriting cy.visit"

----------
Difference
----------
                                                                                                     
   Running:  issue_2196.cy.js                                                                (1 of 1)
 
 
+
+
   issue #2196: overwriting visit
     ✓ fires onBeforeLoad
 
```

After:
```
====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:    13.17.0                                                                            │
  │ Browser:    Firefox 133 (headless)                                                             │
  │ Specs:      1 found (issue_2196.cy.js)                                                         │
  │ Searched:   cypress/e2e/issue_2196.cy.js                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  issue_2196.cy.js                                                                (1 of 1)

Failed to spawn CDP with Firefox. Retrying...

Failed to spawn CDP with Firefox. Retrying again...


  issue #2196: overwriting visit
GET /index.html 200 2.078 ms - 92
GET /index.html 200 0.699 ms - 92
    ✓ fires onBeforeLoad (56ms)


  1 passing (913ms)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     issue_2196.cy.js                                                                 │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  issue_2196.cy.js                         911ms        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        911ms        1        1        -        -        -  

      ✓ calls onBeforeLoad when overwriting cy.visit [firefox] (9268ms)


  1 passing (9s)
```


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
