### PR TITLE
internal: (studio) skip cancelling studio on watched:file:changed

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -206,7 +206,7 @@ describe('Studio Cloud', () => {
     cy.get('[data-cy="recommendation-editor"]').should('contain', aiOutput)
   })
 
-  it('exits studio mode if the spec is changed on the file system', () => {
+  it('does not exit studio mode if the spec is changed on the file system', () => {
     launchStudio({ enableCloudStudio: true })
 
     cy.findByTestId('studio-panel').should('be.visible')

--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -205,4 +205,26 @@ describe('Studio Cloud', () => {
     // Verify that the AI output is correct
     cy.get('[data-cy="recommendation-editor"]').should('contain', aiOutput)
   })
+
+  it('exits studio mode if the spec is changed on the file system', () => {
+    launchStudio({ enableCloudStudio: true })
+
+    cy.findByTestId('studio-panel').should('be.visible')
+
+    // update the spec on the file system to force a rerun through watched:file:changed
+    cy.withCtx(async (ctx) => {
+      await ctx.actions.file.writeFileInProject('cypress/e2e/spec.cy.js', `
+describe('studio functionality', () => {
+  it('visits a basic html page', () => {
+    // new comment
+    cy.visit('cypress/e2e/index.html')
+  })
+})`)
+    })
+
+    cy.waitForSpecToFinish()
+
+    // verify studio is still open
+    cy.findByTestId('studio-panel').should('be.visible')
+  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/10875

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Skipped calling `studioStore.cancel()` when the cloud studio is requested
* Fixed an issue where `rerun` was getting called twice due to `watched:filed:changed` being listened to twice. Depending on timing, this would lead to weird behavior where logs were duplicated on the reporter (it appeared there were two event managers running)

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
* Verify saving in the cloud studio doesn't cancel studio but still reruns the test
* Verify modifying the spec on the file system doesn't cancel studio but still reruns the test

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

https://github.com/user-attachments/assets/2c5e24cf-261d-4545-ad73-3b53f896a6d1

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
