### PR TITLE
chore: skip flaky SelectorPlayground test

### DIFF
--- a/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
+++ b/packages/app/src/runner/selector-playground/SelectorPlayground.cy.tsx
@@ -165,7 +165,8 @@ describe('SelectorPlayground', () => {
     })
   })
 
-  it('shows copy tooltip when button is focused', () => {
+  // TODO: flaky test, but we'll be removing SelectorPlayground in the near future
+  it.skip('shows copy tooltip when button is focused', () => {
     mountSelectorPlayground()
 
     cy.get('[data-cy="playground-copy"]').focus()


### PR DESCRIPTION
### Additional details

Top 11 failure. 

<img width="594" height="87" alt="Screenshot 2025-08-18 at 2 44 34 PM" src="https://github.com/user-attachments/assets/e7c6292d-d201-4c5c-b0aa-3551cb50b50e" />


This test is flaky due to something with our tooltip timing. 

SelectorPlayground will be removed soon in the future and I don't see this as being a feature that would be critical to keep tested anyway. 

<img width="1233" height="718" alt="Screenshot 2025-08-18 at 2 47 49 PM" src="https://github.com/user-attachments/assets/9f52e208-dddd-4555-9566-353c6864f7fa" />


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
