### PR TITLE
chore: wire up beta chrome into circle workflow, update orb, and update firefox to latest

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -2,10 +2,10 @@ version: 2.1
 
 chrome-stable-version: &chrome-stable-version "133.0.6943.53"
 chrome-beta-version: &chrome-beta-version "134.0.6998.3"
-firefox-stable-version: &firefox-stable-version "134.0.2"
+firefox-stable-version: &firefox-stable-version "135.0"
 
 orbs:
-  browser-tools: circleci/browser-tools@1.5.0
+  browser-tools: circleci/browser-tools@1.5.2
 
 defaults: &defaults
   parallelism: 1

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -669,7 +669,7 @@ commands:
             - install-browsers:
                 install-chrome: true
                 google-chrome-channel: << parameters.install-chrome-channel >>
-                google-chrome-version: latest
+                google-chrome-version: *chrome-beta-version
       - when:
           condition:
             equal: [ firefox, << parameters.browser >> ]


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Correctly wires up chrome beta into the workflows file now that the value can be sourced from the file itself. This required an orb update so the new version is referenced here. I also updated firefox to version 135.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
