### PR TITLE
misc: use WHATWG URL for binary download

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.10.1
 
-_Released 02/08/2026 (PENDING)_
+_Released 02/17/2026 (PENDING)_
 
 **Bugfixes:**
 
@@ -10,6 +10,7 @@ _Released 02/08/2026 (PENDING)_
 **Misc:**
 
 - The Node.js path is now displayed correctly in run log headers for typical GitHub Actions paths. ANSI escape sequences are no longer incorrectly displayed for longer Node.js paths. Addresses [#32736](https://github.com/cypress-io/cypress/issues/32736).
+- Fixed an issue that caused a Node.js [DEP0169](https://nodejs.org/docs/latest/api/deprecations.html#DEP0169) deprecation warning to be output when executing `cypress install` to download and install the Cypress binary. Addresses [#33347](https://github.com/cypress-io/cypress/issues/33347).
 
 **Dependency Updates:**
 

--- a/cli/lib/tasks/download.ts
+++ b/cli/lib/tasks/download.ts
@@ -1,7 +1,6 @@
 import os from 'os'
 import assert from 'assert'
 import _ from 'lodash'
-import url from 'url'
 import path from 'path'
 import Debug from 'debug'
 import request from '@cypress/request'
@@ -60,7 +59,7 @@ const getCA = async (): Promise<string | undefined> => {
 }
 
 const prepend = (arch: string, urlPath: string, version: string): string => {
-  const endpoint = url.resolve(getBaseUrl(), urlPath)
+  const endpoint = new URL(urlPath, getBaseUrl()).toString()
   const platform = os.platform()
   const pathTemplate = util.getEnv('CYPRESS_DOWNLOAD_PATH_TEMPLATE', true)
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33347

### Additional details

In Node.js 25.4.0 - 25.6.0 executing `cypress install` to download and install the Cypress binary provokes the Node.js deprecation warning [DEP0169](https://nodejs.org/docs/latest/api/deprecations.html#DEP0169) due to the use of [url.resolve()](https://nodejs.org/docs/latest/api/url.html#urlresolvefrom-to) which belongs to the Node.js [Legacy URL API](https://nodejs.org/docs/latest/api/url.html#legacy-url-api).

[cli/lib/tasks/download.ts](https://github.com/cypress-io/cypress/blob/develop/cli/lib/tasks/download.ts) is migrated from [`url.resolve(from, to)`](https://nodejs.org/docs/latest/api/url.html#urlresolvefrom-to) to the replacement [`new URL(input[, base])`](https://nodejs.org/docs/latest/api/url.html#new-urlinput-base) that belongs to the [WHATWG URL API](https://nodejs.org/docs/latest/api/url.html#the-whatwg-url-api).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CLI binary download URL construction used during installs, so any subtle URL formatting change could break downloads or mirror/path-template setups, though the change is small and localized.
> 
> **Overview**
> Fixes `cypress install` on newer Node.js versions by replacing legacy `url.resolve()` usage in `cli/lib/tasks/download.ts` with `new URL(..., base).toString()` when building the Cypress binary download endpoint.
> 
> Updates the `15.10.1` changelog entry (release date and misc note) to document the resolved Node.js `DEP0169` deprecation warning during binary installation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7760a9d8c83f6e38df265304f7dd610bd39b3714. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
n auto # or manually switch to Node.js 22.19.0
yarn
cd cli
n 25.6.0 # or manually switch to Node.js 25.6.0
yarn test-unit -- download
```

Confirm that test passes and that no `DEP0169` deprecation notice is output.

### How has the user experience changed?

When executing `cypress install` using Node.js 25.4.0 - 25.6.0 the Node.js deprecation warning [DEP0169](https://nodejs.org/docs/latest/api/deprecations.html#DEP0169) similar to the following is no longer output:

> (node:3760) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.

This issue may also affect lower versions of Node.js as the change from Node.js 25.4.0 is backported to lower release lines. See also issue https://github.com/nodejs/node/issues/61724.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
