### PR TITLE
fix: reset:server:state after test run

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -2780,10 +2780,22 @@ describe('src/cy/commands/navigation', () => {
   })
 
   context('resets state', () => {
-    it('resets the server state', () => {
+    it('resets the server state before test runs', () => {
       cy.stub(Cypress, 'backend').log(false).callThrough()
 
       Cypress.emitThen('test:before:run:async', {
+        id: 'r1',
+        currentRetry: 1,
+      })
+      .then(() => {
+        expect(Cypress.backend).to.be.calledWith('reset:server:state')
+      })
+    })
+
+    it('resets the server state after test completes', () => {
+      cy.stub(Cypress, 'backend').log(false).callThrough()
+
+      Cypress.emitThen('test:after:run:async', {
         id: 'r1',
         currentRetry: 1,
       })

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -665,6 +665,15 @@ export default (Commands, Cypress, cy, state, config) => {
     return Cypress.backend('reset:server:state')
   })
 
+  // Clear ServiceWorkerManager state immediately after test completion
+  // to prevent memory accumulation that can cause browser crashes
+  // This is in addition to the cleanup in test:before:run:async
+  Cypress.on('test:after:run:async', () => {
+    // Clear service worker manager state to prevent memory leaks
+    // This helps prevent crashes that occur during cleanup/teardown
+    return Cypress.backend('reset:server:state')
+  })
+
   Cypress.on('test:before:run', reset)
 
   Cypress.on('stability:changed', async (bool, event) => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Also reset `reset:server:state` on `test:after:run:async` in addition to `test:before:run:async`, with e2e tests covering both.
> 
> - **Driver (navigation setup)**
>   - Add `Cypress.on('test:after:run:async', ...)` to call `Cypress.backend('reset:server:state')` to clear state post-test (complements existing pre-test reset).
> - **Tests**
>   - Update and add assertions in `cypress/e2e/commands/navigation.cy.js` to verify server state reset runs both before and after tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 510e00c34f446f1ad192e6e8f69bca2cdc3e9451. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->