### PR TITLE
internal: (studio) only setup protocol if AI is enabled

### DIFF
--- a/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
+++ b/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
@@ -261,8 +261,8 @@ export class StudioLifecycleManager {
 
     telemetryManager.mark(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_MANAGER_SETUP_END)
 
-    if (studioManager.status === 'ENABLED') {
-      debug('Cloud studio is enabled - setting up protocol')
+    if (studioManager.status === 'ENABLED' && this.studioAiAvailable) {
+      debug('Cloud studio is enabled with AI - setting up protocol')
       const protocolManager = new ProtocolManager()
 
       telemetryManager.mark(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_PROTOCOL_GET_START)
@@ -290,7 +290,7 @@ export class StudioLifecycleManager {
 
       studioManager.protocolManager = protocolManager
     } else {
-      debug('Cloud studio is not enabled - skipping protocol setup')
+      debug('Cloud studio is not enabled with AI - skipping protocol setup')
     }
 
     debug('Studio is ready')

--- a/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
@@ -262,7 +262,9 @@ describe('StudioLifecycleManager', () => {
       })
     })
 
-    it('initializes the studio manager and registers it in the data context and sets up protocol when studio is enabled', async () => {
+    it('initializes the studio manager and registers it in the data context and sets up protocol when studio is enabled with AI', async () => {
+      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'true'
+
       studioManagerSetupStub.callsFake((args) => {
         mockStudioManager.status = 'ENABLED'
 
@@ -364,7 +366,99 @@ describe('StudioLifecycleManager', () => {
       })
     })
 
+    it('skips setting up protocol when AI is not enabled', async () => {
+      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'false'
+
+      studioManagerSetupStub.callsFake((args) => {
+        mockStudioManager.status = 'ENABLED'
+
+        return Promise.resolve()
+      })
+
+      studioLifecycleManager.initializeStudioManager({
+        projectId: 'test-project-id',
+        cloudDataSource: mockCloudDataSource,
+        ctx: mockCtx,
+        cfg: mockCfg,
+        debugData: {},
+      })
+
+      const studioReadyPromise = new Promise((resolve) => {
+        studioLifecycleManager?.registerStudioReadyListener((studioManager) => {
+          resolve(studioManager)
+        })
+      })
+
+      const mockManifest = {
+        'server/index.js': 'e1ed3dc8ba9eb8ece23914004b99ad97bba37e80a25d8b47c009e1e4948a6159',
+      }
+
+      ensureStudioBundleStub.resolves(mockManifest)
+
+      await studioReadyPromise
+
+      expect(mockCtx.update).to.be.calledOnce
+      expect(ensureStudioBundleStub).to.be.calledWith({
+        studioPath: path.join(os.tmpdir(), 'cypress', 'studio', 'abc'),
+        studioUrl: 'https://cloud.cypress.io/studio/bundle/abc.tgz',
+        projectId: 'test-project-id',
+      })
+
+      expect(studioManagerSetupStub).to.be.calledWith({
+        script: 'console.log("studio script")',
+        studioPath: path.join(os.tmpdir(), 'cypress', 'studio', 'abc'),
+        studioHash: 'abc',
+        projectSlug: 'test-project-id',
+        cloudApi: {
+          cloudUrl: 'https://cloud.cypress.io',
+          cloudHeaders: { 'Authorization': 'Bearer test-token' },
+          CloudRequest,
+          isRetryableError,
+          asyncRetry,
+        },
+        shouldEnableStudio: true,
+        manifest: mockManifest,
+      })
+
+      expect(postStudioSessionStub).to.be.calledWith({
+        projectId: 'test-project-id',
+      })
+
+      expect(readFileStub).to.be.calledWith(path.join(os.tmpdir(), 'cypress', 'studio', 'abc', 'server', 'index.js'), 'utf8')
+
+      expect(getCaptureProtocolScriptStub).not.to.be.called
+      expect(prepareProtocolStub).not.to.be.called
+
+      expect(initializeTelemetryReporterStub).to.be.calledWith({
+        projectSlug: 'test-project-id',
+        cloudDataSource: mockCloudDataSource,
+      })
+
+      expect(initializeTelemetryReporterStub).to.be.calledWith({
+        projectSlug: 'test-project-id',
+        cloudDataSource: mockCloudDataSource,
+      })
+
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.BUNDLE_LIFECYCLE_START)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.BUNDLE_LIFECYCLE_END)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.POST_STUDIO_SESSION_START)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.POST_STUDIO_SESSION_END)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.ENSURE_STUDIO_BUNDLE_START)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.ENSURE_STUDIO_BUNDLE_END)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_MANAGER_SETUP_START)
+      expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_MANAGER_SETUP_END)
+      expect(markStub).not.to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_PROTOCOL_GET_START)
+      expect(markStub).not.to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_PROTOCOL_GET_END)
+      expect(markStub).not.to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_PROTOCOL_PREPARE_START)
+      expect(markStub).not.to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.STUDIO_PROTOCOL_PREPARE_END)
+
+      expect(reportTelemetryStub).to.be.calledWith(BUNDLE_LIFECYCLE_TELEMETRY_GROUP_NAMES.COMPLETE_BUNDLE_LIFECYCLE, {
+        success: true,
+      })
+    })
+
     it('initializes the studio manager in watch mode when CYPRESS_LOCAL_STUDIO_PATH is set', async () => {
+      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'true'
       process.env.CYPRESS_LOCAL_STUDIO_PATH = '/path/to/studio'
 
       studioManagerSetupStub.callsFake((args) => {

--- a/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
@@ -434,11 +434,6 @@ describe('StudioLifecycleManager', () => {
         cloudDataSource: mockCloudDataSource,
       })
 
-      expect(initializeTelemetryReporterStub).to.be.calledWith({
-        projectSlug: 'test-project-id',
-        cloudDataSource: mockCloudDataSource,
-      })
-
       expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.BUNDLE_LIFECYCLE_START)
       expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.BUNDLE_LIFECYCLE_END)
       expect(markStub).to.be.calledWith(BUNDLE_LIFECYCLE_MARK_NAMES.POST_STUDIO_SESSION_START)


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We don't need to setup protocol if we're using studio without AI features. This PR skips setting up protocol unless studio AI features are enabled

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

If you run the app with debug logs `DEBUG="cypress:*studio*"`, you should be able to see that protocol setup is skipped when `CYPRESS_ENABLE_CLOUD_STUDIO_AI` is not `true`.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

User experience is the same

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
