### PR TITLE
chore: fix the beta release process by using the appropriate branch

### DIFF
--- a/scripts/binary/trigger-publish-binary-pipeline.js
+++ b/scripts/binary/trigger-publish-binary-pipeline.js
@@ -16,6 +16,7 @@ const { getNextVersionForBinary } = require('../get-next-version')
       job_name: process.env.CIRCLE_JOB,
       triggered_workflow_id: process.env.CIRCLE_WORKFLOW_ID,
       triggered_job_url: process.env.CIRCLE_BUILD_URL,
+      branch: process.env.CIRCLE_BRANCH,
       should_persist_artifacts: Boolean(process.env.SHOULD_PERSIST_ARTIFACTS),
       binary_version: nextVersion,
     },


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We need to ensure that the branch of `cypress` is used when publishing artifacts not `main` (which is what the publish binary repo would use by default). This got tweaked inadvertently during the release merge.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
