### PR TITLE
fix: process exit before stdout/stderr are properly flushed

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.8.3
+
+_Released <RELEASE_DATE> (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where output could be cut off when the process exits in CI environments.
+
 ## 15.8.2
 
 _Released 01/06/2026_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,11 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.8.3
 
-_Released xx/xx/xxxx (PENDING)_
+_Released 1/13/2026 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue where output could be cut off when the process exits in CI environments.
+- Fixed an issue where output could be cut off when the process exits in CI environments. Fixed in [#33213](https://github.com/cypress-io/cypress/pull/33213).
 
 ## 15.8.2
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.8.3
 
-_Released <RELEASE_DATE> (PENDING)_
+_Released xx/xx/xxxx (PENDING)_
 
 **Bugfixes:**
 

--- a/packages/server/lib/cypress.ts
+++ b/packages/server/lib/cypress.ts
@@ -20,6 +20,24 @@ const debug = Debug('cypress:server:cypress')
 
 type Mode = 'exit' | 'info' | 'interactive' | 'pkg' | 'record' | 'results' | 'run' | 'smokeTest' | 'version' | 'returnPkg' | 'exitWithCode'
 
+/**
+ * Waits for a writable stream to drain its buffer.
+ * This is necessary because when stdout/stderr is piped (e.g., in CI environments),
+ * writes are buffered and process.exit() would terminate before the buffer is flushed.
+ */
+const waitForStreamDrain = (stream: NodeJS.WriteStream): Promise<void> => {
+  return new Promise((resolve) => {
+    if (!stream.isTTY && stream.writableLength > 0) {
+      debug('waiting for stream to drain, writableLength: %d', stream.writableLength)
+      stream.once('drain', resolve)
+      // Safety timeout to prevent hanging indefinitely
+      setTimeout(resolve, 5000)
+    } else {
+      setImmediate(resolve)
+    }
+  })
+}
+
 const exit = async (code = 0) => {
   // TODO: we shouldn't have to do this
   // but cannot figure out how null is
@@ -40,6 +58,13 @@ const exit = async (code = 0) => {
   await telemetry.shutdown().catch((err: any) => {
     debug('telemetry shutdown errored with: ', err)
   })
+
+  // Wait for stdout/stderr to drain before exiting to prevent truncated output in CI
+  debug('waiting for stdout/stderr to drain before exit')
+  await Promise.all([
+    waitForStreamDrain(process.stdout),
+    waitForStreamDrain(process.stderr),
+  ])
 
   debug('process.exit', code)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> No issues

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
ON CI envs ( like github actions ), processs exit can terminate the process before stdout/stderr are properly flushed.
It lead to a cropped result summary table


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents truncated terminal output in CI by guaranteeing buffered streams flush before exit.
> 
> - Adds `waitForStreamDrain()` and awaits it for `process.stdout` and `process.stderr` in `packages/server/lib/cypress.ts` `exit()`
> - Includes a 5s safety timeout and debug logs while waiting
> - Updates `cli/CHANGELOG.md` with `15.8.3` bugfix entry describing the CI output cut-off fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a128d671aeb12db11a86a1295041cefe9c9ced5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Create a lot of specs files, run Cypress on Ci env like Github Action, the result summary table is cropped.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
No change

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

Not sure how to add tests for this one.

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
