### PR TITLE
internal: keep hook expanded on click of Open in IDE button

### DIFF
--- a/packages/reporter/cypress/e2e/hooks.cy.ts
+++ b/packages/reporter/cypress/e2e/hooks.cy.ts
@@ -160,5 +160,16 @@ describe('hooks', () => {
         },
       })
     })
+
+    it('does not toggle hook collapsible when clicking Open in IDE button', () => {
+      cy.contains('before each').closest('.collapsible').find('.commands-container')
+      .should('be.visible')
+
+      cy.get('.hook-open-in-ide').first().invoke('show').click()
+
+      // Verify the hook remains open (doesn't toggle)
+      cy.contains('before each').closest('.collapsible').find('.commands-container')
+      .should('be.visible')
+    })
   })
 })

--- a/packages/reporter/src/hooks/hooks.tsx
+++ b/packages/reporter/src/hooks/hooks.tsx
@@ -33,7 +33,11 @@ const Hook: React.FC<HookProps> = observer(({ model, showNumber, scrollIntoView 
       header={
         <>
           <HookHeader model={model} number={showNumber ? model.hookNumber : undefined} />
-          {model.invocationDetails && Cypress.testingType !== 'component' && <OpenFileInIDEButton fileDetails={model.invocationDetails} className='hook-open-in-ide' />}
+          {model.invocationDetails && Cypress.testingType !== 'component' && (
+            <span onClick={(e) => e.stopPropagation()}>
+              <OpenFileInIDEButton fileDetails={model.invocationDetails} className='hook-open-in-ide' />
+            </span>
+          )}
         </>
       }
       headerClass='hook-header'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/11174

### Additional details

Clicking open in ide button no longer triggers the toggle of the collapsible

https://github.com/user-attachments/assets/e8cff70f-ea24-4ee4-b2bd-ee363fd98d21



### Steps to test

- yarn cypress:open
- click on open in ide and row for runnables

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
