### PR TITLE
fix: commands not chained off of `cy.get()` or queries properly error when `cy.origin()` is not used and the AUT has navigated away from the primary origin

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -56,6 +56,7 @@ in this [GitHub issue](https://github.com/cypress-io/cypress/issues/30447). Addr
 - Elements whose parent elements has `overflow: clip` and no height/width will now correctly show as hidden. Fixed in [#29778](https://github.com/cypress-io/cypress/pull/29778). Fixes [#23852](https://github.com/cypress-io/cypress/issues/23852).
 - The CSS pseudo-class `:dir()` is now supported when testing in Electron. Addresses [#29766](https://github.com/cypress-io/cypress/issues/29766).
 - Fixed an issue where the spec filename was not updating correctly when changing specs in `open` mode. Fixes [#30852](https://github.com/cypress-io/cypress/issues/30852).
+- `cy.origin()` now correctly errors when the [`cy.window()`](https://docs.cypress.io/api/commands/window), [`cy.document()`](https://docs.cypress.io/api/commands/document), [`cy.title()`](https://docs.cypress.io/api/commands/title), [`cy.url()`](https://docs.cypress.io/api/commands/url), [`cy.location()`](https://docs.cypress.io/api/commands/location) ,[`cy.hash()`](https://docs.cypress.io/api/commands/hash), [`cy.go()`](https://docs.cypress.io/api/commands/go), [`cy.reload()`](https://docs.cypress.io/api/commands/reload), and [`cy.scrollTo()`](https://docs.cypress.io/api/commands/scrollTo) commands are used outside of the `cy.origin()` command after the AUT has navigated away from the primary origin. Fixes [#30848](https://github.com/cypress-io/cypress/issues/30848). Fixed in [#30858](https://github.com/cypress-io/cypress/pull/30858).
 
 **Misc:**
 

--- a/packages/driver/cypress/e2e/e2e/origin/commands/actions.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/actions.cy.ts
@@ -190,22 +190,108 @@ context('cy.origin actions', { browser: '!webkit' }, () => {
 
   context('cross-origin AUT errors', () => {
     // We only need to check .get here because the other commands are chained off of it.
+    // the exceptions are window(), document(), title(), url(), hash(), location(), go(), reload(), and scrollTo()
+    const assertOriginFailure = (err: Error, done: () => void) => {
+      expect(err.message).to.include(`The command was expected to run against origin \`http://localhost:3500\` but the application is at origin \`http://www.foobar.com:3500\`.`)
+      expect(err.message).to.include(`This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.`)
+      expect(err.message).to.include(`Using \`cy.origin()\` to wrap the commands run on \`http://www.foobar.com:3500\` will likely fix this issue.`)
+      expect(err.message).to.include(`cy.origin('http://www.foobar.com:3500', () => {\`\n\`  <commands targeting http://www.foobar.com:3500 go here>\`\n\`})`)
+
+      //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
+      expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
+      expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
+      done()
+    }
+
     it('.get()', { defaultCommandTimeout: 50 }, (done) => {
       cy.on('fail', (err) => {
         expect(err.message).to.include(`Timed out retrying after 50ms:`)
-        expect(err.message).to.include(`The command was expected to run against origin \`http://localhost:3500\` but the application is at origin \`http://www.foobar.com:3500\`.`)
-        expect(err.message).to.include(`This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.`)
-        expect(err.message).to.include(`Using \`cy.origin()\` to wrap the commands run on \`http://www.foobar.com:3500\` will likely fix this issue.`)
-        expect(err.message).to.include(`cy.origin('http://www.foobar.com:3500', () => {\`\n\`  <commands targeting http://www.foobar.com:3500 go here>\`\n\`})`)
-
-        //  make sure that the secondary origin failures do NOT show up as spec failures or AUT failures
-        expect(err.message).not.to.include(`The following error originated from your test code, not from Cypress`)
-        expect(err.message).not.to.include(`The following error originated from your application code, not from Cypress`)
-        done()
+        assertOriginFailure(err, done)
       })
 
       cy.get('a[data-cy="dom-link"]').click()
       cy.get('#button')
+    })
+
+    it('.window()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.window()
+    })
+
+    it('.document()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.document()
+    })
+
+    it('.title()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.title()
+    })
+
+    it('.url()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.url()
+    })
+
+    it('.hash()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.hash()
+    })
+
+    it('.location()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.location()
+    })
+
+    it('.go()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.go('back')
+    })
+
+    it('.reload()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.reload()
+    })
+
+    it('.scrollTo()', (done) => {
+      cy.on('fail', (err) => {
+        assertOriginFailure(err, done)
+      })
+
+      cy.get('a[data-cy="dom-link"]').click()
+      cy.scrollTo('bottom')
     })
   })
 

--- a/packages/driver/cypress/e2e/e2e/origin/commands/viewport.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/viewport.cy.ts
@@ -154,10 +154,10 @@ context('cy.origin viewport', { browser: '!webkit' }, () => {
 
           cy.window().its('innerHeight').should('eq', 480)
           cy.window().its('innerWidth').should('eq', 320)
-        })
 
-        cy.window().then((win) => {
-          win.location.href = 'http://www.idp.com:3500/fixtures/primary-origin.html'
+          cy.window().then((win) => {
+            win.location.href = 'http://www.idp.com:3500/fixtures/primary-origin.html'
+          })
         })
 
         cy.origin('http://www.idp.com:3500', () => {

--- a/packages/driver/cypress/e2e/e2e/origin/navigation.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/navigation.cy.ts
@@ -192,11 +192,11 @@ describe('event timing', { browser: '!webkit' }, () => {
 
     cy.origin('http://www.foobar.com:3500', () => {
       cy.log('inside cy.origin foobar')
-    })
-
-    // This command is run from localhost against the cross-origin aut. Updating href is one of the few allowed commands. See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#location
-    cy.window().then((win) => {
-      win.location.href = 'http://www.idp.com:3500/fixtures/primary-origin.html'
+      // Updating href is one of the few allowed commands. See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#location
+      // However, not everything on the window is accessible. Therefore, we force window() to only run on the same origin as the AUT context
+      cy.window().then((win) => {
+        win.location.href = 'http://www.idp.com:3500/fixtures/primary-origin.html'
+      })
     })
 
     cy.origin('http://www.idp.com:3500', () => {

--- a/packages/driver/src/cy/commands/actions/scroll.ts
+++ b/packages/driver/src/cy/commands/actions/scroll.ts
@@ -325,6 +325,9 @@ export default (Commands, Cypress, cy, state) => {
       const subjectChain = cy.subjectChain()
 
       const ensureScrollability = () => {
+        // Make sure the scroll command can communicate with the AUT
+        Cypress.ensure.commandCanCommunicateWithAUT(cy)
+
         try {
           subject = cy.getSubjectFromChain(subjectChain)
 

--- a/packages/driver/src/cy/commands/location.ts
+++ b/packages/driver/src/cy/commands/location.ts
@@ -4,6 +4,9 @@ import $errUtils from '../../cypress/error_utils'
 
 export default (Commands, Cypress, cy) => {
   Commands.addQuery('url', function url (options: Partial<Cypress.UrlOptions> = {}) {
+    // Make sure the url command can communicate with the AUT.
+    // otherwise, it yields an empty string
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     this.set('timeout', options.timeout)
 
     Cypress.log({ message: '', hidden: options.log === false, timeout: options.timeout })
@@ -16,6 +19,8 @@ export default (Commands, Cypress, cy) => {
   })
 
   Commands.addQuery('hash', function url (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+    // Make sure the hash command can communicate with the AUT.
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     this.set('timeout', options.timeout)
 
     Cypress.log({ message: '', hidden: options.log === false, timeout: options.timeout })
@@ -26,6 +31,10 @@ export default (Commands, Cypress, cy) => {
   Commands.addQuery('location', function location (key, options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
     // normalize arguments allowing key + options to be undefined
     // key can represent the options
+
+    // Make sure the location command can communicate with the AUT.
+    // otherwise the command just yields 'null' and the reason may be unclear to the user.
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     if (_.isObject(key)) {
       options = key
     }

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -616,6 +616,10 @@ export default (Commands, Cypress, cy, state, config) => {
           cleanup()
         }
 
+        // Make sure the reload command can communicate with the AUT.
+        // if we failed for any other reason, we need to display the correct error to the user.
+        Cypress.ensure.commandCanCommunicateWithAUT(cy)
+
         return null
       })
     },
@@ -699,6 +703,9 @@ export default (Commands, Cypress, cy, state, config) => {
           if (typeof cleanup === 'function') {
             cleanup()
           }
+
+          // Make sure the go command can communicate with the AUT.
+          Cypress.ensure.commandCanCommunicateWithAUT(cy)
 
           return null
         })

--- a/packages/driver/src/cy/commands/window.ts
+++ b/packages/driver/src/cy/commands/window.ts
@@ -89,6 +89,9 @@ export default (Commands, Cypress, cy, state) => {
   }
 
   Commands.addQuery('title', function title (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+    // Make sure the window command can communicate with the AUT.
+    // otherwise, it yields an empty string
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     this.set('timeout', options.timeout)
     Cypress.log({ timeout: options.timeout, hidden: options.log === false })
 
@@ -96,6 +99,8 @@ export default (Commands, Cypress, cy, state) => {
   })
 
   Commands.addQuery('window', function windowFn (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+    // Make sure the window command can communicate with the AUT.
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     this.set('timeout', options.timeout)
     Cypress.log({
       hidden: options.log === false,
@@ -114,6 +119,8 @@ export default (Commands, Cypress, cy, state) => {
   })
 
   Commands.addQuery('document', function documentFn (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+    // Make sure the document command can communicate with the AUT.
+    Cypress.ensure.commandCanCommunicateWithAUT(cy)
     this.set('timeout', options.timeout)
     Cypress.log({
       hidden: options.log === false,

--- a/packages/graphql/schemas/cloud.graphql
+++ b/packages/graphql/schemas/cloud.graphql
@@ -333,7 +333,7 @@ type CloudProjectNotFound {
 }
 
 union CloudProjectResult =
-    CloudProject
+  | CloudProject
   | CloudProjectNotFound
   | CloudProjectUnauthorized
 
@@ -456,7 +456,7 @@ type CloudProjectSpec implements Node {
 }
 
 union CloudProjectSpecFlakyResult =
-    CloudFeatureNotEnabled
+  | CloudFeatureNotEnabled
   | CloudProjectSpecFlakyStatus
 
 type CloudProjectSpecFlakyStatus {
@@ -500,7 +500,7 @@ type CloudProjectSpecNotFound {
 }
 
 union CloudProjectSpecResult =
-    CloudProjectSpec
+  | CloudProjectSpec
   | CloudProjectSpecNotFound
   | CloudProjectUnauthorized
 

--- a/system-tests/__snapshots__/web_security_spec.js
+++ b/system-tests/__snapshots__/web_security_spec.js
@@ -30,32 +30,47 @@ exports['e2e web security / when enabled / fails'] = `
 
   1) web security
        fails when clicking <a> to another origin:
+     CypressError: The command was expected to run against origin \`http://localhost:4466\` but the application is at origin \`https://www.foo.com:44665\`.
 
-      Timed out retrying after 4000ms
-      + expected - actual
+This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.
 
-      +'https://www.foo.com:44665/cross_origin'
-      
+Using \`cy.origin()\` to wrap the commands run on \`https://www.foo.com:44665\` will likely fix this issue.
+
+\`cy.origin('https://www.foo.com:44665', () => {\`
+\`  <commands targeting https://www.foo.com:44665 go here>\`
+\`})\`
+
+https://on.cypress.io/cy-visit-succeeded-but-commands-fail
       [stack trace lines]
 
   2) web security
        fails when submitted a form and being redirected to another origin:
+     CypressError: The command was expected to run against origin \`http://localhost:4466\` but the application is at origin \`https://www.foo.com:44665\`.
 
-      Timed out retrying after 4000ms
-      + expected - actual
+This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.
 
-      +'https://www.foo.com:44665/cross_origin'
-      
+Using \`cy.origin()\` to wrap the commands run on \`https://www.foo.com:44665\` will likely fix this issue.
+
+\`cy.origin('https://www.foo.com:44665', () => {\`
+\`  <commands targeting https://www.foo.com:44665 go here>\`
+\`})\`
+
+https://on.cypress.io/cy-visit-succeeded-but-commands-fail
       [stack trace lines]
 
   3) web security
        fails when using a javascript redirect to another origin:
+     CypressError: The command was expected to run against origin \`http://localhost:4466\` but the application is at origin \`https://www.foo.com:44665\`.
 
-      Timed out retrying after 4000ms
-      + expected - actual
+This commonly happens when you have either not navigated to the expected origin or have navigated away unexpectedly.
 
-      +'https://www.foo.com:44665/cross_origin'
-      
+Using \`cy.origin()\` to wrap the commands run on \`https://www.foo.com:44665\` will likely fix this issue.
+
+\`cy.origin('https://www.foo.com:44665', () => {\`
+\`  <commands targeting https://www.foo.com:44665 go here>\`
+\`})\`
+
+https://on.cypress.io/cy-visit-succeeded-but-commands-fail
       [stack trace lines]
 
   4) web security


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #30848

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

While performing the Cypress 14 bug hunt, @jennifer-shehane ran into an issue where this test was failing: 

```js
it(`Verify that items under category News are visible, intentionally will fail`, () => {
  cy.visit("https://ca.yahoo.com/")
  
  cy.findByRole("link", {name: 'News'})
      .should("be.visible")
      .click({force: true})
  
  cy.scrollTo("bottom")
})
```

This has to due with the AUT navigating away from `ca.yahoo.com` to `ca.news.yahoo.com`, which before worked OK since we would inject document domain and  Cypress could still communicate with the subdomain of the navigated AUT, even though the frame is in a cross-origin (same site) context. Now that we do not inject document domain be default, `scrollTo` was trying to be run in a cross-origin (same-site) context, which would fail. When Cypress attempts to access parts of the error, it is unable to due to the frame being in a cross-origin context, which throws the `Can't set property message of which only has a getter` error.

This is not unique to the [`cy.scrollTo()`](https://docs.cypress.io/api/commands/scrollTo) command. The [`cy.window()`](https://docs.cypress.io/api/commands/window), [`cy.document()`](https://docs.cypress.io/api/commands/document), [`cy.title()`](https://docs.cypress.io/api/commands/title), [`cy.url()`](https://docs.cypress.io/api/commands/url), [`cy.location()`](https://docs.cypress.io/api/commands/location) ,[`cy.hash()`](https://docs.cypress.io/api/commands/hash), [`cy.go()`](https://docs.cypress.io/api/commands/go), and [`cy.reload()`](https://docs.cypress.io/api/commands/reload) will throw a similar error in this situation, or return erroneous values as the commands cannot access the AUT. This commands are exceptions because they do not chain off a queryable to run, like `.get()`, which checks to make sure the command is being run on the correct origin.

To fix this test, the test needs to be:

```js
it(`Verify that items under category News are visible, now will pass`, () => {
  cy.visit("https://ca.yahoo.com/")
  
  cy.findByRole("link", {name: 'News'})
      .should("be.visible")
      .click({force: true})
  
  cy.origin('https://ca.news.yahoo.com', () => {
    cy.scrollTo("bottom")
  })
})
```

However, the `Can't set property message of which only has a getter` should not occur in the first place and the user should be prompted on how to fix the issue. To fix this, Cypress should error when the above commands are run when the AUT has navigated away from the primary origin to prompt the user to fix where the command is being run. This gives the user context that they need `cy.origin()` to run the command correctly. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Either run the sample test with the published binary (only linux built on this PR so if testing on a different machine check out the code and run in global mode against a project with this test) or remove that added code and run the regression tests in `actions.cy.ts` to see the commands are allowed to run outside the origin context, which is incorrect.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Now the `scrollTo` in our described test works correctly.

##### Before
<img width="414" alt="Screenshot 2025-01-13 at 10 16 52 AM" src="https://github.com/user-attachments/assets/20bda647-c402-44fa-9ecf-9578418f1fce" />
<img width="414" alt="Screenshot 2025-01-13 at 10 16 35 AM" src="https://github.com/user-attachments/assets/f24fecf8-7870-4e7e-bcde-83701307f9b6" />

##### After

<img width="414" alt="Screenshot 2025-01-13 at 10 15 25 AM" src="https://github.com/user-attachments/assets/7dd7af88-a1ee-4b57-ad20-b6fe127ba0de" />
<img width="414" alt="Screenshot 2025-01-13 at 10 15 16 AM" src="https://github.com/user-attachments/assets/7c9003bc-5a83-4a74-9ad8-1bebdf884545" />

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
