### PR TITLE
fix: Firefox SecureContext behavior for localhost - fixes #18217

### DIFF
--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -496,6 +496,7 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
 
     _.extend(defaultLaunchOptions.preferences, {
       'network.proxy.allow_hijacking_localhost': true,
+      'network.proxy.testing_localhost_is_secure_when_hijacked': true,
       'network.proxy.http': hostname,
       'network.proxy.ssl': hostname,
       'network.proxy.http_port': +port,


### PR DESCRIPTION
This fixes issue #18217, which occurs because Firefox does believe localhost is a secure context when a proxy redirects what localhost points to. 

We are fixing this in Firefox as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1977997, but that will take a while to make it to all released version (and especially our extended support releases)

- Closes #18217 

### Additional details
I tried to follow existing patterns, but it was not immediately clear to my why there are prefs listed at the top of the file and then some only set as `launchOptions` later.

### Steps to test
No automated tests were added. I am new to the codebase, but a manual test of `isSecureContext === true` in a JS global context should now work, when it previously did not.



### How has the user experience changed?
N/A

### PR Tasks
* Would be great if someone else could carry this over the finish line, if there are missing pieces wrt to tests and how cypress work. I familiar with Firefox, but not with cypress (neither the tool nor the code).

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
