### PR TITLE
internal: (studio) update session id on studio initialization

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -485,6 +485,9 @@ export class ProjectBase extends EE {
 
           const studio = await this.ctx.coreData.studioLifecycleManager?.getStudio()
 
+          // Update the session id in the studio manager
+          studio?.updateSessionId(cloudStudioSessionId)
+
           if (this.spec && studio?.protocolManager) {
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CAN_ACCESS_STUDIO_AI_START)
             const canAccessStudioAI = await studio?.canAccessStudioAI(this.browser) ?? false

--- a/packages/server/test/unit/project_spec.js
+++ b/packages/server/test/unit/project_spec.js
@@ -773,6 +773,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
         const mockBeforeSpec = sinon.stub()
         const mockAccessStudioAI = sinon.stub().resolves(true)
         const mockCaptureStudioEvent = sinon.stub().resolves()
+        const mockUpdateSessionId = sinon.stub()
 
         this.project.spec = {}
 
@@ -791,6 +792,8 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
           db: { test: 'db' },
           dbPath: 'test-db-path',
         }
+
+        studioManager.updateSessionId = mockUpdateSessionId
 
         const studioLifecycleManager = new StudioLifecycleManager()
 
@@ -838,6 +841,8 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
           name: 'chrome',
         })
 
+        expect(mockUpdateSessionId.getCall(0).args[0]).to.be.a.uuid()
+
         expect(browsers.connectProtocolToBrowser).to.be.calledWith({
           browser: this.project.browser,
           foundBrowsers: this.project.options.browsers,
@@ -865,6 +870,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
         const mockBeforeSpec = sinon.stub()
         const mockAccessStudioAI = sinon.stub().resolves(true)
         const mockCaptureStudioEvent = sinon.stub().resolves()
+        const mockUpdateSessionId = sinon.stub()
 
         this.project.spec = {}
 
@@ -883,6 +889,8 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
           db: { test: 'db' },
           dbPath: 'test-db-path',
         }
+
+        studioManager.updateSessionId = mockUpdateSessionId
 
         const studioLifecycleManager = new StudioLifecycleManager()
 
@@ -922,6 +930,7 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
         const { cloudStudioSessionId } = await studioInitPromise
 
         expect(cloudStudioSessionId).to.equal('existing-session-id')
+        expect(mockUpdateSessionId).to.be.calledOnceWith('existing-session-id')
       })
 
       it('calls resetBrowserState during onStudioInit when AI is enabled', async function () {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I noticed the studio session id wasn't being passed to the internal studio server and traced it back to here. We need this update to ensure the session is populated for requests from the server-side telemetry+error reporters.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Studio manager with the current `cloudStudioSessionId` during Studio initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9648a9d8531688461ee532506a7d105b91a640f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->