### PR TITLE
chore(deps): update get-windows-proxy to 1.6.3

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@babel/parser": "7.25.3",
     "@cypress/commit-info": "2.2.0",
-    "@cypress/get-windows-proxy": "1.6.2",
+    "@cypress/get-windows-proxy": "1.6.3",
     "@cypress/request": "^3.0.8",
     "@cypress/request-promise": "^5.0.0",
     "@cypress/vite-dev-server": "0.0.0-development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,14 +2769,14 @@
     http-proxy "^1.17.0"
     self-signed-cert "^1.0.1"
 
-"@cypress/get-windows-proxy@1.6.2":
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/@cypress/get-windows-proxy/-/get-windows-proxy-1.6.2.tgz#c2f14c465fce7cf3bb3da4835fb191d80a79c2e3"
-  integrity sha512-Oc8G2I5nigEzU8lnYazYxpEvqxaoER7XxuBo5IIqqt3q+d1+sNGhNDNfCFT9hixea94ummeoeu9pRu6Q6rt1Ig==
+"@cypress/get-windows-proxy@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@cypress/get-windows-proxy/-/get-windows-proxy-1.6.3.tgz#67402f79b4d362c274ea99fca9fe3899efafe97f"
+  integrity sha512-bP3doYg7tzsNmT1RdO75TSjvT9gfRTiTOQXhsCoPez+BkbWDaHDb9oIw+RgmBS/1i/tyLxInVqha/yaHktBkwQ==
   dependencies:
-    debug "4.1.1"
+    debug "4.4.1"
   optionalDependencies:
-    registry-js "1.8.0"
+    registry-js "1.16.1"
 
 "@cypress/parse-domain@2.4.0":
   version "2.4.0"
@@ -13710,10 +13710,10 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7, debug@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+debug@4, debug@4.4.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7, debug@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
+  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
   dependencies:
     ms "^2.1.3"
 
@@ -22917,7 +22917,7 @@ mz@^2.4.0, mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.10.0, nan@^2.12.1, nan@^2.17.0, nan@^2.18.0:
+nan@^2.12.1, nan@^2.17.0, nan@^2.18.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
@@ -23125,7 +23125,7 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-addon-api@^3.1.0:
+node-addon-api@^3.1.0, node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -25511,7 +25511,7 @@ postject@^1.0.0-alpha.6:
   dependencies:
     commander "^9.4.0"
 
-prebuild-install@^5.2.4, prebuild-install@^5.3.5:
+prebuild-install@^5.3.5:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
   integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
@@ -26659,13 +26659,13 @@ registry-js@1.15.0:
     node-addon-api "^3.1.0"
     prebuild-install "^5.3.5"
 
-registry-js@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/registry-js/-/registry-js-1.8.0.tgz#291da86464e5e5937667d7b66f48930fe0a59e42"
-  integrity sha512-ftNNEvm0T4P9lywk5Fd9IZwR9HrmcxqSoX8Jhrktgg5jYeX45Xe4kUI2A/HocaymDhixuRZhQzL5xXecnfJNBw==
+registry-js@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/registry-js/-/registry-js-1.16.1.tgz#e4b6266b0cd27ddaa9e32486090b5ec3a1b05e01"
+  integrity sha512-pQ2kD36lh+YNtpaXm6HCCb0QZtV/zQEeKnkfEIj5FDSpF/oFts7pwizEUkWSvP8IbGb4A4a5iBhhS9eUearMmQ==
   dependencies:
-    nan "^2.10.0"
-    prebuild-install "^5.2.4"
+    node-addon-api "^3.2.1"
+    prebuild-install "^5.3.5"
 
 registry-url@3.1.0:
   version "3.1.0"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/32017

### Additional details

Building Cypress `15.0.0` beta from source on Windows 11 with Visual Studio 2019 or 2022 fails rebuilding dependency [registry-js](https://github.com/desktop/registry-js) from dependency [@cypress/get-windows-proxy@1.6.2](https://github.com/cypress-io/get-windows-proxy/releases/tag/v1.6.2).

Update from [@cypress/get-windows-proxy@1.6.2](https://github.com/cypress-io/get-windows-proxy/releases/tag/v1.6.2) to [@cypress/get-windows-proxy@1.6.3](https://github.com/cypress-io/get-windows-proxy/releases/tag/v1.6.3) in [release/15.0.0/packages/server/package.json](https://github.com/cypress-io/cypress/blob/release/15.0.0/packages/server/package.json).

This updates the dependency [registry-js](https://www.npmjs.com/package/registry-js) from [registry-js@1.8.0](https://github.com/desktop/registry-js/releases/tag/v1.8.0) to [registry-js@1.16.1](https://github.com/desktop/registry-js/releases/tag/v1.16.1), which is the `latest` version. It is compatible with Node.js 22.x and VS2022.

### Steps to test

On Windows 11, 24H2

- Node.js `22.15.1`
- Microsoft Visual Studio Community 2022 (64-bit) Version `17.14.8`
- Python `3.13.5`

Pre-merge test:

```shell
git clone --branch issue-32017-update-get-windows-proxy https://github.com/MikeMcC399/cypress
cd cypress
yarn
```

Post-merge test:

```shell
git clone --branch release/15.0.0 https://github.com/cypress-io/cypress
cd cypress
yarn
```

Confirm no errors in the steps

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

### How has the user experience changed?

Issue for building from source on Windows in CI and for contributors only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
