### PR TITLE
mistake

### DIFF
--- a/packages/data-context/src/data/ProjectConfigIpc.ts
+++ b/packages/data-context/src/data/ProjectConfigIpc.ts
@@ -157,7 +157,11 @@ export class ProjectConfigIpc extends EventEmitter {
 
       let resolved = false
 
-      this._childProcess.on('error', (err) => {
+      this._childProcess.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EPIPE') {
+          return
+        }
+
         debug('unhandled error in child process %s', err)
         this.handleChildProcessError(err, this, resolved, reject)
         reject(err)
@@ -229,7 +233,11 @@ export class ProjectConfigIpc extends EventEmitter {
     return new Promise((resolve, reject) => {
       let resolved = false
 
-      this._childProcess.on('error', (err) => {
+      this._childProcess.on('error', (err: NodeJS.ErrnoException) => {
+        if (err.code === 'EPIPE') {
+          return
+        }
+
         this.handleChildProcessError(err, this, resolved, reject)
         reject(err)
       })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Suppress `EPIPE` errors from the plugin child process in `ProjectConfigIpc` to avoid unnecessary error handling during config load and setup.
> 
> - **IPC/Error Handling (`packages/data-context/src/data/ProjectConfigIpc.ts`)**:
>   - Suppress `EPIPE` in `_childProcess.on('error')` during `loadConfig()` and `registerSetupIpcHandlers()` by early return.
>   - Add explicit `NodeJS.ErrnoException` typing for `err` in these handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1a6f324c4c25d3a415d2c452da2cda978e6f020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->