### PR TITLE
fix: fire test:after:run:async when before and after hooks fail

### DIFF
--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -522,6 +522,13 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           }
 
           if (test) {
+            // test.parent should exist if test exists, but guard against it just in case
+            if (!test.parent) {
+              // Can't determine siblings without a parent, skip sibling-based logic
+              // and let the root suite logic below handle it
+              return false
+            }
+
             const siblings = getAllSiblingTests(test.parent, getTestById)
             const testIsActuallyInSuite = suiteHasTest(this.suite, test.id)
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -574,6 +574,12 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         break
     }
 
+    // Capture suite and runner context before the async function
+    // The async function is a regular function, so 'this' inside it will be the Mocha execution context,
+    // not the runner context. We need to capture these values from the runner context.
+    const suite = this.suite
+    const runnerContext = this
+
     const newArgs = [name, $utils.monkeypatchBeforeAsync(fn,
       async function () {
         // Re-evaluate test in case it was found in shouldFireTestAfterRun
@@ -582,7 +588,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
         // If we still don't have a test, try to find it using the helper
         if (!currentTest) {
-          currentTest = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
+          currentTest = findTestForHook(name, suite, test, getTestFromHookOrFindTest, getTestById, getTests, runnerContext)
         }
 
         const shouldFire = shouldFireTestAfterRun()

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -390,6 +390,57 @@ const isRootSuite = (suite) => {
   return suite && suite.root
 }
 
+// Helper function to find a test for a hook when the normal test lookup fails.
+// This handles cases where tests are skipped due to before hook failures.
+// The _ALREADY_RAN flag is cleared if found, as it prevents events from firing
+// but we need the event to fire for protocol data capture.
+const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTestById, getTests, hook) => {
+  // First try the existing test or getTestFromHookOrFindTest
+  if (!test && getTestFromHookOrFindTest && hook) {
+    test = getTestFromHookOrFindTest(hook)
+  }
+
+  if (test) {
+    return test
+  }
+
+  // Try to find a test that was associated with a hook failure
+  // This test will have failedFromHookId set and is the one that was supposed to run
+  // when the before hook failed
+  const allTests = getTests()
+  const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(suite, t.id))
+
+  if (testWithHookFailure) {
+    return testWithHookFailure
+  }
+
+  // Fallback: find a test from the suite structure
+  // This happens when tests were skipped due to before hook failure
+  let foundTest
+
+  if (hookName === 'afterAll') {
+    foundTest = findLastTestInSuite(suite, () => true)
+  } else if (hookName === 'afterEach') {
+    foundTest = findTestInSuite(suite, () => true)
+  }
+
+  if (foundTest) {
+    // Try to get the test from _testsById first (if it was run)
+    // If not found, use the test directly from the suite structure
+    const resolvedTest = getTestById(foundTest.id) || foundTest
+
+    // Clear _ALREADY_RAN flag if set, as it prevents events from firing
+    // but we need the event to fire for protocol data capture
+    if (resolvedTest && resolvedTest._ALREADY_RAN) {
+      resolvedTest._ALREADY_RAN = false
+    }
+
+    return resolvedTest
+  }
+
+  return null
+}
+
 const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, getTests, cy, abort, getTestFromHookOrFindTest) => {
   // bail if our _runner doesn't have a hook.
   // useful in tests
@@ -407,14 +458,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
       return
     }
 
-    // Try to get the test from getTest() first, but if it's null (which can happen
-    // when a before hook fails and tests are skipped), try to find it from the hook
     let test = getTest()
-
-    if (!test && getTestFromHookOrFindTest) {
-      test = getTestFromHookOrFindTest(this)
-    }
-
     const allTests = getTests()
 
     let shouldFireTestAfterRun = () => false
@@ -422,17 +466,12 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
     switch (name) {
       case 'afterEach':
         shouldFireTestAfterRun = () => {
-          // If we still don't have a test, we can't determine if we should fire
-          // but we should still try to fire the event to ensure protocol data is captured
           if (!test) {
             // For afterEach, if we can't find a test, we should still fire the event
             // to ensure protocol can capture data even when hooks fail
             return true
           }
 
-          // find all of the grep'd tests which share
-          // the same parent suite as our current test
-          // test.parent should exist if test exists, but guard against it just in case
           if (!test.parent) {
             return true
           }
@@ -442,8 +481,6 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           if (this.suite.root) {
             _runner._shouldBufferSuiteEnd = true
 
-            // make sure this test isnt the last test overall but also
-            // isnt the last test in our filtered parent suite's tests array
             if (test.final === false || (test !== _.last(allTests)) && (test !== _.last(tests))) {
               return true
             }
@@ -456,45 +493,17 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
       case 'afterAll':
         shouldFireTestAfterRun = () => {
-          // If we don't have a test, try to find one associated with hook failure
-          // This can happen when a before hook fails and tests are skipped
+          // Try to find a test if we don't have one
           if (!test) {
-            // First, try to find a test that was associated with a hook failure
-            // This test will have failedFromHookId set and is the one that was supposed to run
-            // when the before hook failed. This test should be in _testsById.
-            const allTests = getTests()
-            const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(this.suite, t.id))
+            test = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
 
-            if (testWithHookFailure) {
-              test = testWithHookFailure
+            if (test) {
               setTest(test)
-            } else {
-              // Fallback: For afterAll hooks, find the last test that would have run in this suite
-              // This ensures we can still fire test:after:run:async even when tests were skipped
-              const foundTest = findLastTestInSuite(this.suite, () => true)
-
-              if (foundTest) {
-                // Try to get the test from _testsById first (if it was run)
-                // If not found, use the test directly from the suite structure
-                // (this happens when tests were skipped due to before hook failure)
-                test = getTestById(foundTest.id) || foundTest
-
-                // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
-                if (test && test._ALREADY_RAN) {
-                  test._ALREADY_RAN = false
-                }
-
-                // If we found a test, set it so the rest of the code can use it
-                if (test) {
-                  setTest(test)
-                }
-              }
             }
           }
 
           if (test) {
             const siblings = getAllSiblingTests(test.parent, getTestById)
-
             const testIsActuallyInSuite = suiteHasTest(this.suite, test.id)
 
             // we ensure the test actually belongs to this suite.
@@ -509,7 +518,6 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
             //    we wait until the root suite fires
             // 2. else if we arent the last nested suite we fire if we're
             //    the last test that will run
-
             if (
               (isRootSuite(this.suite) && isLastTest(test, allTests)) ||
               (!isLastSuite(this.suite, allTests) && lastTestThatWillRunInSuite(test, siblings))
@@ -521,17 +529,13 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           // For root suite's afterAll, always try to fire the event if we can find any test
           // This ensures protocol data is captured even when both hooks fail
           if (isRootSuite(this.suite)) {
-            // Try one more time to find a test from the suite
-            const foundTest = findLastTestInSuite(this.suite, () => true)
+            const foundTest = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
 
             if (foundTest) {
-              test = getTestById(foundTest.id) || foundTest
+              test = foundTest
+              setTest(test)
 
-              if (test) {
-                setTest(test)
-
-                return true
-              }
+              return true
             }
           }
 
@@ -548,67 +552,13 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
       async function () {
         // Re-evaluate test in case it was found in shouldFireTestAfterRun
         // Note: test may have been modified by shouldFireTestAfterRun closure for afterAll
-        // We need to check the closure's test variable first since it may have been set
         let currentTest = test
 
-        // If test was found in shouldFireTestAfterRun closure, use it
-        // Otherwise, try to find it using other methods
-        if (!currentTest && getTestFromHookOrFindTest) {
-          currentTest = getTestFromHookOrFindTest(this)
-        }
-
-        // If still no test, try to find it from the suite
-        // This is important when both before and after hooks fail
+        // If we still don't have a test, try to find it using the helper
         if (!currentTest) {
-          if (name === 'afterAll') {
-            // For afterAll, try to find a test that was associated with a hook failure
-            // This test will have failedFromHookId set and is the one that was supposed to run
-            // when the before hook failed. This test should be in _testsById.
-            const allTests = getTests()
-            const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(this.suite, t.id))
-
-            if (testWithHookFailure) {
-              currentTest = testWithHookFailure
-            } else {
-              // Fallback: find the last test that would have run in this suite
-              const foundTest = findLastTestInSuite(this.suite, () => true)
-
-              if (foundTest) {
-                // Try to get the test from _testsById first (if it was run)
-                // If not found, use the test directly from the suite structure
-                // (this happens when tests were skipped due to before hook failure)
-                currentTest = getTestById(foundTest.id) || foundTest
-
-                // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
-                // This is necessary when tests were skipped due to before hook failure
-                // The _ALREADY_RAN flag prevents events from firing, but we need the event
-                // to fire for protocol data capture even when tests were skipped
-                if (currentTest && currentTest._ALREADY_RAN) {
-                  currentTest._ALREADY_RAN = false
-                }
-              }
-            }
-          } else if (name === 'afterEach') {
-            // For afterEach, try to find the first test in the suite
-            // This can happen when a before hook fails and the test was skipped
-            const foundTest = findTestInSuite(this.suite, () => true)
-
-            if (foundTest) {
-              // Try to get the test from _testsById first (if it was run)
-              // If not found, use the test directly from the suite structure
-              currentTest = getTestById(foundTest.id) || foundTest
-
-              // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
-              if (currentTest && currentTest._ALREADY_RAN) {
-                currentTest._ALREADY_RAN = false
-              }
-            }
-          }
+          currentTest = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
         }
 
-        // Check if we should fire the event
-        // Note: shouldFireTestAfterRun may have modified the test variable in its closure
-        // so we need to re-check test after calling it
         const shouldFire = shouldFireTestAfterRun()
 
         // Re-check test in case shouldFireTestAfterRun found and set it
@@ -617,7 +567,6 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         }
 
         if (!shouldFire) {
-          // Allow the hook to complete normally
           return
         }
 
@@ -628,9 +577,6 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         // If we don't have a test, we still need to allow the hook to complete
         // to prevent hanging, but we can't fire test:after:run:async without a test
         if (!currentTest) {
-          // Allow the hook to complete normally even without a test
-          // This prevents hanging when both before and after hooks fail
-          // The hook will complete, but test:after:run:async won't fire
           return
         }
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -392,50 +392,52 @@ const isRootSuite = (suite) => {
 
 // Helper function to find a test for a hook when the normal test lookup fails.
 // This handles cases where tests are skipped due to before hook failures.
-// The _ALREADY_RAN flag is cleared if found, as it prevents events from firing
-// but we need the event to fire for protocol data capture.
+// Returns a test object that can be used to fire test:after:run:async events for protocol data capture.
 const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTestById, getTests, hook) => {
-  // First try the existing test or getTestFromHookOrFindTest
-  if (!test && getTestFromHookOrFindTest && hook) {
-    test = getTestFromHookOrFindTest(hook)
-  }
-
+  // Check if we already have a test
   if (test) {
     return test
+  }
+
+  // Try to get test from hook
+  if (getTestFromHookOrFindTest && hook) {
+    test = getTestFromHookOrFindTest(hook)
+
+    if (test) {
+      return test
+    }
   }
 
   // Try to find a test that was associated with a hook failure
   // This test will have failedFromHookId set and is the one that was supposed to run
   // when the before hook failed
   const allTests = getTests()
-  const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(suite, t.id))
+  const testWithHookFailure = allTests.find((t) => {
+    // Must have failedFromHookId and belong to this suite
+    if (!t.failedFromHookId || !suiteHasTest(suite, t.id)) {
+      return false
+    }
+
+    // Match the hook type that makes sense for the current hook context:
+    // - afterAll hooks run once after all tests, so only match tests that failed from 'before all' hooks
+    // - afterEach hooks run after each test, so match any hook failure (beforeEach or before all)
+    return hookName === 'afterAll' ? t.hookName === 'before all' : true
+  })
 
   if (testWithHookFailure) {
     return testWithHookFailure
   }
 
-  // Fallback: find a test from the suite structure
+  // Fallback: Find a test from the suite structure when we can't find one with failedFromHookId
   // This happens when tests were skipped due to before hook failure
-  let foundTest
-
-  if (hookName === 'afterAll') {
-    foundTest = findLastTestInSuite(suite, () => true)
-  } else if (hookName === 'afterEach') {
-    foundTest = findTestInSuite(suite, () => true)
-  }
+  const foundTest = hookName === 'afterAll'
+    ? findLastTestInSuite(suite, () => true) // afterAll runs after all tests, so use last test
+    : findTestInSuite(suite, () => true) // afterEach runs after each test, so use first test
 
   if (foundTest) {
     // Try to get the test from _testsById first (if it was run)
     // If not found, use the test directly from the suite structure
-    const resolvedTest = getTestById(foundTest.id) || foundTest
-
-    // Clear _ALREADY_RAN flag if set, as it prevents events from firing
-    // but we need the event to fire for protocol data capture
-    if (resolvedTest && resolvedTest._ALREADY_RAN) {
-      resolvedTest._ALREADY_RAN = false
-    }
-
-    return resolvedTest
+    return getTestById(foundTest.id) || foundTest
   }
 
   return null
@@ -466,12 +468,23 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
     switch (name) {
       case 'afterEach':
         shouldFireTestAfterRun = () => {
+          // Try to find a test if we don't have one
           if (!test) {
-            // For afterEach, if we can't find a test, we should still fire the event
-            // to ensure protocol can capture data even when hooks fail
-            return true
+            test = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
+
+            if (test) {
+              setTest(test)
+            }
           }
 
+          if (!test) {
+            // Can't fire the event without a test
+            return false
+          }
+
+          // find all of the grep'd tests which share
+          // the same parent suite as our current test
+          // test.parent should exist if test exists, but guard against it just in case
           if (!test.parent) {
             return true
           }
@@ -481,6 +494,10 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           if (this.suite.root) {
             _runner._shouldBufferSuiteEnd = true
 
+            // Fire the event if:
+            // - The test hasn't been finalized yet (test.final === false), OR
+            // - This test is not the last test overall AND not the last test in its parent suite
+            // This ensures we fire the event for all tests except the very last one
             if (test.final === false || (test !== _.last(allTests)) && (test !== _.last(tests))) {
               return true
             }
@@ -650,8 +667,23 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           await testBeforeAfterRunAsync(currentTest, Cypress, { nextTestHasTestIsolationOn })
         }
 
+        // Clear _ALREADY_RAN flag if set, as it prevents events from firing
+        // but we need the event to fire for protocol data capture
+        // We do this right before firing the events to minimize side effects
+        const wasAlreadyRan = currentTest._ALREADY_RAN
+
+        if (wasAlreadyRan) {
+          currentTest._ALREADY_RAN = false
+        }
+
         testAfterRun(currentTest, Cypress)
         await testAfterRunAsync(currentTest, Cypress)
+
+        // Restore _ALREADY_RAN flag after firing events to prevent side effects
+        // if this test object is used elsewhere
+        if (wasAlreadyRan) {
+          currentTest._ALREADY_RAN = true
+        }
 
         // if the user has stopped the run and we are in run mode, we need to abort,
         // this needs to happen after the test:after:run events have fired

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -61,7 +61,7 @@ const duration = (before: Date, after: Date) => {
   return Number(before) - Number(after)
 }
 
-const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, ...args) => {
+const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, forceFire = false, ...args) => {
   debug('fire: %o', { event })
   if (runnable._fired == null) {
     runnable._fired = {}
@@ -69,8 +69,8 @@ const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, ...args) =
 
   runnable._fired[event] = true
 
-  // don't fire anything again if we are skipped
-  if (runnable._ALREADY_RAN) {
+  // don't fire anything again if we are skipped, unless forceFire is true
+  if (runnable._ALREADY_RAN && !forceFire) {
     return
   }
 
@@ -97,10 +97,10 @@ const testBeforeAfterRunAsync = (test, Cypress, ...args) => {
   })
 }
 
-const testAfterRunAsync = (test, Cypress) => {
+const testAfterRunAsync = (test, Cypress, forceFire = false) => {
   return Promise.try(() => {
     if (!fired(TEST_AFTER_RUN_ASYNC_EVENT, test)) {
-      return fire(TEST_AFTER_RUN_ASYNC_EVENT, test, Cypress)
+      return fire(TEST_AFTER_RUN_ASYNC_EVENT, test, Cypress, forceFire)
     }
   })
 }
@@ -114,12 +114,12 @@ const runnableAfterRunAsync = (runnable, Cypress) => {
   })
 }
 
-const testAfterRun = (test, Cypress) => {
+const testAfterRun = (test, Cypress, forceFire = false) => {
   test.clearTimeout()
   if (!fired(TEST_AFTER_RUN_EVENT, test)) {
     setWallClockDuration(test)
     try {
-      fire(TEST_AFTER_RUN_EVENT, test, Cypress)
+      fire(TEST_AFTER_RUN_EVENT, test, Cypress, forceFire)
     } catch (e) {
       // if the test:after:run listener throws it's likely spec code
       // Since the test status has already been emitted this can't affect the test status.
@@ -667,23 +667,11 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           await testBeforeAfterRunAsync(currentTest, Cypress, { nextTestHasTestIsolationOn })
         }
 
-        // Clear _ALREADY_RAN flag if set, as it prevents events from firing
-        // but we need the event to fire for protocol data capture
-        // We do this right before firing the events to minimize side effects
-        const wasAlreadyRan = currentTest._ALREADY_RAN
-
-        if (wasAlreadyRan) {
-          currentTest._ALREADY_RAN = false
-        }
-
-        testAfterRun(currentTest, Cypress)
-        await testAfterRunAsync(currentTest, Cypress)
-
-        // Restore _ALREADY_RAN flag after firing events to prevent side effects
-        // if this test object is used elsewhere
-        if (wasAlreadyRan) {
-          currentTest._ALREADY_RAN = true
-        }
+        // Force fire the events even if _ALREADY_RAN is set, as we need
+        // the event to fire for protocol data capture when tests are skipped
+        // due to hook failures
+        testAfterRun(currentTest, Cypress, true)
+        await testAfterRunAsync(currentTest, Cypress, true)
 
         // if the user has stopped the run and we are in run mode, we need to abort,
         // this needs to happen after the test:after:run events have fired

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -438,14 +438,15 @@ const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTe
 
   // Fallback: Find a test from the suite structure when we can't find one with failedFromHookId
   // This happens when tests were skipped due to before hook failure
+  // Only return tests that actually ran (are in _testsById), not skipped tests
   const foundTest = hookName === 'afterAll'
     ? findLastTestInSuite(suite, () => true) // afterAll runs after all tests, so use last test
     : findTestInSuite(suite, () => true) // afterEach runs after each test, so use first test
 
   if (foundTest) {
-    // Try to get the test from _testsById first (if it was run)
-    // If not found, use the test directly from the suite structure
-    return getTestById(foundTest.id) || foundTest
+    // Only return tests from _testsById which ensures they actually ran
+    // Don't return tests directly from suite structure as they may have been skipped
+    return getTestById(foundTest.id)
   }
 
   return null
@@ -490,6 +491,15 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
             return false
           }
 
+          // Verify the test actually ran by checking it exists in _testsById
+          // Tests that were skipped won't be in _testsById
+          const testFromById = getTestById(test.id)
+
+          if (!testFromById) {
+            // Test was skipped, don't fire the event
+            return false
+          }
+
           // find all of the grep'd tests which share
           // the same parent suite as our current test
           // test.parent should exist if test exists, but guard against it just in case
@@ -530,6 +540,15 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           }
 
           if (test) {
+            // Verify the test actually ran by checking it exists in _testsById
+            // Tests that were skipped won't be in _testsById
+            const testFromById = getTestById(test.id)
+
+            if (!testFromById) {
+              // Test was skipped, don't fire the event
+              return false
+            }
+
             // test.parent should exist if test exists, but guard against it just in case
             if (!test.parent) {
               // Can't determine siblings without a parent, skip sibling-based logic
@@ -560,16 +579,23 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
             }
           }
 
-          // For root suite's afterAll, always try to fire the event if we can find any test
+          // For root suite's afterAll, try to fire the event if we can find a test that actually ran
           // This ensures protocol data is captured even when both hooks fail
+          // Only fire for tests that actually ran (are in _testsById) or failed due to hooks
           if (isRootSuite(this.suite)) {
             const foundTest = findTestForHook(name, this.suite, test, getTestFromHookOrFindTest, getTestById, getTests, this)
 
             if (foundTest) {
-              test = foundTest
-              setTest(test)
+              // Verify the test actually ran by checking it exists in _testsById
+              // OR it has failedFromHookId (was supposed to run but failed due to hook)
+              const testFromById = getTestById(foundTest.id)
 
-              return true
+              if (testFromById || foundTest.failedFromHookId) {
+                test = foundTest
+                setTest(test)
+
+                return true
+              }
             }
           }
 
@@ -690,10 +716,10 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           await testBeforeAfterRunAsync(currentTest, Cypress, { nextTestHasTestIsolationOn })
         }
 
-        // Force fire the events only if _ALREADY_RAN is set, as we need
-        // the event to fire for protocol data capture when tests are skipped
-        // due to hook failures. Otherwise, use the normal fire behavior.
-        const shouldForceFire = !!currentTest._ALREADY_RAN
+        // Force fire the events only if _ALREADY_RAN is set AND failedFromHookId is set,
+        // as we need the event to fire for protocol data capture when tests failed due to hook failures.
+        // Don't force fire for tests that were simply skipped (_ALREADY_RAN without failedFromHookId).
+        const shouldForceFire = !!(currentTest._ALREADY_RAN && currentTest.failedFromHookId)
 
         testAfterRun(currentTest, Cypress, shouldForceFire)
         await testAfterRunAsync(currentTest, Cypress, shouldForceFire)

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -399,6 +399,12 @@ const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTe
     return test
   }
 
+  // Guard against undefined/null suite to prevent TypeError
+  // This can happen when this.suite is undefined in the runner context
+  if (!suite) {
+    return null
+  }
+
   // Try to get test from hook
   // Only call getTestFromHookOrFindTest if hook has a ctx property (is actually a hook object)
   // The runner context (this) doesn't have ctx, so we skip this path to avoid TypeError

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -488,7 +488,9 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           // the same parent suite as our current test
           // test.parent should exist if test exists, but guard against it just in case
           if (!test.parent) {
-            return true
+            // Can't determine siblings without a parent, skip sibling-based logic
+            // This prevents getAllSiblingTests from being called with a test object instead of a suite
+            return false
           }
 
           const tests = getAllSiblingTests(test.parent, getTestById)

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -444,9 +444,13 @@ const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTe
     : findTestInSuite(suite, () => true) // afterEach runs after each test, so use first test
 
   if (foundTest) {
-    // Only return tests from _testsById which ensures they actually ran
-    // Don't return tests directly from suite structure as they may have been skipped
-    return getTestById(foundTest.id)
+    const testFromById = getTestById(foundTest.id)
+
+    // Only return tests that actually ran OR have failedFromHookId
+    // Tests that are simply skipped (_ALREADY_RAN without failedFromHookId) should not be returned
+    if (testFromById && (!testFromById._ALREADY_RAN || testFromById.failedFromHookId)) {
+      return testFromById
+    }
   }
 
   return null
@@ -492,10 +496,10 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           }
 
           // Verify the test actually ran by checking it exists in _testsById
-          // Tests that were skipped won't be in _testsById
+          // AND that it either ran (!_ALREADY_RAN) or has failedFromHookId (was supposed to run but skipped due to hook)
           const testFromById = getTestById(test.id)
 
-          if (!testFromById) {
+          if (!testFromById || (testFromById._ALREADY_RAN && !testFromById.failedFromHookId)) {
             // Test was skipped, don't fire the event
             return false
           }
@@ -541,10 +545,10 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
           if (test) {
             // Verify the test actually ran by checking it exists in _testsById
-            // Tests that were skipped won't be in _testsById
+            // AND that it either ran (!_ALREADY_RAN) or has failedFromHookId (was supposed to run but skipped due to hook)
             const testFromById = getTestById(test.id)
 
-            if (!testFromById) {
+            if (!testFromById || (testFromById._ALREADY_RAN && !testFromById.failedFromHookId)) {
               // Test was skipped, don't fire the event
               return false
             }
@@ -587,10 +591,10 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
             if (foundTest) {
               // Verify the test actually ran by checking it exists in _testsById
-              // OR it has failedFromHookId (was supposed to run but failed due to hook)
+              // AND that it either ran (!_ALREADY_RAN) or has failedFromHookId (was supposed to run but skipped due to hook)
               const testFromById = getTestById(foundTest.id)
 
-              if (testFromById || foundTest.failedFromHookId) {
+              if (testFromById && (!testFromById._ALREADY_RAN || testFromById.failedFromHookId)) {
                 test = foundTest
                 setTest(test)
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -400,7 +400,9 @@ const findTestForHook = (hookName, suite, test, getTestFromHookOrFindTest, getTe
   }
 
   // Try to get test from hook
-  if (getTestFromHookOrFindTest && hook) {
+  // Only call getTestFromHookOrFindTest if hook has a ctx property (is actually a hook object)
+  // The runner context (this) doesn't have ctx, so we skip this path to avoid TypeError
+  if (getTestFromHookOrFindTest && hook && hook.ctx) {
     test = getTestFromHookOrFindTest(hook)
 
     if (test) {

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -92,7 +92,7 @@ const testBeforeRunAsync = (test, Cypress) => {
 const testBeforeAfterRunAsync = (test, Cypress, ...args) => {
   return Promise.try(() => {
     if (!fired(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test)) {
-      return fire(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test, Cypress, ...args)
+      return fire(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test, Cypress, false, ...args)
     }
   })
 }

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -390,7 +390,7 @@ const isRootSuite = (suite) => {
   return suite && suite.root
 }
 
-const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, getTests, cy, abort) => {
+const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, getTests, cy, abort, getTestFromHookOrFindTest) => {
   // bail if our _runner doesn't have a hook.
   // useful in tests
   if (!_runner.hook) {
@@ -407,7 +407,14 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
       return
     }
 
-    const test = getTest()
+    // Try to get the test from getTest() first, but if it's null (which can happen
+    // when a before hook fails and tests are skipped), try to find it from the hook
+    let test = getTest()
+
+    if (!test && getTestFromHookOrFindTest) {
+      test = getTestFromHookOrFindTest(this)
+    }
+
     const allTests = getTests()
 
     let shouldFireTestAfterRun = () => false
@@ -415,8 +422,21 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
     switch (name) {
       case 'afterEach':
         shouldFireTestAfterRun = () => {
+          // If we still don't have a test, we can't determine if we should fire
+          // but we should still try to fire the event to ensure protocol data is captured
+          if (!test) {
+            // For afterEach, if we can't find a test, we should still fire the event
+            // to ensure protocol can capture data even when hooks fail
+            return true
+          }
+
           // find all of the grep'd tests which share
           // the same parent suite as our current test
+          // test.parent should exist if test exists, but guard against it just in case
+          if (!test.parent) {
+            return true
+          }
+
           const tests = getAllSiblingTests(test.parent, getTestById)
 
           if (this.suite.root) {
@@ -436,9 +456,41 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
       case 'afterAll':
         shouldFireTestAfterRun = () => {
-          // find all of the filtered allTests which share
-          // the same parent suite as our current _test
-          // const t = getTest()
+          // If we don't have a test, try to find one associated with hook failure
+          // This can happen when a before hook fails and tests are skipped
+          if (!test) {
+            // First, try to find a test that was associated with a hook failure
+            // This test will have failedFromHookId set and is the one that was supposed to run
+            // when the before hook failed. This test should be in _testsById.
+            const allTests = getTests()
+            const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(this.suite, t.id))
+
+            if (testWithHookFailure) {
+              test = testWithHookFailure
+              setTest(test)
+            } else {
+              // Fallback: For afterAll hooks, find the last test that would have run in this suite
+              // This ensures we can still fire test:after:run:async even when tests were skipped
+              const foundTest = findLastTestInSuite(this.suite, () => true)
+
+              if (foundTest) {
+                // Try to get the test from _testsById first (if it was run)
+                // If not found, use the test directly from the suite structure
+                // (this happens when tests were skipped due to before hook failure)
+                test = getTestById(foundTest.id) || foundTest
+
+                // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
+                if (test && test._ALREADY_RAN) {
+                  test._ALREADY_RAN = false
+                }
+
+                // If we found a test, set it so the rest of the code can use it
+                if (test) {
+                  setTest(test)
+                }
+              }
+            }
+          }
 
           if (test) {
             const siblings = getAllSiblingTests(test.parent, getTestById)
@@ -466,6 +518,23 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
             }
           }
 
+          // For root suite's afterAll, always try to fire the event if we can find any test
+          // This ensures protocol data is captured even when both hooks fail
+          if (isRootSuite(this.suite)) {
+            // Try one more time to find a test from the suite
+            const foundTest = findLastTestInSuite(this.suite, () => true)
+
+            if (foundTest) {
+              test = getTestById(foundTest.id) || foundTest
+
+              if (test) {
+                setTest(test)
+
+                return true
+              }
+            }
+          }
+
           return false
         }
 
@@ -477,14 +546,98 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
 
     const newArgs = [name, $utils.monkeypatchBeforeAsync(fn,
       async function () {
-        if (!shouldFireTestAfterRun()) return
+        // Re-evaluate test in case it was found in shouldFireTestAfterRun
+        // Note: test may have been modified by shouldFireTestAfterRun closure for afterAll
+        // We need to check the closure's test variable first since it may have been set
+        let currentTest = test
+
+        // If test was found in shouldFireTestAfterRun closure, use it
+        // Otherwise, try to find it using other methods
+        if (!currentTest && getTestFromHookOrFindTest) {
+          currentTest = getTestFromHookOrFindTest(this)
+        }
+
+        // If still no test, try to find it from the suite
+        // This is important when both before and after hooks fail
+        if (!currentTest) {
+          if (name === 'afterAll') {
+            // For afterAll, try to find a test that was associated with a hook failure
+            // This test will have failedFromHookId set and is the one that was supposed to run
+            // when the before hook failed. This test should be in _testsById.
+            const allTests = getTests()
+            const testWithHookFailure = allTests.find((t) => t.failedFromHookId && suiteHasTest(this.suite, t.id))
+
+            if (testWithHookFailure) {
+              currentTest = testWithHookFailure
+            } else {
+              // Fallback: find the last test that would have run in this suite
+              const foundTest = findLastTestInSuite(this.suite, () => true)
+
+              if (foundTest) {
+                // Try to get the test from _testsById first (if it was run)
+                // If not found, use the test directly from the suite structure
+                // (this happens when tests were skipped due to before hook failure)
+                currentTest = getTestById(foundTest.id) || foundTest
+
+                // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
+                // This is necessary when tests were skipped due to before hook failure
+                // The _ALREADY_RAN flag prevents events from firing, but we need the event
+                // to fire for protocol data capture even when tests were skipped
+                if (currentTest && currentTest._ALREADY_RAN) {
+                  currentTest._ALREADY_RAN = false
+                }
+              }
+            }
+          } else if (name === 'afterEach') {
+            // For afterEach, try to find the first test in the suite
+            // This can happen when a before hook fails and the test was skipped
+            const foundTest = findTestInSuite(this.suite, () => true)
+
+            if (foundTest) {
+              // Try to get the test from _testsById first (if it was run)
+              // If not found, use the test directly from the suite structure
+              currentTest = getTestById(foundTest.id) || foundTest
+
+              // If the test has _ALREADY_RAN set, temporarily clear it so the event can fire
+              if (currentTest && currentTest._ALREADY_RAN) {
+                currentTest._ALREADY_RAN = false
+              }
+            }
+          }
+        }
+
+        // Check if we should fire the event
+        // Note: shouldFireTestAfterRun may have modified the test variable in its closure
+        // so we need to re-check test after calling it
+        const shouldFire = shouldFireTestAfterRun()
+
+        // Re-check test in case shouldFireTestAfterRun found and set it
+        if (!currentTest) {
+          currentTest = test
+        }
+
+        if (!shouldFire) {
+          // Allow the hook to complete normally
+          return
+        }
 
         setTest(null)
 
-        if (test.final !== false) {
-          test.final = true
-          if (test.state === 'passed') {
-            if (test?._cypressTestStatusInfo?.outerStatus === 'failed') {
+        // Only proceed with test-related logic if we have a test to work with
+        // testAfterRun and testAfterRunAsync require a test object
+        // If we don't have a test, we still need to allow the hook to complete
+        // to prevent hanging, but we can't fire test:after:run:async without a test
+        if (!currentTest) {
+          // Allow the hook to complete normally even without a test
+          // This prevents hanging when both before and after hooks fail
+          // The hook will complete, but test:after:run:async won't fire
+          return
+        }
+
+        if (currentTest.final !== false) {
+          currentTest.final = true
+          if (currentTest.state === 'passed') {
+            if (currentTest?._cypressTestStatusInfo?.outerStatus === 'failed') {
               // We call _runner.fail here instead of in mocha because we need to make sure none of the hooks mutate the current test state, which might trigger
               // another attempt. This affects our server reporter by reporting the test final status multiple times and incorrect attempt statuses.
               // We can be sure here that the test is settled and we can fail it appropriately if the condition is met.
@@ -494,19 +647,19 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
               // last attempt to be marked as 'passed'. This is where 'forceState' comes into play (see 'calculateTestStatus' in ./driver/src/cypress/mocha.ts)
 
               // If there are other hooks (such as multiple afterEach hooks) that MIGHT impact the end conditions of the test, we only want to fail this ONCE!
-              const lastTestWithErr = (test.prevAttempts || []).find((t) => t.state === 'failed')
+              const lastTestWithErr = (currentTest.prevAttempts || []).find((t) => t.state === 'failed')
               // TODO: figure out serialization with this looked up error as it isn't printed to the console reporter properly.
               const err = lastTestWithErr?.err
 
               // fail the test as it would in the mocha/lib/runner.js as we can now be certain that no other hooks will impact the state of the test (regardless of hierarchy)
-              _runner.fail(test, err)
+              _runner.fail(currentTest, err)
             } else {
               // If the last test attempt passed, but the outerStatus isn't marked as failed, then we want to emit the mocha 'pass' event.
-              Cypress.action('runner:pass', wrap(test))
+              Cypress.action('runner:pass', wrap(currentTest))
             }
           }
 
-          Cypress.action('runner:test:end', wrap(test))
+          Cypress.action('runner:test:end', wrap(currentTest))
 
           _runner._shouldBufferSuiteEnd = false
           _runner._onTestAfterRun.map((fn) => {
@@ -516,7 +669,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           _runner._onTestAfterRun = []
         }
 
-        let topSuite = test
+        let topSuite = currentTest
 
         while (topSuite.parent) {
           topSuite = topSuite.parent
@@ -525,7 +678,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         const isRunMode = !Cypress.config('isInteractive')
         const isHeadedNoExit = Cypress.config('browser').isHeaded && !Cypress.config('exit')
         const shouldAlwaysResetPage = isRunMode && !isHeadedNoExit
-        const isLastTestThatWillRunInSuite = test.final && lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))
+        const isLastTestThatWillRunInSuite = currentTest.final && lastTestThatWillRunInSuite(currentTest, getAllSiblingTests(topSuite, getTestById))
 
         // If we're not in open mode or we're in open mode and not the last test we reset state.
         // The last test will needs to stay so that the user can see what the end result of the AUT was.
@@ -533,7 +686,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           let nextTestHasTestIsolationOn
 
           if (!isLastTestThatWillRunInSuite) {
-            const nextTest = nextTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))
+            const nextTest = nextTestThatWillRunInSuite(currentTest, getAllSiblingTests(topSuite, getTestById))
             const nextTestIsolationOverride = nextTest?._testConfig.unverifiedTestConfig.testIsolation
             const topLevelTestIsolation = Cypress.originalConfig['testIsolation']
 
@@ -548,11 +701,11 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           cy.removeAllListeners('window:load')
 
           // This will navigate to about:blank if test isolation is on
-          await testBeforeAfterRunAsync(test, Cypress, { nextTestHasTestIsolationOn })
+          await testBeforeAfterRunAsync(currentTest, Cypress, { nextTestHasTestIsolationOn })
         }
 
-        testAfterRun(test, Cypress)
-        await testAfterRunAsync(test, Cypress)
+        testAfterRun(currentTest, Cypress)
+        await testAfterRunAsync(currentTest, Cypress)
 
         // if the user has stopped the run and we are in run mode, we need to abort,
         // this needs to happen after the test:after:run events have fired
@@ -1417,7 +1570,7 @@ export default {
       _runner.removeAllListeners()
     }
 
-    overrideRunnerHook(Cypress, _runner, getTestById, getTest, setTest, getTests, cy, abort)
+    overrideRunnerHook(Cypress, _runner, getTestById, getTest, setTest, getTests, cy, abort, getTestFromHookOrFindTest)
 
     // this forces mocha to enqueue a duplicate test in the case of test retries
     const replacePreviousAttemptWith = (test) => {

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -669,11 +669,13 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           await testBeforeAfterRunAsync(currentTest, Cypress, { nextTestHasTestIsolationOn })
         }
 
-        // Force fire the events even if _ALREADY_RAN is set, as we need
+        // Force fire the events only if _ALREADY_RAN is set, as we need
         // the event to fire for protocol data capture when tests are skipped
-        // due to hook failures
-        testAfterRun(currentTest, Cypress, true)
-        await testAfterRunAsync(currentTest, Cypress, true)
+        // due to hook failures. Otherwise, use the normal fire behavior.
+        const shouldForceFire = !!currentTest._ALREADY_RAN
+
+        testAfterRun(currentTest, Cypress, shouldForceFire)
+        await testAfterRunAsync(currentTest, Cypress, shouldForceFire)
 
         // if the user has stopped the run and we are in run mode, we need to abort,
         // this needs to happen after the test:after:run events have fired


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `test:after:run`/`test:after:run:async` fire for tests impacted by hook failures via a force-fire path and robust test lookup in the runner.
> 
> - **Runner lifecycle**:
>   - Add `forceFire` to `fire`, `testAfterRun`, and `testAfterRunAsync` to allow emitting after-run events even when `_ALREADY_RAN` when tied to hook failures.
>   - Introduce `findTestForHook(...)` to resolve the correct test during `afterEach/afterAll` when normal lookup fails (e.g., before hook failures, skipped suites), with guards to avoid simply skipped tests.
>   - Enhance `overrideRunnerHook(...)` to:
>     - Use `findTestForHook` to set the current test for `afterEach/afterAll`.
>     - Gate emission to only tests that actually ran or have `failedFromHookId`; avoid firing for plain skips.
>     - Capture suite/runner context and re-evaluate before emitting.
>     - Compute `shouldForceFire` based on `_ALREADY_RAN && failedFromHookId` and pass to after-run events.
>     - Maintain existing suite buffering and last-test logic with added null/parent guards.
>   - Wire new helper into runner creation by passing `getTestFromHookOrFindTest` to `overrideRunnerHook`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed0e6c680590431dbf0bb8ae26c7ecd3ee50fd62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
