### PR TITLE
wip

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -26,6 +26,6 @@ module.exports = {
   ],
   extends: 'semantic-release-monorepo',
   branches: [
-    { name: 'develop', channel: 'latest' },
+    { name: 'diagnose-release-readiness-2', channel: 'latest' },
   ],
 }

--- a/scripts/semantic-commits/validate-binary-changelog.js
+++ b/scripts/semantic-commits/validate-binary-changelog.js
@@ -12,11 +12,11 @@ const changelog = async () => {
   if (process.env.CIRCLECI) {
     console.log({ checkedInBinaryVersion })
 
-    if (process.env.CIRCLE_BRANCH !== 'develop' && process.env.CIRCLE_BRANCH !== 'add-skip-changelog-validation' && !/^release\/\d+\.\d+\.\d+$/.test(process.env.CIRCLE_BRANCH) && !hasVersionBump) {
-      console.log('Only verify the entire changelog for develop, a release branch or any branch that bumped to the Cypress version in the package.json.')
+    // if (process.env.CIRCLE_BRANCH !== 'develop' && process.env.CIRCLE_BRANCH !== 'add-skip-changelog-validation' && !/^release\/\d+\.\d+\.\d+$/.test(process.env.CIRCLE_BRANCH) && !hasVersionBump) {
+    //   console.log('Only verify the entire changelog for develop, a release branch or any branch that bumped to the Cypress version in the package.json.')
 
-      return
-    }
+    //   return
+    // }
   }
 
   const releaseData = await getReleaseData(latestReleaseInfo)


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Points semantic-release to `diagnose-release-readiness-2` and disables CI branch gating so binary changelog validation runs on all branches.
> 
> - **Release config**:
>   - Update `.releaserc.js` to set `branches` to `{ name: `diagnose-release-readiness-2`, channel: `latest` }`.
> - **CI/Changelog validation**:
>   - In `scripts/semantic-commits/validate-binary-changelog.js`, comment out the CircleCI branch check and early return, causing full changelog validation to run on all branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b98ee7f25dffb5ad319e87a728d27bb7b8bdf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->