### PR TITLE
chore: conditionally install chrome or firefox browser for system-tests depending on the browser passed

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -845,6 +845,14 @@ commands:
       browser:
         description: browser shortname to target
         type: string
+      install-chrome:
+        description: whether or not to install google chrome
+        type: boolean
+        default: false
+      install-firefox:
+        description: whether or not to install firefox
+        type: boolean
+        default: false
     steps:
       - restore_cached_workspace
       - restore_cached_system_tests_deps
@@ -854,8 +862,8 @@ commands:
           steps:
             - install-webkit-deps
       - install-browsers:
-          install-chrome: << parameters.browser == 'chrome' >>
-          install-firefox: << parameters.browser == 'firefox' >>
+          install-chrome: << parameters.install-chrome >>
+          install-firefox: << parameters.install-firefox >>
       - run:
           name: Run system tests
           environment:
@@ -1963,6 +1971,8 @@ jobs:
     steps:
       - run-system-tests:
           browser: chrome
+          install-chrome: true
+          install-firefox: false
 
   system-tests-electron:
     <<: *defaults
@@ -1971,6 +1981,8 @@ jobs:
     steps:
       - run-system-tests:
           browser: electron
+          install-chrome: false
+          install-firefox: false
 
   system-tests-firefox:
     <<: *defaults
@@ -1979,6 +1991,8 @@ jobs:
     steps:
       - run-system-tests:
           browser: firefox
+          install-chrome: false
+          install-firefox: true
 
   system-tests-webkit:
     <<: *defaults
@@ -1987,6 +2001,8 @@ jobs:
     steps:
       - run-system-tests:
           browser: webkit
+          install-chrome: false
+          install-firefox: false
 
   system-tests-non-root:
     <<: *defaults

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -854,8 +854,8 @@ commands:
           steps:
             - install-webkit-deps
       - install-browsers:
-          install-chrome: true
-          install-firefox: true
+          install-chrome: << parameters.browser == 'chrome' >>
+          install-firefox: << parameters.browser == 'firefox' >>
       - run:
           name: Run system tests
           environment:

--- a/system-tests/__snapshots__/browser_path_spec.js
+++ b/system-tests/__snapshots__/browser_path_spec.js
@@ -31,16 +31,10 @@ exports['e2e launching browsers by path works with an installed browser path 1']
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
   │ Screenshots:  0                                                                                │
-  │ Video:        true                                                                             │
+  │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     simple.cy.js                                                                     │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Video)
-
-  -  Started compressing:  Compressing to 32 CRF                                                     
-  -  Finished compressing: /XXX/XXX/XXX/cypress/videos/simple.cy.js.mp4                    (X second)
 
 
 ====================================================================================================

--- a/system-tests/test/browser_path_spec.js
+++ b/system-tests/test/browser_path_spec.js
@@ -39,14 +39,8 @@ describe('e2e launching browsers by path', () => {
 
   it('works with an installed browser path', function () {
     return launcher.detect().then((browsers) => {
-      return browsers.find((browser) => {
-        return browser.family === 'chromium'
-      })
-    }).tap((browser) => {
-      if (!browser) {
-        throw new Error('A \'chromium\' family browser must be installed for this test')
-      }
-    }).get('path')
+      return browsers[0].path
+    })
     // turn binary browser names ("google-chrome") into their absolute paths
     // so that server recognizes them as a path, not as a browser name
     .then((absPath))


### PR DESCRIPTION
### Additional details

I noticed the `system-test-chrome` failing to install Firefox. We don't need to install firefox for system-tests in chrome however. https://app.circleci.com/pipelines/github/cypress-io/cypress/69695/workflows/2a0c3707-cfc3-44e1-85ed-bdf9e9f46ae6/jobs/2862593

This switches the logic to conditionally install the browser depending on the browser we passed to the system-tests.

### Steps to test

system-tests-chrome and system-tests-firefox should still pass and install the browsers properly

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
