### PR TITLE
fix: cypress open - flush stdin on exit

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 02/17/2026 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
+- Fixed an issue where cypress open mode prints raw keys after exiting. Addressed in [#33365](https://github.com/cypress-io/cypress/pull/33365).
 
 **Misc:**
 

--- a/scripts/gulp/tasks/gulpRegistry.ts
+++ b/scripts/gulp/tasks/gulpRegistry.ts
@@ -49,6 +49,7 @@ export async function exitAndRemoveProcess (child: ChildProcess) {
 }
 
 export async function exitAllProcesses () {
+  await new Promise(resolve => process.stdin.once('drain', resolve))
   await Promise.all(Array.from(childProcesses).map(exitAndRemoveProcess))
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

Prevents cypress gulp open mode from printing raw keys after exiting 

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
