### PR TITLE
chore: allow snapshots to be shown in Studio on hover

### DIFF
--- a/packages/app/src/runner/iframe-model.ts
+++ b/packages/app/src/runner/iframe-model.ts
@@ -1,9 +1,6 @@
 import { useSnapshotStore } from './snapshot-store'
 import { useAutStore } from '../store'
 import type { EventManager } from './event-manager'
-// tslint:disable-next-line: no-implicit-dependencies - unsure how to handle these
-import { defaultMessages } from '@cy/i18n'
-import { useStudioStore } from '../store/studio-store'
 
 export interface AutSnapshot {
   id?: number
@@ -107,7 +104,6 @@ export class IframeModel {
   setSnapshots = (snapshotProps: AutSnapshot) => {
     const snapshotStore = useSnapshotStore()
     const autStore = useAutStore()
-    const studioStore = useStudioStore()
 
     if (snapshotStore.isSnapshotPinned) {
       return
@@ -115,10 +111,6 @@ export class IframeModel {
 
     if (autStore.isRunning) {
       return snapshotStore.setTestsRunningError()
-    }
-
-    if (studioStore.isOpen) {
-      return this._studioOpenError()
     }
 
     const { snapshots } = snapshotProps
@@ -235,14 +227,6 @@ export class IframeModel {
 
   _unpinSnapshot = () => {
     useSnapshotStore().$reset()
-  }
-
-  _studioOpenError () {
-    const snapshotStore = useSnapshotStore()
-
-    snapshotStore.setMessage(
-      defaultMessages.runner.snapshot.studioActiveError,
-    )
   }
 
   _storeOriginalState () {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables showing snapshots during Studio by removing Studio-open checks and related error handling in `iframe-model.ts`.
> 
> - **Runner**:
>   - **`packages/app/src/runner/iframe-model.ts`**:
>     - Remove Studio gating for snapshots: delete `useStudioStore` import and `studioStore.isOpen` check in `setSnapshots`.
>     - Remove `_studioOpenError` and `defaultMessages` usage.
>     - Result: snapshots can display while Studio is open; minor cleanup of related code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c27918c73b328bc94501b5abd513dc6572dd05f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->