### PR TITLE
test: resolve flaky choose-a-browser e2e when --browser is passed alone

### DIFF
--- a/packages/launchpad/src/setup/OpenBrowser.vue
+++ b/packages/launchpad/src/setup/OpenBrowser.vue
@@ -25,7 +25,7 @@ import WarningList from '../warning/WarningList.vue'
 import { OpenBrowserDocument, OpenBrowser_CloseBrowserDocument, OpenBrowser_ClearTestingTypeDocument, OpenBrowser_LaunchProjectDocument, OpenBrowser_FocusActiveBrowserWindowDocument, OpenBrowser_ResetLatestVersionTelemetryDocument, OpenBrowser_LocalSettingsDocument } from '../generated/graphql'
 import LaunchpadHeader from './LaunchpadHeader.vue'
 import { useI18n } from '@cy/i18n'
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 
 const { t } = useI18n()
 
@@ -117,15 +117,25 @@ const launch = async () => {
   }
 }
 
-const launchIfBrowserSetInCli = async () => {
-  const shouldLaunchBrowser = (await lsQuery).data.value?.localSettings?.preferences?.shouldLaunchBrowserFromOpenBrowser
+const shouldLaunchBrowserFromOpenBrowser = computed(() => {
+  return lsQuery.data.value?.localSettings?.preferences?.shouldLaunchBrowserFromOpenBrowser
+})
 
-  if (shouldLaunchBrowser) {
-    await launch()
-  }
+const currentTestingType = computed(() => {
+  return query.data.value?.currentProject?.currentTestingType
+})
 
-  return
-}
+// Auto-launch when --browser was passed alone: wait for both LocalSettings and
+// currentProject (so launch() has testingType and actually runs the mutation).
+watch(
+  () => shouldLaunchBrowserFromOpenBrowser.value && currentTestingType.value,
+  (shouldAutoLaunch) => {
+    if (shouldAutoLaunch) {
+      launch()
+    }
+  },
+  { immediate: true },
+)
 
 const backFn = () => {
   clearCurrentTestingType.executeMutation({})
@@ -147,7 +157,6 @@ const setFocusToActiveBrowserWindow = () => {
 
 onMounted(() => {
   resetLatestVersionTelemetry.executeMutation({})
-  launchIfBrowserSetInCli()
 })
 
 </script>


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

Fixes flakiness in the e2e test **"Choose a browser page > System Browsers Detected > launches when --browser is passed alone through the command line"**, which was failing with `AssertionError: expected launchProject to have been called exactly once, but it was never called`.

**Root cause:** When Cypress is opened with only `--browser` (no `--e2e`/`--component`), the launchpad shows testing-type cards first. After the user selects a type, the OpenBrowser view mounts and is supposed to auto-launch via `shouldLaunchBrowserFromOpenBrowser`. The previous logic called `launchIfBrowserSetInCli()` in `onMounted` and did `(await lsQuery)` — but in urql Vue, `useQuery` returns reactive state, not a Promise, so `await lsQuery` did not wait for the LocalSettings request. When the code read `lsQuery.data.value`, it was often still `undefined`, so `launch()` was never called. Separately, when the watch did fire, `launch()` could run before the OpenBrowser query had `currentProject.currentTestingType`, so the mutation was skipped.

**Fix (OpenBrowser.vue):**
- Replaced the `onMounted` + `launchIfBrowserSetInCli()` flow with a single `watch` that depends on **both** `shouldLaunchBrowserFromOpenBrowser` (from LocalSettings) **and** `currentTestingType` (from the OpenBrowser query).
- Auto-launch now runs only when both are ready, so `launch()` always has a `testingType` and executes the mutation once.

No test file changes are in this branch; the test was already updated in a prior iteration (wait for "Choose a browser" + `withRetryableCtx`). This PR is the application fix that makes the test stable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/reactivity change limited to the Open Browser auto-launch trigger; main risk is unintended double-launch or missed launch if the new watcher condition is wrong.
> 
> **Overview**
> Fixes flaky auto-launch in `OpenBrowser.vue` when Cypress is opened with `--browser` alone by replacing the `onMounted`-triggered check with a reactive `watch`.
> 
> The new watcher waits until **both** `localSettings.preferences.shouldLaunchBrowserFromOpenBrowser` and `currentProject.currentTestingType` are available before calling `launch()`, avoiding races where `useQuery` data is still `undefined` and the launch mutation never runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232502efa7f2aaa409d9693929fdf9d155774ec1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Check out the branch and run the launchpad e2e test repeatedly:
   ```bash
   cd packages/launchpad && yarn cypress run --e2e --spec "cypress/e2e/choose-a-browser.cy.ts"
   ```
2. Optionally run only the affected test multiple times to confirm stability:
   - Temporarily add `it.only` and `Cypress._.times(10, () => { it.only(...) })` around the test "launches when --browser is passed alone through the command line", then run the spec and confirm all 10 pass.

### How has the user experience changed?

No user-facing change. Behavior is the same when opening with `--browser` alone; the auto-launch now happens reliably instead of sometimes not firing due to a race.

### PR Tasks

- [x] Have tests been added/updated? (Fix targets existing e2e test stability; no new tests.)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
