### PR TITLE
feat: display the resolved expose values in the resolved config ui

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,7 +12,7 @@ _Released 01/27/2026 (PENDING)_
 - Introduced a new [`cy.env()`](https://docs.cypress.io/api/commands/env) command that can be used to asynchronously and securely access Cypress environment variables. Addressed in [#33181](https://github.com/cypress-io/cypress/pull/33181).
 - Added a [`allowCypressEnv`](https://docs.cypress.io/app/references/configuration#Global) configuration option that disallows use of the deprecated `Cypress.env()` API. Addressed in [#33181](https://github.com/cypress-io/cypress/pull/33181).
 - Introduced the new `Cypress.expose()` API, intended for use of public configuration of non-sensitive values. Addressed in [#33238](https://github.com/cypress-io/cypress/pull/33238).
-- Displays the resolved `expose` values in the App's resolved configuration user interface.
+- Displays the resolved `expose` values in the App's resolved configuration user interface. Addressed in [#33322](https://github.com/cypress-io/cypress/pull/33322).
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@ _Released 01/27/2026 (PENDING)_
 - Introduced a new [`cy.env()`](https://docs.cypress.io/api/commands/env) command that can be used to asynchronously and securely access Cypress environment variables. Addressed in [#33181](https://github.com/cypress-io/cypress/pull/33181).
 - Added a [`allowCypressEnv`](https://docs.cypress.io/app/references/configuration#Global) configuration option that disallows use of the deprecated `Cypress.env()` API. Addressed in [#33181](https://github.com/cypress-io/cypress/pull/33181).
 - Introduced the new `Cypress.expose()` API, intended for use of public configuration of non-sensitive values. Addressed in [#33238](https://github.com/cypress-io/cypress/pull/33238).
+- Displays the resolved `expose` values in the App's resolved configuration user interface.
 
 **Bugfixes:**
 

--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -256,6 +256,8 @@ describe('App: Settings', () => {
         cy.get('[data-cy-config="env"]').contains('INTERNAL_GRAPHQL_PORT')
         cy.get('[data-cy-config="cli"]').contains('fromCli')
         cy.get('[data-cy-config="cli"]').contains('4455')
+        cy.get('[data-cy-config="expose"]').contains('INTERNAL_E2E_TESTING_SELF')
+        cy.get('[data-cy-config="expose"]').contains('value').should('not.exist')
       })
     })
 

--- a/packages/data-context/src/sources/ProjectDataSource.ts
+++ b/packages/data-context/src/sources/ProjectDataSource.ts
@@ -1,6 +1,6 @@
 import os from 'os'
 import chokidar from 'chokidar'
-import type { ResolvedFromConfig, RESOLVED_FROM, TestingType, SpecWithRelativeRoot } from '@packages/types'
+import type { ResolvedFromConfig, TestingType, SpecWithRelativeRoot } from '@packages/types'
 import minimatch from 'minimatch'
 import _ from 'lodash'
 import path from 'path'
@@ -558,26 +558,13 @@ export class ProjectDataSource {
   async getResolvedConfigFields (): Promise<ResolvedFromConfig[]> {
     const config = this.ctx.lifecycleManager.loadedFullConfig?.resolved ?? {}
 
-    interface ResolvedFromWithField extends ResolvedFromConfig {
-      field: typeof RESOLVED_FROM[number]
-    }
-
-    const mapEnvResolvedConfigToObj = (config: ResolvedFromConfig): ResolvedFromWithField => {
-      return Object.entries(config).reduce<ResolvedFromWithField>((acc, [field, value]) => {
-        return {
-          ...acc,
-          value: { ...acc.value, [field]: value.value },
-        }
-      }, {
-        value: {},
-        field: 'env',
-        from: 'env',
-      })
-    }
-
     return Object.entries(config ?? {}).map(([key, value]) => {
-      if (key === 'env' && value) {
-        return mapEnvResolvedConfigToObj(value)
+      if ((key === 'env' || key === 'expose') && value) {
+        return {
+          field: key,
+          from: key,
+          value: Object.fromEntries(Object.entries(value).map(([field, { value }]) => [field, value])),
+        }
       }
 
       return { ...value, field: key }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
With the addition of `expose` values in the config file, the resolve config user interface needed to be updated to accommodate the new config shape.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how resolved config is serialized for the app (including `env`/`expose`), which could affect the settings UI rendering for those fields, but the change is narrowly scoped and covered by an updated e2e test.
> 
> **Overview**
> The resolved configuration view in the App’s Project Settings now includes resolved `expose` values, alongside the existing resolved config sources.
> 
> `ProjectDataSource.getResolvedConfigFields()` is updated to flatten both `env` and `expose` into simple key/value objects for display, and the Settings e2e spec is extended to assert the `expose` section renders and does not leak internal nested `value` fields. The CLI changelog is updated to document the new UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f154244e66997462888f9c473c3c89673c31352d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
Open a project's config in open mode settings, and verify any exposed values are present.

### How has the user experience changed?
The `expose` key is now displayed in the resolved config in open mode's Project Settings.

<img width="935" height="581" alt="Screenshot 2026-02-03 at 11 43 53 AM" src="https://github.com/user-attachments/assets/5f2efdb2-0b02-4e10-b432-0802d63fdccc" />

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
