### PR TITLE
Update commands.js

### DIFF
--- a/npm/webpack-preprocessor/cypress/support/commands.js
+++ b/npm/webpack-preprocessor/cypress/support/commands.js
@@ -23,3 +23,103 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+import 'cypress-xpath';
+
+Cypress.SelectorPlayground.defaults({
+    onElement: ($el) => {
+        const element = $el[0];
+        
+        
+        if (element.id) {
+            return `//*[@id="${element.id}"]`;
+        }
+        
+        
+        if (element.name) {
+            return `//*[@name="${element.name}"]`;
+        }
+
+        
+        const text = element.textContent?.trim();
+        if (text && !element.children.length) {
+            return `//*[text()="${text}"]`;
+        }
+
+        
+        const classes = Array.from(element.classList);
+        if (classes.length) {
+            const uniqueClass = classes.find(className => 
+                document.getElementsByClassName(className).length === 1
+            );
+            if (uniqueClass) {
+                return `//*[contains(@class, "${uniqueClass}")]`;
+            }
+        }
+
+        
+        const tagName = element.tagName.toLowerCase();
+        const attributes = element.attributes;
+        for (let attr of attributes) {
+            if (attr.name !== 'class' && attr.name !== 'style') {
+                return `//${tagName}[@${attr.name}="${attr.value}"]`;
+            }
+        }
+
+        
+        let path = '';
+        let parent = element;
+        while (parent && parent.nodeType === 1) {
+            let index = 1;
+            let sibling = parent.previousSibling;
+            while (sibling) {
+                if (sibling.nodeType === 1 && sibling.tagName === parent.tagName) {
+                    index++;
+                }
+                sibling = sibling.previousSibling;
+            }
+            const pathIndex = (index > 1 ? `[${index}]` : '');
+            path = `/${parent.tagName.toLowerCase()}${pathIndex}${path}`;
+            parent = parent.parentNode;
+        }
+        return `//${tagName}[${getElementIndex(element) + 1}]${getUniquePredicates(element)}`;
+    }
+});
+
+
+function getElementIndex(element) {
+    let index = 0;
+    let prev = element;
+    while (prev = prev.previousElementSibling) {
+        if (prev.tagName === element.tagName) {
+            index++;
+        }
+    }
+    return index;
+}
+
+
+function getUniquePredicates(element) {
+    const predicates = [];
+    
+    
+    const classes = Array.from(element.classList);
+    if (classes.length) {
+        predicates.push(`contains(@class, "${classes[0]}")`);
+    }
+
+    
+    const text = element.textContent?.trim();
+    if (text && text.length > 0) {
+        predicates.push(`contains(text(), "${text.substring(0, 20)}")`);
+    }
+
+    return predicates.length ? '[' + predicates.join(' and ') + ']' : '';
+}
+
+
+Cypress.Commands.add('xpath', (selector, options) => {
+    return cy.xpath(selector, options);
+});
+
+// ... existing code ...


### PR DESCRIPTION
According to my experiences using application testers, I found that finding elements using xpath is the best way to write tests. Also, if you don't use this feature like other testers, you will be left behind in the market. CSS is always changing and is not a good option for selecting elements. On the other hand, adding the xpath plugin alone is not enough to make testing easier because we have to manually find the xpaths and add them to the code. The best solution is to use the playground button.

Using this code, we can see the xpath address for each element in the playground button. This can prevent possible bugs in finding the css element. Also, for this, we need to install the xpath plugin.