### PR TITLE
fix: throw error when connection error to dev server in run mode

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 _Released 03/24/2026 (PENDING)_
 
-**Bugfixes**
+**Bugfixes:**
 
 - Fixed an issue where Cypress may hang when running component tests and a connection to the dev server can no longer be made. Addressed in [#33469](https://github.com/cypress-io/cypress/pull/33469)
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,11 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.12.1
+
+_Released 03/24/2026 (PENDING)_
+
+**Bugfixes**
+
+- Fixed an issue where Cypress may hang when running component tests and a connection to the dev server can no longer be made. Addressed in [#33469](https://github.com/cypress-io/cypress/pull/33469)
 
 ## 15.12.0
 
@@ -9,6 +16,7 @@ _Released 03/10/2026_
 - Adds an option to enable word wrap for Studio panel code. Addressed in [#33411](https://github.com/cypress-io/cypress/pull/33411).
 
 **Bugfixes:**
+
 - Fixed an issue where sending SIGINT (e.g. Ctrl+C) to exit Cypress left the terminal displaying raw characters. Fixes [#33367](https://github.com/cypress-io/cypress/issues/33367). Addressed in [#33431](https://github.com/cypress-io/cypress/pull/33431).
 - Fixed an issue in develop mode (when running Cypress via gulp with file watching) where closing the Electron window did not exit the gulp process, leaving it running. Addressed in [#33431](https://github.com/cypress-io/cypress/pull/33431).
 - Fixed an issue where internal tags on stderr streams were surfacing to the end user CLI during component testing. Addresses [#32769](https://github.com/cypress-io/cypress/issues/32769). Addressed in [#33400](https://github.com/cypress-io/cypress/pull/33400).

--- a/packages/server/lib/controllers/iframes.ts
+++ b/packages/server/lib/controllers/iframes.ts
@@ -61,7 +61,14 @@ export const iframesController = {
 
     nodeProxy.web(req, res, {}, (e) => {
       if (e) {
-        debug('Proxy request error. This is likely the socket hangup issue, we can basically ignore this because the stream will automatically continue once the asset will be available', e)
+        // if we are in run mode and we are not able to connect to the dev server (e.g. it has probably crashed),
+        // we need to throw an error so the app doesn't hang
+        if (config.isTextTerminal && (e as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
+          debug('Connection refused from the dev server. This is likely the dev server has crashed', e)
+          throw e
+        } else {
+          debug('Error from the dev server. This is likely the socket hangup issue during file watching, we can basically ignore this since the App should make another request during rerun', e)
+        }
       }
     })
   },

--- a/packages/server/lib/controllers/iframes.ts
+++ b/packages/server/lib/controllers/iframes.ts
@@ -55,19 +55,18 @@ export const iframesController = {
       req.url = `${config.devServerPublicPathRoute}/${req.params[0]}`
     }
 
-    // use the node proxy here instead of the network proxy
-    // to avoid the user accidentally intercepting and modifying
-    // our internal index.html handler
-
+    // use the node proxy here instead of the network proxy to avoid
+    // the user accidentally intercepting and modifying our internal index.html handler
     nodeProxy.web(req, res, {}, (e) => {
       if (e) {
-        // if we are in run mode and we are not able to connect to the dev server (e.g. it has probably crashed),
-        // we need to throw an error so the app doesn't hang
-        if (config.isTextTerminal && (e as NodeJS.ErrnoException).code === 'ECONNREFUSED') {
-          debug('Connection refused from the dev server. This is likely the dev server has crashed', e)
+        if (config.isTextTerminal) {
+          // if we are in run mode and we receive an error, we need to throw an error so the app doesn't hang
+          debug('Error interacting with the dev server.', e)
           throw e
         } else {
-          debug('Error from the dev server. This is likely the socket hangup issue during file watching, we can basically ignore this since the App should make another request during rerun', e)
+          // if we are in open mode, there can be multiple reasons we can't interact with the dev server (e.g. the config changed and the dev server has restarted, reruns, etc.),
+          // we can ignore this error since the App should make another request (note: it is possible the dev server has crashed or doesn't respond in a timely manner, in which case the App will hang)
+          debug('Error interacting with the dev server. Ignoring since the App should make another request.', e)
         }
       }
     })

--- a/packages/server/test/unit/iframes_spec.js
+++ b/packages/server/test/unit/iframes_spec.js
@@ -29,4 +29,63 @@ describe('controllers/iframes', () => {
       )
     })
   })
+
+  describe('component', () => {
+    let nodeProxy
+    let proxyCallback
+
+    beforeEach(() => {
+      proxyCallback = null
+      nodeProxy = {
+        web: sinon.stub().callsFake((req, res, _options, cb) => {
+          proxyCallback = cb
+        }),
+      }
+    })
+
+    it('throws when in run mode (isTextTerminal) and dev server connection is refused (ECONNREFUSED)', () => {
+      const config = { isTextTerminal: true, devServerPublicPathRoute: '/__cypress/' }
+      const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
+      const res = {}
+
+      iframesController.component({ config, nodeProxy }, req, res)
+
+      expect(nodeProxy.web).to.have.been.calledOnce
+      const err = new Error('connect ECONNREFUSED 127.0.0.1:8080')
+
+      err.code = 'ECONNREFUSED'
+
+      expect(() => proxyCallback(err)).to.throw(err)
+    })
+
+    it('does not throw when in open mode and dev server connection is refused (ECONNREFUSED)', () => {
+      const config = { isTextTerminal: false, devServerPublicPathRoute: '/__cypress/' }
+      const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
+      const res = {}
+
+      iframesController.component({ config, nodeProxy }, req, res)
+
+      expect(nodeProxy.web).to.have.been.calledOnce
+      const err = new Error('connect ECONNREFUSED 127.0.0.1:8080')
+
+      err.code = 'ECONNREFUSED'
+
+      expect(() => proxyCallback(err)).not.to.throw()
+    })
+
+    it('does not throw when in run mode but error is not ECONNREFUSED (e.g. socket hangup)', () => {
+      const config = { isTextTerminal: true, devServerPublicPathRoute: '/__cypress/' }
+      const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
+      const res = {}
+
+      iframesController.component({ config, nodeProxy }, req, res)
+
+      expect(nodeProxy.web).to.have.been.calledOnce
+      const err = new Error('socket hang up')
+
+      err.code = 'ECONNRESET'
+
+      expect(() => proxyCallback(err)).not.to.throw()
+    })
+  })
 })

--- a/packages/server/test/unit/iframes_spec.js
+++ b/packages/server/test/unit/iframes_spec.js
@@ -58,6 +58,21 @@ describe('controllers/iframes', () => {
       expect(() => proxyCallback(err)).to.throw(err)
     })
 
+    it('throws when in run mode (isTextTerminal) and dev server connection is reset (ECONNRESET)', () => {
+      const config = { isTextTerminal: true, devServerPublicPathRoute: '/__cypress/' }
+      const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
+      const res = {}
+
+      iframesController.component({ config, nodeProxy }, req, res)
+
+      expect(nodeProxy.web).to.have.been.calledOnce
+      const err = new Error('connect ECONNRESET 127.0.0.1:8080')
+
+      err.code = 'ECONNRESET'
+
+      expect(() => proxyCallback(err)).to.throw(err)
+    })
+
     it('does not throw when in open mode and dev server connection is refused (ECONNREFUSED)', () => {
       const config = { isTextTerminal: false, devServerPublicPathRoute: '/__cypress/' }
       const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
@@ -69,21 +84,6 @@ describe('controllers/iframes', () => {
       const err = new Error('connect ECONNREFUSED 127.0.0.1:8080')
 
       err.code = 'ECONNREFUSED'
-
-      expect(() => proxyCallback(err)).not.to.throw()
-    })
-
-    it('does not throw when in run mode but error is not ECONNREFUSED (e.g. socket hangup)', () => {
-      const config = { isTextTerminal: true, devServerPublicPathRoute: '/__cypress/' }
-      const req = { query: {}, params: { 0: 'foo.js' }, url: '', headers: {} }
-      const res = {}
-
-      iframesController.component({ config, nodeProxy }, req, res)
-
-      expect(nodeProxy.web).to.have.been.calledOnce
-      const err = new Error('socket hang up')
-
-      err.code = 'ECONNRESET'
 
       expect(() => proxyCallback(err)).not.to.throw()
     })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
When running Cypress in **run mode** (e.g. `cypress run` with component tests), if the dev server is unreachable, the proxy callback in the iframes controller was only logging the error and not rethrowing it. That caused the app to hang instead of failing fast with a clear error.

This change:
- In **run mode** (`config.isTextTerminal`) when the proxy gets an error from the dev server, we now **throw** the error so the run fails instead of hanging.
- In all other cases (e.g. interactive mode), we continue to log and ignore so existing behavior (e.g. retries during rerun) is preserved.

Affected: `packages/server` iframes controller (component-test proxy to dev server).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes component-test iframe proxy error handling to throw in `run` mode, which can turn previously-hanging or silently-ignored dev-server disconnects into hard failures and could affect flaky dev-server scenarios.
> 
> **Overview**
> Prevents `cypress run --component` from hanging when the component dev server becomes unreachable by **throwing proxy errors** from `iframesController.component` when `config.isTextTerminal` is true.
> 
> Keeps existing `open` mode behavior by continuing to log-and-ignore these dev-server proxy errors, and adds unit coverage for both run-mode throw behavior (e.g. `ECONNREFUSED`/`ECONNRESET`) and open-mode non-throw behavior. Also updates the CLI changelog with the new hang fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41285220f565029ffbe81f26b02fa82e182f16ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
1. Start a component testing project that uses a dev server (e.g. Vite or webpack).
2. Run `cypress run` (run mode).
3. While the run is in progress (or before it starts), kill the dev server process so it is no longer listening.
4. **Before:** Cypress could hang waiting on the proxy.
5. **After:** Cypress should fail with a connection-refused error instead of hanging.
6. In interactive mode (`cypress open`), verify that transient errors (e.g. socket hang up during file watching) are still ignored and the app continues to work (e.g. rerun).

### How has the user experience changed?
- **Before:** In run mode, if the dev server crashed or was down, the Cypress run could hang indefinitely.
- **After:** In run mode, Cypress fails with an error when the dev server is unreachable, so users get a fast failure instead of a hang.

<img width="1356" height="1201" alt="Screenshot 2026-03-12 at 2 25 56 PM" src="https://github.com/user-attachments/assets/13f7be1a-dbdf-4ba0-9feb-28da0ff114dc" />

### PR Tasks
- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?