### PR TITLE
chore: enforce CHANGELOG release date MM/DD/YYYY format

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.9.0
 
-_Released 01/13/2026 (PENDING)_
+_Released 1/13/2026 (PENDING)_
 
 **Features:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.9.0
 
-_Released 1/13/2026 (PENDING)_
+_Released 01/13/2026 (PENDING)_
 
 **Features:**
 

--- a/scripts/semantic-commits/parse-changelog.js
+++ b/scripts/semantic-commits/parse-changelog.js
@@ -38,10 +38,10 @@ async function parseChangelog ({ pendingRelease = true, changelogContent = null 
       sections['version'] = line
     } else if (index === 3) {
       nextKnownLineBreak = index + 1
-      if (pendingRelease && !/_Released \d+\/\d+\/\d+ \(PENDING\)_/.test(line)) {
-        throw new Error(`Expected line number ${index + 1} to include "_Released xx/xx/xxxx (PENDING)_"`)
-      } else if (!pendingRelease && !/_Released \d+\/\d+\/\d+_/.test(line)) {
-        throw new Error(`Expected line number ${index + 1} to include "_Released xx/xx/xxxx_"`)
+      if (pendingRelease && !/_Released \d{2}\/\d{2}\/\d{4} \(PENDING\)_/.test(line)) {
+        throw new Error(`Expected line number ${index + 1} to include "_Released MM/DD/YYYY (PENDING)_"`)
+      } else if (!pendingRelease && !/_Released \d{2}\/\d{2}\/\d{4}_/.test(line)) {
+        throw new Error(`Expected line number ${index + 1} to include "_Released MM/DD/YYYY_"`)
       }
 
       sections['releaseDate'] = line


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33215

### Additional details

The [Changelog > Writing Guidelines](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md#writing-guidelines) say:

> The `RELEASE_DATE` follows the `MM/DD/YYYY` format (two-digit month, two-digit day, four-digit year), including leading zeros for any single-digit month or day.

Changelog linting carried out by [scripts/semantic-commits/parse-changelog.js](https://github.com/cypress-io/cypress/blob/develop/scripts/semantic-commits/parse-changelog.js) did not previously check the number of month, day or year digits in the [cli/CHANGELOG.md](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md) source file.

Linting now enforces a two-digit month, two-digit day, four-digit year format for the release date.

In case of error, the message is changed from displaying an "xx/xx/xxxx" format to instead displaying the more informative "MM/DD/YYYY" format which shows the required order of month, day and year fields.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens changelog linting to enforce a strict `MM/DD/YYYY` release date format.
> 
> - Updates regex in `scripts/semantic-commits/parse-changelog.js` to require `\d{2}/\d{2}/\d{4}` for both pending and non-pending releases
> - Revises error messages to explicitly reference `MM/DD/YYYY`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a5476b96114d9eb84cb3431dda97149a04468a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test

I was not able to test this in a fork.

Test by submitting PRs with correct and incorrect release dates for user-facing changes.

CI does not check the changelog for PRs which do not require a changelog entry. In this case there is a log message recorded only:

> Does not contain any user-facing changes that impacts the next Cypress release.

### How has the user experience changed?

No change to the end-user experience. This change affects and assists contributors only.

### PR Tasks

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?