### PR TITLE
breaking: release version 7.x.x of @cypress/vite-dev-server.

### DIFF
--- a/npm/vite-dev-server/README.md
+++ b/npm/vite-dev-server/README.md
@@ -58,7 +58,7 @@ We then merge the sourced config with the user's vite config, and layer on our o
 | >= v6                    | >= v14        |
 | >= v7 (esm only)         | >= v15        |
 
-#### `devServerPublicPathRoute` for Vite v5
+#### `devServerPublicPathRoute` for Vite v5+
 
 If using Vite version 5, setting `devServerPublicPathRoute` may be needed if directly referencing public path url assets in components under test. This is due to Cypress using its own public path, `/__cypress/src`, when running component tests. This can be configured within the `component` namespace below if you wish you set your public path to be the same as your app:
 


### PR DESCRIPTION
NOTE: MUST BE REBASED MERGED IN `release/15.0.0`!!!

BREAKING CHANGE: @cypress/vite-dev-server longer supports vite 4 and supports vite 7 via converting the package to an esm only package, which is a breaking change

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Makes sure `@cypress/vite-dev-server` publishes version `7.x.x` and not `6.x.x`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

run the `npm-release` job locally to see next targeted publish

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
