### PR TITLE
docs: fix grammar in CLI README

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ The CLI is used to build the [cypress npm module](https://www.npmjs.com/package/
 - Allow users to open Cypress in the interactive Test Runner.
 - Allow users to verify that Cypress is installed correctly and executable
 - Allow users to manages the Cypress binary cache
-- Allow users to pass in options that change way tests are ran or recorded (browsers used, specfiles ran, grouping, parallelization)
+- Allow users to pass in options that change the way tests are run or recorded (browsers used, specfiles ran, grouping, parallelization)
 
 ## Building
 


### PR DESCRIPTION
## Summary

Fixes a minor grammar issue in the CLI README.

## Changes

- Fixed: `the way tests are ran` → `the way tests are run`

The past participle of "run" is "run" (not "ran"), so "are run" is grammatically correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a small grammar issue in `cli/README.md` by changing “the way tests are ran” to “the way tests are run” in the CLI responsibilities list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7eb2da6484d462935e010474ab022c229b9c97b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->