### PR TITLE
fix: make sure angular project configs can resolve correctly on windows

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -121,7 +121,7 @@ commands:
           name: Set environment variable to determine whether or not to persist artifacts
           command: |
             echo "Setting SHOULD_PERSIST_ARTIFACTS variable"
-            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "feat/support_next_16" ]]; then
+            echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "fix/angular_dep_resolution_windows" ]]; then
                 export SHOULD_PERSIST_ARTIFACTS=true
             fi' >> "$BASH_ENV"
   # You must run `setup_should_persist_artifacts` command and be using bash before running this command

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -4,7 +4,7 @@ linux-x64:
       - equal: [ develop, << pipeline.git.branch >> ]
       # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
       - equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
-      - equal: [ 'feat/support_next_16', << pipeline.git.branch >> ]
+      - equal: [ 'fix/angular_dep_resolution_windows', << pipeline.git.branch >> ]
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>

--- a/npm/webpack-dev-server/src/helpers/angularHandler.ts
+++ b/npm/webpack-dev-server/src/helpers/angularHandler.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra'
-import { tmpdir } from 'os'
+import { tmpdir, platform } from 'os'
 import * as path from 'path'
 import type { Configuration, RuleSetRule } from 'webpack'
 import type { PresetHandlerResult, WebpackDevServerConfig } from '../devServer'
@@ -183,11 +183,14 @@ export async function getAngularCliModules (projectRoot: string) {
     { logging },
   ] = await Promise.all(angularCLiModules.map(async (dep) => {
     try {
-      const depPath = require.resolve(dep, { paths: [projectRoot] })
+      let depPath = require.resolve(dep, { paths: [projectRoot] })
       // NOTE: @cypress/webpack-dev-server is a CJS package, but we need to import some ESM files and absolute imports.
       // since import statements in TypeScript will get transpiled down to CommonJS require statements, we want to use tsx to leverage
       // an ESM style import here, which supports CommonJS and ESM.
       const { tsImport } = require('tsx/esm/api')
+
+      // NOTE: on Windows, fully qualified paths (ex: C:\Users\username\project\blah) need to be prefixed with `file://` to be properly resolved.
+      depPath = platform() === 'win32' ? `file://${toPosix(depPath)}` : depPath
 
       const module = await tsImport(depPath, __filename)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Fixes an issue discovered with CI failing on `develop` windows jobs https://app.circleci.com/pipelines/github/cypress-io/cypress/77248/workflows/ba670fbd-93f9-4971-9c37-01426358b872/jobs/3309262/parallel-runs/4?filterBy=FAILED that was introduced in #32878. Basically, when looking up dependencies by absolute path on windows, we need to provide the `file://` prefix similar to how we do within the ProjectConfigIpc.

This is currently incredibly difficult to test with a unit test because we cannot mock require.resolve natively within the vitest context, but we are covered in our cy-in-cy tests in the windows CI job (we just need to pay better attention to failures, myself included).

Additionally, this is marked as a fix but ONLY for `@cypress/webpack-dev-server` because we haven't released the binary since #32878 merged, hence the lack of a change entry

When discovery  

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Windows-specific path handling for Angular module imports in the webpack dev server and updates CircleCI filters to include the new branch.
> 
> - **Webpack Dev Server (Angular)**:
>   - Prefix `file://` for resolved Angular CLI module paths on Windows in `npm/webpack-dev-server/src/helpers/angularHandler.ts` (uses `platform()` and `toPosix`).
> - **CI**:
>   - Update CircleCI branch filters and artifact persistence to use `fix/angular_dep_resolution_windows` in `.circleci/src/pipeline/@pipeline.yml` and `workflows/@main.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1c344c138545e28980faf646c8087dc0fbb208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->