### PR TITLE
chore: patch `dtslint` to work until we can find a replacement

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-8-19-2025
+8-28-2025-dtslint

--- a/cli/package.json
+++ b/cli/package.json
@@ -129,6 +129,9 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
+    "./types/net-stubbing": {
+      "types": "./types/net-stubbing.d.ts"
+    },
     "./vue": {
       "types": "./vue/dist/index.d.ts",
       "import": "./vue/dist/cypress-vue.esm-bundler.js",

--- a/cli/types/index.d.ts
+++ b/cli/types/index.d.ts
@@ -4,7 +4,7 @@
 //                 Mike Woudenberg <https://github.com/mikewoudenberg>
 //                 Robbert van Markus <https://github.com/rvanmarkus>
 //                 Nicholas Boll <https://github.com/nicholasboll>
-// TypeScript Version: 4.3
+// TypeScript Version: 5.0
 // Updated by the Cypress team: https://www.cypress.io/about/
 
 /// <reference path="./cy-blob-util.d.ts" />

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
     "**/sharp": "0.29.3",
     "**/socket.io-parser": "4.0.5",
     "**/ua-parser-js": "0.7.33",
+    "@definitelytyped/typescript-versions": "0.1.7",
     "@types/react": "18.3.12",
     "browserify-sign": "4.2.2",
     "devtools-protocol": "0.0.1459876",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,10 +2900,10 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.71", "@definitelytyped/typescript-versions@latest":
-  version "0.0.71"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.71.tgz#08c791e3bf3c2861611edee8f28c72d2db0fb02e"
-  integrity sha512-XJvyYfWQyntq+EdCqRinni9BwenPAoCXTZ3aaKfuir14bEbkIyeyQjuh1R0VkqdahIavyyAoGmYHe9OSYqFwTw==
+"@definitelytyped/typescript-versions@0.1.7", "@definitelytyped/typescript-versions@^0.0.71", "@definitelytyped/typescript-versions@latest":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.1.7.tgz#bd7a50832a21ed5978c2513e558cf0ac0d80cece"
+  integrity sha512-sBzBi1SBn79OkSr8V0H+FzR7QumHk23syPyRxod/VRBrSkgN9rCliIe+nqLoWRAKN8EeKbp00ketnJNLZhucdA==
 
 "@definitelytyped/utils@latest":
   version "0.0.71"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Updates `@definitelytyped/typescript-versions` to `0.1.7` instead of `0.0.77`. We are in an interesting position because `dtslint` has been deprecated for some time, but it is still serving the need of checking the CLI types against various supported versions of TypeScript. However, that hasn't been happening of late as the older versions of `@definitelytyped/typescript-versions` we were using only support up to `4.7`. 

To get newer support, I've resolved us to use `"@definitelytyped/typescript-versions"` `0.1.4` which will typecheck us up to TypeScript `5.9`. `0.1.7` supports up to `5.9` and since we can't set a maximum TypeScript version, we just install the version that has the ceiling determined for us. We can also update this package to check `6.0` if needed.

Oddly, `cypress/types/net-stubbing` started to fail in TypeScript `5.6` when checking the test files. Likely, some type of behavior was fixed in 5.6 that is now resolving this module correctly, so we needed to add the type definition to the `package.json` of the CLI. Now things should be passing correctly

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
