### PR TITLE
fix: retry instance creation when the Cloud request fails

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -33,7 +33,6 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'cacie/30927/retry-error-codeframe'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -44,7 +43,6 @@ macWorkflowFilters: &darwin-workflow-filters
     - equal: [ develop, << pipeline.git.branch >> ]
     # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
     - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-    - equal: [ 'cacie/30927/retry-error-codeframe', << pipeline.git.branch >> ]
     - equal: [ 'chore/browser_spike', << pipeline.git.branch >> ]
     - matches:
         pattern: /^release\/\d+\.\d+\.\d+$/
@@ -155,7 +153,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "cacie/30927/retry-error-codeframe" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@ _Released 2/11/2025 (PENDING)_
 - Fixed a regression introduced in [`14.0.0`](https://docs.cypress.io/guides/references/changelog#14-0-0) where error codeframes in the runner UI were not populated with the correct data in failed retry attempts. Fixes [#30927](https://github.com/cypress-io/cypress/issues/30927).
 - All commands performed in `after` and `afterEach` hooks will now correctly retry when a test fails. Commands that are actions like `.click()` and `.type()` will now perform the action in this situation also. Fixes [#2831](https://github.com/cypress-io/cypress/issues/2831).
 - Fixed an issue in Cypress [`14.0.0`](https://docs.cypress.io/guides/references/changelog#14-0-0) where privileged commands did not run correctly when a spec file or support file contained characters that required encoding. Fixes [#30933](https://github.com/cypress-io/cypress/issues/30933).
+- Re-enabled retrying Cloud instance creation for runs that are parallel or recorded. Fixes [#31002](https://github.com/cypress-io/cypress/issues/31002).
 
 **Dependency Updates:**
 

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -458,17 +458,19 @@ export default {
       'platform',
     ])
 
-    return rp.post({
-      body,
-      url: recordRoutes.instances(runId),
-      json: true,
-      encrypt: preflightResult.encrypt,
-      timeout: timeout ?? SIXTY_SECONDS,
-      headers: {
-        'x-route-version': '5',
-        'x-cypress-run-id': runId,
-        'x-cypress-request-attempt': 0,
-      },
+    return retryWithBackoff((attemptIndex) => {
+      return rp.post({
+        body,
+        url: recordRoutes.instances(runId),
+        json: true,
+        encrypt: preflightResult.encrypt,
+        timeout: timeout ?? SIXTY_SECONDS,
+        headers: {
+          'x-route-version': '5',
+          'x-cypress-run-id': runId,
+          'x-cypress-request-attempt': attemptIndex,
+        },
+      })
     })
     .catch(RequestErrors.StatusCodeError, formatResponseBody)
     .catch(tagError)

--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -19,7 +19,6 @@ exports['e2e record passing passes 1'] = `
                                                                                                     
   Running:  record_error.cy.js                                                              (1 of 4)
   Estimated: X second(s)
-Still waiting to connect to Chrome, retrying in X second(s)(attempt 18/62)
 
 Oops...we found an error preparing this test file:
 

--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -19,6 +19,7 @@ exports['e2e record passing passes 1'] = `
                                                                                                     
   Running:  record_error.cy.js                                                              (1 of 4)
   Estimated: X second(s)
+Still waiting to connect to Chrome, retrying in X second(s)(attempt 18/62)
 
 Oops...we found an error preparing this test file:
 
@@ -4385,7 +4386,7 @@ http://localhost:1234/capture-protocol/upload/?x-amz-credential=XXXXXXXX&x-amz-s
 
 `
 
-exports['e2e record api interaction errors api retries on error errors and does not create or update instances when parallel 1'] = `
+exports['e2e record api interaction errors api retries on error warns and does not create or update instances 1'] = `
 We encountered an unexpected error communicating with our servers.
 
 StatusCodeError: 500 - "Internal Server Error"
@@ -4422,50 +4423,72 @@ We encountered an unexpected error communicating with our servers.
 
 StatusCodeError: 500 - "Internal Server Error"
 
-Because you passed the --parallel flag, this run cannot proceed since it requires a valid response from our servers.
-
-The --group flag you passed was: foo
-The --ciBuildId flag you passed was: ciBuildId123
-
-`
-
-exports['e2e record api interaction errors api retries on error errors and does not create or update instances when recording and not parallel 1'] = `
-We encountered an unexpected error communicating with our servers.
-
-StatusCodeError: 500 - "Internal Server Error"
-
 We will retry 3 more times in X second(s)...
 
-We encountered an unexpected error communicating with our servers.
 
-StatusCodeError: 500 - "Internal Server Error"
+────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                    
+  Running:  record_pass.cy.js                                                               (1 of 1)
+  Estimated: X second(s)
 
-We will retry 2 more times in X second(s)...
 
-We encountered an unexpected error communicating with our servers.
+  record pass
+    ✓ passes
+    - is pending
 
-StatusCodeError: 500 - "Internal Server Error"
 
-We will retry 1 more time in X second(s)...
+  1 passing
+  1 pending
 
+
+  (Results)
+
+  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │ Tests:        2                                                                                │
+  │ Passing:      1                                                                                │
+  │ Failing:      0                                                                                │
+  │ Pending:      1                                                                                │
+  │ Skipped:      0                                                                                │
+  │ Screenshots:  1                                                                                │
+  │ Video:        false                                                                            │
+  │ Duration:     X seconds                                                                        │
+  │ Estimated:    X second(s)                                                                      │
+  │ Spec Ran:     record_pass.cy.js                                                                │
+  └────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+
+  (Screenshots)
+
+  -  /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png                 (400x1022)
+
+
+  (Uploading Cloud Artifacts)
+
+  - Video - Nothing to upload 
+  - Screenshot - 1 kB /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
+  - Test Replay - Nothing to upload - Test Replay is disabled for this project. Enable Test Replay in Cloud project settings
+
+  Uploading Cloud Artifacts: . . . . .
+
+  (Uploaded Cloud Artifacts)
+
+  - Screenshot - Done Uploading 1 kB in Xm, Ys ZZ.ZZms 1/1 /XXX/XXX/XXX/cypress/screenshots/record_pass.cy.js/yay it passes.png
 
 ====================================================================================================
 
-  (Run Starting)
+  (Run Finished)
 
+
+       Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Cypress:    1.2.3                                                                              │
-  │ Browser:    FooBrowser 88                                                                      │
-  │ Specs:      1 found (record_pass.cy.js)                                                        │
-  │ Searched:   cypress/e2e/record_pass*                                                           │
-  │ Params:     Tag: nightly, Group: false, Parallel: false                                        │
-  │ Run URL:    https://dashboard.cypress.io/projects/cjvoj7/runs/12                               │
+  │ ✔  record_pass.cy.js                        XX:XX        2        1        -        1        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
+    ✔  All specs passed!                        XX:XX        2        1        -        1        -  
 
-We encountered an unexpected error communicating with our servers.
 
-StatusCodeError: 500 - "Internal Server Error"
+───────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                       
+  Recorded Run: https://dashboard.cypress.io/projects/cjvoj7/runs/12
 
-Because you passed the --record flag, this run cannot proceed since it requires a valid response from our servers.
 
 `

--- a/system-tests/test/record_spec.js
+++ b/system-tests/test/record_spec.js
@@ -1615,11 +1615,7 @@ describe('e2e record', () => {
 
       setupStubbedServer(routes)
 
-      beforeEach(() => {
-        count = 0
-      })
-
-      it('errors and does not create or update instances when parallel', function () {
+      it('warns and does not create or update instances', function () {
         process.env.API_RETRY_INTERVALS = '1000,2000,3000'
 
         return systemTests.exec(this, {
@@ -1632,7 +1628,6 @@ describe('e2e record', () => {
           parallel: true,
           snapshot: true,
           ciBuildId: 'ciBuildId123',
-          expectedExitCode: 1,
         })
         .then(() => {
           const urls = getRequestUrls()
@@ -1643,30 +1638,12 @@ describe('e2e record', () => {
             'POST /runs',
             'POST /runs',
             'POST /runs/00748421-e035-4a3d-8604-8468cc48bdb5/instances',
-          ])
-        })
-      })
-
-      it('errors and does not create or update instances when recording and not parallel', function () {
-        process.env.API_RETRY_INTERVALS = '1000,2000,3000'
-
-        return systemTests.exec(this, {
-          key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
-          configFile: 'cypress-with-project-id.config.js',
-          spec: 'record_pass*',
-          tag: 'nightly',
-          record: true,
-          snapshot: true,
-          expectedExitCode: 1,
-        })
-        .then(() => {
-          const urls = getRequestUrls()
-
-          expect(urls).to.deep.eq([
-            'POST /runs',
-            'POST /runs',
-            'POST /runs',
-            'POST /runs',
+            'POST /runs/00748421-e035-4a3d-8604-8468cc48bdb5/instances',
+            'POST /instances/e9e81b5e-cc58-4026-b2ff-8ae3161435a6/tests',
+            'POST /instances/e9e81b5e-cc58-4026-b2ff-8ae3161435a6/results',
+            'PUT /screenshots/1.png',
+            'PUT /instances/e9e81b5e-cc58-4026-b2ff-8ae3161435a6/artifacts',
+            'PUT /instances/e9e81b5e-cc58-4026-b2ff-8ae3161435a6/stdout',
             'POST /runs/00748421-e035-4a3d-8604-8468cc48bdb5/instances',
           ])
         })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/31002

### Additional details
Retrying the request to create an instance during recorded or parallel runs was disabled in 13.16.1 to prevent false negative test results, as specs could be skipped if that request was retried. Retrying this request will no longer result in skipped specs. This is a manual revert of https://github.com/cypress-io/cypress/pull/30697, with error message modifications left intact.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
