### PR TITLE
chore: Patch http proxy extend

### DIFF
--- a/packages/server/patches/http-proxy+1.18.1.patch
+++ b/packages/server/patches/http-proxy+1.18.1.patch
@@ -32,9 +32,53 @@ new mode 100755
 diff --git a/node_modules/http-proxy/lib/http-proxy/common.js b/node_modules/http-proxy/lib/http-proxy/common.js
 old mode 100644
 new mode 100755
+index 6513e81..486d4c8
+--- a/node_modules/http-proxy/lib/http-proxy/common.js
++++ b/node_modules/http-proxy/lib/http-proxy/common.js
+@@ -1,6 +1,5 @@
+ var common   = exports,
+     url      = require('url'),
+-    extend   = require('util')._extend,
+     required = require('requires-port');
+ 
+ var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
+@@ -40,10 +39,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
+   );
+ 
+   outgoing.method = options.method || req.method;
+-  outgoing.headers = extend({}, req.headers);
++  outgoing.headers = Object.assign({}, req.headers);
+ 
+   if (options.headers){
+-    extend(outgoing.headers, options.headers);
++    Object.assign(outgoing.headers, options.headers);
+   }
+ 
+   if (options.auth) {
 diff --git a/node_modules/http-proxy/lib/http-proxy/index.js b/node_modules/http-proxy/lib/http-proxy/index.js
 old mode 100644
 new mode 100755
+index 977a4b3..88b2d0f
+--- a/node_modules/http-proxy/lib/http-proxy/index.js
++++ b/node_modules/http-proxy/lib/http-proxy/index.js
+@@ -1,5 +1,4 @@
+ var httpProxy = module.exports,
+-    extend    = require('util')._extend,
+     parse_url = require('url').parse,
+     EE3       = require('eventemitter3'),
+     http      = require('http'),
+@@ -47,9 +46,9 @@ function createRightProxy(type) {
+         args[cntr] !== res
+       ) {
+         //Copy global options
+-        requestOptions = extend({}, options);
++        requestOptions = Object.assign({}, options);
+         //Overwrite with request options
+-        extend(requestOptions, args[cntr]);
++        Object.assign(requestOptions, args[cntr]);
+ 
+         cntr--;
+       }
 diff --git a/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js b/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js
 old mode 100644
 new mode 100755


### PR DESCRIPTION
### Additional details

When running our driver tests in Node.js 22, a DeprecationWarning prints to the terminal output. [See CircleCI output](https://app.circleci.com/pipelines/github/cypress-io/cypress/72454/workflows/2e9fde57-9566-4000-9679-34b94269f772/jobs/2997625)

<img width="1037" height="242" alt="Screenshot 2025-07-22 at 12 47 45 PM" src="https://github.com/user-attachments/assets/54ee232b-cc19-43d6-8f40-5faf76f634c4" />

This is due to our `http-proxy` dependency using `util._extend` when `Object.assign` should be used.

This patches that package, following the updates in the open PR that the package has never released. https://github.com/http-party/node-http-proxy/pull/1666/files



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

I'm unsure if this deprecationwarning would be user facing, but I'm assuming it might.

It's gone from our [CI output](https://app.circleci.com/pipelines/github/cypress-io/cypress/72461/workflows/4129499f-e155-49dc-b4a3-a8ad1b395bc2/jobs/2998098/parallel-runs/2?filterBy=ALL)

<img width="1154" height="256" alt="Screenshot 2025-07-22 at 2 19 24 PM" src="https://github.com/user-attachments/assets/07e97e06-2abd-49c3-b6a2-cde48c89d423" />


### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
