### PR TITLE
chore: bump headless/vue and update to caret dep

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -31,7 +31,7 @@
     "@cypress/mount-utils": "0.0.0-development",
     "@faker-js/faker": "9.6.0",
     "@graphql-typed-document-node/core": "^3.1.0",
-    "@headlessui/vue": "1.4.0",
+    "@headlessui/vue": "^1.7.23",
     "@iconify-json/mdi": "^1.2.3",
     "@intlify/unplugin-vue-i18n": "4.0.0",
     "@module-federation/runtime": "^0.8.11",

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -35,7 +35,7 @@
     "@faker-js/faker": "9.6.0",
     "@graphql-codegen/plugin-helpers": "2.3.2",
     "@graphql-typed-document-node/core": "^3.1.0",
-    "@headlessui/vue": "1.4.0",
+    "@headlessui/vue": "^1.7.23",
     "@iconify-json/logos": "^1.2.4",
     "@iconify-json/mdi": "^1.2.3",
     "@packages/app": "0.0.0-development",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -25,7 +25,7 @@
     "@cypress-design/vue-button": "^1.1.0",
     "@faker-js/faker": "9.6.0",
     "@graphql-typed-document-node/core": "^3.1.0",
-    "@headlessui/vue": "1.4.0",
+    "@headlessui/vue": "^1.7.23",
     "@intlify/unplugin-vue-i18n": "4.0.0",
     "@packages/data-context": "0.0.0-development",
     "@packages/frontend-shared": "0.0.0-development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,10 +4439,12 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@headlessui/vue@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.4.0.tgz#a4a3f392d6e72923f101e307fcfa6c80c00ea446"
-  integrity sha512-BBLDciyKiGK03whaSVkUacDY2Cd5AR05JCUPWQLvQ9HtjQc9tv5RyPpcdmoXJa+XWI10e3U1JxL+8FY7kJMcEQ==
+"@headlessui/vue@^1.7.23":
+  version "1.7.23"
+  resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.7.23.tgz#7fe19dbeca35de9e6270c82c78c4864e6a6f7391"
+  integrity sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==
+  dependencies:
+    "@tanstack/vue-virtual" "^3.0.0-beta.60"
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -7522,6 +7524,18 @@
   dependencies:
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
+
+"@tanstack/virtual-core@3.13.4":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.4.tgz#31ac7710d102ed59463f922ab088dde5a9e62010"
+  integrity sha512-fNGO9fjjSLns87tlcto106enQQLycCKR4DPNpgq3djP5IdcPFdPAmaKjsgzIeRhH7hWrELgW12hYnRthS5kLUw==
+
+"@tanstack/vue-virtual@^3.0.0-beta.60":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/vue-virtual/-/vue-virtual-3.13.4.tgz#0e5e8b6ba03a9a5f27793b2b4325bc4a80b60ad3"
+  integrity sha512-1fPrd3hE1SS4R/9JbX1AlzueY4duCK7ixuLcMW5GMnk9N6WbLo9MioNKiv22V+UaXKOLNy8tLdzT8NYerOFTOQ==
+  dependencies:
+    "@tanstack/virtual-core" "3.13.4"
 
 "@testing-library/cypress@9.0.0":
   version "9.0.0"


### PR DESCRIPTION
### Additional details

Just fixes mostly, shouldn't impact anything. Setting to ^ dep so that it auto updates on minor releases. https://github.com/tailwindlabs/headlessui

This dep is used for standard popover, dialogs, listboxes, menus, radiolabel components.

### Steps to test

Existing tests should pass

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
