### PR TITLE
chore: convert `telemetry` tests from `mocha` to `vitest`

### DIFF
--- a/.circleci/src/workflows/@workflows.yml
+++ b/.circleci/src/workflows/@workflows.yml
@@ -1784,7 +1784,7 @@ jobs:
                   source ./scripts/ensure-node.sh
                   yarn lerna run types
             - sanitize-verify-and-store-mocha-results:
-                expectedResultCount: 17
+                expectedResultCount: 15
 
   verify-release-readiness:
     <<: *defaults

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -3486,7 +3486,7 @@ jobs:
                   yarn lerna run types
                 name: Test types
             - sanitize-verify-and-store-mocha-results:
-                expectedResultCount: 16
+                expectedResultCount: 15
     working_directory: ~/cypress
   v8-integration-tests:
     environment:

--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -106,7 +106,7 @@
 - [ ] packages/server
 - [ ] packages/socket
 - [x] packages/stderr-filtering ✅ **COMPLETED**
-- [ ] packages/telemetry
+- [x] packages/telemetry ✅ **COMPLETED**
 - [ ] packages/ts - ultimate goal is removal and likely not worth the effort to convert
 - [x] packages/types ✅ **COMPLETED**
 - [ ] packages/v8-snapshot-require

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -10,9 +10,8 @@
     "check-ts": "tsc --noEmit && yarn -s tslint",
     "clean": "rimraf dist",
     "test": "yarn test-unit",
-    "test-unit": "mocha --config ./test/.mocharc.js",
-    "test-vi": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
-    "test-vitest": "vitest run",
+    "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
+    "test-unit": "vitest run",
     "tslint": "tslint --config ../ts/tslint.json --project .",
     "watch": "tsc --watch"
   },
@@ -29,7 +28,6 @@
   },
   "devDependencies": {
     "@packages/ts": "0.0.0-development",
-    "mocha": "7.0.1",
     "vitest": "^3.2.4"
   },
   "files": [

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -11,6 +11,8 @@
     "clean": "rimraf dist",
     "test": "yarn test-unit",
     "test-unit": "mocha --config ./test/.mocharc.js",
+    "test-vi": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
+    "test-vitest": "vitest run",
     "tslint": "tslint --config ../ts/tslint.json --project .",
     "watch": "tsc --watch"
   },
@@ -27,7 +29,8 @@
   },
   "devDependencies": {
     "@packages/ts": "0.0.0-development",
-    "mocha": "7.0.1"
+    "mocha": "7.0.1",
+    "vitest": "^3.2.4"
   },
   "files": [
     "dist",

--- a/packages/telemetry/test/.mocharc.js
+++ b/packages/telemetry/test/.mocharc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  require: '@packages/ts/register',
-  reporter: 'mocha-multi-reporters',
-  reporterOptions: {
-    configFile: '../../mocha-reporter-config.json',
-  },
-  spec: 'test/**/*.spec.ts',
-  watchFiles: ['test/**/*.ts', 'src/**/*.ts'],
-}

--- a/packages/telemetry/test/browser.spec.ts
+++ b/packages/telemetry/test/browser.spec.ts
@@ -1,45 +1,45 @@
 // @ts-expect-error
 global.window = {}
 
-import { expect } from 'chai'
-
+import { describe, it, expect, beforeAll } from 'vitest'
 import { telemetry } from '../src/browser'
-
 import { Telemetry as TelemetryClass } from '../src/index'
 
 describe('telemetry is disabled', () => {
   describe('init', () => {
     it('does not throw', () => {
-      expect(telemetry.init({
-        namespace: 'namespace',
-        config: { version: 'version' },
-      })).to.not.throw
+      expect(() => {
+        telemetry.init({
+          namespace: 'namespace',
+          config: { version: 'version' },
+        })
+      }).not.toThrow()
 
-      expect(window.cypressTelemetrySingleton).to.be.undefined
+      expect(window.cypressTelemetrySingleton).toBeUndefined()
     })
   })
 
   describe('attach', () => {
     it('returns void', () => {
-      expect(telemetry.attach()).to.not.throw
+      expect(() => telemetry.attach()).not.toThrow()
     })
   })
 
   describe('startSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.startSpan({ name: 'nope' })).to.be.undefined
+      expect(telemetry.startSpan({ name: 'nope' })).toBeUndefined()
     })
   })
 
   describe('getSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.getSpan('nope')).to.be.undefined
+      expect(telemetry.getSpan('nope')).toBeUndefined()
     })
   })
 
   describe('findActiveSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.findActiveSpan((span) => true)).to.be.undefined
+      expect(telemetry.findActiveSpan((span) => true)).toBeUndefined()
     })
   })
 
@@ -47,37 +47,37 @@ describe('telemetry is disabled', () => {
     it('does not throw', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.endActiveSpanAndChildren(spanny)).to.not.throw
+      expect(() => telemetry.endActiveSpanAndChildren(spanny)).not.toThrow()
     })
   })
 
   describe('getActiveContextObject', () => {
     it('returns an empty object', () => {
-      expect(telemetry.getActiveContextObject().context).to.be.undefined
+      expect(telemetry.getActiveContextObject().context).toBeUndefined()
     })
   })
 
   describe('shutdown', () => {
     it('does not throw', () => {
-      expect(telemetry.shutdown()).to.not.throw
+      expect(() => telemetry.shutdown()).not.toThrow()
     })
   })
 
   describe('attachWebSocket', () => {
     it('does not throw', () => {
-      expect(telemetry.attachWebSocket('s')).to.not.throw
+      expect(() => telemetry.attachWebSocket('s')).not.toThrow()
     })
   })
 
   describe('setRootContext', () => {
     it('does not throw', () => {
-      expect(telemetry.setRootContext()).to.not.throw
+      expect(() => telemetry.setRootContext()).not.toThrow()
     })
   })
 })
 
 describe('telemetry is enabled', () => {
-  before('init', () => {
+  beforeAll(() => {
     // @ts-expect-error
     global.window.__CYPRESS_TELEMETRY__ = {
       context: {
@@ -91,33 +91,35 @@ describe('telemetry is enabled', () => {
       isVerbose: false,
     }
 
-    expect(telemetry.init({
-      namespace: 'namespace',
-      config: { version: 'version' },
-    })).to.not.throw
+    expect(() => {
+      telemetry.init({
+        namespace: 'namespace',
+        config: { version: 'version' },
+      })
+    }).not.toThrow()
 
-    expect(window.cypressTelemetrySingleton).to.be.instanceOf(TelemetryClass)
-    expect(window.cypressTelemetrySingleton.getResources()).to.contain({ herp: 'derp' })
+    expect(window.cypressTelemetrySingleton).toBeInstanceOf(TelemetryClass)
+    expect(window.cypressTelemetrySingleton.getResources()).toEqual(expect.objectContaining({ herp: 'derp' }))
   })
 
   describe('attachWebSocket', () => {
     it('returns true', () => {
       telemetry.attachWebSocket('ws')
 
-      expect(window.cypressTelemetrySingleton?.getExporter()?.ws).to.equal('ws')
+      expect(window.cypressTelemetrySingleton?.getExporter()?.ws).toEqual('ws')
     })
   })
 
   describe('startSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.startSpan({ name: 'nope' })).to.exist
+      expect(telemetry.startSpan({ name: 'nope' })).toBeDefined()
     })
   })
 
   describe('getSpan', () => {
     it('returns undefined', () => {
       telemetry.startSpan({ name: 'nope' })
-      expect(telemetry.getSpan('nope')).to.be.exist
+      expect(telemetry.getSpan('nope')).toBeDefined()
     })
   })
 
@@ -125,7 +127,7 @@ describe('telemetry is enabled', () => {
     it('returns undefined', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.findActiveSpan((span) => true)).to.be.exist
+      expect(telemetry.findActiveSpan((span) => true)).toBeDefined()
       spanny?.end()
     })
   })
@@ -134,9 +136,9 @@ describe('telemetry is enabled', () => {
     it('does not throw', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.endActiveSpanAndChildren(spanny)).to.not.throw
+      expect(() => telemetry.endActiveSpanAndChildren(spanny)).not.toThrow()
 
-      expect(telemetry.getActiveContextObject().context).to.be.undefined
+      expect(telemetry.getActiveContextObject().context).toBeUndefined()
     })
   })
 
@@ -144,14 +146,14 @@ describe('telemetry is enabled', () => {
     it('returns an empty object', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.getActiveContextObject().context.traceparent).to.exist
+      expect(telemetry.getActiveContextObject().context.traceparent).toBeDefined()
       spanny?.end()
     })
   })
 
   describe('shutdown', () => {
     it('does not throw', () => {
-      expect(telemetry.shutdown()).to.not.throw
+      expect(() => telemetry.shutdown()).not.toThrow()
     })
   })
 
@@ -163,20 +165,24 @@ describe('telemetry is enabled', () => {
           config: { version: 'version' },
         })
       } catch (err) {
-        expect(err).to.equal('Telemetry instance has already be initialized')
+        expect(err).toEqual('Telemetry instance has already be initialized')
+
+        return
       }
+
+      throw 'should not be called'
     })
   })
 
   describe('setRootContext', () => {
     it('it sets the context', () => {
       // @ts-expect-error
-      expect(window.cypressTelemetrySingleton?.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b0')
+      expect(window.cypressTelemetrySingleton?.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b0')
 
       telemetry.setRootContext({ context: { traceparent: '00-a14c8519972996a2a0748f2c8db5a775-4ad8bd26672a01b1-01' } })
 
       // @ts-expect-error
-      expect(window.cypressTelemetrySingleton?.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b1')
+      expect(window.cypressTelemetrySingleton?.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b1')
     })
   })
 })

--- a/packages/telemetry/test/detectors/circleCiDetectorSync.spec.ts
+++ b/packages/telemetry/test/detectors/circleCiDetectorSync.spec.ts
@@ -1,105 +1,54 @@
-import { expect } from 'chai'
-
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { circleCiDetectorSync } from '../../src/detectors/circleCiDetectorSync'
 
 describe('circleCiDetectorSync', () => {
   describe('undefined values', () => {
-    const processValues: any = {}
-
     beforeEach(() => {
-      // cache values
-      processValues.CIRCLECI = process.env.CIRCLECI
-      processValues.CIRCLE_BRANCH = process.env.CIRCLE_BRANCH
-      processValues.CIRCLE_JOB = process.env.CIRCLE_JOB
-      processValues.CIRCLE_NODE_INDEX = process.env.CIRCLE_NODE_INDEX
-      processValues.CIRCLE_BUILD_URL = process.env.CIRCLE_BUILD_URL
-      processValues.CIRCLE_BUILD_NUM = process.env.CIRCLE_BUILD_NUM
-      processValues.CIRCLE_SHA1 = process.env.CIRCLE_SHA1
-      processValues.CIRCLE_PR_NUMBER = process.env.CIRCLE_PR_NUMBER
-
-      //reset values
-      delete process.env.CIRCLECI
-      delete process.env.CIRCLE_BRANCH
-      delete process.env.CIRCLE_JOB
-      delete process.env.CIRCLE_NODE_INDEX
-      delete process.env.CIRCLE_BUILD_URL
-      delete process.env.CIRCLE_BUILD_NUM
-      delete process.env.CIRCLE_SHA1
-      delete process.env.CIRCLE_PR_NUMBER
-    })
-
-    afterEach(() => {
-      // Replace values
-      process.env.CIRCLECI = processValues.CIRCLECI
-      process.env.CIRCLE_BRANCH = processValues.CIRCLE_BRANCH
-      process.env.CIRCLE_JOB = processValues.CIRCLE_JOB
-      process.env.CIRCLE_NODE_INDEX = processValues.CIRCLE_NODE_INDEX
-      process.env.CIRCLE_BUILD_URL = processValues.CIRCLE_BUILD_URL
-      process.env.CIRCLE_BUILD_NUM = processValues.CIRCLE_BUILD_NUM
-      process.env.CIRCLE_SHA1 = processValues.CIRCLE_SHA1
-      process.env.CIRCLE_PR_NUMBER = processValues.CIRCLE_PR_NUMBER
+      vi.unstubAllEnvs()
+      vi.stubEnv('CIRCLECI', undefined)
+      vi.stubEnv('CIRCLE_BRANCH', undefined)
+      vi.stubEnv('CIRCLE_JOB', undefined)
+      vi.stubEnv('CIRCLE_NODE_INDEX', undefined)
+      vi.stubEnv('CIRCLE_BUILD_URL', undefined)
+      vi.stubEnv('CIRCLE_BUILD_NUM', undefined)
+      vi.stubEnv('CIRCLE_SHA1', undefined)
+      vi.stubEnv('CIRCLE_PR_NUMBER', undefined)
     })
 
     describe('detect', () => {
       it('returns an empty resource', () => {
         const resource = circleCiDetectorSync.detect()
 
-        expect(resource.attributes).to.be.empty
+        expect(resource.attributes).toEqual({})
       })
     })
   })
 
   describe('defined values', () => {
-    const processValues: any = {}
-
     beforeEach(() => {
-      // cache values
-      processValues.CIRCLECI = process.env.CIRCLECI
-      processValues.CIRCLE_BRANCH = process.env.CIRCLE_BRANCH
-      processValues.CIRCLE_JOB = process.env.CIRCLE_JOB
-      processValues.CIRCLE_NODE_INDEX = process.env.CIRCLE_NODE_INDEX
-      processValues.CIRCLE_BUILD_URL = process.env.CIRCLE_BUILD_URL
-      processValues.CIRCLE_BUILD_NUM = process.env.CIRCLE_BUILD_NUM
-      processValues.CIRCLE_SHA1 = process.env.CIRCLE_SHA1
-      processValues.CIRCLE_PR_NUMBER = process.env.CIRCLE_PR_NUMBER
-
-      //reset values
-      process.env.CIRCLECI = 'circleCi'
-      process.env.CIRCLE_BRANCH = 'circleBranch'
-      process.env.CIRCLE_JOB = 'circleJob'
-      process.env.CIRCLE_NODE_INDEX = 'circleNodeIndex'
-      process.env.CIRCLE_BUILD_URL = 'circleBuildUrl'
-      process.env.CIRCLE_BUILD_NUM = 'circleBuildNum'
-      process.env.CIRCLE_SHA1 = 'circleSha1'
-      process.env.CIRCLE_PR_NUMBER = 'circlePrNumber'
-    })
-
-    afterEach(() => {
-      // Replace values
-      process.env.CIRCLECI = processValues.CIRCLECI
-      process.env.CIRCLE_BRANCH = processValues.CIRCLE_BRANCH
-      process.env.CIRCLE_JOB = processValues.CIRCLE_JOB
-      process.env.CIRCLE_NODE_INDEX = processValues.CIRCLE_NODE_INDEX
-      process.env.CIRCLE_BUILD_URL = processValues.CIRCLE_BUILD_URL
-      process.env.CIRCLE_BUILD_NUM = processValues.CIRCLE_BUILD_NUM
-      process.env.CIRCLE_SHA1 = processValues.CIRCLE_SHA1
-      process.env.CIRCLE_PR_NUMBER = processValues.CIRCLE_PR_NUMBER
+      vi.unstubAllEnvs()
+      vi.stubEnv('CIRCLECI', 'circleCi')
+      vi.stubEnv('CIRCLE_BRANCH', 'circleBranch')
+      vi.stubEnv('CIRCLE_JOB', 'circleJob')
+      vi.stubEnv('CIRCLE_NODE_INDEX', 'circleNodeIndex')
+      vi.stubEnv('CIRCLE_BUILD_URL', 'circleBuildUrl')
+      vi.stubEnv('CIRCLE_BUILD_NUM', 'circleBuildNum')
+      vi.stubEnv('CIRCLE_SHA1', 'circleSha1')
+      vi.stubEnv('CIRCLE_PR_NUMBER', 'circlePrNumber')
     })
 
     describe('detect', () => {
       it('returns a resource with attributes', () => {
         const resource = circleCiDetectorSync.detect()
 
-        console.log(resource.attributes)
-
-        expect(resource.attributes['ci.circle']).to.equal('circleCi')
-        expect(resource.attributes['ci.branch']).to.equal('circleBranch')
-        expect(resource.attributes['ci.job']).to.equal('circleJob')
-        expect(resource.attributes['ci.node']).to.equal('circleNodeIndex')
-        expect(resource.attributes['ci.build-url']).to.equal('circleBuildUrl')
-        expect(resource.attributes['ci.build-number']).to.equal('circleBuildNum')
-        expect(resource.attributes['SHA1']).to.equal('circleSha1')
-        expect(resource.attributes['ci.pr-number']).to.equal('circlePrNumber')
+        expect(resource.attributes['ci.circle']).toEqual('circleCi')
+        expect(resource.attributes['ci.branch']).toEqual('circleBranch')
+        expect(resource.attributes['ci.job']).toEqual('circleJob')
+        expect(resource.attributes['ci.node']).toEqual('circleNodeIndex')
+        expect(resource.attributes['ci.build-url']).toEqual('circleBuildUrl')
+        expect(resource.attributes['ci.build-number']).toEqual('circleBuildNum')
+        expect(resource.attributes['SHA1']).toEqual('circleSha1')
+        expect(resource.attributes['ci.pr-number']).toEqual('circlePrNumber')
       })
     })
   })

--- a/packages/telemetry/test/detectors/githubActionsDetectorSync.spec.ts
+++ b/packages/telemetry/test/detectors/githubActionsDetectorSync.spec.ts
@@ -1,110 +1,69 @@
-import { expect } from 'chai'
-
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { githubActionsDetectorSync } from '../../src/detectors/githubActionsDetectorSync'
 
 describe('githubActionsDetectorSync', () => {
   describe('undefined values', () => {
-    const processValues: any = {}
-
     beforeEach(() => {
-      // cache values
-      processValues.GITHUB_ACTION = process.env.GITHUB_ACTION
-      processValues.GH_BRANCH = process.env.GH_BRANCH
-      processValues.GITHUB_HEAD_REF = process.env.GITHUB_HEAD_REF
-      processValues.GITHUB_REF_NAME = process.env.GITHUB_REF_NAME
-      processValues.GITHUB_RUN_NUMBER = process.env.GITHUB_RUN_NUMBER
-      processValues.GITHUB_SHA = process.env.GITHUB_SHA
-
-      //reset values
-      delete process.env.GITHUB_ACTION
-      delete process.env.GH_BRANCH
-      delete process.env.GITHUB_HEAD_REF
-      delete process.env.GITHUB_REF_NAME
-      delete process.env.GITHUB_RUN_NUMBER
-      delete process.env.GITHUB_SHA
-    })
-
-    afterEach(() => {
-      // Replace values
-      process.env.GITHUB_ACTION = processValues.GITHUB_ACTION
-      process.env.GH_BRANCH = processValues.GH_BRANCH
-      process.env.GITHUB_HEAD_REF = processValues.GITHUB_HEAD_REF
-      process.env.GITHUB_REF_NAME = processValues.GITHUB_REF_NAME
-      process.env.GITHUB_RUN_NUMBER = processValues.GITHUB_RUN_NUMBER
-      process.env.GITHUB_SHA = processValues.GITHUB_SHA
+      vi.unstubAllEnvs()
+      vi.stubEnv('GITHUB_ACTION', undefined)
+      vi.stubEnv('GH_BRANCH', undefined)
+      vi.stubEnv('GITHUB_HEAD_REF', undefined)
+      vi.stubEnv('GITHUB_REF_NAME', undefined)
+      vi.stubEnv('GITHUB_RUN_NUMBER', undefined)
+      vi.stubEnv('GITHUB_SHA', undefined)
     })
 
     describe('detect', () => {
       it('returns an empty resource', () => {
         const resource = githubActionsDetectorSync.detect()
 
-        expect(resource.attributes).to.be.empty
+        expect(resource.attributes).toEqual({})
       })
     })
   })
 
   describe('defined values', () => {
-    const processValues: any = {}
-
     beforeEach(() => {
-      // cache values
-      processValues.GITHUB_ACTION = process.env.GITHUB_ACTION
-      processValues.GH_BRANCH = process.env.GH_BRANCH
-      processValues.GITHUB_HEAD_REF = process.env.GITHUB_HEAD_REF
-      processValues.GITHUB_REF_NAME = process.env.GITHUB_REF_NAME
-      processValues.GITHUB_RUN_NUMBER = process.env.GITHUB_RUN_NUMBER
-      processValues.GITHUB_SHA = process.env.GITHUB_SHA
-
-      //reset values
-      process.env.GITHUB_ACTION = 'githubAction'
-      process.env.GH_BRANCH = 'ghBranch'
-      process.env.GITHUB_HEAD_REF = 'ghHeadRef'
-      process.env.GITHUB_REF_NAME = 'ghRefName'
-      process.env.GITHUB_RUN_NUMBER = 'ghRunNumber'
-      process.env.GITHUB_SHA = 'ghSha'
-    })
-
-    afterEach(() => {
-      // Replace values
-      process.env.GITHUB_ACTION = processValues.GITHUB_ACTION
-      process.env.GH_BRANCH = processValues.GH_BRANCH
-      process.env.GITHUB_HEAD_REF = processValues.GITHUB_HEAD_REF
-      process.env.GITHUB_REF_NAME = processValues.GITHUB_REF_NAME
-      process.env.GITHUB_RUN_NUMBER = processValues.GITHUB_RUN_NUMBER
-      process.env.GITHUB_SHA = processValues.GITHUB_SHA
+      vi.unstubAllEnvs()
+      vi.stubEnv('GITHUB_ACTION', 'githubAction')
+      vi.stubEnv('GH_BRANCH', 'ghBranch')
+      vi.stubEnv('GITHUB_HEAD_REF', 'ghHeadRef')
+      vi.stubEnv('GITHUB_REF_NAME', 'ghRefName')
+      vi.stubEnv('GITHUB_RUN_NUMBER', 'ghRunNumber')
+      vi.stubEnv('GITHUB_SHA', 'ghSha')
     })
 
     describe('detect', () => {
       it('returns a resource with attributes', () => {
         const resource = githubActionsDetectorSync.detect()
 
-        expect(resource.attributes['ci.github_action']).to.equal('githubAction')
-        expect(resource.attributes['ci.branch']).to.equal('ghBranch')
-        expect(resource.attributes['ci.build-number']).to.equal('ghRunNumber')
-        expect(resource.attributes['SHA1']).to.equal('ghSha')
+        expect(resource.attributes['ci.github_action']).toEqual('githubAction')
+        expect(resource.attributes['ci.branch']).toEqual('ghBranch')
+        expect(resource.attributes['ci.build-number']).toEqual('ghRunNumber')
+        expect(resource.attributes['SHA1']).toEqual('ghSha')
       })
 
       it('returns a resource with attributes when GH_BRANCH is missing', () => {
-        delete process.env.GH_BRANCH
+        vi.stubEnv('GH_BRANCH', undefined)
 
         const resource = githubActionsDetectorSync.detect()
 
-        expect(resource.attributes['ci.github_action']).to.equal('githubAction')
-        expect(resource.attributes['ci.branch']).to.equal('ghHeadRef')
-        expect(resource.attributes['ci.build-number']).to.equal('ghRunNumber')
-        expect(resource.attributes['SHA1']).to.equal('ghSha')
+        expect(resource.attributes['ci.github_action']).toEqual('githubAction')
+        expect(resource.attributes['ci.branch']).toEqual('ghHeadRef')
+        expect(resource.attributes['ci.build-number']).toEqual('ghRunNumber')
+        expect(resource.attributes['SHA1']).toEqual('ghSha')
       })
 
       it('returns a resource with attributes when GH_BRANCH and GITHUB_HEAD_REF is missing', () => {
-        delete process.env.GH_BRANCH
-        delete process.env.GITHUB_HEAD_REF
+        vi.stubEnv('GH_BRANCH', undefined)
+        vi.stubEnv('GITHUB_HEAD_REF', undefined)
 
         const resource = githubActionsDetectorSync.detect()
 
-        expect(resource.attributes['ci.github_action']).to.equal('githubAction')
-        expect(resource.attributes['ci.branch']).to.equal('ghRefName')
-        expect(resource.attributes['ci.build-number']).to.equal('ghRunNumber')
-        expect(resource.attributes['SHA1']).to.equal('ghSha')
+        expect(resource.attributes['ci.github_action']).toEqual('githubAction')
+        expect(resource.attributes['ci.branch']).toEqual('ghRefName')
+        expect(resource.attributes['ci.build-number']).toEqual('ghRunNumber')
+        expect(resource.attributes['SHA1']).toEqual('ghSha')
       })
     })
   })

--- a/packages/telemetry/test/index.spec.ts
+++ b/packages/telemetry/test/index.spec.ts
@@ -1,7 +1,5 @@
-import { expect } from 'chai'
-
+import { describe, it, expect } from 'vitest'
 import { Telemetry } from '../src'
-
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 
@@ -20,15 +18,15 @@ describe('init', () => {
       SpanProcessor: BatchSpanProcessor,
     })
 
-    expect(tel).to.not.be.undefined
+    expect(tel).toBeDefined()
     expect(tel.provider).is.instanceOf(NodeTracerProvider)
-    expect(tel.provider.resource.attributes['service.namespace']).to.equal('namespace')
-    expect(tel.provider.resource.attributes['service.version']).to.equal('version')
-    expect(tel.provider.resource.attributes['service.name']).to.equal('cypress-app')
+    expect(tel.provider.resource.attributes['service.namespace']).toEqual('namespace')
+    expect(tel.provider.resource.attributes['service.version']).toEqual('version')
+    expect(tel.provider.resource.attributes['service.name']).toEqual('cypress-app')
     // @ts-expect-error
-    expect(tel.provider.activeSpanProcessor._spanProcessors[0]).is.instanceOf(BatchSpanProcessor)
-    expect(tel.getExporter()).to.equal(exporter)
-    expect(tel.rootContext).to.be.undefined
+    expect(tel.provider.activeSpanProcessor._spanProcessors[0]).toBeInstanceOf(BatchSpanProcessor)
+    expect(tel.getExporter()).toEqual(exporter)
+    expect(tel.rootContext).toBeUndefined()
   })
 
   it('creates a new instance with root context', () => {
@@ -44,9 +42,9 @@ describe('init', () => {
       SpanProcessor: BatchSpanProcessor,
     })
 
-    expect(tel).to.not.be.undefined
-    expect(tel.rootContext).to.not.be.undefined
-    expect(tel.rootAttributes).to.not.be.undefined
+    expect(tel).toBeDefined()
+    expect(tel.rootContext).toBeDefined()
+    expect(tel.rootAttributes).toBeDefined()
   })
 })
 
@@ -67,12 +65,12 @@ describe('startSpan', () => {
     const span = tel.startSpan({ name: 'span' })
 
     // @ts-expect-error
-    expect(span.name).to.equal('span')
+    expect(span.name).toEqual('span')
     // @ts-expect-error
-    expect(span.parentSpanId).to.equal('4ad8bd26672a01b0')
-    expect(tel.activeSpanQueue.length).to.be.lessThan(1)
+    expect(span.parentSpanId).toEqual('4ad8bd26672a01b0')
+    expect(tel.activeSpanQueue.length).toBeLessThan(1)
     // @ts-expect-error
-    expect(tel.spans[span.name]).to.equal(span)
+    expect(tel.spans[span.name]).toEqual(span)
   })
 
   it('starts a span with no parent id', () => {
@@ -90,9 +88,9 @@ describe('startSpan', () => {
     const span = tel.startSpan({ name: 'span' })
 
     // @ts-expect-error
-    expect(span.name).to.equal('span')
+    expect(span.name).toEqual('span')
     // @ts-expect-error
-    expect(span.parentSpanId).to.be.undefined
+    expect(span.parentSpanId).toBeUndefined()
   })
 
   it('starts a span with specific parent', () => {
@@ -112,10 +110,10 @@ describe('startSpan', () => {
     const span = tel.startSpan({ name: 'span', parentSpan })
 
     // @ts-expect-error
-    expect(span.name).to.equal('span')
+    expect(span.name).toEqual('span')
     // @ts-expect-error
-    expect(span.parentSpanId).to.equal(parentSpan._spanContext.spanId)
-    expect(tel.activeSpanQueue.length).to.be.lessThan(1)
+    expect(span.parentSpanId).toEqual(parentSpan._spanContext.spanId)
+    expect(tel.activeSpanQueue.length).toBeLessThan(1)
   })
 
   it('starts an active span', () => {
@@ -133,32 +131,32 @@ describe('startSpan', () => {
     const span = tel.startSpan({ name: 'span', active: true })
 
     // @ts-expect-error
-    expect(span.name).to.equal('span')
+    expect(span.name).toEqual('span')
     // @ts-expect-error
-    expect(span.parentSpanId).to.be.undefined
+    expect(span.parentSpanId).toBeUndefined()
     // @ts-expect-error
-    expect(tel.activeSpanQueue[0].name).to.equal('span')
+    expect(tel.activeSpanQueue[0].name).toEqual('span')
 
     // Start a child that should have the previous span as a parent
     const spanChild = tel.startSpan({ name: 'child' })
 
     // @ts-expect-error
-    expect(spanChild.name).to.equal('child')
+    expect(spanChild.name).toEqual('child')
     // @ts-expect-error
-    expect(spanChild.parentSpanId).to.equal(span._spanContext.spanId)
+    expect(spanChild.parentSpanId).toEqual(span._spanContext.spanId)
 
     // Start a root child that does not have the active parent
     const spanRoot = tel.startSpan({ name: 'root', attachType: 'root' })
 
     // @ts-expect-error
-    expect(spanRoot.name).to.equal('root')
+    expect(spanRoot.name).toEqual('root')
     // @ts-expect-error
-    expect(spanRoot.parentSpanId).to.be.undefined
+    expect(spanRoot.parentSpanId).toBeUndefined()
 
     // end the active span to see it removed from the queue
     span?.end()
 
-    expect(tel.activeSpanQueue.length).to.be.lessThan(1)
+    expect(tel.activeSpanQueue.length).toBeLessThan(1)
   })
 
   it('starts a span with key other than name', () => {
@@ -178,9 +176,9 @@ describe('startSpan', () => {
     const retrievedSpan = tel.getSpan('key')
 
     // @ts-expect-error
-    expect(retrievedSpan.name).to.equal('span')
+    expect(retrievedSpan.name).toEqual('span')
     // @ts-expect-error
-    expect(retrievedSpan._spanContext.spanId).to.equal(span._spanContext.spanId)
+    expect(retrievedSpan._spanContext.spanId).toEqual(span._spanContext.spanId)
   })
 })
 
@@ -200,9 +198,9 @@ describe('getSpan', () => {
 
     const spanny = tel.startSpan({ name: 'spanny' })
 
-    expect(tel.getSpan('spanny')).to.equal(spanny)
+    expect(tel.getSpan('spanny')).toEqual(spanny)
 
-    expect(tel.getSpan('not-found')).to.be.undefined
+    expect(tel.getSpan('not-found')).toBeUndefined()
   })
 })
 
@@ -228,7 +226,7 @@ describe('findActiveSpan', () => {
       return span.name === 'spanny'
     })
 
-    expect(foundSpan).to.equal(spanny)
+    expect(foundSpan).toEqual(spanny)
   })
 })
 
@@ -248,19 +246,19 @@ describe('endActiveSpanAndChildren', () => {
 
     const spanny = tel.startSpan({ name: 'spanny', active: true })
 
-    expect(spanny).to.exist
+    expect(spanny).toBeDefined()
 
     tel.startSpan({ name: 'spannyChild', active: true })
 
-    expect(tel.activeSpanQueue.length).to.equal(2)
+    expect(tel.activeSpanQueue.length).toEqual(2)
 
     tel.endActiveSpanAndChildren(spanny)
 
-    expect(tel.activeSpanQueue.length).to.equal(0)
+    expect(tel.activeSpanQueue.length).toEqual(0)
 
     tel.endActiveSpanAndChildren(spanny)
 
-    expect(tel.activeSpanQueue.length).to.equal(0)
+    expect(tel.activeSpanQueue.length).toEqual(0)
   })
 })
 
@@ -280,13 +278,13 @@ describe('getActiveContextObject', () => {
 
     const emptyContext = tel.getActiveContextObject()
 
-    expect(emptyContext.context).to.be.undefined
+    expect(emptyContext.context).toBeUndefined()
 
     tel.startSpan({ name: 'spanny', active: true })
 
     const context = tel.getActiveContextObject()
 
-    expect(context.context.traceparent).to.exist
+    expect(context.context.traceparent).toBeDefined()
   })
 })
 
@@ -308,14 +306,14 @@ describe('getResources', () => {
       },
     })
 
-    expect(tel.getResources()).to.contain({
+    expect(tel.getResources()).toEqual(expect.objectContaining({
       'service.name': 'cypress-app',
       'telemetry.sdk.language': 'nodejs',
       'telemetry.sdk.name': 'opentelemetry',
       herp: 'derp',
       'service.namespace': 'namespace',
       'service.version': 'version',
-    })
+    }))
   })
 })
 
@@ -344,7 +342,7 @@ describe('shutdown', () => {
 
     await tel.shutdown()
 
-    expect(shutdownCalled).to.be.true
+    expect(shutdownCalled).toBe(true)
   })
 })
 
@@ -362,7 +360,7 @@ describe('getExporter', () => {
       SpanProcessor: BatchSpanProcessor,
     })
 
-    expect(tel.getExporter()).to.equal(exporter)
+    expect(tel.getExporter()).toEqual(exporter)
   })
 })
 
@@ -381,12 +379,12 @@ describe('setRootContext', () => {
     })
 
     // @ts-expect-error
-    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b0')
+    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b0')
 
     tel.setRootContext({ context: { traceparent: '00-a14c8519972996a2a0748f2c8db5a775-4ad8bd26672a01b1-01' } })
 
     // @ts-expect-error
-    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b1')
+    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b1')
   })
 
   it('sets root context', () => {
@@ -403,16 +401,16 @@ describe('setRootContext', () => {
     })
 
     // @ts-expect-error
-    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b0')
+    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b0')
 
     tel.setRootContext()
 
     // @ts-expect-error
-    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b0')
+    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b0')
 
     tel.setRootContext({})
 
     // @ts-expect-error
-    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).to.equal('4ad8bd26672a01b0')
+    expect(tel.rootContext?.getValue(Symbol.for('OpenTelemetry Context Key SPAN'))._spanContext.spanId).toEqual('4ad8bd26672a01b0')
   })
 })

--- a/packages/telemetry/test/node.spec.ts
+++ b/packages/telemetry/test/node.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { telemetry, encodeTelemetryContext, decodeTelemetryContext } from '../src/node'
 import { OTLPTraceExporter as OTLPTraceExporterCloud } from '../src/span-exporters/cloud-span-exporter'
 

--- a/packages/telemetry/test/node.spec.ts
+++ b/packages/telemetry/test/node.spec.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { telemetry, encodeTelemetryContext, decodeTelemetryContext } from '../src/node'
 import { OTLPTraceExporter as OTLPTraceExporterCloud } from '../src/span-exporters/cloud-span-exporter'
 
+// stub out the otlp exporter so we don't send requests to localhost:4318
+vi.mock('@opentelemetry/exporter-trace-otlp-http')
+
 describe('telemetry is disabled', () => {
   describe('init', () => {
     it('does not throw', () => {

--- a/packages/telemetry/test/node.spec.ts
+++ b/packages/telemetry/test/node.spec.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { describe, it, expect, beforeAll } from 'vitest'
 import { telemetry, encodeTelemetryContext, decodeTelemetryContext } from '../src/node'
 import { OTLPTraceExporter as OTLPTraceExporterCloud } from '../src/span-exporters/cloud-span-exporter'
 
@@ -8,35 +7,37 @@ describe('telemetry is disabled', () => {
     it('does not throw', () => {
       const exporter = new OTLPTraceExporterCloud()
 
-      expect(telemetry.init({
-        namespace: 'namespace',
-        version: 'version',
-        exporter,
-      })).to.not.throw
+      expect(() => {
+        telemetry.init({
+          namespace: 'namespace',
+          version: 'version',
+          exporter,
+        })
+      }).not.toThrow()
     })
   })
 
   describe('isEnabled', () => {
     it('returns false', () => {
-      expect(telemetry.isEnabled()).to.be.false
+      expect(telemetry.isEnabled()).toBe(false)
     })
   })
 
   describe('startSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.startSpan({ name: 'nope' })).to.be.undefined
+      expect(telemetry.startSpan({ name: 'nope' })).toBeUndefined()
     })
   })
 
   describe('getSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.getSpan('nope')).to.be.undefined
+      expect(telemetry.getSpan('nope')).toBeUndefined()
     })
   })
 
   describe('findActiveSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.findActiveSpan((span) => true)).to.be.undefined
+      expect(telemetry.findActiveSpan((span) => true)).toBeUndefined()
     })
   })
 
@@ -44,63 +45,65 @@ describe('telemetry is disabled', () => {
     it('does not throw', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.endActiveSpanAndChildren(spanny)).to.not.throw
+      expect(() => telemetry.endActiveSpanAndChildren(spanny)).not.toThrow()
     })
   })
 
   describe('getActiveContextObject', () => {
     it('returns an empty object', () => {
-      expect(telemetry.getActiveContextObject().context).to.be.undefined
+      expect(telemetry.getActiveContextObject().context).toBeUndefined()
     })
   })
 
   describe('getResources', () => {
     it('returns an empty object', () => {
-      expect(telemetry.getResources()).to.not.be.undefined
+      expect(telemetry.getResources()).toBeDefined()
     })
   })
 
   describe('shutdown', () => {
     it('does not throw', () => {
-      expect(telemetry.shutdown()).to.not.throw
+      expect(() => telemetry.shutdown()).not.toThrow()
     })
   })
 
   describe('exporter', () => {
     it('returns undefined', () => {
-      expect(telemetry.exporter()).to.be.undefined
+      expect(telemetry.exporter()).toBeUndefined()
     })
   })
 })
 
 describe('telemetry is enabled', () => {
-  before('init', () => {
-    process.env.CYPRESS_INTERNAL_ENABLE_TELEMETRY = 'true'
+  beforeAll(() => {
+    vi.stubEnv('CYPRESS_INTERNAL_ENABLE_TELEMETRY', 'true')
     const exporter = new OTLPTraceExporterCloud()
 
-    expect(telemetry.init({
-      namespace: 'namespace',
-      version: 'version',
-      exporter,
-    })).to.not.throw
+    expect(() => {
+      telemetry.init({
+        namespace: 'namespace',
+        version: 'version',
+        exporter,
+      })
+    }).not.toThrow()
   })
 
   describe('isEnabled', () => {
     it('returns true', () => {
-      expect(telemetry.isEnabled()).to.be.true
+      expect(telemetry.isEnabled()).toBe(true)
     })
   })
 
   describe('startSpan', () => {
     it('returns undefined', () => {
-      expect(telemetry.startSpan({ name: 'nope' })).to.exist
+      expect(telemetry.startSpan({ name: 'nope' })).toBeDefined()
     })
   })
 
   describe('getSpan', () => {
     it('returns undefined', () => {
       telemetry.startSpan({ name: 'nope' })
-      expect(telemetry.getSpan('nope')).to.be.exist
+      expect(telemetry.getSpan('nope')).toBeDefined()
     })
   })
 
@@ -108,7 +111,7 @@ describe('telemetry is enabled', () => {
     it('returns undefined', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.findActiveSpan((span) => true)).to.be.exist
+      expect(telemetry.findActiveSpan((span) => true)).toBeDefined()
       spanny?.end()
     })
   })
@@ -117,9 +120,9 @@ describe('telemetry is enabled', () => {
     it('does not throw', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.endActiveSpanAndChildren(spanny)).to.not.throw
+      expect(() => telemetry.endActiveSpanAndChildren(spanny)).not.toThrow()
 
-      expect(telemetry.getActiveContextObject().context).to.be.undefined
+      expect(telemetry.getActiveContextObject().context).toBeUndefined()
     })
   })
 
@@ -127,32 +130,32 @@ describe('telemetry is enabled', () => {
     it('returns an empty object', () => {
       const spanny = telemetry.startSpan({ name: 'active', active: true })
 
-      expect(telemetry.getActiveContextObject().context.traceparent).to.exist
+      expect(telemetry.getActiveContextObject().context.traceparent).toBeDefined()
       spanny?.end()
     })
   })
 
   describe('getResources', () => {
     it('returns an empty object', () => {
-      expect(telemetry.getResources()).to.include({
+      expect(telemetry.getResources()).toEqual(expect.objectContaining({
         'service.name': 'cypress-app',
         'telemetry.sdk.language': 'nodejs',
         'telemetry.sdk.name': 'opentelemetry',
         'service.namespace': 'namespace',
         'service.version': 'version',
-      })
+      }))
     })
   })
 
   describe('shutdown', () => {
     it('does not throw', () => {
-      expect(telemetry.shutdown()).to.not.throw
+      expect(() => telemetry.shutdown()).not.toThrow()
     })
   })
 
   describe('exporter', () => {
     it('returns undefined', () => {
-      expect(telemetry.exporter()).to.exist
+      expect(telemetry.exporter()).toBeDefined()
     })
   })
 
@@ -167,8 +170,12 @@ describe('telemetry is enabled', () => {
           exporter,
         })
       } catch (err) {
-        expect(err).to.equal('Telemetry instance has already be initialized')
+        expect(err).toEqual('Telemetry instance has already be initialized')
+
+        return
       }
+
+      throw 'should not be called'
     })
   })
 })
@@ -182,8 +189,8 @@ describe('encode/decode', () => {
 
     const decodedContext = decodeTelemetryContext(encodeTelemetryContext(context))
 
-    expect(decodedContext.context.context.traceparent).to.equal(context.context.context.traceparent)
-    expect(decodedContext.version).to.equal(context.version)
+    expect(decodedContext.context.context.traceparent).toEqual(context.context.context.traceparent)
+    expect(decodedContext.version).toEqual(context.version)
   })
 
   it('it does not throw if passed an empty context', () => {
@@ -192,7 +199,7 @@ describe('encode/decode', () => {
 
     const decodedContext = decodeTelemetryContext(encodeTelemetryContext(context))
 
-    expect(decodedContext.context).to.be.undefined
-    expect(decodedContext.version).to.be.undefined
+    expect(decodedContext.context).toBeUndefined()
+    expect(decodedContext.version).toBeUndefined()
   })
 })

--- a/packages/telemetry/test/processors/on-start-span-processor.spec.ts
+++ b/packages/telemetry/test/processors/on-start-span-processor.spec.ts
@@ -1,19 +1,22 @@
-import { expect } from 'chai'
-
+import { describe, it, expect } from 'vitest'
 import { OnStartSpanProcessor } from '../../src/processors/on-start-span-processor'
 
 describe('on-start-span-processor', () => {
-  it('calls onEnd on start', (done) => {
+  it('calls onEnd on start', async () => {
     const processor = new OnStartSpanProcessor(undefined)
 
     const span = 'span'
 
-    processor.onEnd = (span) => {
-      expect(span).to.equal
-      done()
-    }
+    const promise = new Promise((resolve) => {
+      processor.onEnd = (span) => {
+        expect(span).toEqual('span')
+        resolve()
+      }
+    })
 
-    //@ts-expect-error
+    // @ts-expect-error
     processor.onStart(span, undefined)
+
+    await promise
   })
 })

--- a/packages/telemetry/test/span-exporters/cloud-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/cloud-span-exporter.spec.ts
@@ -1,6 +1,5 @@
-import { expect } from 'chai'
+import { describe, it, expect } from 'vitest'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-
 import { OTLPTraceExporter } from '../../src/span-exporters/cloud-span-exporter'
 
 const genericRequest = { encryption: { encryptRequest: ({ url, method, body }: {url: string, method: string, body: string}) => Promise.resolve({ jwe: 'req' }) } }
@@ -10,17 +9,17 @@ describe('cloudSpanExporter', () => {
     it('sets encrypted header if set', () => {
       const exporter = new OTLPTraceExporter(genericRequest)
 
-      expect(exporter.headers['x-cypress-encrypted']).to.equal('1')
-      expect(exporter.requirementsToExport).to.equal('unknown')
-      expect(exporter.enc).to.not.be.undefined
+      expect(exporter.headers['x-cypress-encrypted']).toEqual('1')
+      expect(exporter.requirementsToExport).toEqual('unknown')
+      expect(exporter.enc).not.toBeUndefined()
     })
 
     it('does not set encrypted header if not set', () => {
       const exporter = new OTLPTraceExporter()
 
-      expect(exporter.headers['x-cypress-encrypted']).to.be.undefined
-      expect(exporter.requirementsToExport).to.equal('met')
-      expect(exporter.enc).to.be.undefined
+      expect(exporter.headers['x-cypress-encrypted']).toBeUndefined()
+      expect(exporter.requirementsToExport).toEqual('met')
+      expect(exporter.enc).toBeUndefined()
     })
   })
 
@@ -34,14 +33,14 @@ describe('cloudSpanExporter', () => {
         callCount++
       }
 
-      expect(exporter.headers['x-project-id']).to.be.undefined
-      expect(exporter.projectId).to.be.undefined
+      expect(exporter.headers['x-project-id']).toBeUndefined()
+      expect(exporter.projectId).toBeUndefined()
 
       exporter.attachProjectId('123')
 
-      expect(exporter.headers['x-project-id']).to.equal('123')
-      expect(exporter.projectId).to.equal('123')
-      expect(callCount).to.equal(1)
+      expect(exporter.headers['x-project-id']).toEqual('123')
+      expect(exporter.projectId).toEqual('123')
+      expect(callCount).toEqual(1)
     })
 
     it('sets requirements to unmet if id is not passed', () => {
@@ -58,17 +57,17 @@ describe('cloudSpanExporter', () => {
         abortCallCount++
       }
 
-      expect(exporter.headers['x-project-id']).to.be.undefined
-      expect(exporter.projectId).to.be.undefined
+      expect(exporter.headers['x-project-id']).toBeUndefined()
+      expect(exporter.projectId).toBeUndefined()
 
       exporter.attachProjectId(undefined)
 
-      expect(exporter.headers['x-project-id']).to.be.undefined
-      expect(exporter.projectId).to.be.undefined
-      expect(callCount).to.equal(0)
+      expect(exporter.headers['x-project-id']).toBeUndefined()
+      expect(exporter.projectId).toBeUndefined()
+      expect(callCount).toEqual(0)
 
-      expect(exporter.requirementsToExport).to.equal('unmet')
-      expect(abortCallCount).to.equal(1)
+      expect(exporter.requirementsToExport).toEqual('unmet')
+      expect(abortCallCount).toEqual(1)
     })
   })
 
@@ -82,12 +81,12 @@ describe('cloudSpanExporter', () => {
         callCount++
       }
 
-      expect(exporter.recordKey).to.be.undefined
+      expect(exporter.recordKey).toBeUndefined()
 
       exporter.attachRecordKey('123')
 
-      expect(exporter.recordKey).to.equal('123')
-      expect(callCount).to.equal(1)
+      expect(exporter.recordKey).toEqual('123')
+      expect(callCount).toEqual(1)
     })
 
     it('sets requirements to unmet  if record key is not passed', () => {
@@ -104,15 +103,15 @@ describe('cloudSpanExporter', () => {
         abortCallCount++
       }
 
-      expect(exporter.recordKey).to.be.undefined
+      expect(exporter.recordKey).toBeUndefined()
 
       exporter.attachRecordKey(undefined)
 
-      expect(exporter.recordKey).to.be.undefined
-      expect(callCount).to.equal(0)
+      expect(exporter.recordKey).toBeUndefined()
+      expect(callCount).toEqual(0)
 
-      expect(exporter.requirementsToExport).to.equal('unmet')
-      expect(abortCallCount).to.equal(1)
+      expect(exporter.requirementsToExport).toEqual('unmet')
+      expect(abortCallCount).toEqual(1)
     })
   })
 
@@ -128,8 +127,8 @@ describe('cloudSpanExporter', () => {
       const authorization = exporter.headers.Authorization
 
       // MTIzOjQ1Ng== is 123:456 base64 encoded
-      expect(authorization).to.equal(`Basic MTIzOjQ1Ng==`)
-      expect(exporter.requirementsToExport).to.equal('met')
+      expect(authorization).toEqual(`Basic MTIzOjQ1Ng==`)
+      expect(exporter.requirementsToExport).toEqual('met')
     })
   })
 
@@ -151,8 +150,8 @@ describe('cloudSpanExporter', () => {
 
       exporter.sendDelayedItems()
 
-      expect(callCount).to.equal(0)
-      expect(exporter.delayedItemsToExport.length).to.equal(1)
+      expect(callCount).toEqual(0)
+      expect(exporter.delayedItemsToExport.length).toEqual(1)
     })
 
     it('does not send if project id is not set', () => {
@@ -173,8 +172,8 @@ describe('cloudSpanExporter', () => {
       exporter.attachRecordKey('123')
       exporter.sendDelayedItems()
 
-      expect(callCount).to.equal(0)
-      expect(exporter.delayedItemsToExport.length).to.equal(1)
+      expect(callCount).toEqual(0)
+      expect(exporter.delayedItemsToExport.length).toEqual(1)
     })
 
     it('does not send if record key is not set', () => {
@@ -195,8 +194,8 @@ describe('cloudSpanExporter', () => {
       exporter.attachProjectId('123')
       exporter.sendDelayedItems()
 
-      expect(callCount).to.equal(0)
-      expect(exporter.delayedItemsToExport.length).to.equal(1)
+      expect(callCount).toEqual(0)
+      expect(exporter.delayedItemsToExport.length).toEqual(1)
     })
 
     it('does send if record key and project id are set', () => {
@@ -218,26 +217,28 @@ describe('cloudSpanExporter', () => {
       exporter.attachRecordKey('123')
       exporter.sendDelayedItems()
 
-      expect(callCount).to.equal(1)
-      expect(exporter.delayedItemsToExport.length).to.equal(0)
+      expect(callCount).toEqual(1)
+      expect(exporter.delayedItemsToExport.length).toEqual(0)
     })
   })
 
   describe('abortDelayedItems', () => {
-    it('aborts any delayed items', (done) => {
+    it('aborts any delayed items', () => {
       const exporter = new OTLPTraceExporter()
 
-      exporter.delayedItemsToExport.push({
-        serviceRequest: 'req',
-        onSuccess: () => {},
-        onError: (error) => {
-          expect(error.message).to.equal('Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.')
-          done()
-        },
-      })
+      return new Promise((resolvePromise) => {
+        exporter.delayedItemsToExport.push({
+          serviceRequest: 'req',
+          onSuccess: () => {},
+          onError: (error) => {
+            expect(error.message).toEqual('Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.')
+            resolvePromise()
+          },
+        })
 
-      exporter.abortDelayedItems()
-      expect(exporter.delayedItemsToExport.length).to.equal(0)
+        exporter.abortDelayedItems()
+        expect(exporter.delayedItemsToExport.length).toEqual(0)
+      })
     })
   })
 
@@ -264,102 +265,108 @@ describe('cloudSpanExporter', () => {
       // @ts-expect-error
       exporter._shutdownOnce = { isCalled: true }
 
-      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).to.be.undefined
+      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).toBeUndefined()
     })
 
-    it('sends a string', (done) => {
+    it('sends a string', () => {
+      return new Promise((resolvePromise, rejectPromise) => {
+        const exporter = new OTLPTraceExporter()
+
+        exporter.convert = (objects) => {
+          throw 'convert should not be called'
+        }
+
+        exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
+          expect(collector).to.not.be.undefined
+          expect(body).toEqual('string')
+          expect(contentType).toEqual('application/json')
+          expect(resolve).to.not.be.undefined
+          expect(reject).to.not.be.undefined
+          resolve()
+        }
+
+        const onSuccess = () => {
+          resolvePromise()
+        }
+
+        const onError = () => {
+          rejectPromise('onError should not be called')
+        }
+
+        exporter.send('string', onSuccess, onError)
+      })
+    })
+
+    it('sends an array of readable spans', () => {
       const exporter = new OTLPTraceExporter()
 
-      exporter.convert = (objects) => {
-        throw 'convert should not be called'
-      }
+      return new Promise((resolvePromise, rejectPromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('string')
 
-      exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-        expect(collector).to.not.be.undefined
-        expect(body).to.equal('string')
-        expect(contentType).to.equal('application/json')
-        expect(resolve).to.not.be.undefined
-        expect(reject).to.not.be.undefined
-        resolve()
-      }
+          return 'string'
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
+          expect(collector).to.not.be.undefined
+          expect(body).toEqual(JSON.stringify('string'))
+          expect(contentType).toEqual('application/json')
+          expect(resolve).to.not.be.undefined
+          expect(reject).to.not.be.undefined
+          resolve()
+        }
 
-      const onError = () => {
-        throw 'onError should not be called'
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      exporter.send('string', onSuccess, onError)
+        const onError = () => {
+          rejectPromise('onError should not be called')
+        }
+
+        exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
 
-    it('sends an array of readable spans', (done) => {
+    it('fails to send the request', () => {
       const exporter = new OTLPTraceExporter()
 
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('string')
+      return new Promise((resolvePromise, rejectPromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('string')
 
-        return 'string'
-      }
+          return 'string'
+        }
 
-      exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-        expect(collector).to.not.be.undefined
-        expect(body).to.equal(JSON.stringify('string'))
-        expect(contentType).to.equal('application/json')
-        expect(resolve).to.not.be.undefined
-        expect(reject).to.not.be.undefined
-        resolve()
-      }
+        exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
+          expect(collector).to.not.be.undefined
+          expect(body).toEqual(JSON.stringify('string'))
+          expect(contentType).toEqual('application/json')
+          expect(resolve).not.toBeUndefined()
+          expect(reject).not.toBeUndefined()
+          // @ts-expect-error
+          reject('err')
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          rejectPromise('onSuccess should not be called')
+        }
 
-      const onError = () => {
-        throw 'onError should not be called'
-      }
+        const onError = (err) => {
+          expect(err).toEqual('err')
+          resolvePromise()
+        }
 
-      exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)
+        exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
 
-    it('fails to send the request', (done) => {
-      const exporter = new OTLPTraceExporter()
-
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('string')
-
-        return 'string'
-      }
-
-      exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-        expect(collector).to.not.be.undefined
-        expect(body).to.equal(JSON.stringify('string'))
-        expect(contentType).to.equal('application/json')
-        expect(resolve).to.not.be.undefined
-        expect(reject).to.not.be.undefined
-        // @ts-expect-error;'
-        reject('err')
-      }
-
-      const onSuccess = () => {
-        throw 'onSuccess should not be called'
-      }
-
-      const onError = (err) => {
-        expect(err).to.equal('err')
-        done()
-      }
-
-      exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)
-    })
-
-    it('encrypts the request', (done) => {
+    it('encrypts the request', () => {
       const encryption = {
         encryptRequest: ({ url, method, body }) => {
-          expect(body).to.equal('string')
+          expect(body).toEqual('string')
 
           return Promise.resolve({ jwe: 'encrypted' })
         },
@@ -372,28 +379,30 @@ describe('cloudSpanExporter', () => {
         },
       })
 
-      exporter.convert = (objects) => {
-        throw 'convert should not be called'
-      }
+      return new Promise((resolvePromise, rejectPromise) => {
+        exporter.convert = (objects) => {
+          throw 'convert should not be called'
+        }
 
-      exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-        expect(collector).to.not.be.undefined
-        expect(body).to.equal(JSON.stringify('encrypted'))
-        expect(contentType).to.equal('application/json')
-        expect(resolve).to.not.be.undefined
-        expect(reject).to.not.be.undefined
-        resolve()
-      }
+        exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
+          expect(collector).not.toBeUndefined()
+          expect(body).toEqual(JSON.stringify('encrypted'))
+          expect(contentType).toEqual('application/json')
+          expect(resolve).not.toBeUndefined()
+          expect(reject).not.toBeUndefined()
+          resolve()
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      const onError = () => {
-        throw 'onError should not be called'
-      }
+        const onError = () => {
+          rejectPromise('onError should not be called')
+        }
 
-      exporter.send('string', onSuccess, onError)
+        exporter.send('string', onSuccess, onError)
+      })
     })
 
     it('delays the request if encryption is enabled authorization is not present', () => {
@@ -423,37 +432,39 @@ describe('cloudSpanExporter', () => {
         throw 'onError should not be called'
       }
 
-      expect(exporter.delayedItemsToExport.length).to.equal(0)
+      expect(exporter.delayedItemsToExport.length).toEqual(0)
 
       exporter.send('string', onSuccess, onError)
 
-      expect(exporter.delayedItemsToExport.length).to.equal(1)
-      expect(exporter.delayedItemsToExport[0].serviceRequest).to.equal('string')
+      expect(exporter.delayedItemsToExport.length).toEqual(1)
+      expect(exporter.delayedItemsToExport[0].serviceRequest).toEqual('string')
     })
 
-    it('errors if requirements are unmet', (done) => {
+    it('errors if requirements are unmet', () => {
       const exporter = new OTLPTraceExporter()
 
-      exporter.requirementsToExport = 'unmet'
+      return new Promise((resolvePromise, rejectPromise) => {
+        exporter.requirementsToExport = 'unmet'
 
-      exporter.convert = (objects) => {
-        throw 'convert should not be called'
-      }
+        exporter.convert = (objects) => {
+          throw 'convert should not be called'
+        }
 
-      exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-        throw 'sendWithHttp should not be called'
-      }
+        exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
+          throw 'sendWithHttp should not be called'
+        }
 
-      const onSuccess = () => {
-        throw 'onSuccess should not be called'
-      }
+        const onSuccess = () => {
+          rejectPromise('onSuccess should not be called')
+        }
 
-      const onError = (error) => {
-        expect(error.message).to.equal('Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.')
-        done()
-      }
+        const onError = (error) => {
+          expect(error.message).toEqual('Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.')
+          resolvePromise()
+        }
 
-      exporter.send('string', onSuccess, onError)
+        exporter.send('string', onSuccess, onError)
+      })
     })
   })
 })

--- a/packages/telemetry/test/span-exporters/cloud-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/cloud-span-exporter.spec.ts
@@ -11,7 +11,7 @@ describe('cloudSpanExporter', () => {
 
       expect(exporter.headers['x-cypress-encrypted']).toEqual('1')
       expect(exporter.requirementsToExport).toEqual('unknown')
-      expect(exporter.enc).not.toBeUndefined()
+      expect(exporter.enc).toBeDefined()
     })
 
     it('does not set encrypted header if not set', () => {
@@ -344,8 +344,8 @@ describe('cloudSpanExporter', () => {
           expect(collector).to.not.be.undefined
           expect(body).toEqual(JSON.stringify('string'))
           expect(contentType).toEqual('application/json')
-          expect(resolve).not.toBeUndefined()
-          expect(reject).not.toBeUndefined()
+          expect(resolve).toBeDefined()
+          expect(reject).toBeDefined()
           // @ts-expect-error
           reject('err')
         }
@@ -385,11 +385,11 @@ describe('cloudSpanExporter', () => {
         }
 
         exporter.sendWithHttp = (collector, body, contentType, resolve, reject) => {
-          expect(collector).not.toBeUndefined()
+          expect(collector).toBeDefined()
           expect(body).toEqual(JSON.stringify('encrypted'))
           expect(contentType).toEqual('application/json')
-          expect(resolve).not.toBeUndefined()
-          expect(reject).not.toBeUndefined()
+          expect(resolve).toBeDefined()
+          expect(reject).toBeDefined()
           resolve()
         }
 

--- a/packages/telemetry/test/span-exporters/console-trace-link-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/console-trace-link-exporter.spec.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { describe, it, expect } from 'vitest'
 import { ConsoleTraceLinkExporter } from '../../src/span-exporters/console-trace-link-exporter'
 
 describe('consoleTraceLinkExporter', () => {
@@ -11,42 +10,44 @@ describe('consoleTraceLinkExporter', () => {
         environment: 'environment',
       })
 
-      //@ts-expect-error
-      expect(exporter._traceUrl).to.equal('https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id')
+      // @ts-expect-error
+      expect(exporter._traceUrl).toEqual('https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id')
     })
   })
 
   describe('export', () => {
-    it('logs the start of the first span with a unique trace', (done) => {
+    it('logs the start of the first span with a unique trace', () => {
       const exporter = new ConsoleTraceLinkExporter({
         serviceName: 'serviceName',
         team: 'team',
         environment: 'environment',
       })
 
-      //@ts-expect-error
+      // @ts-expect-error
       exporter._log = (...args) => {
-        expect(args[0]).to.equal('Trace start: [spanName] - https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id=traceId')
+        expect(args[0]).toEqual('Trace start: [spanName] - https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id=traceId')
       }
 
-      exporter.export([{
-        name: 'spanName',
-        //@ts-expect-error
-        spanContext: () => {
-          return {
-            traceId: 'traceId',
-            spanId: 'spanId',
-          }
-        },
-      }], (result) => {
-        //@ts-expect-error
-        expect(exporter._uniqueTraces['traceId']).to.equal('spanId')
-        expect(result.code).to.equal(0)
-        done()
+      return new Promise((resolve) => {
+        exporter.export([{
+          name: 'spanName',
+          // @ts-expect-error
+          spanContext: () => {
+            return {
+              traceId: 'traceId',
+              spanId: 'spanId',
+            }
+          },
+        }], (result) => {
+          // @ts-expect-error
+          expect(exporter._uniqueTraces['traceId']).toEqual('spanId')
+          expect(result.code).toEqual(0)
+          resolve()
+        })
       })
     })
 
-    it('ignores the start of the second span with a unique trace', (done) => {
+    it('ignores the start of the second span with a unique trace', () => {
       const exporter = new ConsoleTraceLinkExporter({
         serviceName: 'serviceName',
         team: 'team',
@@ -55,7 +56,7 @@ describe('consoleTraceLinkExporter', () => {
 
       exporter.export([{
         name: 'spanName',
-        //@ts-expect-error
+        // @ts-expect-error
         spanContext: () => {
           return {
             traceId: 'traceId',
@@ -64,29 +65,31 @@ describe('consoleTraceLinkExporter', () => {
         },
       }], () => {})
 
-      //@ts-expect-error
+      // @ts-expect-error
       exporter._log = (...args) => {
         throw 'do not call'
       }
 
-      exporter.export([{
-        name: 'spanName',
-        //@ts-expect-error
-        spanContext: () => {
-          return {
-            traceId: 'traceId',
-            spanId: 'spanId2',
-          }
-        },
-      }], (result) => {
-        //@ts-expect-error
-        expect(exporter._uniqueTraces['traceId']).to.not.equal('spanId2')
-        expect(result.code).to.equal(0)
-        done()
+      return new Promise((resolve) => {
+        exporter.export([{
+          name: 'spanName',
+          // @ts-expect-error
+          spanContext: () => {
+            return {
+              traceId: 'traceId',
+              spanId: 'spanId2',
+            }
+          },
+        }], (result) => {
+          // @ts-expect-error
+          expect(exporter._uniqueTraces['traceId']).not.toEqual('spanId2')
+          expect(result.code).toEqual(0)
+          resolve()
+        })
       })
     })
 
-    it('ignores the end of the second span with a unique trace', (done) => {
+    it('ignores the end of the second span with a unique trace', () => {
       const exporter = new ConsoleTraceLinkExporter({
         serviceName: 'serviceName',
         team: 'team',
@@ -95,7 +98,7 @@ describe('consoleTraceLinkExporter', () => {
 
       exporter.export([{
         name: 'spanName',
-        //@ts-expect-error
+        // @ts-expect-error
         spanContext: () => {
           return {
             traceId: 'traceId',
@@ -104,28 +107,30 @@ describe('consoleTraceLinkExporter', () => {
         },
       }], () => {})
 
-      //@ts-expect-error
+      // @ts-expect-error
       exporter._log = (...args) => {
         throw 'do not call'
       }
 
-      exporter.export([{
-        name: 'spanName',
-        ended: true,
-        //@ts-expect-error
-        spanContext: () => {
-          return {
-            traceId: 'traceId',
-            spanId: 'spanId2',
-          }
-        },
-      }], (result) => {
-        expect(result.code).to.equal(0)
-        done()
+      return new Promise((resolve) => {
+        exporter.export([{
+          name: 'spanName',
+          ended: true,
+          // @ts-expect-error
+          spanContext: () => {
+            return {
+              traceId: 'traceId',
+              spanId: 'spanId2',
+            }
+          },
+        }], (result) => {
+          expect(result.code).toEqual(0)
+          resolve()
+        })
       })
     })
 
-    it('logs the end of the first span with a unique trace', (done) => {
+    it('logs the end of the first span with a unique trace', () => {
       const exporter = new ConsoleTraceLinkExporter({
         serviceName: 'serviceName',
         team: 'team',
@@ -134,7 +139,7 @@ describe('consoleTraceLinkExporter', () => {
 
       exporter.export([{
         name: 'spanName',
-        //@ts-expect-error
+        // @ts-expect-error
         spanContext: () => {
           return {
             traceId: 'traceId',
@@ -143,25 +148,28 @@ describe('consoleTraceLinkExporter', () => {
         },
       }], () => {})
 
-      //@ts-expect-error
+      // @ts-expect-error
       exporter._log = (...args) => {
+        // eslint-disable-next-line no-console
         console.log(args)
-        expect(args[0]).to.equal('Trace end: [spanName] - https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id=traceId')
+        expect(args[0]).toEqual('Trace end: [spanName] - https://ui.honeycomb.io/team/environments/environment/datasets/serviceName/trace?trace_id=traceId')
       }
 
-      exporter.export([{
-        name: 'spanName',
-        ended: true,
-        //@ts-expect-error
-        spanContext: () => {
-          return {
-            traceId: 'traceId',
-            spanId: 'spanId',
-          }
-        },
-      }], (result) => {
-        expect(result.code).to.equal(0)
-        done()
+      return new Promise((resolve) => {
+        exporter.export([{
+          name: 'spanName',
+          ended: true,
+          // @ts-expect-error
+          spanContext: () => {
+            return {
+              traceId: 'traceId',
+              spanId: 'spanId',
+            }
+          },
+        }], (result) => {
+          expect(result.code).toEqual(0)
+          resolve()
+        })
       })
     })
   })

--- a/packages/telemetry/test/span-exporters/ipc-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/ipc-span-exporter.spec.ts
@@ -50,8 +50,8 @@ describe('ipcSpanExporter', () => {
 
       exporter.send = (objects, onSuccess, onError) => {
         expect(objects[0].name).toEqual('span')
-        expect(onSuccess).not.toBeUndefined()
-        expect(onError).not.toBeUndefined()
+        expect(onSuccess).toBeDefined()
+        expect(onError).toBeDefined()
       }
 
       expect(exporter.delayedExport.length).toEqual(0)

--- a/packages/telemetry/test/span-exporters/ipc-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/ipc-span-exporter.spec.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { describe, it, expect } from 'vitest'
 import { OTLPTraceExporter } from '../../src/span-exporters/ipc-span-exporter'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
@@ -8,7 +7,7 @@ describe('ipcSpanExporter', () => {
     it('new sets delayedExport to an empty array', () => {
       const exporter = new OTLPTraceExporter()
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
     })
   })
 
@@ -19,12 +18,12 @@ describe('ipcSpanExporter', () => {
       exporter.delayedExport.push({ items: [{ name: 'span' }] as ReadableSpan[], resultCallback: () => {} })
 
       exporter.export = (items, resultCallback) => {
-        expect(items[0].name).to.equal('span')
+        expect(items[0].name).toEqual('span')
       }
 
       exporter.attachIPC({ name: 'ipc', send: () => {} })
 
-      expect(exporter.ipc.name).to.equal('ipc')
+      expect(exporter.ipc.name).toEqual('ipc')
     })
   })
 
@@ -36,12 +35,12 @@ describe('ipcSpanExporter', () => {
         throw 'send should not be called'
       }
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
 
       exporter.export([{ name: 'span' }] as ReadableSpan[], (result) => {})
 
-      expect(exporter.delayedExport.length).to.equal(1)
-      expect(exporter.delayedExport[0].items[0].name).to.equal('span')
+      expect(exporter.delayedExport.length).toEqual(1)
+      expect(exporter.delayedExport[0].items[0].name).toEqual('span')
     })
 
     it('does not delay if ipc is present', () => {
@@ -50,16 +49,16 @@ describe('ipcSpanExporter', () => {
       exporter.ipc = { name: 'ipc', send: () => {} }
 
       exporter.send = (objects, onSuccess, onError) => {
-        expect(objects[0].name).to.equal('span')
-        expect(onSuccess).to.not.be.undefined
-        expect(onError).to.not.be.undefined
+        expect(objects[0].name).toEqual('span')
+        expect(onSuccess).not.toBeUndefined()
+        expect(onError).not.toBeUndefined()
       }
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
 
       exporter.export([{ name: 'span' }] as ReadableSpan[], (result) => {})
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
     })
   })
 
@@ -88,63 +87,67 @@ describe('ipcSpanExporter', () => {
       // @ts-expect-error
       exporter._shutdownOnce = { isCalled: true }
 
-      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).to.be.undefined
+      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).toBeUndefined()
     })
 
-    it('sends via ipc', (done) => {
+    it('sends via ipc', () => {
       const exporter = new OTLPTraceExporter()
 
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('span')
+      return new Promise((resolvePromise, rejectPromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('span')
 
-        return 'span'
-      }
+          return 'span'
+        }
 
-      exporter.ipc = {
-        send: (event, request) => {
-          expect(event).to.equal('export:telemetry')
-          expect(request).to.equal(JSON.stringify('span'))
-        },
-      }
+        exporter.ipc = {
+          send: (event, request) => {
+            expect(event).toEqual('export:telemetry')
+            expect(request).toEqual(JSON.stringify('span'))
+          },
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      const onError = () => {
-        throw 'onError should not be called'
-      }
+        const onError = () => {
+          rejectPromise('onError should not be called')
+        }
 
-      exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+        exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
 
-    it('handles an exception in the ipc send command', (done) => {
+    it('handles an exception in the ipc send command', () => {
       const exporter = new OTLPTraceExporter()
 
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('span')
+      return new Promise((resolvePromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('span')
 
-        return 'span'
-      }
+          return 'span'
+        }
 
-      exporter.ipc = {
-        send: (event, request) => {
-          throw 'ipc error'
-        },
-      }
+        exporter.ipc = {
+          send: (event, request) => {
+            throw 'ipc error'
+          },
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      const onError = (err) => {
-        expect(err).to.equal('ipc error')
-        done()
-      }
+        const onError = (err) => {
+          expect(err).to.equal('ipc error')
+          resolvePromise()
+        }
 
-      exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+        exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
   })
 })

--- a/packages/telemetry/test/span-exporters/websocket-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/websocket-span-exporter.spec.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai'
-
+import { describe, it, expect } from 'vitest'
 import { OTLPTraceExporter } from '../../src/span-exporters/websocket-span-exporter'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
@@ -8,7 +7,7 @@ describe('ipcSpanExporter', () => {
     it('new sets delayedExport to an empty array', () => {
       const exporter = new OTLPTraceExporter()
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
     })
   })
 
@@ -19,12 +18,12 @@ describe('ipcSpanExporter', () => {
       exporter.delayedExport.push({ items: [{ name: 'span' }] as ReadableSpan[], resultCallback: () => {} })
 
       exporter.export = (items, resultCallback) => {
-        expect(items[0].name).to.equal('span')
+        expect(items[0].name).toEqual('span')
       }
 
       exporter.attachWebSocket({ name: 'socket', emit: () => {} })
 
-      expect(exporter.ws.name).to.equal('socket')
+      expect(exporter.ws.name).toEqual('socket')
     })
   })
 
@@ -36,12 +35,12 @@ describe('ipcSpanExporter', () => {
         throw 'send should not be called'
       }
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
 
       exporter.export([{ name: 'span' }] as ReadableSpan[], (result) => {})
 
-      expect(exporter.delayedExport.length).to.equal(1)
-      expect(exporter.delayedExport[0].items[0].name).to.equal('span')
+      expect(exporter.delayedExport.length).toEqual(1)
+      expect(exporter.delayedExport[0].items[0].name).toEqual('span')
     })
 
     it('does not delay if ws is present', () => {
@@ -50,16 +49,16 @@ describe('ipcSpanExporter', () => {
       exporter.ws = { name: 'ws', emit: () => {} }
 
       exporter.send = (objects, onSuccess, onError) => {
-        expect(objects[0].name).to.equal('span')
-        expect(onSuccess).to.not.be.undefined
-        expect(onError).to.not.be.undefined
+        expect(objects[0].name).toEqual('span')
+        expect(onSuccess).not.toBeUndefined()
+        expect(onError).not.toBeUndefined()
       }
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
 
       exporter.export([{ name: 'span' }] as ReadableSpan[], (result) => {})
 
-      expect(exporter.delayedExport.length).to.equal(0)
+      expect(exporter.delayedExport.length).toEqual(0)
     })
   })
 
@@ -88,74 +87,78 @@ describe('ipcSpanExporter', () => {
       // @ts-expect-error
       exporter._shutdownOnce = { isCalled: true }
 
-      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).to.be.undefined
+      expect(exporter.send([{ name: 'string' }] as ReadableSpan[], onSuccess, onError)).toBeUndefined()
     })
 
-    it('sends via websocket', (done) => {
+    it('sends via websocket', () => {
       const exporter = new OTLPTraceExporter()
 
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('span')
+      return new Promise((resolvePromise, rejectPromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('span')
 
-        return 'span'
-      }
+          return 'span'
+        }
 
-      exporter.ws = {
-        emit: (event, subEvent, request, callback) => {
-          expect(event).to.equal('backend:request')
-          expect(subEvent).to.equal('telemetry')
-          expect(request).to.equal(JSON.stringify('span'))
-          expect(callback).to.not.be.undefined
-          callback({})
-        },
-      }
+        exporter.ws = {
+          emit: (event, subEvent, request, callback) => {
+            expect(event).toEqual('backend:request')
+            expect(subEvent).toEqual('telemetry')
+            expect(request).toEqual(JSON.stringify('span'))
+            expect(callback).not.toBeUndefined()
+            callback({})
+          },
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      const onError = () => {
-        throw 'onError should not be called'
-      }
+        const onError = () => {
+          rejectPromise('onError should not be called')
+        }
 
-      exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+        exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
 
-    it('handles an exception in the ipc send command', (done) => {
+    it('handles an exception in the ipc send command', () => {
       const exporter = new OTLPTraceExporter()
 
-      // @ts-expect-error
-      exporter.convert = (objects) => {
-        expect(objects[0].name).to.equal('span')
+      return new Promise((resolvePromise) => {
+        // @ts-expect-error
+        exporter.convert = (objects) => {
+          expect(objects[0].name).toEqual('span')
 
-        return 'span'
-      }
+          return 'span'
+        }
 
-      exporter.ws = {
-        emit: (event, subEvent, request, callback) => {
-          expect(event).to.equal('backend:request')
-          expect(subEvent).to.equal('telemetry')
-          expect(request).to.equal(JSON.stringify('span'))
-          expect(callback).to.not.be.undefined
-          callback({
-            res: {
-              error: 'this broke',
-            },
-          })
-        },
-      }
+        exporter.ws = {
+          emit: (event, subEvent, request, callback) => {
+            expect(event).toEqual('backend:request')
+            expect(subEvent).toEqual('telemetry')
+            expect(request).toEqual(JSON.stringify('span'))
+            expect(callback).not.toBeUndefined()
+            callback({
+              res: {
+                error: 'this broke',
+              },
+            })
+          },
+        }
 
-      const onSuccess = () => {
-        done()
-      }
+        const onSuccess = () => {
+          resolvePromise()
+        }
 
-      const onError = (err) => {
-        expect(err).to.equal('this broke')
-        done()
-      }
+        const onError = (err) => {
+          expect(err).toEqual('this broke')
+          resolvePromise()
+        }
 
-      exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+        exporter.send([{ name: 'span' }] as ReadableSpan[], onSuccess, onError)
+      })
     })
   })
 })

--- a/packages/telemetry/test/span-exporters/websocket-span-exporter.spec.ts
+++ b/packages/telemetry/test/span-exporters/websocket-span-exporter.spec.ts
@@ -50,8 +50,8 @@ describe('ipcSpanExporter', () => {
 
       exporter.send = (objects, onSuccess, onError) => {
         expect(objects[0].name).toEqual('span')
-        expect(onSuccess).not.toBeUndefined()
-        expect(onError).not.toBeUndefined()
+        expect(onSuccess).toBeDefined()
+        expect(onError).toBeDefined()
       }
 
       expect(exporter.delayedExport.length).toEqual(0)
@@ -106,7 +106,7 @@ describe('ipcSpanExporter', () => {
             expect(event).toEqual('backend:request')
             expect(subEvent).toEqual('telemetry')
             expect(request).toEqual(JSON.stringify('span'))
-            expect(callback).not.toBeUndefined()
+            expect(callback).toBeDefined()
             callback({})
           },
         }
@@ -139,7 +139,7 @@ describe('ipcSpanExporter', () => {
             expect(event).toEqual('backend:request')
             expect(subEvent).toEqual('telemetry')
             expect(request).toEqual(JSON.stringify('span'))
-            expect(callback).not.toBeUndefined()
+            expect(callback).toBeDefined()
             callback({
               res: {
                 error: 'this broke',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: [
       'test/detectors/circleCiDetectorSync.spec.ts',
       'test/detectors/githubActionsDetectorSync.spec.ts',
+      'test/processors/on-start-span-processor.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -2,18 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: [
-      'test/detectors/circleCiDetectorSync.spec.ts',
-      'test/detectors/githubActionsDetectorSync.spec.ts',
-      'test/processors/on-start-span-processor.spec.ts',
-      'test/span-exporters/cloud-span-exporter.spec.ts',
-      'test/span-exporters/console-trace-link-exporter.spec.ts',
-      'test/span-exporters/ipc-span-exporter.spec.ts',
-      'test/span-exporters/websocket-span-exporter.spec.ts',
-      'test/browser.spec.ts',
-      'test/index.spec.ts',
-      'test/node.spec.ts',
-    ],
+    include: ['test/**/*.spec.ts'],
     globals: true,
     environment: 'node',
   },

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'test/detectors/circleCiDetectorSync.spec.ts',
+      'test/detectors/githubActionsDetectorSync.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'test/span-exporters/ipc-span-exporter.spec.ts',
       'test/span-exporters/websocket-span-exporter.spec.ts',
       'test/browser.spec.ts',
+      'test/index.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       'test/processors/on-start-span-processor.spec.ts',
       'test/span-exporters/cloud-span-exporter.spec.ts',
       'test/span-exporters/console-trace-link-exporter.spec.ts',
+      'test/span-exporters/ipc-span-exporter.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       'test/detectors/circleCiDetectorSync.spec.ts',
       'test/detectors/githubActionsDetectorSync.spec.ts',
       'test/processors/on-start-span-processor.spec.ts',
+      'test/span-exporters/cloud-span-exporter.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       'test/detectors/githubActionsDetectorSync.spec.ts',
       'test/processors/on-start-span-processor.spec.ts',
       'test/span-exporters/cloud-span-exporter.spec.ts',
+      'test/span-exporters/console-trace-link-exporter.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'test/span-exporters/console-trace-link-exporter.spec.ts',
       'test/span-exporters/ipc-span-exporter.spec.ts',
       'test/span-exporters/websocket-span-exporter.spec.ts',
+      'test/browser.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: [
+      'test/detectors/circleCiDetectorSync.spec.ts',
+    ],
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'test/span-exporters/cloud-span-exporter.spec.ts',
       'test/span-exporters/console-trace-link-exporter.spec.ts',
       'test/span-exporters/ipc-span-exporter.spec.ts',
+      'test/span-exporters/websocket-span-exporter.spec.ts',
     ],
     globals: true,
     environment: 'node',

--- a/packages/telemetry/vitest.config.ts
+++ b/packages/telemetry/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       'test/span-exporters/websocket-span-exporter.spec.ts',
       'test/browser.spec.ts',
       'test/index.spec.ts',
+      'test/node.spec.ts',
     ],
     globals: true,
     environment: 'node',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Converts the telemetry tests from mocha to vitest. Test conversion is mostly 1:1

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `@packages/telemetry` tests to Vitest, adds Vitest config, updates package scripts/deps, adjusts CI expected test counts, and marks telemetry migration complete in docs.
> 
> - **Packages/telemetry**:
>   - Convert tests from Mocha/Chai to Vitest (`expect`/matchers, `beforeAll`, `vi.stubEnv`, Promise-based async, etc.).
>   - Add `vitest.config.ts` and update `package.json` scripts (`test-unit` to `vitest run`, add `test-debug`) and devDeps (replace `mocha` with `vitest`).
>   - Remove Mocha config `test/.mocharc.js`.
> - **CI**:
>   - Update `sanitize-verify-and-store-mocha-results.expectedResultCount` to `15` in `.circleci/src/workflows/@workflows.yml` and `.circleci/workflows.yml`.
> - **Docs**:
>   - Mark `packages/telemetry` as completed in `guides/esm-migration.md` (Phase 2).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6688b5bf227e238723b0bfecbc3f23e19e236e1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->