### PR TITLE
fix: retry file renames for studio and prompt bundles

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 02/08/2026 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks.
+- Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 
 ## 15.10.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.10.1
+
+_Released 02/08/2026 (PENDING)_
+
+**Bugfixes:**
+
+- Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks.
+
 ## 15.10.0
 
 _Released 02/03/2026_

--- a/packages/server/lib/cloud/extract_atomic.ts
+++ b/packages/server/lib/cloud/extract_atomic.ts
@@ -4,6 +4,48 @@ import { ensureDir } from 'fs-extra'
 import path from 'path'
 import writeFileAtomic from 'write-file-atomic'
 
+const MAX_RETRIES = 3
+const RETRY_DELAY_MS = 100
+
+function isRetryableError (err: unknown): err is NodeJS.ErrnoException {
+  const code = typeof err === 'object' && err !== null && 'code' in err
+    ? (err as NodeJS.ErrnoException).code
+    : undefined
+
+  return code === 'EPERM' || code === 'EACCES'
+}
+
+function delay (ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function writeFileAtomicWithRetry (
+  filePath: string,
+  content: Buffer,
+  options: { mode?: number },
+): Promise<void> {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      await writeFileAtomic(filePath, content, {
+        mode: options.mode || 0o644,
+      })
+
+      return
+    } catch (err) {
+      lastError = err
+      if (attempt < MAX_RETRIES && isRetryableError(err)) {
+        await delay(RETRY_DELAY_MS)
+      } else {
+        throw err
+      }
+    }
+  }
+
+  throw lastError
+}
+
 export const extractAtomic = async (archivePath: string, destinationPath: string) => {
   const entryPromises: Promise<void>[] = []
 
@@ -29,7 +71,7 @@ export const extractAtomic = async (archivePath: string, destinationPath: string
 
       const content = Buffer.concat(chunks)
 
-      await writeFileAtomic(targetPath, content, {
+      await writeFileAtomicWithRetry(targetPath, content, {
         mode: entry.mode || 0o644,
       })
     })()
@@ -45,10 +87,9 @@ export const extractAtomic = async (archivePath: string, destinationPath: string
   // Wait for parser to finish and all entry writes to complete
   await new Promise<void>((resolve, reject) => {
     parser.on('end', resolve)
-    // Parser extends NodeJS.ReadWriteStream (EventEmitter), so it supports 'error' events
+    // @ts-expect-error Parser extends NodeJS.ReadWriteStream (EventEmitter), so it supports 'error' events
     // even though the types don't explicitly declare it
-
-    ;(parser as NodeJS.ReadWriteStream).on('error', reject)
+    parser.on('error', reject)
     stream.on('error', reject)
   })
 

--- a/packages/server/test/unit/cloud/extract_atomic_spec.ts
+++ b/packages/server/test/unit/cloud/extract_atomic_spec.ts
@@ -372,6 +372,139 @@ describe('extractAtomic', () => {
     await expect(extractPromise).to.be.rejectedWith('Write error')
   })
 
+  it('should retry on EPERM and succeed when write succeeds on retry', async () => {
+    const archivePath = '/path/to/archive.tar'
+    const destinationPath = '/path/to/destination'
+    const fileContent = Buffer.from('content')
+    const epermError = Object.assign(new Error('EPERM: operation not permitted, rename \'file.txt.123\' -> \'file.txt\''), { code: 'EPERM' })
+
+    writeFileAtomicStub.onFirstCall().rejects(epermError)
+    writeFileAtomicStub.onSecondCall().resolves()
+
+    const mockEntry = Object.assign(new Readable({
+      read () {
+        this.push(fileContent)
+        this.push(null)
+      },
+    }), {
+      type: 'File',
+      path: 'file.txt',
+      mode: 0o644,
+      resume: sinon.stub(),
+    })
+
+    const extractPromise = extractAtomic(archivePath, destinationPath)
+
+    setImmediate(() => {
+      mockParser.emit('entry', mockEntry)
+      mockParser.emit('end')
+    })
+
+    await extractPromise
+
+    expect(writeFileAtomicStub).to.be.calledTwice
+    expect(writeFileAtomicStub).to.be.calledWith(
+      path.join(destinationPath, 'file.txt'),
+      fileContent,
+      { mode: 0o644 },
+    )
+  })
+
+  it('should retry on EACCES and succeed when write succeeds on retry', async () => {
+    const archivePath = '/path/to/archive.tar'
+    const destinationPath = '/path/to/destination'
+    const fileContent = Buffer.from('content')
+    const eaccesError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+
+    writeFileAtomicStub.onFirstCall().rejects(eaccesError)
+    writeFileAtomicStub.onSecondCall().resolves()
+
+    const mockEntry = Object.assign(new Readable({
+      read () {
+        this.push(fileContent)
+        this.push(null)
+      },
+    }), {
+      type: 'File',
+      path: 'file.txt',
+      mode: 0o644,
+      resume: sinon.stub(),
+    })
+
+    const extractPromise = extractAtomic(archivePath, destinationPath)
+
+    setImmediate(() => {
+      mockParser.emit('entry', mockEntry)
+      mockParser.emit('end')
+    })
+
+    await extractPromise
+
+    expect(writeFileAtomicStub).to.be.calledTwice
+  })
+
+  it('should throw when EPERM persists after all retries', async () => {
+    const archivePath = '/path/to/archive.tar'
+    const destinationPath = '/path/to/destination'
+    const fileContent = Buffer.from('content')
+    const epermError = Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+
+    writeFileAtomicStub.rejects(epermError)
+
+    const mockEntry = Object.assign(new Readable({
+      read () {
+        this.push(fileContent)
+        this.push(null)
+      },
+    }), {
+      type: 'File',
+      path: 'file.txt',
+      mode: 0o644,
+      resume: sinon.stub(),
+    })
+
+    const extractPromise = extractAtomic(archivePath, destinationPath)
+
+    setImmediate(() => {
+      mockParser.emit('entry', mockEntry)
+      mockParser.emit('end')
+    })
+
+    await expect(extractPromise).to.be.rejectedWith(epermError)
+    expect(writeFileAtomicStub.callCount).to.equal(4) // initial + 3 retries
+  })
+
+  it('should not retry on non-retryable errors', async () => {
+    const archivePath = '/path/to/archive.tar'
+    const destinationPath = '/path/to/destination'
+    const fileContent = Buffer.from('content')
+    const enospcError = Object.assign(new Error('ENOSPC: no space left'), { code: 'ENOSPC' })
+
+    writeFileAtomicStub.rejects(enospcError)
+
+    const mockEntry = Object.assign(new Readable({
+      read () {
+        this.push(fileContent)
+        this.push(null)
+      },
+    }), {
+      type: 'File',
+      path: 'file.txt',
+      mode: 0o644,
+      resume: sinon.stub(),
+    })
+
+    const extractPromise = extractAtomic(archivePath, destinationPath)
+
+    setImmediate(() => {
+      mockParser.emit('entry', mockEntry)
+      mockParser.emit('end')
+    })
+
+    await expect(extractPromise).to.be.rejectedWith(enospcError)
+    expect(writeFileAtomicStub).to.be.calledOnce
+  })
+
   it('should wait for all file writes to complete before resolving', async () => {
     const archivePath = '/path/to/archive.tar'
     const destinationPath = '/path/to/destination'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress-services/issues/12483

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only adds bounded retries for specific filesystem error codes during extraction; main risk is slightly longer extraction time under repeated failures.
> 
> **Overview**
> Improves Cloud bundle extraction reliability on Windows by retrying `write-file-atomic` writes when they fail with transient `EPERM`/`EACCES` errors (with a short delay and bounded attempts), reducing flake when extracted files are briefly locked.
> 
> Extends the `extractAtomic` unit test suite to cover retry success, retry exhaustion, and non-retryable error behavior, and documents the Windows bugfix in `cli/CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1eb95d95d4de86ba6328e0a2890978c45149012d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->
Bundle files should be able to be renamed without EPERM errors.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>1eb95d9</u></sup><!-- /BUGBOT_STATUS -->