### PR TITLE
chore: Remove unused '@ts-expect-error' directive

### DIFF
--- a/packages/driver/src/cypress/chai_jquery.ts
+++ b/packages/driver/src/cypress/chai_jquery.ts
@@ -238,7 +238,6 @@ export const $chaiJquery = (chai: Chai.ChaiStatic, chaiUtils: Chai.ChaiUtils, ca
     )
   })
 
-  // @ts-expect-error - TODO: Fix this
   chai.Assertion.overwriteProperty('empty', (_super) => {
     return (function (...args) {
       if ($dom.isDom(this._obj)) {


### PR DESCRIPTION
### Additional details

There is a failure in `check-ts` in `develop` shown below. [Link here.](https://app.circleci.com/pipelines/github/cypress-io/cypress/67453/workflows/7e1b8197-9916-4067-91cb-d0b72861ca5c/jobs/2794198)

```
src/cypress/chai_jquery.ts(241,3): error TS2578: Unused '@ts-expect-error' directive.
```

I merged a few separate TS change PRs, so I suspect that one of them fixed this TS error while the other ignored it, so this ignore is no longer needed.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
