### PR TITLE
fix: proxy spec flake in firefox due to improper sweeping and correlation

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released 6/17/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue when using `Cypress.stop()` where a run may be aborted prior to receiving the required runner events causing Test Replay to not be available. Addresses [#31781](https://github.com/cypress-io/cypress/issues/31781).
+- Fixed an issue where prerequests with Firefox BiDi were prematurely being removed or matched incorrectly. Addresses [#31482](https://github.com/cypress-io/cypress/issues/31482).
 
 ## 14.4.1
 

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -141,7 +141,7 @@ export class PreRequests {
       const now = Date.now()
 
       this.pendingPreRequests.removeMatching(({ cdpRequestWillBeSentReceivedTimestamp, browserPreRequest }) => {
-        if (cdpRequestWillBeSentReceivedTimestamp + this.sweepInterval < now) {
+        if (cdpRequestWillBeSentReceivedTimestamp !== 0 && (cdpRequestWillBeSentReceivedTimestamp + this.sweepInterval < now)) {
           debugVerbose('timed out unmatched pre-request: %o', browserPreRequest)
           metrics.unmatchedPreRequests++
 

--- a/packages/proxy/test/unit/http/util/prerequests.spec.ts
+++ b/packages/proxy/test/unit/http/util/prerequests.spec.ts
@@ -309,4 +309,20 @@ describe('http/util/prerequests', () => {
     expect(preRequests.pendingPreRequests.length).to.eq(1)
     expect(preRequests.pendingPreRequests.shift('GET-foo|bar')).not.to.be.undefined
   })
+
+  it('does not remove pre-requests when sweeping if cdpRequestWillBeSentReceivedTimestamp is 0', async () => {
+    // set the current time to 1000 ms
+    sinon.stub(Date, 'now').returns(1000)
+
+    // set a sweeper timer of 10 ms
+    preRequests = new PreRequests(10, 10)
+    preRequests.setProtocolManager(protocolManager)
+
+    preRequests.addPending({ requestId: '1234', url: 'foo', method: 'GET', cdpRequestWillBeSentReceivedTimestamp: 0 } as BrowserPreRequest)
+
+    // give the sweeper plenty of time to run. Iur request should still not be removed
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    expect(preRequests.pendingPreRequests.length).to.eq(1)
+  })
 })

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -172,7 +172,7 @@ export class BidiAutomation {
 
     const resourceType = normalizeResourceType(params.request.initiatorType)
 
-    const urlWithoutHash = url.substring(0, url.indexOf('#')) || url
+    const urlWithoutHash = url.includes('#') ? url.substring(0, url.indexOf('#')) : url
 
     const browserPreRequest: BrowserPreRequest = {
       requestId: params.request.request,

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -172,10 +172,13 @@ export class BidiAutomation {
 
     const resourceType = normalizeResourceType(params.request.initiatorType)
 
+    const urlWithoutHash = url.substring(0, url.indexOf('#')) || url
+
     const browserPreRequest: BrowserPreRequest = {
       requestId: params.request.request,
       method: params.request.method,
-      url,
+      // urls coming into the http middleware contain query params, but lack the hash. To get an accurate key to match on the prerequest, we need to remove the hash.
+      url: urlWithoutHash,
       headers: parsedHeaders,
       resourceType,
       originalResourceType: params.request.initiatorType || params.request.destination,

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -641,7 +641,7 @@ export class ProjectBase extends EE {
 
     if (this.browser.family !== 'chromium') {
       // If we're not in chromium, our strategy for correlating service worker prerequests doesn't work in non-chromium browsers (https://github.com/cypress-io/cypress/issues/28079)
-      // in order to not hang for 2 seconds, we override the prerequest timeout to be 500 ms (which is what it has been historically)
+      // in order to not hang for 2 seconds, we override the prerequest timeout to be 500 ms (which is what it has been historically).
       this._server?.setPreRequestTimeout(500)
     }
   }

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -382,6 +382,32 @@ describe('lib/browsers/bidi_automation', () => {
 
           expect(mockAutomationClient.onRemoveBrowserPreRequest).to.have.been.calledWith('request1')
         })
+
+        it('strips hashes out of the url when adding the prerequest', async () => {
+          BidiAutomation.create(mockWebdriverClient, mockAutomationClient)
+
+          mockRequest.request.url = 'https://www.foobar.com?foo=bar#hash'
+
+          mockWebdriverClient.emit('network.beforeRequestSent', mockRequest)
+
+          await flushPromises()
+
+          expect(mockAutomationClient.onBrowserPreRequest).to.have.been.calledWith({
+            requestId: 'request1',
+            method: 'GET',
+            url: 'https://www.foobar.com?foo=bar',
+            resourceType: 'xhr',
+            originalResourceType: 'xmlhttprequest',
+            initiator: {
+              type: 'preflight',
+            },
+            headers: {
+              foo: 'bar',
+            },
+            cdpRequestWillBeSentTimestamp: 0,
+            cdpRequestWillBeSentReceivedTimestamp: 0,
+          })
+        })
       })
 
       describe('responseStarted / responseCompleted', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31482

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

While revisiting the proxy spec issues, I found two issues. One of them addresses the flake.

Since `cdpRequestWillBeSentReceivedTimestamp` is set to zero and the pre request sweeper checks the interval timing, the expression likely always evaluates to true and removes the prerequest when the sweeper runs. The sweeper runs every 10 seconds, which could coincidentally run while the proxy spec is running in the middle of the rest of the system tests. This is why this is hard to reproduce while running a single system test, because most tests run faster than 10 seconds and the cypress server doesn't run for longer than 10 seconds. But with the full test suite going, the sweeper is going to run multiple times. To fix this, we need to check if `cdpRequestWillBeSentReceivedTimestamp` is set. If it isn't, we should just leverage the default sweeper logic.

Another issue I ran into when looking at this prerequest logic is that hashes are not accounted for in the proxied url in the middleware. When we push prerequests into the prerequest map, firefox bidi DOES contain hashes in the url (routes). To fix this, we remove the hash routes before pushing the url into the prerequest map.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
