### PR TITLE
chore: v15.10.0 release

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.10.0
 
-_Released 01/27/2026 (PENDING)_
+_Released 02/03/2026_
 
 **Deprecations:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "15.9.0",
+  "version": "15.10.0",
   "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Release v15.10.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only changes (version bump and changelog release date) with no runtime code modifications.
> 
> **Overview**
> **Release housekeeping for `15.10.0`.**
> 
> Updates `package.json` version from `15.9.0` to `15.10.0` and marks the `cli/CHANGELOG.md` `15.10.0` entry as released (sets the release date).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebb58ea0ce2c2969b3b7aa1d898f4750b5081bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->