### PR TITLE
fix: Update cy.press signature to be Chainable

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,13 +9,13 @@ _Released 5/20/2025 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue with the experimental usage of WebKit where Cypress incorrectly displayed `0` as the WebKit version. Addresses [#31684](https://github.com/cypress-io/cypress/issues/31684).
 - Fixed an issue where framebusting was occurring when `top.window.location` was being set explicitly. This fix does not require the `experimentalModifyObstructiveThirdPartyCode` configuration option. Addresses [#31687](https://github.com/cypress-io/cypress/issues/31687).
+- `cy.press()` now has a return type of `Chainable<null>` instead of `void` to match the convention of other commands that yield `null`. Addressed in [#31698](https://github.com/cypress-io/cypress/pull/31698).
+- Fixed an issue with the experimental usage of WebKit where Cypress incorrectly displayed `0` as the WebKit version. Addresses [#31684](https://github.com/cypress-io/cypress/issues/31684).
 
 **Misc:**
 
 - Cursor is now available as an IDE option for opening files in Cypress, if it is installed on your system. Addressed in [#31691](https://github.com/cypress-io/cypress/pull/31691).
-- `cy.press()` types now have a return type of `Chainable<null>` instead of `void`. Addressed in [#31698](https://github.com/cypress-io/cypress/pull/31698).
 - The error shown when the `--record` flag is missing has been updated to be shorter. Addressed in [#31676](https://github.com/cypress-io/cypress/pull/31676).
 
 **Dependency Updates:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released 5/20/2025 (PENDING)_
 **Misc:**
 
 - Cursor is now available as an IDE option for opening files in Cypress, if it is installed on your system. Addressed in [#31691](https://github.com/cypress-io/cypress/pull/31691).
+- `cy.press()` types now have a return type of `Chainable<null>` instead of `void`. Addressed in [#31698](https://github.com/cypress-io/cypress/pull/31698).
 
 **Dependency Updates:**
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1755,7 +1755,7 @@ declare namespace Cypress {
      *    cy.press(Cypress.Keyboard.Keys.TAB) // dispatches a keydown and press event to the browser, followed by a keyup event.
      * @see https://on.cypress.io/press
      */
-    press(key: typeof Cypress.Keyboard.Keys[keyof typeof Cypress.Keyboard.Keys], options?: Partial<Loggable & Timeoutable>): void
+    press(key: typeof Cypress.Keyboard.Keys[keyof typeof Cypress.Keyboard.Keys], options?: Partial<Loggable & Timeoutable>): Chainable<null>
 
     /**
      * Get the immediately preceding sibling of each element in a set of the elements.

--- a/packages/driver/src/cy/commands/actions/press.ts
+++ b/packages/driver/src/cy/commands/actions/press.ts
@@ -36,7 +36,7 @@ export default function (Commands: Cypress.Commands, Cypress: Cypress.Cypress, c
 
       // throwErrByPath always throws, but there's no way to indicate that
       // code beyond this point is unreachable to typescript / linters
-      return
+      return null
     }
 
     if (Cypress.browser.family === 'webkit') {
@@ -47,7 +47,7 @@ export default function (Commands: Cypress.Commands, Cypress: Cypress.Cypress, c
         },
       })
 
-      return
+      return null
     }
 
     if (Cypress.browser.name === 'firefox' && Number(Cypress.browser.majorVersion) < 135) {
@@ -71,7 +71,11 @@ export default function (Commands: Cypress.Commands, Cypress: Cypress.Cypress, c
     } catch (err) {
       $errUtils.throwErr(err, { onFail: log })
     }
+
+    return null
   }
 
-  return Commands.add('press', pressCommand)
+  return Commands.addAll({
+    press: pressCommand,
+  })
 }

--- a/packages/driver/test/unit/cy/commands/actions/press.spec.ts
+++ b/packages/driver/test/unit/cy/commands/actions/press.spec.ts
@@ -51,9 +51,9 @@ describe('cy/commands/actions/press', () => {
       },
     }
 
-    // @ts-expect-error - this is a generic mock impl
     Commands = {
-      add: vi.fn(),
+      // @ts-expect-error - this is a generic mock impl
+      addAll: vi.fn(),
     }
 
     // @ts-expect-error
@@ -84,14 +84,14 @@ describe('cy/commands/actions/press', () => {
 
     addCommand(Commands, Cypress, cy, state, config)
 
-    expect(Commands.add).toHaveBeenCalledOnce()
+    expect(Commands.addAll).toHaveBeenCalledOnce()
 
     // @ts-expect-error
-    const [[cmdName, cmd]]: [[string, PressCommand]] = Commands.add.mock.calls
+    const [[obj]]: [[{press: PressCommand}]] = Commands.addAll.mock.calls
 
-    expect(cmdName).toEqual('press')
+    expect(typeof obj.press).toBe('function')
 
-    press = cmd as PressCommand
+    press = obj.press as PressCommand
   })
 
   describe('with a valid key', () => {

--- a/system-tests/projects/cy-press-second-spec-error/cypress/e2e/first_spec.cy.js
+++ b/system-tests/projects/cy-press-second-spec-error/cypress/e2e/first_spec.cy.js
@@ -1,5 +1,7 @@
 describe('this one should pass', () => {
   it('dispatches a key press', () => {
-    cy.press(Cypress.Keyboard.Keys.TAB)
+    cy.press(Cypress.Keyboard.Keys.TAB).then((val) => {
+      expect(val).to.be.null
+    })
   })
 })


### PR DESCRIPTION
Since it's added via `Commands.add`, I believe `cy.press` should have a return type of `Chainable<null>` rather than `void`

### Additional details

### Steps to test

Tests should pass
