### PR TITLE
misc: Improved the hitbox of grouped commands caret

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released 10/20/2025 (PENDING)_
 **Misc:**
 
 - Add top padding for command log labels. Addressed in [#32774](https://github.com/cypress-io/cypress/pull/32774).
+- The hitbox for expanding a grouped command has been widened. Addresses [#32778](https://github.com/cypress-io/cypress/issues/32778). Addressed in [#32783](https://github.com/cypress-io/cypress/pull/32783).
 
 ## 15.5.0
 

--- a/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
+++ b/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
@@ -31,6 +31,10 @@ export const snapshotReporter = () => {
           // don't display command progress bar in snapshot
           $el.attr('style', 'display: none !important')
         },
+        '.runnable-active .runnable-state-icon': ($el) => {
+          // don't display the spinner icon for an active test
+          $el.attr('style', 'display: none !important')
+        },
       },
     })
   })

--- a/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
+++ b/packages/app/cypress/e2e/runner/support/snapshot-reporter.ts
@@ -31,9 +31,9 @@ export const snapshotReporter = () => {
           // don't display command progress bar in snapshot
           $el.attr('style', 'display: none !important')
         },
-        '.runnable-active .runnable-state-icon': ($el) => {
-          // don't display the spinner icon for an active test
-          $el.attr('style', 'display: none !important')
+        '.runnable-active .runnable-state-icon animate': ($el) => {
+          // don't animate the test title spinner icon for an active test
+          $el.attr('repeatCount', '0')
         },
       },
     })

--- a/packages/app/cypress/e2e/runner/ui-states.cy.ts
+++ b/packages/app/cypress/e2e/runner/ui-states.cy.ts
@@ -156,7 +156,7 @@ describe('src/cypress/runner ui states', { retries: 0, defaultCommandTimeout: 60
     it('grouped commands', () => {
       loadSpec({
         filePath: 'runner/ui-states/commands.cy.js',
-        passCount: 8,
+        passCount: 9,
       })
 
       cy.contains('grouped commands').should('be.visible').click()

--- a/packages/app/cypress/e2e/runner/ui-states.cy.ts
+++ b/packages/app/cypress/e2e/runner/ui-states.cy.ts
@@ -152,6 +152,16 @@ describe('src/cypress/runner ui states', { retries: 0, defaultCommandTimeout: 60
       cy.contains('verify element visibility state').should('be.visible').click()
       snapshotReporter()
     })
+
+    it('grouped commands', () => {
+      loadSpec({
+        filePath: 'runner/ui-states/commands.cy.js',
+        passCount: 8,
+      })
+
+      cy.contains('grouped commands').should('be.visible').click()
+      snapshotReporter()
+    })
   })
 
   it('status codes', () => {

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -137,7 +137,6 @@
   }
 
   .command-wrapper-text-group {
-    padding-left: 15px;
     width: 100%;
   }
 
@@ -148,6 +147,7 @@
   .nested-group-expander {
     .command-expander {
       position: relative;
+
       margin-left: -16px !important; // Adjust this value to center the caret on the border
     }
   }
@@ -515,7 +515,10 @@
     padding: 0;
     align-items: center;
     justify-content: center;
+    max-width: 33px;
     height: 28px;
+    width: 33px;
+    padding-left: 15px;
 
     .command-expander {
       margin: 0;

--- a/packages/reporter/src/commands/commands.scss
+++ b/packages/reporter/src/commands/commands.scss
@@ -137,6 +137,7 @@
   }
 
   .command-wrapper-text-group {
+    margin-left: 15px;
     width: 100%;
   }
 
@@ -519,6 +520,7 @@
     height: 28px;
     width: 33px;
     padding-left: 15px;
+    margin-left: -15px;
 
     .command-expander {
       margin: 0;

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/ui-states/commands.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/ui-states/commands.cy.js
@@ -142,4 +142,18 @@ describe('Command Options and UI Display Tests', () => {
     cy.get('#scroll-horizontal button')
     .should('not.be.visible')
   })
+
+  it('grouped commands', () => {
+    cy.visit('cypress/fixtures/uiStates.html')
+
+    cy.get('html').within(() => {
+      cy.get('body').within(() => {
+        cy.get('form').within(() => {
+          cy.get('select').first().within(() => {
+            cy.get('option')
+          })
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/32778

### Additional details

Expands the hitbox of the collapse of grouped commands.

#### Before

<img width="1880" height="826" alt="Image" src="https://github.com/user-attachments/assets/c0fe39b8-1de4-4373-a5b1-53abf2b7134e" />

#### After

<img width="541" height="203" alt="Screenshot 2025-10-21 at 2 36 42 PM" src="https://github.com/user-attachments/assets/06971f7b-4108-4aa7-99a4-e306cd4c1ada" />


https://github.com/user-attachments/assets/0ee16679-62f7-444d-a23d-ff36b3f7c74e

I added a snapshot for [nested grouped commands](https://percy.io/cypress-io/web/cypress/builds/44042295/changed/2334205835?browser=chrome&browser_ids=69&category=changed%2Cunchanged&device_name=&group_snapshots_by=similar_diff&os=&other-browser=&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_public&viewLayout=side-by-side&viewMode=new&width=513&widths=500%2C513%2C1500) to Percy also:

<img width="548" height="440" alt="Screenshot 2025-10-22 at 10 19 30 AM" src="https://github.com/user-attachments/assets/bd7a739c-828f-4c72-b113-d5f26d4634f4" />





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Widens the grouped command caret hitbox in the reporter, adds grouped-commands snapshot test, disables spinner animation in snapshots, and updates the changelog.
> 
> - **Reporter UI (styles)**:
>   - Expand click target for grouped command expander by adjusting `commands.scss` (`.command-expander-column-group` width/padding/margins; shift `.command-wrapper-text-group` to `margin-left`).
> - **Snapshots**:
>   - In `packages/app/cypress/e2e/runner/support/snapshot-reporter.ts`, stop active test title spinner animation via `'.runnable-active .runnable-state-icon animate'` override.
> - **Tests**:
>   - Add "grouped commands" e2e test in `ui-states.cy.ts` and fixture spec `system-tests/.../commands.cy.js`; capture Percy snapshot via `snapshotReporter()`.
> - **Changelog**:
>   - Note widened hitbox for grouped command expansion in `cli/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 516f5de0915a1ddb8891673f5969d8b2463ce4ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->