### PR TITLE
internal: (studio) fix studio AI for development

### DIFF
--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -107,6 +107,7 @@
             :on-studio-panel-close="handleStudioPanelClose"
             :event-manager="eventManager"
             :studio-status="studioStatus"
+            :studio-ai-available="studioStore.cloudStudioRequested"
           />
         </HideDuringScreenshot>
       </template>

--- a/packages/app/src/studio/StudioPanel.vue
+++ b/packages/app/src/studio/StudioPanel.vue
@@ -53,6 +53,7 @@ const props = defineProps<{
   eventManager: EventManager
   studioStatus: string | null
   cloudStudioSessionId?: string
+  studioAiAvailable: boolean
 }>()
 
 interface StudioApp { default: StudioAppDefaultShape }
@@ -76,6 +77,7 @@ const maybeRenderReactComponent = () => {
     canAccessStudioAI: props.canAccessStudioAI,
     onStudioPanelClose: props.onStudioPanelClose,
     studioSessionId: props.cloudStudioSessionId,
+    studioAiAvailable: props.studioAiAvailable,
   })
 
   if (!reactRoot.value) {


### PR DESCRIPTION
https://cypressio.slack.com/archives/C03TYHJKB27/p1752785369590689

On develop, Studio AI isn't able to be enabled by a feature flag. This PR updates the app to pass through the dev feature flag to enable AI when a developer is explicitly enabling cloud studio.