### PR TITLE
fix: force gtk version 3 to avoid Electron 36 from crashing

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -38,7 +38,7 @@ mainBuildFilters: &mainBuildFilters
         - /^release\/\d+\.\d+\.\d+$/
         # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
         - 'update-v8-snapshot-cache-on-develop'
-        - 'chore/updates_post_15'
+        - 'fix/set_fixed_gtk_version'
 
 # usually we don't build Mac app - it takes a long time
 # but sometimes we want to really confirm we are doing the right thing
@@ -49,7 +49,7 @@ macWorkflowFilters: &darwin-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'chore/updates_post_15', << pipeline.git.branch >> ]
+      - equal: [ 'fix/set_fixed_gtk_version', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -60,7 +60,7 @@ linuxArm64WorkflowFilters: &linux-arm64-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'chore/updates_post_15', << pipeline.git.branch >> ]
+      - equal: [ 'fix/set_fixed_gtk_version', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -83,7 +83,7 @@ windowsWorkflowFilters: &windows-workflow-filters
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'chore/updates_post_15', << pipeline.git.branch >> ]
+      - equal: [ 'fix/set_fixed_gtk_version', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
@@ -157,7 +157,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "chore/updates_post_15" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "fix/set_fixed_gtk_version" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 08/26/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where OS distributions and releases were sometimes not properly populated for Module API results and Cloud recordings. Fixes [#30533](https://github.com/cypress-io/cypress/issues/30533). Addressed in [#32283](https://github.com/cypress-io/cypress/pull/32283).
-- Fixed an issue where in rare cases, Cypress would fail to run on GNOME if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361)
+- Fixed an issue where Cypress would fail to run on GNOME if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361).
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
 - Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 08/26/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where OS distributions and releases were sometimes not properly populated for Module API results and Cloud recordings. Fixes [#30533](https://github.com/cypress-io/cypress/issues/30533). Addressed in [#32283](https://github.com/cypress-io/cypress/pull/32283).
+- Fixed an issue where in rare cases where Cypress would fail to run if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361)
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
 - Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 08/26/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where OS distributions and releases were sometimes not properly populated for Module API results and Cloud recordings. Fixes [#30533](https://github.com/cypress-io/cypress/issues/30533). Addressed in [#32283](https://github.com/cypress-io/cypress/pull/32283).
-- Fixed an issue where in rare cases where Cypress would fail to run if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361)
+- Fixed an issue where in rare cases, Cypress would fail to run on GNOME if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361)
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
 - Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
 

--- a/packages/server/lib/util/chromium_flags.ts
+++ b/packages/server/lib/util/chromium_flags.ts
@@ -115,6 +115,7 @@ export const DEFAULT_CHROME_FLAGS = formatChromeFlags(DEFAULT_FLAGS)
 
 export const DEFAULT_ELECTRON_FLAGS = [
   ...formatElectronFlags(DEFAULT_CHROME_FLAGS),
+  // NOTE: Can likely be removed with Electron upgrade to 37+.
   // @see https://github.com/electron/electron/issues/46538
   // @see https://github.com/cypress-io/cypress/issues/32361
   ...formatElectronFlags(['--gtk-version=3']),

--- a/packages/server/lib/util/chromium_flags.ts
+++ b/packages/server/lib/util/chromium_flags.ts
@@ -113,4 +113,9 @@ export const formatElectronFlags = (flags) => {
 
 export const DEFAULT_CHROME_FLAGS = formatChromeFlags(DEFAULT_FLAGS)
 
-export const DEFAULT_ELECTRON_FLAGS = formatElectronFlags(DEFAULT_CHROME_FLAGS)
+export const DEFAULT_ELECTRON_FLAGS = [
+  ...formatElectronFlags(DEFAULT_CHROME_FLAGS),
+  // @see https://github.com/electron/electron/issues/46538
+  // @see https://github.com/cypress-io/cypress/issues/32361
+  ...formatElectronFlags(['--gtk-version=3']),
+]

--- a/packages/server/test/unit/environment_spec.js
+++ b/packages/server/test/unit/environment_spec.js
@@ -44,6 +44,16 @@ describe('lib/environment', () => {
     return process.env['CYPRESS_INTERNAL_ENV'] = env
   })
 
+  // @see https://github.com/electron/electron/issues/46538
+  // @see https://github.com/cypress-io/cypress/issues/32361
+  context('sets gtk-version=3 in Electron >= 36', () => {
+    it('sets launch args', () => {
+      sinon.stub(app.commandLine, 'appendSwitch')
+      require(`../../lib/environment`)
+      expect(app.commandLine.appendSwitch).to.have.been.calledWith('--gtk-version', '3')
+    })
+  })
+
   context('parses ELECTRON_EXTRA_LAUNCH_ARGS', () => {
     let restore = null
 


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32361

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

See https://www.electronjs.org/blog/electron-36-0#behavior-changed-gtk-4-is-the-default-when-running-on-gnome. In rare cases, it looks like GTK 4 is colliding with GTK 2/3 in the Electron process. To avoid this, we are going to set GTK to version 3 which should be supported on all of our supported linux platforms that use GNOME.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
