### PR TITLE
chore: add await to tests that are expecting 'to.be.rejectedWith'

### DIFF
--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -15,6 +15,13 @@ const flushPromises = () => {
   })
 }
 
+// Helper function to wait for async operations to complete
+const waitForAsyncOperation = async (stub: sinon.SinonStub) => {
+  if (stub.called) {
+    await stub.firstCall.returnValue
+  }
+}
+
 describe('lib/browsers/bidi_automation', () => {
   context('BidiAutomation', () => {
     let mockWebdriverClient: WebDriverClient
@@ -115,6 +122,9 @@ describe('lib/browsers/bidi_automation', () => {
 
             await flushPromises()
 
+            // Wait for the networkAddIntercept Promise to resolve if it was called
+            await waitForAsyncOperation(mockWebdriverClient.networkAddIntercept as sinon.SinonStub)
+
             // @ts-expect-error
             expect(bidiAutomationInstance.autContextId).to.equal('456')
             // @ts-expect-error
@@ -156,6 +166,9 @@ describe('lib/browsers/bidi_automation', () => {
             })
 
             await flushPromises()
+
+            // Wait for the networkAddIntercept Promise to resolve if it was called
+            await waitForAsyncOperation(mockWebdriverClient.networkAddIntercept as sinon.SinonStub)
 
             // @ts-expect-error
             expect(bidiAutomationInstance.autContextId).to.equal('456')

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -1044,7 +1044,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageGetCookies = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('get:cookies', {})).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:cookies', {})).to.be.rejectedWith(mockError)
           })
         })
 
@@ -1197,7 +1197,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageGetCookies = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('get:cookie', {})).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:cookie', {})).to.be.rejectedWith(mockError)
           })
         })
 
@@ -1277,7 +1277,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageSetCookie = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('set:cookie', cookie)).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('set:cookie', cookie)).to.be.rejectedWith(mockError)
           })
 
           describe('parsing', () => {
@@ -1722,7 +1722,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageSetCookie = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('add:cookies', cookies)).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('add:cookies', cookies)).to.be.rejectedWith(mockError)
           })
         })
 
@@ -1819,7 +1819,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageSetCookie = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('set:cookies', cookies)).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('set:cookies', cookies)).to.be.rejectedWith(mockError)
 
             expect(mockWebdriverClient.storageDeleteCookies).to.have.been.calledWith({})
           })
@@ -1920,7 +1920,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageGetCookies = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('clear:cookie', cookie)).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('clear:cookie', cookie)).to.be.rejectedWith(mockError)
           })
         })
 
@@ -2067,7 +2067,7 @@ describe('lib/browsers/bidi_automation', () => {
 
             mockWebdriverClient.storageGetCookies = sinon.stub().rejects(mockError)
 
-            expect(bidiAutomationInstance.automationMiddleware.onRequest('clear:cookies', cookies)).to.be.rejectedWith(mockError)
+            await expect(bidiAutomationInstance.automationMiddleware.onRequest('clear:cookies', cookies)).to.be.rejectedWith(mockError)
           })
         })
       })
@@ -2114,12 +2114,12 @@ describe('lib/browsers/bidi_automation', () => {
           mockWebdriverClient.browsingContextActivate = sinon.stub().resolves()
           mockWebdriverClient.browsingContextCaptureScreenshot = sinon.stub().rejects(mockError)
 
-          expect(bidiAutomationInstance.automationMiddleware.onRequest('take:screenshot', {})).to.be.rejectedWith(mockError)
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('take:screenshot', {})).to.be.rejectedWith(mockError)
         })
       })
 
       it('throws a AutomationNotImplemented error when "reset:browser:state" is emitted to inform the default automation client (web extension) to handle it', async () => {
-        expect(bidiAutomationInstance.automationMiddleware.onRequest('reset:browser:state')).to.be.rejectedWith(`Automation command 'reset:browser:state' not implemented by BiDiAutomation`)
+        await expect(bidiAutomationInstance.automationMiddleware.onRequest('reset:browser:state', {})).to.be.rejectedWith(`Automation command 'reset:browser:state' not implemented by BiDiAutomation`)
       })
 
       describe('reset:browser:tabs:for:next:spec', () => {
@@ -2213,7 +2213,7 @@ describe('lib/browsers/bidi_automation', () => {
           //@ts-expect-error
           bidiAutomationInstance.autContextId = undefined
 
-          expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
         })
       })
 
@@ -2256,7 +2256,7 @@ describe('lib/browsers/bidi_automation', () => {
           //@ts-expect-error
           bidiAutomationInstance.autContextId = undefined
 
-          expect(bidiAutomationInstance.automationMiddleware.onRequest('reload:aut:frame', undefined)).to.be.rejectedWith('Cannot reload AUT frame: no AUT context initialized')
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('reload:aut:frame', undefined)).to.be.rejectedWith('Cannot reload AUT frame: no AUT context initialized')
         })
       })
 
@@ -2282,7 +2282,7 @@ describe('lib/browsers/bidi_automation', () => {
           //@ts-expect-error
           bidiAutomationInstance.autContextId = undefined
 
-          expect(bidiAutomationInstance.automationMiddleware.onRequest('navigate:aut:history', undefined)).to.be.rejectedWith('Cannot navigate AUT frame history: no AUT context initialized')
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('navigate:aut:history', undefined)).to.be.rejectedWith('Cannot navigate AUT frame history: no AUT context initialized')
         })
       })
 
@@ -2314,13 +2314,13 @@ describe('lib/browsers/bidi_automation', () => {
           //@ts-expect-error
           bidiAutomationInstance.autContextId = undefined
 
-          expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:title', undefined)).to.be.rejectedWith('Cannot get AUT title no AUT context initialized')
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:title', undefined)).to.be.rejectedWith('Cannot get AUT title no AUT context initialized')
         })
       })
 
-      it('throws an error if an event passed in does not exist', () => {
+      it('throws an error if an event passed in does not exist', async () => {
         // @ts-expect-error
-        expect(bidiAutomationInstance.automationMiddleware.onRequest('foo:bar:baz', {})).to.be.rejectedWith('Automation command \'foo:bar:baz\' not implemented by BiDiAutomation')
+        await expect(bidiAutomationInstance.automationMiddleware.onRequest('foo:bar:baz', {})).to.be.rejectedWith('Automation command \'foo:bar:baz\' not implemented by BiDiAutomation')
       })
     })
   })


### PR DESCRIPTION


### Additional details

Surfaced via BugBot here: https://github.com/cypress-io/cypress/pull/31408#pullrequestreview-3055471808

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
