### PR TITLE
chore: remove css element queries from reporter

### DIFF
--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -31,7 +31,6 @@
     "autoprefixer": "10.4.21",
     "classnames": "^2.5.1",
     "cross-env": "7.0.3",
-    "css-element-queries": "1.2.3",
     "cypress-multi-reporters": "1.4.0",
     "cypress-real-events": "1.14.0",
     "lodash": "^4.17.21",

--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -4,8 +4,6 @@ import { observer } from 'mobx-react'
 import cs from 'classnames'
 import React, { useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
-// @ts-ignore
-import EQ from 'css-element-queries/src/ElementQueries'
 
 import type { RunnablesErrorModel } from './runnables/runnable-error'
 import appStateDefault, { AppState } from './lib/app-state'
@@ -86,7 +84,6 @@ const Reporter: React.FC<SingleReporterProps> = observer(({ appState = appStateD
     })()
 
     shortcuts.start()
-    EQ.init()
     runnablesStore.setRunningSpec(runnerStore.spec.relative)
     // we need to know when the test is mounted for our reporter tests. see
     setIsMounted(true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -13658,11 +13658,6 @@ crypto-random-string@^4.0.0:
   dependencies:
     type-fest "^1.0.1"
 
-css-element-queries@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-1.2.3.tgz#e14940b1fcd4bf0da60ea4145d05742d7172e516"
-  integrity sha512-QK9uovYmKTsV2GXWQiMOByVNrLn2qz6m3P7vWpOR4IdD6I3iXoDw5qtgJEN3Xq7gIbdHVKvzHjdAtcl+4Arc4Q==
-
 css-loader@6.8.1:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.8.1.tgz#0f8f52699f60f5e679eab4ec0fcd68b8e8a50a88"


### PR DESCRIPTION
### Additional details

The `css-element-queries` library provides JavaScript-based element queries that allow CSS to respond to element dimensions rather than viewport dimensions. It enables CSS media queries based on element size rather than screen size.

The library was imported and initialized (`EQ.init()`) but there's no evidence in the codebase that it was actually being used. The reporter's responsive behavior is handled through:

- Modern CSS with Tailwind CSS (version 4.1.10)
- Standard CSS media queries
- Flexbox and CSS Grid layouts

I thought this might improve reporter performance or crashes, but I don't have any solid evidence of this.

### Steps to test

Percy snapshots + reporter CSS look the same on open

### How has the user experience changed?

- No user experience change intended

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
