### PR TITLE
chore: remove warning from webpack:runner about version import

### DIFF
--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1,5 +1,5 @@
 import semverMajor from 'semver/functions/major'
-import { version } from '../../../package.json'
+import packageInfo from '../../../package.json'
 
 import type { SpecFile } from './spec'
 
@@ -28,7 +28,7 @@ export const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'] as const
 
 // Note: ONLY change this in code that will be merged into a release branch
 // for a new major version of Cypress
-export const GET_MAJOR_VERSION_FOR_CONTENT = () => semverMajor(version).toString()
+export const GET_MAJOR_VERSION_FOR_CONTENT = () => semverMajor(packageInfo.version).toString()
 
 export const RUN_ALL_SPECS_KEY = '__all' as const
 


### PR DESCRIPTION
### Additional details

Remove this warning in terminal when running `yarn`

```
webpack:runner: WARNING in ../types/src/constants.ts 16:63-70
webpack:runner: Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
```

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
