### PR TITLE
dependency: bump systeminformation for CVE-2025-68154

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.8.1
+
+_Released 12/30/2025 (PENDING)_
+
+**Dependency Updates:**
+
+- Upgraded `systeminformation` to `5.27.14`. This removes the [CVE-2025-68154](https://github.com/advisories/GHSA-wphj-fx3q-84ch) vulnerability being reported in security scans. Fixes [#33146](https://github.com/cypress-io/cypress/issues/33146).
+
 ## 15.8.0
 
 _Released 12/16/2025_

--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,7 @@
     "proxy-from-env": "1.0.0",
     "request-progress": "^3.0.0",
     "supports-color": "^8.1.1",
-    "systeminformation": "5.27.14",
+    "systeminformation": "^5.27.14",
     "tmp": "~0.2.4",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,7 @@
     "proxy-from-env": "1.0.0",
     "request-progress": "^3.0.0",
     "supports-color": "^8.1.1",
-    "systeminformation": "5.27.7",
+    "systeminformation": "5.27.14",
     "tmp": "~0.2.4",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -28,7 +28,7 @@
     "eslint": "^9.31.0",
     "execa": "4.1.0",
     "mocha": "3.5.3",
-    "systeminformation": "^5.27.7",
+    "systeminformation": "^5.27.14",
     "vitest": "^3.2.4"
   },
   "files": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -116,7 +116,7 @@
     "squirrelly": "7.9.2",
     "strip-ansi": "6.0.1",
     "syntax-error": "1.4.0",
-    "systeminformation": "^5.27.7",
+    "systeminformation": "^5.27.14",
     "tar": "^6.2.1",
     "term-size": "2.1.0",
     "through": "2.3.8",

--- a/system-tests/package.json
+++ b/system-tests/package.json
@@ -87,7 +87,7 @@
     "snap-shot-it": "7.9.10",
     "ssestream": "1.0.1",
     "supertest": "4.0.2",
-    "systeminformation": "^5.27.7",
+    "systeminformation": "^5.27.14",
     "temp-dir": "^2.0.0",
     "webpack": "^5.88.2",
     "ws": "5.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30777,10 +30777,10 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@5.27.7, systeminformation@^5.27.7:
-  version "5.27.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.7.tgz#4dc9d436419948cd5e5f076779a1298220d19a72"
-  integrity sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==
+systeminformation@5.27.14, systeminformation@^5.27.14:
+  version "5.27.14"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
+  integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==
 
 systemjs@^6.15.1:
   version "6.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30777,7 +30777,7 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@5.27.14, systeminformation@^5.27.14:
+systeminformation@^5.27.14:
   version "5.27.14"
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
   integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33146
- Supersedes https://github.com/cypress-io/cypress/pull/33144

### Additional details

Dependabot and `npm audit` report a high severity vulnerability CVE-2025-68154 (https://github.com/advisories/GHSA-wphj-fx3q-84ch) in the npm module [systeminformation](https://www.npmjs.com/package/systeminformation) `<5.27.14` used by Cypress.

The vulnerability is not fixable with `npm audit fix`, apart from downgrading the version of Cypress to `<15.1.0`.

Usage of [systeminformation](https://www.npmjs.com/package/systeminformation) is updated to `5.27.14`

https://github.com/sebhildebrandt/systeminformation/blob/v5.27.14/CHANGELOG.md#version-history
https://github.com/sebhildebrandt/systeminformation/compare/v5.27.7...v5.27.14

### Steps to test

Execute the following and confirm that `systeminformation` is no longer identified as a high severity vulnerability:

```shell
yarn audit --level high --groups dependencies | grep -C 10 systeminformation
```

### How has the user experience changed?

After installing Cypress, Dependabot and `npm audit` no longer report the high severity vulnerability CVE-2025-68154.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

