### PR TITLE
fix: merge per-test env variables with per-suite env variables

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ _Released 02/17/2026 (PENDING)_
 
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 
+- Fixed an issue where per-test environment variables set via test config overrides (e.g. `it('test', { env: { ... } })`) would completely replace per-suite environment variables instead of merging with them. Fixes [#8005](https://github.com/cypress-io/cypress/issues/8005).
+
 **Misc:**
 
 - The Node.js path is now displayed correctly in run log headers for typical GitHub Actions paths. ANSI escape sequences are no longer incorrectly displayed for longer Node.js paths. Addresses [#32736](https://github.com/cypress-io/cypress/issues/32736).

--- a/packages/driver/cypress/e2e/e2e/testConfigOverrides.cy.js
+++ b/packages/driver/cypress/e2e/e2e/testConfigOverrides.cy.js
@@ -210,6 +210,35 @@ describe('per-test config', () => {
     })
   })
 
+  describe('suite env merges with test env', {
+    env: {
+      suiteApi: 'https://staging.dev',
+      commonFlag: 'suite',
+    },
+  }, () => {
+    it('has suite env variables', () => {
+      expect(Cypress.env('suiteApi')).to.equal('https://staging.dev')
+      expect(Cypress.env('commonFlag')).to.equal('suite')
+    })
+
+    it('merges test env with suite env', {
+      env: {
+        testFlag: 42,
+        commonFlag: 'test',
+      },
+    }, () => {
+      expect(Cypress.env('testFlag'), 'test level variable').to.equal(42)
+      expect(Cypress.env('commonFlag'), 'test overrides suite').to.equal('test')
+      expect(Cypress.env('suiteApi'), 'suite level variable').to.equal('https://staging.dev')
+    })
+
+    it('suite env is not affected by previous test env', () => {
+      expect(Cypress.env('suiteApi')).to.equal('https://staging.dev')
+      expect(Cypress.env('commonFlag')).to.equal('suite')
+      expect(Cypress.env('testFlag')).to.not.exist
+    })
+  })
+
   describe('in double nested suite', () => {
     describe('config in suite', {
       foo: true,

--- a/packages/driver/src/cy/testConfigOverrides.ts
+++ b/packages/driver/src/cy/testConfigOverrides.ts
@@ -63,7 +63,14 @@ function setConfig (testConfig: ResolvedTestConfigOverride, config, localConfigO
         err.stack = $errUtils.stackWithReplacedProps({ stack: invocationDetails.stack }, err)
         throw err
       }
-      localConfigOverrides = { ...localConfigOverrides, ...testConfigOverride }
+      // Deep merge 'env' so that test-level env variables are merged with
+      // suite-level env variables instead of replacing them entirely.
+      // https://github.com/cypress-io/cypress/issues/8005
+      const mergedEnv = testConfigOverride.env && localConfigOverrides.env
+        ? { ...localConfigOverrides.env, ...testConfigOverride.env }
+        : testConfigOverride.env || localConfigOverrides.env
+
+      localConfigOverrides = { ...localConfigOverrides, ...testConfigOverride, env: mergedEnv }
     }
   })
 


### PR DESCRIPTION
## User facing changelog

Per-test environment variables set via test config overrides (e.g. `it('test', { env: { ... } })`) now properly merge with per-suite environment variables instead of replacing them entirely.

## What changed

When a `describe` block defines `env` in its config and a test inside it also defines `env`, the test's env vars used to completely replace the suite's env vars. Now they merge properly — test-level values override matching suite keys, while non-overlapping suite env vars remain accessible.

**Before:**
```js
describe('suite', { env: { suiteApi: 'https://staging.dev', flag: 'suite' } }, () => {
  it('test', { env: { testFlag: 42, flag: 'test' } }, () => {
    Cypress.env('suiteApi') // undefined  ← bug
    Cypress.env('flag')     // 'test'     ← correct
    Cypress.env('testFlag') // 42         ← correct
  })
})
```

**After:**
```js
describe('suite', { env: { suiteApi: 'https://staging.dev', flag: 'suite' } }, () => {
  it('test', { env: { testFlag: 42, flag: 'test' } }, () => {
    Cypress.env('suiteApi') // 'https://staging.dev' ← fixed
    Cypress.env('flag')     // 'test'                ← correct
    Cypress.env('testFlag') // 42                    ← correct
  })
})
```

## How has the user experience changed?

Users can now reliably set shared env vars at the suite level and override/extend them at the test level without losing the suite-level values. This brings `env` merging behavior in line with how other config properties (like `foo`, `bar`) already work across nested suites.

## PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue been linked?
- [x] N/A - no docs changes needed (existing behavior was broken, not a new feature)

Fixes #8005