### PR TITLE
misc: Update on.cypress.come urls to correct on.cypress.io urls

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ _Released 1/28/2025 (PENDING)_
 
 **Misc:**
 
+- Some broken links displayed in 14+ now link to the correct documentation URL. Addresses [#30951](https://github.com/cypress-io/cypress/issues/30951). Addressed in [#30953](https://github.com/cypress-io/cypress/pull/30953).
 - Benign Mesa/GLX related warnings are now hidden in the terminal output when running Cypress in certain Linux environments or containers. Addresses [#29521](https://github.com/cypress-io/cypress/issues/29521) and [#29554](https://github.com/cypress-io/cypress/issues/29554).
 
 ## 14.0.0

--- a/packages/errors/__snapshot-html__/EXPERIMENTAL_SKIP_DOMAIN_INJECTION_REMOVED.html
+++ b/packages/errors/__snapshot-html__/EXPERIMENTAL_SKIP_DOMAIN_INJECTION_REMOVED.html
@@ -36,6 +36,6 @@
     </head>
     <body><pre><span style="color:#e05561">The <span style="color:#e5e510">experimentalSkipDomainInjection<span style="color:#e05561"> experiment is over. <span style="color:#e5e510">document.domain<span style="color:#e05561"> injection is now off by default.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">Read the migration guide for Cypress v14.0.0: https://on.cypress.com/migration-guide<span style="color:#e6e6e6">
+<span style="color:#e05561">Read the migration guide for Cypress v14.0.0: https://on.cypress.io/migration-guide<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/__snapshot-html__/INJECT_DOCUMENT_DOMAIN_DEPRECATION.html
+++ b/packages/errors/__snapshot-html__/INJECT_DOCUMENT_DOMAIN_DEPRECATION.html
@@ -36,6 +36,6 @@
     </head>
     <body><pre><span style="color:#e05561">The <span style="color:#e5e510">injectDocumentDomain<span style="color:#e05561"> option is deprecated. Interactions with intra-test navigations to differing hostnames must now be wrapped in <span style="color:#e5e510">cy.origin<span style="color:#e05561"> commands, even if the hostname is a subdomain. This configuration option will be removed in Cypress 15.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.com/inject-document-domain-configuration<span style="color:#e6e6e6">
+<span style="color:#e05561">Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.io/inject-document-domain-configuration<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/__snapshot-html__/INJECT_DOCUMENT_DOMAIN_E2E_ONLY.html
+++ b/packages/errors/__snapshot-html__/INJECT_DOCUMENT_DOMAIN_E2E_ONLY.html
@@ -36,6 +36,6 @@
     </head>
     <body><pre><span style="color:#e05561">The <span style="color:#e5e510">injectDocumentDomain<span style="color:#e05561"> option is only available for E2E testing.<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6">
-<span style="color:#e05561">Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.com/inject-document-domain-configuration<span style="color:#e6e6e6">
+<span style="color:#e05561">Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.io/inject-document-domain-configuration<span style="color:#e6e6e6">
 <span style="color:#e05561"><span style="color:#e6e6e6"></span></span></span></span></span></span></span></span></span></span>
 </pre></body></html>

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1354,7 +1354,7 @@ export const AllCypressErrors = {
     return errTemplate`\
       The ${fmt.highlight(`experimentalSkipDomainInjection`)} experiment is over. ${fmt.highlight('document.domain')} injection is now off by default.
 
-      Read the migration guide for Cypress v14.0.0: https://on.cypress.com/migration-guide
+      Read the migration guide for Cypress v14.0.0: https://on.cypress.io/migration-guide
     `
   },
   // TODO: link to docs on injectDocumentDomain
@@ -1362,7 +1362,7 @@ export const AllCypressErrors = {
     return errTemplate`\
       The ${fmt.highlight('injectDocumentDomain')} option is deprecated. Interactions with intra-test navigations to differing hostnames must now be wrapped in ${fmt.highlight('cy.origin')} commands, even if the hostname is a subdomain. This configuration option will be removed in Cypress 15.
     
-      Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.com/inject-document-domain-configuration
+      Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.io/inject-document-domain-configuration
     `
   },
   INJECT_DOCUMENT_DOMAIN_E2E_ONLY: () => {
@@ -1370,7 +1370,7 @@ export const AllCypressErrors = {
     return errTemplate`\
       The ${fmt.highlight('injectDocumentDomain')} option is only available for E2E testing.
 
-      Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.com/inject-document-domain-configuration
+      Read the documentation for the injectDocumentDomain configuration option: https://on.cypress.io/inject-document-domain-configuration
     `
   },
   FIREFOX_GC_INTERVAL_REMOVED: () => {

--- a/system-tests/__snapshots__/experimental_skip_domain_injection_spec.ts.js
+++ b/system-tests/__snapshots__/experimental_skip_domain_injection_spec.ts.js
@@ -13,7 +13,7 @@ https://on.cypress.io/configuration
 
 The experimentalSkipDomainInjection experiment is over. document.domain injection is now off by default.
 
-Read the migration guide for Cypress v14.0.0: https://on.cypress.com/migration-guide
+Read the migration guide for Cypress v14.0.0: https://on.cypress.io/migration-guide
 
 
 `


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/30951

### Additional details

We released some links in 14.0.0 that go to on.cypress.com instead of on.cypress.io

### Steps to test

How to test this 🤔 

### How has the user experience changed?

These links should correctly route to the intended URL for 14.0.1 versions +

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
