### PR TITLE
fix: ensure that code frames within cy.origin point to the right line of the code

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 10/07/2025 (PENDING)_
 **Bugfixes:**
 
 - Fixed a regression introduced in [`15.0.0`](https://docs.cypress.io/guides/references/changelog#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
+- Fixed code frames in `cy.origin` so that failed commands will show the correct line/column within the corresponding spec file. Addressed in [#32597](https://github.com/cypress-io/cypress/pull/32597).
 
 **Misc:**
 

--- a/packages/driver/src/cross-origin/origin_fn.ts
+++ b/packages/driver/src/cross-origin/origin_fn.ts
@@ -170,17 +170,20 @@ export const handleOriginFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
     })
 
     cy.state('onFail', (err) => {
+      const currentAssertionUserInvocationStack = cy.state('current').get('currentAssertionCommand')?.get('userInvocationStack')
+      const userInvocationStack = cy.state('current').get('userInvocationStack')
+
       setRunnableStateToPassed()
       if (queueFinished) {
         // If the queue is already finished, send this event instead because
         // the primary won't be listening for 'queue:finished' anymore
-        Cypress.specBridgeCommunicator.toPrimary('uncaught:error', { err })
+        Cypress.specBridgeCommunicator.toPrimary('uncaught:error', { err, userInvocationStack, currentAssertionUserInvocationStack })
 
         return
       }
 
       cy.stop()
-      Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err }, { syncGlobals: true })
+      Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err, userInvocationStack, currentAssertionUserInvocationStack }, { syncGlobals: true })
     })
 
     // the name of this function is used to verify if privileged commands are

--- a/packages/driver/src/cross-origin/origin_fn.ts
+++ b/packages/driver/src/cross-origin/origin_fn.ts
@@ -170,17 +170,17 @@ export const handleOriginFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
     })
 
     cy.state('onFail', (err) => {
-      const currentAssertionUserInvocationStack = cy.state('current').get('currentAssertionCommand')?.get('userInvocationStack')
-      const userInvocationStack = cy.state('current').get('userInvocationStack')
-
       setRunnableStateToPassed()
       if (queueFinished) {
         // If the queue is already finished, send this event instead because
         // the primary won't be listening for 'queue:finished' anymore
-        Cypress.specBridgeCommunicator.toPrimary('uncaught:error', { err, userInvocationStack, currentAssertionUserInvocationStack })
+        Cypress.specBridgeCommunicator.toPrimary('uncaught:error', { err })
 
         return
       }
+
+      const currentAssertionUserInvocationStack = cy.state('current').get('currentAssertionCommand')?.get('userInvocationStack')
+      const userInvocationStack = cy.state('current').get('userInvocationStack')
 
       cy.stop()
       Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err, userInvocationStack, currentAssertionUserInvocationStack }, { syncGlobals: true })

--- a/packages/driver/src/cross-origin/origin_fn.ts
+++ b/packages/driver/src/cross-origin/origin_fn.ts
@@ -183,7 +183,7 @@ export const handleOriginFn = (Cypress: Cypress.Cypress, cy: $Cy) => {
       const userInvocationStack = cy.state('current').get('userInvocationStack')
 
       cy.stop()
-      Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err, userInvocationStack, currentAssertionUserInvocationStack }, { syncGlobals: true })
+      Cypress.specBridgeCommunicator.toPrimary('queue:finished', { err, crossOriginUserInvocationStack: currentAssertionUserInvocationStack || userInvocationStack }, { syncGlobals: true })
     })
 
     // the name of this function is used to verify if privileged commands are

--- a/packages/driver/src/cy/commands/origin/index.ts
+++ b/packages/driver/src/cy/commands/origin/index.ts
@@ -118,8 +118,26 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: State
           reject(err)
         }
 
-        const onQueueFinished = ({ err, subject, unserializableSubjectType }) => {
+        const onQueueFinished = ({ err, userInvocationStack, currentAssertionUserInvocationStack, subject, unserializableSubjectType }) => {
           if (err) {
+            if (!currentAssertionUserInvocationStack) {
+              err = $errUtils.enhanceStack({
+                err,
+                userInvocationStack,
+                projectRoot: Cypress.config('projectRoot'),
+              })
+
+              err.crossOriginUserInvocationStack = userInvocationStack
+            } else {
+              err = $errUtils.enhanceStack({
+                err,
+                userInvocationStack: currentAssertionUserInvocationStack,
+                projectRoot: Cypress.config('projectRoot'),
+              })
+
+              err.crossOriginUserInvocationStack = currentAssertionUserInvocationStack
+            }
+
             return _reject(err)
           }
 
@@ -223,6 +241,7 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: State
                   autLocation: Cypress.state('autLocation')?.href,
                   crossOriginCookies: Cypress.state('crossOriginCookies'),
                   isProtocolEnabled: Cypress.state('isProtocolEnabled'),
+                  originUserInvocationStack: userInvocationStack,
                 },
                 config: preprocessConfig(Cypress.config()),
                 env: preprocessEnv(Cypress.env()),

--- a/packages/driver/src/cy/commands/origin/index.ts
+++ b/packages/driver/src/cy/commands/origin/index.ts
@@ -121,20 +121,8 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: State
         const onQueueFinished = ({ err, userInvocationStack, currentAssertionUserInvocationStack, subject, unserializableSubjectType }) => {
           if (err) {
             if (!currentAssertionUserInvocationStack) {
-              err = $errUtils.enhanceStack({
-                err,
-                userInvocationStack,
-                projectRoot: Cypress.config('projectRoot'),
-              })
-
               err.crossOriginUserInvocationStack = userInvocationStack
             } else {
-              err = $errUtils.enhanceStack({
-                err,
-                userInvocationStack: currentAssertionUserInvocationStack,
-                projectRoot: Cypress.config('projectRoot'),
-              })
-
               err.crossOriginUserInvocationStack = currentAssertionUserInvocationStack
             }
 

--- a/packages/driver/src/cy/commands/origin/index.ts
+++ b/packages/driver/src/cy/commands/origin/index.ts
@@ -118,13 +118,9 @@ export default (Commands, Cypress: Cypress.Cypress, cy: Cypress.cy, state: State
           reject(err)
         }
 
-        const onQueueFinished = ({ err, userInvocationStack, currentAssertionUserInvocationStack, subject, unserializableSubjectType }) => {
+        const onQueueFinished = ({ err, crossOriginUserInvocationStack, subject, unserializableSubjectType }) => {
           if (err) {
-            if (!currentAssertionUserInvocationStack) {
-              err.crossOriginUserInvocationStack = userInvocationStack
-            } else {
-              err.crossOriginUserInvocationStack = currentAssertionUserInvocationStack
-            }
+            err.crossOriginUserInvocationStack = crossOriginUserInvocationStack
 
             return _reject(err)
           }

--- a/packages/driver/src/cypress/chainer.ts
+++ b/packages/driver/src/cypress/chainer.ts
@@ -22,9 +22,13 @@ export class $Chainer {
     $Chainer.prototype[key] = function (...args) {
       const privilegeVerification = Cypress.emitMap('command:invocation', { name: key, args })
 
-      const userInvocationStack = $stackUtils.normalizedUserInvocationStack(
+      let userInvocationStack = $stackUtils.normalizedUserInvocationStack(
         (new this.specWindow.Error('command invocation stack')).stack,
       )
+
+      if (cy.state('originUserInvocationStack')) {
+        userInvocationStack = $stackUtils.mergeCrossOriginUserInvocationStack(userInvocationStack, cy.state('originUserInvocationStack'))
+      }
 
       // call back the original function with our new args
       // pass args an as array and not a destructured invocation

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -747,8 +747,6 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       let userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
 
       if (cy.state('originUserInvocationStack')) {
-        // console.log('originUserInvocationStack', cy.state('originUserInvocationStack'))
-        // console.log('userInvocationStack', userInvocationStack)
         userInvocationStack = $stackUtils.mergeCrossOriginUserInvocationStack(userInvocationStack, cy.state('originUserInvocationStack'))
       }
 
@@ -856,8 +854,6 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       let userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
 
       if (cy.state('originUserInvocationStack')) {
-        // console.log('originUserInvocationStack', cy.state('originUserInvocationStack'))
-        // console.log('userInvocationStack', userInvocationStack)
         userInvocationStack = $stackUtils.mergeCrossOriginUserInvocationStack(userInvocationStack, cy.state('originUserInvocationStack'))
       }
 

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -390,7 +390,11 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
 
     err.stack = $stackUtils.normalizedStack(err)
 
-    const userInvocationStack = $errUtils.getUserInvocationStack(err, this.state)
+    let userInvocationStack = err.crossOriginUserInvocationStack
+
+    if (!userInvocationStack) {
+      userInvocationStack = $errUtils.getUserInvocationStack(err, this.state)
+    }
 
     err = $errUtils.enhanceStack({
       err,
@@ -740,7 +744,13 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
         cy.linkSubject(chainer.chainerId, cy.state('chainerId'))
       }
 
-      const userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
+      let userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
+
+      if (cy.state('originUserInvocationStack')) {
+        // console.log('originUserInvocationStack', cy.state('originUserInvocationStack'))
+        // console.log('userInvocationStack', userInvocationStack)
+        userInvocationStack = $stackUtils.mergeCrossOriginUserInvocationStack(userInvocationStack, cy.state('originUserInvocationStack'))
+      }
 
       callback(chainer, userInvocationStack, args, privilegeVerification, true)
 
@@ -843,7 +853,13 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
         cy.linkSubject(chainer.chainerId, cy.state('chainerId'))
       }
 
-      const userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
+      let userInvocationStack = $stackUtils.captureUserInvocationStack(cy.specWindow.Error)
+
+      if (cy.state('originUserInvocationStack')) {
+        // console.log('originUserInvocationStack', cy.state('originUserInvocationStack'))
+        // console.log('userInvocationStack', userInvocationStack)
+        userInvocationStack = $stackUtils.mergeCrossOriginUserInvocationStack(userInvocationStack, cy.state('originUserInvocationStack'))
+      }
 
       callback(chainer, userInvocationStack, args, privilegeVerification)
 

--- a/packages/driver/src/cypress/stack_utils.ts
+++ b/packages/driver/src/cypress/stack_utils.ts
@@ -539,18 +539,23 @@ const mergeCrossOriginUserInvocationStack = (userInvocationStack: string, origin
 
   if (userStackLines.length === 0 || originStackLines.length === 0) return userInvocationStack
 
-  const userStackMatch = userStackLines[0].match(/(\d+):(\d+)\)/)
+  // Note: chrome adds a parenthesis to the end of the stack line and firefox does not
+  const userStackMatch = userStackLines[0].match(/(\d+):(\d+)\)?$/)
 
   if (!userStackMatch) return userInvocationStack
 
   const userLine = Number(userStackMatch[1])
   const userColumn = Number(userStackMatch[2])
-  const originStackMatch = originStackLines[0].match(/(\d+):(\d+)\)/)
+
+  // Note: chrome adds a parenthesis to the end of the stack line and firefox does not
+  const originStackMatch = originStackLines[0].match(/(\d+):(\d+)\)?$/)
 
   if (!originStackMatch) return userInvocationStack
 
   const originLine = Number(originStackMatch[1])
-  const newUserStackLine = `${originStackLines[0].replace(/\d+:\d+\)/, `${originLine + userLine - 1}:${userColumn})`)}`
+
+  // Note: chrome adds a parenthesis to the end of the stack line and firefox does not so we need to keep whatever we find
+  const newUserStackLine = `${originStackLines[0].replace(/(\d+:\d+)(\)?)$/, `${originLine + userLine - 1}:${userColumn}$2`)}`
 
   return userInvocationStack.replace(userStackLines[0], newUserStackLine)
 }

--- a/packages/driver/src/cypress/stack_utils.ts
+++ b/packages/driver/src/cypress/stack_utils.ts
@@ -537,7 +537,7 @@ const mergeCrossOriginUserInvocationStack = (userInvocationStack: string, origin
   const originStackLines = getStackLines(originUserInvocationStack)
   const userStackLines = getStackLines(userInvocationStack)
 
-  if (userStackLines.length === 0) return userInvocationStack
+  if (userStackLines.length === 0 || originStackLines.length === 0) return userInvocationStack
 
   const userStackMatch = userStackLines[0].match(/(\d+):(\d+)\)/)
 

--- a/packages/driver/src/cypress/stack_utils.ts
+++ b/packages/driver/src/cypress/stack_utils.ts
@@ -519,9 +519,40 @@ const normalizedUserInvocationStack = (userInvocationStack) => {
     || line.includes('Chainer.prototype[key]')
     || line.includes('cy.<computed>')
     || line.includes('$Chainer.<computed>')
+    // Remove cross origin stack lines
+    || line.includes('SpecBridgeCommunicator')
+    || (line.includes('at invokeOriginFn') && !line.includes('at eval'))
   }).join('\n')
 
   return normalizeStackIndentation(nonCypressStackLines)
+}
+
+const mergeCrossOriginUserInvocationStack = (userInvocationStack: string, originUserInvocationStack: string) => {
+  // The method here is:
+  // 1. Grab the line/column from the first line of the origin user invocation stack
+  // 2. Add it to and replace the line/column of the first line of the user invocation stack
+  //
+  // Note: If any of our assumptions about the stack format are violated, this will just
+  // return the original user invocation stack to avoid breaking the stack trace.
+  const originStackLines = getStackLines(originUserInvocationStack)
+  const userStackLines = getStackLines(userInvocationStack)
+
+  if (userStackLines.length === 0) return userInvocationStack
+
+  const userStackMatch = userStackLines[0].match(/(\d+):(\d+)\)/)
+
+  if (!userStackMatch) return userInvocationStack
+
+  const userLine = Number(userStackMatch[1])
+  const userColumn = Number(userStackMatch[2])
+  const originStackMatch = originStackLines[0].match(/(\d+):(\d+)\)/)
+
+  if (!originStackMatch) return userInvocationStack
+
+  const originLine = Number(originStackMatch[1])
+  const newUserStackLine = `${originStackLines[0].replace(/\d+:\d+\)/, `${originLine + userLine - 1}:${userColumn})`)}`
+
+  return userInvocationStack.replace(userStackLines[0], newUserStackLine)
 }
 
 export default {
@@ -543,4 +574,5 @@ export default {
   stackWithUserInvocationStackSpliced,
   captureUserInvocationStack,
   getInvocationDetails,
+  mergeCrossOriginUserInvocationStack,
 }

--- a/packages/driver/test/unit/cypress/stack_utils.spec.ts
+++ b/packages/driver/test/unit/cypress/stack_utils.spec.ts
@@ -65,4 +65,73 @@ describe('stack_utils', () => {
       })
     }
   })
+
+  describe('normalizedUserInvocationStack', () => {
+    it('should remove cross origin stack lines', () => {
+      const userInvocationStack = `    at cy.<computed> [as prompt] (cypress:///../driver/src/cypress/cy.ts:657:86)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)
+    at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts:176:42)
+    at SpecBridgeCommunicator.eval (cypress:///../driver/src/cross-origin/origin_fn.ts:180:21)`
+      const normalizedUserInvocationStack = stack_utils.normalizedUserInvocationStack(userInvocationStack)
+
+      expect(normalizedUserInvocationStack).toEqual(`    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)`)
+    })
+  })
+
+  describe('mergeCrossOriginUserInvocationStack', () => {
+    it('should merge line numbers from origin stack into user stack', () => {
+      const userInvocationStack = `    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)`
+      const originUserInvocationStack = `    at Context.eval (http://localhost:9500/__cypress/tests?p=cypress/e2e/run/cross-origin.cy.ts:14:12)`
+
+      const result = stack_utils.mergeCrossOriginUserInvocationStack(userInvocationStack, originUserInvocationStack)
+
+      // The first line should have line number 100 + 657 - 1 = 756, column should remain 86
+      expect(result).toContain('    at Context.eval (http://localhost:9500/__cypress/tests?p=cypress/e2e/run/cross-origin.cy.ts:15:16)')
+    })
+
+    it('should handle different stack formats and preserve the rest of the stack', () => {
+      const userInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:10:20)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)
+    at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts:176:42)
+    at SpecBridgeCommunicator.eval (cypress:///../driver/src/cross-origin/origin_fn.ts:180:21)`
+
+      const originUserInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:5:30)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:1:10)`
+
+      const result = stack_utils.mergeCrossOriginUserInvocationStack(userInvocationStack, originUserInvocationStack)
+
+      // Line should be 5 + 10 - 1 = 14, column should remain 20
+      expect(result).toContain('cypress:///../driver/src/cypress/cy.ts:14:20')
+      // Rest of the stack should be preserved
+      expect(result).toContain('at eval (eval at invokeOriginFn')
+      expect(result).toContain('at invokeOriginFn')
+      expect(result).toContain('at SpecBridgeCommunicator.eval')
+    })
+
+    it('should handle edge case where origin line is 1', () => {
+      const userInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:3:15)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)`
+
+      const originUserInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:1:25)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:1:10)`
+
+      const result = stack_utils.mergeCrossOriginUserInvocationStack(userInvocationStack, originUserInvocationStack)
+
+      // Line should be 1 + 3 - 1 = 3, column should remain 15
+      expect(result).toContain('cypress:///../driver/src/cypress/cy.ts:3:15')
+    })
+
+    it('should handle edge case where user line is 1', () => {
+      const userInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:1:15)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:2:16)`
+
+      const originUserInvocationStack = `    at cy.<computed> [as click] (cypress:///../driver/src/cypress/cy.ts:5:25)
+    at eval (eval at invokeOriginFn (cypress:///../driver/src/cross-origin/origin_fn.ts), <anonymous>:1:10)`
+
+      const result = stack_utils.mergeCrossOriginUserInvocationStack(userInvocationStack, originUserInvocationStack)
+
+      // Line should be 5 + 1 - 1 = 5, column should remain 15
+      expect(result).toContain('cypress:///../driver/src/cypress/cy.ts:5:15')
+    })
+  })
 })

--- a/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
+++ b/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
@@ -55,7 +55,7 @@ describe('cy.origin errors', () => {
   })
 
   verify('failure when using assertion', this, {
-    line: 52,
+    line: 53,
     column: 47,
     message: 'Expected to find element',
     stack: ['cy_origin_error.cy.ts'],

--- a/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
+++ b/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
@@ -19,8 +19,8 @@ describe('cy.origin errors', () => {
   })
 
   verify('command failure', this, {
-    line: 16,
-    column: 8,
+    line: 17,
+    column: 10,
     message: 'Expected to find element',
     stack: ['cy_origin_error.cy.ts'],
     before () {
@@ -37,8 +37,25 @@ describe('cy.origin errors', () => {
   })
 
   verify('failure when using dependency', this, {
-    line: 32,
-    column: 8,
+    line: 35,
+    column: 10,
+    message: 'Expected to find element',
+    stack: ['cy_origin_error.cy.ts'],
+    before () {
+      cy.visit('/primary_origin.html')
+    },
+    skipTitleValidation: true,
+  })
+
+  fail('failure when using assertion', this, () => {
+    cy.origin('http://www.foobar.com:4466', () => {
+      cy.get('#doesnotexist', { timeout: 1 }).should('exist')
+    })
+  })
+
+  verify('failure when using assertion', this, {
+    line: 52,
+    column: 47,
     message: 'Expected to find element',
     stack: ['cy_origin_error.cy.ts'],
     before () {

--- a/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
+++ b/system-tests/projects/e2e/cypress/e2e/cy_origin_error.cy.ts
@@ -44,6 +44,7 @@ describe('cy.origin errors', () => {
     before () {
       cy.visit('/primary_origin.html')
     },
+    // Skip title validation here since the command is deep enough in the test that it does not show the command title
     skipTitleValidation: true,
   })
 

--- a/system-tests/projects/e2e/cypress/support/util.js
+++ b/system-tests/projects/e2e/cypress/support/util.js
@@ -24,6 +24,7 @@ export const verify = (title, ctx, options) => {
     column,
     message,
     stack,
+    skipTitleValidation,
   } = options
 
   const codeFrameFileRegex = new RegExp(`${Cypress.spec.relative}:${line}${column ? `:${column}` : ''}`)
@@ -66,7 +67,9 @@ export const verify = (title, ctx, options) => {
       .invoke('text')
       .should('match', codeFrameFileRegex)
 
-      cy.get('.test-err-code-frame pre span').should('include.text', `fail('${title}',this,()=>`)
+      if (!skipTitleValidation) {
+        cy.get('.test-err-code-frame pre span').should('include.text', `fail('${title}',this,()=>`)
+      }
 
       cy.contains('.test-err-code-frame .runnable-err-file-path', openInIdePath.relative)
     })

--- a/system-tests/test/cy_origin_error_spec.ts
+++ b/system-tests/test/cy_origin_error_spec.ts
@@ -34,7 +34,7 @@ describe('e2e cy.origin errors', () => {
     // keep the port the same to prevent issues with the snapshot
     port: PORT,
     spec: 'cy_origin_error.cy.ts',
-    expectedExitCode: 2,
+    expectedExitCode: 3,
     config: commonConfig,
     async onRun (exec) {
       const { stdout } = await exec()
@@ -43,8 +43,9 @@ describe('e2e cy.origin errors', () => {
       expect(stdout).to.contain('Timed out retrying after 1ms: Expected to find element: `#doesnotexist`, but never found it.')
 
       // check to make sure stack trace contains the 'cy.origin' source
-      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:16:7')
-      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:32:7')
+      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:17:9')
+      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:35:9')
+      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:52:46')
     },
   })
 })

--- a/system-tests/test/cy_origin_error_spec.ts
+++ b/system-tests/test/cy_origin_error_spec.ts
@@ -45,7 +45,7 @@ describe('e2e cy.origin errors', () => {
       // check to make sure stack trace contains the 'cy.origin' source
       expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:17:9')
       expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:35:9')
-      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:52:46')
+      expect(stdout).to.contain('webpack://e2e/./cypress/e2e/cy_origin_error.cy.ts:53:46')
     },
   })
 })


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR fixes code frames within `cy.origin`. It does this by adding a line offset to the user invocation stack for commands within `cy.origin` based on the stack trace of the `eval`ed statement that is executed within `cy.origin`.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes cy.origin error code frames/stack traces to reference the correct spec line/column by merging cross-origin invocation stacks and propagating them through error handling.
> 
> - **Driver (cy.origin error handling)**
>   - Propagate cross-origin user invocation stacks: send `crossOriginUserInvocationStack` from `packages/driver/src/cross-origin/origin_fn.ts` and attach to `err` in `packages/driver/src/cy/commands/origin/index.ts`.
>   - Include `originUserInvocationStack` in state sent to secondary origin; merge into local stacks when capturing command stacks in `packages/driver/src/cypress/cy.ts` and `packages/driver/src/cypress/chainer.ts`.
> - **Stack utilities**
>   - Filter cross-origin frames in `normalizedUserInvocationStack` and add `mergeCrossOriginUserInvocationStack` to adjust top frame line/column across origins (`packages/driver/src/cypress/stack_utils.ts`).
> - **Tests**
>   - Add/adjust unit tests for stack merging and filtering; update system tests to verify correct spec file positions, add assertion case, and support `skipTitleValidation`.
> - **Changelog**
>   - Note bugfix: code frames in `cy.origin` now show correct spec line/column.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c390174bdfcf05badc4e646a4f1c23c45d1c152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->