### PR TITLE
misc: convert `@cypress/webpack-batteries-included-preprocessor` source to TypeScript

### DIFF
--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -34,7 +34,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] npm/vite-dev-server ✅ **COMPLETED** 
 - [x] vite-plugin-cypress-esm ✅ **COMPLETED** 
 - [x] npm/vue ✅ **COMPLETED** 
-- [ ] npm/webpack-batteries-included-preprocessor
+- [x] npm/webpack-batteries-included-preprocessor ✅ **COMPLETED**
 - [x] npm/webpack-dev-server ✅ **COMPLETED** 
 - [ ] npm/webpack-preprocessor **PARTIAL** 
 

--- a/npm/webpack-batteries-included-preprocessor/.gitignore
+++ b/npm/webpack-batteries-included-preprocessor/.gitignore
@@ -1,0 +1,2 @@
+index.js
+index.d.ts

--- a/npm/webpack-batteries-included-preprocessor/eslint.config.ts
+++ b/npm/webpack-batteries-included-preprocessor/eslint.config.ts
@@ -4,7 +4,7 @@ import globals from 'globals'
 export default [
   ...baseConfig,
   {
-    ignores: ['test/fixtures/**/*', 'test/_test-output/**'],
+    ignores: ['test/fixtures/**/*', 'test/_test-output/**', 'index.js', 'index.d.ts'],
   },
   {
     files: ['**/*.js', '**/*.ts'],

--- a/npm/webpack-batteries-included-preprocessor/index.ts
+++ b/npm/webpack-batteries-included-preprocessor/index.ts
@@ -1,12 +1,20 @@
-const path = require('path')
-const Debug = require('debug')
-const getTsConfig = require('get-tsconfig')
-const webpack = require('webpack')
-const webpackPreprocessor = require('@cypress/webpack-preprocessor')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+import path from 'path'
+import Debug from 'debug'
+import type { EventEmitter } from 'events'
+import getTsConfig from 'get-tsconfig'
+import webpack from 'webpack'
+import webpackPreprocessor from '@cypress/webpack-preprocessor'
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 
 const debug = Debug('cypress:webpack-batteries-included-preprocessor')
 const WBADebugNamespace = 'cypress-verbose:webpack-batteries-included-preprocessor:bundle-analyzer'
+
+// NOTE: these types are duplicated from @cypress/webpack-preprocessor as we are unable to currently export them from the main entry.
+interface FileEvent extends EventEmitter {
+  filePath: string
+  outputPath: string
+  shouldWatch: boolean
+}
 
 class TsConfigNotFoundError extends Error {
   constructor () {
@@ -24,17 +32,20 @@ class TypeScriptNotFoundError extends Error {
 
 const typescriptExtensionRegex = /\.m?tsx?$/
 
-const hasTsLoader = (rules) => {
+const hasTsLoader = (rules: any[]) => {
   return rules.some((rule) => {
     if (!rule.use || !Array.isArray(rule.use)) return false
 
-    return rule.use.some((use) => {
+    return rule.use.some((use: any) => {
       return use.loader && use.loader.match(/(^|[^a-zA-Z])ts-loader([^a-zA-Z]|$)/)
     })
   })
 }
 
-const addTypeScriptConfig = (file, options) => {
+const addTypeScriptConfig = (file: { filePath: string }, options: {
+  typescript?: string | boolean
+  webpackOptions?: any
+}) => {
   // returns null if tsconfig cannot be found in the path/parent hierarchy
   const configFile = getTsConfig.getTsconfig(file.filePath)
 
@@ -46,14 +57,15 @@ const addTypeScriptConfig = (file, options) => {
 
   debug(`found user tsconfig.json at ${configFile?.path} with compilerOptions: ${JSON.stringify(configFile?.config?.compilerOptions)}`)
 
-  let typeScriptPath = null
+  let typeScriptPath: string | boolean | undefined | null = null
 
   try {
     if (options.typescript === true) {
-      const configFileDirectory = path.dirname(configFile?.path)
+      const configFileDirectory = path.dirname(configFile?.path ?? '')
 
       // attempt to resolve typescript from the user's tsconfig.json file / project directory
       typeScriptPath = require.resolve('typescript', { paths: [configFileDirectory] })
+      options.typescript = typeScriptPath
     } else {
       typeScriptPath = options.typescript
     }
@@ -65,6 +77,7 @@ const addTypeScriptConfig = (file, options) => {
     throw new TypeScriptNotFoundError()
   }
   // shortcut if we know we've already added typescript support
+  // @ts-expect-error - not typed intentionally
   if (options.__typescriptSupportAdded) return options
 
   const webpackOptions = options.webpackOptions
@@ -117,6 +130,7 @@ const addTypeScriptConfig = (file, options) => {
     silent: true,
   })]
 
+  // @ts-expect-error - not typed intentionally
   options.__typescriptSupportAdded = true
 
   return options
@@ -148,7 +162,7 @@ const getDefaultWebpackOptions = () => {
                 'babel-plugin-add-module-exports',
                 '@babel/plugin-transform-class-properties',
                 '@babel/plugin-transform-object-rest-spread',
-              ].map(require.resolve),
+              ].map((plugin) => require.resolve(plugin)),
               [require.resolve('@babel/plugin-transform-runtime'), {
                 absoluteRuntime: path.dirname(require.resolve('@babel/runtime/package')),
               }],
@@ -239,8 +253,11 @@ const getDefaultWebpackOptions = () => {
   }
 }
 
-const preprocessor = (options = {}) => {
-  return (file) => {
+const preprocessor = (options: {
+  typescript?: string | boolean
+  webpackOptions?: any
+} = {}) => {
+  return (file: FileEvent) => {
     if (!options.typescript && typescriptExtensionRegex.test(file.filePath)) {
       return Promise.reject(new Error(`You are attempting to run a TypeScript file, but do not have TypeScript installed. Ensure you have 'typescript' installed to enable TypeScript support.\n\nThe file: ${file.filePath}`))
     }
@@ -251,6 +268,7 @@ const preprocessor = (options = {}) => {
       options = addTypeScriptConfig(file, options)
     }
 
+    // @ts-expect-error - typescript is casted back to a string | undefined inside addTypeScriptConfig
     return webpackPreprocessor(options)(file)
   }
 }
@@ -260,10 +278,10 @@ preprocessor.defaultOptions = {
   watchOptions: {},
 }
 
-preprocessor.getFullWebpackOptions = (filePath, typescript) => {
+preprocessor.getFullWebpackOptions = (filePath?: string, typescript?: string | boolean) => {
   const webpackOptions = getDefaultWebpackOptions()
 
-  if (typescript) {
+  if (typescript && filePath) {
     return addTypeScriptConfig({ filePath }, { typescript, webpackOptions }).webpackOptions
   }
 
@@ -271,6 +289,7 @@ preprocessor.getFullWebpackOptions = (filePath, typescript) => {
 }
 
 // for testing purposes, but do not add this to the typescript interface
+// @ts-expect-error - not typed intentionally
 preprocessor.__reset = webpackPreprocessor.__reset
 
-module.exports = preprocessor
+export = preprocessor

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -3,9 +3,13 @@
   "version": "0.0.0-development",
   "description": "Cypress preprocessor for bundling JavaScript via webpack with dependencies included and support for various ES features, TypeScript, and CoffeeScript",
   "private": false,
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
+    "build": "tsc || echo 'built, with errors'",
+    "check-ts": "tsc --noEmit",
     "lint": "eslint",
-    "test": "mocha test/**/*.spec.* --timeout 4000"
+    "test": "yarn build && mocha test/**/*.spec.* --timeout 4000"
   },
   "dependencies": {
     "@babel/core": "^7.28.0",
@@ -52,7 +56,7 @@
   },
   "files": [
     "index.js",
-    "empty.js"
+    "index.d.ts"
   ],
   "license": "MIT",
   "repository": {

--- a/npm/webpack-batteries-included-preprocessor/tsconfig.json
+++ b/npm/webpack-batteries-included-preprocessor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "declaration": true,
+  },
+  "include": [
+    "index.ts"
+  ]
+}


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Converts `@cypress/webpack-batteries-included-preprocessor` source to TypeScript. This doesn't touch the test files and does the minimum to get a TypeScript file to build from source

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts the package to TypeScript with build/typing setup, updates the preprocessor implementation and exports, and marks the migration guide as completed.
> 
> - **Package migration to TypeScript**
>   - Rewrite `npm/webpack-batteries-included-preprocessor/index.ts` with ESM-style imports, type annotations (e.g., `FileEvent`), stricter option typing, and `export = preprocessor`.
>   - Add `tsconfig.json` and update `.gitignore`/ESLint ignores for build artifacts (`index.js`, `index.d.ts`).
>   - Update `package.json`:
>     - Add `main: "index.js"`, `types: "index.d.ts"`.
>     - Add `build`/`check-ts` scripts; run build before tests; update `files` to include `index.d.ts`.
> - **Implementation tweaks**
>   - Safer plugin resolution mapping in Babel config; minor typing guards and `@ts-expect-error` annotations.
>   - `getFullWebpackOptions` now accepts optional `filePath` and only adds TS config when both `typescript` and `filePath` are provided.
> - **Docs**
>   - Mark `npm/webpack-batteries-included-preprocessor` as ✅ completed in `guides/esm-migration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db0d256b4d6ab1ac97fa462e38cd3fc2ad18fea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->