### PR TITLE
chore: (studio) don't log to Sentry when user opens studio before initialization

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -25,11 +25,6 @@ import type Protocol from 'devtools-protocol'
 import type { ServiceWorkerClientEvent } from '@packages/proxy/lib/http/util/service-worker-manager'
 import { v4 } from 'uuid'
 import { StudioLifecycleManager } from './cloud/studio/StudioLifecycleManager'
-import { reportStudioError } from './cloud/api/studio/report_studio_error'
-import { CloudRequest } from './cloud/api/cloud_request'
-import { isRetryableError } from './cloud/network/is_retryable_error'
-import { asyncRetry } from './util/async_retry'
-import { getCloudMetadata } from './cloud/get_cloud_metadata'
 import { telemetryManager } from './cloud/studio/telemetry/TelemetryManager'
 import { INITIALIZATION_MARK_NAMES, INITIALIZATION_TELEMETRY_GROUP_NAMES } from './cloud/studio/telemetry/constants/initialization'
 import { TelemetryReporter } from './cloud/studio/telemetry/TelemetryReporter'
@@ -426,22 +421,6 @@ export class ProjectBase extends EE {
 
           if (!isStudioReady) {
             debug('User entered studio mode before cloud studio was initialized')
-            const { cloudUrl, cloudHeaders } = await getCloudMetadata(this.ctx.cloud)
-
-            reportStudioError({
-              cloudApi: {
-                cloudUrl,
-                cloudHeaders,
-                CloudRequest,
-                isRetryableError,
-                asyncRetry,
-              },
-              studioHash: this.id,
-              projectSlug: this.cfg.projectId,
-              error: new Error('User entered studio before cloud studio was initialized'),
-              studioMethod: 'onStudioInit',
-              studioMethodArgs: [],
-            })
 
             endTelemetry({ status: 'studio-not-ready', canAccessStudioAI: false })
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/11442

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

This PR removes the "User entered studio before cloud studio was initialized" error that was getting reported to Sentry. It's not really an error, it just tells us that a user opened studio before we downloaded it from Cloud. If it times out we'll get a separate error for that, and we're already tracking this in Honeycomb as telemetry so it just makes the Sentry list noisy.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No change in UX

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
