### PR TITLE
Fix insecure WebSocket by using secure protocol (wss)

### DIFF
--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -236,7 +236,7 @@ function getSocketSource (config: UrqlClientConfig) {
   // http: -> ws:  &  https: -> wss:
   const protocol = window.location.protocol.replace('http', 'ws')
   const wsUrl = config.target === 'launchpad'
-    ? `ws://${window.location.host}/__launchpad/graphql-ws`
+    ? `${protocol}//${window.location.host}/__launchpad/graphql-ws`
     : `${protocol}//${window.location.host}${config.socketIoRoute}-graphql`
 
   return createWsClient({


### PR DESCRIPTION
This PR addresses a Semgrep SAST finding where the launchpad GraphQL WebSocket connection was hardcoded to use ws://. This bypassed the existing protocol logic that correctly upgrades connections to wss:// when the application is served over HTTPS.

Details

Affected File: packages/frontend-shared/src/graphql/urqlClient.ts

Issue: Insecure WebSocket (detect-insecure-websocket)

Location: ~Line 239

Fix

The hardcoded ws:// URL has been replaced with the dynamically derived protocol already used elsewhere in the file. This ensures the WebSocket connection uses wss:// for HTTPS deployments while retaining ws:// for HTTP/local development.

- ? `ws://${window.location.host}/__launchpad/graphql-ws`
+ ? `${protocol}//${window.location.host}/__launchpad/graphql-ws`

Outcome

Secure WebSocket (wss://) is used automatically over HTTPS

Behavior is consistent across launchpad and non-launchpad targets

Resolves the reported SAST finding with a minimal, targeted change