### PR TITLE
chore: Replace Bluebird.resolve/reject with native Promise.resolve/reject

### DIFF
--- a/cli/lib/tasks/download.ts
+++ b/cli/lib/tasks/download.ts
@@ -202,7 +202,7 @@ const verifyDownloadedFile = async (filename: string, expectedSize?: number, exp
 // {filename: ..., downloaded: true}
 const downloadFromUrl = ({ url, downloadDestination, progress, ca, version, redirectTTL = defaultMaxRedirects }: any): any => {
   if (redirectTTL <= 0) {
-    return Bluebird.reject(new Error(
+    return Promise.reject(new Error(
       stripIndent`
           Failed downloading the Cypress binary.
           There were too many redirects. The default allowance is ${defaultMaxRedirects}.

--- a/cli/lib/util.ts
+++ b/cli/lib/util.ts
@@ -409,7 +409,7 @@ const util = {
   },
 
   isExecutableAsync (filePath: string): any {
-    return Bluebird.resolve(executable(filePath))
+    return Promise.resolve(executable(filePath))
   },
 
   isLinux,

--- a/packages/app/cypress/e2e/runner/reporter-ct-generator.ts
+++ b/packages/app/cypress/e2e/runner/reporter-ct-generator.ts
@@ -631,7 +631,7 @@ export const generateCtUncaughtErrorTests = (server: 'Webpack' | 'Vite', configF
 
     verify('spec Bluebird unhandled rejection', {
       uncaught: true,
-      column: [21, 22],
+      column: [19, 20, 21],
       originalMessage: 'Unhandled promise rejection from the spec',
       message: [
         'The following error originated from your application code',
@@ -642,7 +642,7 @@ export const generateCtUncaughtErrorTests = (server: 'Webpack' | 'Vite', configF
 
     verify('spec Bluebird unhandled rejection with done', {
       uncaught: true,
-      column: [21, 22],
+      column: [19, 20, 21],
       originalMessage: 'Unhandled promise rejection from the spec',
       message: [
         'The following error originated from your application code',

--- a/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter.errors.cy.ts
@@ -204,7 +204,7 @@ describe('errors ui', {
 
     verify('spec Bluebird unhandled rejection', {
       uncaught: true,
-      column: 21,
+      column: 20,
       originalMessage: 'Unhandled promise rejection from the spec',
       message: [
         'The following error originated from your test code',
@@ -214,7 +214,7 @@ describe('errors ui', {
 
     verify('spec Bluebird unhandled rejection with done', {
       uncaught: true,
-      column: 21,
+      column: 20,
       originalMessage: 'Unhandled promise rejection from the spec',
       message: [
         'The following error originated from your test code',

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -582,7 +582,7 @@ export class EventManager {
 
     Cypress.on('collect:run:state', () => {
       if (Cypress.config('hideCommandLog')) {
-        return Bluebird.resolve()
+        return Promise.resolve()
       }
 
       return new Bluebird((resolve) => {

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -582,7 +582,9 @@ export class EventManager {
 
     Cypress.on('collect:run:state', () => {
       if (Cypress.config('hideCommandLog')) {
-        return Promise.resolve()
+        // TODO: Need more refactoring to use native Promise here since
+        // this goes to events.emitThen = map(Bluebird.map) which expect a Bluebird promise
+        return Bluebird.resolve()
       }
 
       return new Bluebird((resolve) => {

--- a/packages/config/src/project/utils.ts
+++ b/packages/config/src/project/utils.ts
@@ -274,7 +274,7 @@ export function relativeToProjectRoot (projectRoot: string, file: string) {
 // async function
 export async function setSupportFileAndFolder (obj: Config, getFilesByGlob: any) {
   if (!obj.supportFile) {
-    return Bluebird.resolve(obj)
+    return Promise.resolve(obj)
   }
 
   obj = _.clone(obj)

--- a/packages/launcher/lib/linux/index.ts
+++ b/packages/launcher/lib/linux/index.ts
@@ -109,7 +109,7 @@ function getLinuxBrowser (
 export function getVersionString (path: string) {
   debugVerbose('finding version string using command "%s --version"', path)
 
-  return Bluebird.resolve(utils.getOutput(path, ['--version']))
+  return utils.getOutput(path, ['--version'])
   .timeout(30000, `Timed out after 30 seconds getting browser version for ${path}`)
   .then((val) => val.stdout)
   .then((val) => val.trim())

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -141,7 +141,7 @@ export function _runStage (type: HttpStages, ctx: any, onError: Function) {
     const middlewareName = _.keys(middlewares)[0]
 
     if (!middlewareName) {
-      return Bluebird.resolve()
+      return Promise.resolve()
     }
 
     const middleware = middlewares[middlewareName]

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -76,14 +76,14 @@ const _getDefaultChromePreferences = (): ChromePreferences => {
  * Reads all known preference files (CHROME_PREFERENCE_PATHS) from disk and return
  * @param userDir
  */
-const _getChromePreferences = (userDir: string): Bluebird<ChromePreferences> => {
+const _getChromePreferences = (userDir: string): Promise<ChromePreferences> => {
   // skip reading the preferences if requested by the user,
   // typically used when the AUT encrypts the user data dir, causing relaunches of the browser not to work
   // see https://github.com/cypress-io/cypress/issues/29330
   if (process.env.IGNORE_CHROME_PREFERENCES) {
     debug('ignoring chrome preferences: not reading from chrome preference files')
 
-    return Bluebird.resolve(_.mapValues(CHROME_PREFERENCE_PATHS, () => ({})))
+    return Promise.resolve(_.mapValues(CHROME_PREFERENCE_PATHS, () => ({})))
   }
 
   debug('reading chrome preferences... %o', { userDir, CHROME_PREFERENCE_PATHS })

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -80,7 +80,7 @@ const rp = request.defaults((params: CypressRequestOptions, callback) => {
   if (params.cacheable && (resp = getCachedResponse(params))) {
     debug('resolving with cached response for %o', { url: params.url })
 
-    return Bluebird.resolve(resp)
+    return Promise.resolve(resp)
   }
 
   _.defaults(params, {

--- a/packages/server/lib/gui/windows.ts
+++ b/packages/server/lib/gui/windows.ts
@@ -232,7 +232,7 @@ export async function open (projectRoot: string, options: WindowOpenOptions, new
   if (knownWin) {
     knownWin.show()
 
-    return Bluebird.resolve(knownWin)
+    return Promise.resolve(knownWin)
   }
 
   recentlyCreatedWindow = true

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -437,7 +437,7 @@ function launchBrowser (options: { browser: Browser, spec: SpecWithRelativeRoot,
 }
 
 async function listenForProjectEnd (project: ProjectBase, exit: boolean): Promise<any> {
-  if (globalThis.CY_TEST_MOCK?.listenForProjectEnd) return Bluebird.resolve(globalThis.CY_TEST_MOCK.listenForProjectEnd)
+  if (globalThis.CY_TEST_MOCK?.listenForProjectEnd) return Promise.resolve(globalThis.CY_TEST_MOCK.listenForProjectEnd)
 
   // if exit is false, we need to intercept the resolution of tests - whether
   // an early exit with intermediate results, or a full run.

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -135,7 +135,7 @@ export class OpenProject {
 
     const afterSpec = () => {
       if (!this.projectBase || cfg.isTextTerminal || !cfg.experimentalInteractiveRunEvents) {
-        return Bluebird.resolve()
+        return Promise.resolve()
       }
 
       return runEvents.execute('after:spec', spec)

--- a/packages/server/lib/saved_state.ts
+++ b/packages/server/lib/saved_state.ts
@@ -93,11 +93,11 @@ interface SavedStateAPI {
   set: (stateToSet: AllowedState) => Bluebird<void>
 }
 
-export const create = (projectRoot?: string, isTextTerminal: boolean = false): Bluebird<SavedStateAPI> => {
+export const create = (projectRoot?: string, isTextTerminal: boolean = false): Promise<SavedStateAPI> => {
   if (isTextTerminal) {
     debug('noop saved state')
 
-    return Bluebird.resolve(FileUtil.noopFile)
+    return Promise.resolve(FileUtil.noopFile)
   }
 
   // @ts-ignore - this is currently affecting the v8-snapshot type checking job as we are importing the file directly from the server package

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -662,7 +662,7 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
     // bail early we dont have a server or we're not
     // currently listening
     if (!this._server || !this.isListening) {
-      return Bluebird.resolve(true)
+      return Promise.resolve(true)
     }
 
     this.reset()

--- a/packages/server/test/unit/cloud/api/utils/fake_proxy_server.ts
+++ b/packages/server/test/unit/cloud/api/utils/fake_proxy_server.ts
@@ -27,6 +27,9 @@ app.get('/error', (req, res) => {
 })
 
 let ca: CA
+let caPromise: Promise<CA> | null = null
+// Cache certificate generation promises per hostname to prevent parallel writes
+const certPromises: Map<string, Promise<{ cert: string, key: string }>> = new Map()
 
 interface DestroyableProxyOptions {
   keepRequests?: boolean
@@ -139,10 +142,27 @@ export async function fakeProxy (opts: FakeProxyOptions) {
 }
 
 async function getHttpsOptions () {
-  ca = await CA.create()
-  const [cert, key] = await ca.generateServerCertificateKeys('localhost')
+  // Ensure CA is only created once, even if called in parallel
+  if (!caPromise) {
+    caPromise = CA.create().then((createdCa) => {
+      ca = createdCa
 
-  return { cert, key }
+      return createdCa
+    })
+  }
+
+  const currentCa = await caPromise
+  const hostname = 'localhost'
+
+  // Serialize certificate generation for the same hostname to prevent file corruption
+  // when multiple HTTPS servers are created in parallel
+  if (!certPromises.has(hostname)) {
+    certPromises.set(hostname, currentCa.generateServerCertificateKeys(hostname).then(([cert, key]) => {
+      return { cert, key }
+    }))
+  }
+
+  return certPromises.get(hostname)!
 }
 
 export function getCA () {

--- a/packages/server/test/unit/open_project_spec.js
+++ b/packages/server/test/unit/open_project_spec.js
@@ -124,7 +124,7 @@ describe('lib/open_project', () => {
       it('executes after:spec on browser close if in interactive mode', function () {
         this.config.experimentalInteractiveRunEvents = true
         this.config.isTextTerminal = false
-        const onBrowserClose = () => Bluebird.resolve()
+        const onBrowserClose = () => Promise.resolve()
 
         return openProject.launch(this.browser, this.spec, { onBrowserClose })
         .then(() => {
@@ -138,7 +138,7 @@ describe('lib/open_project', () => {
       it('does not execute after:spec on browser close if not in interactive mode', function () {
         this.config.experimentalInteractiveRunEvents = true
         this.config.isTextTerminal = true
-        const onBrowserClose = () => Bluebird.resolve()
+        const onBrowserClose = () => Promise.resolve()
 
         return openProject.launch(this.browser, this.spec, { onBrowserClose })
         .then(() => {
@@ -152,7 +152,7 @@ describe('lib/open_project', () => {
       it('does not execute after:spec on browser close if experimental flag is not enabled', function () {
         this.config.experimentalInteractiveRunEvents = false
         this.config.isTextTerminal = false
-        const onBrowserClose = () => Bluebird.resolve()
+        const onBrowserClose = () => Promise.resolve()
 
         return openProject.launch(this.browser, this.spec, { onBrowserClose })
         .then(() => {
@@ -166,7 +166,7 @@ describe('lib/open_project', () => {
       it('does not execute after:spec on browser close if the project is no longer open', function () {
         this.config.experimentalInteractiveRunEvents = true
         this.config.isTextTerminal = false
-        const onBrowserClose = () => Bluebird.resolve()
+        const onBrowserClose = () => Promise.resolve()
 
         return openProject.launch(this.browser, this.spec, { onBrowserClose })
         .then(() => {

--- a/packages/server/test/unit/util/editors_spec.ts
+++ b/packages/server/test/unit/util/editors_spec.ts
@@ -54,7 +54,7 @@ describe('lib/util/editors', () => {
       sinon.stub(shellUtil, 'commandExists').callsFake((command) => {
         const exists = ['code', 'subl', 'vim'].includes(command)
 
-        return Bluebird.resolve(exists)
+        return Promise.resolve(exists)
       })
 
       platform = process.platform
@@ -70,7 +70,7 @@ describe('lib/util/editors', () => {
       // @ts-ignore
       savedState.create.resolves({
         get () {
-          return Bluebird.resolve({ isOther: true, binary: '/path/to/editor', id: 'other' })
+          return Promise.resolve({ isOther: true, binary: '/path/to/editor', id: 'other' })
         },
       })
     })
@@ -112,7 +112,7 @@ describe('lib/util/editors', () => {
         // @ts-ignore
         savedState.create.resolves({
           get () {
-            return Bluebird.resolve({ preferredOpener })
+            return Promise.resolve({ preferredOpener })
           },
         })
 
@@ -130,7 +130,7 @@ describe('lib/util/editors', () => {
         // @ts-ignore
         savedState.create.resolves({
           get () {
-            return Bluebird.resolve({ preferredOpener })
+            return Promise.resolve({ preferredOpener })
           },
         })
 

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught-ct.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught-ct.cy.js
@@ -1,5 +1,4 @@
 import Errors from '../../../src/Errors'
-import Bluebird from 'bluebird'
 import React from 'react'
 
 describe('uncaught errors', { defaultCommandTimeout: 0 }, () => {
@@ -63,13 +62,13 @@ describe('uncaught errors', { defaultCommandTimeout: 0 }, () => {
   })
 
   it('spec Bluebird unhandled rejection', () => {
-    Bluebird.reject(new Error('Unhandled promise rejection from the spec'))
+    Promise.reject(new Error('Unhandled promise rejection from the spec'))
 
     cy.wait(10000)
   })
 
   // eslint-disable-next-line mocha/handle-done-callback
   it('spec Bluebird unhandled rejection with done', (done) => {
-    Bluebird.reject(new Error('Unhandled promise rejection from the spec'))
+    Promise.reject(new Error('Unhandled promise rejection from the spec'))
   })
 })

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/errors/uncaught.cy.js
@@ -1,5 +1,3 @@
-import Bluebird from 'bluebird'
-
 describe('uncaught errors', { defaultCommandTimeout: 0 }, () => {
   it('sync app visit exception', () => {
     cy.visit('cypress/fixtures/errors.html?error-on-visit')
@@ -73,13 +71,13 @@ describe('uncaught errors', { defaultCommandTimeout: 0 }, () => {
   })
 
   it('spec Bluebird unhandled rejection', () => {
-    Bluebird.reject(new Error('Unhandled promise rejection from the spec'))
+    Promise.reject(new Error('Unhandled promise rejection from the spec'))
 
     cy.wait(10000)
   })
 
   // eslint-disable-next-line mocha/handle-done-callback
   it('spec Bluebird unhandled rejection with done', (done) => {
-    Bluebird.reject(new Error('Unhandled promise rejection from the spec'))
+    Promise.reject(new Error('Unhandled promise rejection from the spec'))
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Partially addresses https://github.com/cypress-io/cypress/issues/33032

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Bluebird resolve/reject usages with native Promise across codebase, updates related tests and minor logic, and improves HTTPS cert generation concurrency in tests.
> 
> - **Core/Server**:
>   - Switch `Bluebird.resolve/reject` to `Promise.resolve/reject` in `server`, `open_project`, `modes/run`, `saved_state`, `server-base`.
>   - Chrome prefs helpers now return native `Promise<...>`; minor TODO added in event manager.
> - **CLI/Launcher/Proxy**:
>   - `cli/util.isExecutableAsync`, download redirect error uses native `Promise`.
>   - `launcher/linux#getVersionString` returns native promise (still Bluebird timeout chaining).
>   - Proxy HTTP `_runStage` uses `Promise.resolve()` when no middleware.
> - **Cloud API**:
>   - Cached response path resolves with native `Promise`.
> - **GUI/Windows**:
>   - `open()` returns `Promise.resolve(knownWin)` when reusing window.
> - **Config**:
>   - `setSupportFileAndFolder` early-return uses native `Promise`.
> - **Tests**:
>   - Update reporter expectations (column indices) for unhandled rejections.
>   - System tests remove Bluebird import/usages; use `Promise.reject`.
>   - Fake proxy server: cache CA creation and serialize per-host cert generation to avoid parallel write corruption.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6c98ef6d73d100dc0346b43c0537e5f924813a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->