### PR TITLE
refactor: removes circular dependency between `server` and `errors`

### DIFF
--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@packages/eslint-config": "0.0.0-development",
-    "@packages/server": "0.0.0-development",
     "@packages/ts": "0.0.0-development",
     "@packages/types": "0.0.0-development",
     "@types/node": "22.18.7",

--- a/packages/errors/src/errorUtils.ts
+++ b/packages/errors/src/errorUtils.ts
@@ -4,13 +4,11 @@ import _ from 'lodash'
 import path from 'path'
 
 const pluralize = require('pluralize')
-const humanTime = require('@packages/server/lib/util/human_time')
 
 import type { CypressError, ErrorLike } from './errorTypes'
 
 export {
   pluralize,
-  humanTime,
 }
 
 const whileMatching = (othArr: string[]) => {

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
 import type { BreakingErrResult, TestingType } from '@packages/types'
-import { humanTime, logError, parseResolvedPattern, pluralize } from './errorUtils'
+import { logError, parseResolvedPattern, pluralize } from './errorUtils'
 import { errPartial, errTemplate, fmt, theme } from './errTemplate'
 import { stackWithoutMessage } from './stackUtils'
 import type { ClonedError, ConfigValidationFailureInfo, CypressError, ErrTemplateResult, ErrorLike } from './errorTypes'
@@ -142,11 +142,10 @@ export const AllCypressErrors = {
     return errTemplate`${fmt.off(`\n  `)}This spec and its tests were skipped because the run has been canceled.`
   },
   CLOUD_API_RESPONSE_FAILED_RETRYING: (
-    arg1: { tries: number, delayMs: number, response: Error },
+    arg1: { tries: number, delay: string, response: Error },
   ) => {
     const time = pluralize('time', arg1.tries)
-    const delay = humanTime.long(arg1.delayMs, false)
-
+    const { delay } = arg1
     const message = normalizeNetworkErrorMessage(arg1.response)
 
     return errTemplate`\

--- a/packages/errors/test/__snapshots__/BROWSER_NOT_FOUND_BY_NAME - canary.ansi
+++ b/packages/errors/test/__snapshots__/BROWSER_NOT_FOUND_BY_NAME - canary.ansi
@@ -13,15 +13,6 @@
 [31mYou can also use a custom browser: https://on.cypress.io/customize-browsers[39m
 [31m[39m
 [31mAvailable browsers found on your system are:[39m
-[31m[90m - [39m[31m[94mchrome[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome:beta[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome:canary[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome-for-testing[39m[31m[39m
-[31m[90m - [39m[31m[94mchromium[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox:dev[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox:nightly[39m[31m[39m
-[31m[90m - [39m[31m[94medge[39m[31m[39m
-[31m[90m - [39m[31m[94medge:beta[39m[31m[39m
-[31m[90m - [39m[31m[94medge:canary[39m[31m[39m
-[31m[90m - [39m[31m[94medge:dev[39m[31m[39m
+[31m[90m - [39m[31m[94mChrome 120[39m[31m[39m
+[31m[90m - [39m[31m[94mFirefox 121[39m[31m[39m
+[31m[90m - [39m[31m[94mEdge 119[39m[31m[39m

--- a/packages/errors/test/__snapshots__/BROWSER_NOT_FOUND_BY_NAME.ansi
+++ b/packages/errors/test/__snapshots__/BROWSER_NOT_FOUND_BY_NAME.ansi
@@ -13,15 +13,6 @@
 [31mYou can also use a custom browser: https://on.cypress.io/customize-browsers[39m
 [31m[39m
 [31mAvailable browsers found on your system are:[39m
-[31m[90m - [39m[31m[94mchrome[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome:beta[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome:canary[39m[31m[39m
-[31m[90m - [39m[31m[94mchrome-for-testing[39m[31m[39m
-[31m[90m - [39m[31m[94mchromium[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox:dev[39m[31m[39m
-[31m[90m - [39m[31m[94mfirefox:nightly[39m[31m[39m
-[31m[90m - [39m[31m[94medge[39m[31m[39m
-[31m[90m - [39m[31m[94medge:beta[39m[31m[39m
-[31m[90m - [39m[31m[94medge:canary[39m[31m[39m
-[31m[90m - [39m[31m[94medge:dev[39m[31m[39m
+[31m[90m - [39m[31m[94mChrome 120[39m[31m[39m
+[31m[90m - [39m[31m[94mFirefox 121[39m[31m[39m
+[31m[90m - [39m[31m[94mEdge 119[39m[31m[39m

--- a/packages/errors/test/__snapshots__/INDETERMINATE_CI_BUILD_ID.ansi
+++ b/packages/errors/test/__snapshots__/INDETERMINATE_CI_BUILD_ID.ansi
@@ -7,29 +7,9 @@
 [31m[39m
 [31mThe ciBuildId is automatically detected if you are running Cypress in any of the these CI providers:[39m
 [31m[39m
-[31m[90m - [39m[31m[94mappveyor[39m[31m[39m
-[31m[90m - [39m[31m[94mazure[39m[31m[39m
-[31m[90m - [39m[31m[94mawsCodeBuild[39m[31m[39m
-[31m[90m - [39m[31m[94mbamboo[39m[31m[39m
-[31m[90m - [39m[31m[94mbitbucket[39m[31m[39m
-[31m[90m - [39m[31m[94mbuildkite[39m[31m[39m
-[31m[90m - [39m[31m[94mcircle[39m[31m[39m
-[31m[90m - [39m[31m[94mcodeshipBasic[39m[31m[39m
-[31m[90m - [39m[31m[94mcodeshipPro[39m[31m[39m
-[31m[90m - [39m[31m[94mconcourse[39m[31m[39m
-[31m[90m - [39m[31m[94mcodeFresh[39m[31m[39m
-[31m[90m - [39m[31m[94mdrone[39m[31m[39m
-[31m[90m - [39m[31m[94mgithubActions[39m[31m[39m
-[31m[90m - [39m[31m[94mgitlab[39m[31m[39m
-[31m[90m - [39m[31m[94mgoCD[39m[31m[39m
-[31m[90m - [39m[31m[94mgoogleCloud[39m[31m[39m
-[31m[90m - [39m[31m[94mjenkins[39m[31m[39m
-[31m[90m - [39m[31m[94msemaphore[39m[31m[39m
-[31m[90m - [39m[31m[94mshippable[39m[31m[39m
-[31m[90m - [39m[31m[94mteamfoundation[39m[31m[39m
-[31m[90m - [39m[31m[94mtravis[39m[31m[39m
-[31m[90m - [39m[31m[94mnetlify[39m[31m[39m
-[31m[90m - [39m[31m[94mwebappio[39m[31m[39m
+[31m[90m - [39m[31m[94mGitHub Actions[39m[31m[39m
+[31m[90m - [39m[31m[94mCircleCI[39m[31m[39m
+[31m[90m - [39m[31m[94mJenkins[39m[31m[39m
 [31m[39m
 [31mBecause the ciBuildId could not be auto-detected you must pass the --ci-build-id flag manually.[39m
 [31m[39m

--- a/packages/errors/test/visualSnapshotErrors.spec.ts
+++ b/packages/errors/test/visualSnapshotErrors.spec.ts
@@ -6,10 +6,9 @@ import path from 'path'
 import * as errors from '../src'
 import os from 'os'
 
-// these packages need process.env.CYPRESS_INTERNAL_ENV to be set to 'test' to work, which is set in the global vitest config
-import ciProvider from '@packages/server/lib/util/ci_provider'
-import browsers from '@packages/server/lib/browsers'
-import { knownBrowsers } from '@packages/launcher/lib/known-browsers'
+// Mock data for template params - we only assert template rendering, not real browser/CI data
+const MOCK_FOUND_BROWSERS = ['Chrome 120', 'Firefox 121', 'Edge 119']
+const MOCK_CI_BUILD_ID_PROVIDERS = ['GitHub Actions', 'CircleCI', 'Jenkins']
 
 interface ErrorGenerator<T extends CypressErrorType> {
   default: Parameters<typeof errors.AllCypressErrors[T]>
@@ -184,8 +183,8 @@ describe('visual error templates', () => {
     },
     BROWSER_NOT_FOUND_BY_NAME: () => {
       return {
-        default: ['invalid-browser', browsers.formatBrowsersToOptions(knownBrowsers)],
-        canary: ['canary', browsers.formatBrowsersToOptions(knownBrowsers)],
+        default: ['invalid-browser', MOCK_FOUND_BROWSERS],
+        canary: ['canary', MOCK_FOUND_BROWSERS],
       }
     },
     BROWSER_NOT_FOUND_BY_PATH: () => {
@@ -215,12 +214,12 @@ describe('visual error templates', () => {
       return {
         default: [{
           tries: 3,
-          delayMs: 5000,
+          delay: '5 seconds',
           response: makeApiErr(),
         }],
         lastTry: [{
           tries: 1,
-          delayMs: 5000,
+          delay: '5 seconds',
           response: makeApiErr(),
         }],
       }
@@ -426,7 +425,7 @@ describe('visual error templates', () => {
           group: 'foo',
           parallel: 'false',
         },
-        ciProvider.detectableCiBuildIdProviders()],
+        MOCK_CI_BUILD_ID_PROVIDERS],
       }
     },
     RECORD_PARAMS_WITHOUT_RECORDING: () => {

--- a/packages/server/lib/cloud/api/create_instance.ts
+++ b/packages/server/lib/cloud/api/create_instance.ts
@@ -2,6 +2,7 @@ import { CloudRequest, isRetryableCloudError } from './cloud_request'
 import { asyncRetry, exponentialBackoff } from '../../util/async_retry'
 import * as errors from '../../errors'
 import { isAxiosError } from 'axios'
+import * as humanTime from '../../util/human_time'
 
 const MAX_RETRIES = 3
 
@@ -58,7 +59,7 @@ export const createInstance = async (runId: string, instanceData: CreateInstance
     onRetry: (delay, err) => {
       errors.warning(
         'CLOUD_API_RESPONSE_FAILED_RETRYING', {
-          delayMs: delay,
+          delay: humanTime.long(delay),
           tries: MAX_RETRIES - attemptNumber,
           response: isAxiosError(err) ? err : err instanceof Error ? err : new Error(String(err)),
         },

--- a/packages/server/lib/cloud/api/create_instance.ts
+++ b/packages/server/lib/cloud/api/create_instance.ts
@@ -59,7 +59,7 @@ export const createInstance = async (runId: string, instanceData: CreateInstance
     onRetry: (delay, err) => {
       errors.warning(
         'CLOUD_API_RESPONSE_FAILED_RETRYING', {
-          delay: humanTime.long(delay),
+          delay: humanTime.long(delay, false),
           tries: MAX_RETRIES - attemptNumber,
           response: isAxiosError(err) ? err : err instanceof Error ? err : new Error(String(err)),
         },

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -218,7 +218,7 @@ const retryWithBackoff = (fn, options: { displayRetryErrors?: boolean } = { disp
       if (options.displayRetryErrors) {
         errors.warning(
           'CLOUD_API_RESPONSE_FAILED_RETRYING', {
-            delay: humanTime.long(delayMs),
+            delay: humanTime.long(delayMs, false),
             tries: delays.length - retryIndex,
             response: err,
           },

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -26,7 +26,7 @@ import type { OptionsWithUrl } from 'request-promise'
 import { fs } from '../../util/fs'
 import ProtocolManager from '../protocol'
 import type { ProjectBase } from '../../project-base'
-
+import * as humanTime from '../../util/human_time'
 import { PUBLIC_KEY_VERSION } from '../constants'
 
 // axios implementation disabled until proxy issues can be diagnosed/fixed
@@ -205,7 +205,7 @@ const retryWithBackoff = (fn, options: { displayRetryErrors?: boolean } = { disp
       if (options.displayRetryErrors) {
         errors.warning(
           'CLOUD_API_RESPONSE_FAILED_RETRYING', {
-            delayMs,
+            delay: humanTime.long(delayMs),
             tries: delays.length - retryIndex,
             response: err,
           },

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1605,7 +1605,7 @@ describe('lib/cloud/api', () => {
         expect(errors.warning).to.be.calledThrice
         expect(errors.warning.firstCall.args[0]).to.eql('CLOUD_API_RESPONSE_FAILED_RETRYING')
         expect(errors.warning.firstCall.args[1]).to.eql({
-          delayMs: 30000,
+          delay: '30 seconds',
           tries: 3,
           response: err,
         })

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1611,7 +1611,7 @@ describe('lib/cloud/api', () => {
         })
 
         expect(errors.warning.secondCall.args[1]).to.eql({
-          delay: '60 seconds',
+          delay: '1 minute',
           tries: 2,
           response: err,
         })

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1611,13 +1611,13 @@ describe('lib/cloud/api', () => {
         })
 
         expect(errors.warning.secondCall.args[1]).to.eql({
-          delayMs: 60000,
+          delay: '60 seconds',
           tries: 2,
           response: err,
         })
 
         expect(errors.warning.thirdCall.args[1]).to.eql({
-          delayMs: 120000,
+          delay: '2 minutes',
           tries: 1,
           response: err,
         })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
Dependency cycles make things tough for nx/lerna, etc, to determine the topology of the monorepo. This one was relatively straightforward to fix.

 - removes dependency on `@packages/server` for mock template data in `@packages/errors`
 - removes import middlemen on `human_time`
 - fixes dependency inversion of `human_time` - errors that use it now expect a string instead of a number.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared error-template parameter shapes used by server-side retry logic; low behavioral complexity but mismatches could break warning formatting or tests across packages.
> 
> **Overview**
> Removes the `@packages/errors` package’s dependency on `@packages/server` by dropping the `human_time` re-export from `errorUtils` and replacing server-derived browser/CI provider data in `visualSnapshotErrors.spec.ts` with fixed mock values (updating related snapshots).
> 
> Changes `CLOUD_API_RESPONSE_FAILED_RETRYING` to accept a preformatted `delay: string` instead of `delayMs: number`, and updates server Cloud API retry paths (`create_instance`, `retryWithBackoff`) and their unit tests to format delays via direct `human_time.long()` calls before emitting the warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5abe8fcdd2bfda2bcd7915badae187f9d2df5fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [X] Have tests been added/updated?
- [NA] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [NA] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
