### PR TITLE
feat: escape key for cy.press

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 15.2.1
+## 15.3.0
 
 _Released 9/23/2025 (PENDING)_
+
+**Features:**
+
+- Added Escape key support to `cy.press()`. Addresses[#32429](https://github.com/cypress-io/cypress/issues/32429). Addressed in [#32545](https://github.com/cypress-io/cypress/pull/32545).
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 9/23/2025 (PENDING)_
 
 **Features:**
 
-- Added Escape key support to `cy.press()`. Addresses[#32429](https://github.com/cypress-io/cypress/issues/32429). Addressed in [#32545](https://github.com/cypress-io/cypress/pull/32545).
+- Added Escape key support to [`cy.press()`](http://on.cypress.io/api/press). Addresses[#32429](https://github.com/cypress-io/cypress/issues/32429). Addressed in [#32545](https://github.com/cypress-io/cypress/pull/32545).
 
 **Bugfixes:**
 

--- a/cli/types/cypress-automation.d.ts
+++ b/cli/types/cypress-automation.d.ts
@@ -12,7 +12,8 @@ declare namespace Cypress {
   'Tab' |
   'Backspace' |
   'Delete' |
-  'Insert'
+  'Insert' |
+  'Escape'
 
   type SupportedKey = SupportedNamedKey | string | number
 }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -698,6 +698,7 @@ declare namespace Cypress {
         SPACE: 'Space',
         DELETE: 'Delete',
         INSERT: 'Insert',
+        ESC: 'Escape',
       },
     }
 

--- a/packages/driver/cypress/e2e/commands/actions/press.cy.ts
+++ b/packages/driver/cypress/e2e/commands/actions/press.cy.ts
@@ -8,7 +8,7 @@ describe('src/cy/commands/actions/press', () => {
     cy.visit('/fixtures/input_events.html')
   })
 
-  it('fires the click event on the button when the named key is sent', () => {
+  it('fires the click event on the button when the named key for Space is sent', () => {
     cy.get('#button').focus()
     cy.get('#button').should('be.focused')
     cy.press(Cypress.Keyboard.Keys.SPACE)

--- a/packages/driver/src/cy/keyboard.ts
+++ b/packages/driver/src/cy/keyboard.ts
@@ -1412,6 +1412,7 @@ const Keys: Record<string, Cypress.SupportedNamedKey> = {
   SPACE: 'Space',
   DELETE: 'Delete',
   INSERT: 'Insert',
+  ESC: 'Escape',
 }
 
 export default {

--- a/packages/server/eslint.config.ts
+++ b/packages/server/eslint.config.ts
@@ -5,6 +5,9 @@ export default [
   ...baseConfig,
   {
     languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
       globals: {
         ...globals.node,
         globalThis: 'readonly',

--- a/packages/server/lib/automation/commands/key_press.ts
+++ b/packages/server/lib/automation/commands/key_press.ts
@@ -121,6 +121,7 @@ export const BidiOverrideCodepoints: Record<SupportedNamedKey, string> = {
   'Delete': '\uE017',
   'Insert': '\uE016',
   'Space': '\uE00D',
+  'Escape': '\uE00C',
 }
 
 // any is fine to be used here because the key must be typeguarded before it can be used as a supported key

--- a/packages/types/src/automation.ts
+++ b/packages/types/src/automation.ts
@@ -27,6 +27,7 @@ export const NamedKeys: SupportedNamedKey[] = [
   SpaceKey,
   'Delete',
   'Insert',
+  'Escape',
 ]
 
 // utility type to enable the SupportedKey union type


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/32429

### Additional details
Adds the `Escape` key to the support keys. This list of supported keys is necessary because some need to be overridden with specific unicode codepoints in Webdriver BiDi.

### Steps to test
Use `cy.press(Cypress.Keyboard.Keys.ESC)`, and assert that the escape key is pressed.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [X] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? https://github.com/cypress-io/cypress-documentation/pull/6279
- [X] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
