### PR TITLE
breaking: Remove support for Node.js 18 & 23

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.0.0
 
-_Released X/X/2025 (PENDING)_
+_Released 7/1/2025 (PENDING)_
 
 **Breaking Changes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ _Released X/X/2025 (PENDING)_
 
 **Breaking Changes:**
 
+- Removed support for Node.js 18 and Node.js 23. Addresses [#31302](https://github.com/cypress-io/cypress/issues/31302).
+
 ## 14.2.2
 
 _Released 4/8/2025 (PENDING)_

--- a/cli/package.json
+++ b/cli/package.json
@@ -120,7 +120,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": "^20.0.0 || >=22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "types": "types",
   "exports": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -120,7 +120,7 @@
     "cypress": "bin/cypress"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+    "node": "^20.0.0 || >=22.0.0"
   },
   "types": "types",
   "exports": {

--- a/system-tests/test-binary/node_versions_spec.ts
+++ b/system-tests/test-binary/node_versions_spec.ts
@@ -26,23 +26,23 @@ function smokeTestDockerImage (dockerImage: string) {
 
 describe('binary node versions', () => {
   [
-    'cypress/base:18.16.1',
     'cypress/base:20.12.2',
     'cypress/base:20.18.0',
     'cypress/base:22.0.0',
     'cypress/base:22.7.0',
     'cypress/base:22.12.0',
+    'cypress/base:22.14.0',
   ].forEach(smokeTestDockerImage)
 })
 
 describe('type: module', () => {
   [
-    'cypress/base:18.16.1',
     'cypress/base:20.12.2',
     'cypress/base:20.18.0',
     'cypress/base:22.0.0',
     'cypress/base:22.7.0',
     'cypress/base:22.12.0',
+    'cypress/base:22.14.0',
   ].forEach((dockerImage) => {
     systemTests.it(`can run in ${dockerImage}`, {
       withBinary: true,


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/31302

### Additional details

- Node.js 18 will be EOL on April 30th.
- Node.js 23 will be EOL on Jun 1st.

With Cypress 15 expected to release in June/July, these should not be supported in that release.

We'll have a separate PR to pull in support for 24 in `develop` which is not officially supported yet.

### Steps to test

- I removed our 18 tests and bumped the 22 test to latest. 

### How has the user experience changed?

Cypress is not guaranteed to be able to be installed and ran on Node 18 and 23.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/6138
