### PR TITLE
chore: Check branch for latest chrome versions, not current chrome versions

### DIFF
--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -36,8 +36,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
-      - name: install dependencies
-        run: CI=true yarn
+      - name: Install yaml dependency
+        run: npm install yaml@2.8.0
       - name: Check for new Chrome versions
         id: get-versions
         uses: actions/github-script@v7

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Determine name of new branch and if it already exists
         id: check-branch
         env:
-          BRANCH_NAME: update-chrome-stable-from-${{ steps.get-versions.outputs.current_stable_version }}-beta-from-${{ steps.get-versions.outputs.current_beta_version }}
+          BRANCH_NAME: update-chrome-stable-from-${{ steps.get-versions.outputs.latest_stable_version }}-beta-from-${{ steps.get-versions.outputs.latest_beta_version }}
         run: |
           echo "branch_name=${{ env.BRANCH_NAME }}" >> $GITHUB_OUTPUT
           echo "branch_exists=$(git show-ref --verify --quiet refs/remotes/origin/${{ env.BRANCH_NAME }} && echo 'true')" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update-browser-versions:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     env:
       CYPRESS_BOT_APP_ID: ${{ secrets.CYPRESS_BOT_APP_ID }}
       BASE_BRANCH: develop

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -36,8 +36,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
-      - name: Install yaml dependency
-        run: npm install yaml@2.8.0
+      - name: install dependencies
+        run: CI=true yarn
       - name: Check for new Chrome versions
         id: get-versions
         uses: actions/github-script@v7

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -129,5 +129,4 @@ jobs:
               branchName: '${{ steps.check-branch.outputs.branch_name }}',
               description: '${{ steps.get-versions.outputs.description }}',
               body: 'This PR was auto-generated to update the version(s) of Chrome for driver tests',
-              addToProjectBoard: true,
             })

--- a/scripts/github-actions/update-browser-versions.js
+++ b/scripts/github-actions/update-browser-versions.js
@@ -1,4 +1,3 @@
-const https = require('https')
 const fs = require('fs')
 const yaml = require('yaml')
 const path = require('path')
@@ -10,33 +9,16 @@ const CHROME_BETA_KEY = 'chrome-beta-version'
 const CIRCLECI_WORKFLOWS_FILEPATH = path.join(__dirname, '../../.circleci/src/pipeline/@pipeline.yml')
 
 // https://developer.chrome.com/docs/versionhistory/reference/#platform-identifiers
-const getLatestVersionData = ({ channel, currentVersion }) => {
-  const options = {
-    hostname: 'versionhistory.googleapis.com',
-    port: 443,
-    path: `/v1/chrome/platforms/linux/channels/${channel}/versions?filter=version>${currentVersion}&order_by=version%20desc`,
-    method: 'GET',
+const getLatestVersionData = async ({ channel, currentVersion }) => {
+  const url = `https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/${channel}/versions?filter=version>${currentVersion}&order_by=version%20desc`
+
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`)
   }
 
-  return new Promise((resolve, reject) => {
-    const req = https.request(options, (res) => {
-      let response = ''
-
-      res.on('data', (d) => {
-        response += d.toString()
-      })
-
-      res.on('end', () => {
-        resolve(response)
-      })
-    })
-
-    req.on('error', (err) => {
-      reject(err)
-    })
-
-    req.end()
-  })
+  return await response.text()
 }
 
 const getVersions = async ({ core }) => {

--- a/scripts/unit/github-actions/update-browser-version-spec.js
+++ b/scripts/unit/github-actions/update-browser-version-spec.js
@@ -1,7 +1,6 @@
 const chai = require('chai')
 const fs = require('fs')
 const mockfs = require('mock-fs')
-const nock = require('nock')
 const sinon = require('sinon')
 
 chai.use(require('sinon-chai'))
@@ -22,10 +21,10 @@ const coreStub = () => {
   }
 }
 
+let mockResponses = {}
+
 const stubChromeVersionResult = (channel, result) => {
-  nock('https://versionhistory.googleapis.com')
-  .get((uri) => uri.includes(channel))
-  .reply(200, result)
+  mockResponses[channel] = result
 }
 
 const stubRepoVersions = ({ betaVersion, stableVersion }) => {
@@ -35,6 +34,13 @@ const stubRepoVersions = ({ betaVersion, stableVersion }) => {
 }
 
 const stubChromeVersions = ({ betaVersion, stableVersion }) => {
+  mockResponses = {}
+
+  if (!global.originalFetch) {
+    global.originalFetch = global.fetch
+  }
+
+  // Set up mock responses
   stubChromeVersionResult('stable',
     {
       versions: stableVersion ? [
@@ -56,13 +62,45 @@ const stubChromeVersions = ({ betaVersion, stableVersion }) => {
       ] : [],
       nextPageToken: '',
     })
+
+  // Mock fetch to return the appropriate response based on URL
+  global.fetch = sinon.stub().callsFake((url) => {
+    if (typeof url === 'string') {
+      if (url.includes('/channels/stable/')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(mockResponses.stable || { versions: [], nextPageToken: '' })),
+        })
+      }
+
+      if (url.includes('/channels/beta/')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(mockResponses.beta || { versions: [], nextPageToken: '' })),
+        })
+      }
+    }
+
+    // For other URLs, return error
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    })
+  })
 }
 
 describe('update browser version github action', () => {
   beforeEach(() => {
     sinon.restore()
     mockfs.restore()
-    nock.cleanAll()
+    mockResponses = {}
+    if (global.originalFetch) {
+      global.fetch = global.originalFetch
+      delete global.originalFetch
+    }
   })
 
   context('.getVersions', () => {

--- a/scripts/unit/github-actions/update-browser-version-spec.js
+++ b/scripts/unit/github-actions/update-browser-version-spec.js
@@ -59,6 +59,9 @@ describe('update browser version github action', () => {
   beforeEach(() => {
     sinon.restore()
     mockfs.restore()
+  })
+
+  afterEach(() => {
     if (global.originalFetch) {
       global.fetch = global.originalFetch
       delete global.originalFetch

--- a/scripts/unit/github-actions/update-browser-version-spec.js
+++ b/scripts/unit/github-actions/update-browser-version-spec.js
@@ -21,12 +21,6 @@ const coreStub = () => {
   }
 }
 
-let mockResponses = {}
-
-const stubChromeVersionResult = (channel, result) => {
-  mockResponses[channel] = result
-}
-
 const stubRepoVersions = ({ betaVersion, stableVersion }) => {
   mockfs({
     [CIRCLECI_WORKFLOWS_FILEPATH]: `chrome-stable-version: &chrome-stable-version "${stableVersion}"\nchrome-beta-version: &chrome-beta-version "${betaVersion}"\n`,
@@ -34,61 +28,30 @@ const stubRepoVersions = ({ betaVersion, stableVersion }) => {
 }
 
 const stubChromeVersions = ({ betaVersion, stableVersion }) => {
-  mockResponses = {}
-
   if (!global.originalFetch) {
     global.originalFetch = global.fetch
   }
 
-  // Set up mock responses
-  stubChromeVersionResult('stable',
-    {
-      versions: stableVersion ? [
-        {
-          name: `chrome/platforms/linux/channels/stable/versions/${stableVersion}`,
-          version: stableVersion,
-        },
-      ] : [],
-      nextPageToken: '',
-    })
+  const stableResponse = {
+    versions: stableVersion ? [{ name: `chrome/platforms/linux/channels/stable/versions/${stableVersion}`, version: stableVersion }] : [],
+    nextPageToken: '',
+  }
 
-  stubChromeVersionResult('beta',
-    {
-      versions: betaVersion ? [
-        {
-          name: `chrome/platforms/linux/channels/beta/versions/${betaVersion}`,
-          version: betaVersion,
-        },
-      ] : [],
-      nextPageToken: '',
-    })
+  const betaResponse = {
+    versions: betaVersion ? [{ name: `chrome/platforms/linux/channels/beta/versions/${betaVersion}`, version: betaVersion }] : [],
+    nextPageToken: '',
+  }
 
-  // Mock fetch to return the appropriate response based on URL
   global.fetch = sinon.stub().callsFake((url) => {
-    if (typeof url === 'string') {
-      if (url.includes('/channels/stable/')) {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(JSON.stringify(mockResponses.stable || { versions: [], nextPageToken: '' })),
-        })
-      }
-
-      if (url.includes('/channels/beta/')) {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(JSON.stringify(mockResponses.beta || { versions: [], nextPageToken: '' })),
-        })
-      }
+    if (url.includes('/channels/stable/')) {
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(stableResponse)) })
     }
 
-    // For other URLs, return error
-    return Promise.resolve({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve(''),
-    })
+    if (url.includes('/channels/beta/')) {
+      return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(betaResponse)) })
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`)
   })
 }
 
@@ -96,7 +59,6 @@ describe('update browser version github action', () => {
   beforeEach(() => {
     sinon.restore()
     mockfs.restore()
-    mockResponses = {}
     if (global.originalFetch) {
       global.fetch = global.originalFetch
       delete global.originalFetch


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

We're checking for latest Chrome version, but when we look for a branch that exists for that version, we're looking for a branch for the CURRENT Chrome version - so it would never trigger a PR. 

I'm a bit confused as to what changed recently that broke this or how this ever worked....

Running this action [here](https://github.com/cypress-io/cypress/actions/runs/19515549729/job/55866242696) created the [Pull Request ](https://github.com/cypress-io/cypress/pull/32977)(failed for another reason that I resolved, but I couldn't delete the PR to rerun the action's behaviors again). 

<img width="1034" height="783" alt="Screenshot 2025-11-19 at 2 50 57 PM" src="https://github.com/user-attachments/assets/7dfe2a6a-4dd5-44ec-84c4-0a4814c907d8" />


### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Workflow now branches/PRs against the latest Chrome versions and switches version fetching to `fetch` with updated tests.
> 
> - **CI/Workflow (`.github/workflows/update-browser-versions.yml`)**:
>   - Use `latest_*_version` outputs for `BRANCH_NAME` to check/create branches against latest Chrome versions.
>   - Grant `pull-requests: write` permission.
>   - Remove `addToProjectBoard` option when creating PRs.
> - **Scripts (`scripts/github-actions/update-browser-versions.js`)**:
>   - Replace manual `https` request with async `fetch` in `getLatestVersionData`; add `response.ok` check.
> - **Tests (`scripts/unit/github-actions/update-browser-version-spec.js`)**:
>   - Remove `nock`; stub `global.fetch` with `sinon` and restore after tests.
>   - Adjust stubs to return stable/beta version payloads; keep assertions for outputs and descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a2b39a8816b35fe938c1acef7f8bbef8026935c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->