### PR TITLE
docs: update CHANGELOG dates with leading zeros

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,7 +15,7 @@ _Released 12/16/2025 (PENDING)_
 
 ## 15.7.1
 
-_Released 12/2/2025_
+_Released 12/02/2025_
 
 **Performance:**
 
@@ -55,7 +55,7 @@ _Released 11/19/2025_
 
 ## 15.6.0
 
-_Released 11/4/2025_
+_Released 11/04/2025_
 
 **Features:**
 
@@ -110,7 +110,7 @@ _Released 10/17/2025_
 
 ## 15.4.0
 
-_Released 10/7/2025_
+_Released 10/07/2025_
 
 **Features:**
 
@@ -140,7 +140,7 @@ _Released 10/7/2025_
 
 ## 15.3.0
 
-_Released 9/23/2025_
+_Released 09/23/2025_
 
 **Features:**
 
@@ -159,7 +159,7 @@ _Released 9/23/2025_
 
 ## 15.2.0
 
-_Released 9/9/2025_
+_Released 09/09/2025_
 
 **Features:**
 
@@ -262,7 +262,7 @@ _Released 08/20/2025_
 
 ## 14.5.4
 
-_Released 8/07/2025_
+_Released 08/07/2025_
 
 **Dependency Updates:**
 
@@ -270,7 +270,7 @@ _Released 8/07/2025_
 
 ## 14.5.3
 
-_Released 7/25/2025_
+_Released 07/25/2025_
 
 **Bugfixes:**
 
@@ -284,7 +284,7 @@ _Released 7/25/2025_
 
 ## 14.5.2
 
-_Released 7/15/2025_
+_Released 07/15/2025_
 
 **Bugfixes:**
 
@@ -293,7 +293,7 @@ _Released 7/15/2025_
 
 ## 14.5.1
 
-_Released 7/01/2025_
+_Released 07/01/2025_
 
 **Bugfixes:**
 
@@ -305,7 +305,7 @@ _Released 7/01/2025_
 
 ## 14.5.0
 
-_Released 6/17/2025_
+_Released 06/17/2025_
 
 **Features:**
 
@@ -317,7 +317,7 @@ _Released 6/17/2025_
 
 ## 14.4.1
 
-_Released 6/3/2025_
+_Released 06/03/2025_
 
 **Bugfixes:**
 
@@ -333,7 +333,7 @@ _Released 6/3/2025_
 
 ## 14.4.0
 
-_Released 5/20/2025_
+_Released 05/20/2025_
 
 **Features:**
 
@@ -359,7 +359,7 @@ _Released 5/20/2025_
 
 ## 14.3.3
 
-_Released 5/6/2025_
+_Released 05/06/2025_
 
 **Performance:**
 
@@ -382,7 +382,7 @@ _Released 5/6/2025_
 
 ## 14.3.2
 
-_Released 4/22/2025_
+_Released 04/22/2025_
 
 **Bugfixes:**
 
@@ -391,7 +391,7 @@ _Released 4/22/2025_
 
 ## 14.3.1
 
-_Released 4/17/2025_
+_Released 04/17/2025_
 
 **Performance:**
 
@@ -410,7 +410,7 @@ _Released 4/17/2025_
 
 ## 14.3.0
 
-_Released 4/8/2025_
+_Released 04/08/2025_
 
 **Features:**
 
@@ -435,7 +435,7 @@ _Released 4/8/2025_
 
 ## 14.2.1
 
-_Released 3/26/2025_
+_Released 03/26/2025_
 
 **Bugfixes:**
 
@@ -458,7 +458,7 @@ _Released 3/26/2025_
 
 ## 14.2.0
 
-_Released 3/12/2025_
+_Released 03/12/2025_
 
 **Features:**
 
@@ -477,7 +477,7 @@ _Released 3/12/2025_
 
 ## 14.1.0
 
-_Released 2/25/2025_
+_Released 02/25/2025_
 
 **Features:**
 
@@ -501,7 +501,7 @@ _Released 2/25/2025_
 
 ## 14.0.3
 
-_Released 2/11/2025_
+_Released 02/11/2025_
 
 **Bugfixes:**
 
@@ -514,7 +514,7 @@ _Released 2/11/2025_
 
 ## 14.0.2
 
-_Released 2/05/2025_
+_Released 02/05/2025_
 
 **Bugfixes:**
 
@@ -533,7 +533,7 @@ _Released 2/05/2025_
 
 ## 14.0.1
 
-_Released 1/28/2025_
+_Released 01/28/2025_
 
 **Bugfixes:**
 
@@ -550,7 +550,7 @@ _Released 1/28/2025_
 
 ## 14.0.0
 
-_Released 1/16/2025_
+_Released 01/16/2025_
 
 **Breaking Changes:**
 
@@ -666,7 +666,7 @@ _Released 11/19/2024_
 
 ## 13.15.2
 
-_Released 11/5/2024_
+_Released 11/05/2024_
 
 **Bugfixes:**
 
@@ -703,7 +703,7 @@ _Released 10/24/2024_
 
 ## 13.15.0
 
-_Released 9/25/2024_
+_Released 09/25/2024_
 
 **Features:**
 
@@ -728,7 +728,7 @@ _Released 9/25/2024_
 
 ## 13.14.2
 
-_Released 9/4/2024_
+_Released 09/04/2024_
 
 **Bugfixes:**
 
@@ -737,7 +737,7 @@ _Released 9/4/2024_
 
 ## 13.14.1
 
-_Released 8/29/2024_
+_Released 08/29/2024_
 
 **Bugfixes:**
 
@@ -745,7 +745,7 @@ _Released 8/29/2024_
 
 ## 13.14.0
 
-_Released 8/27/2024_
+_Released 08/27/2024_
 
 **Performance:**
 
@@ -777,7 +777,7 @@ _Released 8/27/2024_
 
 ## 13.13.3
 
-_Released 8/14/2024_
+_Released 08/14/2024_
 
 **Bugfixes:**
 
@@ -794,7 +794,7 @@ _Released 8/14/2024_
 
 ## 13.13.2
 
-_Released 7/31/2024_
+_Released 07/31/2024_
 
 **Performance:**
 
@@ -814,7 +814,7 @@ _Released 7/31/2024_
 
 ## 13.13.1
 
-_Released 7/16/2024_
+_Released 07/16/2024_
 
 **Bugfixes:**
 
@@ -831,7 +831,7 @@ _Released 7/16/2024_
 
 ## 13.13.0
 
-_Released 7/01/2024_
+_Released 07/01/2024_
 
 **Performance:**
 
@@ -855,7 +855,7 @@ _Released 7/01/2024_
 
 ## 13.12.0
 
-_Released 6/18/2024_
+_Released 06/18/2024_
 
 **Features:**
 
@@ -881,7 +881,7 @@ _Released 6/18/2024_
 
 ## 13.11.0
 
-_Released 6/4/2024_
+_Released 06/04/2024_
 
 **Performance:**
 
@@ -903,7 +903,7 @@ _Released 6/4/2024_
 
 ## 13.10.0
 
-_Released 5/21/2024_
+_Released 05/21/2024_
 
 **Features:**
 
@@ -924,7 +924,7 @@ _Released 5/21/2024_
 
 ## 13.9.0
 
-_Released 5/7/2024_
+_Released 05/07/2024_
 
 **Features:**
 
@@ -947,7 +947,7 @@ _Released 5/7/2024_
 
 ## 13.8.1
 
-_Released 4/23/2024_
+_Released 04/23/2024_
 
 **Performance:**
 
@@ -968,7 +968,7 @@ _Released 4/23/2024_
 
 ## 13.8.0
 
-_Released 4/18/2024_
+_Released 04/18/2024_
 
 **Features:**
 
@@ -984,7 +984,7 @@ _Released 4/18/2024_
 
 ## 13.7.3
 
-_Released 4/11/2024_
+_Released 04/11/2024_
 
 **Bugfixes:**
 
@@ -998,7 +998,7 @@ _Released 4/11/2024_
 
 ## 13.7.2
 
-_Released 4/2/2024_
+_Released 04/02/2024_
 
 **Performance:**
 
@@ -1017,7 +1017,7 @@ _Released 4/2/2024_
 
 ## 13.7.1
 
-_Released 3/21/2024_
+_Released 03/21/2024_
 
 **Bugfixes:**
 
@@ -1030,7 +1030,7 @@ _Released 3/21/2024_
 
 ## 13.7.0
 
-_Released 3/13/2024_
+_Released 03/13/2024_
 
 **Features:**
 
@@ -1063,7 +1063,7 @@ _Released 3/13/2024_
 
 ## 13.6.6
 
-_Released 2/22/2024_
+_Released 02/22/2024_
 
 **Bugfixes:**
 
@@ -1071,7 +1071,7 @@ _Released 2/22/2024_
 
 ## 13.6.5
 
-_Released 2/20/2024_
+_Released 02/20/2024_
 
 **Bugfixes:**
 
@@ -1097,7 +1097,7 @@ _Released 2/20/2024_
 
 ## 13.6.4
 
-_Released 1/30/2024_
+_Released 01/30/2024_
 
 **Performance:**
 
@@ -1113,7 +1113,7 @@ _Released 1/30/2024_
 
 ## 13.6.3
 
-_Released 1/16/2024_
+_Released 01/16/2024_
 
 **Bugfixes:**
 
@@ -1165,7 +1165,7 @@ _Released 12/26/2023_
 
 ## 13.6.1
 
-_Released 12/5/2023_
+_Released 12/05/2023_
 
 **Bugfixes:**
 
@@ -1217,7 +1217,7 @@ _Released 11/14/2023_
 
 ## 13.5.0
 
-_Released 11/8/2023_
+_Released 11/08/2023_
 
 **Features:**
 
@@ -1753,7 +1753,7 @@ _Released 01/27/2023_
 
 ## 12.4.0
 
-_Released 1/24/2023_
+_Released 01/24/2023_
 
 **Features:**
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress/issues/32655

### Additional details

Release dates in the [cli/CHANGELOG.md](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md) are inconsistently formatted concerning leading zeros for day and month and are updated to add leading zeroes for consistency where necessary.

All dates are now in the format `MM/DD/YYYY`.

### Steps to test

View the document [cli/CHANGELOG.md](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md) and confirm that all dates have two digit months and days, with leading zeros where necessary.

### How has the user experience changed?

Cosmetic change to [cli/CHANGELOG.md](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md)

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
