### PR TITLE
chore: fix flaky spec.js test where elements were not visible

### DIFF
--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -647,7 +647,8 @@ describe('App: Specs', () => {
           })
 
           cy.contains('Review the docs')
-          .should('have.attr', 'href', 'https://on.cypress.io/styling-components')
+          .should('be.visible')
+          .and('have.attr', 'href', 'https://on.cypress.io/styling-components')
 
           cy.log('should not contain the link if you navigate away and back')
           cy.get('body').type('f')


### PR DESCRIPTION
### Additional details
This spec.js test has been failing periodically. [See Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/61655/overview/7158ddab-0773-485c-81be-7459b15d131c/replay?att=2&roarHideRunsWithDiffGroupsAndTags=1&ts=1744818657156.1&pc=log-http%3A%2F%2Flocalhost%3A4455-1229__command-logs)

My theory is that the test is just moving too fast to the next step in the UI before this docs link is even visible. 

I ran this test locally and it immediately failed, but adding this visibility assertion to ensure it's visible before moving made it pass.

##### Test Replay

![Screenshot 2025-04-16 at 12 27 01 PM](https://github.com/user-attachments/assets/da4e748f-d275-4fdd-a798-5ef3fad4ff5f)


##### Local with assertion

![Screenshot 2025-04-16 at 12 19 41 PM](https://github.com/user-attachments/assets/ec69e9c8-b102-40e3-9dba-0eb092498ec6)


### Steps to test

- In packages/app - run e2e specs.js test

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
