### PR TITLE
fix: ensure that all calls to api.cypress.io and cloud.cypress.io properly set rejectUnauthorized

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,7 +11,7 @@ _Released 10/07/2025 (PENDING)_
 
 - Fixed a regression introduced in [`15.0.0`](https://docs.cypress.io/guides/references/changelog#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
 - Fixed code frames in `cy.origin` so that failed commands will show the correct line/column within the corresponding spec file. Addressed in [#32597](https://github.com/cypress-io/cypress/pull/32597).
-- Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in []()
+- Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in [#32629](https://github.com/cypress-io/cypress/pull/32629)
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ _Released 10/07/2025 (PENDING)_
 
 - Fixed a regression introduced in [`15.0.0`](https://docs.cypress.io/guides/references/changelog#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
 - Fixed code frames in `cy.origin` so that failed commands will show the correct line/column within the corresponding spec file. Addressed in [#32597](https://github.com/cypress-io/cypress/pull/32597).
+- Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in []()
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,7 +11,7 @@ _Released 10/07/2025 (PENDING)_
 
 - Fixed a regression introduced in [`15.0.0`](https://docs.cypress.io/guides/references/changelog#15-0-0) where `dbus` connection error messages appear in docker containers when launching Cypress. Fixes [#32290](https://github.com/cypress-io/cypress/issues/32290).
 - Fixed code frames in `cy.origin` so that failed commands will show the correct line/column within the corresponding spec file. Addressed in [#32597](https://github.com/cypress-io/cypress/pull/32597).
-- Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in [#32629](https://github.com/cypress-io/cypress/pull/32629)
+- Fixed Cypress cloud requests so that they properly verify SSL certificates. Addressed in [#32629](https://github.com/cypress-io/cypress/pull/32629).
 
 **Misc:**
 

--- a/packages/data-context/src/sources/UtilDataSource.ts
+++ b/packages/data-context/src/sources/UtilDataSource.ts
@@ -3,7 +3,7 @@ import type { DataContext } from '../DataContext'
 import { isDependencyInstalled, isDependencyInstalledByName } from '@packages/scaffold-config'
 
 // Require rather than import since data-context is stricter than network and there are a fair amount of errors in agent.
-const { agent } = require('@packages/network')
+const { strictAgent } = require('@packages/network')
 
 /**
  * this.ctx.util....
@@ -17,7 +17,7 @@ export class UtilDataSource {
   fetch (input: RequestInfo | URL, init?: RequestInit) {
     // @ts-ignore agent isn't a part of cross-fetch's API since it's not a part of the browser's fetch but it is a part of node-fetch
     // which is what will be used here
-    return fetch(input, { agent, ...init })
+    return fetch(input, { agent: strictAgent, ...init })
   }
 
   isDependencyInstalled (dependency: Cypress.CypressComponentDependency, projectPath: string) {

--- a/packages/data-context/src/sources/UtilDataSource.ts
+++ b/packages/data-context/src/sources/UtilDataSource.ts
@@ -17,7 +17,7 @@ export class UtilDataSource {
   fetch (input: RequestInfo | URL, init?: RequestInit) {
     // @ts-ignore agent isn't a part of cross-fetch's API since it's not a part of the browser's fetch but it is a part of node-fetch
     // which is what will be used here
-    return fetch(input, { agent: strictAgent, ...init })
+    return fetch(input, { ...init, agent: strictAgent })
   }
 
   isDependencyInstalled (dependency: Cypress.CypressComponentDependency, projectPath: string) {

--- a/packages/data-context/test/unit/sources/UtilDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/UtilDataSource.spec.ts
@@ -3,6 +3,7 @@ import fetch from 'cross-fetch'
 import { createTestDataContext } from '../helper'
 import { UtilDataSource } from '../../../src/sources/UtilDataSource'
 import { DataContext } from '../../../src'
+import { strictAgent } from '@packages/network'
 
 // Mock cross-fetch
 jest.mock('cross-fetch')
@@ -40,7 +41,7 @@ describe('UtilDataSource', () => {
       const result = await utilDataSource.fetch(url, init)
 
       expect(mockedFetch).toHaveBeenCalledWith(url, {
-        agent: expect.any(Object), // strictAgent
+        agent: strictAgent,
         method: 'POST',
         body: 'test',
       })
@@ -86,7 +87,7 @@ describe('UtilDataSource', () => {
       await utilDataSource.fetch(url, init)
 
       expect(mockedFetch).toHaveBeenCalledWith(url, {
-        agent: expect.any(Object),
+        agent: strictAgent,
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ test: 'data' }),

--- a/packages/data-context/test/unit/sources/UtilDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/UtilDataSource.spec.ts
@@ -1,0 +1,96 @@
+// Jest globals are available without import in this environment
+import fetch from 'cross-fetch'
+import { createTestDataContext } from '../helper'
+import { UtilDataSource } from '../../../src/sources/UtilDataSource'
+import { DataContext } from '../../../src'
+
+// Mock cross-fetch
+jest.mock('cross-fetch')
+const mockedFetch = jest.mocked(fetch)
+
+describe('UtilDataSource', () => {
+  let ctx: DataContext
+  let utilDataSource: UtilDataSource
+
+  beforeEach(() => {
+    ctx = createTestDataContext('open')
+    utilDataSource = new UtilDataSource(ctx)
+
+    // Reset all mocks
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    ctx.destroy()
+  })
+
+  describe('#fetch', () => {
+    it('calls fetch with strictAgent and provided options', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ data: 'test' }),
+      } as any
+
+      mockedFetch.mockResolvedValue(mockResponse)
+
+      const url = 'https://example.com/api'
+      const init = { method: 'POST', body: 'test' }
+
+      const result = await utilDataSource.fetch(url, init)
+
+      expect(mockedFetch).toHaveBeenCalledWith(url, {
+        agent: expect.any(Object), // strictAgent
+        method: 'POST',
+        body: 'test',
+      })
+
+      expect(result).toBe(mockResponse)
+    })
+
+    it('calls fetch with only strictAgent when no init options provided', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({ data: 'test' }),
+      } as any
+
+      mockedFetch.mockResolvedValue(mockResponse)
+
+      const url = 'https://example.com/api'
+
+      const result = await utilDataSource.fetch(url)
+
+      expect(mockedFetch).toHaveBeenCalledWith(url, {
+        agent: expect.any(Object), // strictAgent
+      })
+
+      expect(result).toBe(mockResponse)
+    })
+
+    it('merges init options with agent configuration', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+      } as any
+
+      mockedFetch.mockResolvedValue(mockResponse)
+
+      const url = 'https://example.com/api'
+      const init = {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      }
+
+      await utilDataSource.fetch(url, init)
+
+      expect(mockedFetch).toHaveBeenCalledWith(url, {
+        agent: expect.any(Object),
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      })
+    })
+  })
+})

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -467,6 +467,18 @@ class HttpsAgent extends https.Agent {
   }
 }
 
+// NODE_TLS_REJECT_UNAUTHORIZED is set to '0' in Cypress to cover
+// all traffic to the user's app and `agent` honors this by default.
+// Calls to the Cloud should use the `strictAgent` or `api/index`'s
+// request promise implementation instead as they override
+// this functionality to actually reject in unauthorized situations.
 const agent = new CombinedAgent()
 
+// This agent always rejects unauthorized certificates.
+const strictAgent = new CombinedAgent({}, {
+  rejectUnauthorized: true,
+})
+
 export default agent
+
+export { strictAgent }

--- a/packages/network/lib/index.ts
+++ b/packages/network/lib/index.ts
@@ -1,4 +1,4 @@
-import agent from './agent'
+import agent, { strictAgent } from './agent'
 import * as blocked from './blocked'
 import * as connect from './connect'
 import * as cors from './cors'
@@ -14,6 +14,7 @@ export {
   httpUtils,
   uri,
   clientCertificates,
+  strictAgent,
 }
 
 export { allowDestroy } from './allow-destroy'

--- a/packages/server/lib/cloud/api/cloud_request.ts
+++ b/packages/server/lib/cloud/api/cloud_request.ts
@@ -5,7 +5,7 @@ import os from 'os'
 import followRedirects from 'follow-redirects'
 import axios, { AxiosInstance } from 'axios'
 import pkg from '@packages/root'
-import agent from '@packages/network/lib/agent'
+import { strictAgent } from '@packages/network/lib/agent'
 
 import app_config from '../../../config/app.json'
 import { installErrorTransform } from './axios_middleware/transform_error'
@@ -40,8 +40,8 @@ export const createCloudRequest = (options: CreateCloudRequestOptions = {}): Axi
 
   const instance = axios.create({
     baseURL,
-    httpAgent: agent,
-    httpsAgent: agent,
+    httpAgent: strictAgent,
+    httpsAgent: strictAgent,
     headers: {
       'x-os-name': os.platform(),
       'x-cypress-version': pkg.version,

--- a/packages/server/lib/cloud/api/studio/get_studio_bundle.ts
+++ b/packages/server/lib/cloud/api/studio/get_studio_bundle.ts
@@ -2,7 +2,7 @@ import { asyncRetry, linearDelay } from '../../../util/async_retry'
 import { isRetryableError } from '../../network/is_retryable_error'
 import fetch from 'cross-fetch'
 import os from 'os'
-import { agent } from '@packages/network'
+import { strictAgent } from '@packages/network'
 import { PUBLIC_KEY_VERSION } from '../../constants'
 import { createWriteStream } from 'fs'
 import { verifySignatureFromFile } from '../../encryption'
@@ -24,7 +24,7 @@ export const getStudioBundle = async ({ studioUrl, bundlePath }: { studioUrl: st
     try {
       const response = await fetch(studioUrl, {
         // @ts-expect-error - this is supported
-        agent,
+        agent: strictAgent,
         method: 'GET',
         headers: {
           'x-route-version': '1',

--- a/packages/server/lib/cloud/api/studio/post_studio_session.ts
+++ b/packages/server/lib/cloud/api/studio/post_studio_session.ts
@@ -2,7 +2,7 @@ import { asyncRetry, linearDelay } from '../../../util/async_retry'
 import { isRetryableError } from '../../network/is_retryable_error'
 import fetch from 'cross-fetch'
 import os from 'os'
-import { agent } from '@packages/network'
+import { strictAgent } from '@packages/network'
 
 const pkg = require('@packages/root')
 const routes = require('../../routes') as typeof import('../../routes')
@@ -17,7 +17,7 @@ export const postStudioSession = async ({ projectId }: PostStudioSessionOptions)
   return await (asyncRetry(async () => {
     const response = await fetch(routes.apiRoutes.studioSession(), {
       // @ts-expect-error - this is supported
-      agent,
+      agent: strictAgent,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/server/lib/cloud/network/put_fetch.ts
+++ b/packages/server/lib/cloud/network/put_fetch.ts
@@ -2,7 +2,7 @@ import crossFetch from 'cross-fetch'
 import { SystemError } from './system_error'
 import { HttpError } from './http_error'
 import { ParseError } from './parse_error'
-import { agent } from '@packages/network'
+import { strictAgent } from '@packages/network'
 import Debug from 'debug'
 
 const debug = Debug('cypress-verbose:server:cloud:api:put')
@@ -37,7 +37,7 @@ export async function putFetch<
       // types based on that rather than on node-fetch which it
       // actually uses under the hood. node-fetch supports `agent`.
       // @ts-expect-error
-      agent,
+      agent: strictAgent,
     })
 
     if (response.status >= 400) {

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -6,7 +6,7 @@ import Debug from 'debug'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
-import { agent } from '@packages/network'
+import { strictAgent } from '@packages/network'
 import pkg from '@packages/root'
 import env from '../util/env'
 import { putProtocolArtifact } from './api/put_protocol_artifact'
@@ -416,7 +416,7 @@ export class ProtocolManager implements ProtocolManagerShape {
 
       await fetch(routes.apiRoutes.captureProtocolErrors() as string, {
         // @ts-expect-error - this is supported
-        agent,
+        agent: strictAgent,
         method: 'POST',
         body,
         headers: {

--- a/packages/server/test/unit/cloud/api/cloud_request_spec.ts
+++ b/packages/server/test/unit/cloud/api/cloud_request_spec.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon'
 import sinonChai from 'sinon-chai'
 import chai, { expect } from 'chai'
-import agent from '@packages/network/lib/agent'
+import agent, { strictAgent } from '@packages/network/lib/agent'
 import axios, { CreateAxiosDefaults, AxiosInstance } from 'axios'
 import debugLib from 'debug'
 import stripAnsi from 'strip-ansi'
@@ -11,11 +11,13 @@ import app_config from '../../../../config/app.json'
 import os from 'os'
 import pkg from '@packages/root'
 import { transformError } from '../../../../lib/cloud/api/axios_middleware/transform_error'
-import { DestroyableProxy, fakeServer, fakeProxy } from './utils/fake_proxy_server'
+import { DestroyableProxy, fakeServer, fakeProxy, getCA } from './utils/fake_proxy_server'
 import dedent from 'dedent'
 import { PassThrough } from 'stream'
 import fetch from 'cross-fetch'
 import nock from 'nock'
+import { CA } from '@packages/https-proxy'
+import fs from 'fs-extra'
 
 chai.use(sinonChai)
 
@@ -38,8 +40,8 @@ describe('CloudRequest', () => {
     createCloudRequest()
     const cfg = getCreatedConfig()
 
-    expect(cfg.httpAgent).to.eq(agent)
-    expect(cfg.httpsAgent).to.eq(agent)
+    expect(cfg.httpAgent).to.eq(strictAgent)
+    expect(cfg.httpsAgent).to.eq(strictAgent)
   })
 
   describe('Proxy Requests', () => {
@@ -61,9 +63,15 @@ describe('CloudRequest', () => {
     let fakeHttpsProxy: DestroyableProxy
     let fakeHttpsProxyAuth: DestroyableProxy
 
-    let addRequestSpy: sinon.SinonSpy<Parameters<typeof agent['addRequest']>, ReturnType<typeof agent['addRequest']>>
-    let addHttpRequestSpy: sinon.SinonSpy<Parameters<typeof agent.httpAgent['addRequest']>, ReturnType<typeof agent.httpAgent['addRequest']>>
-    let addHttpsRequestSpy: sinon.SinonSpy<Parameters<typeof agent.httpsAgent['addRequest']>, ReturnType<typeof agent.httpsAgent['addRequest']>>
+    let addNormalAgentRequestSpy: sinon.SinonSpy<Parameters<typeof agent['addRequest']>, ReturnType<typeof agent['addRequest']>>
+    let addNormalAgentHttpRequestSpy: sinon.SinonSpy<Parameters<typeof agent.httpAgent['addRequest']>, ReturnType<typeof agent.httpAgent['addRequest']>>
+    let addNormalAgentHttpsRequestSpy: sinon.SinonSpy<Parameters<typeof agent.httpsAgent['addRequest']>, ReturnType<typeof agent.httpsAgent['addRequest']>>
+    let addStrictAgentRequestSpy: sinon.SinonSpy<Parameters<typeof strictAgent['addRequest']>, ReturnType<typeof strictAgent['addRequest']>>
+    let addStrictAgentHttpRequestSpy: sinon.SinonSpy<Parameters<typeof strictAgent.httpAgent['addRequest']>, ReturnType<typeof strictAgent.httpAgent['addRequest']>>
+    let addStrictAgentHttpsRequestSpy: sinon.SinonSpy<Parameters<typeof strictAgent.httpsAgent['addRequest']>, ReturnType<typeof strictAgent.httpsAgent['addRequest']>>
+    let currentAgentRequestSpy: typeof addNormalAgentRequestSpy | typeof addStrictAgentRequestSpy
+    let currentAgentHttpRequestSpy: typeof addNormalAgentHttpRequestSpy | typeof addStrictAgentHttpRequestSpy
+    let currentAgentHttpsRequestSpy: typeof addNormalAgentHttpsRequestSpy | typeof addStrictAgentHttpsRequestSpy
 
     const PROXY_AUTH = `Basic ${Buffer.from('Proxy:test2').toString('base64')}`
     const UPSTREAM_AUTH = `Basic ${Buffer.from('upstream:test').toString('base64')}`
@@ -79,9 +87,13 @@ describe('CloudRequest', () => {
       delete process.env.NO_PROXY
       delete process.env.NODE_TLS_REJECT_UNAUTHORIZED
 
-      addRequestSpy = sinon.spy(agent, 'addRequest')
-      addHttpRequestSpy = sinon.spy(agent.httpAgent, 'addRequest')
-      addHttpsRequestSpy = sinon.spy(agent.httpsAgent, 'addRequest')
+      addNormalAgentRequestSpy = sinon.spy(agent, 'addRequest')
+      addNormalAgentHttpRequestSpy = sinon.spy(agent.httpAgent, 'addRequest')
+      addNormalAgentHttpsRequestSpy = sinon.spy(agent.httpsAgent, 'addRequest')
+
+      addStrictAgentRequestSpy = sinon.spy(strictAgent, 'addRequest')
+      addStrictAgentHttpRequestSpy = sinon.spy(strictAgent.httpAgent, 'addRequest')
+      addStrictAgentHttpsRequestSpy = sinon.spy(strictAgent.httpsAgent, 'addRequest')
 
       fakeHttpUpstream = await fakeServer({})
       fakeHttpUpstreamAuth = await fakeServer({ auth: { username: 'upstream', password: 'test' } })
@@ -92,6 +104,8 @@ describe('CloudRequest', () => {
       fakeHttpProxyAuth = await fakeProxy({ auth: { username: 'Proxy', password: 'test2' } })
       fakeHttpsProxy = await fakeProxy({ https: true })
       fakeHttpsProxyAuth = await fakeProxy({ https: true, auth: { username: 'Proxy', password: 'test2' } })
+
+      strictAgent.httpsAgent.options.ca = [await fs.promises.readFile(getCA().getCACertPath(), 'utf8')]
     })
 
     afterEach(async () => {
@@ -137,6 +151,9 @@ describe('CloudRequest', () => {
       }
 
       if (adapter === 'Axios') {
+        currentAgentRequestSpy = addStrictAgentRequestSpy
+        currentAgentHttpRequestSpy = addStrictAgentHttpRequestSpy
+        currentAgentHttpsRequestSpy = addStrictAgentHttpsRequestSpy
         const CloudReq = createCloudRequest({ baseURL: targetServer.baseUrl })
 
         return CloudReq[method](`/ping`, {}).then((r) => r.data)
@@ -146,6 +163,10 @@ describe('CloudRequest', () => {
         body: {},
         json: true,
       } : {}
+
+      currentAgentRequestSpy = addNormalAgentRequestSpy
+      currentAgentHttpRequestSpy = addNormalAgentHttpRequestSpy
+      currentAgentHttpsRequestSpy = addNormalAgentHttpsRequestSpy
 
       return cloudApi.rp[method]({
         url: `${targetServer.baseUrl}/ping`,
@@ -187,13 +208,13 @@ describe('CloudRequest', () => {
         expect(fakeHttpProxy.requests[0].rawHeaders).to.eql(['Host', `localhost:${fakeHttpsUpstream.port}`])
         expect(fakeHttpProxy.requests[0].method).to.eql('CONNECT')
 
-        expect(addRequestSpy.getCalls().length).to.eq(1)
-        expect(addHttpRequestSpy.getCalls().length).to.eql(0)
-        expect(addHttpsRequestSpy.getCalls().length).to.eql(1)
+        expect(currentAgentRequestSpy.getCalls().length).to.eq(1)
+        expect(currentAgentHttpRequestSpy.getCalls().length).to.eql(0)
+        expect(currentAgentHttpsRequestSpy.getCalls().length).to.eql(1)
       })
 
       it(`${adapter}: issues requests to the correct location when using HTTPS -> HTTPS via Proxy`, async () => {
-        const result = await await executeProxyRequest({ adapter, proxyServer: fakeHttpsProxy, targetServer: fakeHttpsUpstream })
+        const result = await executeProxyRequest({ adapter, proxyServer: fakeHttpsProxy, targetServer: fakeHttpsUpstream })
 
         expect(result).to.eql('OK')
 
@@ -202,9 +223,9 @@ describe('CloudRequest', () => {
         expect(fakeHttpsProxy.requests[0].rawHeaders).to.eql(['Host', `localhost:${fakeHttpsUpstream.port}`])
         expect(fakeHttpsProxy.requests[0].method).to.eql('CONNECT')
 
-        expect(addRequestSpy.getCalls().length).to.eq(1)
-        expect(addHttpRequestSpy.getCalls().length).to.eql(0)
-        expect(addHttpsRequestSpy.getCalls().length).to.eql(1)
+        expect(currentAgentRequestSpy.getCalls().length).to.eq(1)
+        expect(currentAgentHttpRequestSpy.getCalls().length).to.eql(0)
+        expect(currentAgentHttpsRequestSpy.getCalls().length).to.eql(1)
       })
 
       it(`${adapter}: issues requests to the correct location when doing HTTP -> HTTP proxy`, async () => {
@@ -249,9 +270,9 @@ describe('CloudRequest', () => {
         }
 
         expect(fakeHttpProxy.requests[0].method).to.eql('POST')
-        expect(addRequestSpy.getCalls().length).to.eq(1)
-        expect(addHttpRequestSpy.getCalls().length).to.eql(1)
-        expect(addHttpsRequestSpy.getCalls().length).to.eql(0)
+        expect(currentAgentRequestSpy.getCalls().length).to.eq(1)
+        expect(currentAgentHttpRequestSpy.getCalls().length).to.eql(1)
+        expect(currentAgentHttpsRequestSpy.getCalls().length).to.eql(0)
       })
 
       it(`${adapter}: issues requests to the correct location when doing HTTP (auth) -> HTTPS (auth) proxy`, async () => {
@@ -308,9 +329,9 @@ describe('CloudRequest', () => {
 
         expect(fakeHttpProxyAuth.requests[0].method).to.eql('CONNECT')
         expect(fakeHttpsUpstreamAuth.requests[0].method).to.eql('POST')
-        expect(addRequestSpy.getCalls().length).to.eq(1)
-        expect(addHttpRequestSpy.getCalls().length).to.eql(0)
-        expect(addHttpsRequestSpy.getCalls().length).to.eql(1)
+        expect(currentAgentRequestSpy.getCalls().length).to.eq(1)
+        expect(currentAgentHttpRequestSpy.getCalls().length).to.eql(0)
+        expect(currentAgentHttpsRequestSpy.getCalls().length).to.eql(1)
       })
     }
   })
@@ -451,7 +472,7 @@ describe('CloudRequest', () => {
       nock.restore()
 
       // @ts-ignore
-      const addRequestSpy = sinon.stub(agent.httpsAgent, 'addRequest').callsFake((req, options) => {
+      const addRequestSpy = sinon.stub(strictAgent.httpsAgent, 'addRequest').callsFake((req, options) => {
         // fake IncomingMessage
         const res = new PassThrough() as any
 
@@ -479,7 +500,7 @@ describe('CloudRequest', () => {
         method: 'POST',
         body: '{}',
         // @ts-expect-error - this is supported
-        agent,
+        agent: strictAgent,
       })
 
       expect(await result3.json()).to.eql({ ok: true })

--- a/packages/server/test/unit/cloud/api/studio/get_studio_bundle_spec.ts
+++ b/packages/server/test/unit/cloud/api/studio/get_studio_bundle_spec.ts
@@ -66,7 +66,7 @@ describe('getStudioBundle', () => {
     const responseSignature = await getStudioBundle({ studioUrl: 'http://localhost:1234/studio/bundle/abc.tgz', bundlePath: '/tmp/cypress/studio/abc/bundle.tar' })
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -109,7 +109,7 @@ describe('getStudioBundle', () => {
     const responseSignature = await getStudioBundle({ studioUrl: 'http://localhost:1234/studio/bundle/abc.tgz', bundlePath: '/tmp/cypress/studio/abc/bundle.tar' })
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -137,7 +137,7 @@ describe('getStudioBundle', () => {
 
     expect(crossFetchStub).to.be.calledThrice
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -159,7 +159,7 @@ describe('getStudioBundle', () => {
     await expect(getStudioBundle({ studioUrl: 'http://localhost:1234/studio/bundle/abc.tgz', bundlePath: '/tmp/cypress/studio/abc/bundle.tar' })).to.be.rejected
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -199,7 +199,7 @@ describe('getStudioBundle', () => {
     expect(writeResult).to.eq('console.log("studio bundle")')
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -231,7 +231,7 @@ describe('getStudioBundle', () => {
     await expect(getStudioBundle({ studioUrl: 'http://localhost:1234/studio/bundle/abc.tgz', bundlePath: '/tmp/cypress/studio/abc/bundle.tar' })).to.be.rejectedWith('Unable to get studio signature')
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',
@@ -261,7 +261,7 @@ describe('getStudioBundle', () => {
     await expect(getStudioBundle({ studioUrl: 'http://localhost:1234/studio/bundle/abc.tgz', bundlePath: '/tmp/cypress/studio/abc/bundle.tar' })).to.be.rejectedWith('Unable to get studio manifest signature')
 
     expect(crossFetchStub).to.be.calledWith('http://localhost:1234/studio/bundle/abc.tgz', {
-      agent: sinon.match.any,
+      agent: sinon.match((agent) => agent.httpsAgent.options.rejectUnauthorized === true),
       method: 'GET',
       headers: {
         'x-route-version': '1',

--- a/packages/server/test/unit/cloud/api/studio/post_studio_session_spec.ts
+++ b/packages/server/test/unit/cloud/api/studio/post_studio_session_spec.ts
@@ -1,7 +1,7 @@
 import { SystemError } from '../../../../../lib/cloud/network/system_error'
 import { proxyquire } from '../../../../spec_helper'
 import os from 'os'
-import { agent } from '@packages/network'
+import { strictAgent } from '@packages/network'
 import pkg from '@packages/root'
 
 describe('postStudioSession', () => {
@@ -40,7 +40,7 @@ describe('postStudioSession', () => {
       'http://localhost:1234/studio/session',
       {
         method: 'POST',
-        agent,
+        agent: strictAgent,
         headers: {
           'Content-Type': 'application/json',
           'x-os-name': os.platform(),

--- a/packages/server/test/unit/cloud/api/utils/fake_proxy_server.ts
+++ b/packages/server/test/unit/cloud/api/utils/fake_proxy_server.ts
@@ -26,6 +26,8 @@ app.get('/error', (req, res) => {
   res.status(404).json({ ok: false })
 })
 
+let ca: ReturnType<typeof CA.create>
+
 interface DestroyableProxyOptions {
   keepRequests?: boolean
   auth?: {
@@ -137,8 +139,12 @@ export async function fakeProxy (opts: FakeProxyOptions) {
 }
 
 async function getHttpsOptions () {
-  const ca = await CA.create()
+  ca = await CA.create()
   const [cert, key] = await ca.generateServerCertificateKeys('localhost')
 
   return { cert, key }
+}
+
+export function getCA () {
+  return ca
 }


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

There was an earlier [change](https://github.com/cypress-io/cypress/pull/24493) that ensured that calls to the Cypress cloud were properly using `rejectUnauthorized`, but this only affected routes that went through `api/index.ts`. This PR ensures that all Cloud calls properly reject unauthorized calls. 

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route all Cloud-related HTTP requests through a new strictAgent that rejects unauthorized certificates, updating codepaths, tests, and changelog.
> 
> - **Network**:
>   - Introduce `strictAgent` in `packages/network/lib/agent.ts` (always `rejectUnauthorized: true`) and export via `packages/network/lib/index.ts`.
> - **Cloud API/Server**:
>   - Use `strictAgent` for Axios agents in `server/lib/cloud/api/cloud_request.ts`.
>   - Switch fetch calls to `strictAgent` in `server/lib/cloud/api/studio/{get_studio_bundle,post_studio_session}.ts`, `server/lib/cloud/network/put_fetch.ts`, and `server/lib/cloud/protocol.ts`.
> - **Data Context**:
>   - Update `UtilDataSource.fetch` to pass `agent: strictAgent` in `packages/data-context/src/sources/UtilDataSource.ts`.
> - **Tests**:
>   - Add unit tests for `UtilDataSource.fetch` ensuring `strictAgent` usage.
>   - Update Cloud/studio tests to expect `strictAgent`, adjust proxy spies, and add CA handling helpers in test utils.
> - **Changelog**:
>   - Note bugfix: Cloud requests now properly verify SSL certificates in `cli/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9560d9dd0be19b989fa5dd7b5b344b360ba31b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->