### PR TITLE
fix: incorrect loading of ESM based configurations

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 9/23/2025 (PENDING)_
 **Bugfixes:**
 
 - In development mode, Electron `stderr` is piped directly to Cypress' `stderr` to make it clear why Electron failed to start, if it fails to start. Fixes [#32358](https://github.com/cypress-io/cypress/issues/32358). Addressed in [32468](https://github.com/cypress-io/cypress/pull/32468).
+- Fixed an issue where ESM Cypress configurations were not being interpreted correctly. Fixes [#32493](https://github.com/cypress-io/cypress/issues/32493). Fixed in [#32515](https://github.com/cypress-io/cypress/pull/32515).
 
 **Misc:**
 

--- a/packages/server/lib/plugins/child/run_require_async_child.js
+++ b/packages/server/lib/plugins/child/run_require_async_child.js
@@ -83,17 +83,19 @@ function run (ipc, file, projectRoot) {
   // Config file loading of modules is tested within
   // system-tests/projects/config-cjs-and-esm/*
   const loadFile = async (file) => {
+    let errorLoadingCJSConfig = null
+
     try {
       debug('Loading file %s', file)
 
       return require(file)
     } catch (err) {
       if (!err.stack.includes('[ERR_REQUIRE_ESM]') && !err.stack.includes('SyntaxError: Cannot use import statement outside a module')) {
-        throw err
+        errorLoadingCJSConfig = err
       }
     }
 
-    debug('User is loading an ESM config file')
+    debug('User may be trying to load an ESM config file')
 
     try {
       // We cannot replace the initial `require` with `await import` because
@@ -101,11 +103,17 @@ function run (ipc, file, projectRoot) {
       // pathToFileURL for windows interop: https://github.com/nodejs/node/issues/31710
       const fileURL = pathToFileURL(file).href
 
-      debug(`importing esm file %s`, fileURL)
+      debug(`importing config as esm file %s`, fileURL)
+      const config = await import(fileURL)
 
-      return await import(fileURL)
+      return config
     } catch (err) {
       debug('error loading file via native Node.js module loader %s', err.message)
+      if (errorLoadingCJSConfig) {
+        debug('CJS loading initially failed. Rethrowing %s', errorLoadingCJSConfig.message)
+        throw errorLoadingCJSConfig
+      }
+
       throw err
     }
   }

--- a/system-tests/projects/config-cjs-and-esm/config-with-mjs/cypress.config.mjs
+++ b/system-tests/projects/config-cjs-and-esm/config-with-mjs/cypress.config.mjs
@@ -1,4 +1,10 @@
 import { defineConfig } from 'cypress'
+import { resolve } from 'node:path'
+
+const root = import.meta.dirname
+
+// should fail if not loading ESM correctly
+resolve(root, 'dist')
 
 export default defineConfig({
   e2e: { supportFile: false },

--- a/system-tests/test/issue_32493_spec.ts
+++ b/system-tests/test/issue_32493_spec.ts
@@ -4,6 +4,8 @@ describe('e2e issue 32493: ESM config loading should not fail', () => {
   systemTests.setup()
 
   systemTests.it('loads the config file', {
+    spec: 'app.cy.js',
+    browser: 'chrome',
     project: 'config-cjs-and-esm/config-with-mjs',
     expectedExitCode: 0,
   })

--- a/system-tests/test/issue_32493_spec.ts
+++ b/system-tests/test/issue_32493_spec.ts
@@ -1,0 +1,10 @@
+import systemTests from '../lib/system-tests'
+
+describe('e2e issue 32493: ESM config loading should not fail', () => {
+  systemTests.setup()
+
+  systemTests.it('loads the config file', {
+    project: 'config-cjs-and-esm/config-with-mjs',
+    expectedExitCode: 0,
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32493

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fixes an issue where ESM based cypress configs were failing in a `require` context due to using ESM specific imports. To fix the surgically, we attempt to `require` the config, and if it fails, fall through to try importing the config as `ESM`. If the first fails, we just rethrow the first error of the `require`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
