### PR TITLE
fix: allow javascript dependencies to import other files without a file extension

### DIFF
--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -112,6 +112,11 @@ const getDefaultWebpackOptions = () => {
         exclude: [/browserslist/],
         type: 'javascript/auto',
       }, {
+        test: /\.m?js$/,
+        resolve: {
+          fullySpecified: false
+        }
+      }, {
         test: /(\.jsx?|\.mjs)$/,
         exclude: [/node_modules/, /browserslist/],
         type: 'javascript/auto',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

When a dependency used by cypress specs was compiled to javascript and has type `"type": "module",` in the package.json, it throws the following error: 

```
Did you mean 'request-method.js'?
BREAKING CHANGE: The request './request-method' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

As the default typescript transpiler (tsc) does not add file extensions to the imports & exports I think it's best to allow resolving imports without a file extension by default.

Solution by: https://github.com/webpack/webpack/issues/11467#issuecomment-691873586

Also setting `"moduleResolution": "Bundler",` in the tsconfig.json does not seem to make a difference

Kind of like: 

https://stackoverflow.com/questions/62619058/appending-js-extension-on-relative-import-statements-during-typescript-compilat
https://stackoverflow.com/questions/75807785/why-do-i-need-to-include-js-extension-in-typescript-import-for-custom-module

But on webpack level instead of runtime

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Have a helper package which QAs can use, transpiled from typescript with tsc and use it in Cypress specs. 

```ts
// --------- Specs
import { RequestMethod } from 'cypress-helpers';

...do something with this

// --------- Helper package

// package.json
{
    "name": "cypress-helpers",
    "type": "module",
    "main": "index.js"
	...
}

// index.js (barrel file)
export { RequestMethod } from './request-method';

// request-method.js
export var RequestMethod;
(function (RequestMethod) {
    RequestMethod["POST"] = "POST";
    RequestMethod["PUT"] = "PUT";
    RequestMethod["GET"] = "GET";
    RequestMethod["DELETE"] = "DELETE";
})(RequestMethod || (RequestMethod = {}));
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Easier support for external helper packages transpiled by typescript

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
