### PR TITLE
docs: use Visual Studio Build Tools 2022 for Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ If you do not disable these restrictions for the affected Ubuntu versions, then 
 
 Follow the instructions in [Using Python on Windows](https://docs.python.org/3/using/windows.html) to install the current [version of Python](https://www.python.org/downloads/) (`3.14`).
 
-Install the [Visual Studio Community 2022](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community) edition, selecting the `Desktop development with C++` workload.
+Install [Visual Studio 2022 Build Tools](https://aka.ms/vs/17/release/vs_buildtools.exe), selecting the `Desktop development with C++` workload.
 
 Refer to the `node-gyp` [Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) documentation section for a description of alternate ways of providing the `node-gyp` execution environment and for troubleshooting information.
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/33018

### Additional details

- Cypress dependencies that use platform-dependent rebuilds are not compatible with Visual Studio Community 2026. See description and error logs in https://github.com/cypress-io/cypress/issues/33018.

- [CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows) currently instructs to install the "Visual Studio Community 2022 edition" using the URL https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community. This link however now downloads "Visual Studio Community 2026 edition".

- The [Visual Studio download older versions](https://visualstudio.microsoft.com/vs/older-downloads/) page does not include "Visual Studio Community 2022 edition" and states:
  > Older versions require an active Visual Studio Subscription.

- [Visual Studio 2022 - Evergreen bootstrappers](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#evergreen-bootstrappers) lists alternate download URLs, including "Visual Studio 2022 Build Tools" from https://aka.ms/vs/17/release/vs_buildtools.exe supported until Jan 2032. The `msi` version of Node.js for Windows optionally installs the build tools for exactly this purpose.

[CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows) is changed to recommend [Visual Studio 2022 Build Tools](https://aka.ms/vs/17/release/vs_buildtools.exe) instead of "Visual Studio Community 2022 edition".

### Steps to test

On Windows 11 25H2:

Follow the instructions in [CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows) to install Python.

Uninstall any previous installations of Visual Studio. Install [Visual Studio 2022 Build Tools](https://aka.ms/vs/17/release/vs_buildtools.exe), select "Desktop development with C++" workload. Restart computer.

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
nvm install 22.19.0
nvm use 22.19.0
npm install yarn@latest -g
git clean -xfd # if repeating
yarn
```

Confirm that build is successful, particularly check that there are no errors in the steps:

```text
[5/6] Building fresh packages...
[6/6] Cleaning modules...
```

### How has the user experience changed?

Contributor instructions only. Contributors using Microsoft Windows should be able to set up a working environment following the instructions in [CONTRIBUTING > Requirements > Windows](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#windows) in order to build Cypress from source.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Windows setup in CONTRIBUTING to use Visual Studio 2022 Build Tools (Desktop C++ workload) instead of Visual Studio Community 2022.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e3a58c091625f3a984a5f424d8e7251b8f7e22c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->