### PR TITLE
add support xpath in playground button

### DIFF
--- a/npm/vue/cypress/support/commands.js
+++ b/npm/vue/cypress/support/commands.js
@@ -4,3 +4,101 @@ import { mount } from '@cypress/vue'
 Cypress.Commands.add('mount', (comp) => {
   return mount(comp)
 })
+
+import 'cypress-xpath';
+
+Cypress.SelectorPlayground.defaults({
+    onElement: ($el) => {
+        const element = $el[0];
+        
+        
+        if (element.id) {
+            return `//*[@id="${element.id}"]`;
+        }
+        
+        
+        if (element.name) {
+            return `//*[@name="${element.name}"]`;
+        }
+
+        
+        const text = element.textContent?.trim();
+        if (text && !element.children.length) {
+            return `//*[text()="${text}"]`;
+        }
+
+        
+        const classes = Array.from(element.classList);
+        if (classes.length) {
+            const uniqueClass = classes.find(className => 
+                document.getElementsByClassName(className).length === 1
+            );
+            if (uniqueClass) {
+                return `//*[contains(@class, "${uniqueClass}")]`;
+            }
+        }
+
+        
+        const tagName = element.tagName.toLowerCase();
+        const attributes = element.attributes;
+        for (let attr of attributes) {
+            if (attr.name !== 'class' && attr.name !== 'style') {
+                return `//${tagName}[@${attr.name}="${attr.value}"]`;
+            }
+        }
+
+        
+        let path = '';
+        let parent = element;
+        while (parent && parent.nodeType === 1) {
+            let index = 1;
+            let sibling = parent.previousSibling;
+            while (sibling) {
+                if (sibling.nodeType === 1 && sibling.tagName === parent.tagName) {
+                    index++;
+                }
+                sibling = sibling.previousSibling;
+            }
+            const pathIndex = (index > 1 ? `[${index}]` : '');
+            path = `/${parent.tagName.toLowerCase()}${pathIndex}${path}`;
+            parent = parent.parentNode;
+        }
+        return `//${tagName}[${getElementIndex(element) + 1}]${getUniquePredicates(element)}`;
+    }
+});
+
+
+function getElementIndex(element) {
+    let index = 0;
+    let prev = element;
+    while (prev = prev.previousElementSibling) {
+        if (prev.tagName === element.tagName) {
+            index++;
+        }
+    }
+    return index;
+}
+
+
+function getUniquePredicates(element) {
+    const predicates = [];
+    
+    
+    const classes = Array.from(element.classList);
+    if (classes.length) {
+        predicates.push(`contains(@class, "${classes[0]}")`);
+    }
+
+    
+    const text = element.textContent?.trim();
+    if (text && text.length > 0) {
+        predicates.push(`contains(text(), "${text.substring(0, 20)}")`);
+    }
+
+    return predicates.length ? '[' + predicates.join(' and ') + ']' : '';
+}
+
+
+Cypress.Commands.add('xpath', (selector, options) => {
+    return cy.xpath(selector, options);
+});

--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
     "ts-node": "^10.9.2",
     "typescript": "5.3.3",
     "yaml": "2.7.0",
-    "yarn-deduplicate": "3.1.0"
+    "yarn-deduplicate": "3.1.0",
+    "cypress-xpath": "^2.0.1"
   },
   "engines": {
     "node": ">=20.18.1",


### PR DESCRIPTION
Using this code, we can see the xpath address for each element in the playground button. This can prevent possible bugs in finding the css element. Also, for this, we need to install the xpath plugin.
"cypress-xpath" plugin: "^2.0.1" added. To find xpath using playground, I remind you that after this change, you must find the elements with the get.xpath command.

According to my experiences using application testers, I found that finding elements using xpath is the best way to write tests. Also, if you don't use this feature like other testers, you will be left behind in the market. CSS is always changing and is not a good option for selecting elements. On the other hand, adding the xpath plugin alone is not enough to make testing easier because we have to manually find the xpaths and add them to the code. The best solution is to use the playground button.