### PR TITLE
fix: inject HTML before <script> if top-level

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ _Released 12/2/2025 (PENDING)_
 
 - Improved performance when viewing command snapshots in the Command Log. Element highlighting is now significantly faster, especially when highlighting multiple elements or complex pages. This is achieved by reducing redundant style calculations and batching DOM operations to minimize browser reflows. Addressed in [#32951](https://github.com/cypress-io/cypress/pull/32951).
 
+**Bugfixes:**
+
+- Fixed an issue where a <script> element before <html> was not injected properly. Addressed in [#32982](https://github.com/cypress-io/cypress/pull/32982).
+
 ## 15.7.0
 
 _Released 11/19/2025_

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -98,8 +98,8 @@ const isScriptTopLevel = (scriptMatch, htmlMatch) => {
   return scriptIndex < htmlIndex
 }
 
-export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
-  const htmlToInject = await Promise.resolve(getHtmlToInject(opts))
+export async function html (html: string, opts: SecurityOpts & InjectionOpts, mockedHtmlToInject: string = "") {
+  const htmlToInject = mockedHtmlToInject || await Promise.resolve(getHtmlToInject(opts))
 
   // strip clickjacking and framebusting
   // from the HTML if we've been told to

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -79,23 +79,23 @@ const insertAfter = (originalString, match, stringToInsert) => {
   return `${originalString.slice(0, index)} ${stringToInsert}${originalString.slice(index)}`
 }
 
-const isScriptTopLevel = (scriptMatch, headMatch) => {
+const isScriptTopLevel = (scriptMatch, htmlMatch) => {
   if (!scriptMatch) {
     return false
   }
 
-  if (!headMatch) {
+  if (!htmlMatch) {
     return true
   }
 
   const scriptIndex = scriptMatch.index
-  const headIndex = headMatch.index
+  const htmlIndex = htmlMatch.index
 
-  if (scriptIndex === undefined || headIndex === undefined) {
+  if (scriptIndex === undefined || htmlIndex === undefined) {
     return false
   }
 
-  return scriptIndex < headIndex
+  return scriptIndex < htmlIndex
 }
 
 export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
@@ -114,11 +114,13 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
   // TODO: move this into regex-rewriting and have ast-rewriting handle this in its own way
 
   const scriptMatch = html.match(scriptRe)
-  const headMatch = html.match(headRe)
+  const htmlMatch = html.match(htmlRe)
 
-  if (isScriptTopLevel(scriptMatch, headMatch)) {
+  if (isScriptTopLevel(scriptMatch, htmlMatch)) {
     return insertBefore(html, scriptMatch, htmlToInject)
   }
+
+  const headMatch = html.match(headRe)
 
   if (headMatch) {
     return insertAfter(html, headMatch, htmlToInject)
@@ -129,8 +131,6 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
   if (bodyMatch) {
     return insertBefore(html, bodyMatch, `<head> ${htmlToInject} </head>`)
   }
-
-  const htmlMatch = html.match(htmlRe)
 
   if (htmlMatch) {
     return insertAfter(html, htmlMatch, `<head> ${htmlToInject} </head>`)

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -23,6 +23,7 @@ export type InjectionOpts = {
 }
 
 const doctypeRe = /<\!doctype.*?>/i
+const scriptRe = /<script.*?>/i
 const headRe = /<head(?!er).*?>/i
 const bodyRe = /<body.*?>/i
 const htmlRe = /<html.*?>/i
@@ -78,6 +79,25 @@ const insertAfter = (originalString, match, stringToInsert) => {
   return `${originalString.slice(0, index)} ${stringToInsert}${originalString.slice(index)}`
 }
 
+const isScriptTopLevel = (scriptMatch, headMatch) => {
+  if (!scriptMatch) {
+    return false
+  }
+
+  if (!headMatch) {
+    return true
+  }
+
+  const scriptIndex = scriptMatch.index
+  const headIndex = headMatch.index
+
+  if (scriptIndex === undefined || headIndex === undefined) {
+    return false
+  }
+
+  return scriptIndex < headIndex
+}
+
 export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
   const htmlToInject = await Promise.resolve(getHtmlToInject(opts))
 
@@ -93,7 +113,12 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
 
   // TODO: move this into regex-rewriting and have ast-rewriting handle this in its own way
 
+  const scriptMatch = html.match(scriptRe)
   const headMatch = html.match(headRe)
+
+  if (isScriptTopLevel(scriptMatch, headMatch)) {
+    return insertBefore(html, scriptMatch, htmlToInject)
+  }
 
   if (headMatch) {
     return insertAfter(html, headMatch, htmlToInject)

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -98,7 +98,7 @@ const isScriptTopLevel = (scriptMatch, htmlMatch) => {
   return scriptIndex < htmlIndex
 }
 
-export async function html (html: string, opts: SecurityOpts & InjectionOpts, mockedHtmlToInject: string = "") {
+export async function html (html: string, opts: SecurityOpts & InjectionOpts, mockedHtmlToInject: string = '') {
   const htmlToInject = mockedHtmlToInject || await Promise.resolve(getHtmlToInject(opts))
 
   // strip clickjacking and framebusting

--- a/packages/proxy/test/unit/http/util/rewriter.spec.ts
+++ b/packages/proxy/test/unit/http/util/rewriter.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import _ from 'lodash'
 import { html } from '../../../../lib/http/util/rewriter'
 
 const injected = `<script>(() => { TEST })()</script>`
@@ -8,37 +7,37 @@ describe('http/util/rewriter', () => {
   describe('.top-level tests', () => {
     it('just a script tag', async () => {
       expect(await html('<script>Original HTML</script>', {} as any, injected))
-        .toEqual(`${injected} <script>Original HTML</script>`)
+      .toEqual(`${injected} <script>Original HTML</script>`)
     })
 
     it('script tag before a html tag', async () => {
       expect(await html('<script>Original Script</script><html>Test HTML</html>', {} as any, injected))
-        .toEqual(`${injected} <script>Original Script</script><html>Test HTML</html>`)
+      .toEqual(`${injected} <script>Original Script</script><html>Test HTML</html>`)
     })
 
     it('script tag after a html tag', async () => {
       expect(await html('<html>Test HTML</html><script>Original Script</script>', {} as any, injected))
-        .toEqual(`<html> <head> ${injected} </head>Test HTML</html><script>Original Script</script>`)
+      .toEqual(`<html> <head> ${injected} </head>Test HTML</html><script>Original Script</script>`)
     })
 
     it('script tag inside head tag with no body tag', async () => {
       expect(await html('<html><head><script>Original Script</script></head></html>', {} as any, injected))
-        .toEqual(`<html><head> ${injected}<script>Original Script</script></head></html>`)
+      .toEqual(`<html><head> ${injected}<script>Original Script</script></head></html>`)
     })
 
     it('script tag inside head tag with a body tag', async () => {
       expect(await html('<html><head><script>Original Script</script></head><body>Example Body</body></html>', {} as any, injected))
-        .toEqual(`<html><head> ${injected}<script>Original Script</script></head><body>Example Body</body></html>`)
+      .toEqual(`<html><head> ${injected}<script>Original Script</script></head><body>Example Body</body></html>`)
     })
 
     it('script tag inside body tag with no head tag', async () => {
       expect(await html('<html><body><script>Original Script</script></body></html>', {} as any, injected))
-        .toEqual(`<html><head> ${injected} </head> <body><script>Original Script</script></body></html>`)
+      .toEqual(`<html><head> ${injected} </head> <body><script>Original Script</script></body></html>`)
     })
 
     it('script tag inside body tag with a head tag', async () => {
       expect(await html('<html><head>Original Head</head><body><script>Original Script</script></body></html>', {} as any, injected))
-        .toEqual(`<html><head> ${injected}Original Head</head><body><script>Original Script</script></body></html>`)
+      .toEqual(`<html><head> ${injected}Original Head</head><body><script>Original Script</script></body></html>`)
     })
   })
 })

--- a/packages/proxy/test/unit/http/util/rewriter.spec.ts
+++ b/packages/proxy/test/unit/http/util/rewriter.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import _ from 'lodash'
+import { html } from '../../../../lib/http/util/rewriter'
+
+const injected = `<script>(() => { TEST })()</script>`
+
+describe('http/util/rewriter', () => {
+  describe('.top-level tests', () => {
+    it('just a script tag', async () => {
+      expect(await html('<script>Original HTML</script>', {} as any, injected))
+        .toEqual(`${injected} <script>Original HTML</script>`)
+    })
+
+    it('script tag before a html tag', async () => {
+      expect(await html('<script>Original Script</script><html>Test HTML</html>', {} as any, injected))
+        .toEqual(`${injected} <script>Original Script</script><html>Test HTML</html>`)
+    })
+
+    it('script tag after a html tag', async () => {
+      expect(await html('<html>Test HTML</html><script>Original Script</script>', {} as any, injected))
+        .toEqual(`<html> <head> ${injected} </head>Test HTML</html><script>Original Script</script>`)
+    })
+
+    it('script tag inside head tag with no body tag', async () => {
+      expect(await html('<html><head><script>Original Script</script></head></html>', {} as any, injected))
+        .toEqual(`<html><head> ${injected}<script>Original Script</script></head></html>`)
+    })
+
+    it('script tag inside head tag with a body tag', async () => {
+      expect(await html('<html><head><script>Original Script</script></head><body>Example Body</body></html>', {} as any, injected))
+        .toEqual(`<html><head> ${injected}<script>Original Script</script></head><body>Example Body</body></html>`)
+    })
+
+    it('script tag inside body tag with no head tag', async () => {
+      expect(await html('<html><body><script>Original Script</script></body></html>', {} as any, injected))
+        .toEqual(`<html><head> ${injected} </head> <body><script>Original Script</script></body></html>`)
+    })
+
+    it('script tag inside body tag with a head tag', async () => {
+      expect(await html('<html><head>Original Head</head><body><script>Original Script</script></body></html>', {} as any, injected))
+        .toEqual(`<html><head> ${injected}Original Head</head><body><script>Original Script</script></body></html>`)
+    })
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Injects the Cypress payload before a top‑level `<script>` appearing before `<html>`, adds unit tests for edge cases, and updates the changelog.
> 
> - **Proxy Rewriter (`packages/proxy/lib/http/util/rewriter.ts`)**
>   - Detects top‑level `<script>` before `<html>` and injects payload before it (`scriptRe`, `isScriptTopLevel`).
>   - Updates `html()` to accept optional `mockedHtmlToInject` for testing and adjusts injection order.
> - **Tests**
>   - Adds unit tests in `packages/proxy/test/unit/http/util/rewriter.spec.ts` covering top‑level and nested `<script>` scenarios.
> - **Changelog**
>   - Adds bugfix entry noting improper injection when a `<script>` appears before `<html>` in `cli/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51eee9443077bf883b05dd9319ac90bdc34e8356. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->