### PR TITLE
docs: correct target location for changelog.mdx

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -141,7 +141,7 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
     - Optionally, do more thorough tests, for example test the new version of Cypress against the Cypress Cloud repo.
 
 11. Review the release-specific documentation and changelog PR in [cypress-documentation](https://github.com/cypress-io/cypress-documentation). If there is not already a release-specific PR open, create one.
-    - Copy the changelog content for this version from the release PR above into `/docs/guides/references/changelog.mdx`. Adjust any `docs.cypress.io` links to use host-relative paths.
+    - Copy the changelog content for this version from the release PR above into `/docs/app/references/changelog.mdx`. Adjust any `docs.cypress.io` links to use host-relative paths.
     - Merge any release-specific documentation changes into the main release PR.
     - You can view the doc's [branch deploy preview](https://github.com/cypress-io/cypress-documentation/blob/master/CONTRIBUTING.md#pull-requests) by clicking 'Details' on the PR's `netlify-cypress-docs/deploy-preview` GitHub status check.
 


### PR DESCRIPTION
### Additional details

The documentation website source https://github.com/cypress-io/cypress-documentation repo was restructured in Oct 2024 and the location of the reference `changelog.mdx` source file changed from `/docs/guides/references/changelog.mdx` to [/docs/app/references/changelog.mdx](https://github.com/cypress-io/cypress-documentation/commits/main/docs/app/references/changelog.mdx).

Section 11 in the document [guides/release-process.md](https://github.com/cypress-io/cypress/blob/develop/guides/release-process.md) retains an outdated reference to `/docs/guides/references/changelog.mdx`. This is changed to the current correct location of `/docs/app/references/changelog.mdx`.

### Steps to test

Test by inspection. Confirm that the URL https://github.com/cypress-io/cypress-documentation/commits/main/docs/app/references/changelog.mdx contains a current changelog source and compare to the text in Section 11 of the document [guides/release-process.md](https://github.com/cypress-io/cypress/blob/develop/guides/release-process.md).

### How has the user experience changed?

Release team documentation issue only. No impact on external users.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?