### PR TITLE
internal: (studio) Record protocol sentry errors

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,6 +16,7 @@ _Released 01/27/2026 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where the user did not always have the ability to create a new test in Studio. Also, fixed an issue where creating a new test from an empty spec would display the welcome to studio screen instead of the form to name the new test. Addressed in [#33236](https://github.com/cypress-io/cypress/pull/33236).
+- Fixed an issue where errors were not always being recorded when running Studio. Fixed in [#33321](https://github.com/cypress-io/cypress/pull/33321). 
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,12 +1,4 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 15.11.0
-
-_Released 02/10/2026 (PENDING)_
-
-**Bugfixes:**
-
-- Fixed an issue where errors were not always being recorded when running Studio. Fixed in [#33321](https://github.com/cypress-io/cypress/pull/33321). 
-
 ## 15.10.0
 
 _Released 02/03/2026_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.11.0
+
+_Released 02/10/2026 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue where errors were not always being recorded when running Studio. Fixed in [#33321](https://github.com/cypress-io/cypress/pull/33321). 
+
 ## 15.10.0
 
 _Released 02/03/2026_
@@ -17,7 +25,6 @@ _Released 02/03/2026_
 **Bugfixes:**
 
 - Fixed an issue where the user did not always have the ability to create a new test in Studio. Also, fixed an issue where creating a new test from an empty spec would display the welcome to studio screen instead of the form to name the new test. Addressed in [#33236](https://github.com/cypress-io/cypress/pull/33236).
-- Fixed an issue where errors were not always being recorded when running Studio. Fixed in [#33321](https://github.com/cypress-io/cypress/pull/33321). 
 
 **Misc:**
 

--- a/packages/server/lib/cloud/artifacts/upload_artifacts.ts
+++ b/packages/server/lib/cloud/artifacts/upload_artifacts.ts
@@ -258,6 +258,7 @@ export const uploadArtifacts = async (options: UploadArtifactOptions) => {
         specName: spec.name,
         osName: platform.osName,
         projectSlug: projectId,
+        mode: 'record',
       })
     } catch (err) {
       debug('Failed to send protocol errors %o', err)

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -73,6 +73,7 @@ export class ProtocolManager implements ProtocolManagerShape {
     debug('preparing protocol via script')
 
     try {
+      this.options = options
       this._runId = options.runId
       if (script) {
         const cypressProtocolDirectory = path.join(os.tmpdir(), 'cypress', 'protocol')
@@ -82,7 +83,6 @@ export class ProtocolManager implements ProtocolManagerShape {
         const { AppCaptureProtocol } = requireScript<{ AppCaptureProtocol: AppCaptureProtocolConstructor }>(script)
 
         this.AppCaptureProtocol = AppCaptureProtocol
-        this.options = options
       }
     } catch (error) {
       if (CAPTURE_ERRORS) {
@@ -409,6 +409,7 @@ export class ProtocolManager implements ProtocolManagerShape {
     osName: string
     projectSlug?: string
     specName?: string
+    mode?: 'record' | 'studio'
   }) {
     const errors = this._errors.filter(({ fatal }) => !fatal)
 

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -36,6 +36,7 @@ type AppCaptureProtocolConstructor = new (options: ProtocolManagerOptions) => Ap
 export class ProtocolManager implements ProtocolManagerShape {
   private _runId?: string
   private _instanceId?: string
+  private _specName?: string
   private _db?: Database.Database
   private _dbPath?: string
   private _archivePath?: string
@@ -85,7 +86,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       }
     } catch (error) {
       if (CAPTURE_ERRORS) {
-        this._errors.push({
+        this.captureError({
           error,
           args: [script],
           captureMethod: 'prepareProtocol',
@@ -108,7 +109,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       this._protocol = new this.AppCaptureProtocol(this.options)
     } catch (error) {
       if (CAPTURE_ERRORS) {
-        this._errors.push({
+        this.captureError({
           error,
           captureMethod: 'setupProtocol',
           fatal: true,
@@ -134,7 +135,7 @@ export class ProtocolManager implements ProtocolManagerShape {
             await listener(message)
           } catch (error) {
             if (CAPTURE_ERRORS) {
-              this._errors.push({ captureMethod: 'cdpClient.on', fatal: false, error, args: [event, message] })
+              this.captureError({ captureMethod: 'cdpClient.on', fatal: false, error, args: [event, message] })
             } else {
               debug('error in cdpClient.on %o', { error, event, message })
               throw error
@@ -168,7 +169,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       this._protocol = undefined
 
       if (CAPTURE_ERRORS) {
-        this._errors.push({ captureMethod: 'beforeSpec', fatal: true, error, args: [spec], runnableId: this._runnableId })
+        this.captureError({ captureMethod: 'beforeSpec', fatal: true, error, args: [spec], runnableId: this._runnableId })
       } else {
         throw error
       }
@@ -177,6 +178,7 @@ export class ProtocolManager implements ProtocolManagerShape {
 
   private _beforeSpec (spec: FoundSpec & { instanceId: string }) {
     this._instanceId = spec.instanceId
+    this._specName = spec.name
     const cypressProtocolDirectory = path.join(os.tmpdir(), 'cypress', 'protocol')
     const archivePath = path.join(cypressProtocolDirectory, `${spec.instanceId}.tar`)
     const dbPath = path.join(cypressProtocolDirectory, `${spec.instanceId}.db`)
@@ -284,7 +286,7 @@ export class ProtocolManager implements ProtocolManagerShape {
   }
 
   addFatalError (captureMethod: ProtocolCaptureMethod, error: Error, args?: any) {
-    this._errors.push({
+    this.captureError({
       fatal: true,
       error,
       captureMethod,
@@ -358,7 +360,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       }
     } catch (e) {
       if (captureErrors) {
-        this._errors.push({
+        this.captureError({
           error: e,
           captureMethod: 'uploadCaptureArtifact',
           fatal: true,
@@ -382,13 +384,52 @@ export class ProtocolManager implements ProtocolManagerShape {
     await this.invokeAsync('cdpReconnect', { isEssential: true })
   }
 
+  /**
+   * Central handling for errors - if we're in studio mode it will
+   * immediately be dispatched to the cloud for recording, otherwise
+   * it will be stored and the batch will be dispatched when protocol assets
+   * are uploaded.
+   *
+   * @param error
+   */
+  private captureError (error: ProtocolError) {
+    if (this.options?.mode === 'studio') {
+      this.dispatchErrors([error], {
+        osName: os.platform(),
+        projectSlug: this.options?.projectId,
+        specName: this._specName,
+        mode: this.options?.mode,
+      })
+    } else {
+      this._errors.push(error)
+    }
+  }
+
   async reportNonFatalErrors (context?: {
     osName: string
-    projectSlug: string
-    specName: string
+    projectSlug?: string
+    specName?: string
   }) {
     const errors = this._errors.filter(({ fatal }) => !fatal)
 
+    await this.dispatchErrors(errors, context)
+
+    this._errors = []
+  }
+
+  /**
+   * Transmit errors to the cloud.
+   *
+   * @param errors
+   * @param context
+   * @returns
+   */
+  private async dispatchErrors (errors: ProtocolError[], context?: {
+    osName: string
+    projectSlug?: string
+    specName?: string
+    mode?: 'record' | 'studio'
+  }) {
     if (errors.length === 0) {
       return
     }
@@ -428,8 +469,6 @@ export class ProtocolManager implements ProtocolManagerShape {
     } catch (e) {
       debug(`Error calling ProtocolManager.sendErrors: %o, original errors %o`, e, errors)
     }
-
-    this._errors = []
   }
 
   close (): void {
@@ -448,6 +487,7 @@ export class ProtocolManager implements ProtocolManagerShape {
 
     this._archivePath = undefined
     this._instanceId = undefined
+    this._specName = undefined
     this._runId = undefined
     this._errors = []
     this._protocol = undefined
@@ -467,7 +507,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       return this._protocol[method].apply(this._protocol, args)
     } catch (error) {
       if (CAPTURE_ERRORS) {
-        this._errors.push({ captureMethod: method, fatal: isEssential, error, args, runnableId: this._runnableId })
+        this.captureError({ captureMethod: method, fatal: isEssential, error, args, runnableId: this._runnableId })
       } else {
         throw error
       }
@@ -488,7 +528,7 @@ export class ProtocolManager implements ProtocolManagerShape {
       return await this._protocol[method].apply(this._protocol, args)
     } catch (error) {
       if (CAPTURE_ERRORS) {
-        this._errors.push({ captureMethod: method, fatal: isEssential, error, args, runnableId: this._runnableId })
+        this.captureError({ captureMethod: method, fatal: isEssential, error, args, runnableId: this._runnableId })
       } else {
         throw error
       }

--- a/packages/server/test/unit/cloud/protocol_spec.ts
+++ b/packages/server/test/unit/cloud/protocol_spec.ts
@@ -131,6 +131,9 @@ describe('lib/cloud/protocol', () => {
       nativeBinding: path.join(require.resolve('better-sqlite3/build/Release/better_sqlite3.node')),
       verbose: sinon.match.func,
     })
+
+    expect(protocolManager['_instanceId']).to.equal('instanceId')
+    expect(protocolManager['_specName']).to.equal('spec')
   })
 
   it('should be able to initialize a new test', async () => {
@@ -585,6 +588,50 @@ describe('lib/cloud/protocol', () => {
             expect(threw).to.be.false
             expect(fs.unlink).to.be.called
           })
+        })
+      })
+    })
+  })
+
+  describe('.captureError', () => {
+    beforeEach(() => {
+      sinon.stub(protocolManager, 'dispatchErrors').resolves()
+    })
+
+    describe('when mode is `record`', () => {
+      beforeEach(() => {
+        protocolManager['options']['mode'] = 'record'
+      })
+
+      it('should store error into array for later reporting', () => {
+        const err = { captureMethod: 'cdpClient.on', error: new Error(), args: { test: 'test1' } }
+
+        protocolManager['captureError'](err)
+
+        expect(protocolManager['_errors']).to.have.length(1)
+        expect(protocolManager['_errors'][0]).to.include(err)
+        expect(protocolManager['dispatchErrors']).not.to.have.been.called
+      })
+    })
+
+    describe('when mode is `studio`', () => {
+      beforeEach(() => {
+        protocolManager['options']['mode'] = 'studio'
+      })
+
+      it('should immediately dispatch errors to the cloud', () => {
+        const err = { captureMethod: 'cdpClient.on', error: new Error(), args: { test: 'test1' } }
+
+        protocolManager['captureError'](err)
+
+        expect(protocolManager['_errors']).to.have.length(0)
+        expect(protocolManager['dispatchErrors']).to.have.been.called
+        expect(protocolManager['dispatchErrors'].getCall(0).args[0]).to.deep.equal([err])
+        expect(protocolManager['dispatchErrors'].getCall(0).args[1]).to.deep.equal({
+          osName: os.platform(),
+          projectSlug: protocolManager['options']['projectId'],
+          specName: protocolManager['_specName'],
+          mode: 'studio',
         })
       })
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/11898

### Additional details

Errors during protocol processing are currently stored and dispatched as a batch when protocol assets are uploaded. However, in Studio the protocol assets are never uploaded so these errors are lost. This PR updates the logic to check the active mode and, when in studio, immediately dispatch errors so they are properly recorded.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how protocol errors are transmitted (immediate in Studio vs batched on upload) and resets error state after reporting, which could affect observability/diagnostics if the new dispatch path fails or is mis-contextualized.
> 
> **Overview**
> Ensures protocol capture errors aren’t lost in Studio sessions by centralizing error handling in `ProtocolManager`: errors are now **dispatched immediately to the cloud in `studio` mode**, while `record` mode continues batching until `reportNonFatalErrors` is called.
> 
> Extends error reporting context to include an explicit `mode` and tracks `specName` on `beforeSpec` so cloud reports can be attributed correctly; `upload_artifacts` now passes `mode: 'record'` when flushing non-fatal errors after uploads. Unit tests were updated to cover the new `captureError` behavior and spec metadata tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ec14d7b2161bdb4ea8c5355f3c6064ec1bc11d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Easiest way to verify this is through some `console.log`-based debugging; add a log statement in the dispatch function to see if/when errors are transmitted to cloud

Update `protocol.ts`, force `CAPTURE_ERRORS` to true.
Launch a local studio session using local protocol bundle, perform basic smoke test
Either find a way to generate a protocol error or update code in `protocol.ts` to manually throw an error. Re-run smoke test, verify studio session works as expected.
Repeat with a locally-recorded test using the local protocol bundle, verify test records successfully

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
