### PR TITLE
test: fix studio tests

### DIFF
--- a/packages/app/cypress/e2e/studio/helper.ts
+++ b/packages/app/cypress/e2e/studio/helper.ts
@@ -60,8 +60,7 @@ export function inputNewTestName (name: string = 'new-test') {
   cy.findByTestId('test-name-input').type(name)
   cy.findByTestId('create-test-button').click()
 
-  // verify recording is enabled to ensure the panel is fully ready
-  cy.findByTestId('record-button-recording').should('have.text', 'Recording...')
+  cy.findByTestId('record-button-disabled').should('have.text', 'Record')
 
   cy.get('.studio-single-test-container').should('be.visible')
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
We no longer record on the `about:blank` page.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
n/a

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Studio e2e helper to assert the record button is disabled ('Record') after creating a new test instead of expecting 'Recording...'.
> 
> - **Tests (Studio e2e)**:
>   - Update `packages/app/cypress/e2e/studio/helper.ts`:
>     - In `inputNewTestName`, replace assertion on `record-button-recording` ('Recording...') with `record-button-disabled` ('Record') after creating a new test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39684612a4f1f9bc9d01a79c3f2633a3caaca1d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->