### PR TITLE
misc: update code button style for prompt

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,7 +15,8 @@ _Released 10/21/2025 (PENDING)_
 
 **Misc:**
 
-Browser detection in Cypress now always prefers 64-bit browser installs to 32-bit browser installs. Addressed in [#32656](https://github.com/cypress-io/cypress/pull/32656).
+- Browser detection in Cypress now always prefers 64-bit browser installs to 32-bit browser installs. Addressed in [#32656](https://github.com/cypress-io/cypress/pull/32656).
+- Update code button styles on cy.prompt.
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,7 +16,7 @@ _Released 10/21/2025 (PENDING)_
 **Misc:**
 
 - Browser detection in Cypress now always prefers 64-bit browser installs to 32-bit browser installs. Addressed in [#32656](https://github.com/cypress-io/cypress/pull/32656).
-- Update code button styles on cy.prompt. Addressed in [#32745](https://github.com/cypress-io/cypress/pull/32745)
+- Update code button styles and rename Get Code for Code on cy.prompt. Addressed in [#32745](https://github.com/cypress-io/cypress/pull/32745)
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,7 +16,7 @@ _Released 10/21/2025 (PENDING)_
 **Misc:**
 
 - Browser detection in Cypress now always prefers 64-bit browser installs to 32-bit browser installs. Addressed in [#32656](https://github.com/cypress-io/cypress/pull/32656).
-- Update code button styles on cy.prompt.
+- Update code button styles on cy.prompt. Addressed in [#32745](https://github.com/cypress-io/cypress/pull/32745)
 
 **Dependency Updates:**
 

--- a/packages/reporter/src/commands/command.cy.tsx
+++ b/packages/reporter/src/commands/command.cy.tsx
@@ -144,7 +144,7 @@ describe('commands', () => {
         </div>,
       )
 
-      cy.get('.command-prompt-get-code').should('be.visible').should('have.text', 'Get code')
+      cy.get('.command-prompt-get-code').should('be.visible').should('have.text', 'Code')
       cy.get('.command-prompt-get-code-indicator').should('be.visible')
 
       cy.percySnapshot()
@@ -172,7 +172,7 @@ describe('commands', () => {
         </div>,
       )
 
-      cy.get('.command-prompt-get-code').should('be.visible').should('have.text', 'Get code')
+      cy.get('.command-prompt-get-code').should('be.visible').should('have.text', 'Code')
       cy.get('.command-prompt-get-code-indicator').should('be.visible')
 
       cy.percySnapshot()

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -547,14 +547,14 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                     e.stopPropagation()
                     events.emit('prompt:get-code', { testId: model.testId, logId: model.id })
                   }}
-                  className="command-prompt-get-code mr-1 whitespace-nowrap text-[12px]"
+                  className="command-prompt-get-code mr-1 whitespace-nowrap"
                 >
                   <IconTechnologyAngleBrackets
                     className='command-prompt-get-code-indicator pr-1'
                     size='16'
                     strokeColor='white'
                   />
-                  <span>Code</span>
+                  <span className='text-[12px]'>Code</span>
                 </Button>
               )}
             </div>

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -547,14 +547,14 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                     e.stopPropagation()
                     events.emit('prompt:get-code', { testId: model.testId, logId: model.id })
                   }}
-                  className="command-prompt-get-code mr-1 whitespace-nowrap"
+                  className="command-prompt-get-code mr-1 whitespace-nowrap text-[12px]"
                 >
                   <IconTechnologyAngleBrackets
                     className='command-prompt-get-code-indicator pr-1'
                     size='16'
                     strokeColor='white'
                   />
-                  <span className='text-[12px]'>Code</span>
+                  <span>Code</span>
                 </Button>
               )}
             </div>

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -554,7 +554,7 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                     size='16'
                     strokeColor='white'
                   />
-                  <span className='text-[12px]'>Code</span>
+                  <span>Code</span>
                 </Button>
               )}
             </div>

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -554,7 +554,7 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                     size='16'
                     strokeColor='white'
                   />
-                  <span>Get code</span>
+                  <span className='text-[12px]'>Code</span>
                 </Button>
               )}
             </div>

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -104,7 +104,8 @@
 
       .command-prompt-get-code {
         cursor: pointer;
-        font-family: $font-system;     
+        font-family: $font-system;
+        font-size: 12px;
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Update styles and rename Get Code for Code on prompt

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the cy.prompt "Get code" button to "Code", adds a small style tweak, updates tests, and notes the change in the changelog.
> 
> - **Reporter UI**:
>   - Rename prompt button label in `packages/reporter/src/commands/command.tsx` from `Get code` to `Code`.
>   - Add `font-size: 12px` to `.command-prompt-get-code` in `packages/reporter/src/commands/commands.scss`.
>   - Update tests in `packages/reporter/src/commands/command.cy.tsx` to expect `Code`.
> - **Changelog**:
>   - Add Misc entry noting code button style update and label rename in `cli/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0b9dca3a4f5145b31e48a26f36ef1c99148edd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->