### PR TITLE
chore: set allowCypressEnv to false in scaffolded configs

### DIFF
--- a/packages/config/src/ast-utils/addToCypressConfig.ts
+++ b/packages/config/src/ast-utils/addToCypressConfig.ts
@@ -162,7 +162,7 @@ function getEmptyCodeBlock ({ outputType, isProjectUsingESModules, projectRoot }
         import { defineConfig } from 'cypress'
 
         export default defineConfig({
-
+          allowCypressEnv: false,
         })
       `
     }
@@ -171,7 +171,7 @@ function getEmptyCodeBlock ({ outputType, isProjectUsingESModules, projectRoot }
       const { defineConfig } = require('cypress')
 
       module.exports = defineConfig({
-
+        allowCypressEnv: false,
       })
     `
   }
@@ -179,14 +179,14 @@ function getEmptyCodeBlock ({ outputType, isProjectUsingESModules, projectRoot }
   if (outputType === '.ts' || outputType === '.mjs' || isProjectUsingESModules) {
     return dedent`
       export default {
-
+        allowCypressEnv: false,
       }
     `
   }
 
   return dedent`
     module.exports = {
-
+      allowCypressEnv: false,
     }
   `
 }

--- a/packages/config/test/ast-utils/addToCypressConfig.spec.ts
+++ b/packages/config/test/ast-utils/addToCypressConfig.spec.ts
@@ -38,6 +38,8 @@ describe('addToCypressConfig', () => {
       import { defineConfig } from "cypress";
 
       export default defineConfig({
+        allowCypressEnv: false,
+
         e2e: {
           setupNodeEvents(on, config) {
             // implement node event listeners here
@@ -64,8 +66,10 @@ describe('addToCypressConfig', () => {
 
     expect(secondArgTrimmed).toEqual(dedent`
           import { defineConfig } from "cypress";
-    
+
           export default defineConfig({
+            allowCypressEnv: false,
+
             e2e: {
               setupNodeEvents(on, config) {
                 // implement node event listeners here
@@ -94,6 +98,8 @@ describe('addToCypressConfig', () => {
           const { defineConfig } = require("cypress");
     
           module.exports = defineConfig({
+            allowCypressEnv: false,
+
             e2e: {
               setupNodeEvents(on, config) {
                 // implement node event listeners here
@@ -120,6 +126,8 @@ describe('addToCypressConfig', () => {
 
     expect(secondArgTrimmed).toEqual(dedent`
       module.exports = {
+        allowCypressEnv: false,
+
         e2e: {
           setupNodeEvents(on, config) {
             // implement node event listeners here
@@ -146,6 +154,8 @@ describe('addToCypressConfig', () => {
 
     expect(secondArgTrimmed).toEqual(dedent`
       export default {
+        allowCypressEnv: false,
+
         e2e: {
           setupNodeEvents(on, config) {
             // implement node event listeners here

--- a/system-tests/projects/pristine-cjs-project/expected-cypress-js-component-vue.js-3-webpack/cypress.config.js
+++ b/system-tests/projects/pristine-cjs-project/expected-cypress-js-component-vue.js-3-webpack/cypress.config.js
@@ -1,13 +1,15 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress')
 
-const webpackConfig = require("./webpack.config.js");
+const webpackConfig = require('./webpack.config.js')
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   component: {
     devServer: {
-      framework: "vue",
-      bundler: "webpack",
+      framework: 'vue',
+      bundler: 'webpack',
       webpackConfig,
     },
   },
-});
+})

--- a/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress.config.js
+++ b/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress.config.js
@@ -1,11 +1,11 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from "cypress";
 
 export default defineConfig({
   allowCypressEnv: false,
 
   e2e: {
-    setupNodeEvents (on, config) {
+    setupNodeEvents(on, config) {
       // implement node event listeners here
     },
   },
-})
+});

--- a/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress.config.js
+++ b/system-tests/projects/pristine-module/expected-cypress-js-e2e/cypress.config.js
@@ -1,9 +1,11 @@
-import { defineConfig } from "cypress";
+import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents (on, config) {
       // implement node event listeners here
     },
   },
-});
+})

--- a/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress.config.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress.config.js
@@ -1,9 +1,11 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents (on, config) {
       // implement node event listeners here
     },
   },
-});
+})

--- a/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress.config.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e-without-fixtures/cypress.config.js
@@ -1,11 +1,11 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   allowCypressEnv: false,
 
   e2e: {
-    setupNodeEvents (on, config) {
+    setupNodeEvents(on, config) {
       // implement node event listeners here
     },
   },
-})
+});

--- a/system-tests/projects/pristine/expected-cypress-js-e2e/cypress.config.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e/cypress.config.js
@@ -1,9 +1,11 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents (on, config) {
       // implement node event listeners here
     },
   },
-});
+})

--- a/system-tests/projects/pristine/expected-cypress-js-e2e/cypress.config.js
+++ b/system-tests/projects/pristine/expected-cypress-js-e2e/cypress.config.js
@@ -1,11 +1,11 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   allowCypressEnv: false,
 
   e2e: {
-    setupNodeEvents (on, config) {
+    setupNodeEvents(on, config) {
       // implement node event listeners here
     },
   },
-})
+});

--- a/system-tests/projects/pristine/expected-cypress-ts-e2e/cypress.config.ts
+++ b/system-tests/projects/pristine/expected-cypress-ts-e2e/cypress.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  allowCypressEnv: false,
+
   e2e: {
     setupNodeEvents (on, config) {
       // implement node event listeners here


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
While `allowCypressEnv` is considered true by default, `true` is not desirable as a default value in scaffolded config files, as it will be removed in the next major version of Cypress.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `allowCypressEnv: false` by default in generated Cypress config templates and updates tests/fixtures accordingly.
> 
> - Adds `allowCypressEnv: false` to empty/config scaffolds in `addToCypressConfig.ts` for TS/JS/ESM/CJS and when `defineConfig` is unavailable
> - Updates unit tests and system test expected `cypress.config.*` files to include `allowCypressEnv: false`
> - Minor fixture formatting tweaks (quotes/semicolons)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4b8b7a2cc59424b0844cd5b51beef3e7d75ebe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
