### PR TITLE
fix: (cy.prompt) ensure that we do not attach a vue ref to the react root in the cy.prompt modals

### DIFF
--- a/packages/app/src/prompt/PromptGetCodeModal.vue
+++ b/packages/app/src/prompt/PromptGetCodeModal.vue
@@ -46,11 +46,11 @@ const closeModal = () => {
 const container = ref<HTMLDivElement | null>(null)
 const error = ref<string | null>(null)
 const ReactGetCodeModalContents = ref<GetCodeModalContentsShape | null>(null)
-const reactRoot = ref<Root | null>(null)
+const containerReactRootMap = new WeakMap<HTMLElement, Root>()
 const promptStore = usePromptStore()
 
 const maybeRenderReactComponent = () => {
-  if (!ReactGetCodeModalContents.value || !!error.value) {
+  if (!ReactGetCodeModalContents.value || !!error.value || !container.value) {
     return
   }
 
@@ -63,11 +63,18 @@ const maybeRenderReactComponent = () => {
     },
   })
 
-  if (!reactRoot.value) {
-    reactRoot.value = window.UnifiedRunner.ReactDOM.createRoot(container.value)
+  // Store the react root in a weak map keyed by the container. We do this so that we have a reference
+  // to it that's tied to the container value but absolutely do not want to use vue to do the tracking.
+  // If vue tracks it (e.g. using a ref) it creates proxies that do not play nicely with React in
+  // production
+  let reactRoot = containerReactRootMap.get(container.value)
+
+  if (!reactRoot) {
+    reactRoot = window.UnifiedRunner.ReactDOM.createRoot(container.value) as Root
+    containerReactRootMap.set(container.value, reactRoot)
   }
 
-  reactRoot.value?.render(panel)
+  reactRoot.render(panel)
 }
 
 const unmountReactComponent = () => {
@@ -75,7 +82,13 @@ const unmountReactComponent = () => {
     return
   }
 
-  reactRoot.value?.unmount()
+  const reactRoot = containerReactRootMap.get(container.value)
+
+  if (!reactRoot) {
+    return
+  }
+
+  reactRoot.unmount()
 }
 
 onMounted(maybeRenderReactComponent)

--- a/packages/app/src/prompt/PromptMoreInfoNeededModal.vue
+++ b/packages/app/src/prompt/PromptMoreInfoNeededModal.vue
@@ -46,11 +46,11 @@ const closeModal = () => {
 const container = ref<HTMLDivElement | null>(null)
 const error = ref<string | null>(null)
 const ReactMoreInfoNeededModalContents = ref<MoreInfoNeededModalContentsShape | null>(null)
-const reactRoot = ref<Root | null>(null)
+const containerReactRootMap = new WeakMap<HTMLElement, Root>()
 const promptStore = usePromptStore()
 
 const maybeRenderReactComponent = () => {
-  if (!ReactMoreInfoNeededModalContents.value || !!error.value) {
+  if (!ReactMoreInfoNeededModalContents.value || !!error.value || !container.value) {
     return
   }
 
@@ -65,11 +65,18 @@ const maybeRenderReactComponent = () => {
     },
   })
 
-  if (!reactRoot.value) {
-    reactRoot.value = window.UnifiedRunner.ReactDOM.createRoot(container.value)
+  // Store the react root in a weak map keyed by the container. We do this so that we have a reference
+  // to it that's tied to the container value but absolutely do not want to use vue to do the tracking.
+  // If vue tracks it (e.g. using a ref) it creates proxies that do not play nicely with React in
+  // production
+  let reactRoot = containerReactRootMap.get(container.value)
+
+  if (!reactRoot) {
+    reactRoot = window.UnifiedRunner.ReactDOM.createRoot(container.value) as Root
+    containerReactRootMap.set(container.value, reactRoot)
   }
 
-  reactRoot.value?.render(panel)
+  reactRoot.render(panel)
 }
 
 const unmountReactComponent = () => {
@@ -77,7 +84,13 @@ const unmountReactComponent = () => {
     return
   }
 
-  reactRoot.value?.unmount()
+  const reactRoot = containerReactRootMap.get(container.value)
+
+  if (!reactRoot) {
+    return
+  }
+
+  reactRoot.unmount()
 }
 
 onMounted(maybeRenderReactComponent)

--- a/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
+++ b/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
@@ -12,13 +12,13 @@ describe('src/cy/commands/prompt', () => {
     // TODO: add more tests when cy.prompt is built out, but for now this just
     // verifies that the command executes without throwing an error
     // @ts-expect-error - this will not error when we actually release the experimentalPromptCommand flag
-    cy.prompt('Hello, world!')
+    cy.prompt(['Hello, world!'])
 
     cy.visit('http://www.barbaz.com:3500/fixtures/dom.html')
 
     cy.origin('http://www.barbaz.com:3500', () => {
       // @ts-expect-error - this will not error when we actually release the experimentalPromptCommand flag
-      cy.prompt('Hello, world!')
+      cy.prompt(['Hello, world!'])
     })
   })
 
@@ -37,6 +37,6 @@ describe('src/cy/commands/prompt', () => {
 
     cy.visit('http://www.foobar.com:3500/fixtures/dom.html')
     // @ts-expect-error - this will not error when we actually release the experimentalPromptCommand flag
-    cy.prompt('Hello, world!')
+    cy.prompt(['Hello, world!'])
   })
 })


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Using `vue`'s `ref` creates proxies for observability/reactivity. We were using a ref to track on the React root for the Studio Panel, but unfortunately the proxy that gets created causes issues with React's tracking internals. This was causing all sorts of subtle bugs (in production because of how optimizations occur in production vs. development).

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
