### PR TITLE
chore: Revert try blobless checkout method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,7 @@ jobs:
     resource_class: small
     steps:
         - cancel-draft-prs
-        - checkout:
-            method: blobless
+        - checkout
         - restore-src-checksum-cache
         - persist-to-workspace-and-exit-early
         - pack-workflows

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1474,8 +1474,7 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - update_known_hosts
-      - checkout:
-          method: blobless
+      - checkout
       - install-required-node
       - verify-build-setup:
           executor: << parameters.executor >>


### PR DESCRIPTION
Reverts cypress-io/cypress#32738

It looks like blobless checkout is causing issues with semantic release and authenticating to github for reasons that are unclear 
<img width="719" height="320" alt="Screenshot 2025-10-17 at 7 32 54 PM" src="https://github.com/user-attachments/assets/a3822a56-7388-43d4-be84-ec3f5e653de1" />


testing a revert of the commit seems to fix the `verify-release-readiness` job https://app.circleci.com/pipelines/github/cypress-io/cypress/76216/workflows/c97c6454-b81e-456b-8769-1889764c6b6d/jobs/3234552

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces blobless Git checkout with standard checkout in CircleCI `pack-workflows` and `node_modules_install` jobs.
> 
> - **CI (CircleCI)**:
>   - Switch `checkout` from `method: blobless` to standard `checkout`.
>     - `/.circleci/config.yml`: `jobs.pack-workflows.steps`.
>     - `/.circleci/src/pipeline/@pipeline.yml`: `jobs.node_modules_install.steps`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e5fae5d6176d11e226037a19f369fd77152e255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->