### PR TITLE
chore: Revert "chore: release @cypress/schematic-v5.0.0"

### DIFF
--- a/npm/cypress-schematic/CHANGELOG.md
+++ b/npm/cypress-schematic/CHANGELOG.md
@@ -1,15 +1,3 @@
-# [@cypress/schematic-v5.0.0](https://github.com/cypress-io/cypress/compare/@cypress/schematic-v4.3.0...@cypress/schematic-v5.0.0) (2025-12-19)
-
-
-### breaking
-
-* release version 5.0.0 of @cypress/schematic. ([e3c9214](https://github.com/cypress-io/cypress/commit/e3c921412c215ca469f354ab1f4d4c08dd359f58))
-
-
-### BREAKING CHANGES
-
-* release version 5.0.0 of @cypress/schematic, which supports Angular 20 and 21 and adds scaffolding support for @cypress/angular-zoneless for Angular 21+ projects. Since Cypress introduced @cypress/angular-zoneless in Cypress 15.8.0, Cypress ^15.8.0 is now a peer dependency of @cypress/schematic. Additionally, support for Angular 18 and 19 have been removed and will only be supported in @cypress/schematic ^4.0.0.
-
 # [@cypress/schematic-v4.3.0](https://github.com/cypress-io/cypress/compare/@cypress/schematic-v4.2.0...@cypress/schematic-v4.3.0) (2025-12-05)
 
 


### PR DESCRIPTION
This reverts commit 7481afd6bc9d5f134df7a2e9b18a96ef183d79d9.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Reverts the commit semantic commit pushed upstream into `develop` because the release did not actually occur. Once reverted, the `npm-release` job will run correctly as the token is now appropriately configured. 

The `@cypress/schematic@5.0.0` tag has already been deleted from git. I have also verified the correct release is calculated after this revert.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the v5.0.0 release entry in `npm/cypress-schematic/CHANGELOG.md`, restoring v4.3.0 as the latest noted version.
> 
> - **Changelog**: Remove `@cypress/schematic-v5.0.0` section from `npm/cypress-schematic/CHANGELOG.md`, restoring `v4.3.0` as the top entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f9684c5f239cc2b53edbe37ab25900716e246ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
