### PR TITLE
chore: correct troubleshooting links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -5,14 +5,14 @@ body:
     attributes:
       value: |
         ## If you are a customer of Cypress Cloud please utilize our [Support Portal](https://www.cypress.io/support/) for our fastest support!
-        
-        ### Have a question? 👉 [Ask in chat](https://on.cypress.io/chat) or [start a new discussion](https://github.com/cypress-io/cypress/discussions).  
+
+        ### Have a question? 👉 [Ask in chat](https://on.cypress.io/chat) or [start a new discussion](https://github.com/cypress-io/cypress/discussions).
         Issues in the Cypress repo are reserved for bugs and feature requests only.  Questions on how to use Cypress will be closed.
   - type: textarea
     id: current-behavior
     attributes:
       label: Current behavior
-      description: Please provide a description including screenshots, stack traces, etc. [Troubleshooting tips](https://on.cypress.io/troubleshooting).
+      description: Please provide a description including screenshots, stack traces, etc. [Troubleshooting tips](https://docs.cypress.io/app/references/troubleshooting).
       placeholder: Currently...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3-install-issue.yml
+++ b/.github/ISSUE_TEMPLATE/3-install-issue.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         ## If you are a customer of Cypress Cloud please utilize our [Support Portal](https://www.cypress.io/support/) for our fastest support!
-        
+
         ### Have a question? 👉 [Ask in chat](https://on.cypress.io/chat) or [start a new discussion](https://github.com/cypress-io/cypress/discussions).
 
         If you're behind a corporate proxy, make sure to [configure it properly](https://on.cypress.io/proxy-configuration) before install.
@@ -14,7 +14,7 @@ body:
     id: current-behavior
     attributes:
       label: Current behavior
-      description: Please provide a description including screenshots, stack traces, DEBUG logs, etc. [Troubleshooting tips](https://on.cypress.io/troubleshooting)
+      description: Please provide a description including screenshots, stack traces, DEBUG logs, etc. [Troubleshooting tips](https://docs.cypress.io/app/references/troubleshooting)
       placeholder: When I try to download Cypress...
     validations:
       required: true
@@ -22,7 +22,7 @@ body:
     id: debug-logs
     attributes:
       label: Debug logs
-      description: Include DEBUG logs setting [`DEBUG=cypress:*`](https://on.cypress.io/troubleshooting#Print-DEBUG-logs/). Include npm/yarn logs if applicable.
+      description: Include DEBUG logs setting [`DEBUG=cypress:*`](https://docs.cypress.io/app/references/troubleshooting#Print-DEBUG-logs/). Include npm/yarn logs if applicable.
       placeholder: Debug logs
       render: Text
   - type: input

--- a/.github/ISSUE_TEMPLATE/5-cy-prompt-issue.yml
+++ b/.github/ISSUE_TEMPLATE/5-cy-prompt-issue.yml
@@ -11,7 +11,7 @@ body:
     id: current-behavior
     attributes:
       label: Current behavior
-      description: Please provide a description including screenshots, stack traces, etc. [Troubleshooting tips](https://on.cypress.io/troubleshooting).
+      description: Please provide a description including screenshots, stack traces, etc. [Troubleshooting tips](https://docs.cypress.io/app/references/troubleshooting).
       placeholder: Currently...
     validations:
       required: true


### PR DESCRIPTION
- relates to issue https://github.com/cypress-io/cypress/issues/32393

### Additional details

GitHub issue templates in [.github/ISSUE_TEMPLATE](https://github.com/cypress-io/cypress/tree/develop/.github/ISSUE_TEMPLATE) link to https://on.cypress.io/troubleshooting which is redirecting to the wrong URL (https://docs.cypress.io/ui-coverage/troubleshooting).

The affected templates are:
- [1-bug-report.yml](https://github.com/cypress-io/cypress/blob/develop/.github/ISSUE_TEMPLATE/1-bug-report.yml)
- [3-install-issue.yml](https://github.com/cypress-io/cypress/blob/develop/.github/ISSUE_TEMPLATE/3-install-issue.yml)
- [5-cy-prompt-issue.yml](https://github.com/cypress-io/cypress/blob/develop/.github/ISSUE_TEMPLATE/5-cy-prompt-issue.yml)

The links are updated to use the https://docs.cypress.io/app/references/troubleshooting URL for Troubleshooting tips.

### Steps to test

In the following forms, confirm that the troubleshooting information contains relevant information and that it is not showing the irrelevant page https://docs.cypress.io/ui-coverage/troubleshooting

Browse to https://github.com/cypress-io/cypress/issues
Click "New issue"
Select "Bug report"
Click on "Troubleshooting tips"

Browse to https://github.com/cypress-io/cypress/issues
Click "New issue"
Select "Issue during install"
Click on "Troubleshooting tips"
Click on "DEBUG=cypress:*"

Browse to https://github.com/cypress-io/cypress/issues
Click "New issue"
Select "cy.prompt Issue"
Click on "Troubleshooting tips"

### How has the user experience changed?

Users submitting issues will have relevant troubleshooting tips presented to them instead of seeing the irrelevant page https://docs.cypress.io/ui-coverage/troubleshooting

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates GitHub issue templates to point troubleshooting links (including DEBUG logs) to docs.cypress.io references instead of on.cypress.io.
> 
> - **Issue templates**:
>   - `/.github/ISSUE_TEMPLATE/1-bug-report.yml`
>     - Update troubleshooting link to `https://docs.cypress.io/app/references/troubleshooting`.
>   - `/.github/ISSUE_TEMPLATE/3-install-issue.yml`
>     - Update troubleshooting link and DEBUG logs anchor to docs URLs.
>   - `/.github/ISSUE_TEMPLATE/5-cy-prompt-issue.yml`
>     - Update troubleshooting link to `https://docs.cypress.io/app/references/troubleshooting`.
>   - Minor whitespace/formatting cleanup in markdown sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f48df1ca7ae0fd98d1ba64c408637ede8985fd40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->