### PR TITLE
internal: (studio) log the last error from an AggregateError

### DIFF
--- a/packages/server/lib/cloud/api/cy-prompt/report_cy_prompt_error.ts
+++ b/packages/server/lib/cloud/api/cy-prompt/report_cy_prompt_error.ts
@@ -44,6 +44,8 @@ export function reportCyPromptError ({
     return
   }
 
+  const errorToReport = error instanceof AggregateError ? error.errors[error.errors.length - 1] : error
+
   // When developing locally, do not send to Sentry, but instead log to console.
   if (
     process.env.CYPRESS_LOCAL_CY_PROMPT_PATH ||
@@ -51,17 +53,17 @@ export function reportCyPromptError ({
     process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF
   ) {
     // eslint-disable-next-line no-console
-    console.error(`Error in ${cyPromptMethod}:`, error)
+    console.error(`Error in ${cyPromptMethod}:`, errorToReport)
 
     return
   }
 
   let errorObject: Error
 
-  if (!(error instanceof Error)) {
-    errorObject = new Error(String(error))
+  if (!(errorToReport instanceof Error)) {
+    errorObject = new Error(String(errorToReport))
   } else {
-    errorObject = error
+    errorObject = errorToReport
   }
 
   let cyPromptMethodArgsString: string | undefined

--- a/packages/server/lib/cloud/api/studio/report_studio_error.ts
+++ b/packages/server/lib/cloud/api/studio/report_studio_error.ts
@@ -44,26 +44,28 @@ export function reportStudioError ({
     return
   }
 
+  const errorToReport = error instanceof AggregateError ? error.errors[error.errors.length - 1] : error
+
   // When developing locally, do not send to Sentry, but instead log to console.
   if (
     process.env.CYPRESS_LOCAL_STUDIO_PATH ||
     process.env.NODE_ENV === 'development' ||
     process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF
   ) {
-    logError(`Error in ${studioMethod}:`, error)
+    logError(`Error in ${studioMethod}:`, errorToReport)
 
     return
   }
 
   let errorObject: Error
 
-  if (!(error instanceof Error)) {
+  if (!(errorToReport instanceof Error)) {
     // Use safe serialization that handles circular references and other edge cases
-    const message = exception.safeErrorSerialize(error)
+    const message = exception.safeErrorSerialize(errorToReport)
 
     errorObject = new Error(message)
   } else {
-    errorObject = error
+    errorObject = errorToReport
   }
 
   let studioMethodArgsString: string | undefined

--- a/packages/server/lib/cloud/cy-prompt/CyPromptLifecycleManager.ts
+++ b/packages/server/lib/cloud/cy-prompt/CyPromptLifecycleManager.ts
@@ -88,8 +88,6 @@ export class CyPromptLifecycleManager {
       const cloudUrl = ctx.cloud.getCloudUrl(cloudEnv)
       const cloudHeaders = await ctx.cloud.additionalHeaders()
 
-      const lastError = error instanceof AggregateError ? error.errors[error.errors.length - 1] : error
-
       reportCyPromptError({
         cloudApi: {
           cloudUrl,
@@ -101,13 +99,15 @@ export class CyPromptLifecycleManager {
         additionalHeaders: cloudHeaders,
         cyPromptHash: this.cyPromptHash,
         projectSlug: (await ctx.project.getConfig()).projectId || undefined,
-        error: lastError,
+        error,
         cyPromptMethod: 'initializeCyPromptManager',
         cyPromptMethodArgs: [],
       })
 
       // Clean up any registered listeners
       this.listeners = []
+
+      const lastError = error instanceof AggregateError ? error.errors[error.errors.length - 1] : error
 
       return { error: lastError }
     })

--- a/packages/server/test/unit/cloud/api/cy-prompt/report_cy_prompt_error_spec.ts
+++ b/packages/server/test/unit/cloud/api/cy-prompt/report_cy_prompt_error_spec.ts
@@ -288,5 +288,42 @@ describe('lib/cloud/api/cy-prompt/report_cy_prompt_error', () => {
       // Just verify the post was called, don't check debug output
       expect(cloudRequestStub).to.be.called
     })
+
+    it('extracts last error from AggregateError', () => {
+      const aggregateError = new AggregateError(
+        [new Error('First error'), new Error('Second error')],
+        'Multiple errors',
+      )
+
+      reportCyPromptError({
+        cloudApi,
+        cyPromptHash: 'abc123',
+        projectSlug: 'test-project',
+        error: aggregateError,
+        cyPromptMethod: 'testMethod',
+      })
+
+      expect(cloudRequestStub).to.be.calledWithMatch(
+        'http://localhost:1234/cy-prompt/errors',
+        {
+          cyPromptHash: 'abc123',
+          projectSlug: 'test-project',
+          errors: [{
+            name: 'Error',
+            message: 'Second error',
+            stack: sinon.match((stack) => stack.includes('<stripped-path>report_cy_prompt_error_spec.ts')),
+            code: undefined,
+            errno: undefined,
+            cyPromptMethod: 'testMethod',
+            cyPromptMethodArgs: undefined,
+          }],
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      )
+    })
   })
 })

--- a/packages/server/test/unit/cloud/api/studio/report_studio_error_spec.ts
+++ b/packages/server/test/unit/cloud/api/studio/report_studio_error_spec.ts
@@ -342,5 +342,43 @@ describe('lib/cloud/api/studio/report_studio_error', () => {
       // Just verify the post was called, don't check debug output
       expect(cloudRequestStub).to.be.called
     })
+
+    it('extracts last error from AggregateError', () => {
+      const aggregateError = new AggregateError(
+        [new Error('First error'), new Error('Second error')],
+        'Multiple errors',
+      )
+
+      reportStudioError({
+        cloudApi,
+        studioHash: 'abc123',
+        projectSlug: 'test-project',
+        error: aggregateError,
+        studioMethod: 'testMethod',
+      })
+
+      expect(cloudRequestStub).to.be.calledWithMatch(
+        'http://localhost:1234/studio/errors',
+        {
+          studioHash: 'abc123',
+          projectSlug: 'test-project',
+          errors: [{
+            name: 'Error',
+            message: 'Second error',
+            stack: sinon.match((stack) => stack.includes('<stripped-path>report_studio_error_spec.ts')),
+            code: undefined,
+            errno: undefined,
+            studioMethod: 'testMethod',
+            studioMethodArgs: undefined,
+          }],
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'x-cypress-version': '1.2.3',
+          },
+        },
+      )
+    })
   })
 })

--- a/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/cy-prompt/CyPromptLifecycleManager_spec.ts
@@ -637,7 +637,7 @@ describe('CyPromptLifecycleManager', () => {
         },
         cyPromptHash: 'abc',
         projectSlug: 'test-project-id',
-        error: aggregateError.errors[aggregateError.errors.length - 1],
+        error: aggregateError,
         cyPromptMethod: 'initializeCyPromptManager',
         cyPromptMethodArgs: [],
         additionalHeaders: {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/33187

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Instead of logging AggregateErrors to Sentry, we should log the last error in the array. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error reporting by handling `AggregateError` consistently across Studio and Cy Prompt.
> 
> - Use the last inner error from `AggregateError` in `report_studio_error` and `report_cy_prompt_error` for console logging and payload construction
> - `CyPromptLifecycleManager` now forwards the original error to `reportCyPromptError` while still returning the last inner error from `AggregateError`
> - Unit tests added/updated to verify `AggregateError` extraction and updated expectations for error forwarding and request payloads
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66134a0f18a9fef905a7aefa072cfa9b1842ab69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
