### PR TITLE
chore: bump actions/checkout

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -22,7 +22,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'cypress-io/cypress'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ matrix.platform == 'macos-latest' }}
         run: sudo -H pip install setuptools
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}

--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download Fossa binary and install
 # This step utilizes a curl of the latest install pkg from Fossa.  Using a git action from 
 # Fossa doesn't produce the SBOM artifact needed. This manual approach is the only way to 


### PR DESCRIPTION
### Additional details

- Updates all 8 GitHub Actions workflows to use actions/checkout@v6 (from actions/checkout@v4). 
- v5 updated to Node.js 24 runtime. 
- v6 improves credential security by storing credentials in $RUNNER_TEMP instead of .git/config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update GitHub Actions workflows to use actions/checkout@v6 instead of @v4.
> 
> - **CI/GitHub Actions**
>   - Bump `actions/checkout` to `v6` in:
>     - `.github/workflows/semantic-pull-request.yml`
>     - `.github/workflows/snyk_sca_scan.yaml`
>     - `.github/workflows/snyk_static_analysis_scan.yaml`
>     - `.github/workflows/triage_add_to_project.yml`
>     - `.github/workflows/triage_handle_new_comments.yml`
>     - `.github/workflows/update-browser-versions.yml`
>     - `.github/workflows/update_v8_snapshot_cache.yml`
>     - `.github/workflows/upload_release_asset.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbebd129aba891cf39e517579658897488af27bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Will have to make sure they all still run after merge

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
