### PR TITLE
dependency: bump arch dep, write a unit test

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -39,7 +39,7 @@ mainBuildFilters: &mainBuildFilters
         - chore/update_wdio_deps
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'ryanm/chore/add_internal_studio'
+        - 'arch-dep-update'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -50,7 +50,7 @@ macWorkflowFilters: &darwin-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'ryanm/chore/add_internal_studio', << pipeline.git.branch >> ]
+      - equal: [ 'arch-dep-update', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -61,7 +61,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'ryanm/chore/add_internal_studio', << pipeline.git.branch >> ]
+      - equal: [ 'arch-dep-update', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -84,7 +84,7 @@ windowsWorkflowFilters: &windows-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'ryanm/chore/add_internal_studio', << pipeline.git.branch >> ]
+      - equal: [ 'arch-dep-update', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,7 @@ _Released 2/25/2025 (PENDING)_
 
 **Dependency Updates:**
 
+- Upgraded `arch` from `2.2.0` to `3.0.0`. Addressed in [#31139](https://github.com/cypress-io/cypress/pull/31139).
 - Upgraded `chrome-remote-interface` from `0.33.2` to `0.33.3`. Addressed in [#31128](https://github.com/cypress-io/cypress/pull/31128).
 - Upgraded `ci-info` from `4.0.0` to `4.1.0`. Addressed in [#31132](https://github.com/cypress-io/cypress/pull/31132).
 

--- a/cli/lib/util.js
+++ b/cli/lib/util.js
@@ -474,15 +474,6 @@ const util = {
 
       if (osArch === 'arm64') return 'arm64'
 
-      if (osPlatform === 'darwin') {
-        // could possibly be x64 node on arm64 darwin, check if we are being translated by Rosetta
-        // https://stackoverflow.com/a/65347893/3474615
-        const { stdout } = await execa('sysctl', ['-n', 'sysctl.proc_translated']).catch(() => '')
-
-        debug('rosetta check result: %o', { stdout })
-        if (stdout === '1') return 'arm64'
-      }
-
       if (osPlatform === 'linux') {
         // could possibly be x64 node on arm64 linux, check the "machine hardware name"
         // list of names for reference: https://stackoverflow.com/a/45125525/3474615

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
     "@cypress/xvfb": "^1.2.4",
     "@types/sinonjs__fake-timers": "8.1.1",
     "@types/sizzle": "^2.3.2",
-    "arch": "^2.2.0",
+    "arch": "^3.0.0",
     "blob-util": "^2.0.2",
     "bluebird": "^3.7.2",
     "buffer": "^5.7.1",

--- a/cli/test/lib/util_spec.js
+++ b/cli/test/lib/util_spec.js
@@ -590,4 +590,10 @@ describe('util', () => {
       })
     })
   })
+
+  context('.getRealArch', async () => {
+    const arch = await util.getRealArch()
+
+    expect(arch).to.be.oneOf(['ia32', 'x86', 'x64', 'arm64'])
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10311,6 +10311,11 @@ arch@^2.2.0:
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
 
+arch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-3.0.0.tgz#a44e7077da4615fc5f1e3da21fbfc201d2c1817c"
+  integrity sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==
+
 archy@^1.0.0, archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"


### PR DESCRIPTION
### Additional details

`arch` made an update to support returning `arm64` for darwin machines, particularly on rosettaArm  [here](https://github.com/feross/arch/commit/6a6c1f9e9d7aef0e5e6a8662ff209795a0baf7e6#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L22). We wrote our own logic for this already [here](https://github.com/cypress-io/cypress/blob/arch-dep-update/cli/lib/util.js#L477), so I removed that logic so that it should fall back to what `arch()` returns - it should be the same result.

I looked into whether Node.js intends to support getting the real OS arch and they basically said no, that this `arch` package satisfies it well enough. [See my PR to update arch's readme.](https://github.com/feross/arch/pull/30)

### Steps to test

I did add a unit test to make sure one of the arches is returned since there were no unit tests on this. I ran the tests through Windows also.

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
