### PR TITLE
chore: fix pre-release download for win32-arm64

### DIFF
--- a/cli/lib/tasks/install.js
+++ b/cli/lib/tasks/install.js
@@ -19,7 +19,15 @@ const verbose = require('../VerboseRenderer')
 const { buildInfo, version } = require('../../package.json')
 
 function _getBinaryUrlFromBuildInfo (arch, { commitSha, commitBranch }) {
-  return `https://cdn.cypress.io/beta/binary/${version}/${os.platform()}-${arch}/${commitBranch}-${commitSha}/cypress.zip`
+  const platform = os.platform()
+
+  if ((platform === 'win32') && (arch === 'arm64')) {
+    debug(`detected platform ${platform} architecture ${arch} combination`)
+    arch = 'x64'
+    debug(`overriding to download ${platform}-${arch} pre-release binary instead`)
+  }
+
+  return `https://cdn.cypress.io/beta/binary/${version}/${platform}-${arch}/${commitBranch}-${commitSha}/cypress.zip`
 }
 
 const alreadyInstalledMsg = () => {

--- a/cli/test/lib/tasks/install_spec.js
+++ b/cli/test/lib/tasks/install_spec.js
@@ -502,5 +502,12 @@ describe('/lib/tasks/install', function () {
       expect(install._getBinaryUrlFromBuildInfo('x64', buildInfo))
       .to.eq(`https://cdn.cypress.io/beta/binary/0.0.0-development/linux-x64/aBranchName-abc123/cypress.zip`)
     })
+
+    it('overrides win32-arm64 to win32-x64 for pre-release', () => {
+      os.platform.returns('win32')
+
+      expect(install._getBinaryUrlFromBuildInfo('arm64', buildInfo))
+      .to.eq(`https://cdn.cypress.io/beta/binary/0.0.0-development/win32-x64/aBranchName-abc123/cypress.zip`)
+    })
   })
 })


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/31831

### Additional details

Attempting to install the Cypress binary from the pre-release npm package

https://cdn.cypress.io/beta/npm/14.5.0/win32-x64/develop-ec252f8601d9cec4543085667c7e03ecdab8e82f/cypress.tgz

on the GitHub runner

[windows-11-arm](https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md)

fails with

```text
cypress:cli URL: https://cdn.cypress.io/beta/binary/14.5.0/win32-arm64/develop-ec252f8601d9cec4543085667c7e03ecdab8e82f/cypress.zip
    Error: Failed downloading the Cypress binary.
Response code: 404
Response message: Not Found
```

Cypress does not build for `win32-arm64` and so there is no such binary available.

- PR https://github.com/cypress-io/cypress/pull/31784 already resolved this issue for regular releases.

This PR changes the URL selection for pre-releases of Cypress running on `win32-arm64` to download the corresponding `win32-x64` Cypress binary instead.

### Steps to test

After this PR is merged, [install the generated pre-release package](https://docs.cypress.io/app/references/advanced-installation#Install-pre-release-version) into:

https://github.com/MikeMcC399/cypress-example-kitchensink/tree/use/windows-11-arm-beta

Review the results of workflow:

https://github.com/MikeMcC399/cypress-example-kitchensink/actions/workflows/chrome.yml

### How has the user experience changed?

Users will be able to follow the Cypress documentation instructions [Install pre-release version](https://docs.cypress.io/app/references/advanced-installation#Install-pre-release-version) successfully also on [Windows Arm-based PCs](https://support.microsoft.com/en-us/windows/windows-arm-based-pcs-faq-477f51df-2e3b-f68f-31b0-06f5e4f8ebb5).

### PR Tasks

- [X] Have tests been added/updated?
- [X] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? covered by https://github.com/cypress-io/cypress-documentation/pull/6193
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

cc: @AtofStryker 