### PR TITLE
chore: convert `@packages/packherd-require` tests from `mocha` to `vitest`

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1785,7 +1785,7 @@ jobs:
                   source ./scripts/ensure-node.sh
                   yarn lerna run types
             - sanitize-verify-and-store-mocha-results:
-                expectedResultCount: 5
+                expectedResultCount: 4
 
   verify-release-readiness:
     <<: *defaults

--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -103,7 +103,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] packages/net-stubbing ✅ **COMPLETED**
 - [x] packages/network ✅ **COMPLETED**
 - [x] packages/network-tools ✅ **COMPLETED**
-- [ ] packages/packherd-require
+- [x] packages/packherd-require ✅ **COMPLETED**
 - [x] packages/proxy ✅ **COMPLETED**
 - [x] packages/rewriter ✅ **COMPLETED**
 - [x] packages/scaffold-config ✅ **COMPLETED**

--- a/packages/packherd-require/package.json
+++ b/packages/packherd-require/package.json
@@ -10,7 +10,8 @@
     "clean": "rimraf dist",
     "clean-deps": "rimraf node_modules",
     "test": "yarn test-unit",
-    "test-unit": "mocha --config ./test/.mocharc.js",
+    "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0",
+    "test-unit": "vitest run",
     "tslint": "tslint --config ../ts/tslint.json --project .",
     "watch": "tsc --watch"
   },
@@ -22,7 +23,7 @@
   "devDependencies": {
     "@packages/ts": "0.0.0-development",
     "esbuild": "^0.25.2",
-    "mocha": "7.0.1"
+    "vitest": "^3.2.4"
   },
   "files": [
     "dist",

--- a/packages/packherd-require/test/.mocharc.js
+++ b/packages/packherd-require/test/.mocharc.js
@@ -1,9 +1,0 @@
-module.exports = {
-  require: '@packages/ts/register',
-  reporter: 'mocha-multi-reporters',
-  reporterOptions: {
-    configFile: '../../mocha-reporter-config.json',
-  },
-  spec: 'test/**/*.spec.ts',
-  watchFiles: ['test/**/*.ts', 'src/**/*.ts'],
-}

--- a/packages/packherd-require/test/circular-dependency.spec.ts
+++ b/packages/packherd-require/test/circular-dependency.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { describe, it, expect } from 'vitest'
 
 // NOTE: these relative paths only work from the ./dist folder
 require('../test/fixtures/circular-deps/hook-require')
@@ -6,7 +6,7 @@ const result = require('../test/fixtures/circular-deps/lib/entry')
 
 describe('Circular Dependency', () => {
   it('is properly processed', () => {
-    expect(result.origin).to.equal('definitions')
-    expect(result.result).to.equal(4)
+    expect(result.origin).toEqual('definitions')
+    expect(result.result).toEqual(4)
   })
 })

--- a/packages/packherd-require/test/normal-dependency.spec.ts
+++ b/packages/packherd-require/test/normal-dependency.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { describe, it, expect } from 'vitest'
 
 // NOTE: these relative paths only work from the ./dist folder
 require('../test/fixtures/normal-deps/hook-require')
@@ -6,7 +6,7 @@ const result = require('../test/fixtures/normal-deps/lib/entry')
 
 describe('Normal Dependency', () => {
   it('is properly processed', () => {
-    expect(result.origin).to.equal('definitions')
-    expect(result.result).to.equal(4)
+    expect(result.origin).toEqual('definitions')
+    expect(result.result).toEqual(4)
   })
 })

--- a/packages/packherd-require/vitest.config.ts
+++ b/packages/packherd-require/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Converts `@packages/packherd-require` test runner from `mocha` to `vitest`. Changes are very straightforward.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `@packages/packherd-require` tests to Vitest, updates scripts/deps/config, adjusts CI expected test count, and marks progress in the ESM migration guide.
> 
> - **@packages/packherd-require**:
>   - Replace Mocha/Chai with Vitest:
>     - Update `package.json` scripts (`test-unit` → `vitest run`, add `test-debug`) and devDeps (`mocha` → `vitest`).
>     - Remove `test/.mocharc.js`.
>     - Update specs to Vitest API (`describe/it/expect` from `vitest`, `toEqual`).
>     - Add `vitest.config.ts` with Node environment and spec include.
> - **CI**:
>   - In `.circleci/src/pipeline/@pipeline.yml`, reduce `sanitize-verify-and-store-mocha-results.expectedResultCount` from `5` to `4` in `unit-tests`.
> - **Docs**:
>   - In `guides/esm-migration.md`, mark `packages/packherd-require` as ✅ completed in the checklist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16855ad2e20efd3714f47cc7aa1570ff51c33ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->