### PR TITLE
internal: (studio) do not record events if cloud studio is enabled

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -227,4 +227,35 @@ describe('studio functionality', () => {
     // verify studio is still open
     cy.findByTestId('studio-panel').should('be.visible')
   })
+
+  it('does not record studio commands when cloud studio is enabled', () => {
+    launchStudio({ enableCloudStudio: true })
+
+    cy.findByTestId('studio-panel').should('be.visible')
+
+    // Attempt to perform actions that would normally be recorded in regular studio
+    // but should NOT be recorded in when cloud studio is enabled because event listeners are not attached
+    cy.getAutIframe().within(() => {
+      cy.get('p').contains('Count is 0')
+
+      // Try to click the increment button - this should NOT be recorded
+      // because cloud studio event listeners should not be attached
+      cy.get('#increment').realClick().then(() => {
+        cy.get('p').contains('Count is 1')
+      })
+    })
+
+    // Verify that no legacy studio commands were recorded
+    cy.get('.command-is-studio').should('not.exist')
+
+    // Verify that the actual DOM interactions still work (button was clicked, counter incremented)
+    // but they just weren't recorded by the legacy studio event listeners
+    cy.getAutIframe().within(() => {
+      cy.get('p').should('contain', 'Count is 1')
+    })
+
+    cy.findByTestId('studio-panel').should('be.visible')
+
+    cy.get('[data-cy="studio-toolbar"]').should('not.exist')
+  })
 })

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -269,6 +269,8 @@ useSubscription({ query: StudioStatus_ChangeDocument }, (_, data) => {
 })
 
 const cloudStudioRequested = computed(() => {
+  studioStore.setCloudStudioRequested(props.gql.cloudStudioRequested || false)
+
   return props.gql.cloudStudioRequested
 })
 

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -122,6 +122,7 @@ interface StudioRecorderState {
 
   canAccessStudioAI: boolean
   showUrlPrompt: boolean
+  cloudStudioRequested: boolean
 }
 
 export const useStudioStore = defineStore('studioRecorder', {
@@ -138,10 +139,15 @@ export const useStudioStore = defineStore('studioRecorder', {
       _currentId: 1,
       canAccessStudioAI: false,
       showUrlPrompt: true,
+      cloudStudioRequested: false,
     }
   },
 
   actions: {
+    setCloudStudioRequested (cloudStudioRequested: boolean) {
+      this.cloudStudioRequested = cloudStudioRequested
+    },
+
     setShowUrlPrompt (shouldShowUrlPrompt: boolean) {
       this.showUrlPrompt = shouldShowUrlPrompt
     },
@@ -498,6 +504,11 @@ export const useStudioStore = defineStore('studioRecorder', {
 
       this._body = body
 
+      // if we're in cloud studio, we shouldn't attach our own listeners - cloud studio will handle it
+      if (this.cloudStudioRequested) {
+        return
+      }
+
       for (const event of eventTypes) {
         this._body.addEventListener(event, this._recordEvent, {
           capture: true,
@@ -853,7 +864,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       return $el.hasClass('__cypress-studio-assertions-menu')
     },
 
-    _openAssertionsMenu (event) {
+    _openAssertionsMenu (event, addAssertion?: ($el: HTMLElement | JQuery<HTMLElement>, ...args: AssertionArgs) => void) {
       if (!this._body) {
         throw Error('this._body was not defined')
       }
@@ -874,7 +885,7 @@ export const useStudioStore = defineStore('studioRecorder', {
         $body: window.UnifiedRunner.CypressJQuery(this._body),
         props: {
           possibleAssertions: this._generatePossibleAssertions($el),
-          addAssertion: this._addAssertion,
+          addAssertion: addAssertion || this._addAssertion,
           closeMenu: this._closeAssertionsMenu,
         },
       })

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -864,7 +864,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       return $el.hasClass('__cypress-studio-assertions-menu')
     },
 
-    _openAssertionsMenu (event, addAssertion?: ($el: HTMLElement | JQuery<HTMLElement>, ...args: AssertionArgs) => void) {
+    _openAssertionsMenu (event, addAssertion?: ($el: HTMLElement | JQuery<HTMLElement>, ...args: AssertionArgs) => void, generatePossibleAssertions?: ($el: JQuery<Element>) => PossibleAssertions) {
       if (!this._body) {
         throw Error('this._body was not defined')
       }
@@ -884,7 +884,7 @@ export const useStudioStore = defineStore('studioRecorder', {
         $el,
         $body: window.UnifiedRunner.CypressJQuery(this._body),
         props: {
-          possibleAssertions: this._generatePossibleAssertions($el),
+          possibleAssertions: generatePossibleAssertions ? generatePossibleAssertions($el) : this._generatePossibleAssertions($el),
           addAssertion: addAssertion || this._addAssertion,
           closeMenu: this._closeAssertionsMenu,
         },


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/10896

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

For this ticket, we're moving all of the AUT event listener logic over to the cloud studio side. This PR updates the app so that if we're in cloud studio mode, we don't add the event listeners for current studio, since that would result in duplicate event listeners being added.

See related Cloud PR https://github.com/cypress-io/cypress-services/pull/10939

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Test the cloud PR and make sure that when running with current studio you can still record commands

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Both studio experiences should remain the same from a user's perspective. 

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
