### PR TITLE
perf: ensure the pausing event listeners are removed

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 5/6/2025 (PENDING)_
 
+**Performance:**
+
+- Ensure the previous pausing event handlers are removed before new ones are added. Addressed in [#31596](https://github.com/cypress-io/cypress/pull/31596).
+
 **Misc:**
 
 - The URL in the Cypress App no longer displays a white background when the URL is loading. Fixes [#31556](https://github.com/cypress-io/cypress/issues/31556).

--- a/packages/app/src/runner/events/capture-protocol.ts
+++ b/packages/app/src/runner/events/capture-protocol.ts
@@ -75,7 +75,6 @@ export const addCaptureProtocolListeners = (Cypress: Cypress.Cypress) => {
   }
 
   Cypress.on('viewport:changed', viewportChangedHandler)
-  // @ts-expect-error
   Cypress.primaryOriginCommunicator.on('viewport:changed', viewportChangedHandler)
 
   Cypress.on('test:before:run:async', async (attributes) => {

--- a/packages/app/src/runner/events/pausing.ts
+++ b/packages/app/src/runner/events/pausing.ts
@@ -9,13 +9,7 @@ let sendEventsToOrigin: string | null = null
 type GetCypressFunction = () => any
 
 class PauseHandlers {
-  private getCypress: GetCypressFunction
-  private reporterBus: EventEmitter
-
-  constructor (getCypress: GetCypressFunction, reporterBus: EventEmitter) {
-    this.getCypress = getCypress
-    this.reporterBus = reporterBus
-  }
+  constructor (private getCypress: GetCypressFunction, private reporterBus: EventEmitter) {}
 
   nextHandler = () => {
     const Cypress = this.getCypress()

--- a/packages/app/src/runner/events/pausing.ts
+++ b/packages/app/src/runner/events/pausing.ts
@@ -1,12 +1,12 @@
 // tracks whether the cy.pause() was called from the primary driver
 // (value === null) or from a cross-origin spec bridge (value is the origin
 
-import EventEmitter from 'events'
+import type EventEmitter from 'events'
 
 // matching that spec bridge)
 let sendEventsToOrigin: string | null = null
 
-type GetCypressFunction = () => any
+type GetCypressFunction = () => Cypress.Cypress
 
 class PauseHandlers {
   constructor (private getCypress: GetCypressFunction, private reporterBus: EventEmitter) {}

--- a/packages/app/src/runner/events/pausing.ts
+++ b/packages/app/src/runner/events/pausing.ts
@@ -1,12 +1,24 @@
-export const handlePausing = (getCypress, reporterBus) => {
-  const Cypress = getCypress()
-  // tracks whether the cy.pause() was called from the primary driver
-  // (value === null) or from a cross-origin spec bridge (value is the origin
-  // matching that spec bridge)
-  let sendEventsToOrigin = null
+// tracks whether the cy.pause() was called from the primary driver
+// (value === null) or from a cross-origin spec bridge (value is the origin
 
-  reporterBus.on('runner:next', () => {
-    const Cypress = getCypress()
+import EventEmitter from 'events'
+
+// matching that spec bridge)
+let sendEventsToOrigin: string | null = null
+
+type GetCypressFunction = () => any
+
+class PauseHandlers {
+  private getCypress: GetCypressFunction
+  private reporterBus: EventEmitter
+
+  constructor (getCypress: GetCypressFunction, reporterBus: EventEmitter) {
+    this.getCypress = getCypress
+    this.reporterBus = reporterBus
+  }
+
+  nextHandler = () => {
+    const Cypress = this.getCypress()
 
     if (!Cypress) return
 
@@ -17,10 +29,10 @@ export const handlePausing = (getCypress, reporterBus) => {
     } else {
       Cypress.emit('resume:next')
     }
-  })
+  }
 
-  reporterBus.on('runner:resume', () => {
-    const Cypress = getCypress()
+  resumeHandler = () => {
+    const Cypress = this.getCypress()
 
     if (!Cypress) return
 
@@ -34,17 +46,45 @@ export const handlePausing = (getCypress, reporterBus) => {
 
     // pause sequence is over - reset this for subsequent pauses
     sendEventsToOrigin = null
-  })
+  }
 
-  // from the primary driver
-  Cypress.on('paused', (nextCommandName) => {
-    reporterBus.emit('paused', nextCommandName)
-  })
+  pausedHandler = (nextCommandName: string) => {
+    this.reporterBus.emit('paused', nextCommandName)
+  }
 
-  // from a cross-origin spec bridge
-  Cypress.primaryOriginCommunicator.on('paused', ({ nextCommandName, origin }) => {
+  crossOriginPausedHandler = ({ nextCommandName, origin }: { nextCommandName: string, origin: string }) => {
     sendEventsToOrigin = origin
+    this.reporterBus.emit('paused', nextCommandName)
+  }
 
-    reporterBus.emit('paused', nextCommandName)
-  })
+  removeListeners = () => {
+    const Cypress = this.getCypress()
+
+    this.reporterBus.removeListener('runner:next', this.nextHandler)
+    this.reporterBus.removeListener('runner:resume', this.resumeHandler)
+    Cypress.removeListener('paused', this.pausedHandler)
+    Cypress.primaryOriginCommunicator.removeListener('paused', this.crossOriginPausedHandler)
+  }
+
+  addListeners = () => {
+    const Cypress = this.getCypress()
+
+    this.reporterBus.on('runner:next', this.nextHandler)
+    this.reporterBus.on('runner:resume', this.resumeHandler)
+    Cypress.on('paused', this.pausedHandler)
+    Cypress.primaryOriginCommunicator.on('paused', this.crossOriginPausedHandler)
+  }
+}
+
+let currentHandlers: PauseHandlers | null = null
+
+export const handlePausing = (getCypress: GetCypressFunction, reporterBus: EventEmitter) => {
+  // Remove existing handlers if they exist
+  if (currentHandlers) {
+    currentHandlers.removeListeners()
+  }
+
+  // Create new handlers
+  currentHandlers = new PauseHandlers(getCypress, reporterBus)
+  currentHandlers.addListeners()
 }

--- a/packages/driver/types/internal-types-lite.d.ts
+++ b/packages/driver/types/internal-types-lite.d.ts
@@ -7,6 +7,13 @@ declare namespace Cypress {
   interface Cypress {
     runner: any
     state: State
+    emit: import('eventemitter2').EventEmitter2['emit']
+    removeListener: import('eventemitter2').EventEmitter2['removeListener']
+    primaryOriginCommunicator: {
+      toSpecBridge: (origin: string, event: string, data?: any, responseEvent?: string) => void
+      on: import('eventemitter2').EventEmitter2['on']
+      removeListener: import('eventemitter2').EventEmitter2['removeListener']
+    }
   }
 
   interface Actions {
@@ -23,6 +30,7 @@ declare namespace Cypress {
     (action: 'test:after:run:async', fn: (attributes: ObjectLike, test: Mocha.Test) => void)
     (action: 'cy:protocol-snapshot', fn: () => void)
     (action: 'test:before:after:run:async', fn: (attributes: ObjectLike, test: Mocha.Test, options: ObjectLike) => void | Promise<any>): Cypress
+    (action: 'paused', fn: (nextCommandName: string) => void)
   }
 
   interface Backend {

--- a/packages/driver/types/internal-types-lite.d.ts
+++ b/packages/driver/types/internal-types-lite.d.ts
@@ -9,10 +9,9 @@ declare namespace Cypress {
     state: State
     emit: import('eventemitter2').EventEmitter2['emit']
     removeListener: import('eventemitter2').EventEmitter2['removeListener']
-    primaryOriginCommunicator: {
+    primaryOriginCommunicator: import('eventemitter2').EventEmitter2 & {
       toSpecBridge: (origin: string, event: string, data?: any, responseEvent?: string) => void
-      on: import('eventemitter2').EventEmitter2['on']
-      removeListener: import('eventemitter2').EventEmitter2['removeListener']
+      userInvocationStack?: string
     }
   }
 

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -51,10 +51,7 @@ declare namespace Cypress {
     }
     sinon: sinon.SinonApi
     utils: CypressUtils
-    state: State
     events: Events
-    emit: (event: string, payload?: any) => void
-    primaryOriginCommunicator: import('../src/cross-origin/communicator').PrimaryOriginCommunicator
     specBridgeCommunicator: import('../src/cross-origin/communicator').SpecBridgeCommunicator
     mocha: $Mocha
     configure: (config: Cypress.ObjectLike) => void
@@ -97,7 +94,6 @@ declare namespace Cypress {
     (action: 'before:stability:release', fn: () => void)
     (action: '_log:added', fn: (attributes: ObjectLike, log: Cypress.Log) => void): Cypress
     (action: '_log:changed', fn: (attributes: ObjectLike, log: Cypress.Log) => void): Cypress
-    (action: 'paused', fn: (nextCommandName: string) => void)
   }
 
   interface Backend {

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -94,6 +94,7 @@ declare namespace Cypress {
     (action: 'before:stability:release', fn: () => void)
     (action: '_log:added', fn: (attributes: ObjectLike, log: Cypress.Log) => void): Cypress
     (action: '_log:changed', fn: (attributes: ObjectLike, log: Cypress.Log) => void): Cypress
+    (action: 'resume:all', fn: () => void)
   }
 
   interface Backend {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
In open mode, when a new spec is run or the existing spec is rerun, we aren't clearing the reporter listeners in `pausing.ts`. Updated `handlePausing()` to ensure the previous event listeners are removed before new ones are added.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
In open mode, rerun a spec more than 10 times and verify the event emitters memory leak message is not received:

```
index-BJMNOmDZ.js:80727 MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 runner:next listeners added. Use emitter.setMaxListeners() to increase limit
    at _addListener (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:80848:18)
    at EventEmitter.addListener (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:80859:12)
    at handlePausing (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:81077:15)
    at EventManager._addListeners (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:86525:5)
    at EventManager.setup (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:86359:10)
    at Object.executeSpec (https://example.cypress.io/__cypress/assets/assets/index-BJMNOmDZ.js:86909:27)
    at async runSpec (https://example.cypress.io/__cypress/assets/assets/Runner-B30ckd2e.js:7914:5)
    at async EventEmitter.<anonymous> (https://example.cypress.io/__cypress/assets/assets/Runner-B30ckd2e.js:7920:9)
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Before (test fails showing we have two listeners attached when there should've only been one):
<img width="1510" alt="Screenshot 2025-04-28 at 9 41 46 AM" src="https://github.com/user-attachments/assets/75d5f13c-d29d-4d1b-ab68-ff147529a622" />

After (test passes showing the correct amount of listeners attached):
<img width="1624" alt="Screenshot 2025-04-28 at 9 51 30 AM" src="https://github.com/user-attachments/assets/9eceebb1-43d0-4bf6-a7dd-95a9067d8cde" />

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
