### PR TITLE
docs: update puppeteer docs to link to docker image examples

### DIFF
--- a/npm/puppeteer/README.md
+++ b/npm/puppeteer/README.md
@@ -46,7 +46,7 @@ Before using `@cypress/puppeteer`, ensure the following requirements are met:
 
 - Cypress 13.6.0+ is required.
 - Only Chromium-based browsers are supported, such as Chrome for Testing, Chromium, and Electron.
-- Chrome-branded browsers (e.g., standard Chrome) are not supported in version 137+ due to Chrome's removal of the `--load-extension` flag. We recommend using Chrome for Testing or Chromium instead. [See download instructions](https://www.chromium.org/getting-involved/download-chromium/).
+- Chrome-branded browsers (e.g., standard Chrome) are not supported in version 137+ due to Chrome's removal of the `--load-extension` flag. We recommend using Chrome for Testing or Chromium instead. See Cypress Docker image examples for [Chrome for Testing](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chrome-for-testing) and [Chromium](https://github.com/cypress-io/cypress-docker-images/tree/master/examples/chromium).
 
 ## Usage
 


### PR DESCRIPTION
Follwup from https://github.com/cypress-io/cypress/pull/31706

### Additional details

The original docs were linking to Chrome's download docs, but I do think we'd want to push people more towards our docker images in this case, so we should link to our examples.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
