### PR TITLE
chore: fix cypress in cypress test replays

### DIFF
--- a/npm/vite-dev-server/cypress.config.ts
+++ b/npm/vite-dev-server/cypress.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
       delete process.env.HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS
       delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
       process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
-      config.expose.INTERNAL_E2E_TESTING_SELF = 'true'
       process.env.CYPRESS_INTERNAL_VITE_OPEN_MODE_TESTING = 'true'
 
       const { setCyInCyVariables, getCyInCyVariables } = setupCyInCyVariables()

--- a/npm/webpack-dev-server/cypress.config.ts
+++ b/npm/webpack-dev-server/cypress.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
       delete process.env.HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS
       delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
       process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
-      config.expose.INTERNAL_E2E_TESTING_SELF = 'true'
 
       const { e2ePluginSetup } = require('@packages/frontend-shared/cypress/e2e/e2ePluginSetup') as typeof import('@packages/frontend-shared/cypress/e2e/e2ePluginSetup')
       const { setCyInCyVariables, getCyInCyVariables } = setupCyInCyVariables()

--- a/packages/app/cypress.config.ts
+++ b/packages/app/cypress.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
       delete process.env.HTTP_PROXY_TARGET_FOR_ORIGIN_REQUESTS
       delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
       process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
-      config.expose.INTERNAL_E2E_TESTING_SELF = 'true'
       process.env.CYPRESS_INTERNAL_VITE_OPEN_MODE_TESTING = 'true'
 
       const { e2ePluginSetup } = require('@packages/frontend-shared/cypress/e2e/e2ePluginSetup')

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -72,7 +72,6 @@ export async function e2ePluginSetup (on: Cypress.PluginEvents, config: Cypress.
   }
 
   process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
-  config.expose.INTERNAL_E2E_TESTING_SELF = 'true'
 
   delete process.env.CYPRESS_INTERNAL_GRAPHQL_PORT
   delete process.env.CYPRESS_INTERNAL_VITE_DEV
@@ -446,7 +445,7 @@ async function makeE2ETasks () {
         port = '4456'
       }
 
-      const openArgv = [...argv, '--project', Fixtures.projectPath(projectName), '--port', port]
+      const openArgv = [...argv, '--project', Fixtures.projectPath(projectName), '--port', port, '--expose', 'INTERNAL_E2E_TESTING_SELF=true']
 
       // Runs the launchArgs through the whole pipeline for the CLI open process,
       // which probably needs a bit of refactoring / consolidating

--- a/packages/launchpad/cypress.config.ts
+++ b/packages/launchpad/cypress.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
     async setupNodeEvents (on, config) {
       delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
       process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
-      config.expose.INTERNAL_E2E_TESTING_SELF = 'true'
 
       const { e2ePluginSetup } = require('@packages/frontend-shared/cypress/e2e/e2ePluginSetup')
 


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

The ultimate problem here is that setting the expose config where we were in the cy in cy projects was affecting both the parent and the child projects. We want this to only affect the child projects.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Cypress-in-Cypress test configuration to change how an internal flag is propagated. Potential risk is limited to CI/e2e replay behavior if the `--expose` argument is mis-parsed or omitted in some paths.
> 
> **Overview**
> Fixes Cypress-in-Cypress open-mode replays by changing how `INTERNAL_E2E_TESTING_SELF` is provided to the inner Cypress.
> 
> Removes `config.expose.INTERNAL_E2E_TESTING_SELF = 'true'` from multiple `cypress.config.ts` files and `e2ePluginSetup`, and instead appends `--expose INTERNAL_E2E_TESTING_SELF=true` when launching projects in `e2ePluginSetup` (`__internal_openProject`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 212a67e1fa3a32f327d9ef5eef814b12c599b9e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
