### PR TITLE
chore: (cy.prompt) fix prompt driver tests during contributor workflows

### DIFF
--- a/packages/driver/cypress.config.ts
+++ b/packages/driver/cypress.config.ts
@@ -6,6 +6,9 @@ export const baseConfig: Cypress.ConfigOptions = {
   projectId: 'ypt4pf',
   experimentalMemoryManagement: true,
   experimentalWebKitSupport: true,
+  env: {
+    CI: process.env.CI,
+  },
   hosts: {
     'foobar.com': '127.0.0.1',
     '*.foobar.com': '127.0.0.1',

--- a/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
+++ b/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
@@ -21,9 +21,7 @@ describe('src/cy/commands/prompt', () => {
       })
 
       cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
-      cy.prompt(['Click the "click me" button']).then(() => {
-        done(new Error('Expected prompt to fail'))
-      })
+      cy.prompt(['Click the "click me" button'])
     } else {
       cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
       cy.prompt(['Click the "click me" button'])

--- a/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
+++ b/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
@@ -3,33 +3,31 @@ describe('src/cy/commands/prompt', () => {
     Cypress.testingType = 'e2e'
   })
 
-  it('executes the prompt command', (done) => {
-    // TODO: (cy.prompt) We will look into supporting other browsers
-    // as this is rolled out. We will add error messages for other browsers
-    // and add tests if necessary
-    if (Cypress.isBrowser('webkit') || Cypress.isBrowser('firefox')) {
-      return
-    }
-
-    const contributorPr = !Cypress.env('RECORD_KEY') && Cypress.config('isTextTerminal')
+  // TODO: (cy.prompt) We will look into supporting other browsers
+  // as this is rolled out. We will add error messages for other browsers
+  // and add tests if necessary
+  if (!Cypress.isBrowser('webkit') && !Cypress.isBrowser('firefox')) {
+    const contributorPr = Cypress.env('CI') && !Cypress.env('RECORD_KEY') && Cypress.config('isTextTerminal')
 
     if (contributorPr) {
-      cy.on('fail', (err) => {
-        expect(err.message).to.include('Record key not provided')
+      it('executes the prompt command - contributor PR', (done) => {
+        cy.on('fail', (err) => {
+          expect(err.message).to.include('Record key not provided')
 
-        done()
+          done()
+        })
+
+        cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
+        cy.prompt(['Click the "click me" button'])
       })
-
-      cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
-      cy.prompt(['Click the "click me" button'])
     } else {
-      cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
-      cy.prompt(['Click the "click me" button'])
-      cy.get('#log').should('contain', 'clicked').then(() => {
-        done()
+      it('executes the prompt command - normal PR', () => {
+        cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
+        cy.prompt(['Click the "click me" button'])
+        cy.get('#log').should('contain', 'clicked')
       })
     }
-  })
+  }
 
   it('fails when testingType is component', (done) => {
     cy.on('fail', (err) => {

--- a/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
+++ b/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
@@ -3,7 +3,7 @@ describe('src/cy/commands/prompt', () => {
     Cypress.testingType = 'e2e'
   })
 
-  it('executes the prompt command', () => {
+  it('executes the prompt command', (done) => {
     // TODO: (cy.prompt) We will look into supporting other browsers
     // as this is rolled out. We will add error messages for other browsers
     // and add tests if necessary
@@ -11,23 +11,26 @@ describe('src/cy/commands/prompt', () => {
       return
     }
 
-    cy.on('fail', (err) => {
-      // Don't fail when in CI and we don't have a record key and we're failing with the correct error message
-      // This is a sign we are dealing with a contributor PR
-      if (!Cypress.env('RECORD_KEY') && err.message.includes('Record key not provided')) {
-        return
-      }
+    const contributorPr = !Cypress.env('RECORD_KEY') && Cypress.config('isTextTerminal')
 
-      throw err
-    })
+    if (contributorPr) {
+      cy.on('fail', (err) => {
+        expect(err.message).to.include('Record key not provided')
 
-    cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
+        done()
+      })
 
-    // TODO: add more tests when cy.prompt is built out, but for now this just
-    // verifies that the command executes without throwing an error
-    cy.prompt(['Click the "click me" button'])
-
-    cy.get('#log').should('contain', 'clicked')
+      cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
+      cy.prompt(['Click the "click me" button']).then(() => {
+        done(new Error('Expected prompt to fail'))
+      })
+    } else {
+      cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
+      cy.prompt(['Click the "click me" button'])
+      cy.get('#log').should('contain', 'clicked').then(() => {
+        done()
+      })
+    }
   })
 
   it('fails when testingType is component', (done) => {

--- a/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
+++ b/packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts
@@ -11,6 +11,16 @@ describe('src/cy/commands/prompt', () => {
       return
     }
 
+    cy.on('fail', (err) => {
+      // Don't fail when in CI and we don't have a record key and we're failing with the correct error message
+      // This is a sign we are dealing with a contributor PR
+      if (!Cypress.env('RECORD_KEY') && err.message.includes('Record key not provided')) {
+        return
+      }
+
+      throw err
+    })
+
     cy.visit('http://www.foobar.com:3500/fixtures/prompt.html')
 
     // TODO: add more tests when cy.prompt is built out, but for now this just


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fix prompt driver tests during contributor workflows

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust cy.prompt E2E tests to handle contributor CI without a record key and pass `CI` through Cypress config.
> 
> - **E2E Tests (`packages/driver/cypress/e2e/commands/prompt/prompt.cy.ts`)**:
>   - Split prompt test into two paths based on environment:
>     - Contributor CI (no `RECORD_KEY`, `CI` true, `isTextTerminal`): expect failure containing `Record key not provided`.
>     - Normal runs: verify prompt interaction logs `clicked`.
>   - Run only when not `webkit` and not `firefox`.
> - **Config (`packages/driver/cypress.config.ts`)**:
>   - Add `env: { CI: process.env.CI }` to expose CI flag to tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 576b7873ec9d8a6ed45d7b72bddccf9aafd07600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->