### PR TITLE
fix: handle grepFilterSpecs as string "true" from CLI environment variables

### DIFF
--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -68,7 +68,7 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
   const { specPattern, excludeSpecPattern } = config
   const integrationFolder = env.grepIntegrationFolder || process.cwd()
 
-  const grepFilterSpecs = env.grepFilterSpecs === true
+  const grepFilterSpecs = env.grepFilterSpecs === true || String(env.grepFilterSpecs).toLowerCase() === 'true'
 
   if (grepFilterSpecs) {
     debug('specPattern', specPattern)

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe } from 'vitest'
+import { expect, describe, it } from 'vitest'
 import {
   parseGrep,
   parseTitleGrep,
@@ -8,6 +8,7 @@ import {
   shouldTestRunTags,
   shouldTestRunTitle,
 } from '../src/utils'
+import { plugin } from '../src/plugin'
 
 describe('utils', () => {
   describe('parseTitleGrep', () => {
@@ -433,6 +434,86 @@ describe('utils', () => {
     it('passes for substring', () => {
       shouldIt('hello w', 'hello world', true)
       shouldIt('-hello w', 'hello world', false)
+    })
+  })
+
+  describe('plugin', () => {
+    describe('grepFilterSpecs handling', () => {
+      const mockConfig = {
+        specPattern: ['**/*.cy.ts'],
+        excludeSpecPattern: [],
+        env: {},
+      }
+
+      it('handles boolean true', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: true },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles string "true"', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: 'true' },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles string "TRUE"', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: 'TRUE' },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles string "True" (mixed case)', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: 'True' },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles boolean false', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: false },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles string "false"', () => {
+        const config = {
+          ...mockConfig,
+          env: { grepFilterSpecs: 'false' },
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
+
+      it('handles undefined', () => {
+        const config = {
+          ...mockConfig,
+          env: {},
+        }
+        const result = plugin(config)
+
+        expect(result).toBeDefined()
+      })
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE:
- Read the contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md
- Mark this PR as Draft if not ready for review.
-->

- Closes #32676

### Additional details
Fix `grepFilterSpecs` CLI env variable issue. Previously, passing `--env grepFilterSpecs=true` failed because env vars are strings and only boolean `true` was checked.

Changes:
- `npm/grep/src/plugin.ts`: handle boolean `true` and string `"true"` (case-insensitive)
- `npm/grep/test/unit.spec.ts`: added tests for `true`, `"true"`, `"TRUE"`, `"True"`, `false`, `"false"`, and `undefined`
- `npm/grep/README.md`: clarified CLI usage

### Steps to test
1. Run unit tests:
```bash
npm test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Accepts grepFilterSpecs as the string "true" (any case) in the plugin and adds unit tests covering boolean/string values and undefined.
> 
> - **Grep Plugin (`npm/grep/src/plugin.ts`)**
>   - Parse `env.grepFilterSpecs` as enabled when boolean `true` or string `'true'` (case-insensitive).
> - **Tests (`npm/grep/test/unit.spec.ts`)**
>   - Add `plugin` tests validating `grepFilterSpecs` handling for `true`, `'true'`, `'TRUE'`, `'True'`, `false`, `'false'`, and `undefined`.
>   - Minor test import adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a97ad097ec1c99cf6ca7c5e69efd0232a71599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->