### PR TITLE
feat: Add option to 'word wrap' for Studio panel code 

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -20,6 +20,7 @@ _Released 02/24/2026 (PENDING)_
 
 - The Node.js path is now displayed correctly in run log headers for typical GitHub Actions paths. ANSI escape sequences are no longer incorrectly displayed for longer Node.js paths. Addresses [#32736](https://github.com/cypress-io/cypress/issues/32736).
 - Fixed an issue that caused a Node.js [DEP0169](https://nodejs.org/docs/latest/api/deprecations.html#DEP0169) deprecation warning to be output when executing `cypress install` to download and install the Cypress binary. Addresses [#33347](https://github.com/cypress-io/cypress/issues/33347).
+- Adds option to 'word wrap' for Studio panel code. Addressed in [#33411]https://github.com/cypress-io/cypress/pull/33411
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,15 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.12.0
+
+_Released 03/02/2026 (PENDING)_
+
+**Misc:**
+
+- Adds an option to enable word wrap for Studio panel code. Addressed in [#33411](https://github.com/cypress-io/cypress/pull/33411).
+
 ## 15.11.0
 
-_Released 02/24/2026 (PENDING)_
+_Released 02/24/2026
 
 **Features:**
 
@@ -20,7 +28,6 @@ _Released 02/24/2026 (PENDING)_
 
 - The Node.js path is now displayed correctly in run log headers for typical GitHub Actions paths. ANSI escape sequences are no longer incorrectly displayed for longer Node.js paths. Addresses [#32736](https://github.com/cypress-io/cypress/issues/32736).
 - Fixed an issue that caused a Node.js [DEP0169](https://nodejs.org/docs/latest/api/deprecations.html#DEP0169) deprecation warning to be output when executing `cypress install` to download and install the Cypress binary. Addresses [#33347](https://github.com/cypress-io/cypress/issues/33347).
-- Adds option to 'word wrap' for Studio panel code. Addressed in [#33411]https://github.com/cypress-io/cypress/pull/33411
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 _Released 03/02/2026 (PENDING)_
 
-**Misc:**
+**Features:**
 
 - Adds an option to enable word wrap for Studio panel code. Addressed in [#33411](https://github.com/cypress-io/cypress/pull/33411).
 

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -182,6 +182,7 @@ fragment SpecRunner_Preferences on Query {
       isSpecsListOpen
       autoScrollingEnabled
       showFetchRequests
+      codeEditorLineWrap
       reporterWidth
       specListWidth
       studioWidth
@@ -356,7 +357,7 @@ onMounted(() => {
 })
 
 preferences.update('autoScrollingEnabled', props.gql.localSettings.preferences.autoScrollingEnabled ?? true)
-
+preferences.update('codeEditorLineWrap', props.gql.localSettings.preferences.codeEditorLineWrap ?? false)
 preferences.update('showFetchRequests', props.gql.localSettings.preferences.showFetchRequests ?? true)
 
 // if the CYPRESS_NO_COMMAND_LOG environment variable is set,
@@ -442,6 +443,7 @@ onMounted(() => {
     preferences.update('isSpecsListOpen', state.isSpecsListOpen)
     preferences.update('autoScrollingEnabled', state.autoScrollingEnabled)
     preferences.update('showFetchRequests', state.showFetchRequests)
+    preferences.update('codeEditorLineWrap', state.codeEditorLineWrap)
   })
 })
 

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -906,6 +906,7 @@ export class EventManager {
       scrollTop: runState.scrollTop,
       studioActive: hasActiveStudio,
       studioSingleTestActive,
+      codeEditorLineWrap: runState.codeEditorLineWrap,
     } as ReporterStartInfo)
   }
 

--- a/packages/app/src/runner/reporter.ts
+++ b/packages/app/src/runner/reporter.ts
@@ -54,6 +54,7 @@ function renderReporter (
     studioEnabled: window.__CYPRESS_TESTING_TYPE__ === 'e2e',
     runnerStore: store,
     testFilter: specsStore.testFilter,
+    codeEditorLineWrap: runnerUiStore.codeEditorLineWrap,
   })
 
   reactDomRoot = window.UnifiedRunner.ReactDOM.createRoot(root)

--- a/packages/app/src/store/runner-ui-store.ts
+++ b/packages/app/src/store/runner-ui-store.ts
@@ -21,6 +21,7 @@ export type AutomationStatus = keyof typeof automation
 export interface RunnerUiState {
   showChooseExternalEditorModal: boolean
   autoScrollingEnabled: boolean
+  codeEditorLineWrap: boolean
   isSpecsListOpen: boolean
   showFetchRequests: boolean
   specListWidth: number
@@ -48,6 +49,7 @@ export const useRunnerUiStore = defineStore({
       randomString: `${Math.random()}`,
       hideCommandLog: window.__CYPRESS_CONFIG__.hideCommandLog,
       hideRunnerUi: window.__CYPRESS_CONFIG__.hideRunnerUi,
+      codeEditorLineWrap: false,
     }
   },
 

--- a/packages/data-context/graphql/schemaTypes/objectTypes/gql-LocalSettings.ts
+++ b/packages/data-context/graphql/schemaTypes/objectTypes/gql-LocalSettings.ts
@@ -6,6 +6,7 @@ export const LocalSettingsPreferences = objectType({
   description: 'local setting preferences',
   definition (t) {
     t.boolean('autoScrollingEnabled')
+    t.boolean('codeEditorLineWrap')
     t.string('preferredEditorBinary')
     t.boolean('isSpecsListOpen')
     t.boolean('showFetchRequests')

--- a/packages/data-context/schemas/schema.graphql
+++ b/packages/data-context/schemas/schema.graphql
@@ -1409,6 +1409,7 @@ type LocalSettings {
 """local setting preferences"""
 type LocalSettingsPreferences {
   autoScrollingEnabled: Boolean
+  codeEditorLineWrap: Boolean
   debugSlideshowComplete: Boolean
   desktopNotificationsEnabled: Boolean
   dismissNotificationBannerUntil: DateTime

--- a/packages/frontend-shared/cypress/support/mock-graphql/clientTestContext.ts
+++ b/packages/frontend-shared/cypress/support/mock-graphql/clientTestContext.ts
@@ -84,6 +84,7 @@ export function makeClientTestContext (): ClientTestContext {
       preferences: {
         __typename: 'LocalSettingsPreferences',
         autoScrollingEnabled: true,
+        codeEditorLineWrap: false,
         isSideNavigationOpen: false,
         showFetchRequests: true,
         desktopNotificationsEnabled: false,

--- a/packages/reporter/cypress/e2e/header.cy.ts
+++ b/packages/reporter/cypress/e2e/header.cy.ts
@@ -175,6 +175,21 @@ describe('header', () => {
           cy.percySnapshot()
         })
 
+        it('shows code editor line wrap toggle, can toggle it, and emits save:state when clicked', () => {
+          const switchSelector = '[data-cy=code-editor-line-wrap-switch]'
+
+          cy.spy(runner, 'emit')
+
+          cy.get('[data-cy="runnable-options-button"]').click()
+          cy.get('[data-cy="more-options-runnable-popover"]').should('be.visible')
+
+          cy.get(switchSelector).invoke('attr', 'aria-checked').should('eq', 'false')
+          cy.get(switchSelector).click()
+          cy.get(switchSelector).invoke('attr', 'aria-checked').should('eq', 'true')
+          cy.wrap(runner.emit).should('be.calledWith', 'save:state')
+          cy.percySnapshot()
+        })
+
         it('opens the open in IDE button', () => {
           cy.spy(runner, 'emit')
 

--- a/packages/reporter/cypress/e2e/unit/app_state.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/app_state.cy.ts
@@ -161,6 +161,28 @@ describe('app state', () => {
     })
   })
 
+  context('#toggleCodeEditorLineWrap', () => {
+    it('toggles codeEditorLineWrap', () => {
+      const instance = new AppState()
+
+      instance.toggleCodeEditorLineWrap()
+      expect(instance.codeEditorLineWrap).to.be.true
+      instance.toggleCodeEditorLineWrap()
+      expect(instance.codeEditorLineWrap).to.be.false
+    })
+  })
+
+  context('#setCodeEditorLineWrap', () => {
+    it('sets codeEditorLineWrap', () => {
+      const instance = new AppState()
+
+      instance.setCodeEditorLineWrap(true)
+      expect(instance.codeEditorLineWrap).to.be.true
+      instance.setCodeEditorLineWrap(false)
+      expect(instance.codeEditorLineWrap).to.be.false
+    })
+  })
+
   context('#reset', () => {
     it('resets autoScrollingEnabled when it has not been toggled', () => {
       const instance = new AppState()

--- a/packages/reporter/cypress/e2e/unit/events.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/events.cy.ts
@@ -355,11 +355,13 @@ describe('events', () => {
       appState.autoScrollingUserPref = false
       appState.isSpecsListOpen = true
       appState.showFetchRequests = false
+      appState.codeEditorLineWrap = false
       events.emit('save:state')
       expect(runner.emit).to.have.been.calledWith('save:state', {
         autoScrollingEnabled: false,
         isSpecsListOpen: true,
         showFetchRequests: false,
+        codeEditorLineWrap: false,
       })
     })
 

--- a/packages/reporter/src/lib/app-state.ts
+++ b/packages/reporter/src/lib/app-state.ts
@@ -36,7 +36,8 @@ class AppState {
   showFetchRequests = true
   isStopped = false
   hasBeenPaused = defaults.hasBeenPaused
-  _resetAutoScrollingEnabledTo = true;
+  _resetAutoScrollingEnabledTo = true
+  codeEditorLineWrap = false;
   [key: string]: any
 
   constructor () {
@@ -52,6 +53,7 @@ class AppState {
       studioSingleTestActive: observable,
       showFetchRequests: observable,
       hasBeenPaused: observable,
+      codeEditorLineWrap: observable,
     })
   }
 
@@ -136,6 +138,14 @@ class AppState {
 
   toggleShowFetchRequests () {
     this.showFetchRequests = !this.showFetchRequests
+  }
+
+  toggleCodeEditorLineWrap () {
+    this.codeEditorLineWrap = !this.codeEditorLineWrap
+  }
+
+  setCodeEditorLineWrap (codeEditorLineWrap: boolean) {
+    this.codeEditorLineWrap = codeEditorLineWrap
   }
 
   setShowFetchRequests (showFetchRequests: boolean) {

--- a/packages/reporter/src/lib/events.ts
+++ b/packages/reporter/src/lib/events.ts
@@ -205,6 +205,7 @@ const events: Events = {
         autoScrollingEnabled: appState.autoScrollingUserPref,
         isSpecsListOpen: appState.isSpecsListOpen,
         showFetchRequests: appState.showFetchRequests,
+        codeEditorLineWrap: appState.codeEditorLineWrap,
       })
     })
 

--- a/packages/reporter/src/main.tsx
+++ b/packages/reporter/src/main.tsx
@@ -43,6 +43,7 @@ export interface BaseReporterProps {
   renderReporterHeader?: (props: ReporterHeaderProps) => JSX.Element
   studioEnabled: boolean
   runnerStore: MobxRunnerStore
+  codeEditorLineWrap?: boolean
 }
 
 export interface SingleReporterProps extends BaseReporterProps {
@@ -50,7 +51,7 @@ export interface SingleReporterProps extends BaseReporterProps {
 }
 
 // In React Class components (now deprecated), we used to use appState as a default prop. Now since defaultProps are not supported in functional components, we can use ES6 default params to accomplish the same thing
-const Reporter: React.FC<SingleReporterProps> = observer(({ appState = appStateDefault, runner, className, error, runMode = 'single', studioEnabled, autoScrollingEnabled, isSpecsListOpen, showFetchRequests, resetStatsOnSpecChange, renderReporterHeader = (props: ReporterHeaderProps) => <Header {...props} />, runnerStore }) => {
+const Reporter: React.FC<SingleReporterProps> = observer(({ appState = appStateDefault, runner, className, error, runMode = 'single', studioEnabled, autoScrollingEnabled, isSpecsListOpen, showFetchRequests, resetStatsOnSpecChange, renderReporterHeader = (props: ReporterHeaderProps) => <Header {...props} />, runnerStore, codeEditorLineWrap }) => {
   const previousSpecRunId = usePrevious(runnerStore.specRunId)
   const [isMounted, setIsMounted] = useState(false)
   const [isInitialized, setIsInitialized] = useState(false)
@@ -84,6 +85,10 @@ const Reporter: React.FC<SingleReporterProps> = observer(({ appState = appStateD
 
     action('set:show:fetch:requests', () => {
       appState.setShowFetchRequests(showFetchRequests ?? true)
+    })()
+
+    action('set:code:editor:line:wrap', () => {
+      appState.setCodeEditorLineWrap(codeEditorLineWrap ?? false)
     })()
 
     shortcuts.start()

--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -71,6 +71,11 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
     events.emit('save:state')
   }
 
+  const toggleCodeEditorLineWrap = () => {
+    appState.toggleCodeEditorLineWrap()
+    events.emit('save:state')
+  }
+
   // Close popover when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -166,6 +171,25 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
           </span>
         </div>
 
+      </div>
+
+      <div className="runnable-popover-section">
+        <div className="runnable-popover-section-title">Studio preferences</div>
+        <div className="runnable-popover-item-with-toggle">
+          <div className="runnable-popover-item-with-toggle-content">
+            <div className="runnable-popover-item-text">
+              <span className="runnable-popover-item-label">Code editor line wrap</span>
+            </div>
+            <Switch
+              data-cy="code-editor-line-wrap-switch"
+              value={appState.codeEditorLineWrap}
+              onUpdate={action('toggle:code:editor:line:wrap', toggleCodeEditorLineWrap)}
+            />
+          </div>
+          <span className="runnable-popover-item-description">
+            Wrap long lines instead of scrolling horizontally.
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -15,6 +15,7 @@ interface MochaRunnerState {
 export type RunState = MochaRunnerState & ReporterRunState & {
   isSpecsListOpen?: boolean
   showFetchRequests?: boolean
+  codeEditorLineWrap?: boolean
 }
 
 export interface Emissions {

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -13,6 +13,7 @@ export const defaultPreferences: AllowedState = {
   notifyWhenRunStarts: false,
   notifyWhenRunStartsFailing: true,
   notifyWhenRunCompletes: ['failed'],
+  codeEditorLineWrap: false,
 }
 
 export const allowedKeys: Readonly<Array<keyof AllowedState>> = [
@@ -54,6 +55,7 @@ export const allowedKeys: Readonly<Array<keyof AllowedState>> = [
   'notifyWhenRunStartsFailing',
   'notifyWhenRunCompletes',
   'studioFirstUseInstructionsDismissed',
+  'codeEditorLineWrap',
 ] as const
 
 export type AllowedState = Partial<{
@@ -96,4 +98,5 @@ export type AllowedState = Partial<{
   notifyWhenRunStartsFailing: Maybe<boolean>
   notifyWhenRunCompletes: Maybe<NotifyWhenRunCompletes[]>
   studioFirstUseInstructionsDismissed: Maybe<boolean>
+  codeEditorLineWrap: Maybe<boolean>
 }>

--- a/packages/types/src/reporter.ts
+++ b/packages/types/src/reporter.ts
@@ -17,4 +17,5 @@ export interface ReporterStartInfo extends StatsStoreStartInfo {
   studioActive: boolean
   studioSingleTestActive: boolean
   showFetchRequests: boolean
+  codeEditorLineWrap: boolean
 }


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/11175

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches runner↔reporter state plumbing and local-settings GraphQL schema/types, so mismatches or missing defaults could break preference persistence across versions; behavior change is otherwise UI-only.
> 
> **Overview**
> Adds a new **Studio preference** `codeEditorLineWrap` (default `false`) that enables word wrapping for Studio code.
> 
> Plumbs this preference end-to-end: extends local settings GraphQL schema/types and default preferences, propagates it through runner/reporter `save:state` and `reporter:start` payloads, and exposes a new toggle in the runnable options popover. Updates mocks, E2E/unit tests, and the CLI changelog entry for `15.12.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1f63e5150e16805eb0b7ab87185423365c60e05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Adds the option to turn code wrapping in studio. Needs https://github.com/cypress-io/cypress-services/pull/12865

<img width="318" height="460" alt="image" src="https://github.com/user-attachments/assets/c78d3d50-395c-4b28-b5ce-66b71ab5d562" />



Uploading Screen Recording 2026-02-25 at 3.28.57 PM.mov…




### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
