### PR TITLE
internal: use max z index for assertions menu overlay

### DIFF
--- a/packages/app/src/runner/dom.ts
+++ b/packages/app/src/runner/dom.ts
@@ -52,7 +52,7 @@ export function getOrCreateHelperDom ({ body, className, css, studioActive = fal
       left: '0',
       width: '100%',
       height: '100%',
-      zIndex: '9999',
+      zIndex: '2147483647', // use the max z-index value to ensure the shadow dom is on top of all other elements
     })
   }
 

--- a/system-tests/projects/experimental-studio/cypress/e2e/highZIndexModal.html
+++ b/system-tests/projects/experimental-studio/cypress/e2e/highZIndexModal.html
@@ -9,7 +9,7 @@
 			width: 100%;
 			height: 100%;
 			background-color: rgba(0, 0, 0, 0.5);
-			z-index: 2000;
+			z-index: 2147483647;
 			display: flex;
 			justify-content: center;
 			align-items: center;
@@ -81,10 +81,10 @@
 			<button class="modal-close" onclick="closeModal()">&times;</button>
 			<div class="modal-title">Large Modal with High Z-Index</div>
 			<div class="modal-body">
-				<p>This is a large modal that demonstrates a z-index of 2000. The modal covers the entire viewport and is positioned above all other elements on the page.</p>
+				<p>This is a large modal that demonstrates a z-index of 2147483647. The modal covers the entire viewport and is positioned above all other elements on the page.</p>
 				<p>Key features of this modal:</p>
 				<ul>
-					<li>Z-index: 2000 (very high priority)</li>
+					<li>Z-index: 2147483647 (highest priority)</li>
 					<li>Full viewport coverage</li>
 					<li>Semi-transparent background overlay</li>
 					<li>Centered content with responsive design</li>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/11260

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
- For the assertions menu, use the highest possible z-index which is 2147483647 (since it's the largest signed 32-bit integer) so that it'll always be on top of anything on the iframe. Usually those cookies pop ups will have this z-index so that they'll always be on top of anything on the page so we have to match our assertions menu overlay with that z-index.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
- Find any website with high z-index overlays and visit it. Then, open studio and open the assertions menu. The menu should sit on top of anything else on the page. 
```
it('test', function() {
cy.visit('https://www.ketch.com')
});
```

<img width="1193" height="976" alt="image" src="https://github.com/user-attachments/assets/2af57082-3e20-4b59-bb91-ae7d52737ed0" />


Before

https://github.com/user-attachments/assets/a7c7e9d6-c10f-4569-99bb-cf759082bae7



Now

https://github.com/user-attachments/assets/539b4a9f-4d1f-4f57-a036-d660de5b38d7


### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
