### PR TITLE
internal: (studio) only initialize cloud studio bundle when experimentalStudio is enabled in project config

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -161,7 +161,7 @@ export class ProjectBase extends EE {
 
     this._server = new ServerBase(cfg)
 
-    if (!cfg.isTextTerminal) {
+    if (!cfg.isTextTerminal && cfg.resolved.experimentalStudio?.value) {
       const studioLifecycleManager = new StudioLifecycleManager()
 
       studioLifecycleManager.initializeStudioManager({

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -508,6 +508,52 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
         })
       })
     })
+
+    describe('studio initialization', function () {
+      it('does not create studio lifecycle manager when experimental flag is disabled', async function () {
+        const cfg = {
+          isTextTerminal: false,
+          resolved: {
+            experimentalStudio: {
+              value: false,
+            },
+          },
+          projectId: 'test-project',
+          port: 8080,
+        }
+
+        sinon.stub(this.project, 'initializeConfig').resolves(cfg)
+        sinon.stub(this.project, 'saveState').resolves()
+
+        sinon.stub(process, 'chdir')
+
+        await this.project.open()
+
+        expect(this.project.ctx.coreData.studioLifecycleManager).to.be.undefined
+      })
+
+      it('does not create studio lifecycle manager when in text terminal mode', async function () {
+        const cfg = {
+          isTextTerminal: true,
+          resolved: {
+            experimentalStudio: {
+              value: true,
+            },
+          },
+          projectId: 'test-project',
+          port: 8080,
+        }
+
+        sinon.stub(this.project, 'initializeConfig').resolves(cfg)
+        sinon.stub(this.project, 'saveState').resolves()
+
+        sinon.stub(process, 'chdir')
+
+        await this.project.open()
+
+        expect(this.project.ctx.coreData.studioLifecycleManager).to.be.undefined
+      })
+    })
   })
 
   context('#close', () => {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/11040

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We should only download and try to initialize cloud studio if the project has `experimentalStudio` enabled in its configuration. This prevents unnecessary downloads and potential issues for users who don't have studio enabled.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

You can use debug logs (`DEBUG="cypress:*studio*"`) for studio to determine whether or not the cloud studio bundle is being fetched. Disable `experimentalStudio` in your project and open it in Cypress. Make sure that you don't see logs indicating that cloud studio was initialized.

Also verify that you can update the configuration after opening the project in Cypress and it will download the cloud studio bundle if you go from disabled to enabled

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Users shouldn't notice a change in the experience since the download happens behind the scenes

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
