### PR TITLE
chore: require internal pr builds only for packaging artifacts

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -317,9 +317,7 @@ jobs:
         - publish-binary
       requires:
         - node_modules_install
-        - approve-contributor-pr
         - internal-pr-build
-        - external-pr-build
   - wait-for-binary-publish:
       type: approval
       requires:

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -318,6 +318,9 @@ jobs:
       requires:
         - node_modules_install
         - internal-pr-build
+      filters:
+        branches:
+          ignore: /^pull\/[0-9]+/
   - wait-for-binary-publish:
       type: approval
       requires:


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
This external workflow cannot be triggered for contributor PRs; currently the supporting approval job hangs because the external workflow is never triggered. This removes the initial external workflow job from contributor prs, which prevents the approval job from being added to the workflow.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits packaging artifact creation to internal branches by removing external/contributor requirements and adding a branch ignore filter for PR branches.
> 
> - **CI Workflow (`.circleci/src/pipeline/workflows/pull-request.yml`)**:
>   - `create-and-trigger-packaging-artifacts`:
>     - Remove `requires` on `approve-contributor-pr` and `external-pr-build`.
>     - Keep `requires`: `node_modules_install`, `internal-pr-build`.
>     - Add `filters.branches.ignore: /^pull/[0-9]+/` to exclude PR branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd1e72de21a9b319c76cebd50e0c760296b6928f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->