### PR TITLE
fix: correctly discover TypeScript compiler in `@cypress/webpack-batteries-included-preprocessor`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 08/26/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
+- Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
 
 **Misc:**
 

--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -18,7 +18,7 @@ class TsConfigNotFoundError extends Error {
 class TypeScriptNotFoundError extends Error {
   constructor () {
     super('No typescript installable was found. ts-loader needs a version of typescript to work properly. Please install typescript in your project\'s package.json.')
-    this.name = 'TsConfigNotFoundError'
+    this.name = 'TypeScriptNotFoundError'
   }
 }
 
@@ -50,8 +50,10 @@ const addTypeScriptConfig = (file, options) => {
 
   try {
     if (options.typescript === true) {
+      const configFileDirectory = path.dirname(configFile?.path)
+
       // attempt to resolve typescript from the user's tsconfig.json file / project directory
-      typeScriptPath = require.resolve('typescript', { paths: [configFile?.path] })
+      typeScriptPath = require.resolve('typescript', { paths: [configFileDirectory] })
     } else {
       typeScriptPath = options.typescript
     }

--- a/npm/webpack-batteries-included-preprocessor/index.js
+++ b/npm/webpack-batteries-included-preprocessor/index.js
@@ -10,7 +10,14 @@ const WBADebugNamespace = 'cypress-verbose:webpack-batteries-included-preprocess
 
 class TsConfigNotFoundError extends Error {
   constructor () {
-    super('No tsconfig.json found, but typescript is installed. ts-loader needs a tsconfig.json file to work. Please add one to your project in either the root or the cypress directory.')
+    super('No tsconfig.json found. ts-loader needs a tsconfig.json file to work. Please add one to your project in either the root or the cypress directory.')
+    this.name = 'TsConfigNotFoundError'
+  }
+}
+
+class TypeScriptNotFoundError extends Error {
+  constructor () {
+    super('No typescript installable was found. ts-loader needs a version of typescript to work properly. Please install typescript in your project\'s package.json.')
     this.name = 'TsConfigNotFoundError'
   }
 }
@@ -38,7 +45,23 @@ const addTypeScriptConfig = (file, options) => {
   }
 
   debug(`found user tsconfig.json at ${configFile?.path} with compilerOptions: ${JSON.stringify(configFile?.config?.compilerOptions)}`)
-  debug(`using typescript found at ${options.typescript}`)
+
+  let typeScriptPath = null
+
+  try {
+    if (options.typescript === true) {
+      // attempt to resolve typescript from the user's tsconfig.json file / project directory
+      typeScriptPath = require.resolve('typescript', { paths: [configFile?.path] })
+    } else {
+      typeScriptPath = options.typescript
+    }
+
+    debug(`using typescript found at ${typeScriptPath}`)
+  } catch {
+    debug('no user typescript found. Throwing TypeScriptNotFoundError')
+
+    throw new TypeScriptNotFoundError()
+  }
   // shortcut if we know we've already added typescript support
   if (options.__typescriptSupportAdded) return options
 
@@ -72,7 +95,7 @@ const addTypeScriptConfig = (file, options) => {
       {
         loader: require.resolve('ts-loader'),
         options: {
-          compiler: options.typescript,
+          compiler: typeScriptPath,
           // pass in the resolved compiler options from the tsconfig file into ts-loader to most accurately transpile the code
           ...(configFile ? {
             compilerOptions: configFile.config.compilerOptions,

--- a/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
+++ b/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.js
@@ -89,8 +89,8 @@ describe('webpack-batteries-included-preprocessor', () => {
             module: 'ESNext',
             moduleResolution: 'Bundler',
           },
-          path: '/foo/tsconfig.json',
         },
+        path: require.resolve('../../test/fixtures/tsconfig.json'),
       })
 
       const preprocessorCB = preprocessor({
@@ -107,7 +107,7 @@ describe('webpack-batteries-included-preprocessor', () => {
 
       expect(tsLoader.loader).to.contain('ts-loader')
 
-      expect(tsLoader.options.compiler).to.be.true
+      expect(tsLoader.options.compiler).to.equal(require.resolve('typescript'))
       expect(tsLoader.options.logLevel).to.equal('error')
       expect(tsLoader.options.silent).to.be.true
       expect(tsLoader.options.transpileOnly).to.be.true
@@ -126,8 +126,8 @@ describe('webpack-batteries-included-preprocessor', () => {
             module: 'commonjs',
             moduleResolution: 'node10',
           },
-          path: '/foo/tsconfig.json',
         },
+        path: require.resolve('../../test/fixtures/tsconfig.json'),
       })
 
       const preprocessorCB = preprocessor({
@@ -141,8 +141,6 @@ describe('webpack-batteries-included-preprocessor', () => {
       })
 
       const tsLoader = webpackOptions.module.rules[0].use[0]
-
-      expect(tsLoader.options.compiler).to.be.true
 
       expect(tsLoader.options.compilerOptions).to.deep.equal({
         module: 'commonjs',
@@ -164,7 +162,31 @@ describe('webpack-batteries-included-preprocessor', () => {
           filePath: 'foo.ts',
           outputPath: '.js',
         })
-      }).to.throw('No tsconfig.json found, but typescript is installed. ts-loader needs a tsconfig.json file to work. Please add one to your project in either the root or the cypress directory.')
+      }).to.throw('No tsconfig.json found. ts-loader needs a tsconfig.json file to work. Please add one to your project in either the root or the cypress directory.')
+    })
+
+    it('throws an error if the user\'s typescript is not found', () => {
+      getTsConfigMock.returns({
+        config: {
+          compilerOptions: {
+            module: 'commonjs',
+            moduleResolution: 'node16',
+          },
+        },
+        path: '/does/not/exist',
+      })
+
+      const preprocessorCB = preprocessor({
+        typescript: true,
+        webpackOptions,
+      })
+
+      expect(() => {
+        return preprocessorCB({
+          filePath: 'foo.ts',
+          outputPath: '.js',
+        })
+      }).to.throw('No typescript installable was found. ts-loader needs a version of typescript to work properly. Please install typescript in your project\'s package.json.')
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32338

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fixes an issue where TypeScript isn't being correctly resolved in `@cypress/webpack-batteries-included-preprocessor` when used as a standalone package and `typescript` is set to `true`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
