### PR TITLE
fix: find webkit version for playwright-webkit@1.52.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ _Released 5/20/2025 (PENDING)_
 
 - `@cypress/webpack-dev-server` and `@cypress/webpack-batteries-included-preprocessor` now ship with [webpack-bundle-analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer) as a diagnostic tool to determine bundle statistics, which can be enabled via `DEBUG=cypress-verbose:webpack-dev-server:bundle-analyzer` ( component tests using webpack) or `DEBUG=cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer` (e2e tests using webpack, which is the default preprocessor), respectively. Addresses [#30461](https://github.com/cypress-io/cypress/issues/30461).
 
+**Bugfixes:**
+
+- Fixed an issue with the experimental usage of WebKit where Cypress incorrectly displayed `0` as the WebKit version. Addresses [#31684](https://github.com/cypress-io/cypress/issues/31684).
+
 **Dependency Updates:**
 
 - Upgraded `trash` from `5.2.0` to `7.2.0`. Addressed in [#31667](https://github.com/cypress-io/cypress/pull/31667).

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -210,7 +210,7 @@ function extendLaunchOptionsFromPlugins (launchOptions, pluginConfigResult, opti
   return launchOptions
 }
 
-const wkBrowserVersionRe = /BROWSER_VERSION = \'(?<version>[^']+)\'/gm
+const wkBrowserVersionRe = /BROWSER_VERSION\s*=\s*(['"])(?<version>[\d.]+)\1/gm
 
 const getWebKitBrowserVersion = async () => {
   try {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/31684

### Additional details

Cypress incorrectly displays  WebKit version `v0` or `0` when WebKit `18.4` is installed from `playwright-webkit@1.52.0`.

The method to determine the version of WebKit installed, is located in [packages/server/lib/browsers/utils.ts](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/utils.ts) and depends on parsing `node_modules/playwright-core/lib/server/webkit/wkBrowser.js` using the RegEx:

https://github.com/cypress-io/cypress/blob/46f2867b9dafbf991bf7154cb181eb07d9c6ad20/packages/server/lib/browsers/utils.ts#L213

In [playwright@1.52.0](https://github.com/microsoft/playwright/releases/tag/v1.52.0) the RegEx no longer finds a match.

Although there has been no change to the source file https://github.com/microsoft/playwright/blob/v1.52.0/packages/playwright-core/src/server/webkit/wkBrowser.ts since Feb 28, 2025, the transpiled JavaScript file `/playwright-core/lib/server/webkit/wkBrowser.js` bundled into the npm package [playwright-core](https://www.npmjs.com/package/playwright-core) shows major differences between `playwright-core@1.51.0` and `playwright-core@1.52.0`, pointing to a major change in Playwright's build process. This can be viewed on https://www.npmjs.com/package/playwright-core?activeTab=code.

The significant change for detecting the WebKit version is the replacement of single quotes with double quotes:

`playwright-core@1.51.0` Line 34 `/playwright-core/lib/server/webkit/wkBrowser.js`
```js
const BROWSER_VERSION = '18.4';
```

changes to:

`playwright-core@1.52.0` Line 43 `/playwright-core/lib/server/webkit/wkBrowser.js`
```js
const BROWSER_VERSION = "18.4";
```

To accommodate this change, the RegEx is changed to

```js
const wkBrowserVersionRe = /BROWSER_VERSION\s*=\s*(['"])(?<version>[\d.]+)\1/gm
```

This searches for matched single or double quotes containing a version number text with digits and period.

#### Restrictions

- Since this solution is based on an undocumented interface, it remains exposed to unexpected future changes in Playwright releases
- The assumption that the file `playwright-core/lib/server/webkit/wkBrowser.js` is located in a `node_modules` directory, only works for package managers such as npm and Yarn Classic. It fails for pnpm and Yarn Modern Plug'n'Play for instance.

### Steps to test

Ubuntu `24.04.2` LTS, Node.js `20.19.1` LTS, Yarn `1.22.22`

```shell
git clone --branch webkit https://github.com/MikeMcC399/github-action
cd github-action
cd examples/webkit
npm ci
npx playwright install-deps webkit
npx cypress run -b webkit # shows current result
cd ../../..
git clone --branch issue-31684-webkit-version-parsing https://github.com/MikeMcC399/cypress
cd cypress
yarn
yarn cypress:run --project ../github-action/examples/webkit -b webkit
yarn cypress:open --project ../github-action/examples/webkit --e2e
```

#### Test with other versions

In a separate terminal window with `cwd` set to `github-action/examples/webkit`, install different versions of WebKit and re-run Cypress tests:

In `github-action`:

```shell
cd examples/webkit
npm install playwright-webkit@1.24.2 -D # or another version from the table below
npx playwright install-deps webkit
npx cypress run -b webkit # using Cypress 14.3.3
```

| `playwright-webkit` version                                            | Ubuntu    | `run` display | `open` display |
| ---------------------------------------------------------------------- | --------- | ------------- | -------------- |
| [1.24.2](https://github.com/microsoft/playwright/releases/tag/v1.24.2) | `22.04.5` | `16.0`        | `v16`          |
| [1.36.2](https://github.com/microsoft/playwright/releases/tag/v1.36.2) | `22.04.5` | `17.0`        | `v17`          |
| [1.45.0](https://github.com/microsoft/playwright/releases/tag/v1.45.0) | `24.04.2` | `17.4`        | `v17`          |
| [1.46.0](https://github.com/microsoft/playwright/releases/tag/v1.46.0) | `24.04.2` | `18.0`        | `v18`          |
| [1.51.1](https://github.com/microsoft/playwright/releases/tag/v1.51.1) | `24.04.2` | `18.4`        | `v18`          |
| [1.52.0](https://github.com/microsoft/playwright/releases/tag/v1.52.0) | `24.04.2` | `18.4`        | `v18`          |

Ubuntu `24.04` requires a minimum version of `playwright@1.45.0`.

### How has the user experience changed?

For `playwright@1.52.0`. the correct WebKit `v18` version will be shown in the Cypress Launchpad (`cypress open`), `WebKit 18` is shown in logs (`cypress run`) and version `18.4` will be returned programmatically.

### PR Tasks

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

#### System test notes

- See also https://github.com/cypress-io/cypress/issues/29954. Cypress is currently configured to test the three year old [playwright-webkit@1.24.2](https://github.com/microsoft/playwright/releases/tag/v1.24.2) and is hindered from updating by https://github.com/cypress-io/cypress/issues/29973. It would be difficult to test [playwright-webkit@1.52.0](https://github.com/microsoft/playwright/releases/tag/v1.52.0) in system / unit tests without addressing these other issues first. Also, as noted above, the currently configured version of [playwright-webkit@1.24.2](https://github.com/microsoft/playwright/releases/tag/v1.24.2) is incompatible with Ubuntu `24.04`.