### PR TITLE
dependency: upgrade better-sqlite3 from 11.9.1 to 11.10.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 09/16/2025_
 
 **Dependency Updates:**
 
-- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#](https://github.com/cypress-io/cypress/issues/).
+- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#32404](https://github.com/cypress-io/cypress/issues/32404).
 
 ## 15.1.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.1.1
+
+_Released 09/16/2025_
+
+**Dependency Updates:**
+
+- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#](https://github.com/cypress-io/cypress/issues/).
+
 ## 15.1.0
 
 _Released 09/02/2025_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.1.1
 
-_Released 09/16/2025_
+_Released 09/16/2025 (PENDING)_
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 09/16/2025 (PENDING)_
 
 **Dependency Updates:**
 
-- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#32404](https://github.com/cypress-io/cypress/issues/32404).
+- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#32404](https://github.com/cypress-io/cypress/pull/32404).
 
 ## 15.1.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 09/16/2025 (PENDING)_
 
 **Dependency Updates:**
 
-- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.1`. Addressed in [#32404](https://github.com/cypress-io/cypress/pull/32404).
+- Updated [`better-sqlite3`](https://www.npmjs.com/package/better-sqlite3) from `11.9.1` to `11.10.0`. Addressed in [#32404](https://github.com/cypress-io/cypress/pull/32404).
 
 ## 15.1.0
 

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -56,6 +56,8 @@ Upgrading `electron` involves more than just bumping this package's `package.jso
     - [ ] [`/system-tests/test-binary/*`](../../system-tests/test-binary) - update binary system tests to use the newly published Ubuntu and Node images mentioned above, if applicable
     - [ ] Do a global search for the old Node.js version to identify any new areas that may need updating/unification, and update those locations (and this document!)  
 
+- [ ] **Update `better-sqlite3` version if needed** Look through the [commit history](https://github.com/WiseLibs/better-sqlite3/commits/master/) of `better-sqlite3` and find the first version that supports the proper version of `electron`'s prebuilds. Update [`/packages/server/package.json`](../../packages/server/package) and [`/packages/types/package.json`](../../packages/types/package.json) to the appropriate version.
+
 - [ ] **Update `cypress-publish-binary`** For **binary publishing**, make sure the `electron` version that we updated in [`/package.json`](../../package.json) matches the `electron` version inside the [publish binary project](https://github.com/cypress-io/cypress-publish-binary/blob/main/package.json). This is to make sure add-on tests inside the publish-binary repository work locally, but are not required to install the correct version of `electron` in CI when publishing the binary. Ensure the `electron` target in this project's `.circleci` configuration is updated as well. Set the Remove this before merging, and ensure that branch is merged as well.
   - [ ] Create a new branch in `cypress-publish-binary`
   - [ ] Update `electron` version in `package.json`

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,7 +41,7 @@
     "ast-types": "0.13.3",
     "axios": "^1.11.0",
     "base64url": "^3.0.1",
-    "better-sqlite3": "11.9.1",
+    "better-sqlite3": "11.10.0",
     "black-hole-stream": "0.0.1",
     "bluebird": "3.7.2",
     "body-parser": "1.20.3",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "20.16.0",
     "axios": "^1.8.3",
-    "better-sqlite3": "11.5.0",
+    "better-sqlite3": "11.10.0",
     "devtools-protocol": "0.0.1459876",
     "express": "4.21.0",
     "socket.io": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11221,18 +11221,10 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
-better-sqlite3@11.5.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.5.0.tgz#58faa51e02845a578dd154f0083487132ead0695"
-  integrity sha512-e/6eggfOutzoK0JWiU36jsisdWoHOfN9iWiW/SieKvb7SAa6aGNmBM/UKyp+/wWSXpLlWNN8tCPwoDNPhzUvuQ==
-  dependencies:
-    bindings "^1.5.0"
-    prebuild-install "^7.1.1"
-
-better-sqlite3@11.9.1:
-  version "11.9.1"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.9.1.tgz#0540da2f2ce24cbd766bb35db412f4be2c75b8bb"
-  integrity sha512-Ba0KR+Fzxh2jDRhdg6TSH0SJGzb8C0aBY4hR8w8madIdIzzC6Y1+kx5qR6eS1Z+Gy20h6ZU28aeyg0z1VIrShQ==
+better-sqlite3@11.10.0:
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-11.10.0.tgz#2b1b14c5acd75a43fd84d12cc291ea98cef57d98"
+  integrity sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Upgrade `better-sqlite3` from `11.9.1` to `11.10.0`. This helps speed up `yarn` during development since we can just download the binary rather than having to rebuild it every time.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
