### PR TITLE
chore: set release script concurrency to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test-debug": "lerna exec yarn test-debug --ignore=@packages/{driver,root,static,web-config}",
     "test-integration": "lerna exec yarn test-integration --ignore=@packages/{driver,root,static,web-config}",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
-    "test-npm-package-release-script": "npx lerna exec  --concurrency 1 --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
+    "test-npm-package-release-script": "npx lerna exec --concurrency 1 --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
     "test-scripts": "mocha -r packages/ts/register --reporter spec 'scripts/unit/**/*spec.js'",
     "test-scripts-watch": "yarn test-scripts --watch --watch-extensions 'ts,js'",
     "test-system": "yarn workspace @tooling/system-tests test",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test-debug": "lerna exec yarn test-debug --ignore=@packages/{driver,root,static,web-config}",
     "test-integration": "lerna exec yarn test-integration --ignore=@packages/{driver,root,static,web-config}",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
-    "test-npm-package-release-script": "npx lerna exec --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
+    "test-npm-package-release-script": "npx lerna exec  --concurrency 1 --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
     "test-scripts": "mocha -r packages/ts/register --reporter spec 'scripts/unit/**/*spec.js'",
     "test-scripts-watch": "yarn test-scripts --watch --watch-extensions 'ts,js'",
     "test-system": "yarn workspace @tooling/system-tests test",

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -133,10 +133,10 @@ export class ProtocolManager implements ProtocolManagerShape {
           try {
             await listener(message)
           } catch (error) {
+            debug('error in cdpClient.on %O', { error, event, message })
             if (CAPTURE_ERRORS) {
               this._errors.push({ captureMethod: 'cdpClient.on', fatal: false, error, args: [event, message] })
             } else {
-              debug('error in cdpClient.on %O', { error, event, message })
               throw error
             }
           }


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `semantic-release` test script concurrency to 1 and always debug-log errors in `cdpClient.on` within `ProtocolManager.connectToBrowser`.
> 
> - **Scripts**:
>   - Set `test-npm-package-release-script` to run `lerna exec` with `--concurrency 1`.
> - **Server Protocol** (`packages/server/lib/cloud/protocol.ts`):
>   - In `connectToBrowser`, always emit `debug('error in cdpClient.on ...')` on listener errors and retain error capture behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 741be1e4a91628f1ca1622e33c5a5344e1855805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->