### PR TITLE
dependency: update lodash to 4.17.23

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -20,6 +20,7 @@ _Released 01/27/2026 (PENDING)_
 **Dependency Updates:**
 
 - Upgraded `shell-env` to `4.0.1` and `@cypress/commit-info` to `2.2.2`. This removes the [GMS-2020-2](https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/master/npm/execa/GMS-2020-2.yml) vulnerability being reported in security scans. Addressed in [#33226](https://github.com/cypress-io/cypress/pull/33226) and [#33263](https://github.com/cypress-io/cypress/pull/33263).
+- Upgraded `lodash` to `4.17.23`. This removes the [CVE-2025-13465](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) vulnerability being reported in security scans. Addresses [#33269](https://github.com/cypress-io/cypress/issues/33269).
 
 
 ## 15.9.0

--- a/cli/package.json
+++ b/cli/package.json
@@ -45,7 +45,7 @@
     "hasha": "5.2.2",
     "is-installed-globally": "~0.4.0",
     "listr2": "^3.8.3",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "log-symbols": "^4.0.0",
     "minimist": "^1.2.8",
     "ospath": "^1.2.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -64,7 +64,7 @@
     "fuzzysort": "^1.1.4",
     "graphql": "^15.5.1",
     "human-interval": "1.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "mobx": "6.13.6",
     "nanoid": "^5.1.3",
     "p-defer": "^3.0.0",

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -57,7 +57,7 @@
     "http-proxy": "1.18.1",
     "isbinaryfile": "^4.0.8",
     "launch-editor": "2.9.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "micromatch": "^4.0.8",
     "minimatch": "3.1.2",
     "nexus": "^1.2.0-next.15",

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -81,7 +81,7 @@
     "graphql-ws": "^5.5.5",
     "human-interval": "1.0.0",
     "just-my-luck": "3.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "markdown-it": "13.0.1",
     "nock": "13.2.9",
     "p-defer": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22105,10 +22105,15 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@4.17.21, lodash@^4.16.4, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.0:
+lodash@4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@4.17.23, lodash@^4.16.4, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4, lodash@~4.17.0:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33269

### Additional details

`npm audit` and Dependabot report a moderate severity vulnerability CVE-2025-13465 (https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) in `lodash@4.17.21`.

[lodash](https://www.npmjs.com/package/lodash) is updated to `4.17.23` to remediate the vulnerability.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update (security)**
> 
> - Bumps `lodash` to `4.17.23` in `cli`, `packages/app`, `packages/data-context`, and `packages/frontend-shared`
> - Updates `yarn.lock` to resolve `lodash@4.17.23`
> - Adds `CHANGELOG.md` entry documenting the upgrade and mitigation of `GHSA-xxjr-mmjv-4gpg` (CVE-2025-13465)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d420be0041bf79b2e6b13b70d80918beb33f2fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
git clone https://github.com/cypress-io/cypress
cd cypress
yarn
yarn why lodash
```

Confirm no updatable instances of `lodash@4.17.21` reported.

### How has the user experience changed?

`npm audit` and Dependabot no longer report a moderate severity vulnerability CVE-2025-13465 (https://github.com/advisories/GHSA-xxjr-mmjv-4gpg).

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
