### PR TITLE
chore: rm undef is_contributor_pr param on unit test call

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-9-18-2025-x2
+9-30-2025

--- a/.circleci/src/workflows/workflows/@main.yml
+++ b/.circleci/src/workflows/workflows/@main.yml
@@ -478,7 +478,6 @@ linux-x64-contributor:
         requires:
           - contributor-pr
     - unit-tests:
-        is_contributor_pr: true
         requires:
           - build
     - verify-release-readiness:

--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -4377,7 +4377,6 @@ workflows:
           requires:
             - contributor-pr
       - unit-tests:
-          is_contributor_pr: true
           requires:
             - build
       - verify-release-readiness:


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

`unit-tests` job no longer needs the `is_contributor_pr` param and it was removed from the job definition; this removes from the job reference in the contributor pr workflow definition

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `is_contributor_pr` from `unit-tests` job references and bump CircleCI cache version.
> 
> - **CI/Workflows**:
>   - Remove `is_contributor_pr` parameter from `unit-tests` job references in `/.circleci/src/workflows/workflows/@main.yml` and `/.circleci/workflows.yml`.
> - **CI Caching**:
>   - Bump cache key version in `/.circleci/cache-version.txt` to force cache refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943615a1256b5ba24cafd59aa5196eccc4f52518. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->