### PR TITLE
chore: bump system tests yarn project deps to work with Cy 14

### DIFF
--- a/system-tests/projects/yarn-v4.3.1-pnp-dep-resolution/package.json
+++ b/system-tests/projects/yarn-v4.3.1-pnp-dep-resolution/package.json
@@ -2,8 +2,8 @@
   "name": "yarn-v4.3.1-pnp-dep-resolution",
   "version": "0.0.0-test",
   "devDependencies": {
-    "axe-core": "4.9.1",
-    "cypress-axe": "1.5.0"
+    "axe-core": "^4.10.3",
+    "cypress-axe": "^1.6.0"
   },
   "packageManager": "yarn@4.3.1"
 }

--- a/system-tests/projects/yarn-v4.3.1-pnp-dep-resolution/yarn.lock
+++ b/system-tests/projects/yarn-v4.3.1-pnp-dep-resolution/yarn.lock
@@ -5,20 +5,20 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"axe-core@npm:4.9.1":
-  version: 4.9.1
-  resolution: "axe-core@npm:4.9.1"
-  checksum: 10c0/ac9e5a0c6fa115a43ebffc32a1d2189e1ca6431b5a78e88cdcf94a72a25c5964185682edd94fe6bdb1cb4266c0d06301b022866e0e50dcdf6e3cefe556470110
+"axe-core@npm:^4.10.3":
+  version: 4.10.3
+  resolution: "axe-core@npm:4.10.3"
+  checksum: 10c0/1b1c24f435b2ffe89d76eca0001cbfff42dbf012ad9bd37398b70b11f0d614281a38a28bc3069e8972e3c90ec929a8937994bd24b0ebcbaab87b8d1e241ab0c7
   languageName: node
   linkType: hard
 
-"cypress-axe@npm:1.5.0":
-  version: 1.5.0
-  resolution: "cypress-axe@npm:1.5.0"
+"cypress-axe@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "cypress-axe@npm:1.6.0"
   peerDependencies:
     axe-core: ^3 || ^4
-    cypress: ^10 || ^11 || ^12 || ^13
-  checksum: 10c0/bc9aab239fbed99bc64801b1f83c4835047264a4f34f801649e41579014cc1bddbd1379efaf3c4a9e6ff42f359bb7fc028df039d6fba637852370d77be0af5ec
+    cypress: ^10 || ^11 || ^12 || ^13 || ^14
+  checksum: 10c0/c2cda25355dfa9bd1894357a6231985c9c61ff97a1b60b3b57a44bd2ae364ae3a82dd8be8d3deecc7f9ceabb52b8d441c762586f11ce4e2a322c44168ef3b84b
   languageName: node
   linkType: hard
 
@@ -26,7 +26,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "yarn-v4.3.1-pnp-dep-resolution@workspace:."
   dependencies:
-    axe-core: "npm:4.9.1"
-    cypress-axe: "npm:1.5.0"
+    axe-core: "npm:^4.10.3"
+    cypress-axe: "npm:^1.6.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Additional details

`cypress-axe: 1.5.0` doesn't support Cypress 14+ as a peer dep, so this updates those deps. This will remove this error in CI for the yarn 4.3.1 system test. [CircleCI Job](https://app.circleci.com/pipelines/github/cypress-io/cypress/68389/workflows/1434812c-de07-4cbb-b5c4-f739cdd2d5c9/jobs/2824442)

![Screenshot 2025-03-17 at 10 33 45 AM](https://github.com/user-attachments/assets/936402fa-fd8d-4276-8fc6-e6421b1f2623)


### Steps to test

Tests should pass

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
