### PR TITLE
docs: update view dist-tags instructions

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -122,14 +122,14 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
     npm publish /tmp/cypress-prod.tgz --tag dev
     ```
 
-9. Double-check that the new version has been published under the `dev` tag using `npm info cypress` or [available-versions](https://github.com/bahmutov/available-versions). `latest` should still point to the previous version. Example output:
+9. Double-check that the new version has been published under the `dev` tag using `npm view cypress dist-tags`. The `latest` tag should still point to the previous version. Example output:
 
-    ```shell
-    dist-tags:
-    dev: 3.4.0     latest: 3.3.2
+    ```text
+    $ npm view cypress dist-tags
+    { latest: '14.5.3', dev: '14.5.4' }
     ```
 
-    **Note**: It may take several minutes for `npm info` to reflect the latest version info.
+    **Note**: It may take several minutes for `npm view` to reflect the latest version info.
 
 10. Test `cypress@X.Y.Z` to make sure everything is working.
     - Install the new version: `npm install -g cypress@X.Y.Z`


### PR DESCRIPTION
### Additional details

Section 9 in the document [guides/release-process.md](https://github.com/cypress-io/cypress/blob/develop/guides/release-process.md) includes a link to the repo https://github.com/bahmutov/available-versions as an alternative to using `npm info`.

The npm package [available-versions](https://www.npmjs.com/package/available-versions) contains multiple deprecations and unfixable critical vulnerabilities:

> 17 vulnerabilities (4 moderate, 7 high, 6 critical)

Since `npm view cypress dist-tags` is completely sufficient for the task of viewing the `dist-tags` for Cypress in the npm registry, and the [available-versions](https://www.npmjs.com/package/available-versions) package contains vulnerabilities, its reference is removed.

The example is also updated. `npm info` is an alias for [npm view](https://docs.npmjs.com/cli/v11/commands/npm-view), so change to use `view` as it is easier to find in the npm documentation. `npm info` is not listed in the [npm CLI command index](https://docs.npmjs.com/cli/v11/commands).

### Steps to test

Check that the instruction displays the current `dist-tags` for the npm package [cypress](https://www.npmjs.com/package/cypress):

```shell
npm view cypress dist-tags
```

### How has the user experience changed?

Release team documentation issue only. No impact on external users.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
