### PR TITLE
misc: when isolated test in Studio, 'rerun' button should not say 'Run all tests'

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.13.0
+
+_Released 03/17/2026 (PENDING)_
+
+**Misc:**
+
+- When a test is isolated in Studio, 'rerun' button should not say 'Run all tests. It should say 'Run test'. Addressed in [#33466](https://github.com/cypress-io/cypress/pull/33466)
 
 ## 15.12.0
 
@@ -9,6 +16,7 @@ _Released 03/10/2026_
 - Adds an option to enable word wrap for Studio panel code. Addressed in [#33411](https://github.com/cypress-io/cypress/pull/33411).
 
 **Bugfixes:**
+
 - Fixed an issue where sending SIGINT (e.g. Ctrl+C) to exit Cypress left the terminal displaying raw characters. Fixes [#33367](https://github.com/cypress-io/cypress/issues/33367). Addressed in [#33431](https://github.com/cypress-io/cypress/pull/33431).
 - Fixed an issue in develop mode (when running Cypress via gulp with file watching) where closing the Electron window did not exit the gulp process, leaving it running. Addressed in [#33431](https://github.com/cypress-io/cypress/pull/33431).
 - Fixed an issue where internal tags on stderr streams were surfacing to the end user CLI during component testing. Addresses [#32769](https://github.com/cypress-io/cypress/issues/32769). Addressed in [#33400](https://github.com/cypress-io/cypress/pull/33400).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 15.13.0
+## 15.12.1
 
-_Released 03/17/2026 (PENDING)_
+_Released 03/24/2026 (PENDING)_
 
 **Misc:**
 

--- a/npm/vite-dev-server/cypress/support/commands.ts
+++ b/npm/vite-dev-server/cypress/support/commands.ts
@@ -8,7 +8,7 @@ declare global {
        *
        * 1. Waits for the stats to reset which signifies that the test page has loaded
        * 2. Waits for 'Your tests are loading...' to not be present so that we know the tests themselves have loaded
-       * 3. Waits (with a timeout of 30s) for the Rerun all tests button to be present. This ensures all tests have completed
+       * 3. Waits (with a timeout of 30s) for the restart button to be present (Rerun all tests / Run test in Studio single-test mode). This ensures all tests have completed.
        *
        */
       waitForSpecToFinish()
@@ -27,8 +27,8 @@ export const waitForSpecToFinish = () => {
   // Then ensure the tests are running
   cy.contains('Your tests are loading...').should('not.exist')
 
-  // Then ensure the tests have finished
-  cy.get('[aria-label="Rerun all tests"]', { timeout: 30000 })
+  // Wait for the restart button (shows "Rerun all tests" or "Run test" in Studio single-test mode)
+  cy.get('button.restart', { timeout: 30000 })
 }
 
 Cypress.Commands.add('waitForSpecToFinish', waitForSpecToFinish)

--- a/packages/app/cypress/e2e/studio/studio-basic.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-basic.cy.ts
@@ -101,7 +101,7 @@ describe('studio functionality', () => {
 
     cy.get('.cm-line').should('contain.text', `cy.get('#increment').click();`)
 
-    cy.get('button[aria-label="Rerun all tests"]').click()
+    cy.get('button.restart').click()
 
     // dismiss unsaved changes modal
     cy.findByTestId('unsaved-changes-discard-button').click()

--- a/packages/app/cypress/e2e/studio/studio-ui.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-ui.cy.ts
@@ -10,7 +10,7 @@ describe('Cypress Studio - UI and Panel Management', () => {
     cy.get('.cy-tooltip').should('have.text', 'Run test R')
   })
 
-  it('shows Rerun all tests button label on welcome screen', () => {
+  it('shows Run All Tests button label on welcome screen', () => {
     cy.viewport(1500, 1000)
     loadProjectAndRunSpec()
     cy.findByTestId('studio-button').should('be.visible').click()
@@ -18,16 +18,16 @@ describe('Cypress Studio - UI and Panel Management', () => {
     cy.findByTestId('new-test-features').should('be.visible')
 
     cy.get('button.restart').trigger('mouseover')
-    cy.get('.cy-tooltip').should('have.text', 'Rerun all tests R')
+    cy.get('.cy-tooltip').should('have.text', 'Run All Tests R')
   })
 
-  it('shows Rerun all tests button label on new test screen', () => {
+  it('shows Run All Tests button label on new test screen', () => {
     launchStudio({ createNewTestFromSpecHeader: true })
 
     cy.findByTestId('studio-panel').should('be.visible')
     cy.findByTestId('test-name-input').should('be.visible')
     cy.get('button.restart').trigger('mouseover')
-    cy.get('.cy-tooltip').should('have.text', 'Rerun all tests R')
+    cy.get('.cy-tooltip').should('have.text', 'Run All Tests R')
   })
 
   it('closes studio panel when clicking studio button (from the cloud)', () => {

--- a/packages/app/cypress/e2e/studio/studio-ui.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-ui.cy.ts
@@ -2,6 +2,34 @@ import { launchStudio, loadProjectAndRunSpec } from './helper'
 import pDefer from 'p-defer'
 
 describe('Cypress Studio - UI and Panel Management', () => {
+  it('shows Run test button label in single-test mode', () => {
+    launchStudio()
+
+    cy.findByTestId('studio-panel').should('be.visible')
+    cy.get('button.restart').trigger('mouseover')
+    cy.get('.cy-tooltip').should('have.text', 'Run test R')
+  })
+
+  it('shows Rerun all tests button label on welcome screen', () => {
+    cy.viewport(1500, 1000)
+    loadProjectAndRunSpec()
+    cy.findByTestId('studio-button').should('be.visible').click()
+    cy.findByTestId('studio-panel').should('be.visible')
+    cy.findByTestId('new-test-features').should('be.visible')
+
+    cy.get('button.restart').trigger('mouseover')
+    cy.get('.cy-tooltip').should('have.text', 'Rerun all tests R')
+  })
+
+  it('shows Rerun all tests button label on new test screen', () => {
+    launchStudio({ createNewTestFromSpecHeader: true })
+
+    cy.findByTestId('studio-panel').should('be.visible')
+    cy.findByTestId('test-name-input').should('be.visible')
+    cy.get('button.restart').trigger('mouseover')
+    cy.get('.cy-tooltip').should('have.text', 'Rerun all tests R')
+  })
+
   it('closes studio panel when clicking studio button (from the cloud)', () => {
     launchStudio()
 

--- a/packages/app/cypress/e2e/support/execute-spec.ts
+++ b/packages/app/cypress/e2e/support/execute-spec.ts
@@ -13,7 +13,8 @@ declare global {
        * Adapter to wait for a spec to finish in a standard way. It
        *
        * 1. Waits for 'Your tests are loading...' to not be present so that we know the tests themselves have loaded
-       * 2. Waits for the Rerun all tests button to be present. This ensures all tests have completed
+       * 2. Waits for the restart button to be present (Rerun all tests / Run test). This ensures all tests have completed.
+       *    In Studio single-test mode the label is "Run test"; otherwise it is "Rerun all tests".
        *
        * @param expectedResults - The expected results of the spec
        * @param timeout - The timeout for the spec to finish
@@ -29,8 +30,8 @@ export const waitForSpecToFinish = (expectedResults?: ExpectedResults, timeout?:
   // Then ensure the tests are not running
   cy.contains('Your tests are loading...', { timeout: timeout || 30000 }).should('not.exist')
 
-  // Then ensure the tests have finished
-  cy.get('[aria-label="Rerun all tests"]', { timeout: timeout || 30000 })
+  // Then ensure the tests have finished (button shows "Rerun all tests" or "Run test" in Studio single-test mode)
+  cy.get('button.restart', { timeout: timeout || 30000 })
 
   if (expectedResults) {
     shouldHaveTestResults(expectedResults)

--- a/packages/reporter/src/header/controls.tsx
+++ b/packages/reporter/src/header/controls.tsx
@@ -20,8 +20,6 @@ interface Props {
 const Controls: React.FC<Props> = observer(({ events = defaultEvents, appState }: Props) => {
   const emit = (event: string) => () => events.emit(event)
 
-  const rerunLabel = appState.studioSingleTestActive ? 'Run test' : 'Rerun all tests'
-
   return (
     <div className='controls'>
       {appState.isPaused && (
@@ -43,9 +41,9 @@ const Controls: React.FC<Props> = observer(({ events = defaultEvents, appState }
         </Tooltip>
       )}
       {!appState.isRunning && (
-        <Tooltip placement='bottom' title={<p>{rerunLabel} <span className='kbd'>R</span></p>} className='cy-tooltip'>
+        <Tooltip placement='bottom' title={<p>{appState.studioSingleTestActive ? 'Run test' : 'Run All Tests'} <span className='kbd'>R</span></p>} className='cy-tooltip'>
           <div>
-            <Button size='20' variant='outline-dark' aria-label={rerunLabel} className='restart' onClick={emit('restart')}>
+            <Button size='20' variant='outline-dark' aria-label={appState.studioSingleTestActive ? 'Run test' : 'Rerun all tests'} className='restart' onClick={emit('restart')}>
               {appState.studioActive ? (
                 <IconActionRestart transform="scale(-1 1)" strokeColor={iconStrokeColor} />
               ) : (

--- a/packages/reporter/src/header/controls.tsx
+++ b/packages/reporter/src/header/controls.tsx
@@ -20,6 +20,8 @@ interface Props {
 const Controls: React.FC<Props> = observer(({ events = defaultEvents, appState }: Props) => {
   const emit = (event: string) => () => events.emit(event)
 
+  const rerunLabel = appState.studioSingleTestActive ? 'Run test' : 'Rerun all tests'
+
   return (
     <div className='controls'>
       {appState.isPaused && (
@@ -41,9 +43,9 @@ const Controls: React.FC<Props> = observer(({ events = defaultEvents, appState }
         </Tooltip>
       )}
       {!appState.isRunning && (
-        <Tooltip placement='bottom' title={<p>Run All Tests <span className='kbd'>R</span></p>} className='cy-tooltip'>
+        <Tooltip placement='bottom' title={<p>{rerunLabel} <span className='kbd'>R</span></p>} className='cy-tooltip'>
           <div>
-            <Button size='20' variant='outline-dark' aria-label='Rerun all tests' className='restart' onClick={emit('restart')}>
+            <Button size='20' variant='outline-dark' aria-label={rerunLabel} className='restart' onClick={emit('restart')}>
               {appState.studioActive ? (
                 <IconActionRestart transform="scale(-1 1)" strokeColor={iconStrokeColor} />
               ) : (


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/12718

Needs https://github.com/cypress-io/cypress-services/pull/12996 to be merged in first so that the tests can pass.

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- When a test is isolated in Studio, and user hover over “Rerun” button, the tooltip say “Run All Tests”, which is not correct because it reruns just isolated test.

Outside of studio single test mode, including the new test screen in studio and the welcome screen
<img width="1920" height="842" alt="image" src="https://github.com/user-attachments/assets/7f0cf757-7ae1-4ce7-b27d-4719a460ee63" />


Inside studio with single test focused 
<img width="1916" height="850" alt="image" src="https://github.com/user-attachments/assets/bcee2e5d-d66b-404e-a37b-a72fd51e0ebe" />





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX tweak plus test-selector updates; primary risk is minor flake/regression if the `button.restart` selector or `aria-label` change affects existing automation/accessibility expectations.
> 
> **Overview**
> **Fixes Studio’s restart button labeling in single-test mode.** The reporter header control now renders tooltip text as `Run test` (instead of `Run All Tests`) when `studioSingleTestActive` is true, while keeping `Run All Tests` elsewhere; the button’s `aria-label` is also conditional.
> 
> **Updates E2E automation to match the new behavior.** `waitForSpecToFinish` helpers and Studio tests switch from targeting `[aria-label="Rerun all tests"]` to `button.restart`, and new UI assertions cover tooltip text across single-test, welcome, and new-test screens. Changelog adds a `15.12.1` misc entry for the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d91649a463c12fd759ee1316e19c8b38c10f2531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
