### PR TITLE
chore: enhance wbip to handle unsupported moduleResolution 

### DIFF
--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -38,7 +38,7 @@ const addTypeScriptConfig = (file, options) => {
   }
 
   debug(`found user tsconfig.json at ${configFile?.path} with compilerOptions: ${JSON.stringify(configFile?.config?.compilerOptions)}`)
-
+  debug(`using typescript found at ${options.typescript}`)
   // shortcut if we know we've already added typescript support
   if (options.__typescriptSupportAdded) return options
 
@@ -57,6 +57,13 @@ const addTypeScriptConfig = (file, options) => {
 
   const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
   // node will try to load a projects tsconfig.json instead of the node
+
+  // tsx parses the moduleResolution default to node10 as well as moduleResolution="node" to node10
+  // ts-loader struggles to validate the node10 moduleResolution option depending on the version of typescript used,
+  // so we set it to node which is the same as node 10. @see https://www.typescriptlang.org/tsconfig/#moduleResolution.
+  if (configFile?.config?.compilerOptions?.moduleResolution === 'node10') {
+    configFile.config.compilerOptions.moduleResolution = 'node'
+  }
 
   webpackOptions.module.rules.push({
     test: typescriptExtensionRegex,

--- a/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
+++ b/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
@@ -119,6 +119,37 @@ describe('webpack-batteries-included-preprocessor', () => {
       })
     })
 
+    it('overrides node10 option as node as they are the same thing and is simpler for ts-loader to parse', () => {
+      getTsConfigMock.returns({
+        config: {
+          compilerOptions: {
+            module: 'commonjs',
+            moduleResolution: 'node10',
+          },
+          path: '/foo/tsconfig.json',
+        },
+      })
+
+      const preprocessorCB = preprocessor({
+        typescript: true,
+        webpackOptions,
+      })
+
+      preprocessorCB({
+        filePath: 'foo.ts',
+        outputPath: '.js',
+      })
+
+      const tsLoader = webpackOptions.module.rules[0].use[0]
+
+      expect(tsLoader.options.compiler).to.be.true
+
+      expect(tsLoader.options.compilerOptions).to.deep.equal({
+        module: 'commonjs',
+        moduleResolution: 'node',
+      })
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/18938. ts-loader needs a tsconfig.json file to work.
     it('throws an error if the user\'s tsconfig.json is not found', () => {
       getTsConfigMock.returns(null)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

A few internal users of Cypress have been running into this error when using Cypress 15 
<img width="1706" height="653" alt="Screenshot 2025-08-14 at 3 14 31 PM" src="https://github.com/user-attachments/assets/08b2d8f9-5089-4e1f-8214-c2db1fa5b8aa" />

This is likely due to TypeScript not directly being installed in their project, but is installed in a parent project and is an incompatible version, such as TypeScript 4.

because `tsx` resolves the default `moduleResolution` and `moduleResolution=node` to `moduleResolution=node10`, which isn't supported in every TypeScript version, it causes compilation problems. 

This PR defaults `node10` to `node` inside module resolution as it represents the same value https://www.typescriptlang.org/tsconfig/#moduleResolution

I've also added the resolved `TypeScript` path to make this issue easier to debug if users run into this

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
