### PR TITLE
chore: convert eslint-plugin-dev tests to typescript and vitest

### DIFF
--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -84,7 +84,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 
 - [x] cli ✅ **COMPLETED** 
 - [x] npm/cypress-schematic ✅ **COMPLETED**
-- [ ] npm/eslint-plugin-dev
+- [x] npm/eslint-plugin-dev ✅ **COMPLETED**
 - [x] npm/grep ✅ **COMPLETED** 
 - [x] npm/puppeteer ✅ **COMPLETED** 
 - [x] npm/vite-dev-server ✅ **COMPLETED** 

--- a/npm/eslint-plugin-dev/package.json
+++ b/npm/eslint-plugin-dev/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint --ext .js,json,.eslintrc .",
     "lint-changed": "node ./lib/scripts/lint-changed",
     "lint-fix": "npm run lint -- --fix",
-    "test": "mocha"
+    "test": "vitest"
   },
   "dependencies": {
     "bluebird": "3.5.5",
@@ -22,8 +22,7 @@
     "eslint-plugin-json-format": "^2.0.0",
     "eslint-plugin-mocha": "^8.2.0",
     "eslint-plugin-promise": "^4.2.1",
-    "sinon": "^7.3.2",
-    "sinon-chai": "^3.7.0"
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "@babel/eslint-parser": "^7.28.0",

--- a/npm/eslint-plugin-dev/test/arrow-body-multiline-braces.spec.ts
+++ b/npm/eslint-plugin-dev/test/arrow-body-multiline-braces.spec.ts
@@ -1,8 +1,8 @@
-const path = require('path')
-const eslint = require('eslint')
-const plugin = require('../lib')
-const _ = require('lodash')
-const { expect } = require('chai')
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import eslint from 'eslint'
+import plugin from '../lib'
+import _ from 'lodash'
 
 const pluginName = '__plugin__'
 const ESLint = eslint.ESLint
@@ -42,14 +42,14 @@ describe('arrow-body-multiline-braces', () => {
       fix: true,
     })
 
-    expect(result.output).to.contain('{')
+    expect(result.output).toContain('{')
   })
 
   it('lint oneline js', async () => {
     const filename = './fixtures/oneline.js'
     const result = await execute(filename, { fix: false })
 
-    expect(result.output).not.ok
-    expect(result.errorCount).eq(0)
+    expect(result.output).toBeUndefined()
+    expect(result.errorCount).toBe(0)
   })
 })

--- a/npm/eslint-plugin-dev/test/no-only.spec.ts
+++ b/npm/eslint-plugin-dev/test/no-only.spec.ts
@@ -1,8 +1,8 @@
-const path = require('path')
-const eslint = require('eslint')
-const plugin = require('..')
-const _ = require('lodash')
-const { expect } = require('chai')
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import eslint from 'eslint'
+import plugin from '../lib'
+import _ from 'lodash'
 
 const ruleName = 'no-only'
 const pluginName = '__plugin__'
@@ -43,11 +43,11 @@ describe('no-only', () => {
       fix: true,
     })
 
-    expect(result.errorCount).eq(3)
-    expect(result.messages[0].message).to.contain('it')
-    expect(result.messages[1].message).to.contain('describe')
-    expect(result.messages[2].message).to.contain('context')
+    expect(result.errorCount).toEqual(3)
+    expect(result.messages[0].message).toContain('it')
+    expect(result.messages[1].message).toContain('describe')
+    expect(result.messages[2].message).toContain('context')
 
-    expect(result.output).not.exist
+    expect(result.output).toBeUndefined()
   })
 })

--- a/npm/eslint-plugin-dev/test/no-return-before.spec.ts
+++ b/npm/eslint-plugin-dev/test/no-return-before.spec.ts
@@ -1,9 +1,9 @@
-const path = require('path')
-const eslint = require('eslint')
-const plugin = require('..')
-const _ = require('lodash')
-const { stripIndent } = require('common-tags')
-const { expect } = require('chai')
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import eslint from 'eslint'
+import plugin from '../lib'
+import _ from 'lodash'
+import { stripIndent } from 'common-tags'
 
 const ruleName = 'no-return-before'
 const pluginName = '__plugin__'
@@ -42,7 +42,7 @@ describe(ruleName, () => {
     const filename = './fixtures/no-return-before-pass.js'
     const result = await execute(filename)
 
-    expect(result.errorCount).equal(0)
+    expect(result.errorCount).toEqual(0)
   })
 
   it('fail', async () => {
@@ -51,15 +51,15 @@ describe(ruleName, () => {
       fix: false,
     })
 
-    expect(result.errorCount).equal(4)
-    expect(result.messages[0].message).to.contain(`after 'describe'`)
+    expect(result.errorCount).toEqual(4)
+    expect(result.messages[0].message).toContain(`after 'describe'`)
   })
 
   it('fix fail', async () => {
     const filename = './fixtures/no-return-before-fail.js'
     const result = await execute(filename)
 
-    expect(result.output).equal(`${stripIndent`
+    expect(result.output).toEqual(`${stripIndent`
     describe('outer', ()=>{
       describe('some test', ()=>{
         context('some test', ()=>{
@@ -89,11 +89,11 @@ describe(ruleName, () => {
         },
       })
 
-      expect(result.errorCount).equal(1)
+      expect(result.errorCount).toEqual(1)
 
-      expect(result.messages[0].message).to.contain('someFn')
+      expect(result.messages[0].message).toContain('someFn')
 
-      expect(result.output).not.not.exist
+      expect(result.output).toBeUndefined()
     })
   })
 })

--- a/npm/eslint-plugin-dev/test/skip-comment.spec.ts
+++ b/npm/eslint-plugin-dev/test/skip-comment.spec.ts
@@ -1,8 +1,10 @@
-const path = require('path')
-const eslint = require('eslint')
-const plugin = require('..')
-const _ = require('lodash')
-const { expect } = require('chai')
+import { describe, it, expect } from 'vitest'
+
+import path from 'path'
+import eslint from 'eslint'
+import _ from 'lodash'
+
+const plugin = require('../lib')
 
 const ruleName = 'skip-comment'
 const pluginName = '__plugin__'
@@ -43,7 +45,7 @@ describe('skip-comment', () => {
       fix: true,
     })
 
-    expect(result.errorCount).equal(0)
+    expect(result.errorCount).toEqual(0)
   })
 
   it('skip test without comment', async () => {
@@ -52,17 +54,17 @@ describe('skip-comment', () => {
       fix: true,
     })
 
-    expect(result.errorCount).equal(3)
+    expect(result.errorCount).toEqual(3)
 
-    expect(result.messages[0].message).to.contain('it')
-    expect(result.messages[0].message).to.contain('NOTE:')
-    expect(result.messages[0].message).to.contain('TODO:')
-    expect(result.messages[1].message).to.contain('describe')
-    expect(result.messages[1].message).to.contain('NOTE:')
-    expect(result.messages[2].message).to.contain('context')
-    expect(result.messages[2].message).to.contain('NOTE:')
+    expect(result.messages[0].message).toContain('it')
+    expect(result.messages[0].message).toContain('NOTE:')
+    expect(result.messages[0].message).toContain('TODO:')
+    expect(result.messages[1].message).toContain('describe')
+    expect(result.messages[1].message).toContain('NOTE:')
+    expect(result.messages[2].message).toContain('context')
+    expect(result.messages[2].message).toContain('NOTE:')
 
-    expect(result.output).not.not.exist
+    expect(result.output).toBeUndefined()
   })
 
   describe('config', () => {
@@ -81,12 +83,12 @@ describe('skip-comment', () => {
         },
       })
 
-      expect(result.errorCount).equal(1)
+      expect(result.errorCount).toEqual(1)
 
-      expect(result.messages[0].message).to.contain('it')
-      expect(result.messages[0].message).to.contain('FOOBAR:')
+      expect(result.messages[0].message).toContain('it')
+      expect(result.messages[0].message).toContain('FOOBAR:')
 
-      expect(result.output).not.exist
+      expect(result.output).toBeUndefined()
     })
   })
 })

--- a/npm/eslint-plugin-dev/vitest.config.ts
+++ b/npm/eslint-plugin-dev/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.spec.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -29609,7 +29609,7 @@ sinon@7.3.2:
     nise "^1.4.10"
     supports-color "^5.5.0"
 
-sinon@7.5.0, sinon@^7.3.2:
+sinon@7.5.0:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
   integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Migrates `eslint-plugin-dev` tests to `vitest`. There is an ongoing effort to update this package to Eslint 9+ and migrating the tests is just to help with formaility of migrating off `mocha`, even though it doesn't provide a whole lot of value except test unification

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates @cypress/eslint-plugin-dev tests from Mocha/Chai to Vitest with TypeScript, updates package scripts/config, and marks the guide checklist as completed.
> 
> - **npm/eslint-plugin-dev**:
>   - **Tests**: Convert from Mocha/Chai (CJS) to Vitest with TypeScript; update assertions and imports.
>   - **Config**: Add `vitest.config.ts` with node environment and glob; switch `package.json` `test` script to `vitest`.
>   - **Deps**: Remove `sinon`/`sinon-chai`; add `vitest` as a dev dependency.
> - **Docs**:
>   - Mark `npm/eslint-plugin-dev` as ✅ completed in Phase 2 of `guides/esm-migration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5d6645aa265e65605c2850377a428895b700125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->