### PR TITLE
docs: update node-gyp Windows contributor requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,9 @@ If you do not disable these restrictions for the affected Ubuntu versions, then 
 
 #### Windows
 
-When using [`nvm`](https://github.com/coreybutler/nvm-windows) and changing node versions, node install tools are not installed automatically. This is needed for `node-gyp` to rebuild `better-sqlite3`. If you are failing to build Cypress because of this, either with a Python install missing or a VSCode version not being detected by `node-gyp`, you likely need to run the `install_tools.bat` outlined in the [better-sqlite3 troubleshooting guide](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md).
+Install the current [version of Python](https://devguide.python.org/versions/) (`3.13`) from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation) and install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, selecting the `Desktop development with C++` workload.
+
+Refer to the `node-gyp` [Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) documentation section for a description of alternate ways of providing the `node-gyp` execution environment and for troubleshooting information.
 
 #### Corepack
 


### PR DESCRIPTION
### Additional details

The [CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows) section includes information about how to set up a Windows system so that it can execute the package re-build section when installing Cypress dependencies from source with the `yarn` command, so that the build can be successful. [node-gyp](https://github.com/nodejs/node-gyp) is at the heart of the rebuild process and this needs prerequisites to be installed.

None of the Node.js version managers provide any function to install `node-gyp` prerequisites. The reference to `nvm` is therefore misleading.

The [better-sqlite3 > Troubleshooting installation](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md) document assumes that Node.js is being installed on Windows using a Windows Installer `.msi` package for a single version of Node.js, instead of using a Node.js version manager. The [install_tools.bat](https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat) script, quoted in these instructions, is outdated and installs the old Visual Studio 2019 version, not the current Visual Studio 2022 version. Although this still works with Cypress 15, the version installed is no longer officially supported by Node.js 22.x.

In [CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows), link instead to the [node-gyp > Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) documentation section, as reference, and copy a suggested preference to install, based on current versions:

- Install the current [version of Python](https://devguide.python.org/versions/) (`3.13`) from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation)

- Install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition selecting the `Desktop development with C++` workload

### Steps to test

On Windows 11 24H2

- Install Python `3.13` from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation). Remove any other installed versions of Python.

- Install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, current version `17.14.3`, selecting the `Desktop development with C++` workload

Then execute:

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
nvm install 22.15.1 # or set Node.js manually to 22.15.1
nvm use 22.15.1
npm install yarn -g
export DISABLE_SNAPSHOT_REQUIRE=1 # see issue https://github.com/cypress-io/cypress/issues/28739
git clean -xfd # if repeating
yarn
```

Confirm that installing dependencies and building packages (including `better-sqlite3`) was successful, and that the following log sequence shows no errors between the steps:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

```shell
yarn start
```

Confirm that Cypress starts in the Projects UI view.

### How has the user experience changed?

Documentation change for contributors only when building and running Cypress from source with `yarn install && yarn start` for instance. No end-user change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
