### PR TITLE
Allow Disabling Automated Firefox Extension Installation via Cypress Env Variable

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -771,15 +771,20 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
       process.env.CYPRESS_REMOTE_DEBUGGING_PORT = cdpPort.toString()
     }
 
-    // install the browser extensions
-    await Promise.all(_.map(launchOptions.extensions, async (path) => {
-      debug(`installing extension at path: ${path}`)
-      const id = await webdriverClient.installAddOn(path, true)
+    // Check if extension installation is enabled
+    const shouldInstallExtensions = process.env.CYPRESS_FIREFOX_EXTENSION_INSTALL !== 'false'
 
-      debug(`extension with id ${id} installed!`)
+    if (shouldInstallExtensions) {
+      // Install the browser extensions
+      await Promise.all(_.map(launchOptions.extensions, async (path) => {
+        debug(`installing extension at path: ${path}`)
+        const id = await webdriverClient.installAddOn(path, true)
 
-      return
-    }))
+        debug(`extension with id ${id} installed!`)
+      }))
+    } else {
+      debug('Skipping Firefox extension installation due to CYPRESS_FIREFOX_EXTENSION_INSTALL=false')
+    }
 
     debug('setting up firefox utils')
     const client = await firefoxUtil.setup({ automation, url, webdriverClient, remotePort: cdpPort, useWebDriverBiDi: USE_WEBDRIVER_BIDI, onError: options.onError })


### PR DESCRIPTION
## Description:  
In our organisation we use a custom Firefox build in a restricted environment. Starting from #30324, where the geckodriver was introduced to install the Cypress Firefox extension, this process fails in our setup with the following error message:
```
Cypress failed to make a connection to Firefox.

This usually indicates there was a problem opening the Firefox browser.

unknown error: WebDriverError: Expected absolute path: [Exception... "Component returned failure code: 0x80520001 (NS_ERROR_FILE_UNRECOGNIZED_PATH) [nsIFile.initWithPath]"  nsresult: "0x80520001 (NS_ERROR_FILE_UNRECOGNIZED_PATH)"  location: "JS frame :: chrome://remote/content/marionette/addon.sys.mjs :: install :: line 72"  data: no] when running "moz/addon/install" with method "POST" and args "{"path":"/.../run-39277/CypressExtension","temporary":true}"
    at FetchRequest._request (file:///.../app/packages/server/node_modules/webdriver/build/node.js:1700:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async <embedded>:2770:14517
    at async Promise.all (index 0)
    at async Object.Y (<embedded>:2770:14409)
    at async Object.open (<embedded>:2770:30476)
    at async v.relaunchBrowser (<embedded>:2879:38794)
```
### Investigation & Root Cause

Our setup deviates from a standard Firefox installation, which seems to be the cause of this failure. Since the extension installation is now an enforced step, Cypress cannot proceed if the process fails.

### Proposed Solution

Introduce a custom Cypress environment variable (e.g., `CYPRESS_FIREFOX_EXTENSION_INSTALL`) that:

1. Allows disabling automated installation of the Firefox extension.
2. Optionally, allows Cypress to continue execution even if the installation fails.

This would enable us to manually install the extension on the browser beforehand while keeping Cypress functional in our environment.

### Why This Matters

While this is a niche use case, some users in our organization are not familiar with coding or modifying Cypress locally. Adding this option would significantly improve usability for such environments.

### Additional Information

A potential fix has been suggested in a pull request, but I’m open to other approaches that might better align with Cypress’s development roadmap.

Would appreciate any feedback on this!

### How has the user experience changed?
The user experience has not been changed. 

### PR Tasks
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
