### PR TITLE
chore: make the `@packages/types` an independent bundle

### DIFF
--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -63,7 +63,7 @@
 - [x] packages/stderr-filtering ✅ **COMPLETED**
 - [ ] packages/telemetry **PARTIAL** - entry point is JS
 - [ ] packages/ts **PARTIAL** - ultimate goal is removal and likely not worth the effort to convert
-- [ ] packages/types **PARTIAL** - entry point is JS
+- [x] packages/types ✅ **COMPLETED**
 - [x] packages/v8-snapshot-require
 - [x] packages/web-config
 

--- a/packages/types/.gitignore
+++ b/packages/types/.gitignore
@@ -1,1 +1,2 @@
-src/**/*.js
+esm/
+cjs/

--- a/packages/types/index.js
+++ b/packages/types/index.js
@@ -1,5 +1,0 @@
-if (process.env.CYPRESS_INTERNAL_ENV !== 'production') {
-  require('@packages/ts/register')
-}
-
-module.exports = require('./src')

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,12 +2,15 @@
   "name": "@packages/types",
   "version": "0.0.0-development",
   "private": true,
-  "main": "index.js",
-  "browser": "src/index.ts",
+  "main": "cjs/index.js",
+  "browser": "esm/index.js",
   "scripts": {
-    "build-prod": "tsc || echo 'built, with type errors'",
-    "check-ts": "tsc --noEmit",
-    "clean": "rimraf --glob 'src/*.js' 'src/**/*.js'",
+    "build": "yarn build:esm && yarn build:cjs",
+    "build-prod": "yarn build",
+    "build:cjs": "rimraf cjs && tsc -p tsconfig.cjs.json",
+    "build:esm": "rimraf esm && tsc -p tsconfig.esm.json",
+    "check-ts": "tsc -p tsconfig.cjs.json --noEmit",
+    "clean": "rimraf cjs esm",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, .",
     "test": "vitest run"
   },
@@ -15,19 +18,23 @@
     "semver": "^7.7.1"
   },
   "devDependencies": {
+    "@packages/root": "0.0.0-development",
     "@types/node": "22.18.0",
     "axios": "^1.8.3",
     "better-sqlite3": "11.10.0",
     "devtools-protocol": "0.0.1459876",
     "express": "4.21.0",
+    "rimraf": "^6.0.1",
     "socket.io": "4.0.1",
     "typescript": "~5.4.5",
     "vitest": "^3.2.4"
   },
   "files": [
-    "src/*"
+    "cjs/*",
+    "esm/*"
   ],
   "types": "src/index.ts",
+  "module": "esm/index.js",
   "workspaces": {
     "nohoist": [
       "devtools-protocol"

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1,5 +1,5 @@
 import semverMajor from 'semver/functions/major'
-import packageInfo from '../../../package.json'
+import packageInfo from '@packages/root'
 
 import type { SpecFile } from './spec'
 

--- a/packages/types/tsconfig.base.json
+++ b/packages/types/tsconfig.base.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../ts/tsconfig.json",
   "include": [
     "src/*.ts",
     "src/**/*.ts"
@@ -11,13 +10,14 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "allowJs": true,
-    "types": [],
     "noUncheckedIndexedAccess": true,
     "ignoreDeprecations": "5.0",
-    /* 
-     * TODO: remove importsNotUsedAsValues after typescript 5.5 and up as it will no longer work. If we want the same behavior
-     * as importsNotUsedAsValues, we need to use "verbatimModuleSyntax", which will require this package to be an ES Module.
-     */
     "importsNotUsedAsValues": "error",
-  },
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": [
+      "mocha",
+      "node"
+    ]
+  }
 }

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./cjs",
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  }
+}

--- a/packages/types/tsconfig.esm.json
+++ b/packages/types/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./esm",
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Builds both CJS and ESM (for frontend packages) for `@package/types` and gets rid of the CommonJS ONLY entrypoint. Both ESM and CJS entrypoints are now supported. Types are used as source to be compatible with older styles of commonjs bundling. Types are not shipped with the package so we can get away with pointing to `src`. 

The main reason we need to transpile this package is it doesn't just include types, but also constants, which requires transpilation

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Builds @packages/types to both CJS and ESM with new configs and scripts, removes runtime shim, updates imports, and marks the package as completed in the ESM migration guide.
> 
> - **Packages/types**:
>   - **Build outputs**: Add dual builds to `cjs/` and `esm/` with `tsconfig.cjs.json` and `tsconfig.esm.json`; update `package.json` (`main`, `browser`, `module`, `files`, scripts) to target built outputs.
>   - **Entrypoint cleanup**: Remove `index.js` shim that required `@packages/ts/register` and proxied to `src`.
>   - **Config**: Update `.gitignore` to ignore `cjs/` and `esm/`; enhance `tsconfig.base.json` (skipLibCheck, resolveJsonModule, types).
>   - **Code**: Change `src/constants.ts` to import package info from `@packages/root` instead of repository `package.json`.
> - **Docs**:
>   - Mark `packages/types` as ✅ in `guides/esm-migration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e970bf3cc463b682f16f651d7e92f556c535a046. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->