### PR TITLE
chore: correct grammar & typos in CHANGELOG linting

### DIFF
--- a/scripts/semantic-commits/change-categories.js
+++ b/scripts/semantic-commits/change-categories.js
@@ -18,13 +18,13 @@ const userFacingChanges = {
     release: 'major',
   },
   dependency: {
-    description: 'A change to a dependency that impact the user',
+    description: 'A change to a dependency that impacts the user',
     section: '**Dependency Updates:**',
     message: changeLinkPhrases.default,
     release: 'patch',
   },
   deprecation: {
-    description: 'A API deprecation notice for users',
+    description: 'An API deprecation notice for users',
     section: '**Deprecations:**',
     message: changeLinkPhrases.default,
     release: 'minor',

--- a/scripts/semantic-commits/get-binary-release-data.js
+++ b/scripts/semantic-commits/get-binary-release-data.js
@@ -21,14 +21,14 @@ const ensureAuth = () => {
  *
  * @param {object} latestReleaseInfo - data of the latest tag published on npm
  * @param {string} latestReleaseInfo.version - version of Cypress
- * @param {string} latestReleaseInfo.commitDate - data of release
+ * @param {string} latestReleaseInfo.commitDate - date of release
  * @param {string} latestReleaseInfo.buildSha - git commit associated with published content
  */
 const getChangedFilesSinceLastRelease = (latestReleaseInfo) => {
   const stdout = childProcess.execSync(`git diff ${latestReleaseInfo.buildSha}.. --name-only`, { encoding: 'utf8' })
 
   if (!stdout) {
-    console.log('no files changes since last release')
+    console.log('no file changes since last release')
 
     return []
   }
@@ -102,7 +102,7 @@ const fetchPullRequest = async (octokit, pullNumber) => {
  *
  * @param {object} latestReleaseInfo - data of the latest tag published on npm
  * @param {string} latestReleaseInfo.version - version of Cypress
- * @param {string} latestReleaseInfo.commitDate - data of release
+ * @param {string} latestReleaseInfo.commitDate - date of release
  * @param {string} latestReleaseInfo.buildSha - git commit associated with published content
  */
 const getReleaseData = async (latestReleaseInfo) => {

--- a/scripts/semantic-commits/validate-changelog.js
+++ b/scripts/semantic-commits/validate-changelog.js
@@ -6,7 +6,7 @@ const hasUserFacingChange = (type) => Object.keys(userFacingChanges).includes(ty
 
 /**
  * Formats the resolved message that is appended to the changelog entry to indicate what
- * issues where addressed by a given change. If no issues are addressed, it references the
+ * issues were addressed by a given change. If no issues are addressed, it references the
  * pull request which made the change.
  */
 function _getResolvedMessage (semanticType, prNumber, associatedIssues = []) {
@@ -55,7 +55,7 @@ function _printChangeLogExample (semanticType, prNumber, associatedIssues = []) 
 }
 
 /**
- * Ensures the changelog entry was added to the correct changelog section given it's semantic commit type
+ * Ensures the changelog entry was added to the correct changelog section given its semantic commit type
  * and that it includes the correct reference(s) to the issue(s) or pull request the commit addressed.
  */
 function _validateEntry (changelog, { commitMessage, prNumber, semanticType, associatedIssues }) {
@@ -122,7 +122,7 @@ const _handleErrors = (errors) => {
 }
 
 /**
- * Determines if the Cypress changelog has the correct next version and changelog entires given the provided
+ * Determines if the Cypress changelog has the correct next version and changelog entries given the provided
  * list of commits.
  *
  * Can be skipped by setting the SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES
@@ -143,7 +143,7 @@ async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, c
   const hasUserFacingCommits = commits.some(({ semanticType }) => hasUserFacingChange(semanticType))
 
   if (!hasUserFacingCommits) {
-    console.log('Does not contain any user-facing changes that impacts the next Cypress release.')
+    console.log('Does not contain any user-facing changes that impact the next Cypress release.')
 
     return []
   }
@@ -156,7 +156,7 @@ async function validateChangelog ({ changedFiles, nextVersion, pendingRelease, c
   let errors = []
 
   if (binaryFiles.length === 0) {
-    console.log('Does not contain changes that impacts the next Cypress release.')
+    console.log('Does not contain changes that impact the next Cypress release.')
 
     return []
   }

--- a/scripts/unit/semantic-commits/validate-changelog-spec.js
+++ b/scripts/unit/semantic-commits/validate-changelog-spec.js
@@ -233,7 +233,7 @@ _Released 01/17/2033 (PENDING)_
           }],
         })
 
-        expect(console.log).to.be.calledWith('Does not contain any user-facing changes that impacts the next Cypress release.')
+        expect(console.log).to.be.calledWith('Does not contain any user-facing changes that impact the next Cypress release.')
       })
 
       it('when commit does not include cli or binary file changes', async () => {
@@ -250,7 +250,7 @@ _Released 01/17/2033 (PENDING)_
           }],
         })
 
-        expect(console.log).to.be.calledWith('Does not contain changes that impacts the next Cypress release.')
+        expect(console.log).to.be.calledWith('Does not contain changes that impact the next Cypress release.')
       })
 
       it('when current branch is in SKIP_RELEASE_CHANGELOG_VALIDATION_FOR_BRANCHES env var', async () => {


### PR DESCRIPTION
### Additional details

Corrects grammar and typos in CI linting files found in [scripts/semantic-commits](https://github.com/cypress-io/cypress/tree/develop/scripts/semantic-commits).

### Steps to test

Check by inspected code only, since these are text changes without any change to logic.

### How has the user experience changed?

No change to the end-user experience. This change affects contributors only.

### PR Tasks

- [X] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines wording across changelog/release scripts and synchronizes tests with updated messages.
> 
> - Updates descriptions, comments, and console messages in `change-categories.js`, `get-binary-release-data.js`, and `validate-changelog.js` (e.g., "impacts" vs "impact", "were" vs "where", "its" vs "it's", "entries" typo)
> - Adjusts `validate-changelog-spec.js` expectations to match revised log strings
> - No logic changes; only text/message corrections
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d69fff692739dbb8ecc1ae3c6506b2c7cd7ac4c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->