### PR TITLE
perf: skip :visible filter count when log:false

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 11/18/2025 (PENDING)_
 
+**Performance:**
+
+- Hidden command log entries (for commands with `log: false`) will no longer perform expensive visibility assessments for subject elements. Addressed in [#32948](https://github.com/cypress-io/cypress/pull/32948).
+
 **Bugfixes:**
 
 - Fixed an issue where [`cy.wrap()`](https://docs.cypress.io/api/commands/wrap) would cause infinite recursion and freeze the Cypress App when called with objects containing circular references. Fixes [#24715](https://github.com/cypress-io/cypress/issues/24715). Addressed in [#32917](https://github.com/cypress-io/cypress/pull/32917).

--- a/packages/driver/cypress/e2e/cypress/log.cy.js
+++ b/packages/driver/cypress/e2e/cypress/log.cy.js
@@ -182,6 +182,19 @@ describe('src/cypress/log', function () {
       expect(this.fireChangeEvent).to.have.been.called
     })
 
+    describe('when log is hidden', function () {
+      it('does not filter by :visible when setting el attributes', function () {
+        const log = new Log(this.createSnapshot, this.state, this.config, this.fireChangeEvent)
+
+        log.set({ hidden: true })
+        const el = cy.$$('<div />')
+
+        cy.spy(el, 'filter')
+        log.set({ $el: el })
+        expect(el.filter).not.to.have.been.called
+      })
+    })
+
     describe('when protocol is disabled', function () {
       it('does not truncate message value', function () {
         this.state.withArgs('isProtocolEnabled').returns(false)

--- a/packages/driver/src/cypress/log.ts
+++ b/packages/driver/src/cypress/log.ts
@@ -464,11 +464,11 @@ export class Log {
     return err.stack || err.message
   }
 
-  setElAttrs () {
+  setElAttrs (): Log {
     const $el = this.get('$el')
 
     if (!$el) {
-      return
+      return this
     }
 
     if (_.isElement($el)) {
@@ -488,7 +488,7 @@ export class Log {
     return this.set({
       highlightAttr: HIGHLIGHT_ATTR,
       numElements: $el.length,
-      visible: this.get('visible') ?? $el.length === $el.filter(':visible').length,
+      visible: this.get('hidden') ? undefined : this.get('visible') ?? $el.length === $el.filter(':visible').length,
     })
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
When `log:false`, we don't need to determine whether any matched elements are visible. Because the log entry won't be visible.

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips `:visible` filtering for hidden (`log: false`) command logs and makes `setElAttrs` chainable, with tests and changelog updates.
> 
> - **Driver (logging)**
>   - Optimize `Log.setElAttrs()` to skip `:visible` filtering when `hidden` is set, avoiding costly DOM checks.
>   - Change `setElAttrs` to return the `Log` instance for chaining.
> - **Tests**
>   - Add spec in `packages/driver/cypress/e2e/cypress/log.cy.js` asserting no `.filter(':visible')` when log is hidden.
> - **Changelog**
>   - Update `cli/CHANGELOG.md` with performance note about skipping visibility assessments for hidden command logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f45427cc87124ca681230880e698adce6a3c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->