### PR TITLE
docs: add package name and version formatting to changelog guidelines

### DIFF
--- a/guides/writing-the-cypress-changelog.md
+++ b/guides/writing-the-cypress-changelog.md
@@ -54,6 +54,24 @@ The changelog should include anything that was merged into the `develop` branch 
     - When no issues, but PR: "Addressed in [#12]([https://github.com/cypress-io/cypress/issues/12](https://github.com/cypress-io/cypress/issues/1234))."
     - When multiple issues: "Fixes [#12]([https://github.com/cypress-io/cypress/issues/12](https://github.com/cypress-io/cypress/issues/1234)), [#13]([https://github.com/cypress-io/cypress/issues/13](https://github.com/cypress-io/cypress/issues/1234)) and [#14]([https://github.com/cypress-io/cypress/issues/14](https://github.com/cypress-io/cypress/issues/1234))."
 
+## Formatting
+
+### Package Names and Versions
+
+Enclose the following in backticks (\`):
+
+| Item                                                                                                     | Pattern                                  | Example                      |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------- |
+| [npm package name](https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields) | lower case, hyphen / underscore optional | `tar-fs`                     |
+| [semver version](https://semver.org/)                                                                    | `X.Y.Z` (no `v`)                         | `3.1.0`                      |
+| [npm semver ranges](https://github.com/npm/node-semver/blob/main/README.md#ranges)                       | caret `^`, tilde `~`, comparator         | `^3.0.0` `~0.6.1` `>=15.0.4` |
+
+No backticks for:
+
+| Item                      | Pattern | Example |
+| ------------------------- | ------- | ------- |
+| npm package major version | `X`     | 15      |
+
 ## Release
 
 At the time of the release, the releaser will:


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/32168

### Additional details

#### Situation

Unclear documentation for formatting version references leads to inconsistent formatting of some aspects of the [CHANGELOG.md](https://github.com/cypress-io/cypress/blob/develop/cli/CHANGELOG.md) which is sourced into the published [changelog](https://docs.cypress.io/app/references/changelog) website reference page.

##### Change

Add to the contributor's reference guide [Cypress App - Managing the Release Changelog](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md):



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit formatting guidance in `guides/writing-the-cypress-changelog.md` to standardize version/package references.
> 
> - Adds a **Formatting** section detailing backtick usage for `npm` package names, `semver` versions (`X.Y.Z`), and ranges (`^`, `~`, comparators)
> - Clarifies that major version numbers (e.g., 15) should not be wrapped in backticks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af05d5af0d69280d16918cee605d27432f2328a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Documentation change only.

### How has the user experience changed?

Only relevant for contributors.

### PR Tasks
<!--
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
