### PR TITLE
internal: (studio) update e2e tests for creating new tests in studio

### DIFF
--- a/packages/app/cypress/e2e/studio/helper.ts
+++ b/packages/app/cypress/e2e/studio/helper.ts
@@ -39,12 +39,7 @@ export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite 
     }
 
     cy.findByTestId('studio-panel').should('be.visible')
-    if (createNewTestFromSuite || createNewTestFromSpecHeader) {
-      // if we are creating a new test from a suite or spec header, we should see the create test button rather than the new test button from the welcome screen
-      cy.findByTestId('create-test-button').should('be.visible')
-    } else {
-      cy.findByTestId('new-test-button').should('not.exist')
-    }
+    cy.findByTestId('create-test-button').should('be.visible')
   } else {
     cy.get('@runnable-wrapper')
     .findByTestId('launch-studio')

--- a/packages/app/cypress/e2e/studio/helper.ts
+++ b/packages/app/cypress/e2e/studio/helper.ts
@@ -39,7 +39,12 @@ export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite 
     }
 
     cy.findByTestId('studio-panel').should('be.visible')
-    cy.findByTestId('new-test-button').should('be.visible')
+    if (createNewTestFromSuite || createNewTestFromSpecHeader) {
+      // if we are creating a new test from a suite or spec header, we should see the create test button rather than the new test button from the welcome screen
+      cy.findByTestId('create-test-button').should('be.visible')
+    } else {
+      cy.findByTestId('new-test-button').should('not.exist')
+    }
   } else {
     cy.get('@runnable-wrapper')
     .findByTestId('launch-studio')
@@ -55,8 +60,13 @@ export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite 
   }
 }
 
-export function inputNewTestName (name: string = 'new-test') {
-  cy.findByTestId('new-test-button').click()
+export function inputNewTestName ({ name = 'new-test', createNewTestFromSuite = false, createNewTestFromSpecHeader = false }:
+{ name?: string, createNewTestFromSuite?: boolean, createNewTestFromSpecHeader?: boolean } = {}) {
+  if (!createNewTestFromSuite && !createNewTestFromSpecHeader) {
+    // we only need to click the new test button if we are not creating a new test from a suite or spec header
+    cy.findByTestId('new-test-button').click()
+  }
+
   cy.findByTestId('test-name-input').type(name)
   cy.findByTestId('create-test-button').click()
 

--- a/packages/app/cypress/e2e/studio/helper.ts
+++ b/packages/app/cypress/e2e/studio/helper.ts
@@ -55,9 +55,8 @@ export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite 
   }
 }
 
-export function inputNewTestName ({ name = 'new-test', createNewTestFromSuite = false, createNewTestFromSpecHeader = false }:
-{ name?: string, createNewTestFromSuite?: boolean, createNewTestFromSpecHeader?: boolean } = {}) {
-  if (!createNewTestFromSuite && !createNewTestFromSpecHeader) {
+export function inputNewTestName ({ name = 'new-test', creatingNewTestFromWelcomeScreen = true }: { name?: string, creatingNewTestFromWelcomeScreen?: boolean } = {}) {
+  if (creatingNewTestFromWelcomeScreen) {
     // we only need to click the new test button if we are not creating a new test from a suite or spec header
     cy.findByTestId('new-test-button').click()
   }

--- a/packages/app/cypress/e2e/studio/studio-navigation.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-navigation.cy.ts
@@ -43,7 +43,7 @@ describe('Cypress Studio - Navigation and URL Management', () => {
   it('updates the AUT url when creating a new test', () => {
     launchStudio({ specName: 'navigation.cy.js', createNewTestFromSuite: true })
 
-    inputNewTestName({ createNewTestFromSuite: true })
+    inputNewTestName({ creatingNewTestFromWelcomeScreen: false })
 
     cy.findByTestId('aut-url-input').should('have.focus').type('cypress/e2e/navigation.html{enter}')
 

--- a/packages/app/cypress/e2e/studio/studio-navigation.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-navigation.cy.ts
@@ -43,7 +43,7 @@ describe('Cypress Studio - Navigation and URL Management', () => {
   it('updates the AUT url when creating a new test', () => {
     launchStudio({ specName: 'navigation.cy.js', createNewTestFromSuite: true })
 
-    inputNewTestName()
+    inputNewTestName({ createNewTestFromSuite: true })
 
     cy.findByTestId('aut-url-input').should('have.focus').type('cypress/e2e/navigation.html{enter}')
 

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -130,10 +130,10 @@ describe('studio functionality', () => {
 
     inputNewTestName({ creatingNewTestFromWelcomeScreen: false })
 
-    cy.percySnapshot()
-
     // make sure that the visit has run and we're recording studio commands
     cy.get('[data-cy="record-button-recording"]').should('be.visible')
+
+    cy.percySnapshot()
 
     incrementCounter(0)
 

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -15,7 +15,7 @@ describe('Cypress Studio - New Test Creation', () => {
   it('creates a new test from spec header', () => {
     launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSpecHeader: true })
 
-    inputNewTestName({ createNewTestFromSpecHeader: true })
+    inputNewTestName({ creatingNewTestFromWelcomeScreen: false })
 
     cy.contains('new-test').click()
 
@@ -128,7 +128,7 @@ describe('studio functionality', () => {
   it('creates a new test for a specific suite with the url already defined', () => {
     launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSuite: true })
 
-    inputNewTestName({ createNewTestFromSuite: true })
+    inputNewTestName({ creatingNewTestFromWelcomeScreen: false })
 
     cy.percySnapshot()
 

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -15,7 +15,7 @@ describe('Cypress Studio - New Test Creation', () => {
   it('creates a new test from spec header', () => {
     launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSpecHeader: true })
 
-    inputNewTestName()
+    inputNewTestName({ createNewTestFromSpecHeader: true })
 
     cy.contains('new-test').click()
 
@@ -128,10 +128,7 @@ describe('studio functionality', () => {
   it('creates a new test for a specific suite with the url already defined', () => {
     launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSuite: true })
 
-    // create a new test from a specific suite
-    cy.findByTestId('create-new-test-from-suite').click()
-
-    inputNewTestName()
+    inputNewTestName({ createNewTestFromSuite: true })
 
     cy.percySnapshot()
 

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -132,6 +132,9 @@ describe('studio functionality', () => {
 
     cy.percySnapshot()
 
+    // make sure that the visit has run and we're recording studio commands
+    cy.get('[data-cy="record-button-recording"]').should('be.visible')
+
     incrementCounter(0)
 
     cy.findByTestId('studio-save-button').click()


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

We updated the screen that the user sees in the studio panel depending on the button that they click to open the panel. This PR updates the e2e tests to match that behavior. It also fixes an issue where we were getting a detached DOM error when asserting on elements in the AUT iframe.

Detached DOM issue:
https://cloud.cypress.io/projects/ypt4pf/runs/66905/overview/ff0fae1f-3022-4865-9f74-a235d56437c0/replay?roarHideRunsWithDiffGroupsAndTags=1&ts=1761658484931.7&att=1

New test button issues:
https://cloud.cypress.io/projects/ypt4pf/runs/66914/overview/ca6734e3-2711-4abc-9cea-68e1d393dc88?roarHideRunsWithDiffGroupsAndTags=1

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Run the tests in `studio-new-tests.cy.ts`

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Studio test helper and updates e2e specs to align with new new-test flow and `create-test-button` selector, including conditional handling when launched from suite/spec header.
> 
> - **Studio e2e helper (`packages/app/cypress/e2e/studio/helper.ts`)**:
>   - Refactor `inputNewTestName` to accept `{ name, creatingNewTestFromWelcomeScreen }` and conditionally click `new-test-button` based on context.
>   - Update assertions to use `create-test-button` instead of `new-test-button`.
> - **Navigation tests (`studio-navigation.cy.ts`)**:
>   - Use `inputNewTestName({ creatingNewTestFromWelcomeScreen: false })` when creating tests from a suite.
> - **New tests creation (`studio-new-tests.cy.ts`)**:
>   - Use `inputNewTestName({ creatingNewTestFromWelcomeScreen: false })` for suite/spec-header flows.
>   - Remove redundant click of `create-new-test-from-suite` (now handled by helper) and ensure recording state before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0a9b3776b237a0fd039ca3ccc6b1e9365b2d376. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->