### PR TITLE
fix: update stop button to immediately update UI

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 14.5.2
+
+_Released 7/15/2025 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed a regression introduced in [`14.5.0`](https://docs.cypress.io/guides/references/changelog#14-5-0) where the Stop button would not immediately stop the spec timer. Addresses [#31920](https://github.com/cypress-io/cypress/issues/31920).
+
 ## 14.5.1
 
 _Released 7/01/2025_

--- a/packages/app/cypress/e2e/runner/runner.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/runner.ui.cy.ts
@@ -289,9 +289,14 @@ describe('src/cypress/runner', () => {
     it('user can stop test execution', () => {
       loadSpec({
         filePath: 'runner/stop-execution.runner.cy.js',
-        passCount: 0,
-        failCount: 1,
       })
+
+      // Click the stop button to stop execution
+      cy.get('.stop').click()
+
+      // Verify the UI updates immediately - stop button disappears, restart appears
+      cy.get('.stop', { timeout: 100 }).should('not.exist')
+      cy.get('.restart', { timeout: 100 }).should('be.visible')
 
       cy.get('.runnable-err-message').should('not.contain', 'ran afterEach even though specs were stopped')
       cy.get('.runnable-err-message').should('contain', 'Cypress test was stopped while running this command.')

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/stop-execution.runner.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/stop-execution.runner.cy.js
@@ -1,10 +1,9 @@
 describe('stop execution', () => {
   it('test stops while running', () => {
-    cy.timeout(200)
+    // ensure the timeout is long enough so we can verify the
+    // UI changes but not too long so we can verify the error message
+    cy.timeout(2000)
     cy.get('.not-exist')
-    setTimeout(() => {
-      cy.$$('button.stop', parent.document).click()
-    }, 100)
   })
 
   afterEach(function () {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/31920

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* When the Stop button is pressed in open mode, we now immediately abort the run (same behavior before https://github.com/cypress-io/cypress/pull/31830 was implemented) to ensure the user is provided immediate feedback by stopping the spec timer and updating the Stop button to a Re-run button. In run mode, we still wait until after the `test:after:run:async` event.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
* Hit the stop button in open mode and verify the spec timer is stopped and the button changes to a re-run button.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
14.4.1:

https://github.com/user-attachments/assets/e3871a65-30a9-4c7e-bca7-068223f3d865

14.5.0:

https://github.com/user-attachments/assets/92142154-b261-4800-aa74-817d85cf190f

After changes:

https://github.com/user-attachments/assets/fd8e039c-4c67-4fa1-9d6b-333146be05b2

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
