### PR TITLE
chore: try to address flake in 'stop' test in app

### DIFF
--- a/packages/app/cypress/e2e/runner/runner.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/runner.ui.cy.ts
@@ -292,6 +292,10 @@ describe('src/cypress/runner', () => {
         filePath: 'runner/stop-execution.runner.cy.js',
       })
 
+      // Wait for the command to start running (ensure it's in retry mode)
+      // The command will be retrying cy.get('.not-exist')
+      cy.get('.command-state-pending, .command-state-running', { timeout: 5000 })
+
       // Click the stop button to stop execution
       cy.get('.stop').click()
 
@@ -299,8 +303,10 @@ describe('src/cypress/runner', () => {
       cy.get('.stop', { timeout: 100 }).should('not.exist')
       cy.get('.restart', { timeout: 100 }).should('be.visible')
 
-      cy.get('.runnable-err-message').should('not.contain', 'ran afterEach even though specs were stopped')
-      cy.get('.runnable-err-message').should('contain', 'Cypress test was stopped while running this command.')
+      // Wait for the error message to appear - it may take time to propagate
+      cy.get('.runnable-err-message', { timeout: 5000 })
+      .should('not.contain', 'ran afterEach even though specs were stopped')
+      .and('contain', 'Cypress test was stopped while running this command.')
     })
   })
 })


### PR DESCRIPTION
### Additional details

This test flake is driving me crazy, it seems more frequent in contributor PRs? Example of failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/77867/workflows/dbacc6a6-8480-4b0c-bc45-d87d1898ef66/jobs/3357462/tests



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deflakes the runner “stop execution” e2e test by adding waits for a running command and for the error message to appear before asserting.
> 
> - **Tests (e2e)**:
>   - Updates `packages/app/cypress/e2e/runner/runner.ui.cy.ts` "user can stop test execution" spec:
>     - Waits for a pending/running command (`.command-state-pending, .command-state-running`) before clicking `stop`.
>     - Waits for `.runnable-err-message` with timeout, chaining assertions to avoid flake.
>     - Keeps UI assertions for `stop` disappearing and `restart` visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f0233c953532d2e56ba391534cf194475ebff99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
