### PR TITLE
chore: sync Firefox contentblocking preference change from Bug 1977066

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -72,7 +72,7 @@ const defaultPreferences = {
 
   // Prevent various error message on the console
   // jest-puppeteer asserts that no error message is emitted by the console
-  'browser.contentblocking.features.standard': '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+  'browser.contentblocking.features.standard': '-tp,tpPrivate,cookieBehavior0,-cryptoTP,-fp',
 
   // Enable the dump function: which sends messages to the system
   // console


### PR DESCRIPTION
Expected value of this preference changed since Firefox 139, but this specific usage was missed (see https://bugzilla.mozilla.org/show_bug.cgi?id=1977066).

Initial change landed in https://bugzilla.mozilla.org/show_bug.cgi?id=1956556