### PR TITLE
internal: (studio) emit graphql-refetch to browser window on Launchpad logout

### DIFF
--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -136,6 +136,7 @@ export class AuthActions {
       this.setAuthenticatedUser(null)
       this.ctx.cloud.reset()
       this.ctx.emitter.authChange()
+      this.ctx.emitter.toApp()
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/cypress-io/cypress-services/pull/12758

### Additional details

When a user logs out via the Cypress Launchpad while Studio is open in the browser window (Runner view), the browser window's Pinia store was never notified of the auth change.

**Root cause:** The `logout()` method in `AuthActions.ts` emitted `authChange()` which triggers GraphQL subscriptions, but the Runner view doesn't mount `HeaderBarContent.vue` (which subscribes to `authChange`). Without that subscription active, the Urql cache in the browser window was never updated, so `CloudViewerAndProject.vue`'s `watchEffect` never re-ran, and the Pinia store stayed stale. Studio would continue to show AI as enabled and attempt API requests that would fail.

**Fix:** Added `this.ctx.emitter.toApp()` after `this.ctx.emitter.authChange()` in the `logout()` method. This emits a `graphql-refetch` event to the browser window's socket, causing the `pubSubExchange` to refetch all watched queries including `CloudViewerAndProject_RequiredData`. This updates the Pinia store, and Studio's existing `$subscribe` listener detects the auth state transition and triggers a reload.

### Steps to test

1. Open Cypress with `yarn cypress:open` and log in
2. Open a spec file so you're in the Runner view with Studio visible
3. Confirm Studio AI is enabled/working
4. Switch to the Launchpad window and click "Log Out"
5. Switch back to the browser window — Studio should detect the logout and reload, showing the logged-out state

### How has the user experience changed?

**Before:** Logging out from the Launchpad while Studio was open in the browser left Studio in a stale state — AI appeared enabled but API requests would fail silently.

**After:** Studio detects the logout and reloads, correctly reflecting the logged-out state.

### PR Tasks

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single, additive event emission on logout; low risk aside from potential extra refetch/re-render behavior in the app window.
> 
> **Overview**
> Ensures logout events propagate to the Runner/browser window by emitting `this.ctx.emitter.toApp()` after `authChange()` in `AuthActions.logout()`.
> 
> This forces the app-side GraphQL/Urql cache to refetch watched queries on logout, preventing Studio from remaining in a stale authenticated state when logout happens from the Launchpad.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01aae46c6c3561efd41cc74c6bf9b1c4a34c25b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->