### PR TITLE
chore: make sure the constant for the welcome screen is patched

### DIFF
--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -402,7 +402,7 @@ function visitLaunchpad (options: { showWelcome?: boolean } = { showWelcome: fal
         // avoid re-stubbing already stubbed prompts in case we call getPreferences multiple times
         if ((ctx._apis.localSettingsApi.getPreferences as any).wrappedMethod === undefined) {
           o.sinon.stub(ctx._apis.localSettingsApi, 'getPreferences').resolves({ majorVersionWelcomeDismissed: {
-            [13]: Date.now(),
+            [14]: Date.now(),
           } })
         }
       }).then(() => {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -25,7 +25,7 @@ export const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'] as const
 
 // Note: ONLY change this in code that will be merged into a release branch
 // for a new major version of Cypress
-export const MAJOR_VERSION_FOR_CONTENT = '13'
+export const MAJOR_VERSION_FOR_CONTENT = '14'
 
 export const RUN_ALL_SPECS_KEY = '__all' as const
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There is a bug in the welcome screen code where the welcome screen is not being shown because the `MAJOR_VERSION_FOR_CONTENT` was not set in https://github.com/cypress-io/cypress/pull/30845.

The goal here is to merge this in and publish this binary as `14.0.0` in the Cypress CDN as the package is still currently in dev mode

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
