### PR TITLE
chore: update app to cypress-example-kitchensink v5.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+
+jobs:
+  no_op:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run: echo "no op as GH pages does not need a circle job to deploy. Disregard this job and related workflows..."
+workflows:
+  main:
+    jobs:
+      - no_op

--- a/commands/assertions.html
+++ b/commands/assertions.html
@@ -136,7 +136,7 @@ cy.get('.assertion-table')
   .should('be.visible')</code></pre>
 
             <p>Note: find even more examples of matching element's text content in this
-              <a href="https://on.cypress.io/using-cypress-faq#How-do-I-get-an-element’s-text-contents" target="_blank">FAQ answer</a>.
+              <a href="https://docs.cypress.io/app/faq#How-do-I-get-an-elements-text-contents" target="_blank">FAQ answer</a>.
             </p>
           </div>
           <div class="col-xs-5">

--- a/commands/spies-stubs-clocks.html
+++ b/commands/spies-stubs-clocks.html
@@ -44,7 +44,7 @@
               <li><a href="/commands/aliasing">Aliasing</a></li>
               <li><a href="/commands/waiting">Waiting</a></li>
               <li><a href="/commands/network-requests">Network Requests</a></li>
-              <li><a href="/commands/fixtures">Fixtures</a></li>
+              <li><a href="/commands/files">Files</a></li>
               <li><a href="/commands/storage">Storage</a></li>
               <li><a href="/commands/cookies">Cookies</a></li>
               <li class="active"><a href="/commands/spies-stubs-clocks">Spies, Stubs &amp; Clocks</a></li>


### PR DESCRIPTION
- follows on from PR https://github.com/cypress-io/cypress/pull/32520

### Additional details

Builds the app changes pulled in through PR https://github.com/cypress-io/cypress/pull/32520 to the [gh-pages](https://github.com/cypress-io/cypress/tree/gh-pages) for automatic publication to https://example.cypress.io.

Sourced from [cypress-example-kitchensink@5.1.2](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v5.1.2)

### Steps to test

After merge, open:

1. https://example.cypress.io/commands/spies-stubs-clocks click on Commands > Files and confirm that https://example.cypress.io/commands/files opens, showing documentation for `cy.fixture()` (instead of previous link to Fixtures, resulting in 404 error)
2. https://example.cypress.io/commands/assertions, click on link "FAQ answer" and confirm that How do I get an element's text contents? is opened and displayed (instead of "Page Not Found" message)

### How has the user experience changed?

Removes dead links on https://example.cypress.io

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?