### PR TITLE
chore: convert v8-snapshot-require tests to vitest

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1787,7 +1787,7 @@ jobs:
                   source ./scripts/ensure-node.sh
                   yarn lerna run types
             - sanitize-verify-and-store-mocha-results:
-                expectedResultCount: 9
+                expectedResultCount: 8
 
   verify-release-readiness:
     <<: *defaults

--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -111,7 +111,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] packages/telemetry ✅ **COMPLETED**
 - [ ] packages/ts - ultimate goal is removal and likely not worth the effort to convert
 - [x] packages/types ✅ **COMPLETED**
-- [ ] packages/v8-snapshot-require
+- [x] packages/v8-snapshot-require ✅ **COMPLETED**
 
 ### Phase 3: Bundle ESM/CJS versions of NPM packages 
 

--- a/packages/v8-snapshot-require/package.json
+++ b/packages/v8-snapshot-require/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf dist",
     "clean-deps": "rimraf node_modules",
     "test": "yarn test-unit",
-    "test-unit": "mocha --config ./test/.mocharc.js",
+    "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
+    "test-unit": "vitest run",
     "tslint": "tslint --config ../ts/tslint.json --project .",
     "watch": "tsc --watch"
   },
@@ -21,7 +22,7 @@
   },
   "devDependencies": {
     "@tooling/packherd": "0.0.0-development",
-    "mocha": "7.0.1"
+    "vitest": "^3.2.4"
   },
   "files": [
     "dist",

--- a/packages/v8-snapshot-require/test/.mocharc.js
+++ b/packages/v8-snapshot-require/test/.mocharc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  require: '@packages/ts/register',
-  reporter: 'mocha-multi-reporters',
-  reporterOptions: {
-    configFile: '../../mocha-reporter-config.json',
-  },
-  spec: 'test/**/*.spec.ts',
-  watchFiles: ['test/**/*.ts', 'src/**/*.ts'],
-}

--- a/packages/v8-snapshot-require/test/dependency-map.circular.spec.ts
+++ b/packages/v8-snapshot-require/test/dependency-map.circular.spec.ts
@@ -1,7 +1,7 @@
+import { describe, it, expect } from 'vitest'
 import { buildDependencyMap } from '@tooling/v8-snapshot'
 import { DependencyMap } from '../src/dependency-map'
 import type { Metadata } from '../src/types'
-import { expect } from 'chai'
 
 const ROOT = 'lib/root.js'
 const FOO = 'lib/foo.js'
@@ -84,18 +84,18 @@ const dp = new DependencyMap(map)
 
 describe('dependency map: circular', () => {
   it('creates a map with circular dep - all deps ', () => {
-    expect(dp.allDepsOf(ROOT)).to.deep.equal(ALL_ROOT)
-    expect(dp.allDepsOf(FOO)).to.deep.equal(ALL_FOO)
-    expect(dp.allDepsOf(BAR)).to.deep.equal(ALL_BAR)
-    expect(dp.allDepsOf(BAZ)).to.deep.equal(ALL_BAZ)
-    expect(dp.allDepsOf(FOZ)).to.deep.equal(ALL_FOZ)
+    expect(dp.allDepsOf(ROOT)).toEqual(ALL_ROOT)
+    expect(dp.allDepsOf(FOO)).toEqual(ALL_FOO)
+    expect(dp.allDepsOf(BAR)).toEqual(ALL_BAR)
+    expect(dp.allDepsOf(BAZ)).toEqual(ALL_BAZ)
+    expect(dp.allDepsOf(FOZ)).toEqual(ALL_FOZ)
   })
 
   it('creates a map with circular dep - direct deps ', () => {
-    expect(dp.directDepsOf(ROOT)).to.deep.equal(DIRECT_ROOT)
-    expect(dp.directDepsOf(FOO)).to.deep.equal(DIRECT_FOO)
-    expect(dp.directDepsOf(BAR)).to.deep.equal(DIRECT_BAR)
-    expect(dp.directDepsOf(BAZ)).to.deep.equal(DIRECT_BAZ)
-    expect(dp.directDepsOf(FOZ)).to.deep.equal(DIRECT_FOZ)
+    expect(dp.directDepsOf(ROOT)).toEqual(DIRECT_ROOT)
+    expect(dp.directDepsOf(FOO)).toEqual(DIRECT_FOO)
+    expect(dp.directDepsOf(BAR)).toEqual(DIRECT_BAR)
+    expect(dp.directDepsOf(BAZ)).toEqual(DIRECT_BAZ)
+    expect(dp.directDepsOf(FOZ)).toEqual(DIRECT_FOZ)
   })
 })

--- a/packages/v8-snapshot-require/test/dependency-map.spec.ts
+++ b/packages/v8-snapshot-require/test/dependency-map.spec.ts
@@ -1,7 +1,7 @@
+import { describe, it, expect } from 'vitest'
 import { buildDependencyMap } from '@tooling/v8-snapshot'
 import { DependencyMap } from '../src/dependency-map'
 import type { Metadata } from '../src/types'
-import { expect } from 'chai'
 
 const NO_DEPS = 'lib/fixtures/no-deps.js'
 const SYNC_DEPS = 'lib/fixtures/sync-deps.js'
@@ -68,7 +68,7 @@ describe('dependency map', () => {
     const cache: Record<string, NodeModule> = {}
 
     for (const id of allIds) {
-      expect(dp.loadedButNotCached(id, loaded, cache), `${id} not 'loaded but not cached'`).to.be.false
+      expect(dp.loadedButNotCached(id, loaded, cache), `${id} not 'loaded but not cached'`).toBe(false)
     }
 
     for (const id of allIds) {
@@ -76,7 +76,7 @@ describe('dependency map', () => {
       loaded.add(id)
     }
     for (const id of allIds) {
-      expect(dp.loadedButNotCached(id, loaded, cache), `${id} not 'loaded but not cached'`).to.be.false
+      expect(dp.loadedButNotCached(id, loaded, cache), `${id} not 'loaded but not cached'`).toBe(false)
     }
 
     delete cache[NO_DEPS]
@@ -84,7 +84,7 @@ describe('dependency map', () => {
     for (const id of allIds) {
       const res = id === NO_DEPS
 
-      expect(dp.loadedButNotCached(id, loaded, cache)).to.equal(res, `${id} ${res ? '' : 'not '} 'loaded but not cached'`)
+      expect(dp.loadedButNotCached(id, loaded, cache)).toEqual(res, `${id} ${res ? '' : 'not '} 'loaded but not cached'`)
     }
 
     delete cache[SYNC_DEPS]
@@ -92,7 +92,7 @@ describe('dependency map', () => {
     for (const id of allIds) {
       const res = id === NO_DEPS || id === SYNC_DEPS
 
-      expect(dp.loadedButNotCached(id, loaded, cache)).to.equal(res, `${id} ${res ? '' : 'not '} 'loaded but not cached'`)
+      expect(dp.loadedButNotCached(id, loaded, cache)).toEqual(res, `${id} ${res ? '' : 'not '} 'loaded but not cached'`)
     }
   })
 
@@ -107,20 +107,20 @@ describe('dependency map', () => {
 
     load(NO_DEPS)
 
-    expect(dp.criticalDependencyLoadedButNotCached(SYNC_DEPS, loaded, cache), 'SYNC_DEPS needs no reload').to.be.false
+    expect(dp.criticalDependencyLoadedButNotCached(SYNC_DEPS, loaded, cache), 'SYNC_DEPS needs no reload').toBe(false)
 
     delete cache[NO_DEPS]
 
-    expect(dp.criticalDependencyLoadedButNotCached(SYNC_DEPS, loaded, cache), 'SYNC_DEPS needs reload since not in cache and NO_DEPS is direct dep').to.be.true
+    expect(dp.criticalDependencyLoadedButNotCached(SYNC_DEPS, loaded, cache), 'SYNC_DEPS needs reload since not in cache and NO_DEPS is direct dep').toBe(true)
 
-    expect(dp.criticalDependencyLoadedButNotCached(DEEP_SYNC_DEPS, loaded, cache), 'DEEP_SYNC_DEPS needs reload since a cache free path to NO_DEPS exists').to.be.true
+    expect(dp.criticalDependencyLoadedButNotCached(DEEP_SYNC_DEPS, loaded, cache), 'DEEP_SYNC_DEPS needs reload since a cache free path to NO_DEPS exists').toBe(true)
 
-    expect(dp.criticalDependencyLoadedButNotCached(KEEP_JS, loaded, cache), 'KEEP_JS needs reload since a cache free path to NO_DEPS exists').to.be.true
+    expect(dp.criticalDependencyLoadedButNotCached(KEEP_JS, loaded, cache), 'KEEP_JS needs reload since a cache free path to NO_DEPS exists').toBe(true)
 
     load(SYNC_DEPS)
 
-    expect(dp.criticalDependencyLoadedButNotCached(DEEP_SYNC_DEPS, loaded, cache), 'DEEP_SYNC_DEPS needs no reload since no cache free path to NO_DEPS exists').to.be.false
+    expect(dp.criticalDependencyLoadedButNotCached(DEEP_SYNC_DEPS, loaded, cache), 'DEEP_SYNC_DEPS needs no reload since no cache free path to NO_DEPS exists').toBe(false)
 
-    expect(dp.criticalDependencyLoadedButNotCached(KEEP_JS, loaded, cache), 'KEEP_JS needs no reload since no cache free path to NO_DEPS exists').to.be.false
+    expect(dp.criticalDependencyLoadedButNotCached(KEEP_JS, loaded, cache), 'KEEP_JS needs no reload since no cache free path to NO_DEPS exists').toBe(false)
   })
 })

--- a/packages/v8-snapshot-require/vitest.config.ts
+++ b/packages/v8-snapshot-require/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

converts `@packages/v8-snapshot-require` tests from mocha to vitest. Conversion is 1:1

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates @packages/v8-snapshot-require tests to Vitest, adds vitest config, updates CI test count, and marks the migration checklist as completed.
> 
> - **Packages**:
>   - **`@packages/v8-snapshot-require`**:
>     - Replace Mocha/Chai with Vitest in test files (`expect(...).toEqual/toBe`, add `vitest` imports).
>     - Add `vitest.config.ts` (Node env, globals, include `test/**/*.spec.ts`).
>     - Update `package.json` scripts (`test-unit` -> `vitest run`, add `test-debug`) and devDeps (`mocha` -> `vitest`).
> - **CI**:
>   - Adjust `sanitize-verify-and-store-mocha-results.expectedResultCount` in `.circleci/src/pipeline/@pipeline.yml` from `9` to `8`.
> - **Docs**:
>   - Update `guides/esm-migration.md` to mark `packages/v8-snapshot-require` as ✅ completed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9860c1752c0e9b41b5d21f37ed7b25a721423a8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->