### PR TITLE
chore: update the docker-compose to use base-internal image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,7 +381,7 @@ Sometimes tests pass locally, but fail in CI. Our CI environment is dockerized. 
 2. Run the following command from the root of the project:
 
 ```shell
-$ yarn docker
+yarn docker
 ```
 
 There is a script [scripts/run-docker-local.sh](scripts/run-docker-local.sh) that runs the cypress image (see [CircleCI config](.circleci/config.yml) for the current image name).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - .:/opt/cypress
   ci:
     # This should mirror the image used in workflows.yml
-    image: cypress/browsers-internal:node20.18.1-bullseye-chrome131-ff133
+    image: cypress/base-internal:20.18.1-bullseye
     ports:
       - 5566:5566
       - 5567:5567


### PR DESCRIPTION
### Additional details

Our base-image was updated and used throughout Cypress repo with the intention of using it over the browsers-internal images. See https://github.com/cypress-io/cypress-docker-images/pull/1289

This PR updates our `docker-compose`, used for local contributing, to also use the base-internal image, so we don't have to make 2 internal images to test this repo. 

I tested that `yarn docker` works for contributing.

### Steps to test

- Run `yarn docker`

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
