### PR TITLE
fix: prevent hang when waiting on multiple intercepts and navigating

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,7 @@ _Released 03/10/2026 (PENDING)_
 **Bugfixes:**
 
 - Fixed an issue where internal tags on stderr streams were surfacing to the end user CLI during component testing. Addresses [#32769](https://github.com/cypress-io/cypress/issues/32769). Addressed in [#33400](https://github.com/cypress-io/cypress/pull/33400).
+- Fixed an issue where Cypress may hang when waiting on multiple intercepts and the page navigates causing a stability change. Addressed in [#33446](https://github.com/cypress-io/cypress/pull/33446).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,4 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-
 ## 15.12.0
 
 _Released 03/10/2026 (PENDING)_

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -3659,6 +3659,36 @@ describe('network stubbing', { retries: 15 }, function () {
       .wait('@foo.bar.request', { timeout: 100 })
     })
 
+    it('does not hang when waiting on multiple aliases across navigation', function (done) {
+      const triggerUrl = uniqueRoute('/trigger-navigation')
+      const neverAUrl = uniqueRoute('/never-a')
+      const neverBUrl = uniqueRoute('/never-b')
+      const slowPageUrl = '/fixtures/empty.html?stability-repro=1'
+
+      testFailWaiting((err) => {
+        expect(err.message).to.contain('`cy.wait()` timed out waiting')
+        done()
+      })
+
+      cy.intercept(`${triggerUrl}*`, 'ok').as('trigger')
+      cy.intercept(`${neverAUrl}*`).as('neverA')
+      cy.intercept(`${neverBUrl}*`).as('neverB')
+      cy.intercept('/fixtures/empty.html?stability-repro=1', {
+        delay: 2000,
+        fixture: 'empty.html',
+      })
+      .then(() => {
+        const win = cy.state('window')
+
+        setTimeout(() => {
+          $.get(triggerUrl).always(() => {
+            win.location.href = slowPageUrl
+          })
+        }, 50)
+      })
+      .wait(['@neverA', '@neverB', '@trigger'], { timeout: 300 })
+    })
+
     it('can alias a route without stubbing it', function () {
       cy.intercept(/fixtures\/app/).as('getFoo').then(function () {
         $.get('/fixtures/app.json')

--- a/packages/driver/cypress/e2e/cy/stability.cy.ts
+++ b/packages/driver/cypress/e2e/cy/stability.cy.ts
@@ -1,0 +1,99 @@
+import type { ICypress } from '../../../src/cypress'
+import type { StateFunc } from '../../../src/cypress/state'
+import { create } from '../../../src/cy/stability'
+
+const createState = (initialState: Record<string, any> = {}): StateFunc => {
+  const values = { ...initialState }
+
+  const state = (function (key?: string | Record<string, any>, value?: any) {
+    if (typeof key === 'undefined') {
+      return values
+    }
+
+    if (typeof key === 'object') {
+      Object.assign(values, key)
+
+      return values
+    }
+
+    if (arguments.length === 2) {
+      values[key] = value
+    }
+
+    return values[key]
+  }) as StateFunc
+
+  return state
+}
+
+describe('src/cy/stability', () => {
+  it('releases all waiters registered while unstable', () => {
+    const order: string[] = []
+    const state = createState({ isStable: false })
+    const CypressMock = {
+      action: (name: string) => {
+        if (name === 'cy:before:stability:release') {
+          order.push('before-release')
+
+          return Promise.resolve()
+        }
+
+        return undefined
+      },
+    } as ICypress
+    const stability = create(CypressMock, state)
+
+    const first = stability.whenStable(() => {
+      order.push('first')
+    })
+    const second = stability.whenStable(() => {
+      order.push('second')
+    })
+
+    stability.isStable(true, 'test release waiters')
+
+    return Promise.all([first, second]).then(() => {
+      expect(order).to.deep.equal(['before-release', 'first', 'second'])
+    })
+  })
+
+  it('keeps new unstable waiters for the next stability cycle', () => {
+    const state = createState({ isStable: false })
+    const CypressMock = {
+      action: (name: string) => {
+        if (name === 'cy:before:stability:release') {
+          return Promise.resolve()
+        }
+
+        return undefined
+      },
+    } as ICypress
+    const stability = create(CypressMock, state)
+    const order: string[] = []
+    let secondWaiterResolved = false
+    let secondWaiter: Promise<unknown> | undefined
+
+    const firstWaiter = stability.whenStable(() => {
+      order.push('first')
+      stability.isStable(false, 'flip unstable during release')
+      secondWaiter = stability.whenStable(() => {
+        order.push('second')
+        secondWaiterResolved = true
+      })
+    })
+
+    stability.isStable(true, 'first release')
+
+    return firstWaiter
+    .then(() => {
+      expect(secondWaiterResolved).to.equal(false)
+
+      stability.isStable(true, 'second release')
+
+      return secondWaiter
+    })
+    .then(() => {
+      expect(order).to.deep.equal(['first', 'second'])
+    })
+  })
+})

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -2,6 +2,9 @@ import Promise from 'bluebird'
 import type { ICypress } from '../cypress'
 import type { StateFunc } from '../cypress/state'
 
+// Error used when rejecting pending waiters after a test reset (avoids stale callbacks running in the next test).
+const STABILITY_RESET_ERROR = new Error('Stability waiters cleared due to test reset')
+
 export const create = (Cypress: ICypress, state: StateFunc) => {
   const whenStableQueue: Array<{
     fn: () => any
@@ -9,7 +12,16 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
     resolve: (value?: any) => void
   }> = []
 
+  const reset = () => {
+    const pending = whenStableQueue.splice(0)
+
+    for (const waiter of pending) {
+      waiter.reject(STABILITY_RESET_ERROR)
+    }
+  }
+
   return {
+    reset,
     isStable: (stable: boolean = true, event: string) => {
       // if the state is already in the desired state, return
       if (state('isStable') === stable) {
@@ -63,4 +75,6 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
   }
 }
 
-export interface IStability extends ReturnType<typeof create> {}
+// Omit 'reset' so $Cy can implement IStability without conflicting with its own reset(test) method.
+// Stability reset is exposed on the cy instance as resetStability.
+export interface IStability extends Omit<ReturnType<typeof create>, 'reset'> {}

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -2,9 +2,6 @@ import Promise from 'bluebird'
 import type { ICypress } from '../cypress'
 import type { StateFunc } from '../cypress/state'
 
-// Error used when rejecting pending waiters after a test reset (avoids stale callbacks running in the next test).
-const STABILITY_RESET_ERROR = new Error('Stability waiters cleared due to test reset')
-
 export const create = (Cypress: ICypress, state: StateFunc) => {
   const whenStableQueue: Array<{
     fn: () => any
@@ -15,8 +12,9 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
   const reset = () => {
     const pending = whenStableQueue.splice(0)
 
+    // reject each waiter so they don't run in the next test
     for (const waiter of pending) {
-      waiter.reject(STABILITY_RESET_ERROR)
+      waiter.reject(new Error('Stability waiters cleared due to test reset'))
     }
   }
 

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -2,51 +2,65 @@ import Promise from 'bluebird'
 import type { ICypress } from '../cypress'
 import type { StateFunc } from '../cypress/state'
 
-// eslint-disable-next-line @cypress/dev/arrow-body-multiline-braces
-export const create = (Cypress: ICypress, state: StateFunc) => ({
-  isStable: (stable: boolean = true, event: string) => {
-    if (state('isStable') === stable) {
-      return
-    }
+export const create = (Cypress: ICypress, state: StateFunc) => {
+  const whenStableQueue: Array<{
+    fn: () => any
+    reject: (reason?: any) => void
+    resolve: (value?: any) => void
+  }> = []
 
-    state('isStable', stable)
-
-    // we notify the outside world because this is what the runner uses to
-    // show the 'loading spinner' during an app page loading transition event
-    Cypress.action('cy:stability:changed', stable, event)
-
-    if (!stable) {
-      return
-    }
-
-    Cypress.action('cy:before:stability:release')
-    .then(async () => {
-      const whenStable = state('whenStable')
-
-      if (whenStable) {
-        await whenStable()
+  return {
+    isStable: (stable: boolean = true, event: string) => {
+      // if the state is already in the desired state, return
+      if (state('isStable') === stable) {
+        return
       }
-    })
-  },
 
-  whenStable: (fn: () => any) => {
-    if (state('isStable') !== false) {
-      return Promise.try(fn)
-    }
+      // set the state to the desired state
+      state('isStable', stable)
 
-    return new Promise((resolve, reject) => {
-      // then when we become stable
-      state('whenStable', () => {
-        // reset this callback function
-        state('whenStable', null)
+      // we notify the outside world because this is what the runner uses to
+      // show the 'loading spinner' during an app page loading transition event
+      Cypress.action('cy:stability:changed', stable, event)
 
-        // and invoke the original function
-        Promise.try(fn)
-        .then(resolve)
-        .catch(reject)
+      // if the state is unstable, return
+      if (!stable) {
+        return
+      }
+
+      // release the when stable queue
+      Cypress.action('cy:before:stability:release')
+      .then(async () => {
+        // get the waiters to release
+        const waitersToRelease = whenStableQueue.splice(0)
+
+        // if there are no waiters to release, return
+        if (!waitersToRelease.length) {
+          return
+        }
+
+        // release the waiters
+        await Promise.all(waitersToRelease.map((waiter) => {
+          return Promise.try(waiter.fn)
+          .then(waiter.resolve)
+          .catch(waiter.reject)
+        }))
       })
-    })
-  },
-})
+    },
+
+    whenStable: (fn: () => any) => {
+      // if the state is stable, call the function immediately
+      if (state('isStable') !== false) {
+        return Promise.try(fn)
+      }
+
+      // otherwise, queue the function to be called when stable
+      return new Promise((resolve, reject) => {
+        // queue one waiter per caller while unstable so no registrations can overwrite each other
+        whenStableQueue.push({ fn, resolve, reject })
+      })
+    },
+  }
+}
 
 export interface IStability extends ReturnType<typeof create> {}

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -195,6 +195,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
   getStyles: ISnapshots['getStyles']
 
   resetTimer: ReturnType<typeof createTimer>['reset']
+  resetStability: ReturnType<typeof createStability>['reset']
   overrides: IOverrides
 
   // Private methods
@@ -254,6 +255,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
 
     this.isStable = stability.isStable
     this.whenStable = stability.whenStable
+    this.resetStability = stability.reset
 
     const assertions = createAssertions(Cypress, this)
 
@@ -655,6 +657,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       this.queue.reset()
       this.queue.clear()
       this.resetTimer()
+      this.resetStability()
       this.removeAllListeners()
       this.testConfigOverride.restoreAndSetTestConfigOverrides(test, this.Cypress.config, this.Cypress.env)
     } catch (err) {

--- a/packages/driver/src/cypress/state.ts
+++ b/packages/driver/src/cypress/state.ts
@@ -31,7 +31,6 @@ export interface StateFunc {
   (k: 'specWindow', v?: Window): Window
   (k: 'runnable', v?: CypressRunnable): CypressRunnable
   (k: 'isStable', v?: boolean): boolean
-  (k: 'whenStable', v?: null | (() => Promise<any>)): () => Promise<any>
   (k: 'current', v?: $Command): $Command
   (k: 'canceled', v?: boolean): boolean
   (k: 'error', v?: Error): Error

--- a/packages/driver/test/unit/cy/stability.spec.ts
+++ b/packages/driver/test/unit/cy/stability.spec.ts
@@ -1,4 +1,4 @@
-import type { ICypress } from '../../../src/cypress'
+import { describe, it, expect } from 'vitest'
 import type { StateFunc } from '../../../src/cypress/state'
 import { create } from '../../../src/cy/stability'
 
@@ -40,8 +40,8 @@ describe('src/cy/stability', () => {
 
         return undefined
       },
-    } as ICypress
-    const stability = create(CypressMock, state)
+    }
+    const stability = create(CypressMock as any, state)
 
     const first = stability.whenStable(() => {
       order.push('first')
@@ -53,7 +53,7 @@ describe('src/cy/stability', () => {
     stability.isStable(true, 'test release waiters')
 
     return Promise.all([first, second]).then(() => {
-      expect(order).to.deep.equal(['before-release', 'first', 'second'])
+      expect(order).toEqual(['before-release', 'first', 'second'])
     })
   })
 
@@ -67,8 +67,8 @@ describe('src/cy/stability', () => {
 
         return undefined
       },
-    } as ICypress
-    const stability = create(CypressMock, state)
+    }
+    const stability = create(CypressMock as any, state)
     const order: string[] = []
     let secondWaiterResolved = false
     let secondWaiter: Promise<unknown> | undefined
@@ -86,14 +86,45 @@ describe('src/cy/stability', () => {
 
     return firstWaiter
     .then(() => {
-      expect(secondWaiterResolved).to.equal(false)
+      expect(secondWaiterResolved).toBe(false)
 
       stability.isStable(true, 'second release')
 
       return secondWaiter
     })
     .then(() => {
-      expect(order).to.deep.equal(['first', 'second'])
+      expect(order).toEqual(['first', 'second'])
+    })
+  })
+
+  it('reset() clears queue and rejects pending waiters to avoid test pollution', () => {
+    const order: string[] = []
+    const state = createState({ isStable: false })
+    const CypressMock = {
+      action: () => Promise.resolve(),
+    }
+    const stability = create(CypressMock as any, state)
+
+    const waiterPromise = stability.whenStable(() => {
+      order.push('ran')
+    })
+
+    stability.reset()
+
+    return waiterPromise
+    .then(
+      () => {
+        throw new Error('waiter should have been rejected')
+      },
+      (err: Error) => {
+        expect(err.message).toBe('Stability waiters cleared due to test reset')
+      },
+    )
+    .then(() => {
+      expect(order).toEqual([])
+      state('isStable', undefined)
+      stability.isStable(true, 'next test')
+      expect(order).toEqual([])
     })
   })
 })

--- a/packages/driver/test/unit/cypress/cy.spec.ts
+++ b/packages/driver/test/unit/cypress/cy.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { vi, describe, it, expect } from 'vitest'
+import { $Cy } from '../../../src/cypress/cy'
+
+describe('$Cy reset', () => {
+  it('calls resetStability() when reset(test) is run so stability queue is cleared between tests', () => {
+    const resetStability = vi.fn()
+    const stateFn = vi.fn(function () {
+      return {
+        window: undefined,
+        document: undefined,
+        $autIframe: undefined,
+        specWindow: undefined,
+        activeSessions: undefined,
+        isProtocolEnabled: undefined,
+      }
+    }) as ReturnType<typeof vi.fn> & { reset: ReturnType<typeof vi.fn> }
+
+    stateFn.reset = vi.fn()
+    const mockCy = {
+      state: stateFn,
+      queue: { reset: vi.fn(), clear: vi.fn() },
+      resetTimer: vi.fn(),
+      resetStability,
+      removeAllListeners: vi.fn(),
+      testConfigOverride: { restoreAndSetTestConfigOverrides: vi.fn() },
+      Cypress: { config: vi.fn(), env: vi.fn() },
+      fail: vi.fn(),
+    }
+
+    const reset = $Cy.prototype.reset
+
+    reset.call(mockCy, { title: 'test', fn: () => {} })
+
+    expect(resetStability).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> N/A

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

**Why was this change necessary?**  
`cy.wait()` with multiple aliases could hang when a page navigation occurred during the wait. The stability module stored a single `whenStable` callback in state, so when multiple waiters registered (e.g. for each alias), each registration overwrote the previous one. Only one waiter would be released when the page became stable; the others never ran, causing a hang.

**What is affected?**  
- `packages/driver`: stability module and its usage. The stability module now keeps a queue of waiters registered while unstable and releases all of them when stability is restored, instead of a single callback in state. The `whenStable` key was removed from Cypress state.

**Implementation details:**  
- Replaced the single `state('whenStable', fn)` callback with a `whenStableQueue` array inside the stability closure. Each call to `whenStable()` pushes `{ fn, resolve, reject }` onto the queue. When `isStable(true)` runs, all queued waiters are invoked and the queue is cleared. New waiters registered during the release cycle (e.g. when a waiter flips stability back to false) remain in the queue for the next stability cycle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core driver stability/wait logic used by retries and command execution, which could affect timing/order of command release in edge cases. Added e2e and unit tests reduce regression risk but behavior is central to test execution.
> 
> **Overview**
> Prevents `cy.wait(['@a','@b',...])` from hanging when navigation flips stability by replacing the single `whenStable` callback with an internal queue that releases *all* waiters when stability returns.
> 
> Adds a stability `reset` hook (exposed as `cy.resetStability()` and invoked from `$Cy.reset(test)`) to clear/reject pending waiters between tests, and removes `whenStable` from Cypress state. Includes new e2e and unit tests covering multi-alias navigation and stability queue/reset behavior, plus a changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e85a3e6d48113fb5cb0dfb68ce8726b0bd12431c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

1. Run the new e2e test:  
   `yarn cypress run --spec "packages/driver/cypress/e2e/commands/net_stubbing.cy.ts" --config "testName=does not hang when waiting on multiple aliases across navigation"`  
   (or run the full net_stubbing spec and confirm that test passes).
2. Run the new stability unit tests:  
   `yarn test packages/driver/cypress/e2e/cy/stability.cy.ts`  
   (or the equivalent test command for that spec in this repo).
3. Optionally: in a project using Cypress, use `cy.wait(['@alias1', '@alias2', '@alias3'])` and trigger a navigation before all requests complete; the command should time out with a clear error instead of hanging.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

**Before:** In some cases, `cy.wait()` with multiple aliases could hang indefinitely when the page navigated during the wait (e.g. redirect or `location.href` change).  
**After:** The wait completes: either all aliases are satisfied, or the command times out with the usual "`cy.wait()` timed out waiting" error. No hang.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
