### PR TITLE
chore: update test to ensure button is visible before clicking

### DIFF
--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -564,8 +564,9 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
       })
 
       cy.visitApp('/runs')
+      cy.findByText(defaultMessages.runs.errors.unauthorized.button).should('be.visible')
       cy.findByText(defaultMessages.runs.errors.unauthorized.button).click()
-      cy.findByText(defaultMessages.runs.errors.unauthorizedRequested.button).should('exist')
+      cy.findByText(defaultMessages.runs.errors.unauthorizedRequested.button).should('be.visible')
     })
   })
 


### PR DESCRIPTION
### Additional details

This Test Replay is not showing the element as visible - may be some timing issue because it shouldn't actually click the button, but I want to be able to see this screen and have it processed for UI Cov and a11y views also. 

This PR updates the test to assert it is visible before clicking and also updates an 'exist' assertion to 'be.visible'

- [Original Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/62975/test-results/7a459e11-2433-443b-ada7-5d0c21b5a5a6/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A4455-1367__command-logs&specs=%5B%7B%22label%22%3A%22runs.cy.ts%22%2C%22value%22%3A%22%5B%5C%2255d1a1d2-fee1-42df-90ba-bf28e5f9bcff%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1749582045935.7)

![Screenshot 2025-06-11 at 9 06 26 AM](https://github.com/user-attachments/assets/85a67275-fc79-4fdd-8fc2-f82c20468f2a)

- [New Test Replay](https://cloud.cypress.io/projects/ypt4pf/runs/62978/test-results/250ca039-da62-456c-a997-08da1b7ddf7e/replay?actions=%5B%5D&att=1&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&pc=log-http%3A%2F%2Flocalhost%3A4455-1393__command-logs&specs=%5B%7B%22label%22%3A%22runs.cy.ts%22%2C%22value%22%3A%22%5B%5C%2244c21a42-fabd-4662-a44c-509cd4714ff5%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D&ts=1749648025819.1&utm_source=github)

<img width="1637" alt="Screenshot 2025-06-11 at 9 57 02 AM" src="https://github.com/user-attachments/assets/d3f96008-4671-4f87-b0bd-f14d98cba284" />



### Steps to test

- runs.cy.ts specfile passes and has button visible in Test Replay

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
