### PR TITLE
dependency: update tmp to ~0.2.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 8/12/2025 (PENDING)_
 **Dependency Updates:**
 
 - Upgraded `tar-fs` to `2.1.3` and `3.1.0` in places we can control, to resolve [CVE-2024-12905](https://github.com/advisories/GHSA-pq67-2wwv-3xjx). `@puppeteer/browsers` still references `3.0.4`, but it is only used to download browsers which is not a feature of `puppeteer` that we utilize. Addressed in [#32160](https://github.com/cypress-io/cypress/pull/32160).
+- Upgraded `tmp` from `~0.2.3` to `~0.2.4`. This removes the [CVE-2025-54798](https://github.com/advisories/GHSA-52f5-9888-hmc6) vulnerability being reported in security scans. Addresses [#32176](https://github.com/cypress-io/cypress/issues/32176).
 
 ## 14.5.3
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -60,7 +60,7 @@
     "request-progress": "^3.0.0",
     "semver": "^7.7.1",
     "supports-color": "^8.1.1",
-    "tmp": "~0.2.3",
+    "tmp": "~0.2.4",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",
     "yauzl": "^2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -31118,10 +31118,10 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.2.0, tmp@^0.2.1, tmp@~0.2.1, tmp@~0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
-  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+tmp@^0.2.0, tmp@^0.2.1, tmp@~0.2.1, tmp@~0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
+  integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/32176

### Additional details

Dependabot and `npm audit` report a low severity vulnerability CVE-2025-54798 in the npm module [tmp](https://www.npmjs.com/package/tmp) `<=0.2.3`.

[tmp](https://www.npmjs.com/package/tmp) is updated from `~0.2.3` to `~0.2.4`

### Steps to test

```shell
git clone https://github.com/cypress-io
cd cypress-io
npm install yarn@latest -g
yarn why tmp
```

Confirm that `tmp@0.2.4` is shown.

### How has the user experience changed?

After updating to a Cypress version containing this PR, Dependabot and `npm audit` no longer report a low severity vulnerability CVE-2025-54798.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?