### PR TITLE
chore: attempt to reduce windows flake for cy-in-cy tests pertaining to reporter rendering

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -91,11 +91,7 @@ windowsWorkflowFilters: &windows-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal:
-          [
-            'ryanm/fix/having-trouble-debugging-your-ci-failures',
-            << pipeline.git.branch >>
-          ]
+      - equal: [ 'chore/fix_reporter_app_cy_in_cy_flake', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>

--- a/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress-e2e.cy.ts
@@ -214,8 +214,7 @@ describe('Cypress In Cypress E2E', { viewportWidth: 1500, defaultCommandTimeout:
     cy.specsPageIsVisible()
     cy.contains('withFailure.spec').click()
     cy.contains('[aria-controls=reporter-inline-specs-list]', 'Specs')
-    // A bit of a hack, but our cy-in-cy test needs to wait for the reporter to fully render before pressing the "f" key to expand the "Search specs" menu.
-    // Otherwise, the "f" keypress happens before the event is registered, which causes the "Search Specs" menu to not expand.
+
     cy.get('[data-cy="runnable-header"]').should('be.visible')
     cy.get('body').type('f')
     cy.contains('Search specs')

--- a/packages/app/cypress/e2e/reporter_header.cy.ts
+++ b/packages/app/cypress/e2e/reporter_header.cy.ts
@@ -11,6 +11,7 @@ describe('Reporter Header', () => {
     })
 
     it('selects the correct spec in the Specs List', () => {
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
 
       cy.get('[data-selected-spec="true"]').should('contain', 'dom-content').should('have.length', '1')
@@ -19,6 +20,7 @@ describe('Reporter Header', () => {
 
     // TODO: Reenable as part of https://github.com/cypress-io/cypress/issues/23902
     it.skip('filters the list of specs when searching for specs', () => {
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
 
       cy.findByTestId('specs-list-panel').within(() => {

--- a/packages/app/cypress/e2e/runner/pluginEvents.cy.ts
+++ b/packages/app/cypress/e2e/runner/pluginEvents.cy.ts
@@ -57,6 +57,7 @@ describe('plugin events', () => {
         })
       })
 
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
       cy.get('div[title="run_events_spec_2.cy.js"]').click()
       cy.waitForSpecToFinish({

--- a/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/sessions.ui.cy.ts
@@ -772,6 +772,7 @@ describe('runner/cypress sessions.open_mode.spec', () => {
   })
 
   it('persists global session and does not persists spec session when selecting a different spec', () => {
+    cy.get('[data-cy="runnable-header"]').should('be.visible')
     cy.get('body').type('f')
     cy.get('div[title="blank_session.cy.js"]').click()
 

--- a/packages/app/cypress/e2e/specs.cy.ts
+++ b/packages/app/cypress/e2e/specs.cy.ts
@@ -651,6 +651,7 @@ describe('App: Specs', () => {
           .and('have.attr', 'href', 'https://on.cypress.io/styling-components')
 
           cy.log('should not contain the link if you navigate away and back')
+          cy.get('[data-cy="runnable-header"]').should('be.visible')
           cy.get('body').type('f')
           cy.get('[data-cy=spec-file-item]').first().click()
           cy.get('#spec-runner-header').should('not.contain', 'Review the docs')

--- a/packages/app/cypress/e2e/specs_list_component.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_component.cy.ts
@@ -27,6 +27,7 @@ describe('App: Spec List (Component)', () => {
   it('highlights the currently running spec', () => {
     cy.contains('fails').click()
     cy.contains('[aria-controls=reporter-inline-specs-list]', 'Specs')
+    cy.get('[data-cy="runnable-header"]').should('be.visible')
     cy.get('body').type('f')
     cy.get('[data-selected-spec="true"]').should('contain', 'fails')
     cy.get('[data-selected-spec="false"]').should('contain', 'foo')

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -121,6 +121,7 @@ describe('App: Spec List (E2E)', () => {
 
       cy.contains('[aria-controls=reporter-inline-specs-list]', 'Specs')
       cy.findByText('Your tests are loading...').should('not.be.visible')
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
 
       cy.get('[data-selected-spec="true"]').contains('dom-content.spec.js')
@@ -136,8 +137,6 @@ describe('App: Spec List (E2E)', () => {
       cy.findByText('Your tests are loading...').should('not.be.visible')
 
       cy.contains('[aria-controls=reporter-inline-specs-list]', 'Specs')
-      // A bit of a hack, but our cy-in-cy test needs to wait for the reporter to fully render before pressing the "f" key to expand the "Search specs" menu.
-      // Otherwise, the "f" keypress happens before the event is registered, which causes the "Search Specs" menu to not expand.
       cy.get('[data-cy="runnable-header"]').should('be.visible')
       // open the inline spec list
       cy.get('body').type('f')

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -195,6 +195,7 @@ e2e: {
       cy.waitForSpecToFinish()
       cy.get('[data-model-state="passed"]').should('contain', 'renders the test content')
 
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
       .should('have.length', 28)
@@ -221,6 +222,7 @@ e2e: {
       cy.waitForSpecToFinish()
       cy.get('[data-model-state="passed"]').should('contain', 'renders the test content')
 
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
       .should('have.length', 28)
@@ -297,6 +299,7 @@ e2e: {
       cy.waitForSpecToFinish()
       cy.get('[data-model-state="passed"]').should('contain', 'renders the test content')
 
+      cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
       cy.get('[data-cy="spec-file-item"]')
       .should('have.length', 28)


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Occasionally it looks like some of the cy-in-cy tests are still flaking in windows after the reporter refactor in #31284. This is mainly due to calling the 'f' keyboard shortcut before the reporter is fully rendered, so the menu doesn't expand and the test fails. Why this is more prevalent on windows I am not sure. Waiting for the reporter to render seems to be the best fix here and has worked in the past for similar tests that were identified already problematic at the time of #31284

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
