### PR TITLE
fix: set cdpRequestWillBeSentReceivedTimestamp within firefox bidi to…

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,14 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+
+## 14.2.2
+
+_Released 4/8/2025 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where Firefox BiDi was prematurely removing prerequests on pending requests. Fixes [#31376](https://github.com/cypress-io/cypress/issues/31376).
+
+
 ## 14.2.1
 
 _Released 3/25/2025_

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -174,9 +174,10 @@ export class BidiAutomation {
       resourceType,
       originalResourceType: params.request.initiatorType || params.request.destination,
       initiator: params.initiator,
-      // Since we are NOT using CDP, we set the values to -1 to indicate that we do not have this information.
-      cdpRequestWillBeSentTimestamp: -1,
-      cdpRequestWillBeSentReceivedTimestamp: -1,
+      // Since we are NOT using CDP, we set the values to 0 to indicate that we do not have this information.
+      // This is important when determining pre-request timeout and removal behavior
+      cdpRequestWillBeSentTimestamp: 0,
+      cdpRequestWillBeSentReceivedTimestamp: 0,
     }
 
     debugVerbose(`prerequest received for request ID ${params.request.request}: %o`, browserPreRequest)

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -282,8 +282,8 @@ describe('lib/browsers/bidi_automation', () => {
               type: 'other',
             },
             headers: {},
-            cdpRequestWillBeSentTimestamp: -1,
-            cdpRequestWillBeSentReceivedTimestamp: -1,
+            cdpRequestWillBeSentTimestamp: 0,
+            cdpRequestWillBeSentReceivedTimestamp: 0,
           })
 
           expect(mockWebdriverClient.networkContinueRequest).to.have.been.calledWith({
@@ -327,8 +327,8 @@ describe('lib/browsers/bidi_automation', () => {
             headers: {
               foo: 'bar',
             },
-            cdpRequestWillBeSentTimestamp: -1,
-            cdpRequestWillBeSentReceivedTimestamp: -1,
+            cdpRequestWillBeSentTimestamp: 0,
+            cdpRequestWillBeSentReceivedTimestamp: 0,
           })
 
           expect(mockWebdriverClient.networkContinueRequest).to.have.been.calledWith({


### PR DESCRIPTION
… avoid downstream impacts

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31376

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Looks like #31328 was only part of the picture. In addition to removing the prerequest when a request fails to continue, we also need to set `cdp` timing properties to `0` instead of `-1` as there is a downstream impact when setting the value to something no falsey, which can be seen [here](https://github.com/cypress-io/cypress/blob/develop/packages/proxy/lib/http/util/prerequests.ts#L144)

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
