### PR TITLE
internal: (studio) remove studioAiAvailable property

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-cloud.cy.ts
@@ -161,76 +161,8 @@ describe('Studio Cloud', () => {
     cy.findByTestId('recommendation-editor').should('contain', aiOutput)
   })
 
-  it('opens a cloud studio session with AI marked as coming soon', () => {
-    cy.mockNodeCloudRequest({
-      url: '/studio/testgen/n69px6/enabled',
-      method: 'get',
-      body: { enabled: true },
-    })
-
-    // this endpoint gets called twice, so we need to mock it twice
-    cy.mockNodeCloudRequest({
-      url: '/studio/testgen/n69px6/enabled',
-      method: 'get',
-      body: { enabled: true },
-    })
-
-    const aiOutput = 'cy.get(\'button\').should(\'have.text\', \'Increment\')'
-
-    cy.mockNodeCloudStreamingRequest({
-      url: '/studio/testgen/n69px6/generate',
-      method: 'post',
-      body: { recommendations: [{ content: aiOutput }] },
-    })
-
-    cy.mockStudioFullSnapshot({
-      fullSnapshot: {
-        id: 1,
-        nodeType: 1,
-        nodeName: 'div',
-        localName: 'div',
-        nodeValue: 'div',
-        children: [],
-        shadowRoots: [],
-      },
-      url: 'http://localhost:3000/cypress/e2e/index.html',
-    })
-
-    const deferred = pDefer()
-
-    loadProjectAndRunSpec()
-
-    cy.findByTestId('studio-panel').should('not.exist')
-
-    cy.intercept('/cypress/e2e/index.html', () => {
-      // wait for the promise to resolve before responding
-      // this will ensure the studio panel is loaded before the test finishes
-      return deferred.promise
-    }).as('indexHtml')
-
-    cy.contains('visits a basic html page')
-    .closest('.runnable-wrapper')
-    .findByTestId('launch-studio')
-    .click()
-
-    // cloud studio is loaded immediately
-    cy.findByTestId('studio-panel').then(() => {
-      // check for the loading panel from the app first
-      cy.get('[data-cy="loading-studio-panel"]').should('be.visible')
-      // we've verified the studio panel is loaded, now resolve the promise so the test can finish
-      deferred.resolve()
-    })
-
-    cy.wait('@indexHtml')
-
-    // Studio re-executes spec before waiting for commands - wait for the spec to finish executing.
-    cy.waitForSpecToFinish()
-
-    // Verify the studio panel is still open
-    cy.findByTestId('studio-panel')
-
-    // make sure studio is not loading
-    cy.get('[data-cy="loading-studio-panel"]').should('not.exist')
+  it('studio AI is marked as coming soon', () => {
+    launchStudio()
 
     // Verify that AI is coming soon
     cy.get('[data-cy="ai-status-text"]').should('contain.text', 'Coming soon')

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -98,7 +98,6 @@
             :event-manager="eventManager"
             :studio-status="studioStatus"
             :aut-url-selector="autUrlSelector"
-            :studio-ai-available="studioAiAvailable"
           />
         </HideDuringScreenshot>
       </template>
@@ -168,7 +167,6 @@ fragment SpecRunner_Preferences on Query {
 gql`
 fragment SpecRunner_Studio on Query {
   cloudStudioRequested
-  studioAiAvailable
 }
 `
 
@@ -269,10 +267,6 @@ const cloudStudioRequested = computed(() => {
   studioStore.setCloudStudioRequested(props.gql.cloudStudioRequested || false)
 
   return props.gql.cloudStudioRequested
-})
-
-const studioAiAvailable = computed(() => {
-  return props.gql.studioAiAvailable || false
 })
 
 const studioBetaAvailable = computed(() => {

--- a/packages/app/src/studio/StudioPanel.vue
+++ b/packages/app/src/studio/StudioPanel.vue
@@ -53,7 +53,6 @@ const props = defineProps<{
   studioStatus: string | null
   cloudStudioSessionId?: string
   autUrlSelector: string
-  studioAiAvailable: boolean
 }>()
 
 interface StudioApp { default: StudioAppDefaultShape }
@@ -80,7 +79,6 @@ const maybeRenderReactComponent = () => {
     onStudioPanelClose: props.onStudioPanelClose,
     studioSessionId: props.cloudStudioSessionId,
     autUrlSelector: props.autUrlSelector,
-    studioAiAvailable: props.studioAiAvailable,
   })
 
   // Store the react root in a weak map keyed by the container. We do this so that we have a reference

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -423,7 +423,6 @@ async function makeE2ETasks () {
       // Cypress in Cypress testing breaks pretty heavily in terms of the inner Cypress's protocol. For now, we essentially
       // disable the protocol by using a dummy protocol that does nothing and allowing tests to mock studio full snapshots as needed.
       process.env.CYPRESS_LOCAL_PROTOCOL_PATH = dummyProtocolPath
-      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'true'
 
       let projectMatched = false
 

--- a/packages/graphql/schemas/schema.graphql
+++ b/packages/graphql/schemas/schema.graphql
@@ -1874,9 +1874,6 @@ type Query {
   """The files that have just been scaffolded"""
   scaffoldedFiles: [ScaffoldedFile!]
 
-  """Whether studio AI is available"""
-  studioAiAvailable: Boolean
-
   """Previous versions of cypress and their release date"""
   versions: VersionData
 

--- a/packages/graphql/src/schemaTypes/objectTypes/gql-Query.ts
+++ b/packages/graphql/src/schemaTypes/objectTypes/gql-Query.ts
@@ -89,12 +89,6 @@ export const Query = objectType({
       resolve: (source, args, ctx) => ctx.coreData.studioLifecycleManager?.cloudStudioRequested ?? false,
     })
 
-    t.field('studioAiAvailable', {
-      type: 'Boolean',
-      description: 'Whether studio AI is available',
-      resolve: (source, args, ctx) => ctx.coreData.studioLifecycleManager?.studioAiAvailable ?? false,
-    })
-
     t.nonNull.field('localSettings', {
       type: LocalSettings,
       description: 'local settings on a device-by-device basis',

--- a/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
+++ b/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
@@ -51,10 +51,6 @@ export class StudioLifecycleManager {
     return true
   }
 
-  public get studioAiAvailable () {
-    return !!(process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI === 'true')
-  }
-
   /**
    * Initialize the studio manager and possibly set up protocol.
    * Also registers this instance in the data context.

--- a/packages/server/lib/cloud/studio/studio.ts
+++ b/packages/server/lib/cloud/studio/studio.ts
@@ -91,9 +91,8 @@ export class StudioManager implements StudioManagerShape {
 
   async canAccessStudioAI (browser: Cypress.Browser): Promise<boolean> {
     const envEnabled = process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI === 'true'
-    const canAccessStudioAI = await this.invokeAsync('canAccessStudioAI', { isEssential: true }, browser)
 
-    return envEnabled && !!canAccessStudioAI
+    return envEnabled && !!(await this.invokeAsync('canAccessStudioAI', { isEssential: true }, browser))
   }
 
   async initializeStudioAI (options: StudioAIInitializeOptions): Promise<void> {

--- a/packages/server/lib/cloud/studio/studio.ts
+++ b/packages/server/lib/cloud/studio/studio.ts
@@ -90,9 +90,10 @@ export class StudioManager implements StudioManagerShape {
   }
 
   async canAccessStudioAI (browser: Cypress.Browser): Promise<boolean> {
-    const envEnabled = !!(process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI === 'true' || process.env.CYPRESS_LOCAL_STUDIO_PATH)
+    const envEnabled = process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI === 'true'
+    const canAccessStudioAI = await this.invokeAsync('canAccessStudioAI', { isEssential: true }, browser)
 
-    return envEnabled && ((await this.invokeAsync('canAccessStudioAI', { isEssential: true }, browser)) ?? false)
+    return envEnabled && !!canAccessStudioAI
   }
 
   async initializeStudioAI (options: StudioAIInitializeOptions): Promise<void> {

--- a/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
@@ -170,13 +170,6 @@ describe('StudioLifecycleManager', () => {
     })
   })
 
-  describe('studioAiAvailable', () => {
-    it('is true when CYPRESS_ENABLE_CLOUD_STUDIO_AI is true', () => {
-      process.env.CYPRESS_ENABLE_CLOUD_STUDIO_AI = 'true'
-      expect(studioLifecycleManager.studioAiAvailable).to.be.true
-    })
-  })
-
   describe('initializeStudioManager', () => {
     it('initializes the studio manager and registers it in the data context and does not set up protocol when studio is initialized', async () => {
       studioManagerSetupStub.callsFake((args) => {

--- a/packages/server/test/unit/cloud/studio/studio_spec.ts
+++ b/packages/server/test/unit/cloud/studio/studio_spec.ts
@@ -176,36 +176,6 @@ describe('lib/cloud/studio', () => {
 
       expect(result).to.be.false
     })
-
-    it('returns true when CYPRESS_LOCAL_STUDIO_PATH is set and studio server can access AI', async () => {
-      process.env.CYPRESS_LOCAL_STUDIO_PATH = 'path/to/studio'
-
-      sinon.stub(studio, 'canAccessStudioAI').resolves(true)
-
-      const result = await studioManager.canAccessStudioAI(browser)
-
-      expect(result).to.be.true
-    })
-
-    it('returns false when CYPRESS_LOCAL_STUDIO_PATH is not set and studio server can access AI', async () => {
-      process.env.CYPRESS_LOCAL_STUDIO_PATH = undefined
-
-      sinon.stub(studio, 'canAccessStudioAI').resolves(true)
-
-      const result = await studioManager.canAccessStudioAI(browser)
-
-      expect(result).to.be.false
-    })
-
-    it('returns false when CYPRESS_LOCAL_STUDIO_PATH is set and studio server cannot access AI', async () => {
-      process.env.CYPRESS_LOCAL_STUDIO_PATH = 'path/to/studio'
-
-      sinon.stub(studio, 'canAccessStudioAI').resolves(false)
-
-      const result = await studioManager.canAccessStudioAI(browser)
-
-      expect(result).to.be.false
-    })
   })
 
   describe('addSocketListeners', () => {

--- a/packages/types/src/studio/index.ts
+++ b/packages/types/src/studio/index.ts
@@ -19,7 +19,6 @@ export interface StudioLifecycleManagerShape {
   isStudioReady: () => boolean
   registerStudioReadyListener: (listener: (studioManager: StudioManagerShape) => void) => void
   cloudStudioRequested: boolean
-  studioAiAvailable: boolean
   updateStatus: (status: StudioStatus) => void
   getCurrentStatus: () => StudioStatus | undefined
   retry: () => void


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
* Removed `studioAiAvailble` property
* Removed `CYPRESS_LOCAL_STUDIO_PATH` check from `canAccessStudioAI`

Essentially, the AI status will have two states right now (Enabled and Coming Soon).

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
