### PR TITLE
misc: update `playwright-webkit` from `1.24.2` to `1.56.1` and `base-internal` image from Debian Bullseye to Debian Trixie

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -8,8 +8,8 @@ version: 2.1
 chrome-stable-version: &chrome-stable-version "141.0.7390.107"
 chrome-beta-version: &chrome-beta-version "142.0.7444.34"
 firefox-stable-version: &firefox-stable-version "142.0"
-base-internal-bullseye: &base-internal-bullseye cypress/base-internal:22.19.0-bullseye
-base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry
+base-internal-trixie: &base-internal-trixie cypress/base-internal:22.19.0-trixie
+base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry-trixie
 # Lowest Node.js version we support of the minimum major version supported
 # See https://docs.cypress.io/app/get-started/install-cypress#Nodejs
 base-internal-minimum-node: &base-internal-minimum-node cypress/base-internal:20.15.0
@@ -46,7 +46,7 @@ executors:
   # the Docker image with Cypress dependencies and Chrome browser
   cy-doc:
     docker:
-      - image: *base-internal-bullseye
+      - image: *base-internal-trixie
     # by default, we use "medium" to balance performance + CI costs. bump or reduce on a per-job basis if needed.
     resource_class: medium
     environment:
@@ -54,7 +54,7 @@ executors:
 
   kitchensink-executor:
     docker:
-      - image: *base-internal-bullseye
+      - image: *base-internal-trixie
     # by default, we use "medium" to balance performance + CI costs. bump or reduce on a per-job basis if needed.
     resource_class: medium
     environment:
@@ -63,7 +63,7 @@ executors:
   # Docker image with non-root "node" user
   non-root-docker-user:
     docker:
-      - image: *base-internal-bullseye
+      - image: *base-internal-trixie
         user: node
     environment:
       PLATFORM: linux
@@ -587,7 +587,7 @@ commands:
                       version: << parameters.google-chrome-for-testing-version >>
                       install_chromedriver: false
 
-  # This code builds better-sqlite3 on Debian 11 (Bullseye). This is necessary because Debian 10 has the oldest glibc version (2.31) that we support.
+  # This code builds better-sqlite3 on Debian 11 (Bullseye). This is necessary because Debian 11 has the oldest glibc version (2.31) that we support.
   #
   # Since this is running Docker remote (because the job running the command may not be using an executor with the appropriate glibc version), we need to 
   # copy the project into the container, and copy the built plugin out of the container because the host running docker does not have access to the 
@@ -1937,7 +1937,7 @@ jobs:
     parallelism: 1
     working_directory: ~/cypress
     docker:
-      - image: *base-internal-bullseye
+      - image: *base-internal-trixie
     environment:
       # needed to inform the bootstrap-docker-container.sh script to link the binary in the system-test project directory
       REPO_DIR: /root/cypress

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -20,6 +20,7 @@ _Released 10/20/2025 (PENDING)_
 - Add top padding for command log labels. Addressed in [#32774](https://github.com/cypress-io/cypress/pull/32774).
 - The hitbox for expanding a grouped command has been widened. Addresses [#32778](https://github.com/cypress-io/cypress/issues/32778). Addressed in [#32783](https://github.com/cypress-io/cypress/pull/32783).
 - Have cursor on hover of the AUT URL to show as pointer. Addresses [#32777](https://github.com/cypress-io/cypress/issues/32777). Addressed in [#32782](https://github.com/cypress-io/cypress/pull/32782).
+- WebKit now prefers a cookie's fully qualified `domain` when requesting a cookie value via [`cy.getCookie()`](https://docs.cypress.io/api/commands/getcookie). If none are found, the cookie's apex domain will be used as a fallback. Addresses [#29954](https://github.com/cypress-io/cypress/issues/29954), [#29973](https://github.com/cypress-io/cypress/issues/29973) and [#30392](https://github.com/cypress-io/cypress/issues/30392). Addressed in [#32852](https://github.com/cypress-io/cypress/pull/32852).
 
 **Dependency Updates:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - .:/opt/cypress
   ci:
     # This should mirror the image used in workflows.yml
-    image: cypress/base-internal:22.19.0-bullseye
+    image: cypress/base-internal:22.19.0-trixie
     ports:
       - 5566:5566
       - 5567:5567

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "npm-packlist": "9.0.0",
     "p-defer": "^3.0.0",
     "patch-package": "8.0.0",
-    "playwright-webkit": "1.24.2",
+    "playwright-webkit": "1.56.1",
     "pluralize": "8.0.0",
     "print-arch": "1.0.0",
     "proxyquire": "2.1.3",

--- a/packages/driver/cypress/e2e/commands/cookies.cy.js
+++ b/packages/driver/cypress/e2e/commands/cookies.cy.js
@@ -123,10 +123,13 @@ describe('src/cy/commands/cookies - no stub', () => {
 
       cy.getCookies({ domain: 'www.foobar.com' }).then((cookies) => {
         expect(cookies).to.have.length(2)
-        expect(cookies[0].name).to.equal('key1')
-        expect(cookies[0].domain).to.match(/\.?www\.foobar\.com/)
-        expect(cookies[1].name).to.equal('key2')
-        expect(cookies[1].domain).to.match(/\.?foobar\.com/)
+
+        const sortedCookies = Cypress._.sortBy(cookies, 'name')
+
+        expect(sortedCookies[0].name).to.equal('key1')
+        expect(sortedCookies[0].domain).to.match(/\.?www\.foobar\.com/)
+        expect(sortedCookies[1].name).to.equal('key2')
+        expect(sortedCookies[1].domain).to.match(/\.?foobar\.com/)
       })
 
       cy.getCookies({ domain: 'barbaz.com' }).then((cookies) => {
@@ -1380,8 +1383,12 @@ describe('src/cy/commands/cookies', () => {
       // other browsers do not return sameSite at all
       const sameSite = (
         Cypress.isBrowser('webkit')
-      ) ? 'no_restriction' :
-        Cypress.isBrowser('firefox') ? 'unspecified' : null
+        // There is an odd inconsistency when setting an undefined cookie context in WebKit in WebKit 26.
+        // On linux based machines, the sameSite will be set to `lax`, but on MacOS the sameSite is set to `None` (no_restriction).
+        // There is no difference in the webkit-automation logic within cypress so the inconsistency must lie in the OS
+        // implement of WebKit
+      ) ? Cypress.platform === 'darwin' ? 'no_restriction' : 'lax'
+        : Cypress.isBrowser('firefox') ? 'unspecified' : null
 
       if (sameSite) {
         cy.getCookie('five').should('include', { sameSite })

--- a/packages/electron/.cursor/rules/electron-upgrade.mdc
+++ b/packages/electron/.cursor/rules/electron-upgrade.mdc
@@ -67,14 +67,14 @@ When Electron is upgraded, the bundled Node.js version often changes. Sync this 
 ```bash
 # File: /docker-compose.yml
 # Update the base-internal image reference:
-# "cypress/base-internal:22.18.0-bullseye" -> "cypress/base-internal:NEW_NODE_VERSION-bullseye"
+# "cypress/base-internal:22.18.0-trixie" -> "cypress/base-internal:NEW_NODE_VERSION-trixie"
 ```
 
 ### CircleCI Workflows
 ```bash
 # File: /.circleci/src/@workflows.yml
 # Update base-internal image references:
-# "base-internal-bullseye: &base-internal-bullseye cypress/base-internal:22.18.0-bullseye" -> "base-internal-bullseye: &base-internal-bullseye cypress/base-internal:NEW_NODE_VERSION-bullseye"
+# "base-internal-trixie: &base-internal-trixie cypress/base-internal:22.18.0-trixie" -> "base-internal-trixie: &base-internal-trixie cypress/base-internal:NEW_NODE_VERSION-trixie"
 # "base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.18.0-yarn-berry" -> "base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:NEW_NODE_VERSION-yarn-berry"
 # "base-internal-minimum-node: &base-internal-minimum-node cypress/base-internal:22.18.0" -> "base-internal-minimum-node: &base-internal-minimum-node cypress/base-internal:NEW_NODE_VERSION"
 ```

--- a/packages/server/lib/automation/util.ts
+++ b/packages/server/lib/automation/util.ts
@@ -12,8 +12,9 @@ export type CyCookie = Pick<chrome.cookies.Cookie, 'name' | 'value' | 'expiratio
 // @ts-ignore
 export type CyCookieFilter = chrome.cookies.GetAllDetails
 
-export const cookieMatches = (cookie: CyCookie | playwright.Cookie, filter?: CyCookieFilter) => {
-  if (filter?.domain && !domainMatch(filter?.domain, cookie.domain)) {
+export const cookieMatches = (cookie: CyCookie | playwright.Cookie, filter?: CyCookieFilter, options?: { strictDomain: boolean }) => {
+  if (filter?.domain) {
+    if (options?.strictDomain ? filter?.domain !== cookie.domain : !domainMatch(filter?.domain, cookie.domain))
     return false
   }
 

--- a/packages/server/lib/browsers/webkit-automation.ts
+++ b/packages/server/lib/browsers/webkit-automation.ts
@@ -270,11 +270,19 @@ export class WebKitAutomation {
 
     if (!cookies.length) return null
 
-    const cookie = cookies.find((cookie) => {
-      return cookieMatches(cookie, filter)
+    // first attempt to match cookie on strict domain
+    let cookie = cookies.find((cookie) => {
+      return cookieMatches(cookie, filter, { strictDomain: true })
     })
 
-    if (!cookie) return null
+    if (!cookie) {
+      cookie = cookies.find((cookie) => {
+          // if unable to match closest via strict domain, then return a cookie that matches the apex domain
+        return cookieMatches(cookie, filter)
+      })
+
+      if (!cookie) return null
+    }
 
     return normalizeGetCookieProps(cookie)
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -198,7 +198,7 @@
     "mocked-env": "1.2.4",
     "mockery": "2.1.0",
     "nock": "13.2.9",
-    "playwright-webkit": "1.24.2",
+    "playwright-webkit": "1.56.1",
     "proxyquire": "2.1.3",
     "repl.history": "0.1.4",
     "request-promise": "4.2.6",

--- a/packages/server/test/unit/automation/util_spec.ts
+++ b/packages/server/test/unit/automation/util_spec.ts
@@ -45,5 +45,19 @@ context('lib/automation/util', () => {
 
       expect(cookieMatches(cookie, filter)).to.be.false
     })
+
+    it('strict matches exact domain with strictDomain=true', () => {
+      const cookie = { domain: 'www.example.com' } as CyCookie
+      const filter = { domain: 'www.example.com' }
+
+      expect(cookieMatches(cookie, filter, { strictDomain: true })).to.be.true
+    })
+
+    it('fails apex domain match with strictDomain=true', () => {
+      const cookie = { domain: 'example.com' } as CyCookie
+      const filter = { domain: 'www.example.com' }
+
+      expect(cookieMatches(cookie, filter, { strictDomain: true })).to.be.false
+    })
   })
 })

--- a/system-tests/test-binary/module_api_spec.ts
+++ b/system-tests/test-binary/module_api_spec.ts
@@ -3,7 +3,7 @@ import systemTests from '../lib/system-tests'
 describe('module API', () => {
   systemTests.it('can run module API Mocha spec', {
     timeout: 240000,
-    dockerImage: 'cypress/base-internal:22.19.0-bullseye',
+    dockerImage: 'cypress/base-internal:22.19.0-trixie',
     withBinary: true,
     project: 'module-api',
     browser: 'electron',

--- a/yarn.lock
+++ b/yarn.lock
@@ -26750,17 +26750,17 @@ platform@1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
   integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
-playwright-core@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.2.tgz#47bc5adf3dcfcc297a5a7a332449c9009987db26"
-  integrity sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==
+playwright-core@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.56.1.tgz#24a66481e5cd33a045632230aa2c4f0cb6b1db3d"
+  integrity sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==
 
-playwright-webkit@1.24.2:
-  version "1.24.2"
-  resolved "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.24.2.tgz#a81c59c75538172cadd2efcf2ec955dd9b2d9666"
-  integrity sha512-o0JJUWkQ228rNU+a14FVEPf7uUnA+cOrpKM4vsHqLew42sn4Q9ns0rl8pZwekv4u6054OMki4LbKDpvY5ulPgg==
+playwright-webkit@1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/playwright-webkit/-/playwright-webkit-1.56.1.tgz#b440ab027ea0b9323516e74ebb520d8d40fa5ec4"
+  integrity sha512-o+0xBhr6BM024k1GAvfuWt69NpqZr/UPH5igxWjzIkt0XUw8/qNBk5ghrZ9gN9kahxvoilO0+aGQrbpn4XDKMw==
   dependencies:
-    playwright-core "1.24.2"
+    playwright-core "1.56.1"
 
 plist@3.1.0, plist@^3.0.0, plist@^3.0.4, plist@^3.0.5, plist@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #29973
- Closes #29954
- Closes #30392

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Updates WebKit to version 26 as previous versions are no longer available. There are some behavior changes with the update, some which are commented on the PR. 

It looks like there is some cookie ordering inconsistencies between the linux/mac builds of webkit. In order to make this consistent, we check for a strict domain match when running `getCookie` and if no match is found, we then fall back to the apex domain.

Additionally, now that we are updating WebKit, we can now update from Debian Bullseye (Debian 11) to Debian Trixie (Debian 13). The `cypress-docker-images` PR to add `trixie` `base-internal` images is https://github.com/cypress-io/cypress-docker-images/pull/1440

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades WebKit (playwright-webkit) and switches CI/Docker images to Debian Trixie, adding strict-domain cookie matching with apex fallback and updating tests/changelog accordingly.
> 
> - **WebKit / Cookies**:
>   - Update `playwright-webkit` to `1.56.1` (and lockfile).
>   - Implement strict-domain cookie matching in `cookieMatches()` (optional `{ strictDomain: true }`).
>   - `webkit-automation`: `getCookie()` first matches exact domain, falls back to apex; normalize cookie props unchanged.
> - **CI/CD & Docker**:
>   - Migrate base images from Bullseye to Trixie: new anchors `base-internal-trixie`, `base-internal-yarn-berry` in `.circleci` and image refs in `docker-compose.yml` and system tests.
>   - Minor pipeline comment fix regarding Debian 11 glibc note.
> - **Tests**:
>   - Add unit tests for strict domain matching; adjust cookie tests (stable sorting) and system test image refs.
> - **Docs/Changelog**:
>   - Changelog: WebKit now prefers fully qualified cookie domain, falls back to apex.
>   - Electron upgrade doc: update image name examples to `-trixie`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e64deb26a46dc3f415fdd9702056e1b4ce7b943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->