### PR TITLE
chore: fix sinon-chai relative path rewrite as it is breaking type checking in the cypress cli externally

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -38,7 +38,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'misc/throw_error_on_extension_chrome_137'
+        - 'misc/chore/fix_sinon_chai_rewrite'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing

--- a/cli/scripts/post-install.js
+++ b/cli/scripts/post-install.js
@@ -71,7 +71,7 @@ makeReferenceTypesCommentRelative('chai', '../chai/index.d.ts', sinonChaiFilenam
 makeReferenceTypesCommentRelative('sinon', '../sinon/index.d.ts', sinonChaiFilename)
 
 // and an import sinon line to be changed to relative path
-shell.sed('-i', 'from \'sinon\';', 'from \'../sinon\';', sinonChaiFilename)
+shell.sed('-i', 'from \"sinon\";', 'from \"../sinon\";', sinonChaiFilename)
 
 // copy experimental network stubbing type definitions
 // so users can import: `import 'cypress/types/net-stubbing'`


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The `sinon-chai` updates in #[31716](https://github.com/cypress-io/cypress/pull/31716) introduced a failure in https://app.circleci.com/pipelines/github/cypress-io/cypress/70732/workflows/85cb0258-851d-40aa-ac39-5e863f6d7caf/jobs/2904496. This had to do with us [rewriting](https://github.com/cypress-io/cypress/blob/develop/cli/scripts/post-install.js#L74) the type imports to be relative imports`in @types/sinon-chai` and a few other type packages in the post install. In `@types/sinon-chai` `3.2.9`, the imports used single quotes, but changed to double quotes in `3.2.10`. This broke the rewrite and it failed silently only until the type checking was performed against the binary in CI.

##### `<=3.2.9`
<img width="203" alt="Screenshot 2025-05-16 at 10 14 40 AM" src="https://github.com/user-attachments/assets/e7ae70c3-2668-4f5a-9939-07fe9f13dff9" />

##### `>=3.2.10`
<img width="203" alt="Screenshot 2025-05-16 at 10 14 32 AM" src="https://github.com/user-attachments/assets/652be635-e7c5-4272-a2ca-8ec038834e33" />

In the future, this likely should be a patch-package instead of a post install script because it will fail loudly and not silently like we saw here.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Failing job in todomvc should now pass

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

`npx tsc` should not fail externally in the binary

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
