### PR TITLE
chore: fix local login flow where detecting machine ID is problematic

### DIFF
--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -8,7 +8,7 @@ import * as RequestErrors from '@cypress/request-promise/errors'
 
 import pkg from '@packages/root'
 
-import * as machineId from '../machine_id'
+import { machineId } from '../machine_id'
 import * as errors from '../../errors'
 
 import Bluebird from 'bluebird'
@@ -607,7 +607,7 @@ export default {
   postLogout (authToken) {
     return Bluebird.join(
       this.getAuthUrls(),
-      machineId.machineId(),
+      machineId(),
       (urls, machineId) => {
         return rp.post({
           url: urls.dashboardLogoutUrl,

--- a/packages/server/lib/cloud/machine_id.ts
+++ b/packages/server/lib/cloud/machine_id.ts
@@ -1,8 +1,11 @@
-import nmi from 'node-machine-id'
+import { machineId as nodeMachineId } from 'node-machine-id'
 
-export function machineId () {
-  return nmi.machineId()
-  .catch(() => {
+export async function machineId () {
+  try {
+    const machineId = await nodeMachineId()
+
+    return machineId
+  } catch (error) {
     return null
-  })
+  }
 }


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fixes an issue that @ryanthemanuel discovered while trying to login to Cypress Cloud locally. The binary works, but locally the `node-machine-id` export isn't being destructured properly in the TypeScript context. This fixes the issue

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `machine_id` to an async named export and updates `postLogout` to import/call `machineId()` accordingly.
> 
> - **Server/Cloud**:
>   - **Machine ID module (`packages/server/lib/cloud/machine_id.ts`)**:
>     - Switch to named import from `node-machine-id` and export an `async` `machineId()` using `try/catch`, returning `null` on error.
>   - **API (`packages/server/lib/cloud/api/index.ts`)**:
>     - Update import to `import { machineId } from '../machine_id'` and call `machineId()` in `postLogout`, sending result via `x-machine-id` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29dc8188238b5eb606c28bcb3fea9a37e063b30a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->