### PR TITLE
dependency: update simple-git for CVE-2026-28292

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 
+## 15.12.1
+
+_Released 03/24/2026 (PENDING)_
+
+**Dependency Updates:**
+
+- Upgraded `simple-git` from `3.27.0` to `3.32.3` to address [Improper Handling of Case Sensitivity](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15457646) (CVE-2026-28292) vulnerability reported in security scans.
+
 ## 15.12.0
 
 _Released 03/10/2026_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,7 +6,7 @@ _Released 03/24/2026 (PENDING)_
 
 **Dependency Updates:**
 
-- Upgraded `simple-git` from `3.27.0` to `3.32.3` to address [Improper Handling of Case Sensitivity](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15457646) (CVE-2026-28292) vulnerability reported in security scans.
+- Upgraded `simple-git` from `3.27.0` to `3.32.3` to address [Improper Handling of Case Sensitivity](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15457646) (CVE-2026-28292) vulnerability reported in security scans. Addressed in [#33470](https://github.com/cypress-io/cypress/pull/33470)
 
 ## 15.12.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,4 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-
 ## 15.12.1
 
 _Released 03/24/2026 (PENDING)_

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -70,7 +70,7 @@
     "p-defer": "^3.0.0",
     "pinia": "2.0.0-rc.14",
     "rollup-plugin-copy": "3.4.0",
-    "simple-git": "^3.27.0",
+    "simple-git": "^3.32.3",
     "sinon": "13.0.2",
     "tailwindcss": "^3.3.1",
     "vite": "^6.3.5",

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -71,7 +71,7 @@
     "semver": "^7.7.3",
     "send": "0.19.0",
     "server-destroy": "1.0.1",
-    "simple-git": "^3.27.0",
+    "simple-git": "^3.32.3",
     "stringify-object": "^3.0.0",
     "tsx": "4.20.6",
     "underscore.string": "^3.3.6",

--- a/patches/simple-git+3.33.0.patch
+++ b/patches/simple-git+3.33.0.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/simple-git/dist/cjs/index.js b/node_modules/simple-git/dist/cjs/index.js
+index 027f227..f0e3828 100644
+--- a/node_modules/simple-git/dist/cjs/index.js
++++ b/node_modules/simple-git/dist/cjs/index.js
+@@ -1805,10 +1805,8 @@ var init_tasks_pending_queue = __esm({
+       static getName(name = "empty") {
+         return `task:${name}:${++_TasksPendingQueue.counter}`;
+       }
+-      static {
+-        this.counter = 0;
+-      }
+     };
++    TasksPendingQueue.counter = 0;
+   }
+ });
+ 
+diff --git a/node_modules/simple-git/dist/esm/index.js b/node_modules/simple-git/dist/esm/index.js
+index ee39dec..44fe293 100644
+--- a/node_modules/simple-git/dist/esm/index.js
++++ b/node_modules/simple-git/dist/esm/index.js
+@@ -1231,10 +1231,8 @@ var init_tasks_pending_queue = __esm({
+       static getName(name = "empty") {
+         return `task:${name}:${++_TasksPendingQueue.counter}`;
+       }
+-      static {
+-        this.counter = 0;
+-      }
+     };
++    TasksPendingQueue.counter = 0;
+   }
+ });
+ 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14204,7 +14204,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@4.4.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.5, debug@^4.3.6, debug@^4.3.7, debug@^4.4.0, debug@^4.4.1:
+debug@4, debug@4.4.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4, debug@^4.3.6, debug@^4.3.7, debug@^4.4.0, debug@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -28508,14 +28508,14 @@ simple-get@^4.0.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-simple-git@^3.27.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.27.0.tgz#f4b09e807bda56a4a3968f635c0e4888d3decbd5"
-  integrity sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==
+simple-git@^3.32.3:
+  version "3.33.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.33.0.tgz#b903dc70f5b93535a4f64ff39172da43058cfb88"
+  integrity sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
-    debug "^4.3.5"
+    debug "^4.4.0"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one --> N/A — security dependency update.

### Additional details
- **Why was this change necessary?** Security scans reported [Improper Handling of Case Sensitivity](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15457646) (CVE-2026-28292) in `simple-git`.
- **What is affected?** `@packages/app` and `@packages/data-context` — both depend on `simple-git`. Upgraded from `3.27.0` to `^3.32.3` (lockfile resolved to `3.33.0`).
- **Implementation:** Version bump in both package.json files and CHANGELOG entry for 15.12.1.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core git integration dependency (`simple-git`) used by the app/data layer; behavior changes in git command execution or output could impact project setup/status flows. Includes a `patch-package` override of vendored `simple-git` build output, which could drift from upstream and affect runtime if the patch no longer applies cleanly.
> 
> **Overview**
> Updates `@packages/app` and `@packages/data-context` to use `simple-git` `^3.32.3` (lockfile resolves to `3.33.0`) to remediate CVE-2026-28292, and records the change in the `15.12.1` changelog.
> 
> Adds a `patch-package` patch for `simple-git@3.33.0` adjusting how `TasksPendingQueue.counter` is initialized in the published CJS/ESM bundles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db815840ba773ec0abdb77c27798690c8e9e33fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
- `yarn` to install updated lockfile.
- Smoke-check any flows that use git (e.g. project setup, git status in the app). No API changes to `simple-git` are expected for this upgrade.

### How has the user experience changed?
No user-facing behavior change; dependency security update only.

### PR Tasks
- [ ] Have tests been added/updated? [na] — dependency upgrade only.
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? [na]
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? [na]