### PR TITLE
feat: add global test timeout configuration option

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3012,6 +3012,12 @@ declare namespace Cypress {
      */
     taskTimeout: number
     /**
+     * Global test timeout in milliseconds. If a test (including all its hooks) exceeds this duration, it will fail.
+     * Set to 0 to disable global test timeout.
+     * @default 0
+     */
+    testTimeout: number
+    /**
      * Path to folder where application files will attempt to be served from
      * @default root project folder
      */

--- a/packages/config/src/options.ts
+++ b/packages/config/src/options.ts
@@ -430,6 +430,11 @@ const driverConfigOptions: Array<DriverConfigOption> = [
     validation: validate.isNumber,
     overrideLevel: 'any',
   }, {
+    name: 'testTimeout',
+    defaultValue: 0,
+    validation: validate.isNumber,
+    overrideLevel: 'any',
+  }, {
     name: 'testIsolation',
     defaultValue: true,
     validation: (key: string, value: any, opts: ValidationOptions) => {

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -962,7 +962,9 @@ export default {
     invalid_interface: 'Invalid mocha interface `{{name}}`',
     timed_out: 'Cypress command timeout of `{{ms}}ms` exceeded.',
     global_test_timeout: {
-      message: 'Test exceeded the global timeout of `{{ms}}ms`. The test ran for `{{elapsed}}ms` before being stopped.',
+      message: `Test exceeded the global timeout of \`{{ms}}ms\`. The test ran for \`{{elapsed}}ms\` before being stopped.
+
+Check the browser console for detailed diagnostics including the command queue and current state.`,
       docsUrl: 'https://on.cypress.io/test-timeout',
     },
     overspecified: {

--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -961,6 +961,10 @@ export default {
     async_timed_out: 'Timed out after `{{ms}}ms`. The `done()` callback was never invoked!',
     invalid_interface: 'Invalid mocha interface `{{name}}`',
     timed_out: 'Cypress command timeout of `{{ms}}ms` exceeded.',
+    global_test_timeout: {
+      message: 'Test exceeded the global timeout of `{{ms}}ms`. The test ran for `{{elapsed}}ms` before being stopped.',
+      docsUrl: 'https://on.cypress.io/test-timeout',
+    },
     overspecified: {
       message: stripIndent`\
         Cypress detected that you returned a promise in a test, but also invoked a done callback. Return a promise -or- invoke a done callback, not both.

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -61,6 +61,35 @@ const duration = (before: Date, after: Date) => {
   return Number(before) - Number(after)
 }
 
+const setupGlobalTestTimeout = (test, Cypress, cy) => {
+  const testTimeout = Cypress.config('testTimeout')
+
+  if (testTimeout > 0 && !test._globalTimeoutId) {
+    debug('setting up global test timeout: %dms', testTimeout)
+    test._globalTimeoutId = setTimeout(() => {
+      const elapsed = duration(new Date(), test.wallClockStartedAt)
+      const err = $errUtils.errByPath('mocha.global_test_timeout', {
+        ms: testTimeout,
+        elapsed,
+      })
+
+      debug('global test timeout exceeded: %dms elapsed', elapsed)
+      test._globalTimeoutId = null
+
+      // fail the test via cy.fail which handles the error properly
+      cy.fail(err)
+    }, testTimeout)
+  }
+}
+
+const clearGlobalTestTimeout = (test) => {
+  if (test._globalTimeoutId) {
+    debug('clearing global test timeout')
+    clearTimeout(test._globalTimeoutId)
+    test._globalTimeoutId = null
+  }
+}
+
 const fire = (event: typeof RUNNER_EVENTS[number], runnable, Cypress, ...args) => {
   debug('fire: %o', { event })
   if (runnable._fired == null) {
@@ -116,6 +145,7 @@ const runnableAfterRunAsync = (runnable, Cypress) => {
 
 const testAfterRun = (test, Cypress) => {
   test.clearTimeout()
+  clearGlobalTestTimeout(test)
   if (!fired(TEST_AFTER_RUN_EVENT, test)) {
     setWallClockDuration(test)
     try {
@@ -1693,6 +1723,8 @@ export default {
 
         if (test.wallClockStartedAt == null) {
           test.wallClockStartedAt = wallClockStartedAt
+          // Set up global test timeout if configured
+          setupGlobalTestTimeout(test, Cypress, cy)
         }
 
         const isHook = runnable.type === 'hook'

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -61,6 +61,62 @@ const duration = (before: Date, after: Date) => {
   return Number(before) - Number(after)
 }
 
+const collectTimeoutDiagnostics = (cy, Cypress) => {
+  const diagnostics: Record<string, any> = {}
+
+  try {
+    // Get current command being executed
+    const currentCommand = cy.state('current')
+
+    if (currentCommand) {
+      diagnostics.currentCommand = {
+        name: currentCommand.get('name'),
+        args: currentCommand.get('args'),
+        type: currentCommand.get('type'),
+        timeout: currentCommand.get('timeout'),
+      }
+    }
+
+    // Get command queue state
+    const queue = cy.queue
+    const commands = queue.get()
+
+    diagnostics.commandQueue = {
+      total: commands.length,
+      names: queue.names().slice(-20), // last 20 command names
+      currentIndex: queue.index,
+    }
+
+    // Get all logs from the queue
+    const logs = queue.logs()
+
+    diagnostics.logs = logs.slice(-10).map((log) => ({
+      name: log.get('name'),
+      message: log.get('message'),
+      state: log.get('state'),
+      type: log.get('type'),
+    }))
+
+    // Get current URL
+    const win = cy.state('window')
+
+    if (win) {
+      diagnostics.currentUrl = win.location?.href
+    }
+
+    // Get aliases
+    const aliases = cy.state('aliases') || {}
+
+    diagnostics.aliases = Object.keys(aliases)
+
+  } catch (e) {
+    debug('error collecting timeout diagnostics: %o', e)
+    diagnostics.error = 'Failed to collect some diagnostics'
+  }
+
+  return diagnostics
+}
+
 const setupGlobalTestTimeout = (test, Cypress, cy) => {
   const testTimeout = Cypress.config('testTimeout')
 
@@ -68,12 +124,50 @@ const setupGlobalTestTimeout = (test, Cypress, cy) => {
     debug('setting up global test timeout: %dms', testTimeout)
     test._globalTimeoutId = setTimeout(() => {
       const elapsed = duration(new Date(), test.wallClockStartedAt)
+
+      // Collect diagnostic information before failing
+      const diagnostics = collectTimeoutDiagnostics(cy, Cypress)
+
+      debug('global test timeout exceeded: %dms elapsed, diagnostics: %o', elapsed, diagnostics)
+
+      // Log diagnostics to console for debugging
+      // eslint-disable-next-line no-console
+      console.group('🕐 Global Test Timeout Diagnostics')
+      // eslint-disable-next-line no-console
+      console.log('Test:', test.title)
+      // eslint-disable-next-line no-console
+      console.log('Timeout:', testTimeout, 'ms')
+      // eslint-disable-next-line no-console
+      console.log('Elapsed:', elapsed, 'ms')
+
+      if (diagnostics.currentCommand) {
+        // eslint-disable-next-line no-console
+        console.log('Current Command:', diagnostics.currentCommand.name)
+      }
+
+      if (diagnostics.commandQueue) {
+        // eslint-disable-next-line no-console
+        console.log('Command Queue:', diagnostics.commandQueue.names.join(' → '))
+      }
+
+      if (diagnostics.currentUrl) {
+        // eslint-disable-next-line no-console
+        console.log('Current URL:', diagnostics.currentUrl)
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('Full diagnostics:', diagnostics)
+      // eslint-disable-next-line no-console
+      console.groupEnd()
+
       const err = $errUtils.errByPath('mocha.global_test_timeout', {
         ms: testTimeout,
         elapsed,
       })
 
-      debug('global test timeout exceeded: %dms elapsed', elapsed)
+      // Attach diagnostics to the error for programmatic access
+      ;(err as any).diagnostics = diagnostics
+
       test._globalTimeoutId = null
 
       // fail the test via cy.fail which handles the error properly


### PR DESCRIPTION
## Summary

This PR adds a new `testTimeout` configuration option that allows setting a global maximum duration for tests. Unlike existing command-level timeouts (`defaultCommandTimeout`, `responseTimeout`, etc.), this option limits the **total** duration of a test including all its hooks.

## Problem

Currently, Cypress has no way to enforce a global test timeout. Each individual command has its own timeout, but a test could theoretically run indefinitely if each command completes within its respective timeout. Users have requested the ability to fail tests that exceed a certain total duration.

## Solution

Add a new `testTimeout` configuration option:

- **Default value**: `0` (disabled, for backward compatibility)
- **Behavior**: If a test (including beforeEach/afterEach hooks) exceeds this duration, it fails automatically
- **Override level**: Can be set globally or per-test via `it('test', { testTimeout: 30000 }, ...)`
- **Diagnostics**: When timeout occurs, detailed diagnostic information is logged to help debugging

## Example Usage

```javascript
// cypress.config.js
module.exports = defineConfig({
  testTimeout: 60000, // 60 seconds max per test
})

// Or per-test
it('my test', { testTimeout: 30000 }, () => {
  // test code
})
```

## Diagnostics on Timeout

When a test times out, the following diagnostic information is captured and logged to the browser console:

- **Current Command**: The command that was executing when timeout occurred
- **Command Queue**: List of all commands (last 20) that were queued
- **Recent Logs**: Last 10 log entries with their state
- **Current URL**: The URL the test was on
- **Aliases**: All registered aliases

Example console output:
```
🕐 Global Test Timeout Diagnostics
  Test: should load the page
  Timeout: 5000 ms
  Elapsed: 5001 ms
  Current Command: get
  Command Queue: visit → get → should → click → get
  Current URL: http://localhost:3000/dashboard
  Full diagnostics: { ... }
```

The diagnostics are also attached to the error object as `err.diagnostics` for programmatic access.

## Changes

| File | Change |
|------|--------|
| `packages/config/src/options.ts` | Added `testTimeout` config option with default `0` |
| `cli/types/cypress.d.ts` | Added TypeScript type definition with docs |
| `packages/driver/src/cypress/error_messages.ts` | Added error message for timeout with diagnostics hint |
| `packages/driver/src/cypress/runner.ts` | Implemented timeout setup/cleanup logic + diagnostics collection |

## Implementation Details

- Timeout is set when the test starts (when `wallClockStartedAt` is first set)
- Timeout is cleared when test completes (in `testAfterRun`)
- On retry, a new timeout is set for the new attempt
- Uses `cy.fail()` to properly fail the test and trigger cleanup
- Collects diagnostics in a try/catch to ensure timeout failure even if diagnostics collection fails

## Testing

- [ ] Unit tests for config option
- [ ] System tests for timeout behavior
- [ ] Documentation update

---

**Note**: This is a proof-of-concept implementation. Additional testing and edge case handling may be needed for production readiness.