### PR TITLE
chore: convert `@packages/net-stubbing` tests to `vitest` from `mocha`

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1786,7 +1786,7 @@ jobs:
                   source ./scripts/ensure-node.sh
                   yarn lerna run types
             - sanitize-verify-and-store-mocha-results:
-                expectedResultCount: 7
+                expectedResultCount: 6
 
   verify-release-readiness:
     <<: *defaults

--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -100,7 +100,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] packages/electron ✅ **COMPLETED**
 - [x] packages/icons ✅ **COMPLETED**
 - [x] packages/launcher ✅ **COMPLETED**
-- [ ] packages/net-stubbing
+- [x] packages/net-stubbing ✅ **COMPLETED**
 - [x] packages/network ✅ **COMPLETED**
 - [x] packages/network-tools ✅ **COMPLETED**
 - [ ] packages/packherd-require

--- a/packages/net-stubbing/package.json
+++ b/packages/net-stubbing/package.json
@@ -8,7 +8,9 @@
     "check-ts": "tsc --noEmit && yarn -s tslint",
     "clean-deps": "rimraf node_modules",
     "lint": "eslint --ext .ts,.json, .",
-    "test": "CYPRESS_INTERNAL_ENV=test mocha -r @packages/ts/register --reporter mocha-multi-reporters --reporter-options configFile=../../mocha-reporter-config.json --exit test/unit/*",
+    "test": "vitest",
+    "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
+    "test-watch": "vitest watch",
     "tslint": "tslint --config ../ts/tslint.json --project ."
   },
   "dependencies": {
@@ -26,8 +28,7 @@
     "@packages/server": "0.0.0-development",
     "@packages/telemetry": "0.0.0-development",
     "@types/mime": "^3.0.1",
-    "chai": "4.2.0",
-    "mocha": "7.1.2"
+    "vitest": "^3.2.4"
   },
   "files": [
     "lib"

--- a/packages/net-stubbing/test/unit/driver-events.spec.ts
+++ b/packages/net-stubbing/test/unit/driver-events.spec.ts
@@ -1,10 +1,10 @@
+import { describe, it, expect } from 'vitest'
 import {
   _restoreMatcherOptionsTypes,
 } from '../../lib/server/driver-events'
-import { expect } from 'chai'
 
 describe('driver events', function () {
-  context('._restoreMatcherOptionsTypes', function () {
+  describe('._restoreMatcherOptionsTypes', function () {
     it('rehydrates regexes properly', function () {
       const { url } = _restoreMatcherOptionsTypes({
         url: {
@@ -13,8 +13,8 @@ describe('driver events', function () {
         },
       })
 
-      expect(url).to.be.instanceOf(RegExp)
-      .and.include({
+      expect(url).toBeInstanceOf(RegExp)
+      expect(url).toMatchObject({
         flags: 'gim',
         source: 'aaa',
       })

--- a/packages/net-stubbing/test/unit/intercepted-request.spec.ts
+++ b/packages/net-stubbing/test/unit/intercepted-request.spec.ts
@@ -1,17 +1,13 @@
-import chai, { expect } from 'chai'
+import { describe, it, expect, vi } from 'vitest'
 import _ from 'lodash'
-import sinon from 'sinon'
-import sinonChai from 'sinon-chai'
 import { InterceptedRequest } from '../../lib/server/intercepted-request'
 import { state as NetStubbingState } from '../../lib/server/state'
 
-chai.use(sinonChai)
-
 describe('InterceptedRequest', () => {
-  context('handleSubscriptions', () => {
+  describe('handleSubscriptions', () => {
     it('handles subscriptions as expected', async () => {
       const socket = {
-        toDriver: sinon.stub(),
+        toDriver: vi.fn(),
       }
       const state = NetStubbingState()
       const interceptedRequest = new InterceptedRequest({
@@ -45,10 +41,10 @@ describe('InterceptedRequest', () => {
 
       const data = { foo: 'bar' }
 
-      socket.toDriver.callsFake((eventName, subEventName, frame) => {
-        expect(eventName).to.eq('net:stubbing:event')
-        expect(subEventName).to.eq('before:request')
-        expect(frame).to.deep.include({
+      socket.toDriver.mockImplementation((eventName, subEventName, frame) => {
+        expect(eventName).toEqual('net:stubbing:event')
+        expect(subEventName).toEqual('before:request')
+        expect(frame).toMatchObject({
           subscription: {
             eventName: 'before:request',
             await: true,
@@ -65,12 +61,12 @@ describe('InterceptedRequest', () => {
         mergeChanges: _.merge,
       })
 
-      expect(socket.toDriver).to.be.calledTwice
+      expect(socket.toDriver).toHaveBeenCalledTimes(2)
     })
 
     it('ignores disabled subscriptions', async () => {
       const socket = {
-        toDriver: sinon.stub(),
+        toDriver: vi.fn(),
       }
       const state = NetStubbingState()
       const interceptedRequest = new InterceptedRequest({
@@ -99,10 +95,10 @@ describe('InterceptedRequest', () => {
 
       const data = { foo: 'bar' }
 
-      socket.toDriver.callsFake((eventName, subEventName, frame) => {
-        expect(eventName).to.eq('net:stubbing:event')
-        expect(subEventName).to.eq('before:request')
-        expect(frame).to.deep.include({
+      socket.toDriver.mockImplementation((eventName, subEventName, frame) => {
+        expect(eventName).toEqual('net:stubbing:event')
+        expect(subEventName).toEqual('before:request')
+        expect(frame).toMatchObject({
           subscription: {
             eventName: 'before:request',
             await: true,
@@ -119,7 +115,7 @@ describe('InterceptedRequest', () => {
         mergeChanges: _.merge,
       })
 
-      expect(socket.toDriver).to.be.calledOnce
+      expect(socket.toDriver).toHaveBeenCalledOnce()
     })
   })
 })

--- a/packages/net-stubbing/test/unit/route-matching.spec.ts
+++ b/packages/net-stubbing/test/unit/route-matching.spec.ts
@@ -1,15 +1,15 @@
+import { describe, it, expect } from 'vitest'
 import {
   _doesRouteMatch,
   _getMatchableForRequest,
   getRoutesForRequest,
 } from '../../lib/server/route-matching'
 import { RouteMatcherOptions } from '../../lib/types'
-import { expect } from 'chai'
 import { CypressIncomingRequest } from '@packages/proxy'
 import { BackendRoute } from '../../lib/server/types'
 
 describe('intercept-request', function () {
-  context('._getMatchableForRequest', function () {
+  describe('._getMatchableForRequest', function () {
     it('converts a fully-fledged req into a matchable shape', function () {
       const req = {
         headers: {
@@ -23,7 +23,7 @@ describe('intercept-request', function () {
 
       const matchable = _getMatchableForRequest(req)
 
-      expect(matchable).to.deep.eq({
+      expect(matchable).toEqual({
         auth: {
           username: 'foo',
           password: 'bar',
@@ -43,7 +43,7 @@ describe('intercept-request', function () {
     })
   })
 
-  context('._doesRouteMatch', function () {
+  describe('._doesRouteMatch', function () {
     const tryMatch = (req: Partial<CypressIncomingRequest>, matcher: RouteMatcherOptions, expected = true) => {
       req = {
         method: 'GET',
@@ -51,7 +51,7 @@ describe('intercept-request', function () {
         ...req,
       }
 
-      expect(_doesRouteMatch(matcher, req as CypressIncomingRequest)).to.eq(expected)
+      expect(_doesRouteMatch(matcher, req as CypressIncomingRequest)).toEqual(expected)
     }
 
     it('matches exact URL', function () {
@@ -172,7 +172,7 @@ describe('intercept-request', function () {
     })
   })
 
-  context('.getRoutesForRequest', function () {
+  describe('.getRoutesForRequest', function () {
     it('matches middleware, then handlers', function () {
       const routes: Partial<BackendRoute>[] = [
         {
@@ -216,7 +216,7 @@ describe('intercept-request', function () {
         e.push(route.id)
       }
 
-      expect(e).to.deep.eq(['1', '3', '4', '2'])
+      expect(e).toEqual(['1', '3', '4', '2'])
     })
 
     it('yields identical matches', function () {
@@ -255,7 +255,7 @@ describe('intercept-request', function () {
         matchedRouteIds.push(route.id)
       }
 
-      expect(matchedRouteIds).to.deep.eq(['1', '1'])
+      expect(matchedRouteIds).toEqual(['1', '1'])
     })
   })
 })

--- a/packages/net-stubbing/test/unit/util.spec.ts
+++ b/packages/net-stubbing/test/unit/util.spec.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from 'vitest'
 import { getBodyEncoding, parseContentType } from '../../lib/server/util'
-import { expect } from 'chai'
 import { join } from 'path'
 import { readFileSync } from 'fs'
 
@@ -10,7 +10,7 @@ describe('net-stubbing util', () => {
     it('returns application/json', () => {
       const str = JSON.stringify({ foo: 'bar' })
 
-      expect(parseContentType(str)).to.eq('application/json')
+      expect(parseContentType(str)).toEqual('application/json')
     })
 
     it('returns text/html', () => {
@@ -20,23 +20,23 @@ describe('net-stubbing util', () => {
 </html>\
 `
 
-      expect(parseContentType(str)).to.eq('text/html')
+      expect(parseContentType(str)).toEqual('text/html')
     })
 
     it('returns text/plain', () => {
       const str = 'foobar<p>baz'
 
-      expect(parseContentType(str)).to.eq('text/plain')
+      expect(parseContentType(str)).toEqual('text/plain')
     })
 
     it('returns text/plain by default', () => {
-      expect(parseContentType()).to.eq('text/plain')
+      expect(parseContentType()).toEqual('text/plain')
     })
   })
 
-  context('getBodyEncoding', () => {
+  describe('getBodyEncoding', () => {
     it('returns null without data', () => {
-      expect(getBodyEncoding(null)).to.equal(null)
+      expect(getBodyEncoding(null)).toBeNull()
 
       const emptyRequest = {
         body: null,
@@ -46,7 +46,7 @@ describe('net-stubbing util', () => {
         httpVersion: '1.1',
       }
 
-      expect(getBodyEncoding(emptyRequest)).to.equal(null)
+      expect(getBodyEncoding(emptyRequest)).toBeNull()
     })
 
     it('returns utf8', () => {
@@ -70,7 +70,7 @@ describe('net-stubbing util', () => {
           httpVersion: '1.1',
         }
 
-        expect(getBodyEncoding(req), contentType).to.equal('utf8')
+        expect(getBodyEncoding(req), contentType).toEqual('utf8')
       })
     })
 
@@ -83,7 +83,7 @@ describe('net-stubbing util', () => {
         httpVersion: '1.1',
       }
 
-      expect(getBodyEncoding(req), 'text').to.equal('utf8')
+      expect(getBodyEncoding(req), 'text').toEqual('utf8')
     })
 
     it('falls back to inspecting bytes to find image', () => {
@@ -95,7 +95,7 @@ describe('net-stubbing util', () => {
         httpVersion: '1.1',
       }
 
-      expect(getBodyEncoding(req), 'image').to.equal('binary')
+      expect(getBodyEncoding(req), 'image').toEqual('binary')
     })
   })
 })

--- a/packages/net-stubbing/vitest.config.ts
+++ b/packages/net-stubbing/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    env: {
+      CYPRESS_INTERNAL_ENV: 'test',
+    },
+    include: ['test/**/*.spec.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -23966,36 +23966,6 @@ mocha@7.1.0:
     yargs-parser "13.1.1"
     yargs-unparser "1.6.0"
 
-mocha@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
-  integrity sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
-  dependencies:
-    ansi-colors "3.2.3"
-    browser-stdout "1.3.1"
-    chokidar "3.3.0"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "3.0.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.5"
-    ms "2.1.1"
-    node-environment-flags "1.0.6"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
-
 mocha@7.2.0, mocha@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.2.0.tgz#01cc227b00d875ab1eed03a75106689cfed5a604"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

converts the `@packages/net-stubbing` tests from `mocha` to `vitest`. Conversion was mostly 1:1

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `@packages/net-stubbing` unit tests to Vitest, updates package scripts/config, adjusts CI test-results count, and marks migration complete in docs.
> 
> - **Tests (`@packages/net-stubbing`)**:
>   - Convert unit tests from Mocha/Chai/Sinon to Vitest in `test/unit/*.spec.ts` (use `describe/it/expect`, `vi.fn`, and `toEqual/toMatchObject`, etc.).
>   - Add Vitest config: `packages/net-stubbing/vitest.config.ts` (Node env, globals, includes, `CYPRESS_INTERNAL_ENV=test`).
> - **Package Configuration**:
>   - `packages/net-stubbing/package.json`:
>     - Replace Mocha test script with `vitest`; add `test-watch` and `test-debug`.
>     - Remove `mocha`/`chai` dev deps; add `vitest`.
> - **CI**:
>   - `.circleci/src/pipeline/@pipeline.yml`: reduce `sanitize-verify-and-store-mocha-results.expectedResultCount` from `7` to `6` in `unit-tests` job.
> - **Docs**:
>   - `guides/esm-migration.md`: mark `packages/net-stubbing` as ✅ completed under Phase 2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 398aa65b6d57e58822117a32360bbb8ec41a6d2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->