### PR TITLE
docs: update Python Linux contributor requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ You must have the following installed on your system to contribute locally:
 
 `sudo apt install build-essential` meets the additional requirements to run `node-gyp` in the context of building Cypress from source.
 `python` is pre-installed on Debian-based systems including Ubuntu.
-The Python versions shipped with Ubuntu versions `20.04`, `22.04` and `24.*` are compatible with Cypress requirements.
+The default Python versions included with Debian `>=11` and Ubuntu `>=22.04`, which range from Python `3.9` - `3.13`, are all compatible with Cypress requirements.
 
 For Ubuntu `>=24.04`, disable "Unprivileged user namespace restrictions" permanently for the entire system by executing the following commands that are derived from the [Ubuntu 24.04 Release notes](https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890):
 


### PR DESCRIPTION
### Additional details

The [CONTRIBUTING > Requirements > Debian/Ubuntu](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#debianubuntu) section includes information about Python versions needed for Debian and Ubuntu.

Debian is not mentioned, and Python version 3.8 used in Ubuntu 20.04 has already reached [End of support](https://www.python.org/downloads/).

All default Python versions for `Debian >=11` and Ubuntu `>=22.04` can be used to build Cypress from source.

### Steps to test

On each currently supported Debian / Ubuntu distro, confirm the version of Python and build Cypress from source:

| Distro | Version        | Codename        | Default Python version | Workarounds |
| ------ | -------------- | --------------- | ---------------------- | ----------- |
| Debian | `11`           | bullseye        | `3.9.x`                |             |
| Ubuntu | `22.04.04` LTS | Jammy Jellyfish | `3.10.x`               |             |
| Debian | `12`           | bookworm        | `3.11.x`               | 3)          |
| Ubuntu | `24.04` LTS    | Noble Numbat    | `3.12.x`               | 1)          |
| Ubuntu | `25.04`        | Plucky Puffin   | `3.13.x`               | 1) 2)       |
| Debian | `13`           | trixie          | `3.13.x`               | 2) 3)       |

Before testing, remove any alternate Python versions installed, for instance, according to previous instructions in https://github.com/cypress-io/cypress/blob/8dc09ea5165bb80babf32fc4af990fe9d993df24/CONTRIBUTING.md#requirements.

#### Workarounds

1) See [CONTRIBUTING > Requirements > Debian/Ubuntu](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#debianubuntu) for "Unprivileged user namespace restrictions" workaround

    ```shell
    echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf
    sudo sysctl --system
    ```

2) See https://github.com/cypress-io/cypress/issues/32192#issuecomment-3180059483 for V8 snapshot failure workaround

    ```shell
    export DISABLE_SNAPSHOT_REQUIRE=1
    ```

3) See https://github.com/cypress-io/cypress/issues/32361#issuecomment-3228470484

    ```shell
    export ELECTRON_EXTRA_LAUNCH_ARGS=--gtk-version=3
    ```

#### Commands

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
n auto # or set Node.js manually to 22.15.1
npm install yarn -g
yarn
```

Confirm that installing dependencies and building packages was successful, and that the following log sequence shows no errors between the steps:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

```shell
yarn start
```

Confirm that Cypress starts in the Projects UI view.

### How has the user experience changed?

Documentation change for contributors only when building and running Cypress from source with `yarn install && yarn start` for instance. No end-user change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
