### PR TITLE
chore: Revert "chore: correct --spec usage in workflows (#32264)"

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -728,13 +728,13 @@ commands:
               yarn $YARN_CMD --record $PARALLEL --browser <<parameters.browser>> --runner-ui
             else
               # external PR
-              TESTFILES=$(circleci tests glob "cypress/e2e/**/*.cy.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL | tr '\n' ',' | sed 's/,$//')
+              TESTFILES=$(circleci tests glob "cypress/e2e/**/*.cy.*" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               echo "Test files for this machine are $TESTFILES"
 
               if [[ -z "$TESTFILES" ]]; then
                 echo "Empty list of test files"
               fi
-              yarn $YARN_CMD --browser <<parameters.browser>> --spec "$TESTFILES" --runner-ui
+              yarn $YARN_CMD --browser <<parameters.browser>> --spec $TESTFILES --runner-ui
             fi
           working_directory: packages/driver
       - sanitize-verify-and-store-mocha-results
@@ -822,10 +822,10 @@ commands:
               if [[ <<parameters.type>> == 'ct' ]]; then
                 # component tests are located side by side with the source codes.
                 # for the app component tests, ignore specs that are known to cause failures on contributor PRs (see https://discuss.circleci.com/t/how-to-exclude-certain-files-from-circleci-test-globbing/41028)
-                TESTFILES=$(find src -regextype posix-extended -name '*.cy.*' | circleci tests split --total=$CIRCLE_NODE_TOTAL | tr '\n' ',' | sed 's/,$//')
+                TESTFILES=$(find src -regextype posix-extended -name '*.cy.*' | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               else
                 GLOB="cypress/e2e/**/*cy.*"
-                TESTFILES=$(circleci tests glob "$GLOB" | circleci tests split --total=$CIRCLE_NODE_TOTAL | tr '\n' ',' | sed 's/,$//')
+                TESTFILES=$(circleci tests glob "$GLOB" | circleci tests split --total=$CIRCLE_NODE_TOTAL)
               fi
 
               echo "Test files for this machine are $TESTFILES"
@@ -838,7 +838,7 @@ commands:
               PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
               PERCY_ENABLE=${PERCY_TOKEN:-0} \
               PERCY_PARALLEL_TOTAL=-1 \
-              yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --spec "$TESTFILES"
+              yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --spec $TESTFILES
             fi
       - run:
           command: |
@@ -1970,7 +1970,7 @@ jobs:
           name: Bootstrap the Cypress binary and run binary system test
           command: |
             # we need to bootstrap the binary into our project directory and run the tests
-            source ./system-tests/scripts/bootstrap-docker-container.sh 'yarn cypress run --component --spec "src/mount.cy.ts,src/App.cy.ts"'
+            source ./system-tests/scripts/bootstrap-docker-container.sh 'yarn cypress run --component --spec src/mount.cy.ts src/App.cy.ts'
 
   system-tests-chrome:
     <<: *defaults


### PR DESCRIPTION
This reverts commit 362d506d0e7fc6a70ff366d419465cccc2d94717.

### Additional details

[Some of our tests ](https://app.circleci.com/pipelines/github/cypress-io/cypress/74323/workflows/152943d9-6e53-438d-9dde-ce560d553f62/jobs/3112893)are failing with the new glob updates - these tests were only run on `develop` so the issue was not seen before. 

This needs deeper investigation before merging again to ensure all tests are running properly.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
