### PR TITLE
chore: add node 24 base image to binary system tests

### DIFF
--- a/system-tests/test-binary/node_versions_spec.ts
+++ b/system-tests/test-binary/node_versions_spec.ts
@@ -32,6 +32,7 @@ describe('binary node versions', () => {
     'cypress/base:22.0.0',
     'cypress/base:22.7.0',
     'cypress/base:22.12.0',
+    'cypress/base:24.0.0',
   ].forEach(smokeTestDockerImage)
 })
 
@@ -43,6 +44,7 @@ describe('type: module', () => {
     'cypress/base:22.0.0',
     'cypress/base:22.7.0',
     'cypress/base:22.12.0',
+    'cypress/base:24.0.0',
   ].forEach((dockerImage) => {
     systemTests.it(`can run in ${dockerImage}`, {
       withBinary: true,


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31581

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Adds Node 24, which released May 6th, 2025, to Cypress' binary system tests 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
