### PR TITLE
fix: login attempts subsequent to a cancelled one now launch the browser and can complete

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 02/17/2026 (PENDING)_
 
 **Bugfixes:**
 
-- Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Addressed in [#33366](https://github.com/cypress-io/cypress/pull/33366).
+- Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Fixed in [#33366](https://github.com/cypress-io/cypress/pull/33366). Fixes [#33350](https://github.com/cypress-io/cypress/issues/33350).
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 
 **Misc:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@ _Released 02/17/2026 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Addressed in [#33366](https://github.com/cypress-io/cypress/pull/33366).
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 
 **Misc:**

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -131,7 +131,7 @@ const rp = request.defaults((params, callback) => {
         const options = this // request promise options
 
         const throwStatusCodeErrWithResp = (message, responseBody) => {
-          // @ts-expect-error - we're hoping that `options.url` is valid here
+          // @ts-ignore - server's check-ts fails on this, but driver's check-ts does not, so expect-error is not appropriate
           throw new RequestErrors.StatusCodeError(response.statusCode, message, options, responseBody)
         }
 

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -80,7 +80,7 @@ const rp = request.defaults((params: CypressRequestOptions, callback) => {
   if (params.cacheable && (resp = getCachedResponse(params))) {
     debug('resolving with cached response for %o', { url: params.url })
 
-    return Promise.resolve(resp)
+    return Bluebird.resolve(resp)
   }
 
   _.defaults(params, {
@@ -380,6 +380,7 @@ export default {
     return rp.get({
       url: apiRoutes.auth(),
       json: true,
+      cacheable: true,
       headers: {
         'x-route-version': '2',
       },

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -73,8 +73,19 @@ export interface CypressRequestOptions extends OptionsWithUrl {
   cacheable?: boolean
 }
 
+// We extend the RequestPromiseOptions interface with our own properties in an
+// ad-hoc manner. Declaring this extension allows us to use typedefs without
+// having to modify the original type definitions (which would be incorrect)
+declare module '@cypress/request-promise' {
+  interface RequestPromiseOptions {
+    cacheable?: boolean
+    url?: string
+    encrypt?: boolean | 'always' | 'signed'
+  }
+}
+
 // TODO: migrate to fetch from @cypress/request
-const rp = request.defaults((params: CypressRequestOptions, callback) => {
+const rp = request.defaults((params, callback) => {
   let resp
 
   if (params.cacheable && (resp = getCachedResponse(params))) {
@@ -99,7 +110,7 @@ const rp = request.defaults((params: CypressRequestOptions, callback) => {
     'x-cypress-version': pkg.version,
   })
 
-  const method = params.method.toLowerCase()
+  const method = params.method?.toLowerCase()
 
   // use %j argument to ensure deep nested properties are serialized
   debug(
@@ -120,6 +131,7 @@ const rp = request.defaults((params: CypressRequestOptions, callback) => {
         const options = this // request promise options
 
         const throwStatusCodeErrWithResp = (message, responseBody) => {
+          // @ts-expect-error - we're hoping that `options.url` is valid here
           throw new RequestErrors.StatusCodeError(response.statusCode, message, options, responseBody)
         }
 
@@ -158,7 +170,8 @@ const rp = request.defaults((params: CypressRequestOptions, callback) => {
       headers['x-cypress-encrypted'] = PUBLIC_KEY_VERSION
     }
 
-    return request[method](params, callback).promise()
+    // @ts-expect-error - we're hoping that the method is valid here
+    return request[method](params, callback).promise() as RequestPromise<any>
   })
   .tap((resp) => {
     if (params.cacheable) {
@@ -597,7 +610,7 @@ export default {
     })
   },
 
-  createCrashReport (body, authToken, timeout = 3000) {
+  createCrashReport (body, authToken, maxTimeout = 3000) {
     return rp.post({
       url: apiRoutes.exceptions(),
       json: true,
@@ -606,7 +619,7 @@ export default {
         bearer: authToken,
       },
     })
-    .timeout(timeout)
+    .timeout(maxTimeout)
     .catch(tagError)
   },
 

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -380,7 +380,6 @@ export default {
     return rp.get({
       url: apiRoutes.auth(),
       json: true,
-      cacheable: true,
       headers: {
         'x-route-version': '2',
       },

--- a/packages/server/lib/cloud/user.ts
+++ b/packages/server/lib/cloud/user.ts
@@ -13,7 +13,7 @@ export = {
     return cache.setUser(user)
   },
 
-  getBaseLoginUrl (): string {
+  getBaseLoginUrl (): Bluebird<string> {
     return api.getAuthUrls().get('dashboardAuthUrl')
   },
 

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1361,6 +1361,16 @@ describe('lib/cloud/api', () => {
         expect(err).to.have.property('isApiError', true)
       })
     })
+
+    it('caches the response from the first request', () => {
+      return api.getAuthUrls()
+      .then(() => {
+        // nock will throw if this makes a second HTTP call
+        return api.getAuthUrls()
+      }).then((urls) => {
+        expect(urls).to.deep.eq(AUTH_URLS)
+      })
+    })
   })
 
   context('.postLogout', () => {

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1361,16 +1361,6 @@ describe('lib/cloud/api', () => {
         expect(err).to.have.property('isApiError', true)
       })
     })
-
-    it('caches the response from the first request', () => {
-      return api.getAuthUrls()
-      .then(() => {
-        // nock will throw if this makes a second HTTP call
-        return api.getAuthUrls()
-      }).then((urls) => {
-        expect(urls).to.deep.eq(AUTH_URLS)
-      })
-    })
   })
 
   context('.postLogout', () => {

--- a/packages/ts/index.d.ts
+++ b/packages/ts/index.d.ts
@@ -1,13 +1,7 @@
 // missing type definitions for libraries
 
-declare module '@cypress/get-windows-proxy' {
-  type ProxyConfig = {
-    httpProxy: string
-    noProxy: string
-  }
-  function getWindowsProxy(): Optional<ProxyConfig>
-  export = getWindowsProxy
-}
+/// <reference path="typedefs/cypress-get-windows-proxy.d.ts" />
+/// <reference path="typedefs/cypress-request-promise.d.ts" />
 
 declare module 'http' {
   import { Socket } from 'net'

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -23,6 +23,11 @@
     "register.js",
     "registerDir.js"
   ],
+  "types": [
+    "index.d.ts",
+    "typedefs/cypress-request-promise.d.ts",
+    "typedefs/request-promise.d.ts"
+  ],
   "license": "MIT",
   "nx": {}
 }

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -24,9 +24,7 @@
     "registerDir.js"
   ],
   "types": [
-    "index.d.ts",
-    "typedefs/cypress-request-promise.d.ts",
-    "typedefs/request-promise.d.ts"
+    "index.d.ts"
   ],
   "license": "MIT",
   "nx": {}

--- a/packages/ts/typedefs/cypress-get-windows-proxy.d.ts
+++ b/packages/ts/typedefs/cypress-get-windows-proxy.d.ts
@@ -1,0 +1,8 @@
+declare module '@cypress/get-windows-proxy' {
+  type ProxyConfig = {
+    httpProxy: string
+    noProxy: string
+  }
+  function getWindowsProxy(): Optional<ProxyConfig>
+  export = getWindowsProxy
+}

--- a/packages/ts/typedefs/cypress-request-promise.d.ts
+++ b/packages/ts/typedefs/cypress-request-promise.d.ts
@@ -1,0 +1,98 @@
+declare module '@cypress/request-promise' {
+  import type request from 'request'
+  import type BluebirdPromise from 'bluebird'
+
+  namespace requestPromise {
+    // RequestPromise is actually a Bluebird promise at runtime, so it has all Bluebird methods
+    // We extend request.Request for compatibility but the actual value is a BluebirdPromise
+    interface RequestPromise<T = any> extends request.Request, BluebirdPromise<T> {
+      // Keep these for explicit typing, but BluebirdPromise already has them
+      then: BluebirdPromise<T>['then']
+      catch: BluebirdPromise<T>['catch']
+      finally: BluebirdPromise<T>['finally']
+      cancel: BluebirdPromise<T>['cancel']
+      promise(): BluebirdPromise<T>
+      // Explicitly declare timeout as a method (not a property) to match runtime behavior
+      timeout(ms: number, message?: string | Error): RequestPromise<T>
+    }
+
+    interface RequestPromiseOptions extends request.CoreOptions {
+      simple?: boolean | undefined
+      transform?(body: any, response: request.Response, resolveWithFullResponse?: boolean): any
+      transform2xxOnly?: boolean | undefined
+      resolveWithFullResponse?: boolean | undefined
+      agent?: CombinedAgent | null
+    }
+
+    type RequestPromiseAPI<T = any> = request.RequestAPI<
+      RequestPromise<T>,
+      RequestPromiseOptions,
+      request.RequiredUriUrl
+    > & {
+      // Support for defaults() with a function parameter (extension pattern)
+      defaults(
+        fn: (params: RequestPromiseOptions, callback?: request.RequestCallback) => BluebirdPromise<any>
+      ): RequestPromiseAPI
+    }
+
+    type OptionsWithUri = request.UriOptions & RequestPromiseOptions
+    type OptionsWithUrl = request.UrlOptions & RequestPromiseOptions
+    type Options = OptionsWithUri | OptionsWithUrl
+  }
+
+  const requestPromise: requestPromise.RequestPromiseAPI
+  export = requestPromise
+}
+
+declare module '@cypress/request-promise/errors' {
+  import http = require('http')
+  import rp = require('@cypress/request-promise')
+
+  export interface RequestError extends Error {
+    name: 'RequestError'
+    cause: any
+    error: any
+    options: rp.Options
+    response: http.IncomingMessage
+  }
+
+  export interface RequestErrorConstructor {
+    new (cause: any, options: rp.Options, response: http.IncomingMessage): RequestError
+    (cause: any, options: rp.Options, response: http.IncomingMessage): RequestError
+    prototype: RequestError
+  }
+
+  export const RequestError: RequestErrorConstructor
+
+  export interface StatusCodeError extends Error {
+    name: 'StatusCodeError'
+    statusCode: number
+    error: any
+    options: rp.Options
+    response: http.IncomingMessage
+  }
+
+  export interface StatusCodeErrorConstructor extends Error {
+    new (statusCode: number, body: any, options: rp.Options, response: http.IncomingMessage): StatusCodeError
+    (statusCode: number, body: any, options: rp.Options, response: http.IncomingMessage): StatusCodeError
+    prototype: StatusCodeError
+  }
+
+  export const StatusCodeError: StatusCodeErrorConstructor
+
+  export interface TransformError extends Error {
+    name: 'TransformError'
+    cause: any
+    error: any
+    options: rp.Options
+    response: http.IncomingMessage
+  }
+
+  export interface TransformErrorConstructor extends Error {
+    new (cause: any, options: rp.Options, response: http.IncomingMessage): TransformError
+    (cause: any, options: rp.Options, response: http.IncomingMessage): TransformError
+    prototype: TransformError
+  }
+
+  export const TransformError: TransformErrorConstructor
+}


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/33350

### Additional details
The return value of `request.defaults` in `packages/server/lib/cloud/api/index.ts` was a Bluebird promise when the request was made, and a native Promise when the request was cacheable and there was a cached value.

This caused a (synchronous) runtime error in `packages/server/lib/cloud/user.ts#getBaseLoginUrl()` when a second login attempt was made. Our gql server caught and swallowed this synchronous error, making it look like the login attempt never resolved *or* rejected. Since this error was thrown before opening the browser, the browser never opened.

This fix:
- returns a resolved Bluebird promise from `rp.defaults` when a cacheable request is made, and a cache for that request exists
- adds type definitions for `@cypress/request`
- adds additional type hinting to `packages/server/lib/cloud/api/index.ts` to prevent similar issues in the future


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to promise-return behavior in the Cloud API client plus type-definition plumbing; risk is limited to Cloud request/caching code paths.
> 
> **Overview**
> Fixes a Cloud login hang where a cancelled/incomplete first login could prevent subsequent login attempts from launching the browser by ensuring cached Cloud API responses resolve as **Bluebird** promises (not native `Promise`) in `packages/server/lib/cloud/api/index.ts`.
> 
> Adds/organizes TypeScript typings for `@cypress/request-promise` (and `@cypress/get-windows-proxy`) via new `packages/ts/typedefs/*` files and module augmentation in the Cloud API wrapper to make the request options/promise shape explicit and reduce future type mismatches; also tweaks a few minor type/parameter names (e.g. `createCrashReport` timeout arg) and updates the CLI changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 553342f3f3c819dc23be6eb61572b4eea6f04c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
1. run `cypress open`
2. click `Log in` on the launchpad
3. click `Log in` in the modal
4. Switch back to the launchpad after the browser launches and close the modal
5. click `Log in` and then `Log in` again
6. The browser launches

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [NA] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
