### PR TITLE
internal: (studio) set entry source when user initializes studio

### DIFF
--- a/packages/app/src/runner/event-manager-types.ts
+++ b/packages/app/src/runner/event-manager-types.ts
@@ -1,6 +1,6 @@
 import type { FileDetails } from '@packages/types'
 import type { ScriptError } from '../store'
-import type { CommandLog, StudioLog } from '../store/studio-store'
+import type { CommandLog, EntrySource, StudioLog } from '../store/studio-store'
 import type { CypressInCypressMochaEvent } from './event-manager'
 
 interface BeforeScreenshot {
@@ -42,7 +42,7 @@ export type LocalBusEmitsMap = {
   'studio:save': StudioSavePayload
   'studio:cancel': undefined
   'studio:copy:to:clipboard': () => void
-  'studio:init:suite': { suiteId: string, showUrlPrompt?: boolean }
+  'studio:init:suite': { suiteId?: string, entrySource?: EntrySource, showUrlPrompt?: boolean }
 
   // Reporter Events
   'reporter:log:add': CommandLog

--- a/packages/app/src/runner/event-manager-types.ts
+++ b/packages/app/src/runner/event-manager-types.ts
@@ -42,7 +42,7 @@ export type LocalBusEmitsMap = {
   'studio:save': StudioSavePayload
   'studio:cancel': undefined
   'studio:copy:to:clipboard': () => void
-  'studio:init:suite': { suiteId?: string, entrySource?: EntrySource, showUrlPrompt?: boolean }
+  'studio:init:suite': { suiteId: string, entrySource?: EntrySource, showUrlPrompt?: boolean }
 
   // Reporter Events
   'reporter:log:add': CommandLog

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -10,7 +10,7 @@ import { logger } from './logger'
 import type { SocketShape } from '@packages/socket/lib/types'
 import { automation, useRunnerUiStore, useSpecStore } from '../store'
 import { useScreenshotStore } from '../store/screenshot-store'
-import { useStudioStore } from '../store/studio-store'
+import { EntrySource, useStudioStore } from '../store/studio-store'
 import { getAutIframeModel } from '.'
 import { handlePausing } from './events/pausing'
 import { addTelemetryListeners } from './events/telemetry'
@@ -279,8 +279,15 @@ export class EventManager {
     this.reporterBus.on('studio:init:test', studioInitTest)
     this.localBus.on('studio:init:test', studioInitTest)
 
-    const studioInitSuite = ({ suiteId, showUrlPrompt = true }: { suiteId: string, showUrlPrompt?: boolean }) => {
-      this.studioStore.setSuiteId(suiteId)
+    const studioInitSuite = ({ suiteId, showUrlPrompt = true, entrySource }: { suiteId?: string, showUrlPrompt?: boolean, entrySource?: EntrySource }) => {
+      if (suiteId) {
+        this.studioStore.setSuiteId(suiteId)
+      }
+
+      if (entrySource) {
+        this.studioStore.setEntrySource(entrySource)
+      }
+
       this.studioStore.setShowUrlPrompt(showUrlPrompt)
 
       this.ws.emit('studio:init', { sessionId: this.studioStore.sessionId }, ({ canAccessStudioAI, cloudStudioSessionId, error }) => {

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -279,10 +279,8 @@ export class EventManager {
     this.reporterBus.on('studio:init:test', studioInitTest)
     this.localBus.on('studio:init:test', studioInitTest)
 
-    const studioInitSuite = ({ suiteId, showUrlPrompt = true, entrySource }: { suiteId?: string, showUrlPrompt?: boolean, entrySource?: EntrySource }) => {
-      if (suiteId) {
-        this.studioStore.setSuiteId(suiteId)
-      }
+    const studioInitSuite = ({ suiteId, showUrlPrompt = true, entrySource }: { suiteId: string, showUrlPrompt?: boolean, entrySource?: EntrySource }) => {
+      this.studioStore.setSuiteId(suiteId)
 
       if (entrySource) {
         this.studioStore.setEntrySource(entrySource)

--- a/packages/app/src/store/studio-store.ts
+++ b/packages/app/src/store/studio-store.ts
@@ -82,6 +82,8 @@ export interface StudioLog {
   isAssertion?: boolean
 }
 
+export type EntrySource = 'welcome' | 'new-test-root' | 'new-test-suite' | 'edit'
+
 interface StudioRecorderState {
   saveModalIsOpen: boolean
   instructionModalIsOpen: boolean
@@ -112,6 +114,7 @@ interface StudioRecorderState {
   _isStudioCreatedTest: boolean
   newTestLineNumber?: number
   _originalGrepSettings: Record<string, string>
+  entrySource?: EntrySource
 }
 
 function getUrlParams () {
@@ -150,6 +153,7 @@ export const useStudioStore = defineStore('studioRecorder', {
       newTestLineNumber: undefined,
       _isStudioCreatedTest: false,
       _originalGrepSettings: {},
+      entrySource: undefined,
     }
   },
 
@@ -231,6 +235,10 @@ export const useStudioStore = defineStore('studioRecorder', {
 
     setUrl (url?: string) {
       this.url = url
+    },
+
+    setEntrySource (entrySource: EntrySource) {
+      this.entrySource = entrySource
     },
 
     testFailed () {

--- a/packages/app/src/studio/StudioButton.vue
+++ b/packages/app/src/studio/StudioButton.vue
@@ -44,7 +44,7 @@ function toggleStudioPanel () {
   if (studioStore.isOpen) {
     props.eventManager.emit('studio:cancel', undefined)
   } else {
-    props.eventManager.emit('studio:init:suite', { suiteId: 'r1', showUrlPrompt: false })
+    props.eventManager.emit('studio:init:suite', { suiteId: 'r1', entrySource: 'welcome', showUrlPrompt: false })
   }
 }
 </script>

--- a/packages/reporter/cypress/e2e/runnables.cy.ts
+++ b/packages/reporter/cypress/e2e/runnables.cy.ts
@@ -164,7 +164,7 @@ describe('runnables', () => {
 
         cy.contains('Cypress Studio').click()
 
-        cy.wrap(runner.emit).should('be.calledWith', 'studio:init:suite', { suiteId: 'r1' })
+        cy.wrap(runner.emit).should('be.calledWith', 'studio:init:suite', { suiteId: 'r1', entrySource: undefined })
       })
     })
 

--- a/packages/reporter/cypress/e2e/suites.cy.ts
+++ b/packages/reporter/cypress/e2e/suites.cy.ts
@@ -164,7 +164,7 @@ describe('suites', () => {
         cy.get('[data-cy="create-new-test-from-suite"]').click()
       })
 
-      cy.wrap(runner.emit).should('be.calledWith', 'studio:init:suite', { suiteId: 'r2' })
+      cy.wrap(runner.emit).should('be.calledWith', 'studio:init:suite', { suiteId: 'r2', entrySource: 'new-test-suite' })
     })
   })
 })

--- a/packages/reporter/cypress/e2e/unit/events.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/events.cy.ts
@@ -370,7 +370,7 @@ describe('events', () => {
 
     it('emits studio:init:suite with suite id on studio:init:suite', () => {
       events.emit('studio:init:suite', { suiteId: 'suite id' })
-      expect(runner.emit).to.have.been.calledWith('studio:init:suite', { suiteId: 'suite id' })
+      expect(runner.emit).to.have.been.calledWith('studio:init:suite', { suiteId: 'suite id', entrySource: undefined })
     })
 
     it('emits studio:remove:command with command id on studio:remove:command', () => {

--- a/packages/reporter/src/header/CreateNewTestButton.tsx
+++ b/packages/reporter/src/header/CreateNewTestButton.tsx
@@ -9,7 +9,7 @@ export const CreateNewTestButton = ({ suiteId, dataCy }: { suiteId: string, data
     e.preventDefault()
     e.stopPropagation()
 
-    events.emit('studio:init:suite', { suiteId })
+    events.emit('studio:init:suite', { suiteId, entrySource: 'new-test-suite' })
   }, [events, suiteId])
 
   return (

--- a/packages/reporter/src/lib/events.ts
+++ b/packages/reporter/src/lib/events.ts
@@ -11,6 +11,8 @@ import type { ReporterStartInfo, ReporterRunState } from '@packages/types'
 
 const localBus = new EventEmitter()
 
+type StudioEntrySource = 'welcome' | 'new-test-root' | 'new-test-suite' | 'edit'
+
 interface InitEvent {
   appState: AppState
   runnablesStore: RunnablesStore
@@ -222,8 +224,8 @@ const events: Events = {
       runner.emit('studio:init:test', { testId })
     })
 
-    localBus.on('studio:init:suite', ({ suiteId }: { suiteId: string }) => {
-      runner.emit('studio:init:suite', { suiteId })
+    localBus.on('studio:init:suite', ({ suiteId, entrySource }: { suiteId: string, entrySource?: StudioEntrySource }) => {
+      runner.emit('studio:init:suite', { suiteId, entrySource })
     })
 
     localBus.on('studio:remove:command', (commandId) => {

--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -57,7 +57,7 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
   }
 
   const handleNewTest = () => {
-    events.emit('studio:init:suite', { suiteId: 'r1' })
+    events.emit('studio:init:suite', { suiteId: 'r1', entrySource: 'new-test-root' })
     setIsOpen(false)
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/11814

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR adds `entrySource` to the studio store which allows us to deduce in cloud studio how the user initialized studio. This will inform which view we show in the panel and will be sent with telemetry.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Test with my [services PR](https://github.com/cypress-io/cypress-services/pull/12039)

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

No user-facing changes

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Plumbs `entrySource` through `studio:init:suite` events and stores it in Studio state to identify how Studio was launched.
> 
> - **Studio (App)**:
>   - Add `EntrySource` type and `entrySource` field to `studio-store` with `setEntrySource` action.
>   - Update `event-manager` to accept optional `entrySource` on `studio:init:suite` and set it on the store.
>   - Extend `LocalBusEmitsMap` for `studio:init:suite` payload to include optional `entrySource`.
> - **Reporter**:
>   - Emit `entrySource` with `studio:init:suite` from `CreateNewTestButton` (`new-test-suite`) and runnable popover (`new-test-root`).
>   - Pass through optional `entrySource` in `events.ts` to runner.
> - **UI**:
>   - `StudioButton.vue` emits `entrySource: 'welcome'` when opening Studio.
> - **Tests**:
>   - Update e2e/unit tests to expect `entrySource` in `studio:init:suite` emissions (explicit values or `undefined`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13c9d34a655e3d4397f695b143946ec1209f58e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->