### PR TITLE
internal: (studio) wire up cloud studio AI enabled feature flag

### DIFF
--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -179,11 +179,6 @@ fragment SpecRunner_Preferences on Query {
 gql`
 fragment SpecRunner_Studio on Query {
   cloudStudioRequested
-}
-`
-
-gql`
-fragment SpecRunner_StudioAiAvailable on Query {
   studioAiAvailable
 }
 `
@@ -287,8 +282,6 @@ const cloudStudioRequested = computed(() => {
 })
 
 const studioAiAvailable = computed(() => {
-  studioStore.setStudioAiAvailable(props.gql.studioAiAvailable || false)
-
   return props.gql.studioAiAvailable
 })
 

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -108,6 +108,7 @@
             :event-manager="eventManager"
             :studio-status="studioStatus"
             :aut-url-selector="autUrlSelector"
+            :studio-ai-available="studioAiAvailable"
           />
         </HideDuringScreenshot>
       </template>
@@ -178,6 +179,12 @@ fragment SpecRunner_Preferences on Query {
 gql`
 fragment SpecRunner_Studio on Query {
   cloudStudioRequested
+}
+`
+
+gql`
+fragment SpecRunner_StudioAiAvailable on Query {
+  studioAiAvailable
 }
 `
 
@@ -277,6 +284,12 @@ const cloudStudioRequested = computed(() => {
   studioStore.setCloudStudioRequested(props.gql.cloudStudioRequested || false)
 
   return props.gql.cloudStudioRequested
+})
+
+const studioAiAvailable = computed(() => {
+  studioStore.setStudioAiAvailable(props.gql.studioAiAvailable || false)
+
+  return props.gql.studioAiAvailable
 })
 
 const studioBetaAvailable = computed(() => {

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -282,7 +282,7 @@ const cloudStudioRequested = computed(() => {
 })
 
 const studioAiAvailable = computed(() => {
-  return props.gql.studioAiAvailable
+  return props.gql.studioAiAvailable || false
 })
 
 const studioBetaAvailable = computed(() => {

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -125,6 +125,7 @@ interface StudioRecorderState {
   cloudStudioRequested: boolean
   cloudStudioSessionId?: string
   newTestLineNumber?: number
+  studioAiAvailable: boolean
 }
 
 export const useStudioStore = defineStore('studioRecorder', {
@@ -143,12 +144,17 @@ export const useStudioStore = defineStore('studioRecorder', {
       showUrlPrompt: true,
       cloudStudioRequested: false,
       cloudStudioSessionId: undefined,
+      studioAiAvailable: false,
     }
   },
 
   actions: {
     setCloudStudioRequested (cloudStudioRequested: boolean) {
       this.cloudStudioRequested = cloudStudioRequested
+    },
+
+    setStudioAiAvailable (studioAiAvailable: boolean) {
+      this.studioAiAvailable = studioAiAvailable
     },
 
     setShowUrlPrompt (shouldShowUrlPrompt: boolean) {

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -125,7 +125,6 @@ interface StudioRecorderState {
   cloudStudioRequested: boolean
   cloudStudioSessionId?: string
   newTestLineNumber?: number
-  studioAiAvailable: boolean
 }
 
 export const useStudioStore = defineStore('studioRecorder', {
@@ -144,17 +143,12 @@ export const useStudioStore = defineStore('studioRecorder', {
       showUrlPrompt: true,
       cloudStudioRequested: false,
       cloudStudioSessionId: undefined,
-      studioAiAvailable: false,
     }
   },
 
   actions: {
     setCloudStudioRequested (cloudStudioRequested: boolean) {
       this.cloudStudioRequested = cloudStudioRequested
-    },
-
-    setStudioAiAvailable (studioAiAvailable: boolean) {
-      this.studioAiAvailable = studioAiAvailable
     },
 
     setShowUrlPrompt (shouldShowUrlPrompt: boolean) {

--- a/packages/app/src/studio/StudioPanel.vue
+++ b/packages/app/src/studio/StudioPanel.vue
@@ -53,6 +53,7 @@ const props = defineProps<{
   studioStatus: string | null
   cloudStudioSessionId?: string
   autUrlSelector: string
+  studioAiAvailable: boolean
 }>()
 
 interface StudioApp { default: StudioAppDefaultShape }
@@ -79,6 +80,7 @@ const maybeRenderReactComponent = () => {
     onStudioPanelClose: props.onStudioPanelClose,
     studioSessionId: props.cloudStudioSessionId,
     autUrlSelector: props.autUrlSelector,
+    studioAiAvailable: props.studioAiAvailable,
   })
 
   // Store the react root in a weak map keyed by the container. We do this so that we have a reference

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -1874,6 +1874,9 @@ type Query {
   """The files that have just been scaffolded"""
   scaffoldedFiles: [ScaffoldedFile!]
 
+  """Whether studio AI is available"""
+  studioAiAvailable: Boolean
+
   """Previous versions of cypress and their release date"""
   versions: VersionData
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Query.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Query.ts
@@ -89,6 +89,12 @@ export const Query = objectType({
       resolve: (source, args, ctx) => ctx.coreData.studioLifecycleManager?.cloudStudioRequested ?? false,
     })
 
+    t.field('studioAiAvailable', {
+      type: 'Boolean',
+      description: 'Whether studio AI is available',
+      resolve: (source, args, ctx) => ctx.coreData.studioLifecycleManager?.studioAiAvailable ?? false,
+    })
+
     t.nonNull.field('localSettings', {
       type: LocalSettings,
       description: 'local settings on a device-by-device basis',

--- a/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
+++ b/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
@@ -51,6 +51,10 @@ export class StudioLifecycleManager {
     return true
   }
 
+  public get studioAiAvailable () {
+    return !!(process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI === 'true')
+  }
+
   /**
    * Initialize the studio manager and possibly set up protocol.
    * Also registers this instance in the data context.

--- a/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
@@ -170,6 +170,13 @@ describe('StudioLifecycleManager', () => {
     })
   })
 
+  describe('studioAiAvailable', () => {
+    it('is true when CYPRESS_ENABLE_CLOUD_STUDIO_AI is true', () => {
+      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'true'
+      expect(studioLifecycleManager.studioAiAvailable).to.be.true
+    })
+  })
+
   describe('initializeStudioManager', () => {
     it('initializes the studio manager and registers it in the data context and does not set up protocol when studio is initialized', async () => {
       studioManagerSetupStub.callsFake((args) => {

--- a/packages/types/src/studio/index.ts
+++ b/packages/types/src/studio/index.ts
@@ -19,6 +19,7 @@ export interface StudioLifecycleManagerShape {
   isStudioReady: () => boolean
   registerStudioReadyListener: (listener: (studioManager: StudioManagerShape) => void) => void
   cloudStudioRequested: boolean
+  studioAiAvailable: boolean
   updateStatus: (status: StudioStatus) => void
   getCurrentStatus: () => StudioStatus | undefined
   retry: () => void


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR passes a prop that indicates whether or not studio AI is enabled based on whether `CYPRESS_ENABLE_CLOUD_STUDIO_AI` is `true`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Verify against this branch: https://github.com/cypress-io/cypress-services/pull/11148

Verify that if you pass `CYPRESS_ENABLE_CLOUD_STUDIO_AI=true` when you start the cypress app, that studio AI is enabled. Verify that if you don't pass this environment variable that studio AI is marked as "coming soon".

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
