### PR TITLE
fix: (studio) support showing command snapshots

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,8 @@ _Released 10/20/2025 (PENDING)_
 
 **Bugfixes:**
 
-- Fixes an issue where grouped command text jumps up and down when expanding and collapsing in the command log. Addressed in [#32757](https://github.com/cypress-io/cypress/pull/32757).
+- Fixed an issue where grouped command text jumps up and down when expanding and collapsing in the command log. Addressed in [#32757](https://github.com/cypress-io/cypress/pull/32757).
+- Fixed an issue where command snapshots were not correctly displayed in Studio. Addressed in [#32808](https://github.com/cypress-io/cypress/pull/32808)
 
 **Misc:**
 

--- a/packages/app/cypress/e2e/studio/studio-basic.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-basic.cy.ts
@@ -163,4 +163,24 @@ describe('studio functionality', () => {
 
     cy.findByTestId('studio-toolbar').should('not.exist')
   })
+
+  it('supports showing and hiding a command snapshot', () => {
+    launchStudio()
+
+    incrementCounter(0)
+
+    // hover over the visit command to show a snapshot
+    cy.get('.command-name-visit').realHover()
+    cy.getAutIframe().within(() => {
+      // verify the count in the snapshot is 0
+      cy.get('p').should('contain', 'Count is 0')
+    })
+
+    // hover over the html element to hide the snapshot
+    cy.get('html').realHover()
+    cy.getAutIframe().within(() => {
+      // verify the count in the live page is 1
+      cy.get('p').should('contain', 'Count is 1')
+    })
+  })
 })

--- a/packages/app/src/runner/iframe-model.ts
+++ b/packages/app/src/runner/iframe-model.ts
@@ -1,9 +1,6 @@
 import { useSnapshotStore } from './snapshot-store'
 import { useAutStore } from '../store'
 import type { EventManager } from './event-manager'
-// tslint:disable-next-line: no-implicit-dependencies - unsure how to handle these
-import { defaultMessages } from '@cy/i18n'
-import { useStudioStore } from '../store/studio-store'
 
 export interface AutSnapshot {
   id?: number
@@ -107,7 +104,6 @@ export class IframeModel {
   setSnapshots = (snapshotProps: AutSnapshot) => {
     const snapshotStore = useSnapshotStore()
     const autStore = useAutStore()
-    const studioStore = useStudioStore()
 
     if (snapshotStore.isSnapshotPinned) {
       return
@@ -115,10 +111,6 @@ export class IframeModel {
 
     if (autStore.isRunning) {
       return snapshotStore.setTestsRunningError()
-    }
-
-    if (studioStore.isOpen) {
-      return this._studioOpenError()
     }
 
     const { snapshots } = snapshotProps
@@ -235,14 +227,6 @@ export class IframeModel {
 
   _unpinSnapshot = () => {
     useSnapshotStore().$reset()
-  }
-
-  _studioOpenError () {
-    const snapshotStore = useSnapshotStore()
-
-    snapshotStore.setMessage(
-      defaultMessages.runner.snapshot.studioActiveError,
-    )
   }
 
   _storeOriginalState () {

--- a/packages/frontend-shared/src/locales/en-US.json
+++ b/packages/frontend-shared/src/locales/en-US.json
@@ -961,8 +961,7 @@
       "testsRunningError": "Cannot show snapshot while tests are running",
       "snapshotMissingError": "The snapshot is missing. Displaying current state of the DOM.",
       "defaultTitle": "DOM snapshot",
-      "pinnedTitle": "Pinned",
-      "studioActiveError": "Cannot show snapshot while creating commands in Studio"
+      "pinnedTitle": "Pinned"
     },
     "selectorPlayground": {
       "matches": "No matches | {n} match | {n} matches",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Removed code that was preventing the command snapshots from being shown in Studio. The behavior should be the exact same as it is in regular Cypress now.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables command snapshots in Studio by removing the Studio-open block in the runner, adds an e2e test for show/hide behavior, removes the related i18n string, and updates the changelog.
> 
> - **Studio Runner (`packages/app/src/runner/iframe-model.ts`)**:
>   - Remove Studio-open guard in `setSnapshots` and delete `_studioOpenError`, allowing snapshots while Studio is open.
>   - Drop unused imports of `@cy/i18n` and `useStudioStore`.
> - **E2E Tests (`packages/app/cypress/e2e/studio/studio-basic.cy.ts`)**:
>   - Add test verifying showing and hiding command snapshots via hover with state assertions.
> - **i18n (`packages/frontend-shared/src/locales/en-US.json`)**:
>   - Remove `runner.snapshot.studioActiveError` string.
> - **Changelog (`cli/CHANGELOG.md`)**:
>   - Add bugfix entry for Studio command snapshots not displaying; tweak grouped command text bullet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2547ea5e2703d33d0eefe00b3b495692f463a9c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Pin and unpin a command snapshot. Verify you can still interact with the page after unpinning.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

https://github.com/user-attachments/assets/11fd40ed-1418-453c-a245-8ec93f1dd418

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?