### PR TITLE
chore: convert `@cypress/puppeteer` plugin unit tests from `mocha` to `vitest`

### DIFF
--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -82,7 +82,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] npm/cypress-schematic ✅ **COMPLETED**
 - [ ] npm/eslint-plugin-dev
 - [x] npm/grep ✅ **COMPLETED** 
-- [ ] npm/puppeteer
+- [x] npm/puppeteer ✅ **COMPLETED** 
 - [x] npm/vite-dev-server ✅ **COMPLETED** 
 - [ ] npm/webpack-batteries-included-preprocessor
 - [ ] npm/webpack-dev-server

--- a/npm/puppeteer/.mocharc.json
+++ b/npm/puppeteer/.mocharc.json
@@ -1,7 +1,0 @@
-{
-  "watch-ignore": [
-    "node_modules"
-  ],
-  "require": "ts-node/register",
-  "exit": true
-}

--- a/npm/puppeteer/eslint.config.ts
+++ b/npm/puppeteer/eslint.config.ts
@@ -1,12 +1,13 @@
 import { baseConfig } from '@packages/eslint-config'
 
-const allowDefaultProject = ['cypress.config.ts', 'eslint.config.ts', 'support/index.js']
+const allowDefaultProject = ['cypress.config.ts', 'eslint.config.ts', 'support/index.js', 'vitest.config.ts']
 
 export default [
   ...baseConfig,
   {
     languageOptions: {
       parserOptions: {
+        tsconfigRootDir: __dirname,
         projectService: {
           allowDefaultProject,
         },

--- a/npm/puppeteer/package.json
+++ b/npm/puppeteer/package.json
@@ -12,8 +12,9 @@
     "cypress:run": "node ../../scripts/cypress.js run --browser chrome",
     "lint": "eslint",
     "semantic-release": "semantic-release",
-    "test": "mocha test/unit/*.spec.ts",
-    "test-watch": "yarn test & chokidar '**/*.ts' 'test/unit/*.ts' -c 'yarn test'",
+    "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0 --hook-timeout=0",
+    "test": "vitest run",
+    "test-watch": "vitest --watch",
     "watch": "rimraf dist && tsc --watch"
   },
   "dependencies": {
@@ -23,17 +24,13 @@
   "devDependencies": {
     "@packages/eslint-config": "0.0.0-development",
     "@types/node": "^22.18.7",
-    "chai-as-promised": "^7.1.1",
     "chokidar": "^3.5.3",
     "eslint": "^9.31.0",
     "express": "4.21.0",
-    "mocha": "^9.2.2",
     "rimraf": "^6.0.1",
     "semantic-release": "22.0.12",
-    "sinon": "^13.0.1",
-    "sinon-chai": "^3.7.0",
-    "ts-node": "^10.9.2",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "cypress": ">=13.6.0"

--- a/npm/puppeteer/test/tsconfig.json
+++ b/npm/puppeteer/test/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "noEmit": true,
-    "types": ["mocha"]
   },
   "include": ["**/*.ts"],
 }

--- a/npm/puppeteer/test/unit/activateMainTab.spec.ts
+++ b/npm/puppeteer/test/unit/activateMainTab.spec.ts
@@ -76,14 +76,22 @@ describe('activateMainTab', () => {
   it('sends a tab activation request to the plugin, and rejects if it times out', async () => {
     vi.mocked(mockBrowser.pages).mockResolvedValue([mockPage] as Page[])
 
-    try {
-      vi.advanceTimersByTimeAsync(ACTIVATION_TIMEOUT + 1)
-      await activateMainTab(mockBrowser as Browser)
-      throw new Error('Should be unreachable as activateMainTab should have timed out')
-    } catch (error) {
-      expect(window.removeEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function))
-      expect(error).toBeUndefined()
-    }
+    return new Promise<void>(async (resolve) => {
+      mockPage.evaluate = vi.fn().mockImplementation(async (fn, ...args) => {
+        try {
+          await fn(...args)
+        } catch (error) {
+          expect(window.removeEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function))
+          expect(error).toBeUndefined()
+          resolve()
+        }
+      })
+
+        const activationPromise = activateMainTab(mockBrowser as Browser)
+
+        await vi.advanceTimersByTimeAsync(ACTIVATION_TIMEOUT + 1)
+        await activationPromise
+    })
   })
 
   describe('when cy in cy', () => {

--- a/npm/puppeteer/test/unit/activateMainTab.spec.ts
+++ b/npm/puppeteer/test/unit/activateMainTab.spec.ts
@@ -1,15 +1,8 @@
-import { expect, use } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-import sinon from 'sinon'
-import sinonChai from 'sinon-chai'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import type { Browser, Page } from 'puppeteer-core'
 import { activateMainTab, ACTIVATION_TIMEOUT } from '../../src/plugin/activateMainTab'
 
-use(chaiAsPromised)
-use(sinonChai)
-
 describe('activateMainTab', () => {
-  let clock: sinon.SinonFakeTimers
   let prevWin: Window
   let prevDoc: Document
   let prevTop: Window & typeof globalThis
@@ -22,14 +15,12 @@ describe('activateMainTab', () => {
   let mockPage: Partial<Page>
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
-
+    vi.useFakeTimers()
     window = {
-      addEventListener: sinon.stub(),
-      removeEventListener: sinon.stub(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
 
-      // @ts-ignore sinon gets confused about postMessage type declaration
-      postMessage: sinon.stub(),
+      postMessage: vi.fn(),
     }
 
     mockDocument = {
@@ -41,60 +32,58 @@ describe('activateMainTab', () => {
     // activateMainTab is eval'd in browser context, but the tests exec in a
     // node context. We don't necessarily need to do this swap, but it makes the
     // tests more portable.
-    // @ts-ignore
     prevWin = global.window
     prevDoc = global.document
-    // @ts-ignore
+    // @ts-expect-error
     prevTop = global.top
-    //@ts-ignore
+    // @ts-expect-error
     global.window = window
     global.document = mockDocument as Document
-    //@ts-ignore
+    // @ts-expect-error
     global.top = mockTop
 
     mockPage = {
-      evaluate: sinon.stub().callsFake((fn, ...args) => fn(...args)),
+      evaluate: vi.fn().mockImplementation((fn, ...args) => fn(...args)),
     }
 
     mockBrowser = {
-      pages: sinon.stub(),
+      pages: vi.fn(),
     }
   })
 
   afterEach(() => {
-    clock.restore()
-    // @ts-ignore
+    vi.clearAllTimers()
+    // @ts-expect-error
     global.window = prevWin
-    // @ts-ignore
     global.top = prevTop
     global.document = prevDoc
   })
 
   it('sends a tab activation request to the plugin, and resolves when the ack event is received', async () => {
-    const pagePromise = Promise.resolve([mockPage])
+    vi.mocked(mockBrowser.pages).mockResolvedValue([mockPage] as Page[])
+    vi.mocked(window.addEventListener).mockImplementation((event, listener) => {
+      if (event === 'message') {
+        // @ts-expect-error
+        listener({ data: { message: 'cypress:extension:main:tab:activated' } })
+      }
+    })
 
-    ;(mockBrowser.pages as sinon.SinonStub).returns(pagePromise)
-    const p = activateMainTab(mockBrowser as Browser)
+    await activateMainTab(mockBrowser as Browser)
 
-    await pagePromise
-    // @ts-ignore
-    window.addEventListener.withArgs('message').yield({ data: { message: 'cypress:extension:main:tab:activated' } })
-    expect(window.postMessage).to.be.calledWith({ message: 'cypress:extension:activate:main:tab' })
-
-    expect(p).to.eventually.be.true
+    expect(window.postMessage).toHaveBeenCalledExactlyOnceWith({ message: 'cypress:extension:activate:main:tab' })
   })
 
   it('sends a tab activation request to the plugin, and rejects if it times out', async () => {
-    const pagePromise = Promise.resolve([mockPage])
+    vi.mocked(mockBrowser.pages).mockResolvedValue([mockPage] as Page[])
 
-    ;(mockBrowser.pages as sinon.SinonStub).returns(pagePromise)
-    await pagePromise
-
-    const p = activateMainTab(mockBrowser as Browser)
-
-    clock.tick(ACTIVATION_TIMEOUT + 1)
-
-    expect(p).to.be.rejected
+    try {
+      vi.advanceTimersByTimeAsync(ACTIVATION_TIMEOUT + 1)
+      await activateMainTab(mockBrowser as Browser)
+      throw new Error('Should be unreachable as activateMainTab should have timed out')
+    } catch (error) {
+      expect(window.removeEventListener).toHaveBeenCalledExactlyOnceWith('message', expect.any(Function))
+      expect(error).toBeUndefined()
+    }
   })
 
   describe('when cy in cy', () => {
@@ -103,16 +92,11 @@ describe('activateMainTab', () => {
     })
 
     it('does not try to send tab activation message', async () => {
-      const pagePromise = Promise.resolve([mockPage])
+      vi.mocked(mockBrowser.pages).mockResolvedValue([mockPage] as Page[])
+      await activateMainTab(mockBrowser as Browser)
 
-      ;(mockBrowser.pages as sinon.SinonStub).returns(pagePromise)
-
-      const p = activateMainTab(mockBrowser as Browser)
-
-      await pagePromise
-      expect(window.postMessage).not.to.be.called
-      expect(window.addEventListener).not.to.be.called
-      await p
+      expect(window.postMessage).not.toHaveBeenCalled()
+      expect(window.addEventListener).not.toHaveBeenCalled()
     })
   })
 })

--- a/npm/puppeteer/test/unit/retry.spec.ts
+++ b/npm/puppeteer/test/unit/retry.spec.ts
@@ -1,53 +1,49 @@
-import { expect, use } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-import sinon from 'sinon'
-import sinonChai from 'sinon-chai'
-
+import { describe, it, expect, vi } from 'vitest'
 import { retry } from '../../src/plugin'
-
-use(chaiAsPromised)
-use(sinonChai)
 
 describe('#retry', () => {
   it('returns result of passing 1st attempt', async () => {
-    const fn = sinon.stub().returns('passes 1st attempt')
+    const fn = vi.fn().mockReturnValue('passes 1st attempt')
     const result = await retry(fn)
 
-    expect(fn).to.be.calledOnce
-    expect(result).to.equal('passes 1st attempt')
+    expect(fn).toHaveBeenCalledOnce()
+    expect(result).toEqual('passes 1st attempt')
   })
 
   it('retries after delay and returns result of subsequent passing attempt', async () => {
-    const fn = sinon.stub()
+    const fn = vi.fn()
 
-    fn.onFirstCall().throws('fail')
-    fn.onSecondCall().returns('passes 2nd attempt')
+    fn.mockImplementationOnce(() => { throw new Error('fail') })
+    fn.mockImplementationOnce(() => { return 'passes 2nd attempt' })
 
     const result = await retry(fn, { delayBetweenTries: 1 })
 
-    expect(fn).to.be.calledTwice
-    expect(result).to.equal('passes 2nd attempt')
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(result).toEqual('passes 2nd attempt')
   })
 
   it('retries up to timeout and returns result of subsequent passing attempt', async () => {
-    const fn = sinon.stub()
+    const fn = vi.fn()
 
-    fn.throws('fail')
-    fn.onCall(5).returns('passes 5th attempt')
+    fn.mockImplementationOnce(() => { throw new Error('fail') })
+    fn.mockImplementationOnce(() => { throw new Error('fail') })
+    fn.mockImplementationOnce(() => { throw new Error('fail') })
+    fn.mockImplementationOnce(() => { throw new Error('fail') })
+    fn.mockImplementationOnce(() => { return 'passes 5th attempt' })
 
     const result = await retry(fn, { delayBetweenTries: 1 })
 
-    expect(fn.callCount).to.equal(6)
-    expect(result).to.equal('passes 5th attempt')
+    expect(fn).toHaveBeenCalledTimes(5)
+    expect(result).toEqual('passes 5th attempt')
   })
 
   it('fails if function does not pass before timeout', async () => {
-    const fn = sinon.stub().callsFake(() => {
+    const fn = vi.fn().mockImplementation(() => {
       throw new Error('fail')
     })
 
     await expect(
       retry(fn, { timeout: 5, delayBetweenTries: 1 }),
-    ).to.be.rejectedWith('Failed retrying after 5ms: fail')
+    ).rejects.toThrow('Failed retrying after 5ms: fail')
   })
 })

--- a/npm/puppeteer/test/unit/setup.spec.ts
+++ b/npm/puppeteer/test/unit/setup.spec.ts
@@ -1,131 +1,147 @@
-import { expect, use } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
+import { describe, it, expect, vi, Mock } from 'vitest'
 import type { PuppeteerNode, Browser } from 'puppeteer-core'
-import sinon from 'sinon'
-import sinonChai from 'sinon-chai'
-import { MessageHandler } from '../../src/plugin/setup'
 import { setup } from '../../src/plugin'
-import * as activateMainTabExport from '../../src/plugin/activateMainTab'
+import { activateMainTab } from '../../src/plugin/activateMainTab'
 
-use(chaiAsPromised)
-use(sinonChai)
+vi.mock('../../src/plugin/activateMainTab')
 
-type StubbedMessageHandler = sinon.SinonStub<Parameters<MessageHandler>, ReturnType<MessageHandler>>
+const flushPromises = () => {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve)
+  })
+}
 
 describe('#setup', () => {
   let mockBrowser: Partial<Browser>
   let mockPuppeteer: Pick<PuppeteerNode, 'connect'>
-  let on: sinon.SinonStub
-  let onMessage: Record<string, StubbedMessageHandler>
+  let on: Mock
+  let onMessage: Record<string, Mock>
 
   const testTask = 'test'
-  let testTaskHandler: StubbedMessageHandler
-
-  function getTask () {
-    return on.withArgs('task').lastCall.args[1].__cypressPuppeteer__
-  }
-
-  function simulateBrowserLaunch () {
-    return on.withArgs('after:browser:launch').yield({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
-  }
+  let testTaskHandler: Mock
 
   beforeEach(() => {
-    sinon.stub(activateMainTabExport, 'activateMainTab')
+    vi.mocked(activateMainTab).mockClear()
+
     mockBrowser = {
-      disconnect: sinon.stub().resolves(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
     }
 
     mockPuppeteer = {
-      connect: sinon.stub().resolves(mockBrowser),
+      connect: vi.fn().mockResolvedValue(mockBrowser),
     }
 
-    on = sinon.stub()
+    on = vi.fn()
 
-    testTaskHandler = sinon.stub()
+    testTaskHandler = vi.fn()
 
     onMessage = {
       [testTask]: testTaskHandler,
     }
   })
 
-  afterEach(() => {
-    sinon.reset()
-
-    ;(activateMainTabExport.activateMainTab as sinon.SinonStub).restore()
-  })
-
   it('registers `after:browser:launch` and `task` handlers', () => {
     setup({ on, onMessage })
 
-    expect(on).to.be.calledWith('after:browser:launch')
-    expect(on).to.be.calledWith('task')
+    expect(on).toHaveBeenCalledWith('after:browser:launch', expect.any(Function))
+    expect(on).toHaveBeenCalledWith('task', {
+      __cypressPuppeteer__: expect.any(Function),
+    })
   })
 
   it('errors if registering `after:browser:launch` fails', () => {
     const error = new Error('Event not registered')
 
     error.stack = '<error stack>'
-    on.throws(error)
+    on.mockImplementation(() => { throw error })
 
-    expect(() => setup({ on, onMessage })).to.throw('Could not set up `after:browser:launch` task. Ensure you are running Cypress >= 13.6.0. The following error was encountered:\n\n<error stack>')
+    expect(() => setup({ on, onMessage })).toThrow('Could not set up `after:browser:launch` task. Ensure you are running Cypress >= 13.6.0. The following error was encountered:\n\n<error stack>')
   })
 
   describe('running message handler', () => {
     it('connects puppeteer to browser', async () => {
+      on.mockImplementation((event, handler) => {
+        if (event === 'after:browser:launch') {
+          handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          return handler.__cypressPuppeteer__({ name: testTask, args: [] })
+        }
+      })
+
       setup({
         on,
         puppeteer: mockPuppeteer as PuppeteerNode,
         onMessage,
       })
 
-      simulateBrowserLaunch()
-
-      const task = getTask()
-
-      await task({ name: testTask, args: [] })
-
-      expect(mockPuppeteer.connect).to.be.calledWith({
+      expect(mockPuppeteer.connect).toHaveBeenCalledWith({
         browserWSEndpoint: 'ws://debugger',
         defaultViewport: null,
       })
     })
 
     it('calls the specified message handler with the browser and args', async () => {
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          return handler.__cypressPuppeteer__({ name: testTask, args: ['arg1', 'arg2'] })
+        }
+      })
+
       setup({
         on,
         puppeteer: mockPuppeteer as PuppeteerNode,
         onMessage,
       })
 
-      simulateBrowserLaunch()
+      await flushPromises()
 
-      const task = getTask()
-
-      await task({ name: testTask, args: ['arg1', 'arg2'] })
-
-      expect(testTaskHandler).to.be.calledWith(mockBrowser, 'arg1', 'arg2')
+      expect(testTaskHandler).toHaveBeenCalledWith(mockBrowser, 'arg1', 'arg2')
     })
 
     it('disconnects the browser once the message handler is finished', async () => {
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          return handler.__cypressPuppeteer__({ name: testTask, args: ['arg1', 'arg2'] })
+        }
+      })
+
       setup({
         on,
         puppeteer: mockPuppeteer as PuppeteerNode,
         onMessage,
       })
 
-      simulateBrowserLaunch()
+      await flushPromises()
 
-      const task = getTask()
-
-      await task({ name: testTask, args: ['arg1', 'arg2'] })
-
-      expect(mockBrowser.disconnect).to.be.called
+      expect(mockBrowser.disconnect).toHaveBeenCalled()
     })
 
     it('returns the result of the handler', async () => {
-      const resolution = 'result'
+      onMessage[testTask].mockResolvedValue('result')
 
-      onMessage[testTask].resolves(resolution)
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: testTask, args: ['arg1', 'arg2'] })
+
+          return taskResult
+        }
+      })
 
       setup({
         on,
@@ -133,189 +149,324 @@ describe('#setup', () => {
         onMessage,
       })
 
-      simulateBrowserLaunch()
+      await flushPromises()
 
-      const task = getTask()
-      const returnValue = await task({ name: testTask, args: ['arg1', 'arg2'] })
-
-      expect(returnValue).to.equal(resolution)
+      expect(taskResult).toEqual('result')
     })
 
     it('returns null if message handler returns undefined', async () => {
-      onMessage[testTask].resolves(undefined)
+      onMessage[testTask].mockResolvedValue(undefined)
+
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: testTask, args: ['arg1', 'arg2'] })
+
+          return taskResult
+        }
+      })
+
       setup({
         on,
         puppeteer: mockPuppeteer as PuppeteerNode,
         onMessage,
       })
 
-      simulateBrowserLaunch()
-
-      const task = getTask()
-      const returnValue = await task({ name: testTask, args: ['arg1', 'arg2'] })
-
-      expect(returnValue).to.be.null
+      await flushPromises()
+      expect(taskResult).toBeNull()
     })
 
     it('returns error object if debugger URL reference is lost', async () => {
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: 'nonexistent', args: [] })
+
+          return taskResult
+        }
+      })
+
       setup({ on, onMessage })
 
-      const task = getTask()
-      const returnValue = await task({ name: 'nonexistent', args: [] })
+      await flushPromises()
 
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal(
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual(
         'Lost the reference to the browser. This usually occurs because the Cypress config was reloaded without the browser re-launching. Close and re-open the browser.',
       )
     })
 
     it('returns error object if browser is not supported', async () => {
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'Firefox' }, {})
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: 'nonexistent', args: [] })
+
+          return taskResult
+        }
+      })
+
       setup({ on, onMessage })
 
-      on.withArgs('after:browser:launch').yield({ family: 'Firefox' }, {})
+      await flushPromises()
 
-      const task = getTask()
-      const returnValue = await task({ name: 'nonexistent', args: [] })
-
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal(
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual(
         'Only browsers in the "Chromium" family are supported. You are currently running a browser with the family: Firefox',
       )
     })
 
     it('disconnects browser and returns error object if message handler errors', async () => {
-      testTaskHandler.rejects(new Error('handler error'))
+      testTaskHandler.mockRejectedValue(new Error('handler error'))
+
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: testTask, args: ['arg1', 'arg2'] })
+
+          return taskResult
+        }
+      })
+
       setup({
         on,
         puppeteer: mockPuppeteer as PuppeteerNode,
         onMessage,
       })
 
-      simulateBrowserLaunch()
+      await flushPromises()
 
-      const task = getTask()
-      const returnValue = await task({ name: testTask, args: ['arg1', 'arg2'] })
-
-      expect(mockBrowser.disconnect).to.be.called
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal('handler error')
+      expect(mockBrowser.disconnect).toHaveBeenCalled()
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual('handler error')
     })
 
     it('returns error object if message handler with given name cannot be found', async () => {
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: 'nonexistent', args: [] })
+
+          return taskResult
+        }
+      })
+
       setup({ on, onMessage })
 
-      simulateBrowserLaunch()
+      await flushPromises()
 
-      const task = getTask()
-      const returnValue = await task({ name: 'nonexistent', args: [] })
-
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal(
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual(
         'Could not find message handler with the name `nonexistent`. Registered message handler names are: test.',
       )
     })
 
     it('returns error object if message handler with given name cannot be found', async () => {
+      let taskResult: any = null
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: 'notAFunction', args: [] })
+
+          return taskResult
+        }
+      })
+
       // @ts-expect-error
       setup({ on, onMessage: { notAFunction: true } })
 
-      simulateBrowserLaunch()
-      const task = getTask()
-      const returnValue = await task({ name: 'notAFunction', args: [] })
-
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal(
+      await flushPromises()
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual(
         'Message handlers must be functions, but the message handler for the name `notAFunction` was type `boolean`.',
       )
     })
 
     it('calls activateMainTab if there is a page in the browser', async () => {
-      (activateMainTabExport.activateMainTab as sinon.SinonStub).withArgs(mockBrowser).resolves()
+      let taskResult: any = null
+
+      vi.mocked(activateMainTab).mockImplementation((browser) => {
+        if (browser === mockBrowser) {
+          return Promise.resolve()
+        }
+
+        return Promise.reject(new Error('browser not found'))
+      })
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: testTask, args: [] })
+
+          return taskResult
+        }
+      })
+
       setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
-      const task = getTask()
 
-      simulateBrowserLaunch()
-      await task({ name: testTask, args: [] })
-
-      expect(activateMainTabExport.activateMainTab).to.be.calledWith(mockBrowser)
+      await flushPromises()
+      expect(activateMainTab).toHaveBeenCalledWith(mockBrowser)
     })
 
     it('returns an error object if activateMainTab rejects', async () => {
-      (activateMainTabExport.activateMainTab as sinon.SinonStub).withArgs(mockBrowser).rejects()
+      let taskResult: any = null
+
+      vi.mocked(activateMainTab).mockImplementation((browser) => {
+        if (browser === mockBrowser) {
+          return Promise.reject()
+         }
+
+        return Promise.resolve()
+      })
+
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          taskResult = await handler.__cypressPuppeteer__({ name: testTask, args: [] })
+
+          return taskResult
+        }
+      })
 
       setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
-      simulateBrowserLaunch()
 
-      const task = getTask()
+      await flushPromises()
 
-      const returnValue = await task({ name: testTask, args: [] })
-
-      expect(returnValue.__error__).to.be.an('object')
-      expect(returnValue.__error__.message).to.equal(
+      expect(taskResult.__error__).toBeInstanceOf(Object)
+      expect(taskResult.__error__.message).toEqual(
         'Cannot communicate with the Cypress Chrome extension. Ensure the extension is enabled when using the Puppeteer plugin.',
       )
     })
 
     it('does not try to activate main tab when the browser is headless', async () => {
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: false }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
+
+        if (event === 'task') {
+          return handler.__cypressPuppeteer__({ name: testTask, args: [] })
+        }
+      })
+
       setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
-      on.withArgs('after:browser:launch').yield({ family: 'chromium', isHeaded: false }, { webSocketDebuggerUrl: 'ws://debugger' })
-      const task = getTask()
 
-      await task({ name: testTask, args: [] })
-
-      expect(activateMainTabExport.activateMainTab).not.to.be.called
+      await flushPromises()
+      expect(activateMainTab).not.toHaveBeenCalled()
     })
 
     it('does not try to activate main tab when the browser is electron', async () => {
-      setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
-      on.withArgs('after:browser:launch').yield({ family: 'chromium', isHeaded: true, name: 'electron' }, { webSocketDebuggerUrl: 'ws://debugger' })
-      const task = getTask()
+      on.mockImplementation(async (event, handler) => {
+        if (event === 'after:browser:launch') {
+          return handler({ family: 'chromium', isHeaded: true, name: 'electron' }, { webSocketDebuggerUrl: 'ws://debugger' })
+        }
 
-      await task({ name: testTask, args: [] })
-      expect(activateMainTabExport.activateMainTab).not.to.be.called
+        if (event === 'task') {
+          return handler.__cypressPuppeteer__({ name: testTask, args: [] })
+        }
+      })
+
+      setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
+
+      await flushPromises()
+      expect(activateMainTab).not.toHaveBeenCalled()
     })
 
     it('catastrophically fails when the browser is Google Chrome Branded 137 and up and we are running in headed mode', async () => {
-      setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
-      expect(() => {
-        on.withArgs('after:browser:launch').yield({ family: 'chromium', isHeaded: true, name: 'chrome', majorVersion: '137' }, { webSocketDebuggerUrl: 'ws://debugger' })
-      }).to.throw('@cypress/puppeteer does not work in Google Chrome v137 and higher in cypress open mode (or headed run mode). If you need to use @cypress/puppeteer in headed mode, please use Electron, Chrome for Testing, Chromium, or another Chrome variant that supports loading extensions.')
+      await new Promise<void>((resolve) => {
+        on.mockImplementationOnce(async (event, handler) => {
+          if (event === 'after:browser:launch') {
+            try {
+               handler({ family: 'chromium', isHeaded: true, name: 'chrome', majorVersion: '137' }, { webSocketDebuggerUrl: 'ws://debugger' })
+            } catch (error) {
+              expect(error).toBeInstanceOf(Error)
+              expect(error.message).toEqual('@cypress/puppeteer does not work in Google Chrome v137 and higher in cypress open mode (or headed run mode). If you need to use @cypress/puppeteer in headed mode, please use Electron, Chrome for Testing, Chromium, or another Chrome variant that supports loading extensions.')
+              resolve()
+            }
+          }
+        })
 
-      expect(() => {
-        on.withArgs('after:browser:launch').yield({ family: 'chromium', isHeaded: true, name: 'chrome', majorVersion: '141' }, { webSocketDebuggerUrl: 'ws://debugger' })
-      }).to.throw('@cypress/puppeteer does not work in Google Chrome v137 and higher in cypress open mode (or headed run mode). If you need to use @cypress/puppeteer in headed mode, please use Electron, Chrome for Testing, Chromium, or another Chrome variant that supports loading extensions.')
+        setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
+      })
+
+      await new Promise<void>((resolve) => {
+        on.mockImplementationOnce(async (event, handler) => {
+          if (event === 'after:browser:launch') {
+            try {
+               handler({ family: 'chromium', isHeaded: true, name: 'chrome', majorVersion: '141' }, { webSocketDebuggerUrl: 'ws://debugger' })
+            } catch (error) {
+              expect(error).toBeInstanceOf(Error)
+              expect(error.message).toEqual('@cypress/puppeteer does not work in Google Chrome v137 and higher in cypress open mode (or headed run mode). If you need to use @cypress/puppeteer in headed mode, please use Electron, Chrome for Testing, Chromium, or another Chrome variant that supports loading extensions.')
+              resolve()
+            }
+          }
+        })
+
+        setup({ on, onMessage, puppeteer: mockPuppeteer as PuppeteerNode })
+      })
     })
   })
 
   describe('validation', () => {
     it('errors if options argument is not provided', () => {
       // @ts-expect-error
-      expect(() => setup()).to.throw('Must provide options argument to `setup`.')
+      expect(() => setup()).toThrow('Must provide options argument to `setup`.')
     })
 
     it('errors if options argument is not an object', () => {
       // @ts-expect-error
-      expect(() => setup(true)).to.throw('The options argument provided to `setup` must be an object.')
+      expect(() => setup(true)).toThrow('The options argument provided to `setup` must be an object.')
     })
 
     it('errors if `on` option is not provided', () => {
       // @ts-expect-error
-      expect(() => setup({})).to.throw('Must provide `on` function to `setup`.')
+      expect(() => setup({})).toThrow('Must provide `on` function to `setup`.')
     })
 
     it('errors if `on` option is not a function', () => {
       // @ts-expect-error
-      expect(() => setup({ on: 'string' })).to.throw('The `on` option provided to `setup` must be a function.')
+      expect(() => setup({ on: 'string' })).toThrow('The `on` option provided to `setup` must be a function.')
     })
 
     it('errors if `onMessage` option is not provided', () => {
       // @ts-expect-error
-      expect(() => setup({ on: sinon.stub() })).to.throw('Must provide `onMessage` object to `setup`.')
+      expect(() => setup({ on: vi.fn() })).toThrow('Must provide `onMessage` object to `setup`.')
     })
 
     it('errors if `onMessage` option is not an object', () => {
       // @ts-expect-error
-      expect(() => setup({ on: sinon.stub(), onMessage: () => {} })).to.throw('The `onMessage` option provided to `setup` must be an object.')
+      expect(() => setup({ on: vi.fn(), onMessage: () => {} })).toThrow('The `onMessage` option provided to `setup` must be an object.')
     })
   })
 })

--- a/npm/puppeteer/vitest.config.ts
+++ b/npm/puppeteer/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -12524,13 +12524,6 @@ chai-as-promised@7.1.1:
   dependencies:
     check-error "^1.0.2"
 
-chai-as-promised@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz#70cd73b74afd519754161386421fb71832c6d041"
-  integrity sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==
-  dependencies:
-    check-error "^1.0.2"
-
 chai-subset@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates @cypress/puppeteer unit tests from Mocha/Chai/Sinon to Vitest and updates related configs, scripts, and docs.
> 
> - **Testing (npm/puppeteer)**:
>   - Migrate unit tests from Mocha/Chai/Sinon to Vitest in `test/unit/*.spec.ts` (use `vi` mocks, timers, and Jest-style assertions).
>   - Remove Mocha config `npm/puppeteer/.mocharc.json`.
>   - Add Vitest config `npm/puppeteer/vitest.config.ts`.
> - **Scripts/Deps**:
>   - Update `npm/puppeteer/package.json` scripts to use Vitest (`test`, `test-watch`, `test-debug`).
>   - Remove Mocha/Chai/Sinon-related dev deps; add `vitest`.
> - **Type/ESLint Config**:
>   - Update `npm/puppeteer/test/tsconfig.json` to drop Mocha types.
>   - Tweak `npm/puppeteer/eslint.config.ts` to set `tsconfigRootDir` and allow `vitest.config.ts`.
> - **Docs**:
>   - Mark `npm/puppeteer` as completed in Phase 2 of `guides/esm-migration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2444bca15e3d366b12268d6fc322b5e8fc3d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->