### PR TITLE
dependency: update systeminformation to 5.31.1

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,7 +23,7 @@ _Released 02/17/2026 (PENDING)_
 - Upgraded `qs` to `6.14.2` to address [CVE-2026-2391](https://github.com/advisories/GHSA-w7fw-mjwx-w883) vulnerability reported in security scans. Addresses [#33363](https://github.com/cypress-io/cypress/issues/33363).
 - Upgraded `rimraf` to `6.1.1` to address [CVE-2026-25547](https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2) vulnerability reported in security scans. Addressed in [#33336](https://github.com/cypress-io/cypress/pull/33336).
 - Upgraded `squirrelly` to `9.1.0` to address [CVE-2021-32819](https://nvd.nist.gov/vuln/detail/CVE-2021-32819) vulnerability reported in security scans. Addresses [#33354](https://github.com/cypress-io/cypress/issues/33354).
-- Upgraded `systeminformation` to `5.31.1` to address [CVE-2026-26280](https://github.com/advisories/GHSA-9c88-49p5-5ggf) vulnerability reported in security scans. Addresses [#33389](https://github.com/cypress-io/cypress/issues/33389).
+- Upgraded `systeminformation` to `5.31.1` to address [CVE-2026-26280](https://github.com/advisories/GHSA-9c88-49p5-5ggf) and [CVE-2026-26318](https://github.com/advisories/GHSA-5vv4-hvf7-2h46) vulnerabilities reported in security scans. Addresses [#33389](https://github.com/cypress-io/cypress/issues/33389).
 
 ## 15.10.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,6 +23,7 @@ _Released 02/17/2026 (PENDING)_
 - Upgraded `qs` to `6.14.2` to address [CVE-2026-2391](https://github.com/advisories/GHSA-w7fw-mjwx-w883) vulnerability reported in security scans. Addresses [#33363](https://github.com/cypress-io/cypress/issues/33363).
 - Upgraded `rimraf` to `6.1.1` to address [CVE-2026-25547](https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2) vulnerability reported in security scans. Addressed in [#33336](https://github.com/cypress-io/cypress/pull/33336).
 - Upgraded `squirrelly` to `9.1.0` to address [CVE-2021-32819](https://nvd.nist.gov/vuln/detail/CVE-2021-32819) vulnerability reported in security scans. Addresses [#33354](https://github.com/cypress-io/cypress/issues/33354).
+- Upgraded `systeminformation` to `5.31.1` to address [CVE-2026-26280](https://github.com/advisories/GHSA-9c88-49p5-5ggf) vulnerability reported in security scans. Addresses [#33389](https://github.com/cypress-io/cypress/issues/33389).
 
 ## 15.10.0
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,7 @@
     "proxy-from-env": "1.0.0",
     "request-progress": "^3.0.0",
     "supports-color": "^8.1.1",
-    "systeminformation": "^5.27.14",
+    "systeminformation": "^5.31.1",
     "tmp": "~0.2.4",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29718,10 +29718,10 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@^5.27.14, systeminformation@^5.27.7:
-  version "5.27.14"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.27.14.tgz#9f2b181521c151dad4972d47936ebb49a3271e9d"
-  integrity sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==
+systeminformation@^5.27.7, systeminformation@^5.31.1:
+  version "5.31.1"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.31.1.tgz#5f88aa1db7470af87b6288baf1738603cafd1c4a"
+  integrity sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==
 
 systemjs@^6.15.1:
   version "6.15.1"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33389

### Additional details

`npm audit` and Dependabot report a high severity vulnerability CVE-2026-26280 (https://github.com/advisories/GHSA-9c88-49p5-5ggf) in the dependency [systeminformation@<5.30.8](https://github.com/sebhildebrandt/systeminformation/releases/tag/v5.30.8) in existing Cypress projects.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump to address a known vulnerability; behavior changes should be limited to system info reporting from the upstream library.
> 
> **Overview**
> Updates the CLI dependency `systeminformation` from `5.27.14` to `5.31.1` and refreshes `yarn.lock` accordingly.
> 
> Adds a changelog entry noting the upgrade as a security fix for **CVE-2026-26280**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 652f2d6604be094d826687352bae1c5628a6f4b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
yarn
yarn why systeminformation
```

Confirm that `systeminformation@5.31.1` is listed

```shell
yarn cypress info --dev
```

Confirm that System Platform / System Memory is shown correctly.

### How has the user experience changed?

After updating Cypress, the high severity vulnerabilities:

- CVE-2026-26280 (https://github.com/advisories/GHSA-9c88-49p5-5ggf) `<5.30.8`
- CVE-2026-26318 (https://github.com/advisories/GHSA-5vv4-hvf7-2h46) `<=5.30.7`

should no longer be reported.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

cc: @mschile 
