### PR TITLE
docs: update namespace restrictions contributor workaround

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,20 @@ You must have the following installed on your system to contribute locally:
 `python` is pre-installed on Debian-based systems including Ubuntu.
 The Python versions shipped with Ubuntu versions `20.04`, `22.04` and `24.*` are compatible with Cypress requirements.
 
-For Ubuntu `24.04` and above, refer also to the [Ubuntu 24.04 Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890) in the section "Unprivileged user namespace restrictions" and apply one of the workarounds to disable unprivileged user namespace restrictions for the entire system, either for one boot or persistently, as described. If you do not do this you may receive an error which includes the text `FATAL:setuid_sandbox_host.cc` when you try to run Cypress on these versions of Ubuntu after building Cypress from source.
+For Ubuntu `>=24.04`, disable "Unprivileged user namespace restrictions" permanently for the entire system by executing the following commands that are derived from the [Ubuntu 24.04 Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890):
+
+```shell
+echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf
+sudo sysctl --system
+```
+
+If you prefer to disable the restrictions for one boot only, use instead:
+
+```shell
+echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+```
+
+If you do not disable these restrictions for the affected Ubuntu versions, then Cypress may exit with a fatal error when you try to run Cypress after building Cypress from source. The error includes the text `FATAL:setuid_sandbox_host.cc` and may be hidden, pending resolution of issue https://github.com/cypress-io/cypress/issues/32358.
 
 #### Windows
 


### PR DESCRIPTION
### Additional details

The [CONTRIBUTING > Requirements > Debian/Ubuntu](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#debianubuntu) section includes instructions for disabling the "Unprivileged user namespace restrictions" in Ubuntu `>=24.04` that require contributors to research in the [Ubuntu 24.04 Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890). Internal links to this document are not supported, so it is less convenient to find the necessary section.

Explicit instructions to persistently disable the restrictions are added to the documentation section with the following command:

```shell
echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf
sudo sysctl --system
```

The restriction and workaround only applies to Ubuntu `>=24.04`. The Debian distro, including the latest release Debian 13 (trixie), does not have this restriction.

As a further complication with Cypress `15.0.0`, Cypress now fails silently. See https://github.com/cypress-io/cypress/issues/32358.

### Steps to test

On Ubuntu `24.04.3` LTS

Execute:

```shell
echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf
sudo sysctl --system
git clone https://github.com/cypress-io/cypress
cd cypress
n auto # or set Node.js manually
npm install yarn -g
yarn
yarn start
```

Confirm that Cypress starts up and displays the "What's New in Cypress" info on first use of a new major version, and then the Projects selection UI.

### How has the user experience changed?

Documentation addition for contributors only. No end-user change. This step is not necessary when installing and using the npm package [cypress](https://www.npmjs.com/package/cypress). It is only necessary when building and running Cypress from source with `yarn install && yarn start` for instance.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

