### PR TITLE
feat: ship webpack-bundle-analyzer with`@cypress/webpack-dev-server` and `@cypress/webpack-batteries-included-preprocessor`

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,3 +1,3 @@
 # Bump this version to force CI to re-create the cache from scratch.
 
-4-29-2025
+5-12-2025

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -38,7 +38,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'update-trash'
+        - 'feat/add_webpack_bundle_analyzer'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -49,7 +49,7 @@ macWorkflowFilters: &darwin-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'update-trash', << pipeline.git.branch >> ]
+      - equal: [ 'feat/add_webpack_bundle_analyzer', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -60,7 +60,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'update-trash', << pipeline.git.branch >> ]
+      - equal: [ 'feat/add_webpack_bundle_analyzer', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -83,7 +83,7 @@ windowsWorkflowFilters: &windows-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'chore/fix_reporter_app_cy_in_cy_flake', << pipeline.git.branch >> ]
+      - equal: [ 'feat/add_webpack_bundle_analyzer', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -157,7 +157,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "update-trash" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "feat/add_webpack_bundle_analyzer" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,12 +1,15 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 14.3.4
+## 14.4.0
 
 _Released 5/20/2025 (PENDING)_
+
+**Features:**
+
+- `@cypress/webpack-dev-server` and `@cypress/webpack-batteries-included-preprocessor` now ship with [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) as a diagnostic tool to determine bundle statistics, which can be enabled via `DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer` ( component tests using webpack) or `DEBUG=cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer` (e2e tests using webpack, which is the default preprocessor), respectively. Addresses [#30461](https://github.com/cypress-io/cypress/issues/30461).
 
 **Dependency Updates:**
 
 - Upgraded `trash` from `5.2.0` to `7.2.0`. Addressed in [#31667](https://github.com/cypress-io/cypress/pull/31667).
-
 
 ## 14.3.3
 

--- a/npm/webpack-batteries-included-preprocessor/README.md
+++ b/npm/webpack-batteries-included-preprocessor/README.md
@@ -46,6 +46,10 @@ module.exports = (on) => {
 
 Other than the `typescript` option, this preprocessor supports the same options as [@cypress/webpack-preprocessor](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor#readme), so see its [README](https://github.com/cypress-io/cypress/tree/develop/npm/webpack-preprocessor#readme) for more information.
 
+## Debugging
+
+If having issues with chunk load errors or bundle size problems, specifically in your end-to-end tests, please try setting `DEBUG=cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer` before starting Cypress to get a `webpack-bundle-analyzer` report to help determine the cause of the issue. If filing an issue with Cypress, please include this report with your issue to better help us serve your issue.
+
 ## Contributing
 
 Use the [version of Node that matches Cypress](https://github.com/cypress-io/cypress/blob/develop/.node-version).

--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -2,8 +2,10 @@ const path = require('path')
 const webpack = require('webpack')
 const Debug = require('debug')
 const webpackPreprocessor = require('@cypress/webpack-preprocessor')
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 const debug = Debug('cypress:webpack-batteries-included-preprocessor')
+const WBADebugNamespace = 'cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer'
 
 const hasTsLoader = (rules) => {
   return rules.some((rule) => {
@@ -136,6 +138,10 @@ const getDefaultWebpackOptions = () => {
         // @see https://github.com/cypress-io/cypress/issues/27947.
         process: require.resolve('process/browser.js'),
       }),
+      // If the user is trying to debug their bundle, we'll add the BundleAnalyzerPlugin
+      // to see the size of the support file (first bundle when running `cypress open`)
+      // and spec files (subsequent bundles when running `cypress open`)
+      ...(Debug.enabled(WBADebugNamespace) ? [new BundleAnalyzerPlugin()] : []),
     ],
     resolve: {
       extensions: ['.js', '.json', '.jsx', '.mjs', '.coffee'],

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -44,7 +44,8 @@
     "url": "^0.11.1",
     "util": "^0.12.5",
     "vm-browserify": "^1.1.2",
-    "webpack": "^5.88.2"
+    "webpack": "^5.88.2",
+    "webpack-bundle-analyzer": "4.10.2"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "0.0.0-development",

--- a/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
+++ b/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 const decache = require('decache')
 const mock = require('mock-require')
 const sinon = require('sinon')
+const Debug = require('debug')
 
 describe('webpack-batteries-included-preprocessor', () => {
   beforeEach(() => {
@@ -28,6 +29,20 @@ describe('webpack-batteries-included-preprocessor', () => {
 
       expect(result.module.rules).to.have.length(4)
       expect(result.module.rules[3].use[0].loader).to.include('ts-loader')
+    })
+
+    it('adds the BundleAnalyzerPlugin if the user is trying to debug their bundle', () => {
+      Debug.enable('cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer')
+
+      // since debug needs to be hydrated before requiring the preprocessor, we need to decache
+      // and require again
+      decache('../../index')
+      preprocessor = require('../../index')
+      const result = preprocessor.getFullWebpackOptions('file/path', 'typescript/path')
+
+      expect(result.plugins).to.have.length(2)
+      expect(result.plugins[1].constructor.name).to.equal('BundleAnalyzerPlugin')
+      Debug.disable()
     })
   })
 

--- a/npm/webpack-dev-server/README.md
+++ b/npm/webpack-dev-server/README.md
@@ -39,6 +39,10 @@ export default defineConfig({
 })
 ```
 
+## Debugging
+
+If having issues with chunk load errors or bundle size problems, specifically in your component tests, please try setting `DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer` before starting Cypress to get a `webpack-bundle-analyzer` report to help determine the cause of the issue. If filing an issue with Cypress, please include this report with your issue to better help us serve your issue.
+
 ## Testing
 
 Unit tests can be run with `yarn test`. Integration tests can be run with `yarn cypress:run`

--- a/npm/webpack-dev-server/package.json
+++ b/npm/webpack-dev-server/package.json
@@ -25,6 +25,7 @@
     "semver": "^7.7.1",
     "speed-measure-webpack-plugin": "1.4.2",
     "tslib": "^2.3.1",
+    "webpack-bundle-analyzer": "4.10.2",
     "webpack-dev-server": "^5.1.0",
     "webpack-merge": "^5.4.0"
   },
@@ -32,6 +33,7 @@
     "@types/node": "20.16.0",
     "@types/proxyquire": "^1.3.28",
     "@types/speed-measure-webpack-plugin": "^1.3.4",
+    "@types/webpack-bundle-analyzer": "4.7.0",
     "chai": "^4.3.6",
     "dedent": "^0.7.0",
     "mocha": "^9.2.2",

--- a/npm/webpack-dev-server/src/createWebpackDevServer.ts
+++ b/npm/webpack-dev-server/src/createWebpackDevServer.ts
@@ -4,6 +4,7 @@ import type { Configuration as WebpackDevServer4Configuration } from 'webpack-de
 import type { WebpackDevServerConfig } from './devServer'
 import type { SourceRelativeWebpackResult } from './helpers/sourceRelativeWebpackModules'
 import { makeWebpackConfig } from './makeWebpackConfig'
+import { isWebpackBundleAnalyzerEnabled } from './util'
 
 const debug = debugLib('cypress:webpack-dev-server:start')
 
@@ -76,6 +77,10 @@ function webpackDevServer5 (
     devMiddleware: {
       publicPath: devServerPublicPathRoute,
       stats: finalWebpackConfig.stats ?? 'minimal',
+      ...(isWebpackBundleAnalyzerEnabled() ? {
+        // the bundle needs to be written to disk in order to determine source map sizes
+        writeToDisk: true,
+      } : {}),
     },
     hot: false,
     // Only enable file watching & reload when executing tests in `open` mode
@@ -111,6 +116,10 @@ function webpackDevServer4 (
     devMiddleware: {
       publicPath: devServerPublicPathRoute,
       stats: finalWebpackConfig.stats ?? 'minimal',
+      ...(isWebpackBundleAnalyzerEnabled() ? {
+        // the bundle needs to be written to disk in order to determine source map sizes
+        writeToDisk: true,
+      } : {}),
     },
     hot: false,
     // Only enable file watching & reload when executing tests in `open` mode

--- a/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
+++ b/npm/webpack-dev-server/src/makeDefaultWebpackConfig.ts
@@ -3,6 +3,8 @@ import debugLib from 'debug'
 import type { Configuration } from 'webpack'
 import type { CreateFinalWebpackConfig } from './createWebpackDevServer'
 import { CypressCTWebpackPlugin } from './CypressCTWebpackPlugin'
+import { isWebpackBundleAnalyzerEnabled, WBADebugNamespace } from './util'
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 
 const debug = debugLib('cypress:webpack-dev-server:makeDefaultWebpackConfig')
 
@@ -95,9 +97,14 @@ export function makeCypressWebpackConfig (
         webpack,
         indexHtmlFile,
       }),
+      ...(isWebpackBundleAnalyzerEnabled() ? [new BundleAnalyzerPlugin()] : []),
     ],
     devtool: 'inline-source-map',
   } as any
+
+  if (isWebpackBundleAnalyzerEnabled()) {
+    debugLib(WBADebugNamespace)('webpack-bundle-analyzer is enabled.')
+  }
 
   if (isRunMode) {
     // if justInTimeCompile is configured, we need to watch for file changes as the spec entries are going to be updated per test

--- a/npm/webpack-dev-server/src/util.ts
+++ b/npm/webpack-dev-server/src/util.ts
@@ -1,0 +1,7 @@
+import debug from 'debug'
+
+export const WBADebugNamespace = 'cypress-verbose:webpack-dev-server:bundle-analyzer'
+
+export const isWebpackBundleAnalyzerEnabled = () => {
+  return debug.enabled(WBADebugNamespace)
+}

--- a/npm/webpack-dev-server/test/devServer-unit.spec.ts
+++ b/npm/webpack-dev-server/test/devServer-unit.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 
 import { createModuleMatrixResult } from './test-helpers/createModuleMatrixResult'
 import EventEmitter from 'events'
+import debug from 'debug'
 
 const cypressConfig = {
   projectRoot: path.join(__dirname, 'test-fixtures'),
@@ -78,5 +79,45 @@ describe('devServer', function () {
 
     expect(result.server).to.be.instanceOf(require('webpack-dev-server'))
     expect(result.version).to.eq(5)
+  })
+
+  // Writing to disk includes the correct source map size, where the difference wil lbe made up from stat size vs parsed size
+  // This is critical if a user is trying to debug to determine if they have large source maps or other large files in their dev-server under test
+  describe('writes to disk if DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer is set', async () => {
+    const WEBPACK_DEV_SERVER_VERSIONS: (4 | 5)[] = [4, 5]
+
+    beforeEach(() => {
+      debug.enable('cypress-verbose:webpack-dev-server:bundle-analyzer')
+    })
+
+    afterEach(() => {
+      debug.disable()
+    })
+
+    WEBPACK_DEV_SERVER_VERSIONS.forEach((version) => {
+      it(`works for webpack-dev-server v${version}`, async () => {
+        const { devServer } = proxyquire('../src/devServer', {
+          './helpers/sourceRelativeWebpackModules': {
+            sourceDefaultWebpackDependencies: () => {
+              // using webpack version to wds version as it really doesn't matter much when testing here.
+              // webpack config is tested separately in makeWebpackConfig tests
+              return createModuleMatrixResult({
+                webpack: version,
+                webpackDevServer: version,
+              })
+            } },
+        }) as typeof import('../src/devServer')
+
+        const result = await devServer.create({
+          specs: [],
+          cypressConfig,
+          webpackConfig: {},
+          devServerEvents: new EventEmitter(),
+        })
+
+        // @ts-expect-error
+        expect(result.server.options.devMiddleware.writeToDisk).to.be.true
+      })
+    })
   })
 })

--- a/npm/webpack-dev-server/test/devServer-unit.spec.ts
+++ b/npm/webpack-dev-server/test/devServer-unit.spec.ts
@@ -81,7 +81,7 @@ describe('devServer', function () {
     expect(result.version).to.eq(5)
   })
 
-  // Writing to disk includes the correct source map size, where the difference wil lbe made up from stat size vs parsed size
+  // Writing to disk includes the correct source map size, where the difference will be made up from stat size vs parsed size
   // This is critical if a user is trying to debug to determine if they have large source maps or other large files in their dev-server under test
   describe('writes to disk if DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer is set', async () => {
     const WEBPACK_DEV_SERVER_VERSIONS: (4 | 5)[] = [4, 5]

--- a/npm/webpack-dev-server/test/makeWebpackConfig.spec.ts
+++ b/npm/webpack-dev-server/test/makeWebpackConfig.spec.ts
@@ -1,6 +1,8 @@
 import Chai, { expect } from 'chai'
 import EventEmitter from 'events'
 import snapshot from 'snap-shot-it'
+import path from 'path'
+import debug from 'debug'
 import { IgnorePlugin } from 'webpack'
 import { WebpackDevServerConfig } from '../src/devServer'
 import { CYPRESS_WEBPACK_ENTRYPOINT, makeWebpackConfig } from '../src/makeWebpackConfig'
@@ -8,7 +10,7 @@ import { createModuleMatrixResult } from './test-helpers/createModuleMatrixResul
 import sinon from 'sinon'
 import SinonChai from 'sinon-chai'
 import type { SourceRelativeWebpackResult } from '../src/helpers/sourceRelativeWebpackModules'
-import path from 'path'
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 
 Chai.use(SinonChai)
 
@@ -448,6 +450,46 @@ describe('makeWebpackConfig', () => {
             expect(actual.watchOptions?.ignored).to.deep.equal(/node_modules/)
           })
         })
+      })
+    })
+  })
+
+  // Gives users a diagnostic output with webpack-bundle-analyzer to get a visible representation of their webpack bundle, which they can send to us
+  // to give us an idea what issues they may be experiencing
+  describe('enables webpack-bundle-analyzer if DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer is set', async () => {
+    const WEBPACK_VERSIONS: (4 | 5)[] = [4, 5]
+
+    beforeEach(() => {
+      debug.enable('cypress-verbose:webpack-dev-server:bundle-analyzer')
+    })
+
+    afterEach(() => {
+      debug.disable()
+    })
+
+    WEBPACK_VERSIONS.forEach((version) => {
+      it(`works for webpack v${version}`, async () => {
+        const actual = await makeWebpackConfig({
+          devServerConfig: {
+            specs: [],
+            cypressConfig: {
+              projectRoot: '.',
+              devServerPublicPathRoute: '/test-public-path',
+              baseUrl: null,
+            } as Cypress.PluginConfigOptions,
+            webpackConfig: {
+              entry: { main: 'src/index.js' },
+            },
+            devServerEvents: new EventEmitter(),
+          },
+          sourceWebpackModulesResult: createModuleMatrixResult({
+            webpack: version,
+            webpackDevServer: version,
+          }),
+        })
+
+        expect(actual.plugins).to.have.length(3)
+        expect(actual.plugins[2]).to.be.instanceOf(BundleAnalyzerPlugin)
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,7 +2929,7 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@discoveryjs/json-ext@^0.5.0":
+"@discoveryjs/json-ext@0.5.7", "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
@@ -8577,6 +8577,15 @@
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
   integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
+"@types/webpack-bundle-analyzer@4.7.0":
+  version "4.7.0"
+  resolved "https://registry.npmjs.org/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz#fe199e724ce3d38705f6f1ba4d62429b7c360541"
+  integrity sha512-c5i2ThslSNSG8W891BRvOd/RoCjI2zwph8maD22b1adtSns20j+0azDDMCK06DiVrzTgnwiDl5Ntmu1YRJw8Sg==
+  dependencies:
+    "@types/node" "*"
+    tapable "^2.2.0"
+    webpack "^5"
+
 "@types/webpack-sources@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
@@ -9763,10 +9772,12 @@ acorn-walk@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.1.1, acorn-walk@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+acorn-walk@^8.0.0, acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+  version "8.3.4"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
 
 acorn@^6.4.1:
   version "6.4.2"
@@ -9778,7 +9789,7 @@ acorn@^7.0.0, acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.11.3, acorn@^8.12.1, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^8.0.4, acorn@^8.11.0, acorn@^8.11.3, acorn@^8.12.1, acorn@^8.14.0, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.14.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
@@ -13880,7 +13891,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
-debounce@^1.2.0:
+debounce@^1.2.0, debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -14769,7 +14780,7 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -18377,6 +18388,13 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -18689,6 +18707,11 @@ html-entities@^2.3.2, html-entities@^2.4.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.5.2.tgz#201a3cf95d3a15be7099521620d19dfb4f65359f"
   integrity sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==
+
+html-escaper@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-minifier-terser@^5.0.1:
   version "5.1.1"
@@ -24528,7 +24551,7 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-opener@^1.4.1, opener@^1.4.2, opener@^1.5.1:
+opener@^1.4.1, opener@^1.4.2, opener@^1.5.1, opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
@@ -28614,7 +28637,7 @@ sinon@^10.0.0:
     nise "^4.1.0"
     supports-color "^7.1.0"
 
-sirv@^2.0.4:
+sirv@^2.0.3, sirv@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
   integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
@@ -32259,6 +32282,24 @@ webidl-conversions@^7.0.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
+webpack-bundle-analyzer@4.10.2:
+  version "4.10.2"
+  resolved "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz#633af2862c213730be3dbdf40456db171b60d5bd"
+  integrity sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==
+  dependencies:
+    "@discoveryjs/json-ext" "0.5.7"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    commander "^7.2.0"
+    debounce "^1.2.1"
+    escape-string-regexp "^4.0.0"
+    gzip-size "^6.0.0"
+    html-escaper "^2.0.2"
+    opener "^1.5.2"
+    picocolors "^1.0.0"
+    sirv "^2.0.3"
+    ws "^7.3.1"
+
 webpack-cli@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
@@ -32850,10 +32891,10 @@ ws@8.2.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.2.tgz#ca684330c6dd6076a737250ed81ac1606cb0a63e"
   integrity sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==
 
-"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.2.0:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
-  integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.2.0, ws@^7.3.1:
+  version "7.5.10"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.0.0, ws@^8.13.0, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0:
   version "8.18.0"


### PR DESCRIPTION
to help better diagnose build issues for cypress users

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #30461

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There are still come comments funneling in on https://github.com/cypress-io/cypress/issues/28644 where `cypress-support-file` fails with a chunk load error during component testing. This is usually due to the support file being quite large, sometimes having a large inline source map in the bundle. This change is to help diagnose what is going on in the end user's bundle without having them need to set up a customer `webpack-bundle-analyzer` to see what is going on.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

enable the feature via setting the `cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer` when running e2e tests and  and `cypress-verbose:webpack-dev-server:bundle-analyzer` when running CT tests.

The bundle analyzer should host a visual representation of the bundle on port `8888`

#### Example when running e2e
<img width="1728" alt="Screenshot 2025-05-01 at 2 58 53 PM" src="https://github.com/user-attachments/assets/1cda075b-4d8c-4353-bd8c-a310c6e5733e" />

#### Example when running ct
<img width="1728" alt="Screenshot 2025-05-01 at 2 13 04 PM" src="https://github.com/user-attachments/assets/8a1c35fe-bdf4-411e-9f6e-e6d92fc89029" />


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
