### PR TITLE
internal: Add support for Studio first use instructions

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -403,6 +403,7 @@ export class ProjectBase extends EE {
       onReloadBrowser: options.onReloadBrowser,
       onFocusTests: options.onFocusTests,
       onSpecChanged: options.onSpecChanged,
+      getSavedState: this.getSavedState.bind(this),
       onSavedStateChanged: this.saveState.bind(this),
       closeExtraTargets: this.closeExtraTargets,
 
@@ -713,6 +714,12 @@ export class ProjectBase extends EE {
   }
 
   // Saved state
+
+  async getSavedState (options: { type: 'global' | 'project' } = { type: 'project' }) {
+    const state = await savedState.create(options.type === 'project' ? this.projectRoot : undefined, this.cfg.isTextTerminal)
+
+    return state.get()
+  }
 
   // forces saving of project's state by first merging with argument
   async saveState (stateChanges = {}, options: { type: 'global' | 'project' } = { type: 'project' }) {

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -403,7 +403,7 @@ export class ProjectBase extends EE {
       onReloadBrowser: options.onReloadBrowser,
       onFocusTests: options.onFocusTests,
       onSpecChanged: options.onSpecChanged,
-      onSavedStateChanged: (state: any) => this.saveState(state),
+      onSavedStateChanged: this.saveState.bind(this),
       closeExtraTargets: this.closeExtraTargets,
 
       onStudioInit: async () => {
@@ -715,16 +715,16 @@ export class ProjectBase extends EE {
   // Saved state
 
   // forces saving of project's state by first merging with argument
-  async saveState (stateChanges = {}) {
+  async saveState (stateChanges = {}, options: { type: 'global' | 'project' } = { type: 'project' }) {
     if (!this.cfg) {
       throw new Error('Missing project config')
     }
 
-    if (!this.projectRoot) {
+    if (options.type === 'project' && !this.projectRoot) {
       throw new Error('Missing project root')
     }
 
-    let state = await savedState.create(this.projectRoot, this.cfg.isTextTerminal)
+    let state = await savedState.create(options.type === 'project' ? this.projectRoot : undefined, this.cfg.isTextTerminal)
 
     state.set(stateChanges)
     this.cfg.state = await state.get()

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -716,6 +716,10 @@ export class ProjectBase extends EE {
   // Saved state
 
   async getSavedState (options: { type: 'global' | 'project' } = { type: 'project' }) {
+    if (!this.cfg) {
+      throw new Error('Missing project config trying to get saved state')
+    }
+
     const state = await savedState.create(options.type === 'project' ? this.projectRoot : undefined, this.cfg.isTextTerminal)
 
     return state.get()
@@ -724,7 +728,7 @@ export class ProjectBase extends EE {
   // forces saving of project's state by first merging with argument
   async saveState (stateChanges = {}, options: { type: 'global' | 'project' } = { type: 'project' }) {
     if (!this.cfg) {
-      throw new Error('Missing project config')
+      throw new Error('Missing project config trying to save state')
     }
 
     if (options.type === 'project' && !this.projectRoot) {

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -157,6 +157,7 @@ export class SocketBase {
       onChromiumRun () {},
       onReloadBrowser () {},
       closeExtraTargets () {},
+      getSavedState () {},
       onSavedStateChanged () {},
       onTestFileChange () {},
       onCaptureVideoFrames () {},
@@ -579,6 +580,12 @@ export class SocketBase {
           }
 
           return cb(s || {}, cachedTestState)
+        })
+
+        socket.on('get:app:state', async (opts, cb) => {
+          const state = await options.getSavedState(opts)
+
+          cb({ data: state })
         })
 
         socket.on('save:app:state', (state, cb) => {

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -583,9 +583,13 @@ export class SocketBase {
         })
 
         socket.on('get:app:state', async (opts, cb) => {
-          const state = await options.getSavedState(opts)
+          try {
+            const state = await options.getSavedState(opts)
 
-          cb({ data: state })
+            cb({ data: state })
+          } catch (error) {
+            cb({ error: errors.cloneErr(error) })
+          }
         })
 
         socket.on('save:app:state', (state, cb) => {

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -582,7 +582,10 @@ export class SocketBase {
         })
 
         socket.on('save:app:state', (state, cb) => {
-          options.onSavedStateChanged(state)
+          const opts = state.__options
+          const stateWithoutOptions = _.omit(state, '__options')
+
+          options.onSavedStateChanged(stateWithoutOptions, opts)
 
           // we only use the 'ack' here in tests
           if (cb) {

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -81,13 +81,18 @@ describe('lib/project-base', () => {
   })
 
   context('#saveState', function () {
-    beforeEach(function () {
+    beforeEach(async function () {
       const supportFile = path.join('the', 'save', 'state', 'test')
 
       this.project.cfg = { supportFile }
 
-      return savedState.create(this.project.projectRoot)
-      .then((state) => state.remove())
+      const globalState = await savedState.create()
+
+      await globalState.remove()
+
+      const projectState = await savedState.create(this.project.projectRoot)
+
+      await projectState.remove()
     })
 
     afterEach(function () {
@@ -118,6 +123,33 @@ describe('lib/project-base', () => {
       .then(() => this.project.saveState({ appWidth: 42 }))
       .then(() => this.project.saveState({ appWidth: 'modified' }))
       .then((state) => expect(state).to.deep.eq({ appWidth: 'modified' }))
+    })
+
+    it('saves global state when type is global', async function () {
+      await this.project.saveState({ reporterWidth: 1 }, { type: 'global' })
+
+      const state = await savedState.create()
+      .then((state) => state.get())
+
+      expect(state).to.deep.eq({ reporterWidth: 1 })
+    })
+
+    it('saves project state when type is project', async function () {
+      await this.project.saveState({ reporterWidth: 2 }, { type: 'project' })
+
+      const state = await savedState.create(this.project.projectRoot)
+      .then((state) => state.get())
+
+      expect(state).to.deep.eq({ reporterWidth: 2 })
+    })
+
+    it('saves project state when type is undefined', async function () {
+      await this.project.saveState({ reporterWidth: 3 })
+
+      const state = await savedState.create(this.project.projectRoot)
+      .then((state) => state.get())
+
+      expect(state).to.deep.eq({ reporterWidth: 3 })
     })
   })
 

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -80,6 +80,38 @@ describe('lib/project-base', () => {
     expect(p.projectRoot).to.eq(path.resolve(path.join('..', 'foo', 'bar')))
   })
 
+  context('#getSavedState', () => {
+    beforeEach(async function () {
+      const globalState = await savedState.create()
+
+      await globalState.remove()
+      await globalState.set({ reporterWidth: 400 })
+
+      const projectState = await savedState.create(this.project.projectRoot)
+
+      await projectState.remove()
+      await projectState.set({ reporterWidth: 500 })
+    })
+
+    it('returns global state when type is global', async function () {
+      const state = await this.project.getSavedState({ type: 'global' })
+
+      expect(state).to.deep.eq({ reporterWidth: 400 })
+    })
+
+    it('returns project state when type is project', async function () {
+      const state = await this.project.getSavedState({ type: 'project' })
+
+      expect(state).to.deep.eq({ reporterWidth: 500 })
+    })
+
+    it('returns project state when type is undefined', async function () {
+      const state = await this.project.getSavedState()
+
+      expect(state).to.deep.eq({ reporterWidth: 500 })
+    })
+  })
+
   context('#saveState', function () {
     beforeEach(async function () {
       const supportFile = path.join('the', 'save', 'state', 'test')

--- a/packages/server/test/unit/socket_spec.js
+++ b/packages/server/test/unit/socket_spec.js
@@ -262,6 +262,19 @@ describe('lib/socket', () => {
           done()
         })
       })
+
+      it('handles errors thrown by getSavedState', function (done) {
+        const err = new Error('boom')
+
+        this.options.getSavedState.rejects(err)
+
+        this.client.emit('get:app:state', { type: 'global' }, (resp) => {
+          expect(this.options.getSavedState).to.be.calledWith({ type: 'global' })
+          expect(resp.error).to.deep.eq(errors.cloneErr(err))
+
+          done()
+        })
+      })
     })
 
     context('on(save:app:state)', () => {

--- a/packages/server/test/unit/socket_spec.js
+++ b/packages/server/test/unit/socket_spec.js
@@ -64,6 +64,7 @@ describe('lib/socket', () => {
       })
       .then(() => {
         this.options = {
+          getSavedState: sinon.stub(),
           onSavedStateChanged: sinon.spy(),
           onStudioInit: sinon.stub(),
           onStudioDestroy: sinon.stub(),
@@ -246,6 +247,19 @@ describe('lib/socket', () => {
           expect(resp.error).to.deep.eq(errors.cloneErr(err))
 
           return done()
+        })
+      })
+    })
+
+    context('on(get:app:state)', () => {
+      it('calls getSavedState with options and returns the state', function (done) {
+        this.options.getSavedState.resolves({ reporterWidth: 500 })
+
+        this.client.emit('get:app:state', { type: 'global' }, (resp) => {
+          expect(this.options.getSavedState).to.be.calledWith({ type: 'global' })
+          expect(resp.data).to.deep.eq({ reporterWidth: 500 })
+
+          done()
         })
       })
     })

--- a/packages/server/test/unit/socket_spec.js
+++ b/packages/server/test/unit/socket_spec.js
@@ -251,11 +251,11 @@ describe('lib/socket', () => {
     })
 
     context('on(save:app:state)', () => {
-      it('calls onSavedStateChanged with the state', function (done) {
-        return this.client.emit('save:app:state', { reporterWidth: 500 }, () => {
-          expect(this.options.onSavedStateChanged).to.be.calledWith({ reporterWidth: 500 })
+      it('calls onSavedStateChanged with the state and options', function (done) {
+        this.client.emit('save:app:state', { reporterWidth: 500, __options: { type: 'global' } }, () => {
+          expect(this.options.onSavedStateChanged).to.be.calledWith({ reporterWidth: 500 }, { type: 'global' })
 
-          return done()
+          done()
         })
       })
     })

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -51,6 +51,7 @@ export const allowedKeys: Readonly<Array<keyof AllowedState>> = [
   'notifyWhenRunStarts',
   'notifyWhenRunStartsFailing',
   'notifyWhenRunCompletes',
+  'studioFirstUseInstructionsDismissed',
 ] as const
 
 type Maybe<T> = T | null | undefined
@@ -93,4 +94,5 @@ export type AllowedState = Partial<{
   notifyWhenRunStarts: Maybe<boolean>
   notifyWhenRunStartsFailing: Maybe<boolean>
   notifyWhenRunCompletes: Maybe<NotifyWhenRunCompletes[]>
+  studioFirstUseInstructionsDismissed: Maybe<boolean>
 }>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/11112

### Additional details

Adds support for https://github.com/cypress-io/cypress-services/pull/11343 by 
- Allow-listing the `studioFirstUseInstructionsDismissed` saved state key
- Allowing whether state is saved globally or per-project to be specified
- Adding a socket event for getting the saved state

### Steps to test

Follow the steps to test https://github.com/cypress-io/cypress-services/pull/11343

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
