### PR TITLE
chore: release v15.11.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.11.0
 
-_Released 02/24/2026 (PENDING)_
+_Released 02/24/2026_
 
 **Features:**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "15.10.0",
+  "version": "15.11.0",
   "description": "Cypress is a next generation front end testing tool built for the modern web",
   "private": true,
   "scripts": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
     "test-unit": "echo 'no unit tests'"
   },
   "devDependencies": {
-    "cypress-example-kitchensink": "5.2.0",
+    "cypress-example-kitchensink": "5.2.1",
     "gh-pages": "5.0.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14041,12 +14041,12 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-cypress-example-kitchensink@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-5.2.0.tgz#0a7be481e1e25edbbf98d39de559c983c40f1a42"
-  integrity sha512-Q8dNSJXrR5j/HiuzXK4nPXOG+3s05QxnhV3gfsdV0Rl3uwsf3r38UFk4Fgi6uEd/URQM2Kl5NbZjLj9mj+OE8Q==
+cypress-example-kitchensink@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-5.2.1.tgz#55cbf633d283b3e63b1c02862ee8e812a92e64b6"
+  integrity sha512-pM6CizO1uPyFkkuNO6QaewO7yEBfccBslYDlDO4H+rXK4nRC8EwTOHgGiiCqAqg31VfP8HVSBjsj1plvXfSk+Q==
   dependencies:
-    npm-run-all2 "7.0.2"
+    npm-run-all2 "8.0.4"
     serve "14.2.5"
 
 cypress-multi-reporters@1.4.0:
@@ -24268,15 +24268,15 @@ npm-registry-fetch@^18.0.0, npm-registry-fetch@^18.0.1:
     npm-package-arg "^12.0.0"
     proc-log "^5.0.0"
 
-npm-run-all2@7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/npm-run-all2/-/npm-run-all2-7.0.2.tgz#26155c140b5e3f1155efd7f5d67212c8027b397c"
-  integrity sha512-7tXR+r9hzRNOPNTvXegM+QzCuMjzUIIq66VDunL6j60O4RrExx32XUhlrS7UK4VcdGw5/Wxzb3kfNcFix9JKDA==
+npm-run-all2@8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/npm-run-all2/-/npm-run-all2-8.0.4.tgz#bcc070fd0cdb8d45496ec875d99a659a112e3f74"
+  integrity sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==
   dependencies:
     ansi-styles "^6.2.1"
     cross-spawn "^7.0.6"
     memorystream "^0.3.1"
-    minimatch "^9.0.0"
+    picomatch "^4.0.2"
     pidtree "^0.6.0"
     read-package-json-fast "^4.0.0"
     shell-quote "^1.7.3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release/version metadata and example/dependency lockfile updates only; no runtime product logic changes in this diff.
> 
> **Overview**
> Cuts the `15.11.0` release by bumping the root package version to `15.11.0` and marking the `cli/CHANGELOG.md` entry as released (removes *PENDING*).
> 
> Updates the `@packages/example` dev dependency `cypress-example-kitchensink` to `5.2.1` and refreshes the corresponding `yarn.lock` entries (including `npm-run-all2` resolution changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fab87030fc0e7650efee2b971d75780970e5d3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->