### PR TITLE
misc: Add Cursor IDE to Cypress recognized file editors

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 5/20/2025 (PENDING)_
 
+**Misc:**
+
+- Cursor is now available as an IDE option for opening files in Cypress, if it is installed on your system. Addressed in [#31691](https://github.com/cypress-io/cypress/pull/31691).
+
 **Dependency Updates:**
 
 - Upgraded `trash` from `5.2.0` to `7.2.0`. Addressed in [#31667](https://github.com/cypress-io/cypress/pull/31667).

--- a/packages/frontend-shared/src/gql-components/ChooseExternalEditor.vue
+++ b/packages/frontend-shared/src/gql-components/ChooseExternalEditor.vue
@@ -95,7 +95,7 @@ const icons: Record<string, FunctionalComponent<SVGAttributes, {}>> = {
 const customEditor = { id: 'custom', icon: Terminal, name: 'Custom', binary: 'custom' }
 
 const editorOptions = computed(() => {
-  const editors = props.gql.localSettings.availableEditors?.map((x) => ({ ...x, icon: icons[x.id] })) || []
+  const editors = props.gql.localSettings.availableEditors?.map((x) => ({ ...x, icon: icons[x.id] ?? icons['custom'] })) || []
 
   editors.push(customEditor)
 

--- a/packages/server/lib/util/env-editors.ts
+++ b/packages/server/lib/util/env-editors.ts
@@ -2,6 +2,10 @@ import type { Editor } from '@packages/types'
 
 export const linuxEditors = [
   {
+    id: 'cursor',
+    binary: 'cursor',
+    name: 'Cursor',
+  }, {
     id: 'atom',
     binary: 'atom',
     name: 'Atom',
@@ -54,6 +58,10 @@ export const linuxEditors = [
 
 export const macOSEditors = [
   {
+    id: 'cursor',
+    binary: '/Applications/Cursor.app/Contents/MacOS/Cursor',
+    name: 'Cursor',
+  }, {
     id: 'atom',
     binary: 'atom',
     name: 'Atom',
@@ -130,6 +138,10 @@ export const macOSEditors = [
 
 export const windowsEditors = [
   {
+    id: 'cursor',
+    binary: 'Cursor.exe',
+    name: 'Cursor',
+  }, {
     id: 'brackets',
     binary: 'Brackets.exe',
     name: 'Brackets',


### PR DESCRIPTION
### Additional details

I realized Cypress doesn't look for Cursor IDE when selecting an IDE to open files with - and didn't want to find the Application's install path. So I added Cursor as supported.

I couldn't find a logo for cursor that was within our existing icon dependency, so I just defaulted to a generic icon which I think is better than notthing.

### Steps to test

- With cursor installed, run `yarn cypress:open` with your `preferredEditorBinary` cleared from your `__global__` preferences.

### How has the user experience changed?

#### Before

![Screenshot 2025-05-12 at 3 16 34 PM](https://github.com/user-attachments/assets/0fc68a62-6f98-4223-90a6-0c3726b8ca73)

#### After

![Screenshot 2025-05-12 at 3 59 07 PM](https://github.com/user-attachments/assets/28ff7730-0fa2-4afe-8435-4e7d6e2592bc)


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
