### PR TITLE
chore: Update Studio Beta UI to be back to white background

### DIFF
--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -37,7 +37,7 @@ describe('Cypress Studio', () => {
       launchStudio({ enableCloudStudio: true })
 
       cy.viewport(1500, 1000)
-      cy.get('data-cy=studio-header').should('be.visible')
+      cy.get('data-cy="studio-toolbar"').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -33,6 +33,14 @@ describe('Cypress Studio', () => {
       })
     })
 
+    it('displays Studio header', () => {
+      launchStudio({ enableCloudStudio: true })
+
+      cy.viewport(1500, 1000)
+      cy.get('data-cy=studio-header').should('be.visible')
+      cy.percySnapshot()
+    })
+
     it('immediately loads the studio panel', () => {
       const deferred = pDefer()
 

--- a/packages/app/cypress/e2e/studio/studio.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio.cy.ts
@@ -37,7 +37,7 @@ describe('Cypress Studio', () => {
       launchStudio({ enableCloudStudio: true })
 
       cy.viewport(1500, 1000)
-      cy.get('data-cy="studio-toolbar"').should('be.visible')
+      cy.get('[data-cy="studio-toolbar"]').should('be.visible')
       cy.percySnapshot()
     })
 

--- a/packages/app/src/runner/studio/StudioControls.vue
+++ b/packages/app/src/runner/studio/StudioControls.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="border-y flex border-gray-50 w-full justify-between"
+    class="border-y flex border-gray-50 bg-white w-full justify-between"
     data-cy="studio-toolbar"
   >
     <div class="flex">


### PR DESCRIPTION
### Additional details

With the dark mode update in the AUT, the Studio background ended up being dark, which was not what we wanted.

### Steps to test

- In `packages/app` run `yarn cypress:open` and click to add a command to a test that you choose to run

### How has the user experience changed?


#### 4.2.0 Behavior

![Screenshot 2025-03-25 at 3 53 21 PM](https://github.com/user-attachments/assets/30848390-38e7-47dc-83d9-0111c16e8ded)


#### Before Change (with dark mode)

![Screenshot 2025-03-25 at 3 47 35 PM](https://github.com/user-attachments/assets/830a85c7-9b20-4202-9e82-efbd8d0b66a5)


#### After

![Screenshot 2025-03-25 at 3 54 30 PM](https://github.com/user-attachments/assets/3187fcad-7e20-41c1-bd16-3a536bf75482)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
