### PR TITLE
internal: only capture anonymous studio started analytics when cloud studio is disabled

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -431,21 +431,26 @@ export class ProjectBase extends EE {
 
         const studio = await this.ctx.coreData.studioLifecycleManager?.getStudio()
 
-        try {
-          studio?.captureStudioEvent({
-            type: StudioMetricsTypes.STUDIO_STARTED,
-            machineId: await this.ctx.coreData.machineId,
-            projectId: this.cfg.projectId,
-            browser: this.browser ? {
-              name: this.browser.name,
-              family: this.browser.family,
-              channel: this.browser.channel,
-              version: this.browser.version,
-            } : undefined,
-            cypressVersion: pkg.version,
-          })
-        } catch (error) {
-          debug('Error capturing studio event:', error)
+        const isCloudStudio = !!(process.env.CYPRESS_ENABLE_CLOUD_STUDIO || process.env.CYPRESS_LOCAL_STUDIO_PATH)
+
+        // only capture studio started event if the user is accessing legacy studio
+        if (!isCloudStudio) {
+          try {
+            studio?.captureStudioEvent({
+              type: StudioMetricsTypes.STUDIO_STARTED,
+              machineId: await this.ctx.coreData.machineId,
+              projectId: this.cfg.projectId,
+              browser: this.browser ? {
+                name: this.browser.name,
+                family: this.browser.family,
+                channel: this.browser.channel,
+                version: this.browser.version,
+              } : undefined,
+              cypressVersion: pkg.version,
+            })
+          } catch (error) {
+            debug('Error capturing studio event:', error)
+          }
         }
 
         if (this.spec && studio?.protocolManager) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

Follow-up for https://github.com/cypress-io/cypress-services/issues/10501

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We only want to capture the studio started event if the user does **not** have cloud studio enabled.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
