### PR TITLE
fix: move @cypress/schematic npm registry query to https

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@ _Released 08/26/2025 (PENDING)_
 - Fixed an issue where Cypress would fail to run on GNOME if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361).
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
 - Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
+- Fixed an issue using `@cypress/schematic` where Cypress was added to an Angular project with version `latest` instead of the current latest version of Cypress. Fixes [#32388](https://github.com/cypress-io/cypress/issues/32388).
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,7 +13,6 @@ _Released 08/26/2025 (PENDING)_
 - Fixed an issue where Cypress would fail to run on GNOME if GTK 4 and GTK 2/3 were detected in the Electron process. Addresses [#32361](https://github.com/cypress-io/cypress/issues/32361).
 - Fixed an issue where the open Studio button would incorrectly show for component tests. Addressed in [#32315](https://github.com/cypress-io/cypress/pull/32315).
 - Fixed an issue where the TypeScript compiler wasn't being resolved correctly when `@cypress/webpack-batteries-included-preprocessor` was used as a standalone package. Fixes [#32338](https://github.com/cypress-io/cypress/issues/32338).
-- Fixed an issue using `@cypress/schematic` where Cypress was added to an Angular project with version `latest` instead of the current latest version of Cypress. Fixes [#32388](https://github.com/cypress-io/cypress/issues/32388).
 
 **Misc:**
 

--- a/npm/cypress-schematic/src/schematics/utils/index.ts
+++ b/npm/cypress-schematic/src/schematics/utils/index.ts
@@ -2,7 +2,7 @@ import { readdirSync } from 'fs'
 import { resolve } from 'path'
 import { getSystemPath, normalize, strings } from '@angular-devkit/core'
 import { Tree, apply, url, applyTemplates, move, Rule } from '@angular-devkit/schematics'
-import { get } from 'http'
+import { get } from 'https'
 import { Schema } from '../ng-generate/cypress-test/schema'
 
 import { getPackageJsonDependency } from './dependencies'
@@ -30,7 +30,7 @@ export function getLatestNodeVersion (packageName: string): Promise<NodePackage>
   const DEFAULT_VERSION = 'latest'
 
   return new Promise((resolve) => {
-    return get(`http://registry.npmjs.org/${packageName}`, (res) => {
+    return get(`https://registry.npmjs.org/${packageName}`, (res) => {
       let rawData = ''
 
       res.on('data', (chunk) => (rawData += chunk))


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/32388

### Additional details

[@cypress/schematic](https://www.npmjs.com/package/@cypress/schematic) was querying the [npm registry](https://docs.npmjs.com/cli/v11/using-npm/registry) `registry.npmjs.org` using the `http` protocol.

Since Oct 4, 2021, the npm registry requires TLS `1.2`, see [The npm registry is deprecating TLS 1.0 and TLS 1.1](https://github.blog/security/supply-chain-security/npm-registry-deprecating-tls-1-0-tls-1-1/). Attempting to use `http` does not meet this requirement.

The attempt to query the npm package record http://registry.npmjs.org/cypress was failing and instead Cypress installation fell back to using the literal version `latest`, also leaving this value in the updated `package.json` if `ng add @cypress/schematic` was invoked.

[npm/cypress-schematic/src/schematics/utils/index.ts](https://github.com/cypress-io/cypress/blob/develop/npm/cypress-schematic/src/schematics/utils/index.ts) is updated to query the npm registry using `https` instead of `http`.

### Steps to test

On Ubuntu `24.04.3` LTS, execute:

```shell
git clone --branch issue-32388-schematic-http-registry-query https://github.com/MikeMcC399/cypress
cd cypress
n auto # or manually set Node.js to 22.15.1
npm install yarn@latest -g
yarn
cd ..
git clone --branch 32388-angular-20 https://github.com/MikeMcC399/cypress-test-tiny
cd cypress-test-tiny
cd angular-app
ng add ../../cypress/npm/cypress-schematic --e2e --component
npm why cypress
npx cypress info
```

Confirm that cypress shows a numerical version, not the literal text `latest`

```text
$ npm why cypress
cypress@15.0.0 dev
node_modules/cypress
  dev cypress@"15.0.0" from the root project
```


### How has the user experience changed?

When following the instructions in [npm/cypress-schematic > README > Adding E2E and Component Testing](https://github.com/cypress-io/cypress/tree/develop/npm/cypress-schematic#adding-e2e-and-component-testing) using `ng add @cypress/schematic`, Cypress is saved to the `devDependencies` key section of the `package.json` file with its exact latest version, for example:

```json
    "cypress": "15.0.0"
```

instead of

```json
    "cypress": "latest"
```

### PR Tasks

- [ ] Have tests been added/updated? (existing tests do not check this aspect, they only check that Cypress / Angular works)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? Only mentioned in https://docs.cypress.io/app/guides/migration/protractor-to-cypress and no changes necessary
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
