### PR TITLE
docs: update contributing requirements for corepack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ We try to tag all issues with a `pkg/` or `npm/` tag describing the appropriate 
 You must have the following installed on your system to contribute locally:
 
 - [`Node.js`](https://nodejs.org/en/) (See the root [.node-version](.node-version) file for the required version. You can find a list of tools on [node-version-usage](https://github.com/shadowspawn/node-version-usage) to switch the version of [`Node.js`](https://nodejs.org/en/) based on [.node-version](.node-version).)
-- [`Yarn v1 Classic`](https://yarnpkg.com/en/docs/install). If you have [`Node.js`](https://nodejs.org/en/) experimental [corepack](https://nodejs.org/docs/latest/api/corepack.html) enabled, installation of the Yarn package manager will be handled automatically. Attempting to install Yarn globally with npm will fail if [corepack](https://nodejs.org/docs/latest/api/corepack.html) is enabled.
+- [`Yarn v1 Classic`](https://yarnpkg.com/en/docs/install) (See also [Corepack](#corepack) below.)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
 
 #### Debian/Ubuntu
@@ -215,6 +215,10 @@ For Ubuntu `24.04` and above, refer also to the [Ubuntu 24.04 Release notes](htt
 #### Windows
 
 Currently no additional instructions for installation requirements.
+
+#### Corepack
+
+The Cypress repo is compatible with Corepack and contains a `packageManager` field in the root [package.json](./package.json) file to automatically install Yarn. Cypress does not however require you to enable Corepack. It is classed as experimental and not suitable for production by the Node.js organization. Refer to the repo [corepack](https://github.com/nodejs/corepack#readme) for instructions, known issues and workarounds.
 
 ### Getting Started
 


### PR DESCRIPTION
### Additional details

The [CONTRIBUTING Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) section currently contains a link to the Corepack documentation on the Node.js site https://nodejs.org/docs/latest/api/corepack.html.

The Node.js organization will stop distributing a bundled version of Corepack starting with the Node.js `25` release line and is planning to remove this link.

As a result, the Cypress documentation is changed so that Corepack is now described in a separate section in [CONTRIBUTING Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements). This section then links to the repo https://github.com/nodejs/corepack#readme instead of linking to the [Node.js API docs](https://nodejs.org/docs/latest/api/corepack.html) where the information is in the process of being removed.

Cypress contributors are advised that Cypress is compatible with Corepack and that Corepack is not required.

Corepack remains experimental.

### Steps to test

N/A

### How has the user experience changed?

Documentation changes for contributors only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
