### PR TITLE
fix: move currentMoreInfoNeededModalInfo.onCancel to onClose

### DIFF
--- a/packages/app/src/prompt/PromptMoreInfoNeededModal.vue
+++ b/packages/app/src/prompt/PromptMoreInfoNeededModal.vue
@@ -48,6 +48,7 @@ withDefaults(defineProps<{
 })
 
 const closeModal = () => {
+  promptStore.currentMoreInfoNeededModalInfo?.onCancel()
   emit('close')
 }
 
@@ -68,7 +69,6 @@ const maybeRenderReactComponent = () => {
     logId: promptStore.currentMoreInfoNeededModalInfo?.logId,
     eventManager: window.getEventManager(),
     onClose: () => {
-      promptStore.currentMoreInfoNeededModalInfo?.onCancel()
       closeModal()
     },
   })


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/11798

### Additional details

"Esc" key does not continue execution in the same way that closing the modal with a click does.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
