### PR TITLE
fix: auto scroll behavior

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-4-7-2025-v1
+4-17-2025-v1

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 14.3.2
+
+_Released 4/22/2025 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed and issue where auto scroll in the Cypress Reporter was not happening correctly. Fixes [#31530](https://github.com/cypress-io/cypress/issues/31530).
+
 ## 14.3.1
 
 _Released 4/17/2025_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 4/22/2025 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed and issue where auto scroll in the Cypress Reporter was not happening correctly. Fixes [#31530](https://github.com/cypress-io/cypress/issues/31530).
+- Fixed an issue where auto scroll in the Cypress Command Log was not scrolling correctly. Fixes [#31530](https://github.com/cypress-io/cypress/issues/31530).
 
 ## 14.3.1
 

--- a/packages/driver/cypress/support/utils.ts
+++ b/packages/driver/cypress/support/utils.ts
@@ -43,7 +43,7 @@ export const clickCommandLog = (sel, type?) => {
       assert(false, 'failed to get command log React instance')
     }
 
-    // forces the runner off (NOTE: this will break auto scrolling in open for for tests that use this helper specifically)
+    // forces the runner off (NOTE: this will break auto scrolling in open mode for tests that use this helper specifically)
     appStateInstance.isRunning = false
     const inner = $(commandLogEl).find('.command-wrapper-text')
 

--- a/packages/driver/cypress/support/utils.ts
+++ b/packages/driver/cypress/support/utils.ts
@@ -43,6 +43,7 @@ export const clickCommandLog = (sel, type?) => {
       assert(false, 'failed to get command log React instance')
     }
 
+    // forces the runner off (NOTE: this will break auto scrolling in open for for tests that use this helper specifically)
     appStateInstance.isRunning = false
     const inner = $(commandLogEl).find('.command-wrapper-text')
 

--- a/packages/reporter/src/agents/agents.tsx
+++ b/packages/reporter/src/agents/agents.tsx
@@ -28,13 +28,15 @@ export interface AgentsProps {
   model: AgentsModel
 }
 
-const AgentsList = observer(({ model }: AgentsProps) => (
+const AgentsList: React.FC<AgentsProps> = observer(({ model }: AgentsProps) => (
   <tbody>
     {_.map(model.agents, (agent) => <Agent key={agent.id} model={agent} />)}
   </tbody>
 ))
 
-const Agents = observer(({ model }: AgentsProps) => {
+AgentsList.displayName = 'AgentsList'
+
+const Agents: React.FC<AgentsProps> = observer(({ model }: AgentsProps) => {
   if (!model.agents.length) {
     return null
   }
@@ -66,6 +68,8 @@ const Agents = observer(({ model }: AgentsProps) => {
       </div>
     </div>)
 })
+
+Agents.displayName = 'Agents'
 
 export { Agent, AgentsList }
 

--- a/packages/reporter/src/attempts/attempts.tsx
+++ b/packages/reporter/src/attempts/attempts.tsx
@@ -70,7 +70,7 @@ const Attempt: React.FC<AttemptProps> = observer(({ model, scrollIntoView, studi
           <Agents model={model} />
           <Routes model={model} />
           <div className='runnable-commands-region'>
-            {model.hasCommands ? <Hooks model={model} /> : <NoCommands />}
+            {model.hasCommands ? <Hooks model={model} scrollIntoView={scrollIntoView} /> : <NoCommands />}
           </div>
           {model.state === 'failed' && (
             <div className='attempt-error-region'>

--- a/packages/reporter/src/attempts/attempts.tsx
+++ b/packages/reporter/src/attempts/attempts.tsx
@@ -92,7 +92,15 @@ const Attempt: React.FC<AttemptProps> = observer(({ model, scrollIntoView, studi
   )
 })
 
-const Attempts = observer(({ test, scrollIntoView, studioActive }: {test: TestModel, scrollIntoView: Function, studioActive: boolean}) => {
+Attempt.displayName = 'Attempt'
+
+interface AttemptsProps {
+  test: TestModel
+  scrollIntoView: Function
+  studioActive: boolean
+}
+
+const Attempts: React.FC<AttemptsProps> = observer(({ test, scrollIntoView, studioActive }: AttemptsProps) => {
   return (<ul className={cs('attempts', {
     'has-multiple-attempts': test.hasMultipleAttempts,
   })}>
@@ -108,6 +116,8 @@ const Attempts = observer(({ test, scrollIntoView, studioActive }: {test: TestMo
     })}
   </ul>)
 })
+
+Attempts.displayName = 'Attempts'
 
 export { Attempt, AttemptHeader, NoCommands }
 

--- a/packages/reporter/src/commands/command.cy.tsx
+++ b/packages/reporter/src/commands/command.cy.tsx
@@ -29,6 +29,7 @@ describe('commands', () => {
                 numElements: 1,
               })
             }
+            scrollIntoView={() => {}}
           />
         </div>,
       )
@@ -96,6 +97,7 @@ describe('commands', () => {
                   numElements: 1,
                 })
               }
+              scrollIntoView={() => {}}
             />
           ))}
         </div>,

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import cs from 'classnames'
 import Markdown from 'markdown-it'
 import { observer } from 'mobx-react'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useState, useEffect } from 'react'
 import Tooltip from '@cypress/react-tooltip'
 
 import appState from '../lib/app-state'
@@ -321,6 +321,7 @@ interface CommandProps {
   model: CommandModel
   aliasesWithDuplicates: Array<Alias> | null
   groupId?: number
+  scrollIntoView: Function
 }
 
 const CommandDetails: React.FC<CommandDetailsProps> = observer(({ model, groupId, aliasesWithDuplicates }) => (
@@ -400,8 +401,22 @@ const CommandControls: React.FC<CommandControlsProps> = observer(({ model, comma
 
 CommandControls.displayName = 'CommandControls'
 
-const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates, groupId }) => {
+const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates, groupId, scrollIntoView }) => {
   const [showTimeout, setShowTimeout] = useState<TimeoutID | undefined>(undefined)
+
+  useEffect(() => {
+    /**
+    * When moving class components into functional components (@see https://github.com/cypress-io/cypress/pull/31284),
+    * we introduced a bug where the command log was not scrolling into view when a command
+    * was added. This has to do with more efficient DOM rendering in React where the
+    * <Attempt> component does not call useEffect when it's children update.
+    *
+    * To fix this, we need to call the scroll handler when a <Command> is added to the test
+    *
+    * @see https://github.com/cypress-io/cypress/issues/31530 for more details
+    */
+    scrollIntoView()
+  }, [])
 
   if (model.group && groupId !== model.group) {
     return null
@@ -527,6 +542,7 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                 model={child}
                 aliasesWithDuplicates={null}
                 groupId={model.id}
+                scrollIntoView={scrollIntoView}
               />
             ))}
           </ul>

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useState } from 'react'
 import Tooltip from '@cypress/react-tooltip'
 
 import appState from '../lib/app-state'
-import events from '../lib/events'
+import events, { Events } from '../lib/events'
 import FlashOnClick from '../lib/flash-on-click'
 import StateIcon from '../lib/state-icon'
 import Tag from '../lib/tag'
@@ -100,6 +100,12 @@ const shouldShowCount = (aliasesWithDuplicates: Array<Alias> | null, aliasName: 
   return _.includes(aliasesWithDuplicates, aliasName)
 }
 
+interface NavColumnsProps {
+  model: CommandModel
+  isPinned: boolean
+  toggleColumnPin: () => void
+}
+
 /**
  * NavColumns Rules:
  *   > Command Number Column
@@ -111,7 +117,7 @@ const shouldShowCount = (aliasesWithDuplicates: Array<Alias> | null, aliasName: 
  *   > Expander Column
  *      - When the log is a group log and it has children logs, it will display the chevron icon
  */
-const NavColumns = observer(({ model, isPinned, toggleColumnPin }) => (
+const NavColumns: React.FC<NavColumnsProps> = observer(({ model, isPinned, toggleColumnPin }) => (
   <>
     <div className='command-number-column' onClick={toggleColumnPin}>
       {model._isPending() && <RunningIcon data-cy="reporter-running-icon" className='fa-spin' />}
@@ -126,13 +132,15 @@ const NavColumns = observer(({ model, isPinned, toggleColumnPin }) => (
   </>
 ))
 
+NavColumns.displayName = 'NavColumns'
+
 interface AliasReferenceProps {
   aliasObj: AliasObject
   model: CommandModel
   aliasesWithDuplicates: Array<Alias> | null
 }
 
-const AliasReference = observer(({ aliasObj, model, aliasesWithDuplicates }: AliasReferenceProps) => {
+const AliasReference: React.FC<AliasReferenceProps> = observer(({ aliasObj, model, aliasesWithDuplicates }: AliasReferenceProps) => {
   const showCount = shouldShowCount(aliasesWithDuplicates, aliasObj.name, model)
   const toolTipMessage = showCount ? `Found ${aliasObj.ordinal} alias for: '${aliasObj.name}'` : `Found an alias for: '${aliasObj.name}'`
 
@@ -147,12 +155,14 @@ const AliasReference = observer(({ aliasObj, model, aliasesWithDuplicates }: Ali
   )
 })
 
+AliasReference.displayName = 'AliasReference'
+
 interface AliasesReferencesProps {
   model: CommandModel
   aliasesWithDuplicates: Array<Alias> | null
 }
 
-const AliasesReferences = observer(({ model, aliasesWithDuplicates }: AliasesReferencesProps) => {
+const AliasesReferences: React.FC<AliasesReferencesProps> = observer(({ model, aliasesWithDuplicates }: AliasesReferencesProps) => {
   const aliases = ([] as Array<AliasObject>).concat((model.referencesAlias as AliasObject))
 
   if (!aliases.length) {
@@ -173,7 +183,9 @@ const AliasesReferences = observer(({ model, aliasesWithDuplicates }: AliasesRef
   )
 })
 
-const Interceptions = observer(({ interceptions, wentToOrigin, status }: RenderProps) => {
+AliasesReferences.displayName = 'AliasesReferences'
+
+const Interceptions: React.FC<RenderProps> = observer(({ interceptions, wentToOrigin, status }: RenderProps) => {
   if (!interceptions?.length) {
     return null
   }
@@ -209,11 +221,12 @@ const Interceptions = observer(({ interceptions, wentToOrigin, status }: RenderP
   )
 })
 
+Interceptions.displayName = 'Interceptions'
 interface AliasesProps {
   model: CommandModel
 }
 
-const Aliases = observer(({ model }: AliasesProps) => {
+const Aliases: React.FC<AliasesProps> = observer(({ model }: AliasesProps) => {
   if (!model.alias || model.aliasType === 'route') return null
 
   const aliases = ([] as Array<Alias>).concat(model.alias)
@@ -241,11 +254,13 @@ const Aliases = observer(({ model }: AliasesProps) => {
   )
 })
 
+Aliases.displayName = 'Aliases'
+
 interface MessageProps {
   model: CommandModel
 }
 
-const Message = observer(({ model }: MessageProps) => (
+const Message: React.FC<MessageProps> = observer(({ model }: MessageProps) => (
   <span className='command-message'>
     {!!model.renderProps.indicator && (
       <i
@@ -265,11 +280,13 @@ const Message = observer(({ model }: MessageProps) => (
   </span>
 ))
 
+Message.displayName = 'Message'
+
 interface ProgressProps {
   model: CommandModel
 }
 
-const Progress = observer(({ model }: ProgressProps) => {
+const Progress: React.FC<ProgressProps> = observer(({ model }: ProgressProps) => {
   if (model.state !== 'pending' || !model.timeout || !model.wallClockStartedAt) {
     return null
   }
@@ -286,13 +303,27 @@ const Progress = observer(({ model }: ProgressProps) => {
   )
 })
 
-interface Props {
+Progress.displayName = 'Progress'
+
+interface CommandDetailsProps {
+  model: CommandModel
+  groupId: number | undefined
+  aliasesWithDuplicates: Array<Alias> | null
+}
+
+interface CommandControlsProps {
+  model: CommandModel
+  commandName: string
+  events: Events
+}
+
+interface CommandProps {
   model: CommandModel
   aliasesWithDuplicates: Array<Alias> | null
   groupId?: number
 }
 
-const CommandDetails = observer(({ model, groupId, aliasesWithDuplicates }) => (
+const CommandDetails: React.FC<CommandDetailsProps> = observer(({ model, groupId, aliasesWithDuplicates }) => (
   <span className={cs('command-info')}>
     <span className='command-method'>
       <span>
@@ -307,7 +338,9 @@ const CommandDetails = observer(({ model, groupId, aliasesWithDuplicates }) => (
   </span>
 ))
 
-const CommandControls = observer(({ model, commandName, events }) => {
+CommandDetails.displayName = 'CommandDetails'
+
+const CommandControls: React.FC<CommandControlsProps> = observer(({ model, commandName, events }) => {
   const displayNumOfElements = model.state !== 'pending' && model.numElements != null && model.numElements !== 1
   const isSystemEvent = model.type === 'system' && model.event
   const isSessionCommand = commandName === 'session'
@@ -365,7 +398,9 @@ const CommandControls = observer(({ model, commandName, events }) => {
   )
 })
 
-const Command: React.FC<Props> = observer(({ model, aliasesWithDuplicates, groupId }) => {
+CommandControls.displayName = 'CommandControls'
+
+const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates, groupId }) => {
   const [showTimeout, setShowTimeout] = useState<TimeoutID | undefined>(undefined)
 
   if (model.group && groupId !== model.group) {
@@ -511,6 +546,8 @@ const Command: React.FC<Props> = observer(({ model, aliasesWithDuplicates, group
     </>
   )
 })
+
+Command.displayName = 'Command'
 
 export { Aliases, AliasesReferences, Message, Progress }
 

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -114,4 +114,6 @@ const TestError: React.FC<TestErrorProps> = ({ err, groupLevel = 0, testId, comm
   )
 }
 
+TestError.displayName = 'TestError'
+
 export default observer(TestError)

--- a/packages/reporter/src/header/controls.tsx
+++ b/packages/reporter/src/header/controls.tsx
@@ -24,7 +24,7 @@ interface Props {
   appState: AppState
 }
 
-const Controls = observer(({ events = defaultEvents, appState }: Props) => {
+const Controls: React.FC<Props> = observer(({ events = defaultEvents, appState }: Props) => {
   const emit = (event: string) => () => events.emit(event)
   const togglePreferencesMenu = () => {
     appState.togglePreferencesMenu()
@@ -81,5 +81,7 @@ const Controls = observer(({ events = defaultEvents, appState }: Props) => {
     </div>
   )
 })
+
+Controls.displayName = 'Controls'
 
 export default Controls

--- a/packages/reporter/src/header/header.tsx
+++ b/packages/reporter/src/header/header.tsx
@@ -22,7 +22,7 @@ export interface ReporterHeaderProps {
   runnablesStore: RunnablesStore
 }
 
-const Header = observer(({ appState, events = defaultEvents, statsStore, runnablesStore }: ReporterHeaderProps) => (
+const Header: React.FC<ReporterHeaderProps> = observer(({ appState, events = defaultEvents, statsStore, runnablesStore }: ReporterHeaderProps) => (
   <header>
     <Tooltip placement='bottom' title={<p>{appState.isSpecsListOpen ? 'Collapse' : 'Expand'} Specs List <span className='kbd'>F</span></p>} wrapperClassName='toggle-specs-wrapper' className='cy-tooltip'>
       <button
@@ -46,5 +46,7 @@ const Header = observer(({ appState, events = defaultEvents, statsStore, runnabl
     <Controls appState={appState} />
   </header>
 ))
+
+Header.displayName = 'Header'
 
 export default Header

--- a/packages/reporter/src/header/stats.tsx
+++ b/packages/reporter/src/header/stats.tsx
@@ -14,7 +14,7 @@ interface Props {
   stats: StatsStore
 }
 
-const Stats = observer(({ stats }: Props) => (
+const Stats: React.FC<Props> = observer(({ stats }: Props) => (
   <ul aria-label='Stats' className='stats'>
     <li className='passed'>
       <PassedIcon aria-hidden="true" />
@@ -33,5 +33,7 @@ const Stats = observer(({ stats }: Props) => (
     </li>
   </ul>
 ))
+
+Stats.displayName = 'Stats'
 
 export default Stats

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -62,7 +62,7 @@ export interface HookProps {
   showNumber: boolean
 }
 
-const Hook = observer(({ model, showNumber }: HookProps) => (
+const Hook: React.FC<HookProps> = observer(({ model, showNumber }: HookProps) => (
   <li className={cs('hook-item', { 'hook-failed': model.failed, 'hook-studio': model.isStudio })}>
     <Collapsible
       header={<HookHeader model={model} number={showNumber ? model.hookNumber : undefined} />}
@@ -78,6 +78,8 @@ const Hook = observer(({ model, showNumber }: HookProps) => (
   </li>
 ))
 
+Hook.displayName = 'Hook'
+
 export interface HooksModel {
   hooks: HookModel[]
   hookCount: { [name in HookName]: number }
@@ -89,7 +91,7 @@ export interface HooksProps {
   model: HooksModel
 }
 
-const Hooks = observer(({ state = appState, model }: HooksProps) => (
+const Hooks: React.FC<HooksProps> = observer(({ state = appState, model }: HooksProps) => (
   <ul className='hooks-container'>
     {_.map(model.hooks, (hook) => {
       if (hook.commands.length || (hook.isStudio && state.studioActive && model.state === 'passed')) {
@@ -100,6 +102,8 @@ const Hooks = observer(({ state = appState, model }: HooksProps) => (
     })}
   </ul>
 ))
+
+Hooks.displayName = 'Hooks'
 
 export { Hook, HookHeader }
 

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -60,9 +60,10 @@ const StudioNoCommands = () => (
 export interface HookProps {
   model: HookModel
   showNumber: boolean
+  scrollIntoView: Function
 }
 
-const Hook: React.FC<HookProps> = observer(({ model, showNumber }: HookProps) => (
+const Hook: React.FC<HookProps> = observer(({ model, showNumber, scrollIntoView }: HookProps) => (
   <li className={cs('hook-item', { 'hook-failed': model.failed, 'hook-studio': model.isStudio })}>
     <Collapsible
       header={<HookHeader model={model} number={showNumber ? model.hookNumber : undefined} />}
@@ -71,7 +72,7 @@ const Hook: React.FC<HookProps> = observer(({ model, showNumber }: HookProps) =>
       isOpen
     >
       <ul className='commands-container'>
-        {_.map(model.commands, (command) => <Command key={command.id} model={command} aliasesWithDuplicates={model.aliasesWithDuplicates} />)}
+        {_.map(model.commands, (command) => <Command key={command.id} model={command} aliasesWithDuplicates={model.aliasesWithDuplicates} scrollIntoView={scrollIntoView} />)}
         {model.showStudioPrompt && <StudioNoCommands />}
       </ul>
     </Collapsible>
@@ -89,13 +90,14 @@ export interface HooksModel {
 export interface HooksProps {
   state?: AppState
   model: HooksModel
+  scrollIntoView: Function
 }
 
-const Hooks: React.FC<HooksProps> = observer(({ state = appState, model }: HooksProps) => (
+const Hooks: React.FC<HooksProps> = observer(({ state = appState, model, scrollIntoView }: HooksProps) => (
   <ul className='hooks-container'>
     {_.map(model.hooks, (hook) => {
       if (hook.commands.length || (hook.isStudio && state.studioActive && model.state === 'passed')) {
-        return <Hook key={hook.hookId} model={hook} showNumber={model.hookCount[hook.hookName] > 1} />
+        return <Hook key={hook.hookId} model={hook} scrollIntoView={scrollIntoView} showNumber={model.hookCount[hook.hookName] > 1} />
       }
 
       return null

--- a/packages/reporter/src/lib/file-name-opener.tsx
+++ b/packages/reporter/src/lib/file-name-opener.tsx
@@ -16,7 +16,7 @@ interface Props {
  * Renders a link-style element that presents a tooltip on hover
  * and opens the file in an external editor when selected.
  */
-const FileNameOpener = observer((props: Props) => {
+const FileNameOpener: React.FC<Props> = observer((props: Props) => {
   const { displayFile, originalFile, line, column } = props.fileDetails
 
   return (
@@ -34,5 +34,7 @@ const FileNameOpener = observer((props: Props) => {
     </Tooltip>
   )
 })
+
+FileNameOpener.displayName = 'FileNameOpener'
 
 export default FileNameOpener

--- a/packages/reporter/src/lib/flash-on-click.tsx
+++ b/packages/reporter/src/lib/flash-on-click.tsx
@@ -40,4 +40,5 @@ const FlashOnClick: React.FC<Props> = observer(({ message, onClick, wrapperClass
   )
 })
 
+FlashOnClick.displayName = 'FlashOnClick'
 export default FlashOnClick

--- a/packages/reporter/src/lib/open-file-in-ide.tsx
+++ b/packages/reporter/src/lib/open-file-in-ide.tsx
@@ -19,4 +19,5 @@ const OpenFileInIDE: React.FC<Props> = observer((props) => {
   )
 })
 
+OpenFileInIDE.displayName = 'OpenFileInIDE'
 export default OpenFileInIDE

--- a/packages/reporter/src/lib/state-icon.tsx
+++ b/packages/reporter/src/lib/state-icon.tsx
@@ -15,7 +15,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
   isStudio?: boolean
 }
 
-const StateIcon = observer((props: Props) => {
+const StateIcon: React.FC<Props> = observer((props: Props) => {
   const { state, isStudio, ...rest } = props
 
   if (state === 'active') {
@@ -58,5 +58,7 @@ const StateIcon = observer((props: Props) => {
     <PendingIcon />
   )
 })
+
+StateIcon.displayName = 'StateIcon'
 
 export default StateIcon

--- a/packages/reporter/src/lib/switch.tsx
+++ b/packages/reporter/src/lib/switch.tsx
@@ -27,4 +27,6 @@ const Switch: React.FC<Props> = observer(({ value, 'data-cy': dataCy, size = 'lg
   )
 })
 
+Switch.displayName = 'Switch'
+
 export default Switch

--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -131,6 +131,7 @@ const Reporter: React.FC<SingleReporterProps> = observer(({ appState = appStateD
   )
 })
 
+Reporter.displayName = 'Reporter'
 declare global {
   interface Window {
     Cypress: any

--- a/packages/reporter/src/preferences/testing-preferences.tsx
+++ b/packages/reporter/src/preferences/testing-preferences.tsx
@@ -11,7 +11,7 @@ interface Props {
   appState: AppState
 }
 
-const TestingPreferences = observer(({
+const TestingPreferences: React.FC<Props> = observer(({
   events = defaultEvents,
   appState,
 }: Props) => {
@@ -42,5 +42,7 @@ const TestingPreferences = observer(({
     </div>
   )
 })
+
+TestingPreferences.displayName = 'TestingPreferences'
 
 export default TestingPreferences

--- a/packages/reporter/src/routes/routes.tsx
+++ b/packages/reporter/src/routes/routes.tsx
@@ -38,17 +38,19 @@ export interface RouteListProps {
   model: RouteListModel
 }
 
-const RoutesList = observer(({ model }: RouteListProps) => (
+const RoutesList: React.FC<RouteListProps> = observer(({ model }: RouteListProps) => (
   <tbody>
     {_.map(model.routes, (route) => <Route key={route.id} model={route} />)}
   </tbody>
 ))
 
+RoutesList.displayName = 'RoutesList'
+
 export interface RoutesProps {
   model: RouteListModel
 }
 
-const Routes = observer(({ model }: RoutesProps) => {
+const Routes: React.FC<RoutesProps> = observer(({ model }: RoutesProps) => {
   if (!model.routes.length) {
     return null
   }
@@ -90,6 +92,8 @@ const Routes = observer(({ model }: RoutesProps) => {
     </div>
   )
 })
+
+Routes.displayName = 'Routes'
 
 export { Route, RoutesList }
 

--- a/packages/reporter/src/runnables/runnable-and-suite.tsx
+++ b/packages/reporter/src/runnables/runnable-and-suite.tsx
@@ -22,7 +22,7 @@ interface SuiteProps {
   canSaveStudioLogs: boolean
 }
 
-const Suite = observer(({ eventManager = events, model, studioEnabled, canSaveStudioLogs }: SuiteProps) => {
+const Suite: React.FC<SuiteProps> = observer(({ eventManager = events, model, studioEnabled, canSaveStudioLogs }: SuiteProps) => {
   const _launchStudio = useCallback((e: MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -65,6 +65,8 @@ const Suite = observer(({ eventManager = events, model, studioEnabled, canSaveSt
   )
 })
 
+Suite.displayName = 'Suite'
+
 export interface RunnableProps {
   model: TestModel | SuiteModel
   appState: AppState
@@ -91,6 +93,8 @@ const Runnable: React.FC<RunnableProps> = observer(({ appState: appStateProps = 
     </li>
   )
 })
+
+Runnable.displayName = 'Runnable'
 
 export { Suite }
 

--- a/packages/reporter/src/runnables/runnable-header.tsx
+++ b/packages/reporter/src/runnables/runnable-header.tsx
@@ -56,4 +56,6 @@ const RunnableHeader: React.FC<RunnableHeaderProps> = observer(({ spec, statsSto
   )
 })
 
+RunnableHeader.displayName = 'RunnableHeader'
+
 export default RunnableHeader

--- a/packages/reporter/src/runnables/runnables.tsx
+++ b/packages/reporter/src/runnables/runnables.tsx
@@ -91,7 +91,7 @@ interface RunnablesListProps {
   canSaveStudioLogs: boolean
 }
 
-const RunnablesList = observer(({ runnables, studioEnabled, canSaveStudioLogs }: RunnablesListProps) => (
+const RunnablesList: React.FC<RunnablesListProps> = observer(({ runnables, studioEnabled, canSaveStudioLogs }: RunnablesListProps) => (
   <div className='wrap'>
     <ul className='runnables'>
       {_.map(runnables, (runnable) =>
@@ -105,6 +105,8 @@ const RunnablesList = observer(({ runnables, studioEnabled, canSaveStudioLogs }:
   </div>
 ))
 
+RunnablesList.displayName = 'RunnablesList'
+
 export interface RunnablesContentProps {
   runnablesStore: RunnablesStore
   spec: Cypress.Cypress['spec']
@@ -113,7 +115,7 @@ export interface RunnablesContentProps {
   canSaveStudioLogs: boolean
 }
 
-const RunnablesContent = observer(({ runnablesStore, spec, error, studioEnabled, canSaveStudioLogs }: RunnablesContentProps) => {
+const RunnablesContent: React.FC<RunnablesContentProps> = observer(({ runnablesStore, spec, error, studioEnabled, canSaveStudioLogs }: RunnablesContentProps) => {
   const { isReady, runnables, runnablesHistory } = runnablesStore
 
   if (!isReady) {
@@ -142,6 +144,8 @@ const RunnablesContent = observer(({ runnablesStore, spec, error, studioEnabled,
     />
   )
 })
+
+RunnablesContent.displayName = 'RunnablesContent'
 
 export interface RunnablesProps {
   error?: RunnablesErrorModel
@@ -189,6 +193,8 @@ const Runnables: React.FC<RunnablesProps> = observer(({ appState, scroller, erro
     </div>
   )
 })
+
+Runnables.displayName = 'Runnables'
 
 export { RunnablesList }
 

--- a/packages/reporter/src/sessions/sessions.tsx
+++ b/packages/reporter/src/sessions/sessions.tsx
@@ -13,7 +13,7 @@ export interface SessionPanelProps {
   model: Record<string, SessionsModel>
 }
 
-const SessionRow = (model: SessionsModel) => {
+const SessionRow: React.FC<SessionsModel> = (model) => {
   const { name, isGlobalSession, id, status, testId } = model
 
   const printToConsole = (id) => {
@@ -43,7 +43,7 @@ const SessionRow = (model: SessionsModel) => {
   )
 }
 
-const Sessions = ({ model }: SessionPanelProps) => {
+const Sessions: React.FC<SessionPanelProps> = ({ model }) => {
   const sessions = Object.values(model)
 
   if (sessions.length === 0) {

--- a/packages/reporter/src/test/test.tsx
+++ b/packages/reporter/src/test/test.tsx
@@ -187,4 +187,5 @@ const Test: React.FC<TestProps> = observer(({ model, events: eventsProps = event
   )
 })
 
+Test.displayName = 'Test'
 export default Test


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31530

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

It looks like with the changes to the reporter in https://github.com/cypress-io/cypress/pull/31284 that we accidentally broke auto scroll in a handful of scenarios. This looks to be caused by the `<Attempt>` component no longer always updating when the component tree beneath it (the child components) are updated, which tracks with how `useEffect` is supposed to work. To fix this, we really should be calling the scroll handler when a new `<Command>` is added to the test. This way, if auto scroll is configured, the scroll will happen.

Additionally, using React Dev Tools  (RDT) is incredibly difficult with the way most of our components are invoked, mainly due to arrow functions and our mobx wrapper. To get better RDT support, I have added `displayName`s to all the functional components. see https://mobx.js.org/react-integration.html

This allows us to actually see what components are in the tree (as opposed to anonymous components)
![Screenshot 2025-04-17 at 2 19 49 PM](https://github.com/user-attachments/assets/c5c5e827-712d-4abc-be84-fb47a48e5c8c)

I tried to add a cy-in-cy test to test this behavior, but the issue is the auto scroll doesn't happen while the test is running, but scrolls to the bottom command after the run in completed because the `<Attempt>` component updates. In other words, I can't find a deterministic way to test this fix in an end to end fashion.

I'd review this as two commits. The first is the changes to React Dev Tools and the second is the actual bugfix

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

User will have correct support for auto scroll

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
