### PR TITLE
chore(deps): update dependency cypress-example-kitchensink to 5.0.0

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "cross-env": "6.0.3",
-    "cypress-example-kitchensink": "4.0.0",
+    "cypress-example-kitchensink": "5.0.0",
     "gh-pages": "5.0.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13717,10 +13717,10 @@ cypress-each@^1.11.0:
   resolved "https://registry.yarnpkg.com/cypress-each/-/cypress-each-1.11.0.tgz#013c9b43a950f157bcf082d4bd0bb424fb370441"
   integrity sha512-zeqeQkppPL6BKLIJdfR5IUoZRrxRudApJapnFzWCkkrmefQSqdlBma2fzhmniSJ3TRhxe5xpK3W3/l8aCrHvwQ==
 
-cypress-example-kitchensink@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-4.0.0.tgz#a47566a06ef9273c379649406698a5bfa8022311"
-  integrity sha512-Ot0MlAHrtcx3Snd0JHxQFIEOoCgP/MwKflPlTqqqX3JbQOhT0WtS24+iUF/hJplrkOz/2iM17d/rmd+U3f8A2A==
+cypress-example-kitchensink@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-5.0.0.tgz#d3757014cd38c94e1cda0d18d953a19dd4c1d7d5"
+  integrity sha512-/u81WtivUHX9gObcr4Fjj6a0FhJFqIQoN++k2Wqmeo2bVkO7AtOwVFGoy/V0LhY6MsfXXkQ0pklVFhcDLi4yxA==
   dependencies:
     npm-run-all2 "7.0.2"
     serve "14.2.4"


### PR DESCRIPTION
### Additional details

Updates [packages/example/package.json](https://github.com/cypress-io/cypress/blob/develop/packages/example/package.json) from [cypress-example-kitchensink@4.0.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v4.0.0) to [cypress-example-kitchensink@5.0.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v4.1.0).

### Steps to test

```shell
yarn
yarn workspace @packages/example build
```

### How has the user experience changed?

This version change includes minor formatting changes to E2E example tests optionally scaffolded in Cypress after installation by selecting "Scaffold example specs" in `cypress open`.

- See https://github.com/cypress-io/cypress-example-kitchensink/pull/966 for details

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?