### PR TITLE
misc: correct documentation system-requirements link in error message

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released 4/22/2025 (PENDING)_
 **Misc:**
 
 - The UI of the reporter and URL were updated to a darker gray background for better color contrast. Addressed in [#31475](https://github.com/cypress-io/cypress/pull/31475).
+- Fixed an issue where the error message output when attempting to install Cypress on an unsupported architecture included an outdated documentation link to Cypress system requirements. Fixes [#31512](https://github.com/cypress-io/cypress/issues/31512).
 
 ## 14.3.0
 

--- a/cli/__snapshots__/install_spec.js
+++ b/cli/__snapshots__/install_spec.js
@@ -274,7 +274,7 @@ Installing Cypress (version: 1.2.3)
 exports['error when installing on unsupported os'] = `
 Error: The Cypress App could not be installed. Your machine does not meet the operating system requirements.
 
-https://on.cypress.io/guides/getting-started/installing-cypress#system-requirements
+https://on.cypress.io/app/get-started/install-cypress#System-requirements
 
 ----------
 

--- a/cli/lib/errors.js
+++ b/cli/lib/errors.js
@@ -42,7 +42,7 @@ const invalidOS = {
   description: 'The Cypress App could not be installed. Your machine does not meet the operating system requirements.',
   solution: stripIndent`
 
-  ${chalk.blue('https://on.cypress.io/guides/getting-started/installing-cypress#system-requirements')}`,
+  ${chalk.blue('https://on.cypress.io/app/get-started/install-cypress#System-requirements')}`,
 }
 
 const failedDownload = {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/31512

### Additional details

The link https://on.cypress.io/guides/getting-started/installing-cypress#system-requirements that is logged if an attempt is made to install Cypress on an unsupported architecture, such as Windows 11 `arm64`, uses a bookmark with an incorrect case. Bookmarks in general are case sensitive and this applies also to the https://docs.cypress.io/ site.

The link is changed to the current correct target:

https://on.cypress.io/app/get-started/install-cypress#System-requirements

which then dynamically forwards to:

https://docs.cypress.io/app/get-started/install-cypress#System-requirements

### Steps to test

Attempt to install Cypress on Windows 11 `arm64`, click on the link in the error message and confirm that the System requirements section of the documentation is displayed.

### How has the user experience changed?

This is a UI change only. Clicking on the link in the error message changes as shown in the screenshots below for BEFORE and AFTER:

**BEFORE**

![System requirements BEFORE](https://github.com/user-attachments/assets/d8f38c1c-4e2c-4c78-8df7-28b8f5c48b72)

**AFTER**

![System requirements AFTER](https://github.com/user-attachments/assets/96d588d2-1ecd-4b92-8346-858f9e3a2ab0)

### PR Tasks

- [X] Have tests been added/updated? (snapshots updated)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
