### PR TITLE
fix: make sure script and stack are both decoded before comparing

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -82,7 +82,7 @@ windowsWorkflowFilters: &windows-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'chore/browser_spike', << pipeline.git.branch >> ]
+      - equal: [ 'fix/em_dash_priv_command', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 2/11/2025 (PENDING)_
 
+**Bugfixes:**
+
+- Fixed an issue in Cypress [`14.0.2`](https://docs.cypress.io/guides/references/changelog#14-0-2) where privileged commands did not run correctly when a spec file or support file contained certain encoded characters. Fixes [#31034](https://github.com/cypress-io/cypress/issues/31034) and [#31060](https://github.com/cypress-io/cypress/issues/31060).
+
 **Dependency Updates:**
 
 - Upgraded `compression` from `1.7.4` to `1.7.5`. Addressed in [#31004](https://github.com/cypress-io/cypress/pull/31004).

--- a/packages/driver/cypress/e2e/issues/issue—31034.cy.js
+++ b/packages/driver/cypress/e2e/issues/issue—31034.cy.js
@@ -1,0 +1,7 @@
+// @see https://github.com/cypress-io/cypress/issues/31034
+describe('issue #31034', { browser: '!webkit' }, () => {
+  it('is able to run privileged commands when there is a em dash (—) in the spec name', () => {
+    cy.visit('/fixtures/files-form.html')
+    cy.get('#basic').selectFile('cypress/fixtures/valid.json')
+  })
+})

--- a/packages/server/lib/privileged-commands/privileged-channel.js
+++ b/packages/server/lib/privileged-commands/privileged-channel.js
@@ -92,15 +92,17 @@
         script = replace.call(script, queryStringRegex, '')
       }
 
-      // stack URLs come in URI encoded by default.
-      // we need to make sure our script names are also URI encoded
-      // so the comparisons match
-      let scriptName = encodeURI(script)
+      // stack URLs come in encoded by default (similar to URI but not entirely accurate).
+      // we need to make sure our script and stack are both decoded entirely to make sure the comparisons are accurate.
+      try {
+        const decodedScript = decodeURIComponent(script)
 
-      // we do NOT want to encode backslashes (\) as this causes pathing issues on Windows
-      scriptName = scriptName.replace(/%5C/g, '\\')
+        const decodedStack = decodeURIComponent(err.stack)
 
-      return stringIncludes.call(err.stack, scriptName)
+        return stringIncludes.call(decodedStack, decodedScript)
+      } catch (e) {
+        return false
+      }
     })
 
     return filteredLines.length > 0


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31034
- Closed #31060

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

With `14.0.2`, we attempted to fix the privileged command channel by encoding the script uri to more accurately compare apples to apples when checking where the privileged command was invoked. However, the stack traces are not exactly encoded exactly to the specification, which caused other errors when trying to check the privileged command. 

To solve this, we are going to try comparing apples to apples via decoding the stack and the script name, so the text comparisons should match.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
