### PR TITLE
chore: remove redundant config('exit') check in runner.ts

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,7 +14,6 @@ _Released 02/17/2026 (PENDING)_
 - Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Fixed in [#33366](https://github.com/cypress-io/cypress/pull/33366). Fixes [#33350](https://github.com/cypress-io/cypress/issues/33350).
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 - The capture protocol is now properly cleaned up when the protocol is re-initialized or when the run closes, ensuring CDP client listeners and resources are removed. Addressed in [#33391](https://github.com/cypress-io/cypress/pull/33391).
-- Simplified redundant conditional logic in `shouldAlwaysResetPage` and `pause` command by removing an unused `config('exit')` check. Addresses [#32064](https://github.com/cypress-io/cypress/issues/32064). Addressed in [#33399](https://github.com/cypress-io/cypress/pull/33399).
 
 **Misc:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,7 @@ _Released 02/17/2026 (PENDING)_
 - Fixed an issue where a cancelled or incomplete login attempt would not properly open a browser window or tab, and required a restart of Cypress to enable a new login attempt. Fixed in [#33366](https://github.com/cypress-io/cypress/pull/33366). Fixes [#33350](https://github.com/cypress-io/cypress/issues/33350).
 - Fixed an issue on Windows where extracting the Studio or Prompt bundle could fail with `EPERM: operation not permitted` when renaming extracted files. The extract step now retries on EPERM/EACCES with a short delay to handle transient file locks. Addressed in [#33330](https://github.com/cypress-io/cypress/pull/33330).
 - The capture protocol is now properly cleaned up when the protocol is re-initialized or when the run closes, ensuring CDP client listeners and resources are removed. Addressed in [#33391](https://github.com/cypress-io/cypress/pull/33391).
+- Simplified redundant conditional logic in `shouldAlwaysResetPage` and `pause` command by removing an unused `config('exit')` check. Addresses [#32064](https://github.com/cypress-io/cypress/issues/32064). Addressed in [#33399](https://github.com/cypress-io/cypress/pull/33399).
 
 **Misc:**
 

--- a/packages/driver/src/cy/commands/debugging.ts
+++ b/packages/driver/src/cy/commands/debugging.ts
@@ -43,7 +43,7 @@ export default (Commands, Cypress, cy, state, config) => {
   // pause should indefinitely pause until the user
   // presses a key or clicks in the UI to continue
   Commands.addQuery('pause', function pause (options: Partial<Cypress.Loggable> = {}) {
-    if (!config('isInteractive') && (!config('browser').isHeaded || config('exit'))) {
+    if (!config('isInteractive') && !config('browser').isHeaded) {
       return _.identity
     }
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -523,8 +523,7 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         }
 
         const isRunMode = !Cypress.config('isInteractive')
-        const isHeadedNoExit = Cypress.config('browser').isHeaded && !Cypress.config('exit')
-        const shouldAlwaysResetPage = isRunMode && !isHeadedNoExit
+        const shouldAlwaysResetPage = isRunMode && !Cypress.config('browser').isHeaded
         const isLastTestThatWillRunInSuite = test.final && lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))
 
         // If we're not in open mode or we're in open mode and not the last test we reset state.

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation-describe-config.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation-describe-config.spec.js
@@ -1,8 +1,7 @@
 const shouldAlwaysResetPage = (config) => {
   const isRunMode = !config('isInteractive')
-  const isHeadedNoExit = config('browser').isHeaded && !config('exit')
 
-  return isRunMode && !isHeadedNoExit
+  return isRunMode && !config('browser').isHeaded
 }
 
 const TEST_METADATA = {

--- a/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
+++ b/system-tests/projects/cypress-in-cypress/cypress/e2e/test-isolation.spec.js
@@ -1,8 +1,7 @@
 const shouldAlwaysResetPage = (config) => {
   const isRunMode = !config('isInteractive')
-  const isHeadedNoExit = config('browser').isHeaded && !config('exit')
 
-  return isRunMode && !isHeadedNoExit
+  return isRunMode && !config('browser').isHeaded
 }
 
 const TEST_METADATA = {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/32064

### Additional details

This change removes the redundant `Cypress.config('exit')` check from three locations:

1. `shouldAlwaysResetPage` calculation in `runner.ts`
2. `pause` command condition in `debugging.ts`
3. Corresponding test helper functions in system tests

There is no Cypress configuration option called `exit`, so `Cypress.config('exit')` always returns `undefined` (falsy). This means `!Cypress.config('exit')` is always `true`, making the entire `isHeadedNoExit` variable equivalent to just `Cypress.config('browser').isHeaded`. The simplified expression `isRunMode && !Cypress.config('browser').isHeaded` produces identical behavior to the original.

This is a code cleanup with no behavioral or user-facing impact.

### Steps to test

1. Run existing system tests for test isolation:
   - `test-isolation.spec.js`
   - `test-isolation-describe-config.spec.js`
2. Verify the `pause` command behavior is unchanged in both headed and headless modes

### How has the user experience changed?

N/A — No user-facing changes. This is an internal code cleanup only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?