### PR TITLE
fix: ensure that the text alignment for grouped command logs is consistent

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@ _Released 10/21/2025 (PENDING)_
 - An error is no longer thrown during command execution when the application under test overwrites the `window.$` property with a non-function. Fixes [#1502](https://github.com/cypress-io/cypress/issues/1502). Fixed in [#32682](https://github.com/cypress-io/cypress/pull/32682).
 - When running `cypress` in Cypress development environments, or when `ELECTRON_ENABLE_LOGGING` is otherwise set to 1, certain messages written to `stderr` will no longer be bracketed with verbose tags. Addresses [#32569](https://github.com/cypress-io/cypress/issues/32569). Addressed in [#32674](https://github.com/cypress-io/cypress/pull/32674).
 - Improve performance of time between specs by not resetting the `file_systems` `StorageType` state when executing the CDP command `Storage.clearDataForOrigin`. Fixed in [#32703](https://github.com/cypress-io/cypress/pull/32703).
+- Fixes an issue where grouped command text jumps up and down when expanding and collapsing in the command log. Addressed in [#32757](https://github.com/cypress-io/cypress/pull/32757).
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.5.1
+
+_Released 10/20/2025 (PENDING)_
+
+**Bugfixes:**
+
+- Fixes an issue where grouped command text jumps up and down when expanding and collapsing in the command log. Addressed in [#32757](https://github.com/cypress-io/cypress/pull/32757).
+
 ## 15.5.0
 
 _Released 10/17/2025_
@@ -12,7 +20,6 @@ _Released 10/17/2025_
 - An error is no longer thrown during command execution when the application under test overwrites the `window.$` property with a non-function. Fixes [#1502](https://github.com/cypress-io/cypress/issues/1502). Fixed in [#32682](https://github.com/cypress-io/cypress/pull/32682).
 - When running `cypress` in Cypress development environments, or when `ELECTRON_ENABLE_LOGGING` is otherwise set to 1, certain messages written to `stderr` will no longer be bracketed with verbose tags. Addresses [#32569](https://github.com/cypress-io/cypress/issues/32569). Addressed in [#32674](https://github.com/cypress-io/cypress/pull/32674).
 - Improve performance of time between specs by not resetting the `file_systems` `StorageType` state when executing the CDP command `Storage.clearDataForOrigin`. Fixed in [#32703](https://github.com/cypress-io/cypress/pull/32703).
-- Fixes an issue where grouped command text jumps up and down when expanding and collapsing in the command log. Addressed in [#32757](https://github.com/cypress-io/cypress/pull/32757).
 
 **Misc:**
 

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -486,7 +486,7 @@
     .command-expander {
       color: $gray-500;
       transform: rotate(-90deg);
-      transform-origin: center;
+      // transform-origin: center;
       transition: transform 150ms ease-out;
 
       path {
@@ -514,7 +514,7 @@
     padding: 0;
     align-items: center;
     justify-content: center;
-    height: 28px;
+    // height: 28px;
 
     .command-expander {
       margin: 0;

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -486,6 +486,7 @@
     .command-expander {
       color: $gray-500;
       transform: rotate(-90deg);
+      transform-origin: center;
       transition: transform 150ms ease-out;
 
       path {
@@ -513,6 +514,7 @@
     padding: 0;
     align-items: center;
     justify-content: center;
+    height: 28px;
 
     .command-expander {
       margin: 0;

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -487,7 +487,7 @@
     .command-expander {
       color: $gray-500;
       transform: rotate(-90deg);
-      // transform-origin: center;
+      transform-origin: center;
       transition: transform 150ms ease-out;
 
       path {
@@ -515,7 +515,7 @@
     padding: 0;
     align-items: center;
     justify-content: center;
-    // height: 28px;
+    height: 28px;
 
     .command-expander {
       margin: 0;

--- a/scripts/gulp/monorepoPaths.ts
+++ b/scripts/gulp/monorepoPaths.ts
@@ -21,6 +21,7 @@ export const monorepoPaths = {
   pkgLaunchpad: path.join(__dirname, '../../packages/launchpad'),
   pkgNetStubbing: path.join(__dirname, '../../packages/net-stubbing'),
   pkgNetwork: path.join(__dirname, '../../packages/network'),
+  pkgNetworkTools: path.join(__dirname, '../../packages/network-tools'),
   pkgPackherdRequire: path.join(__dirname, '../../packages/packherd-require'),
   pkgProxy: path.join(__dirname, '../../packages/proxy'),
   pkgReporter: path.join(__dirname, '../../packages/reporter'),


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-services/issues/12045

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

This PR fixes an issue where grouped text jumps when expanded/collapsed.

Before:

https://github.com/user-attachments/assets/afb5fb49-d60c-4939-8b13-89e89504db0f

After:

https://github.com/user-attachments/assets/83ca74e5-53d1-474e-8c5e-5ceacb242048

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes grouped command log alignment by adjusting expander styles, adds 15.5.1 changelog entry, and maps `packages/network-tools` in monorepo paths.
> 
> - **Reporter (styles):**
>   - Set `transform-origin: center` on `.command-expander` and add `height: 28px` to `.command-expander-column-group` in `packages/reporter/src/commands/commands.scss` to keep grouped command text aligned during expand/collapse.
> - **Changelog:**
>   - Add `15.5.1` with a bugfix note for grouped command text jumping in `cli/CHANGELOG.md`.
> - **Build/Tooling:**
>   - Add `pkgNetworkTools` → `packages/network-tools` mapping in `scripts/gulp/monorepoPaths.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3153d742a51c2531f5608f3da0b1786b407a628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->