### PR TITLE
misc: Add some missing types + Convert js driver/query tests to ts

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ _Released 2/25/2025 (PENDING)_
 
 - Viewport width, height, and scale now display in a badge above the application under test. The dropdown describing how to set viewport height and width has been removed from the UI. Additionally, component tests now show a notice about URL navigation being disabled in component tests. Addresses [#30999](https://github.com/cypress-io/cypress/issues/30999). Addressed in [#31119](https://github.com/cypress-io/cypress/pull/31119).
 - Updated types around `.readFile()` and `.scrollTo()` arguments and `Cypress.dom` methods. Addressed in [#31055](https://github.com/cypress-io/cypress/pull/31055).
-- Updates types around `.shadow()` and `.root()` options. Addressed in [#31154](https://github.com/cypress-io/cypress/pull/31154).
+- Updated types around `.shadow()` and `.root()` options. Addressed in [#31154](https://github.com/cypress-io/cypress/pull/31154).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 2/25/2025 (PENDING)_
 **Misc:**
 
 - Updated types around `.readFile()` and `.scrollTo()` arguments and `Cypress.dom` methods. Addressed in [#31055](https://github.com/cypress-io/cypress/pull/31055).
+- Updates types around `.shadow()` and `.root()` options. Addressed in [#31154](https://github.com/cypress-io/cypress/pull/31154).
 
 **Dependency Updates:**
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1898,7 +1898,7 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/root
      */
-    root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable & Timeoutable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
+    root<E extends Node = HTMLHtmlElement>(options?: Partial<LogTimeoutOptions>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
 
     /**
      * Take a screenshot of the application under test and the Cypress Command Log.

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1898,7 +1898,7 @@ declare namespace Cypress {
      *
      * @see https://on.cypress.io/root
      */
-    root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
+    root<E extends Node = HTMLHtmlElement>(options?: Partial<Loggable & Timeoutable>): Chainable<JQuery<E>> // can't do better typing unless we ignore the `.within()` case
 
     /**
      * Take a screenshot of the application under test and the Cypress Command Log.
@@ -1979,6 +1979,18 @@ declare namespace Cypress {
      * @see https://on.cypress.io/shadow
      */
     shadow(): Chainable<Subject>
+
+      /**
+     * Traverse into an element's shadow root.
+     *
+     * @example
+     *    cy.get('my-component')
+     *    .shadow({ timeout: 10000, log: false })
+     *    .find('.my-button')
+     *    .click()
+     * @see https://on.cypress.io/shadow
+     */
+    shadow(options?: Partial<LogTimeoutOptions>): Chainable<Subject>
 
     /**
      * Create an assertion. Assertions are automatically retried until they pass or time out.
@@ -2732,6 +2744,7 @@ declare namespace Cypress {
 
   interface CheckClearOptions extends Loggable, Timeoutable, ActionableOptions { }
 
+  interface LogTimeoutOptions extends Loggable, Timeoutable { }
   /**
    * Object to change the default behavior of .click().
    */

--- a/packages/driver/cypress/component/spec.cy.ts
+++ b/packages/driver/cypress/component/spec.cy.ts
@@ -1,7 +1,6 @@
 const { sinon } = Cypress
 
 describe('component testing', () => {
-  /** @type {Cypress.Agent<sinon.SinonSpy>} */
   let uncaughtExceptionStub
 
   before(() => {
@@ -16,6 +15,7 @@ describe('component testing', () => {
 
   beforeEach(() => {
     uncaughtExceptionStub.resetHistory()
+    // @ts-expect-error - TODO: it thinks this could be null, but a null check didn't help
     document.querySelector('[data-cy-root]').innerHTML = ''
   })
 
@@ -28,7 +28,7 @@ describe('component testing', () => {
       throw new Error('An error!')
     })
 
-    document.querySelector('[data-cy-root]').appendChild($el)
+    document.querySelector('[data-cy-root]')?.appendChild($el)
     cy.get('button').click().then(() => {
       expect(uncaughtExceptionStub).to.have.been.calledOnceWithExactly(null)
       expect(Cypress.log).to.be.calledWithMatch(sinon.match({ 'message': `Error: An error!`, name: 'uncaught exception' }))
@@ -40,11 +40,12 @@ describe('component testing', () => {
     const $el = document.createElement('button')
 
     $el.innerText = `Don't click it!`
+    // @ts-expect-error - testing an error state
     $el.addEventListener('click', new Promise((_, reject) => {
       reject('Promise rejected with a string!')
     }))
 
-    document.querySelector('[data-cy-root]').appendChild($el)
+    document.querySelector('[data-cy-root]')?.appendChild($el)
     cy.get('button').click().then(() => {
       expect(uncaughtExceptionStub).to.have.been.calledOnceWithExactly(null)
       expect(Cypress.log).to.be.calledWithMatch(sinon.match({ 'message': `Error: "Promise rejected with a string!"`, name: 'uncaught exception' }))

--- a/packages/driver/cypress/component/spec.cy.ts
+++ b/packages/driver/cypress/component/spec.cy.ts
@@ -15,8 +15,11 @@ describe('component testing', () => {
 
   beforeEach(() => {
     uncaughtExceptionStub.resetHistory()
-    // @ts-expect-error - TODO: it thinks this could be null, but a null check didn't help
-    document.querySelector('[data-cy-root]').innerHTML = ''
+    const root = document.querySelector('[data-cy-root]')
+
+    if (root) {
+      root.innerHTML = ''
+    }
   })
 
   it('fails and shows an error', () => {

--- a/packages/driver/cypress/e2e/commands/querying/focused.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/focused.cy.ts
@@ -1,4 +1,4 @@
-const { assertLogLength } = require('../../../support/utils')
+import { assertLogLength } from '../../../support/utils'
 
 const { _ } = Cypress
 

--- a/packages/driver/cypress/e2e/commands/querying/root.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/root.cy.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error TODO: fix this reference
 const { _ } = Cypress
 
 describe('src/cy/commands/querying', () => {

--- a/packages/driver/cypress/e2e/commands/querying/shadow_dom.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/shadow_dom.cy.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error TODO: fix this reference
 const { _ } = Cypress
 
 describe('src/cy/commands/querying - shadow dom', () => {

--- a/packages/driver/cypress/e2e/commands/querying/within.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/within.cy.ts
@@ -1,4 +1,4 @@
-const { assertLogLength } = require('../../../support/utils')
+import { assertLogLength } from '../../../support/utils'
 
 const { _ } = Cypress
 
@@ -30,12 +30,16 @@ describe('src/cy/commands/querying/within', () => {
       const span = cy.$$('#nested-div span:contains(foo)')
 
       cy.contains('foo').then(($span) => {
-        expect($span.get(0)).not.to.eq(span.get(0))
+        const firstSpan = $span?.[0] as unknown as HTMLElement
+
+        expect(firstSpan).not.to.eq(span.get(0))
       })
 
       cy.get('#nested-div').within(() => {
         cy.contains('foo').then(($span) => {
-          expect($span.get(0)).to.eq(span.get(0))
+          const firstSpan = $span?.[0] as unknown as HTMLElement
+
+          expect(firstSpan).to.eq(span.get(0))
         })
       })
     })
@@ -129,6 +133,7 @@ describe('src/cy/commands/querying/within', () => {
       })
 
       cy.then(() => {
+        // @ts-expect-error - TODO: Look at where cy._events would be defined
         expect(cy._events).not.to.have.property('command:start')
       })
     })
@@ -309,6 +314,7 @@ describe('src/cy/commands/querying/within', () => {
             done()
           })
 
+          // @ts-expect-error - testing invalid input
           cy.get('body').within(value)
         })
       })

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -14,7 +14,6 @@ type GetOptions = Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.Withi
 }>
 
 type ContainsOptions = Partial<Cypress.Loggable & Cypress.Timeoutable & Cypress.CaseMatchable & Cypress.Shadow>
-type ShadowOptions = Partial<Cypress.Loggable & Cypress.Timeoutable>
 
 type QueryCommandOptions = 'get' | 'contains' | 'shadow' | ''
 
@@ -143,7 +142,7 @@ function getAlias (selector, log, cy) {
   }
 }
 
-function validateTimeoutFromOpts (options: GetOptions | ContainsOptions | ShadowOptions = {}, queryCommand: QueryCommandOptions = '') {
+function validateTimeoutFromOpts (options: GetOptions | ContainsOptions | Cypress.LogTimeoutOptions = {}, queryCommand: QueryCommandOptions = '') {
   if (!isEmpty(queryCommand) && _.isPlainObject(options) && options.hasOwnProperty('timeout') && !_.isFinite(options.timeout)) {
     $errUtils.throwErrByPath(`${queryCommand}.invalid_option_timeout`, {
       args: { timeout: options.timeout },
@@ -368,7 +367,8 @@ export default (Commands, Cypress, cy, state) => {
     }
   })
 
-  Commands.addQuery('shadow', function contains (userOptions: ShadowOptions = {}) {
+  Commands.addQuery('shadow', function contains (userOptions: Cypress.LogTimeoutOptions) {
+    userOptions = userOptions || {}
     const log = Cypress.log({
       hidden: userOptions.log === false,
       timeout: userOptions.timeout,

--- a/packages/driver/src/cy/commands/querying/root.ts
+++ b/packages/driver/src/cy/commands/querying/root.ts
@@ -1,5 +1,6 @@
 export default (Commands, Cypress, cy, state) => {
-  Commands.addQuery('root', function root (options: Partial<Cypress.Loggable & Cypress.Timeoutable> = {}) {
+  Commands.addQuery('root', function root (options: Cypress.LogTimeoutOptions) {
+    options = options || {}
     const log = Cypress.log({
       timeout: options.timeout,
       hidden: options.log === false,

--- a/packages/driver/types/internal-types-lite.d.ts
+++ b/packages/driver/types/internal-types-lite.d.ts
@@ -48,7 +48,7 @@ declare namespace Cypress {
      * If `as` is chained to the current command, return the alias name used.
      */
     getNextAlias: IAliases['getNextAlias']
-    noop: <T>(v: T) => Cypress.Chainable<T>
+    noop: <T>(v?: T) => Cypress.Chainable<T>
     now: <T>(string, v: T) => Cypress.Chainable<T>
     queue: CommandQueue
     retry: IRetries['retry']


### PR DESCRIPTION
### Additional details

- Converting `driver/cypress.e2e/commands/querying` test files to TypeScript. 
- Found a couple of places where our official types were not correct, so fixed those.

### Steps to test

ts-check passes and tests pass

### How has the user experience changed?

- Better types for `.root()` and `.shadow()`

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
