### PR TITLE
fix: (cy.prompt) improve the get project options performance by running promises in parallel

### DIFF
--- a/packages/server/lib/cloud/cy-prompt/CyPromptLifecycleManager.ts
+++ b/packages/server/lib/cloud/cy-prompt/CyPromptLifecycleManager.ts
@@ -62,9 +62,14 @@ export class CyPromptLifecycleManager {
     }
 
     const getProjectOptions = async () => {
+      const [user, config] = await Promise.all([
+        ctx.actions.auth.authApi.getUser(),
+        ctx.project.getConfig(),
+      ])
+
       return {
-        user: await ctx.actions.auth.authApi.getUser(),
-        projectSlug: (await ctx.project.getConfig()).projectId || undefined,
+        user,
+        projectSlug: config.projectId || undefined,
         record,
         key,
         isOpenMode: ctx.isOpenMode,

--- a/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
@@ -246,7 +246,7 @@ describe('CyPromptLifecycleManager', () => {
 
       const getProjectOptions = cyPromptManagerSetupStub.args[0][0].getProjectOptions
 
-      expect(getProjectOptions()).to.be.rejectedWith('getUser failed')
+      await expect(getProjectOptions()).to.be.rejectedWith('getUser failed')
     })
 
     it('handles errors when getProjectConfig fails', async () => {
@@ -305,7 +305,7 @@ describe('CyPromptLifecycleManager', () => {
 
       const getProjectOptions = cyPromptManagerSetupStub.args[0][0].getProjectOptions
 
-      expect(getProjectOptions()).to.be.rejectedWith('getProjectConfig failed')
+      await expect(getProjectOptions()).to.be.rejectedWith('getProjectConfig failed')
     })
 
     it('only calls ensureCyPromptBundle once per cy prompt hash', async () => {

--- a/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
@@ -190,6 +190,124 @@ describe('CyPromptLifecycleManager', () => {
       expect(readFileStub).to.be.calledWith(path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc', 'server', 'index.js'), 'utf8')
     })
 
+    it('handles errors when getUser fails but getProjectConfig succeeds', async () => {
+      cyPromptLifecycleManager.initializeCyPromptManager({
+        cloudDataSource: mockCloudDataSource,
+        ctx: mockCtx,
+        record: true,
+        key: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      const cyPromptReadyPromise = new Promise((resolve) => {
+        cyPromptLifecycleManager?.registerCyPromptReadyListener(async (cyPromptManager) => {
+          resolve(cyPromptManager)
+        })
+      })
+
+      const mockManifest = {
+        'server/index.js': 'c3c4ab913ca059819549f105e756a4c4471df19abef884ce85eafc7b7970e7b4',
+      }
+
+      ensureCyPromptBundleStub.resolves(mockManifest)
+
+      await cyPromptReadyPromise
+
+      expect(mockCtx.update).to.be.calledOnce
+      expect(ensureCyPromptBundleStub).to.be.calledWith({
+        cyPromptPath: path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc'),
+        cyPromptUrl: 'https://cloud.cypress.io/cy-prompt/bundle/abc.tgz',
+        projectId: 'test-project-id',
+      })
+
+      expect(cyPromptManagerSetupStub).to.be.calledWith({
+        script: 'console.log("cy-prompt script")',
+        cyPromptPath: path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc'),
+        cyPromptHash: 'abc',
+        cloudApi: {
+          cloudUrl: 'https://cloud.cypress.io',
+          CloudRequest,
+          createCloudRequest,
+          isRetryableError,
+          asyncRetry,
+        },
+        getProjectOptions: sinon.match.func,
+        manifest: mockManifest,
+      })
+
+      expect(postCyPromptSessionStub).to.be.calledWith({
+        projectId: 'test-project-id',
+      })
+
+      expect(mockCloudDataSource.getCloudUrl).to.be.calledWith('test')
+      expect(mockCloudDataSource.additionalHeaders).to.be.called
+      expect(readFileStub).to.be.calledWith(path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc', 'server', 'index.js'), 'utf8')
+
+      mockCtx.actions.auth.authApi.getUser = sinon.stub().rejects(new Error('getUser failed'))
+
+      const getProjectOptions = cyPromptManagerSetupStub.args[0][0].getProjectOptions
+
+      expect(getProjectOptions()).to.be.rejectedWith('getUser failed')
+    })
+
+    it('handles errors when getProjectConfig fails', async () => {
+      cyPromptLifecycleManager.initializeCyPromptManager({
+        cloudDataSource: mockCloudDataSource,
+        ctx: mockCtx,
+        record: true,
+        key: '123e4567-e89b-12d3-a456-426614174000',
+      })
+
+      const cyPromptReadyPromise = new Promise((resolve) => {
+        cyPromptLifecycleManager?.registerCyPromptReadyListener(async (cyPromptManager) => {
+          resolve(cyPromptManager)
+        })
+      })
+
+      const mockManifest = {
+        'server/index.js': 'c3c4ab913ca059819549f105e756a4c4471df19abef884ce85eafc7b7970e7b4',
+      }
+
+      ensureCyPromptBundleStub.resolves(mockManifest)
+
+      await cyPromptReadyPromise
+
+      expect(mockCtx.update).to.be.calledOnce
+      expect(ensureCyPromptBundleStub).to.be.calledWith({
+        cyPromptPath: path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc'),
+        cyPromptUrl: 'https://cloud.cypress.io/cy-prompt/bundle/abc.tgz',
+        projectId: 'test-project-id',
+      })
+
+      expect(cyPromptManagerSetupStub).to.be.calledWith({
+        script: 'console.log("cy-prompt script")',
+        cyPromptPath: path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc'),
+        cyPromptHash: 'abc',
+        cloudApi: {
+          cloudUrl: 'https://cloud.cypress.io',
+          CloudRequest,
+          createCloudRequest,
+          isRetryableError,
+          asyncRetry,
+        },
+        getProjectOptions: sinon.match.func,
+        manifest: mockManifest,
+      })
+
+      expect(postCyPromptSessionStub).to.be.calledWith({
+        projectId: 'test-project-id',
+      })
+
+      expect(mockCloudDataSource.getCloudUrl).to.be.calledWith('test')
+      expect(mockCloudDataSource.additionalHeaders).to.be.called
+      expect(readFileStub).to.be.calledWith(path.join(os.tmpdir(), 'cypress', 'cy-prompt', 'abc', 'server', 'index.js'), 'utf8')
+
+      mockCtx.project.getConfig = sinon.stub().rejects(new Error('getProjectConfig failed'))
+
+      const getProjectOptions = cyPromptManagerSetupStub.args[0][0].getProjectOptions
+
+      expect(getProjectOptions()).to.be.rejectedWith('getProjectConfig failed')
+    })
+
     it('only calls ensureCyPromptBundle once per cy prompt hash', async () => {
       cyPromptLifecycleManager.initializeCyPromptManager({
         cloudDataSource: mockCloudDataSource,


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/11305

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This is a slight improvement to `getProjectOptions` so that we can run the different async pieces in parallel.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
