### PR TITLE
fix: force CloudRequest to use 443 for https requests

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 7/15/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed a regression introduced in [`14.5.0`](https://docs.cypress.io/guides/references/changelog#14-5-0) where the Stop button would not immediately stop the spec timer. Addresses [#31920](https://github.com/cypress-io/cypress/issues/31920).
+- Fixed an issue with the `CloudRequest` where it used the wrong port for `https` requests. Addressed in [#31992](https://github.com/cypress-io/cypress/pull/31992).
 
 ## 14.5.1
 

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -126,7 +126,7 @@ export const createProxySock = (opts: CreateProxySockOpts, cb: CreateProxySockCb
 
 export const isRequestHttps = (options: http.RequestOptions) => {
   // WSS connections will not have an href, but you can tell protocol from the defaultAgent
-  return _.get(options, '_defaultAgent.protocol') === 'https:' || (options.href || '').slice(0, 6) === 'https:'
+  return _.get(options, '_defaultAgent.protocol') === 'https:' || options.protocol === 'https:' || (options.href || '').slice(0, 6) === 'https:'
 }
 
 export const isResponseStatusCode200 = (head: string) => {
@@ -225,6 +225,11 @@ export class CombinedAgent {
     }
 
     const isHttps = isRequestHttps(options)
+
+    // Ensure that an HTTPS requests are using 443
+    if (isHttps && options.port === 80) {
+      options.port = 443
+    }
 
     if (!options.href) {
       // options.path can contain query parameters, which url.format will not-so-kindly urlencode for us...

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -226,7 +226,7 @@ export class CombinedAgent {
 
     const isHttps = isRequestHttps(options)
 
-    // Ensure that an HTTPS requests are using 443
+    // Ensure that HTTPS requests are using 443
     if (isHttps && options.port === 80) {
       options.port = 443
     }


### PR DESCRIPTION
### Additional details

Based on how the http request is constructed from different libraries like `axios` & `node-fetch`, there are potential cases we've seen where the `CloudRequest` is using port `80` rather than `443`. This adds some additional logic & conditionals in the agent layer to account for these cases.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
