### PR TITLE
chore: skip flaky cy.pause test in webkit

### DIFF
--- a/system-tests/projects/e2e/cypress/e2e/pause.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/pause.cy.js
@@ -1,4 +1,5 @@
-describe('cy.pause()', () => {
+// TODO: fix flaky test (webkit)
+describe('cy.pause()', { browser: '!webkit' }, () => {
   it('pauses', () => {
     let didPause = false
 


### PR DESCRIPTION
### Additional details

This system-test for cy.pause() has recently become VERY flaky within the webkit browser. This PR skips that test within the webkit browser. 

CI: https://app.circleci.com/pipelines/github/cypress-io/cypress/69432/workflows/8f93a011-ccc6-479c-99ab-b4d64038a126/jobs/2852696

![Screenshot 2025-04-10 at 8 26 16 AM](https://github.com/user-attachments/assets/bded0119-baa9-44c7-aacd-b0d18ca7a674)

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
