### PR TITLE
fix: make sure privileged commands can run when there is a space in the spec or support file name

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 2/11/2025 (PENDING)_
 **Bugfixes:**
 
 - All commands performed in `after` and `afterEach` hooks will now correctly retry when a test fails. Commands that are actions like `.click()` and `.type()` will now perform the action in this situation also. Fixes [#2831](https://github.com/cypress-io/cypress/issues/2831).
-- Privileged commands will now run correctly when a spec file or support file contains characters that require encoding. Fixes [#30933](https://github.com/cypress-io/cypress/issues/30933).
+- Fixed an issue in Cypress [`14.0.0`](https://docs.cypress.io/guides/references/changelog#14-0-0) where privileged commands did not run correctly when a spec file or support file contained characters that required encoding. Fixes [#30933](https://github.com/cypress-io/cypress/issues/30933).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 2/11/2025 (PENDING)_
 **Bugfixes:**
 
 - All commands performed in `after` and `afterEach` hooks will now correctly retry when a test fails. Commands that are actions like `.click()` and `.type()` will now perform the action in this situation also. Fixes [#2831](https://github.com/cypress-io/cypress/issues/2831).
+- Privileged commands will now run correctly when a spec file or support file contains characters that require encoding. Fixes [#30933](https://github.com/cypress-io/cypress/issues/30933).
 
 **Dependency Updates:**
 

--- a/packages/driver/cypress/e2e/issues/issue 30933.cy.js
+++ b/packages/driver/cypress/e2e/issues/issue 30933.cy.js
@@ -1,0 +1,7 @@
+// @see https://github.com/cypress-io/cypress/issues/30933
+describe('issue #30933', { browser: '!webkit' }, () => {
+  it('is able to run privileged commands when there is a space in the spec name', () => {
+    cy.visit('/fixtures/files-form.html')
+    cy.get('#basic').selectFile('cypress/fixtures/valid.json')
+  })
+})

--- a/packages/server/lib/privileged-commands/privileged-channel.js
+++ b/packages/server/lib/privileged-commands/privileged-channel.js
@@ -92,7 +92,12 @@
         script = replace.call(script, queryStringRegex, '')
       }
 
-      return stringIncludes.call(err.stack, script)
+      // stack URLs come in URI encoded by default.
+      // we need to make sure our script names are also URI encoded
+      // so the comparisons match
+      const scriptName = encodeURI(script)
+
+      return stringIncludes.call(err.stack, scriptName)
     })
 
     return filteredLines.length > 0


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #30933

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

With the release of Cypress 14, some of the logic around stack lines and traces changed. One thing we forgot to check for when matching script to stack traces lines is whether both strings are encoded the same way. The stack trace URLs are URI encoded, but the script files are not. This means that if there is a space or unicode character in the file name we will not be able to correctly match the command invocation destination, which throws the error.

#### Before fix
<img width="1728" alt="Screenshot 2025-01-31 at 2 13 01 PM" src="https://github.com/user-attachments/assets/9513e07a-cfd6-4f90-af1f-78dbf1869561" />

#### After fix
<img width="1728" alt="Screenshot 2025-01-31 at 2 15 25 PM" src="https://github.com/user-attachments/assets/bfc393ab-a215-47b4-9891-893f101b20c6" />

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
