### PR TITLE
dependency: update fast-xml-parser to 4.5.4

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,4 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-
 ## 15.12.0
 
 _Released 03/10/2026 (PENDING)_
@@ -15,6 +14,7 @@ _Released 03/10/2026 (PENDING)_
 **Dependency Updates:**
 
 - Upgraded `basic-ftp` to `5.2.0` to address [CVE-2026-27699](https://github.com/advisories/GHSA-5rq4-664w-9x2c) vulnerability reported in security scans. Addresses [#33436](https://github.com/cypress-io/cypress/issues/33436).
+- Upgraded `fast-xml-parser` to `4.5.4` to address [CVE-2026-25896](https://github.com/advisories/GHSA-m7jm-9gc2-mpf2) vulnerability reported in security scans. Addresses [#33434](https://github.com/cypress-io/cypress/issues/33434).
 
 ## 15.11.0
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "eslint-plugin-vue": "7.18.0",
     "execa": "4.1.0",
-    "fast-xml-parser": "^4.5.3",
+    "fast-xml-parser": "^4.5.4",
     "filesize": "10.1.6",
     "fs-extra": "9.1.0",
     "glob": "7.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16697,12 +16697,12 @@ fast-xml-parser@4.2.5:
   dependencies:
     strnum "^1.0.5"
 
-fast-xml-parser@^4.5.0, fast-xml-parser@^4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz#c54d6b35aa0f23dc1ea60b6c884340c006dc6efb"
-  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
+fast-xml-parser@^4.5.0, fast-xml-parser@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz#64e52ddf1308001893bd225d5b1768840511c797"
+  integrity sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==
   dependencies:
-    strnum "^1.1.1"
+    strnum "^1.0.5"
 
 fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -29648,7 +29648,7 @@ strip-outer@^1.0.1:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-strnum@^1.0.5, strnum@^1.1.1:
+strnum@^1.0.5:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33434

### Additional details

Trivy and Docker Scout report the critical severity vulnerability CVE-2026-25896 (https://github.com/advisories/GHSA-m7jm-9gc2-mpf2) in the Cypress Docker image `cypress/included:15.11.0` (current `latest`) regarding `fast-xml-parser@4.5.3`.

Update `fast-xml-parser` to [4.5.4](https://www.npmjs.com/package/fast-xml-parser/v/4.5.4)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change intended to remediate CVE-2026-25896. Main risk is unforeseen parsing behavior differences in the updated library version.
> 
> **Overview**
> Updates the `fast-xml-parser` dependency to `^4.5.4` and refreshes `yarn.lock` accordingly (including updated transitive `strnum` resolution).
> 
> Adds a `cli/CHANGELOG.md` entry noting the upgrade as a security fix for **CVE-2026-25896**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57013b4dce853243705442a7585140af9256c684. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
yarn
yarn why fast-xml-parser
```

and confirm that `fast-xml-parser@4.5.4` is shown

### How has the user experience changed?

When using a newer `cypress/included` Docker image, security scanners should no longer report the critical vulnerability:

CVE-2026-25896 (https://github.com/advisories/GHSA-m7jm-9gc2-mpf2)

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?