### PR TITLE
breaking: make the minimum zone.js version in @cypress/angular 0.14.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 07/01/2025 (PENDING)_
 **Breaking Changes:**
 
 - Removed support for Angular 17. The minimum supported version is now `18.0.0`. Addresses [#31303](https://github.com/cypress-io/cypress/issues/31303).
+- `@cypress/angular` now requires a minimum of `zone.js` `0.14.0`. Addresses [#31582](https://github.com/cypress-io/cypress/issues/31582).
 - Removed support for Node.js 18 and Node.js 23. Addresses [#31302](https://github.com/cypress-io/cypress/issues/31302).
 - Removed support for [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol) with the [firefox](https://www.mozilla.org/) browser. Addresses [#31189](https://github.com/cypress-io/cypress/issues/31189).
 - Removed support of the deprecated 3 argument signature of `cy.stub`. Use `cy.stub(object, name).callsFake(fn)` instead. Addresses [#31346](https://github.com/cypress-io/cypress/issues/31346).

--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -26,7 +26,7 @@
     "@angular/core": ">=18.0.0",
     "@angular/platform-browser-dynamic": ">=18.0.0",
     "rxjs": ">=7.5.0",
-    "zone.js": ">=0.13.0"
+    "zone.js": ">=0.14.0"
   },
   "files": [
     "dist"

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -123,12 +123,6 @@ export type MountResponse<T> = {
   component: T
 };
 
-// 'zone.js/testing' is not properly aliasing `it.skip` but it does provide `xit`/`xspecify`
-// Written up under https://github.com/angular/angular/issues/46297 but is not seeing movement
-// so we'll patch here pending a fix in that library
-// @ts-ignore Ignore so that way we can bypass semantic error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
-globalThis.it.skip = globalThis.xit
-
 @Injectable()
 class CypressAngularErrorHandler implements ErrorHandler {
   handleError (error: Error): void {

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -95,7 +95,7 @@
     "vite": "^5.4.18",
     "vitest": "^2.1.8",
     "webpack": "^5.88.2",
-    "zone.js": "0.9.0"
+    "zone.js": "0.15.0"
   },
   "files": [
     "patches"

--- a/yarn.lock
+++ b/yarn.lock
@@ -32645,10 +32645,10 @@ zod@^3.22.5:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.5.tgz#b9b09db03f6700b0d0b75bf0dbf0c5fc46155220"
   integrity sha512-HqnGsCdVZ2xc0qWPLdO25WnseXThh0kEYKIdV5F/hTHO75hNZFp8thxSeHhiPrHZKrFTo1SOgkAj9po5bexZlw==
 
-zone.js@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.9.0.tgz#f42319d657f7616724ed40c5907d4614b4c683fa"
-  integrity sha512-EfygvVnLxPSCMSgJ4h7SoY+XNr7ybdwvvwEQ70lvMFl9coNnciXSyWi8Kg6znK1ubyUSffkCKvleSQpLuUKw0Q==
+zone.js@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.15.0.tgz#4810624e58d6dcf7b8379c1631765589917a0d8f"
+  integrity sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==
 
 zone.js@~0.14.6:
   version "0.14.6"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31582

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Makes the `zone.js` minimum version `0.14.0` in order for Cypress to avoid re-patching `it.skip`, which is fixed in `zone.js` `0.14.0`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
