### PR TITLE
chore: (cy.prompt) refactor getTestsState to take a runnable id

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -995,9 +995,9 @@ describe('src/cy/commands/navigation', () => {
         .withArgs('preserve:run:state')
         .callsFake(fn)
 
-        cy.visit('http://localhost:4200')
-
-        expect(mockGetTestsState).to.be.calledWith('r2')
+        cy.visit('http://localhost:4200').then(() => {
+          expect(mockGetTestsState).to.be.calledWith('r2')
+        })
       })
 
       it('replaces window.location when origins don\'t match', (done) => {
@@ -1028,9 +1028,9 @@ describe('src/cy/commands/navigation', () => {
         .withArgs('preserve:run:state')
         .resolves()
 
-        cy.visit('http://localhost:4200')
-
-        expect(mockGetTestsState).to.be.calledWith('r2')
+        cy.visit('http://localhost:4200').then(() => {
+          expect(mockGetTestsState).to.be.calledWith('r2')
+        })
       })
     })
 

--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -950,11 +950,13 @@ describe('src/cy/commands/navigation', () => {
     })
 
     describe('when origins don\'t match', () => {
+      let mockGetTestsState
+
       beforeEach(() => {
         Cypress.emit('test:before:run', { id: 'r2' })
 
         cy.stub(Cypress.runner, 'getEmissions').returns([])
-        cy.stub(Cypress.runner, 'getTestsState').returns([])
+        mockGetTestsState = cy.stub(Cypress.runner, 'getTestsState').returns([])
         cy.stub(Cypress.runner, 'getStartTime').returns('12345')
         cy.stub(Cypress.Log, 'countLogsByTests').withArgs([]).returns(1)
         cy.stub(Cypress.runner, 'countByTestState')
@@ -994,6 +996,8 @@ describe('src/cy/commands/navigation', () => {
         .callsFake(fn)
 
         cy.visit('http://localhost:4200')
+
+        expect(mockGetTestsState).to.be.calledWith('r2')
       })
 
       it('replaces window.location when origins don\'t match', (done) => {
@@ -1025,6 +1029,8 @@ describe('src/cy/commands/navigation', () => {
         .resolves()
 
         cy.visit('http://localhost:4200')
+
+        expect(mockGetTestsState).to.be.calledWith('r2')
       })
     })
 

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -1074,7 +1074,7 @@ export default (Commands, Cypress, cy, state, config) => {
           // state for like scrollTop
           let runState: RunState = {
             currentId: id,
-            tests: Cypress.runner.getTestsState(),
+            tests: Cypress.runner.getTestsState(id),
             startTime: Cypress.runner.getStartTime(),
             emissions: Cypress.runner.getEmissions(),
           }

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1901,8 +1901,7 @@ export default {
         return _emissions
       },
 
-      getTestsState () {
-        const id = _test != null ? _test.id : undefined
+      getTestsState (id: string) {
         const tests = {}
 
         // bail if we dont have a current test

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1901,7 +1901,8 @@ export default {
         return _emissions
       },
 
-      getTestsState (id: string) {
+      getTestsState (testId?: string) {
+        const id = testId ?? (_test != null ? _test.id : undefined)
         const tests = {}
 
         // bail if we dont have a current test


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This refactor enables a few things we want to do in `cy.prompt`. It should require no functional changes.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
