### PR TITLE
chore: attempt flake fix for `cy.title()` only logs once

### DIFF
--- a/guides/esm-migration.md
+++ b/guides/esm-migration.md
@@ -28,7 +28,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [ ] npm/eslint-plugin-dev
 - [x] npm/grep ✅ **COMPLETED** 
 - [x] npm/mount-utils ✅ **COMPLETED**  
-- [ ] npm/puppeteer **PARTIAL** 
+- [x] npm/puppeteer ✅ **COMPLETED** 
 - [x] npm/react ✅ **COMPLETED** 
 - [x] npm/svelte ✅ **COMPLETED** 
 - [x] npm/vite-dev-server ✅ **COMPLETED** 
@@ -36,7 +36,7 @@ When migrating some of these projects away from the `ts-node` entry [see `@packa
 - [x] npm/vue ✅ **COMPLETED** 
 - [x] npm/webpack-batteries-included-preprocessor ✅ **COMPLETED**
 - [x] npm/webpack-dev-server ✅ **COMPLETED** 
-- [ ] npm/webpack-preprocessor **PARTIAL** 
+- [x] npm/webpack-preprocessor ✅ **COMPLETED** 
 
 ##### Binary Packages
 

--- a/packages/driver/cypress/e2e/commands/window.cy.js
+++ b/packages/driver/cypress/e2e/commands/window.cy.js
@@ -481,7 +481,7 @@ describe('src/cy/commands/window', () => {
     })
 
     describe('errors', {
-      defaultCommandTimeout: 50,
+      defaultCommandTimeout: 200,
     }, () => {
       beforeEach(function () {
         this.logs = []


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #32681

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

I have a hunch that this is failing in CI due to there just not being enough time for all logs to propagate on AMD64, where as we can't reproduce locally because arm64 runs significantly faster

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `defaultCommandTimeout` in `#title` error tests and mark `npm/puppeteer` and `npm/webpack-preprocessor` as completed in ESM migration guide.
> 
> - **Tests**:
>   - Increase `defaultCommandTimeout` from `50` to `200` in `describe('errors')` for `#title` in `packages/driver/cypress/e2e/commands/window.cy.js`.
> - **Docs**:
>   - Update ESM migration checklist in `guides/esm-migration.md`:
>     - Mark `npm/puppeteer` as ✅ completed.
>     - Mark `npm/webpack-preprocessor` as ✅ completed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc8bb4440df0c194331d724d206f325ba1778d78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->