### PR TITLE
chore: fix flaky sessions spec

### DIFF
--- a/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
@@ -3,6 +3,8 @@ import { snapshotReporter } from './support/snapshot-reporter'
 
 const validateSessionsInstrumentPanel = (sessionIds: Array<string> = []) => {
   cy.get('.sessions-container')
+  // there could be multiple retries where multiple session containers are rendered
+  .first()
   .should('contain', `Sessions (${sessionIds.length})`)
   .as('instrument_panel')
   .click()


### PR DESCRIPTION
### Additional details

- [Test Replay of flaky test](https://cloud.cypress.io/projects/ypt4pf/runs/60481/test-results/c82ec37c-773c-4a21-8ba6-237618161fe8/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%7B%22value%22%3Atrue%2C%22label%22%3A%22Flaky%22%7D%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A4455-434__command-logs&specs=%5B%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1739910800656.4001&utm_source=github)

I noticed this flaky test in our app tests, where we're trying to get a `.sessions-container` but sometimes our tests find 2 of those elements. This is due to the spec we're seeding having retries on and sometimes that second sessions-container in the retry has already rendered when we're querying for it. 

Updated the test to look for the first element.

![Screenshot 2025-02-18 at 4 26 26 PM](https://github.com/user-attachments/assets/e72642c9-3160-4793-bd44-45cfa9902ea4)


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
