### PR TITLE
internal: updated studio panel to display immediately

### DIFF
--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -239,7 +239,7 @@ const studioStatus = computed(() => {
 })
 
 const shouldShowStudioPanel = computed(() => {
-  return studioStatus.value === 'INITIALIZED' && studioStore.isActive
+  return studioStatus.value === 'INITIALIZED' && (studioStore.isLoading || studioStore.isActive)
 })
 
 const hideCommandLog = runnerUiStore.hideCommandLog

--- a/scripts/semantic-commits/change-categories.js
+++ b/scripts/semantic-commits/change-categories.js
@@ -78,6 +78,10 @@ const changeCatagories = {
     description: 'Adding missing or correcting existing tests',
     release: false,
   },
+  wip: {
+    description: 'Work in progress that is not visible to the user',
+    release: false,
+  },
 }
 
 // Used by @semantic-release/commit-analyzer to determine next version for npm packages

--- a/scripts/semantic-commits/change-categories.js
+++ b/scripts/semantic-commits/change-categories.js
@@ -78,8 +78,8 @@ const changeCatagories = {
     description: 'Adding missing or correcting existing tests',
     release: false,
   },
-  wip: {
-    description: 'Work in progress that is not visible to the user',
+  internal: {
+    description: 'Features or fixes available to internal Cypress users only',
     release: false,
   },
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/10223

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Updated the studio panel to display when the studio `isLoading` which is set when the user clicks the wand to enter studio.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Enter studio and verify the studio panel is displayed before the test completes.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Studio panel is displayed immediately.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
