### PR TITLE
fix: use smaller icon for Open in IDE button

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@ _Released 02/17/2026 (PENDING)_
 
 **Bugfixes:**
 
+- Fixed the Open in IDE button using an oversized icon by switching to a smaller icon size. Addressed in [#33387](https://github.com/cypress-io/cypress/pull/33387). Fixes [#32779](https://github.com/cypress-io/cypress/issues/32779).
 - Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Fixed in [#33366](https://github.com/cypress-io/cypress/pull/33366). Fixes [#33350](https://github.com/cypress-io/cypress/issues/33350).
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 

--- a/packages/reporter/src/header/OpenFileInIDEButton.tsx
+++ b/packages/reporter/src/header/OpenFileInIDEButton.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const OpenFileInIDEButton = ({ fileDetails, className }: Props) => {
   return (<>
-    <Button size='20' variant='outline-dark' className={cx('open-in-ide-button', className)} onClick={() => events.emit('open:file:unified', fileDetails)}><IconWindowCodeEditorSmall strokeColor='gray-500' fillColor='gray-900' /> Open in IDE </Button>
+    <Button size='20' variant='outline-dark' className={cx('open-in-ide-button', className)} onClick={() => events.emit('open:file:unified', fileDetails)}><IconWindowCodeEditorSmall size='12' strokeColor='gray-500' fillColor='gray-900' /> Open in IDE </Button>
     <span className={cx('button-hover-shadow')} />
   </>
   )


### PR DESCRIPTION
- Closes #32779

### Additional details

Sets the `IconWindowCodeEditorSmall` icon size to `12` in the Open in IDE button, as specified in the issue's Figma reference. The button container size remains `20` — only the icon inside is downsized for a cleaner inline appearance next to test/hook names.

### Steps to test

1. Open a spec file that has hooks (before/after)
2. Hover over a hook row
3. Verify the Open in IDE button icon is now smaller (12px)

### How has the user experience changed?

The Open in IDE icon inline with tests and hooks is now smaller, matching the Figma design.