### PR TITLE
test: Update test to prevent rehydrated DOM error in Cypress test

### DIFF
--- a/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
@@ -7,6 +7,9 @@ const validateSessionsInstrumentPanel = (sessionIds: Array<string> = []) => {
   .first()
   .should('contain', `Sessions (${sessionIds.length})`)
   .as('instrument_panel')
+
+  cy.get('.sessions-container')
+  .first()
   .click()
 
   sessionIds.forEach((id) => {


### PR DESCRIPTION
### Additional details

Ran into this failing with the DOM updating underneath it, so updated the chaining to do the action alone.

[View Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/60724/test-results/3f98b680-9f3e-4f7b-b6ad-89b5ad55a152/replay?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&testingTypesEnum=%5B%5D&ts=1741121120003.0999&utm_source=github&att=1) of flaky test

![Screenshot 2025-03-04 at 3 51 21 PM](https://github.com/user-attachments/assets/eab4e1af-cc86-4a2a-9e19-26172ed1a01d)


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
