### PR TITLE
chore: remove `ssh-keyscan` as it shouldn't be necessary

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -118,7 +118,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "ryanm/fix/rename-exclude-from-ai" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "chore/fix_builds" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command
@@ -1473,7 +1473,6 @@ jobs:
         default: false
     resource_class: << parameters.resource_class >>
     steps:
-      - update_known_hosts
       - checkout
       - install-required-node
       - verify-build-setup:

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -4,7 +4,7 @@ linux-x64:
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'ryanm/fix/rename-exclude-from-ai', << pipeline.git.branch >> ]
+      - equal: [ 'chore/fix_builds', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Currently, our windows [builds](https://app.circleci.com/pipelines/github/cypress-io/cypress/76428/workflows/aad0edca-fe31-47be-a96e-2fd3fd3c80eb/jobs/3248811) are failing with this error:

<img width="1579" height="351" alt="Screenshot 2025-10-24 at 10 00 16 AM" src="https://github.com/user-attachments/assets/213a76b1-19ee-4570-b9fb-1d66c54f12f6" />

due to this issue https://github.com/PowerShell/Win32-OpenSSH/issues/2140

The reason it was introduced in the first place to our CI is we run the `stable` tag for `windows-server-2022-gui`, which just recently bumped from `2024.04.1` to `2024.12.1`, which includes a newer version Open SSH for Windows.

To mitigate this, I think we can just remove the `ssh-keyscan` method from our CI job as the checkout job should have updated keys. My guess is we used this to patch around some previous checkout issues and I would like to try and remove it first and see if any issues creep up in the future as opposed to possibility maintaining something we likely no longer need.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the ssh-keyscan step and switches branch filters/conditions to `chore/fix_builds` in CircleCI configs.
> 
> - **CI (CircleCI)**:
>   - Remove `update_known_hosts` step from `node_modules_install` (drops `ssh-keyscan` usage).
>   - Update `setup_should_persist_artifacts` branch condition to use `chore/fix_builds` instead of `ryanm/fix/rename-exclude-from-ai`.
>   - Adjust workflow branch filters in `workflows/@main.yml` to include `chore/fix_builds` and remove the old branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b36e218215faa8dd55cc7f9a18118518c52cd2cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->