### PR TITLE
chore: fix cy.location() not retrying chained `its()` then chained `should()` 

### DIFF
--- a/packages/driver/cypress/e2e/commands/location.cy.js
+++ b/packages/driver/cypress/e2e/commands/location.cy.js
@@ -416,11 +416,15 @@ describe('src/cy/commands/location', () => {
     it('eventually returns a given key', function () {
       cy.stub(Cypress, 'automation').withArgs('get:aut:url')
       .onFirstCall().resolves('http://localhost:3500')
-      .onSecondCall().resolves('http://localhost:3500/my/path')
+      .resolves('http://localhost:3500/my/path')
 
       cy.location('pathname').should('equal', '/my/path')
       .then(() => {
-        expect(Cypress.automation).to.have.been.calledTwice
+        // should be called 3 times:
+        // 1. initial call cy.location('pathname')
+        // 2. the should() assertion
+        // 3. the then() callback
+        expect(Cypress.automation).to.have.been.calledThrice
       })
     })
 

--- a/packages/driver/src/cy/commands/helpers/location.ts
+++ b/packages/driver/src/cy/commands/helpers/location.ts
@@ -59,8 +59,28 @@ export function getUrlFromAutomation (Cypress: Cypress.Cypress, options: Partial
     }
   })
 
-  return () => {
+  return (options: {
+    retryAfterResolve?: boolean
+  } = {
+    retryAfterResolve: false,
+  }) => {
     if (fullUrlObj) {
+      // In some cases, Cypress will want to retry fetching the url object after it is resolved.
+      // For instance, in the case of the command yielding an object, like cy.location().
+
+      // If cy.location().its('url').should('equal', 'https://www.foobar.com') initially fails the 'should' assertion,
+      // Cypress will want to retry fetching the url object as the onFail handler is NOT called when the subject is chained after 'its'.
+
+      // This does NOT apply if the assertion is chained directly after the command, like cy.location().should('equal', 'https://www.foobar.com').
+      // This examples DOES call the onFail handler and fetching the url will be retried from the context of the onFail handler.
+      if (options?.retryAfterResolve) {
+        const resolvedFullUrlObj = fullUrlObj
+
+        fullUrlObj = null
+
+        return resolvedFullUrlObj
+      }
+
       return fullUrlObj
     }
 

--- a/packages/driver/src/cy/commands/helpers/location.ts
+++ b/packages/driver/src/cy/commands/helpers/location.ts
@@ -13,6 +13,7 @@ export function getUrlFromAutomation (Cypress: Cypress.Cypress, options: Partial
   this.set('timeout', timeout)
 
   let fullUrlObj: any = null
+  let hasBeenInitiallyResolved = false
   let automationPromise: Promise<void> | null = null
   // need to set a valid type on this
   let mostRecentError = new UrlNotYetAvailableError()
@@ -21,8 +22,6 @@ export function getUrlFromAutomation (Cypress: Cypress.Cypress, options: Partial
     if (automationPromise) {
       return automationPromise
     }
-
-    fullUrlObj = null
 
     automationPromise = Cypress.automation('get:aut:url', {})
     .timeout(timeout)
@@ -73,13 +72,14 @@ export function getUrlFromAutomation (Cypress: Cypress.Cypress, options: Partial
 
       // This does NOT apply if the assertion is chained directly after the command, like cy.location().should('equal', 'https://www.foobar.com').
       // This examples DOES call the onFail handler and fetching the url will be retried from the context of the onFail handler.
-      if (options?.retryAfterResolve) {
-        const resolvedFullUrlObj = fullUrlObj
-
-        fullUrlObj = null
-
-        return resolvedFullUrlObj
+      if (options?.retryAfterResolve && hasBeenInitiallyResolved) {
+        // tslint:disable-next-line no-floating-promises
+        getUrlFromAutomation()
       }
+
+      // We only want to retry if the url object has been resolved at least once.
+      // Otherwise, this will always fetch n + 1 times which is usually unnecessary.
+      hasBeenInitiallyResolved = true
 
       return fullUrlObj
     }

--- a/packages/driver/src/cy/commands/location.ts
+++ b/packages/driver/src/cy/commands/location.ts
@@ -93,7 +93,7 @@ export function locationQueryCommand (Cypress: Cypress.Cypress, cy: Cypress.Cypr
   const fn = Cypress.isBrowser('webkit') ? cy.getRemoteLocation : getUrlFromAutomation.bind(this)(Cypress, options)
 
   return () => {
-    const location = fn()
+    const location = Cypress.isBrowser('webkit') ? fn() : fn({ retryAfterResolve: true })
 
     if (location === '') {
       // maybe the page's domain is "invisible" to us

--- a/packages/driver/test/unit/cy/commands/helpers/location.spec.ts
+++ b/packages/driver/test/unit/cy/commands/helpers/location.spec.ts
@@ -132,6 +132,66 @@ describe('cy/commands/helpers/location', () => {
         })
       })
 
+      it('retries returning the url object after the automation promise is resolved and { retryAfterResolve: true } is passed', async () => {
+        // @ts-expect-error
+        mockCypress.automation.mockImplementationOnce(() => {
+          // no-op promise to simulate the waiting for the automation client
+          return new Bluebird.Promise((resolve) => resolve('https://www.example.com#foobar'))
+        })
+
+        // @ts-expect-error
+        mockCypress.automation.mockImplementationOnce(() => {
+          // no-op promise to simulate the waiting for the automation client
+          return new Bluebird.Promise((resolve) => resolve('https://www.foobar.com#foobar'))
+        })
+
+        const fn = getUrlFromAutomation.call(mockContext, mockCypress, mockOptions)
+
+        expect(() => {
+          fn({ retryAfterResolve: true })
+        }).toThrow()
+
+        // flush the microtask queue so we have a url value next time we call fn()
+        await flushPromises()
+
+        const url = fn({ retryAfterResolve: true })
+
+        expect(url).toEqual({
+          protocol: 'https:',
+          host: 'www.example.com',
+          hostname: 'www.example.com',
+          hash: '#foobar',
+          search: '',
+          pathname: '/',
+          port: '',
+          origin: 'https://www.example.com',
+          href: 'https://www.example.com/#foobar',
+          searchParams: expect.any(Object),
+        })
+
+        expect(() => {
+          fn({ retryAfterResolve: true })
+        }).toThrow()
+
+        // flush the microtask queue so we have a url value next time we call fn()
+        await flushPromises()
+
+        const url2 = fn({ retryAfterResolve: true })
+
+        expect(url2).toEqual({
+          protocol: 'https:',
+          host: 'www.foobar.com',
+          hostname: 'www.foobar.com',
+          hash: '#foobar',
+          search: '',
+          pathname: '/',
+          port: '',
+          origin: 'https://www.foobar.com',
+          href: 'https://www.foobar.com/#foobar',
+          searchParams: expect.any(Object),
+        })
+      })
+
       it('throws an error when the automation promise is rejected and propagates the error', async () => {
         // @ts-expect-error
         mockCypress.automation.mockImplementation(() => {

--- a/packages/driver/test/unit/cy/commands/helpers/location.spec.ts
+++ b/packages/driver/test/unit/cy/commands/helpers/location.spec.ts
@@ -140,7 +140,7 @@ describe('cy/commands/helpers/location', () => {
         })
 
         // @ts-expect-error
-        mockCypress.automation.mockImplementationOnce(() => {
+        mockCypress.automation.mockImplementation(() => {
           // no-op promise to simulate the waiting for the automation client
           return new Bluebird.Promise((resolve) => resolve('https://www.foobar.com#foobar'))
         })
@@ -170,8 +170,9 @@ describe('cy/commands/helpers/location', () => {
         })
 
         expect(() => {
+          // in this case the fn will returned the cached url object until the new one is available
           fn({ retryAfterResolve: true })
-        }).toThrow()
+        }).not.toThrow()
 
         // flush the microtask queue so we have a url value next time we call fn()
         await flushPromises()

--- a/packages/driver/test/unit/cy/commands/location.spec.ts
+++ b/packages/driver/test/unit/cy/commands/location.spec.ts
@@ -303,6 +303,76 @@ describe('cy/commands/location', () => {
           locationQueryCommand.call(mockContext, mockCypress, mockCy, 'doesnotexist', {})()
         }).toThrow('Location object does not have key: `doesnotexist`')
       })
+
+      it('retries the command even after the location has resolved', () => {
+        // @ts-expect-error
+        getUrlFromAutomation.mockReturnValueOnce((opts) => {
+          expect(opts).toEqual({ retryAfterResolve: true })
+
+          return {
+            protocol: 'https:',
+            host: 'www.example.com',
+            hostname: 'www.example.com',
+            hash: '#foobar',
+            search: '',
+            pathname: '/',
+            port: '',
+            origin: 'https://www.example.com',
+            href: 'https://www.example.com/#foobar',
+            searchParams: expect.any(Object),
+          }
+        })
+
+        // @ts-expect-error
+        getUrlFromAutomation.mockReturnValueOnce((opts) => {
+          expect(opts).toEqual({ retryAfterResolve: true })
+
+          return {
+            protocol: 'https:',
+            host: 'www.foobar.com',
+            hostname: 'www.foobar.com',
+            hash: '#foobar',
+            search: '',
+            pathname: '/',
+            port: '',
+            origin: 'https://www.foobar.com',
+            href: 'https://www.foobar.com/#foobar',
+            searchParams: expect.any(Object),
+          }
+        })
+
+        const urlObj = locationQueryCommand.call(mockContext, mockCypress, mockCy, undefined, {})()
+
+        expect(urlObj).toEqual({
+          protocol: 'https:',
+          host: 'www.example.com',
+          hostname: 'www.example.com',
+          hash: '#foobar',
+          search: '',
+          pathname: '/',
+          port: '',
+          origin: 'https://www.example.com',
+          href: 'https://www.example.com/#foobar',
+          searchParams: expect.any(Object),
+        })
+
+        const urlObj2 = locationQueryCommand.call(mockContext, mockCypress, mockCy, undefined, {})()
+
+        expect(urlObj2).toEqual({
+          protocol: 'https:',
+          host: 'www.foobar.com',
+          hostname: 'www.foobar.com',
+          hash: '#foobar',
+          search: '',
+          pathname: '/',
+          port: '',
+          origin: 'https://www.foobar.com',
+          href: 'https://www.foobar.com/#foobar',
+          searchParams: expect.any(Object),
+        })
+
+        expect(getUrlFromAutomation).toHaveBeenCalledTimes(2)
+      })
     })
 
     describe('webkit', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #31841

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

With the changes to having an async query for `cy.location()`, one of the studio tests was failing due to `cy.location().its('hash').should('contain', 'foo')` was failing. This has to do with the location changing mid navigation, which is accounted for in `cy.location()`m but not in chainers that invoke a retry of the query. This is a problem if `its()` was used as it just grabs the already cached property already and will never update

This change is to make it that the url is refetched if the `cy.location()` query is rerun after fetching the initial value. This way retries off any chainer or even fail handlers are now called to update the object.

This should only be an issue with `cy.location()` from the added commands as it is the only one the yields and object.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Unit tests have been added. I did not add an e2e test for this change as I am thinking its a bit hard to consistenly do deterministically.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Keeps the behavior the same as to what is currently in Cypress 14 to the end user

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
