### PR TITLE
fix: make sure legacy output spies work as intended

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 14.5.4
+
+_Released 8/12/2025_
+
+**Bugfixes:**
+
+- Fixed an issue where Angular legacy `Output()` decorators were broken when making component instance field references safe. Fixes [#32137](https://github.com/cypress-io/cypress/issues/32137).
+
 ## 14.5.3
 
 _Released 7/25/2025_

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -430,7 +430,10 @@ function setupComponent<T> (
     getComponentOutputs(fixture.componentRef.componentType).forEach((key) => {
       const property = component[key]
 
-      if (property instanceof EventEmitter) {
+      // With the introduction of https://github.com/cypress-io/cypress/pull/31993, we want to make sure that component inputs are reference safe inside cy.mount().
+      // However, the exception to this is if the user passes in a Cypress output spy as a property in order to maintain backwards compatibility.
+      // @ts-expect-error
+      if (property instanceof EventEmitter || (config?.componentProperties?.hasOwnProperty(key) && config?.componentProperties[key] instanceof EventEmitter)) {
       // only assign props if they are passed into the component
         if (config?.componentProperties?.hasOwnProperty(key)) {
         // @ts-expect-error

--- a/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.cy.ts
+++ b/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.cy.ts
@@ -1,0 +1,18 @@
+import { SignalsInputComponent } from './signals.input.component'
+import { createOutputSpy, mount } from 'cypress/angular'
+
+describe('with output spies', () => {
+  // regression test for https://github.com/cypress-io/cypress/issues/32137
+  it('should emit events on button click', () => {
+    mount(SignalsInputComponent, {
+      componentProperties: {
+        newOutput: createOutputSpy('newOutput'),
+        oldOutput: createOutputSpy('oldOutput'),
+      },
+    })
+
+    cy.get('#test-button').click()
+    cy.get('@oldOutput').should('have.been.called')
+    cy.get('@newOutput').should('have.been.called')
+  })
+})

--- a/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.html
+++ b/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.html
@@ -1,0 +1,1 @@
+<button id="test-button" (click)="onButtonClick()">Test</button>

--- a/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.ts
+++ b/system-tests/projects/angular-signals/src/signals-inputs/signals.input.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Output, output } from '@angular/core'
+import { CommonModule } from '@angular/common'
+
+@Component({
+  selector: 'signals-input-component',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './signals.input.component.html',
+})
+export class SignalsInputComponent {
+  newOutput = output()
+  @Output() oldOutput: EventEmitter<void> = new EventEmitter()
+
+  onButtonClick () {
+    this.newOutput.emit()
+    this.oldOutput.emit()
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32137

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

With the introduction of #31993 to keep angular component props reference safe we accidentally introduced a regression with output spies where the  implementation itself cannot be reference safe without a breaking change. To solve this, `EventEmitter` instances passed into the component prop, which in most cases is either a output spy or a `cy.spy()`, will overwrite the prop in the component in order to preserve existing functionality. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
