### PR TITLE
dependency: update basic-ftp to 5.2.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 15.12.0
 
-_Released 03/02/2026 (PENDING)_
+_Released 03/10/2026 (PENDING)_
 
 **Features:**
 
@@ -11,6 +11,10 @@ _Released 03/02/2026 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where internal tags on stderr streams were surfacing to the end user CLI during component testing. Addresses [#32769](https://github.com/cypress-io/cypress/issues/32769). Addressed in [#33400](https://github.com/cypress-io/cypress/pull/33400).
+
+**Dependency Updates:**
+
+- Upgraded `basic-ftp` to `5.2.0` to address [CVE-2026-27699](https://github.com/advisories/GHSA-5rq4-664w-9x2c) vulnerability reported in security scans. Addresses [#33436](https://github.com/cypress-io/cypress/issues/33436).
 
 ## 15.11.0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11561,9 +11561,9 @@ basic-auth@2.0.1, basic-auth@~2.0.0:
     safe-buffer "5.1.2"
 
 basic-ftp@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.3.tgz#b14c0fe8111ce001ec913686434fe0c2fb461228"
-  integrity sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.0.tgz#7c2dff63c918bde60e6bad1f2ff93dcf5137a40a"
+  integrity sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==
 
 batch@0.6.1:
   version "0.6.1"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33436

### Additional details

Trivy and Docker Scout report the critical severity vulnerability CVE-2026-27699 (https://github.com/advisories/GHSA-5rq4-664w-9x2c) in `cypress/included:15.11.0` (current `latest`).

[basic-ftp](https://www.npmjs.com/package/basic-ftp) is a transient dependency of Cypress.

Remove `basic-ftp` from `yarn.lock` and run `yarn` to resync to [basic-ftp@5.2.0](https://github.com/patrickjuchli/basic-ftp/releases/tag/v5.2.0)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency bump plus changelog entry; main risk is unforeseen behavior changes in the transitive `basic-ftp` package, but it’s a patch/minor update intended to remediate CVE-2026-27699.
> 
> **Overview**
> Updates the lockfile to pull in `basic-ftp@5.2.0` (from `5.0.3`) to remediate **CVE-2026-27699** flagged by security scans.
> 
> Updates `cli/CHANGELOG.md` for `15.12.0` by adjusting the pending release date and documenting the dependency/security update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 801c2be8d14e33f0cdea3da7a266fed4301070f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
yarn
yarn why basic-ftp
```

and confirm that `basic-ftp@5.2.0` is shown

### How has the user experience changed?

When using a newer `cypress/included` Docker image, security scanners should no longer report the critical vulnerability:

CVE-2026-27699 (https://github.com/advisories/GHSA-5rq4-664w-9x2c)

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?