### PR TITLE
test: fix studio failing tests because of unsaved changes modal and visit url popup

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-basic.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-basic.cy.ts
@@ -66,6 +66,9 @@ describe('studio functionality', () => {
 
     cy.findByTestId('studio-header-studio-button').click()
 
+    // dismiss unsaved changes modal
+    cy.findByTestId('unsaved-changes-discard-button').click()
+
     assertClosingPanelWithoutChanges()
   })
 
@@ -99,6 +102,9 @@ describe('studio functionality', () => {
     cy.get('.cm-line').should('contain.text', `cy.get('#increment').click();`)
 
     cy.get('button[aria-label="Rerun all tests"]').click()
+
+    // dismiss unsaved changes modal
+    cy.findByTestId('unsaved-changes-discard-button').click()
 
     cy.waitForSpecToFinish()
     // after reloading we should still be in studio mode but the commands should be removed

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -299,7 +299,6 @@ it('new-test', function() {
   })
 
   describe('prompt for a new url', () => {
-    const urlPrompt = '// Visit a page by entering a url in the address bar or typing a cy.visit command here'
     const autUrl = 'http://localhost:4455/cypress/e2e/index.html'
     const visitUrl = 'cypress/e2e/index.html'
 
@@ -314,13 +313,13 @@ it('new-test', function() {
 
       cy.findByTestId('aut-url-input').should('have.focus')
 
-      cy.get('.cm-line').should('contain.text', urlPrompt)
+      cy.findByTestId('studio-error-visit-url-banner').should('exist')
     }
 
     const assertAutUrlInput = () => {
       cy.findByTestId('aut-url-input').should('have.value', autUrl)
 
-      cy.get('.cm-line').should('not.contain.text', urlPrompt)
+      cy.findByTestId('studio-error-visit-url-banner').should('not.exist')
 
       cy.get('.cm-line').should('contain.text', `cy.visit('${visitUrl}')`)
     }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Fixes these failing tests for studio-new-tests.cy.ts and studio-basic.cy.ts

https://cloud.cypress.io/projects/ypt4pf/runs/68808/overview?roarHideRunsWithDiffGroupsAndTags=1

https://cloud.cypress.io/projects/ypt4pf/runs/68777/overview/b45784d9-d44d-463e-a5f8-d2dbf159065b?roarHideRunsWithDiffGroupsAndTags=1


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes only adjust Cypress E2E test expectations and flows; main risk is brittleness if the new modal/banner test ids or timing differ across environments.
> 
> **Overview**
> Adjusts Studio E2E coverage to handle the **unsaved changes** confirmation: tests that close Studio via the header button or rerun tests now explicitly click `unsaved-changes-discard-button` before asserting the panel closes/commands reset.
> 
> Updates the “prompt for a new url” new-test assertions to expect the `studio-error-visit-url-banner` instead of checking for a placeholder prompt line in the editor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327ecb306c0729d41e8b88c1ea8079f3de993302. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
