### PR TITLE
misc: update some of the dark gray UI to be darker gray for better co…

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 14.3.1
 
-_Released 4/22/2025_
+_Released 4/22/2025 (PENDING)_
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 14.3.1
+
+_Released 4/22/2025_
+
+**Misc:**
+
+- The UI of the reporter and URL were updated to a darker gray background for better color contrast. Addressed in [#31475](https://github.com/cypress-io/cypress/pull/31475).
+
 ## 14.3.0
 
 _Released 4/8/2025_

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
@@ -8,9 +8,9 @@
       <button
         data-cy="playground-activator"
         :disabled="isDisabled"
-        class="bg-gray-900 border rounded-md flex h-full border-gray-800 outline-solid outline-indigo-500 transition w-[40px] duration-150 items-center justify-center hover:bg-gray-800"
+        class="bg-gray-1100 border rounded-md flex h-full border-gray-800 outline-solid outline-indigo-500 transition w-[40px] duration-150 items-center justify-center hover:bg-gray-800"
         :aria-label="t('runner.selectorPlayground.toggle')"
-        :class="[selectorPlaygroundStore.show ? 'bg-gray-800 border-gray-700' : 'bg-gray-900']"
+        :class="[selectorPlaygroundStore.show ? 'bg-gray-800 border-gray-700' : 'bg-gray-1100']"
         @click="togglePlayground"
       >
         <i-cy-crosshairs_x16 class="icon-dark-gray-300" />

--- a/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderOpenMode.vue
@@ -2,7 +2,7 @@
   <div
     id="spec-runner-header"
     ref="autHeaderEl"
-    class="h-full bg-gray-1000 border-l-[1px] border-gray-900 min-h-[64px] text-[14px]"
+    class="h-full bg-gray-1100 border-l-[1px] border-gray-900 min-h-[64px] text-[14px]"
   >
     <div class="flex flex-wrap grow p-[16px] gap-[12px] justify-end h-[64px]">
       <button

--- a/packages/app/src/runner/SpecRunnerHeaderRunMode.vue
+++ b/packages/app/src/runner/SpecRunnerHeaderRunMode.vue
@@ -2,7 +2,7 @@
   <div
     id="spec-runner-header"
     ref="autHeaderEl"
-    class="bg-gray-1000 border-l-[1px] border-gray-900 min-h-[64px] px-[16px] text-[14px]"
+    class="bg-gray-1100 border-l-[1px] border-gray-900 min-h-[64px] px-[16px] text-[14px]"
   >
     <!-- this is similar to the Open Mode header but it's not interactive, so can be a lot smaller-->
     <div class="flex grow flex-wrap py-[16px] gap-[12px] justify-end">

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@antfu/utils": "^0.7.8",
     "@babel/code-frame": "7.26.2",
-    "@cypress-design/css": "^1.0.0",
+    "@cypress-design/css": "^1.1.0",
     "@faker-js/faker": "9.6.0",
     "@graphql-codegen/plugin-helpers": "2.3.2",
     "@graphql-typed-document-node/core": "^3.1.0",

--- a/packages/reporter/src/attempts/attempts.scss
+++ b/packages/reporter/src/attempts/attempts.scss
@@ -115,7 +115,7 @@
       cursor: pointer;
 
       &:hover {
-        background-color: $gray-1000;
+        background-color: $gray-1100;
       }
     }
 

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -507,7 +507,7 @@
 
   // rendered within ../attempts/attempts.tsx
   .no-commands {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     border: 1px solid $gray-900;
     border-radius: 3px;
     box-shadow: inset 0 1px 1px rgba($white, 0.05);

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -2,7 +2,7 @@ $code-border-radius: 4px;
 
 .reporter {
   .error {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     min-height: 20px;
     padding: 24px;
 
@@ -262,7 +262,7 @@ $code-border-radius: 4px;
   }
 
   .test-err-code-frame {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     border: 1px dashed rgba(245, 154, 169, 0.1);
     border-radius: $code-border-radius;
     margin: 0 0 10px;

--- a/packages/reporter/src/errors/prism.scss
+++ b/packages/reporter/src/errors/prism.scss
@@ -10,7 +10,7 @@ pre[class*="language-"] {
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-	background: $gray-1000;
+	background: $gray-1100;
 }
 
 // .token.comment,
@@ -52,7 +52,7 @@ pre[class*="language-"] {
 .token.important,
 .token.variable {
 	color: $orange-400;
-  background: $gray-1000;
+  background: $gray-1100;
 }
 
 .token.atrule,

--- a/packages/reporter/src/header/header.scss
+++ b/packages/reporter/src/header/header.scss
@@ -2,7 +2,7 @@ $color-transition: color 150ms ease-out;
 
 .reporter {
   header {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     display: flex;
     flex-shrink: 0;
     flex-wrap: wrap;

--- a/packages/reporter/src/lib/base.scss
+++ b/packages/reporter/src/lib/base.scss
@@ -1,7 +1,7 @@
 body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,button,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img,a img{border:none;}address,caption,cite,code,dfn,em,strong,th,var,optgroup{font-style:inherit;font-weight:inherit;}del,ins{text-decoration:none;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:baseline;}sub{vertical-align:baseline;}legend{color:$white;}
 
 .reporter {
-  background-color: $gray-1000;
+  background-color: $gray-1100;
   bottom: 0;
   color: $gray-200;
   display: flex;

--- a/packages/reporter/src/lib/mixins.scss
+++ b/packages/reporter/src/lib/mixins.scss
@@ -1,5 +1,5 @@
 @mixin inner-header {
-  background: $gray-1000;
+  background: $gray-1100;
   display: block;
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
   font-size: 14px;

--- a/packages/reporter/src/lib/variables.scss
+++ b/packages/reporter/src/lib/variables.scss
@@ -114,7 +114,7 @@ $err-header-background: #3A243B;
 $err-header-text: $red-300;
 $err-text: $red-400;
 
-$reporter-section-background: #171926; // not a brand color
+$reporter-section-background: #121522; // not a brand color
 
 $warn-border: 2px solid $orange-300;
 $warn-text: $orange-300;

--- a/packages/reporter/src/lib/variables.scss
+++ b/packages/reporter/src/lib/variables.scss
@@ -9,6 +9,7 @@ $gray-700: #5a5f7a;
 $gray-800: #434861;
 $gray-900: #2e3247;
 $gray-1000: #1b1e2e;
+$gray-1100: #161827;
 
 $red-50: #fbeff1;
 $red-100: #fad9df;

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -4,7 +4,7 @@
   min-height: 0; // needed for firefox or else scrolling gets funky
 
   .container {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     flex-grow: 2;
     overflow-y: auto;
   }
@@ -21,7 +21,7 @@
   }
 
   .no-tests {
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     min-height: 20px;
     padding: 24px;
 
@@ -86,7 +86,7 @@
   .runnable {
     width: 100%;
     color: $gray-400;
-    background-color: $gray-1000;
+    background-color: $gray-1100;
     overflow: auto;
     line-height: 18px;
     padding-left: 0;
@@ -98,7 +98,7 @@
       .collapsible-header {
         &:focus {
           .collapsible-header-inner {
-            background-color: $gray-1000;
+            background-color: $gray-1100;
             cursor: pointer;
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2665,10 +2665,10 @@
   dependencies:
     "@cypress-design/icon-registry" "^1.5.1"
 
-"@cypress-design/css@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@cypress-design/css/-/css-1.0.0.tgz#65c48ee7c7f62446e239f3590016e8817d09b816"
-  integrity sha512-FtKERQybOTBd+2USvTKQVZYnXE9EF2y8hLCslm2iNyb1TbcKU4fLc3aeSTEFKupDsZxCCYDDQJHSYxjWjgYiTg==
+"@cypress-design/css@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@cypress-design/css/-/css-1.1.0.tgz#707d6d51fb7a43be304a501fccdc08d2c134825c"
+  integrity sha512-xHLkTQNKIpKqcK0bVQBOTCISDBV+Z+HD8MyfQyNKuYRy408bwzICi+LsrSf0attsqEoE57Jp2n6VoNbNbPXHqg==
   dependencies:
     "@tailwindcss/container-queries" "^0.1.1"
     lodash "^4.17.21"


### PR DESCRIPTION
### Additional details

This updates the background of the reporter areas to the correct background color from [Figma](https://www.figma.com/design/XYBgOykHfLCi1yT4Va7GLO/Test-generation?node-id=783-44695&p=f&t=KGoGTuL5WmeTqQ19-0).

- URL bar bg
- Reporter bg
	- Commands bg
	- Errors stack bg
	- loading tests bg
- Selector playground bg

This background color was introduced to create more contrast for better accessibility

### Steps to test

- Within `packages/app`, run `yarn cypress:open`

### How has the user experience changed?

#### Before

![Screenshot 2025-04-10 at 8 52 38 AM](https://github.com/user-attachments/assets/93c7044c-cb80-489b-831c-08d06dd548f4)


#### After

![Screenshot 2025-04-10 at 8 56 51 AM](https://github.com/user-attachments/assets/2d87b2a7-0105-4e1d-ba0a-de26610d32da)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
