### PR TITLE
chore: do not run pause() system test in webkit

### DIFF
--- a/system-tests/test/pause_headed_exit_spec.ts
+++ b/system-tests/test/pause_headed_exit_spec.ts
@@ -1,6 +1,9 @@
 import systemTests from '../lib/system-tests'
 import childProcess from 'child_process'
 
+// these system tests are skipped in webkit due to flake.
+// TODO: https://github.com/cypress-io/cypress/issues/31503
+
 describe('cy.pause() in run mode', () => {
   systemTests.setup()
 

--- a/system-tests/test/pause_headed_exit_spec.ts
+++ b/system-tests/test/pause_headed_exit_spec.ts
@@ -15,6 +15,7 @@ describe('cy.pause() in run mode', () => {
     headed: true,
     noExit: true,
     expectedExitCode: null,
+    browser: '!webkit',
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
         if (buf.toString().includes('not exiting due to options.exit being false')) {
@@ -38,6 +39,7 @@ describe('cy.pause() in run mode', () => {
     headed: false,
     noExit: true,
     expectedExitCode: null,
+    browser: '!webkit',
     onSpawn: (cp) => {
       cp.stdout.on('data', (buf) => {
         if (buf.toString().includes('not exiting due to options.exit being false')) {
@@ -62,6 +64,7 @@ describe('cy.pause() in run mode', () => {
     headed: true,
     noExit: false,
     expectedExitCode: 0,
+    browser: '!webkit',
   })
 
   systemTests.it('does not pause without --headed and --no-exit', {
@@ -75,5 +78,6 @@ describe('cy.pause() in run mode', () => {
     headed: false,
     noExit: false,
     expectedExitCode: 0,
+    browser: '!webkit',
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
Verify that the `pause_headed_exit_spec` system tests do not run in webkit

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
