### PR TITLE
fix: extranous angular warnings

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -37,6 +37,7 @@ _Released 08/12/2025 (PENDING)_
 - Upgraded `tmp` from `~0.2.3` to `~0.2.4`. This removes the [CVE-2025-54798](https://github.com/advisories/GHSA-52f5-9888-hmc6) vulnerability being reported in security scans. Addresses [#32176](https://github.com/cypress-io/cypress/issues/32176).
 - Fixed an issue where `.fixture()` calls with a specified encoding would sometimes still attempt to parse the file based on its extension. Files with an explicit encoding are now always treated as raw content. Fixes [#32139](https://github.com/cypress-io/cypress/issues/32139).
 - Fixed an issue where `.fixture()` calls with different encoding options would return inconsistent content based on execution order. Fixes [#32138](https://github.com/cypress-io/cypress/issues/32138).
+- Fixed an issue where Angular Component Testing was printing extraneous warnings to the console by default. By default, errors only will now print to the console. This can still be overridden by passing in a custom webpack config or setting the `verbose` option inside your `angular.json`. Addresses [#26456](https://github.com/cypress-io/cypress/issues/26456).
 
 **Misc:**
 

--- a/npm/webpack-dev-server/src/helpers/angularHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/angularHandler.ts
@@ -298,6 +298,14 @@ async function getAngularCliWebpackConfig (devServerConfig: AngularWebpackDevSer
     },
   )
 
+  // @see https://github.com/cypress-io/cypress/issues/26456
+  // if verbose is not set, we set the stats to errors-only
+  // users can either override this stat by passing in a custom webpack config
+  // or by setting the verbose option to true
+  if (!buildOptions.verbose) {
+    config.stats = 'errors-only'
+  }
+
   delete config.entry.main
 
   return config

--- a/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
+++ b/npm/webpack-dev-server/test/handlers/angularHandler.spec.ts
@@ -38,6 +38,7 @@ describe('angularHandler', function () {
     expect(webpackConfig).to.exist
     expect((webpackConfig?.entry as any).main).to.be.undefined
     expect(sourceWebpackModulesResult.framework?.importPath).to.include(path.join('@angular-devkit', 'build-angular'))
+    expect(webpackConfig.stats).to.equal('errors-only')
     const projectConfig = await getProjectConfig(projectRoot)
 
     expect(projectConfig).to.deep.eq({


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #26456

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Users for some time, users have been displeased with the default webpack stat options offered by `@angular-devkit/build-angular`. To fix this, Cypress will now default the webpack stat options to `'errors-only'`. This can still be overridden via a custom webpack config or setting `verbose` to `true` inside the end user `angular.json`

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
