### PR TITLE
docs: remove contributing reference to resolved issue #32358

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ If you prefer to disable the restrictions for one boot only, use instead:
 echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 ```
 
-If you do not disable these restrictions for the affected Ubuntu versions, then Cypress may exit with a fatal error when you try to run Cypress after building Cypress from source. The error includes the text `FATAL:setuid_sandbox_host.cc` and may be hidden, pending resolution of issue https://github.com/cypress-io/cypress/issues/32358.
+If you do not disable these restrictions for the affected Ubuntu versions, then Cypress may exit with a fatal error when you try to run Cypress after building Cypress from source. The error message includes the text `FATAL:setuid_sandbox_host.cc`.
 
 #### Windows
 


### PR DESCRIPTION
### Additional details

- In the [CONTRIBUTING > Debian/Ubuntu](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#debianubuntu) remove the reference to the resolved issue #32358.

### Steps to test

Using Ubuntu `24.04.3` LTS:

```shell
sudo rm -rf /etc/sysctl.d/60-apparmor-namespace.conf # remove any workaround for "Unprivileged user namespace restrictions"
sudo sysctl --system
git clone https://github.com/cypress-io/cypress
cd cypress
n auto # or manually set Node.js to 22.19.0
npm install yarn@latest -g
git clean -xfd
yarn
yarn start # error message "FATAL:setuid_sandbox_host.cc"
echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/60-apparmor-namespace.conf # add workaround
sudo sysctl --system
yarn start # Cypress starts without error message
```

Confirm that an error message is output when no workaround is applied, and that applying the workaround allows Cypress to start and to function.

Error condition example:

```text
$ yarn start
yarn run v1.22.22
$ yarn ensure-deps
$ ./scripts/ensure-dependencies.sh
success Folder in sync.
$ cypress open --dev --global
[17688:1010/122831.765578:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:169] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /home/mike/github/cypress-io/cypress/packages/electron/dist/Cypress/chrome-sandbox is owned by root and has mode 4755.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After applying workaround:

```text
$ yarn start
yarn run v1.22.22
$ yarn ensure-deps
$ ./scripts/ensure-dependencies.sh
success Folder in sync.
$ cypress open --dev --global

DevTools listening on ws://127.0.0.1:39213/devtools/browser/33105a85-f78d-4b17-92bd-ab8a56223c96
[17886:1010/123032.307548:ERROR:ui/gfx/x/atom_cache.cc:232] Add _NET_WM_WINDOW_TYPE_INDEX to kAtomsToCache
```

- See also https://github.com/cypress-io/cypress/issues/30895 for unrelated error message.

### How has the user experience changed?

Contributor issue only, when building Cypress from source and running on Ubuntu `>=24.04`.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the outdated issue reference and slightly rewords the fatal error note in the Debian/Ubuntu section of `CONTRIBUTING.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d45cc6afdd42981ab5b11e8691d5eaa2be8d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->