### PR TITLE
chore: set debug verbose on stderr-filtering logs

### DIFF
--- a/packages/stderr-filtering/lib/FilterTaggedContent.ts
+++ b/packages/stderr-filtering/lib/FilterTaggedContent.ts
@@ -3,7 +3,7 @@ import { StringDecoder } from 'string_decoder'
 import { LineDecoder } from './LineDecoder'
 import Debug from 'debug'
 import { writeWithBackpressure } from './writeWithBackpressure'
-const debug = Debug('cypress:stderr-filtering:FilterTaggedContent')
+const debugVerbose = Debug('cypress-verbose:stderr-filtering:FilterTaggedContent')
 
 /**
  * Filters content based on start and end tags, supporting multi-line tagged content.
@@ -53,7 +53,7 @@ export class FilterTaggedContent extends Transform {
 
       this.lineDecoder?.write(str)
 
-      debug('processing str for tags: "%s"', str)
+      debugVerbose('processing str for tags: "%s"', str)
 
       for (const line of Array.from(this.lineDecoder || [])) {
         await this.processLine(line)
@@ -71,7 +71,7 @@ export class FilterTaggedContent extends Transform {
    * @param callback Callback to call when flushing is complete
    */
   flush = async (callback: (err?: Error) => void) => {
-    debug('flushing')
+    debugVerbose('flushing')
     this.ensureDecoders()
     try {
       for (const line of Array.from(this.lineDecoder?.end() || [])) {
@@ -146,12 +146,12 @@ export class FilterTaggedContent extends Transform {
   }
 
   private async writeToWasteStream (line: string, encoding?: BufferEncoding | 'buffer') {
-    debug('writing to waste stream: "%s"', line)
+    debugVerbose('writing to waste stream: "%s"', line)
     await writeWithBackpressure(this.wasteStream, Buffer.from(line, (encoding === 'buffer' ? 'utf8' : encoding) ?? 'utf8'))
   }
 
   private async pass (line: string, encoding?: BufferEncoding | 'buffer') {
-    debug('passing: "%s"', line)
+    debugVerbose('passing: "%s"', line)
     this.push(Buffer.from(line, (encoding === 'buffer' ? 'utf8' : encoding) ?? 'utf8'))
   }
 }

--- a/packages/stderr-filtering/lib/LineDecoder.ts
+++ b/packages/stderr-filtering/lib/LineDecoder.ts
@@ -10,7 +10,7 @@
 import Debug from 'debug'
 import { END_TAG } from './constants'
 
-const debug = Debug(`cypress:stderr-filtering:LineDecoder:${process.pid}`)
+const debugVerbose = Debug(`cypress-verbose:stderr-filtering:LineDecoder:${process.pid}`)
 
 export class LineDecoder {
   private buffer: string = ''
@@ -23,7 +23,7 @@ export class LineDecoder {
    * @param chunk The string chunk to add to the buffer
    */
   public write (chunk: string) {
-    debug('writing chunk to line decoder', { chunk })
+    debugVerbose('writing chunk to line decoder', { chunk })
     this.buffer += chunk
   }
 
@@ -37,7 +37,7 @@ export class LineDecoder {
    * @yields Complete lines with newline characters preserved
    */
   * [Symbol.iterator] (): Generator<string> {
-    debug('iterating over lines in line decoder')
+    debugVerbose('iterating over lines in line decoder')
 
     let nextLine: string | undefined = undefined
 
@@ -45,8 +45,8 @@ export class LineDecoder {
       nextLine = this.nextLine()
 
       if (nextLine) {
-        debug('yielding line:', nextLine)
-        debug('buffer size:', this.buffer.length)
+        debugVerbose('yielding line:', nextLine)
+        debugVerbose('buffer size:', this.buffer.length)
         yield nextLine
       }
     } while (nextLine)
@@ -79,7 +79,7 @@ export class LineDecoder {
     const endsWithOverrideToken = newlineIndex < 0 ? this.buffer.endsWith(this.overrideToken) : false
 
     if (endsWithOverrideToken) {
-      debug('ends with override token')
+      debugVerbose('ends with override token')
       const line = this.buffer
 
       this.buffer = ''
@@ -88,7 +88,7 @@ export class LineDecoder {
     }
 
     if (newlineIndex >= 0) {
-      debug('contains a newline')
+      debugVerbose('contains a newline')
       const line = this.buffer.slice(0, newlineIndex + length)
 
       this.buffer = this.buffer.slice(newlineIndex + length)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

I've been unable to debug anything else with these logs on.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
