### PR TITLE
docs: update Windows contributor guidance for Python 3.14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,9 @@ If you do not disable these restrictions for the affected Ubuntu versions, then 
 
 #### Windows
 
-Install the current [version of Python](https://devguide.python.org/versions/) (`3.13`) from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation) and install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, selecting the `Desktop development with C++` workload.
+Follow the instructions in [Using Python on Windows](https://docs.python.org/3/using/windows.html) to install the current [version of Python](https://www.python.org/downloads/) (`3.14`).
+
+Install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, selecting the `Desktop development with C++` workload.
 
 Refer to the `node-gyp` [Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) documentation section for a description of alternate ways of providing the `node-gyp` execution environment and for troubleshooting information.
 


### PR DESCRIPTION
### Additional details

Python `3.14` was released on Oct 7, 2025.

Beginning with Python `3.14` (current latest) the documentation [Using Python on Windows](https://docs.python.org/3/using/windows.html) now recommends using the Python Install Manager which can be downloaded from  [python.org/downloads](https://www.python.org/downloads/) or through the [Microsoft Store app](https://apps.microsoft.com/detail/9NQ7512CXL7T).

This differs from instructions for earlier versions, such as for Python `3.13`, which lists the [Microsoft Store package](https://docs.python.org/3.13/using/windows.html#windows-store) to obtain an individual version. This section has been removed for Python `3.14`.

Add information about using Python `3.14` to [CONTRIBUTING > Requirements](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#requirements) by referring to the online documentation [Using Python on Windows](https://docs.python.org/3/using/windows.html).

### Steps to test

On Windows 11 `25H2`, Node.js `22.19.0` LTS

1. Go to Settings > Apps > Installed apps
2. Uninstall any installed Python components, such as Python 3.13.5 and Python Launcher 3.13
3. Using the [Microsoft Store app link](https://apps.microsoft.com/detail/9NQ7512CXL7T), select "View in Store" and then install the "Python Install Manager" on the local machine.
4. Open the Python Install Manager and, if necessary, fix Windows path length restrictions and app execution alias settings, enabling `python` and `python3`
5. Add commands directory to PATH
6. If prompted, install latest version of CPython, otherwise enter `py install default`
7. Install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, selecting the `Desktop development with C++` workload, or if already installed, open the Video Studio Installer and confirm that all installations are up to date.

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
npm install yarn@latest -g
git clean -xfd # if repeating
yarn
```

Confirm that Cypress is able to build from source successfully. In particular, confirm that there are no errors between the steps:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

Install the earliest supported version Python `3.9` (see https://www.python.org/downloads/) and temporarily set this as the default version:

```shell
py install 3.9
export PYTHON_MANAGER_DEFAULT=3.9
```

Repeat the above tests, confirming that Cypress can be built from source on Windows also with Python 3.9.

### How has the user experience changed?

Documentation update for contributors only, working on Windows and when building and running Cypress from source. No end-user change.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `CONTRIBUTING.md` Windows requirements to reference Python 3.14 via official Windows docs and clarifies Visual Studio installation as a separate step.
> 
> - **Docs**:
>   - **Windows setup in `CONTRIBUTING.md`**:
>     - Replace Python install instructions to follow official "Using Python on Windows" docs and target `Python 3.14`.
>     - Adjust links from MS Store/devguide to `python.org/downloads` and Windows usage docs.
>     - Split out and retain `Visual Studio Community 2022` with `Desktop development with C++` workload as a separate step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e54ba39bd9f3592586e603db7ec8411653988a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->