### PR TITLE
internal: (studio) fix skipped test styling

### DIFF
--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -351,7 +351,7 @@
         color: $pending;
 
         strong {
-          color: $indigo-300;
+          color: $gray-500;
         }
       }
     }

--- a/packages/reporter/src/lib/variables.scss
+++ b/packages/reporter/src/lib/variables.scss
@@ -101,7 +101,7 @@ $white: white;
 
 $pass: $jade-400;
 $fail: $red-400;
-$pending: $indigo-400;
+$pending: $gray-700;
 $pinned: $purple-400;
 $retried: $orange-400;
 

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -396,7 +396,7 @@ $dotted-line-left-padding: 19px;
 
     &.test.runnable-pending {
       .runnable-title {
-        color: $indigo-300;
+        color: $gray-500;
       }
 
       .runnable-commands-region {


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
This PR fixes a styling issue where skipped tests in the Cypress Reporter were displayed with indigo colors instead of the intended gray, as per Figma design.

The fix involves:
- Updating the `$pending` SCSS variable in `packages/reporter/src/lib/variables.scss` from `$indigo-400` to `$gray-700`.
- Changing hardcoded `$indigo-300` references to `$gray-500` in `packages/reporter/src/commands/commands.scss` and `packages/reporter/src/runnables/runnables.scss` to ensure consistent gray styling for skipped test titles and command details.

### Steps to test
1.  Run Cypress tests that include skipped tests (e.g., using `it.skip()`).
2.  Open the Cypress Test Runner.
3.  Observe the skipped tests in the reporter.
4.  Verify that the skipped test titles, borders, and associated command details are now displayed in shades of gray, consistent with the design.

### How has the user experience changed?
**Before:** Skipped tests in the reporter displayed with indigo borders and text.
**After:** Skipped tests now display with gray borders and text, aligning with the design specification for skipped states.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened