### PR TITLE
internal: Hide studio buttons when running All Specs via experimentalRunAllSpecs mode

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -329,7 +329,7 @@ describe('studio functionality', () => {
     cy.waitForSpecToFinish()
 
     // Verify that we're running all specs by checking the header
-    cy.get('.runnable-title').should('contain', 'All Specs')
+    cy.get('[data-cy="runnable-header"]').should('contain', 'All Specs')
 
     // Verify that the studio button is NOT visible when running all specs
     cy.findByTestId('studio-button').should('not.exist')
@@ -352,8 +352,8 @@ describe('studio functionality', () => {
     cy.waitForSpecToFinish()
 
     // Verify that we're running a single spec (not all specs)
-    cy.get('.runnable-title').should('contain', 'spec.cy.js')
-    cy.get('.runnable-title').should('not.contain', 'All Specs')
+    cy.get('[data-cy="runnable-header"]').should('contain', 'spec.cy.js')
+    cy.get('[data-cy="runnable-header"]').should('not.contain', 'All Specs')
 
     // Verify that the studio button IS visible when running a single spec
     cy.findByTestId('studio-button').should('be.visible')

--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -296,6 +296,69 @@ describe('studio functionality', () => {
     cy.findByTestId('studio-toolbar').should('not.exist')
   })
 
+  it('hides studio button when running all specs', () => {
+    // Use the run-all-specs project which already has run-all-specs enabled
+    cy.scaffoldProject('run-all-specs')
+    cy.openProject('run-all-specs')
+
+    // Enable experimental studio by modifying the config
+    cy.withCtx(async (ctx) => {
+      const configPath = 'cypress.config.js'
+      const configContent = await ctx.actions.file.readFileInProject(configPath)
+      const updatedConfig = configContent.replace(
+        'experimentalRunAllSpecs: true,',
+        'experimentalRunAllSpecs: true,\n    experimentalStudio: true,',
+      )
+
+      await ctx.actions.file.writeFileInProject(configPath, updatedConfig)
+    })
+
+    cy.startAppServer('e2e')
+    cy.visitApp()
+    cy.specsPageIsVisible()
+
+    // Spawns new browser so we need to stub this
+    cy.withCtx((ctx, { sinon }) => {
+      sinon.stub(ctx.actions.project, 'launchProject').resolves()
+    })
+
+    // Run all specs
+    cy.findByTestId('run-all-specs-for-all').click()
+
+    // Wait for the runner to load
+    cy.waitForSpecToFinish()
+
+    // Verify that we're running all specs by checking the header
+    cy.get('.runnable-title').should('contain', 'All Specs')
+
+    // Verify that the studio button is NOT visible when running all specs
+    cy.findByTestId('studio-button').should('not.exist')
+
+    // Verify that the studio panel is NOT visible
+    cy.findByTestId('studio-panel').should('not.exist')
+  })
+
+  it('shows studio button when running a single spec', () => {
+    // Use the existing experimental-studio project
+    cy.scaffoldProject('experimental-studio')
+    cy.openProject('experimental-studio')
+    cy.startAppServer('e2e')
+    cy.visitApp()
+    cy.specsPageIsVisible()
+
+    // Run a single spec instead of all specs
+    cy.get('[data-cy-row="spec.cy.js"]').click()
+
+    cy.waitForSpecToFinish()
+
+    // Verify that we're running a single spec (not all specs)
+    cy.get('.runnable-title').should('contain', 'spec.cy.js')
+    cy.get('.runnable-title').should('not.contain', 'All Specs')
+
+    // Verify that the studio button IS visible when running a single spec
+    cy.findByTestId('studio-button').should('be.visible')
+  })
+
   describe('failing to load studio and retrying', () => {
     it('displays error panel when studio bundle fails to load', () => {
       // Intercept the studio bundle request and make it fail

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -116,6 +116,7 @@
 
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { REPORTER_ID, RUNNER_ID } from './utils'
 import InlineSpecList from '../specs/InlineSpecList.vue'
 import { getAutIframeModel, getEventManager } from '.'
@@ -218,6 +219,7 @@ const props = defineProps<{
   gql: SpecRunnerFragment
 }>()
 
+const route = useRoute()
 const eventManager = getEventManager()
 
 const autStore = useAutStore()
@@ -284,7 +286,10 @@ const shouldShowStudioButton = computed(() => {
   const experimentalStudioConfig = props.gql.currentProject?.config?.find((item) => item.field === 'experimentalStudio')
   const experimentalStudioEnabled = experimentalStudioConfig?.value === true
 
-  return !!cloudStudioRequested.value && !studioStore.isOpen && experimentalStudioEnabled
+  // Check if we're running all specs by looking at the route query
+  const isRunningAllSpecs = route.query.file === '__all'
+
+  return !!cloudStudioRequested.value && !studioStore.isOpen && experimentalStudioEnabled && !isRunningAllSpecs
 })
 
 const shouldShowStudioPanel = computed(() => {

--- a/packages/reporter/cypress/e2e/tests.cy.ts
+++ b/packages/reporter/cypress/e2e/tests.cy.ts
@@ -5,7 +5,7 @@ import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 let runner: EventEmitter
 let runnables: RootRunnable
 
-function visitAndRenderReporter (studioEnabled: boolean = false, studioActive: boolean = false) {
+function visitAndRenderReporter (studioEnabled: boolean = false, studioActive: boolean = false, specRelative: string = 'relative/path/to/foo.js') {
   cy.fixture('runnables').then((_runnables) => {
     runnables = _runnables
   })
@@ -16,7 +16,7 @@ function visitAndRenderReporter (studioEnabled: boolean = false, studioActive: b
 
   runnerStore.setSpec({
     name: 'foo.js',
-    relative: 'relative/path/to/foo.js',
+    relative: specRelative,
     absolute: '/absolute/path/to/foo.js',
   })
 
@@ -194,6 +194,36 @@ describe('tests', () => {
       cy.get('@testWrapper')
       .should('not.have.class', 'is-open')
       .find('.collapsible-content').should('not.exist')
+    })
+  })
+
+  describe('studio controls', () => {
+    it('hides launch studio icon when running all specs', () => {
+      visitAndRenderReporter(true, false, '__all')
+
+      cy.contains('test 1').realHover()
+      cy.get('[data-cy="launch-studio"]').should('not.exist')
+    })
+
+    it('shows launch studio icon when running a single spec', () => {
+      visitAndRenderReporter(true, false, 'relative/path/to/foo.js')
+
+      cy.contains('test 1').realHover()
+      cy.get('[data-cy="launch-studio"]').should('exist')
+    })
+
+    it('hides new test button in suites when running all specs', () => {
+      visitAndRenderReporter(true, false, '__all')
+
+      cy.contains('suite 1').realHover()
+      cy.get('[data-cy="create-new-test-button"]').should('not.exist')
+    })
+
+    it('shows new test button in suites when running a single spec', () => {
+      visitAndRenderReporter(true, false, 'relative/path/to/foo.js')
+
+      cy.contains('suite 1').realHover()
+      cy.get('[data-cy="create-new-test-button"]').should('exist')
     })
   })
 })

--- a/packages/reporter/src/runnables/runnable-and-suite.tsx
+++ b/packages/reporter/src/runnables/runnable-and-suite.tsx
@@ -25,6 +25,7 @@ interface SuiteProps {
   model: SuiteModel
   studioEnabled: boolean
   canSaveStudioLogs: boolean
+  spec?: Cypress.Cypress['spec']
 }
 
 const headerIconDefaultProps = {
@@ -33,7 +34,7 @@ const headerIconDefaultProps = {
   className: 'header-icon',
 }
 
-const Suite: React.FC<SuiteProps> = observer(({ eventManager = events, model, studioEnabled, canSaveStudioLogs }: SuiteProps) => {
+const Suite: React.FC<SuiteProps> = observer(({ eventManager = events, model, studioEnabled, canSaveStudioLogs, spec }: SuiteProps) => {
   const _launchStudio = useCallback((e: MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -78,7 +79,7 @@ const Suite: React.FC<SuiteProps> = observer(({ eventManager = events, model, st
           {getHeaderIcon(isOpen)}
         </div>
         <span className='runnable-title'>{model.title}</span>
-        {(studioEnabled && !appState.studioActive) && (
+        {(studioEnabled && !appState.studioActive && spec?.relative !== '__all') && (
           <>
             <Button data-cy='create-new-test-button' size='20' onClick={_launchStudio} variant='outline-dark' className={cs('launch-studio-button')} >
               <IconActionAddMedium strokeColor='gray-500' />
@@ -100,6 +101,7 @@ const Suite: React.FC<SuiteProps> = observer(({ eventManager = events, model, st
           studioEnabled={studioEnabled}
           canSaveStudioLogs={canSaveStudioLogs}
           shouldShowConnectingDots={shouldShowConnectionDots(model.children, runnable, index)}
+          spec={spec}
         />)
       })}
     </ul>
@@ -130,13 +132,14 @@ export interface RunnableProps {
   studioEnabled: boolean
   canSaveStudioLogs: boolean
   shouldShowConnectingDots: boolean
+  spec?: Cypress.Cypress['spec']
 }
 
 // NOTE: some of the driver tests dig into the React instance for this component
 // in order to mess with its internal state. converting it to a functional
 // component breaks that, so it needs to stay a Class-based component or
 // else the driver tests need to be refactored to support it being functional
-const Runnable: React.FC<RunnableProps> = observer(({ appState: appStateProps = appState, model, studioEnabled, canSaveStudioLogs, shouldShowConnectingDots }) => {
+const Runnable: React.FC<RunnableProps> = observer(({ appState: appStateProps = appState, model, studioEnabled, canSaveStudioLogs, shouldShowConnectingDots, spec }) => {
   return (<>
     <li
       className={cs(`${model.type} runnable runnable-${model.state}`, {
@@ -147,10 +150,11 @@ const Runnable: React.FC<RunnableProps> = observer(({ appState: appStateProps = 
       data-model-state={model.state}
     >
       {model.type === 'test'
-        ? <Test model={model as TestModel} studioEnabled={studioEnabled} canSaveStudioLogs={canSaveStudioLogs} />
+        ? <Test model={model as TestModel} studioEnabled={studioEnabled} canSaveStudioLogs={canSaveStudioLogs} spec={spec} />
         : <Suite model={model as SuiteModel}
           studioEnabled={studioEnabled}
           canSaveStudioLogs={canSaveStudioLogs}
+          spec={spec}
         />}
     </li>
     {shouldShowConnectingDots && <div className='runnable-dotted-line' />}

--- a/packages/reporter/src/runnables/runnables.tsx
+++ b/packages/reporter/src/runnables/runnables.tsx
@@ -88,9 +88,10 @@ interface RunnablesListProps {
   runnables: RunnableArray
   studioEnabled: boolean
   canSaveStudioLogs: boolean
+  spec: Cypress.Cypress['spec']
 }
 
-const RunnablesList: React.FC<RunnablesListProps> = observer(({ runnables, studioEnabled, canSaveStudioLogs }: RunnablesListProps) => {
+const RunnablesList: React.FC<RunnablesListProps> = observer(({ runnables, studioEnabled, canSaveStudioLogs, spec }: RunnablesListProps) => {
   return (
     <div className='wrap'>
       <ul className='runnables'>
@@ -101,6 +102,7 @@ const RunnablesList: React.FC<RunnablesListProps> = observer(({ runnables, studi
             canSaveStudioLogs={canSaveStudioLogs}
             studioEnabled={studioEnabled}
             shouldShowConnectingDots={shouldShowConnectionDots(runnables, runnable, index)}
+            spec={spec}
           />))}
       </ul>
     </div>
@@ -143,6 +145,7 @@ const RunnablesContent: React.FC<RunnablesContentProps> = observer(({ runnablesS
       runnables={isRunning ? runnables : runnablesHistory[specPath]}
       studioEnabled={studioEnabled}
       canSaveStudioLogs={canSaveStudioLogs}
+      spec={spec}
     />
   )
 })

--- a/packages/reporter/src/test/test.tsx
+++ b/packages/reporter/src/test/test.tsx
@@ -88,9 +88,10 @@ interface TestProps {
   model: TestModel
   studioEnabled: boolean
   canSaveStudioLogs: boolean
+  spec?: Cypress.Cypress['spec']
 }
 
-const Test: React.FC<TestProps> = observer(({ model, events: eventsProps = events, appState: appStateProps = appState, scroller: scrollerProps = scroller, studioEnabled, canSaveStudioLogs }) => {
+const Test: React.FC<TestProps> = observer(({ model, events: eventsProps = events, appState: appStateProps = appState, scroller: scrollerProps = scroller, studioEnabled, canSaveStudioLogs, spec }) => {
   const containerRef = useRef(null)
   const [isMounted, setIsMounted] = useState(false)
 
@@ -135,7 +136,10 @@ const Test: React.FC<TestProps> = observer(({ model, events: eventsProps = event
   const _controls = () => {
     let controls: Array<JSX.Element> = []
 
-    if (studioEnabled && !appStateProps.studioActive && model.state !== 'pending') {
+    // Check if we're running all specs by looking at the spec relative path
+    const isRunningAllSpecs = spec?.relative === '__all'
+
+    if (studioEnabled && !appStateProps.studioActive && model.state !== 'pending' && !isRunningAllSpecs) {
       controls.push(
         <LaunchStudioIcon
           key={`studio-command-${model}`}


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/11118

### Additional details

Studio doesn't work properly when running 'All' specs with `experimentalRunAllSpecs` turned on. It doesn't work today in Studio either (it fails to save). 

This PR removes the entrypoints into Studio if a user clicks to 'Run All Specs'. Hiding the:
- Studio button
- 'Edit in Studio' buttons
- 'New Test' buttons

When switching specs - the entire browser refreshes, so maintaining more granular state back and forth between spec and all specs should not be necessary. 

### Steps to test

- Run `yarn cypress:open` with a project with `experimentalStudio` and `experimentalRunAllSpecs` set to true.
- Run a specfile - see the Studio buttons present
- Run 'All Specs' or a subset of tests in a folder - see the Studio buttons hidden
- Switch in between them and ensure correct states
- Change the config option and ensure it updates properly.

### How has the user experience changed?

No Studio buttons when in All Specs mode

<img width="1149" height="420" alt="Screenshot 2025-07-17 at 2 36 19 PM" src="https://github.com/user-attachments/assets/76b94a95-bea5-4e36-a0f2-5263cd275cfc" />


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
