### PR TITLE
chore: fix AUT discovery if frame name is not present

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -492,7 +492,13 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
       }
 
       if (!frame) {
-        throw new Error('Could not find AUT frame')
+        // if for whatever reason we cannot identify the AUT frame by name, we will fall back ot the first child frame that exists.
+        // The first child frame should always be the AUT frame, followed by the spec frame
+        if (frameTree?.childFrames?.[0]) {
+          frame = frameTree.childFrames[0]
+        } else {
+          throw new Error('Could not find AUT frame')
+        }
       }
 
       return frame.frame

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -492,7 +492,7 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
       }
 
       if (!frame) {
-        // if for whatever reason we cannot identify the AUT frame by name, we will fall back ot the first child frame that exists.
+        // if for whatever reason we cannot identify the AUT frame by name, we will fall back to the first child frame that exists.
         // The first child frame should always be the AUT frame, followed by the spec frame
         if (frameTree?.childFrames?.[0]) {
           frame = frameTree.childFrames[0]

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -802,6 +802,46 @@ context('lib/browsers/cdp_automation', () => {
         })
       })
 
+      it('does not throw if the AUT frame cannot be found by name', async function () {
+        this.sendDebuggerCommand.withArgs('Page.getFrameTree').resolves({
+          frameTree:
+            {
+              childFrames: [
+                {
+                  frame: {
+                    id: '1',
+                    name: '123456789',
+                    url: 'http://localhost:3500/fixtures/dom.html',
+                  },
+                },
+              ],
+            },
+        })
+
+        this.sendDebuggerCommand.withArgs('Runtime.evaluate').resolves({
+          result: {
+            type: 'string',
+            value: 'mock title',
+          },
+        })
+
+        // @ts-expect-error
+        cdpAutomation.executionContexts.set(123, {
+          auxData: {
+            frameId: '1',
+          },
+        })
+
+        const resp = await this.onRequest('get:aut:title')
+
+        expect(resp).to.equal('mock title')
+
+        expect(this.sendDebuggerCommand).to.be.calledWith('Runtime.evaluate', {
+          expression: 'window.document.title',
+          contextId: 123,
+        })
+      })
+
       it('fails if the frame cannot be found', async function () {
         expect(this.onRequest('get:aut:title')).to.be.rejectedWith('Could not find AUT frame')
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32124

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

In certain cases, the AUT frame name is missing from the CDP `getFrameTree` payload. In the case of the Cypress app, the AUT frame should always be the first frame, followed by the spec fame as it is the order they are created in. This fix falls back to the first child frame if Cypress cannot discover the frame by name. 

<img width="641" height="648" alt="Screenshot 2025-08-04 at 12 37 46 PM" src="https://github.com/user-attachments/assets/2fb41ac9-cb7f-4b05-999a-ff2f019b0405" />


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
