### PR TITLE
test: retry flaky system tests

### DIFF
--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -68,6 +68,10 @@ export type ItOptions = ExecOptions & {
    * Same as using `systemTests.it.skip`.
    */
   skip?: boolean
+  /**
+   * If set, the system test will be retried up to the given number of times.
+   */
+  retries?: number
 }
 
 type ExecOptions = {
@@ -501,6 +505,7 @@ const localItFn = function (title: string, opts: ItOptions) {
   const DEFAULT_OPTIONS = {
     only: false,
     skip: false,
+    retries: 0,
     browser: [],
     snapshot: false,
     onStdout: _.noop,

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -537,7 +537,10 @@ const localItFn = function (title: string, opts: ItOptions) {
     const testTitle = `${title} [${browser}]`
 
     return mochaItFn(testTitle, function () {
-      this.retries(options.retries)
+      // Only set retries when explicitly provided; otherwise allow Mocha to inherit from parent suite
+      if ('retries' in opts) {
+        this.retries(options.retries)
+      }
 
       if (options.useSeparateBrowserSnapshots) {
         title = testTitle

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -537,6 +537,8 @@ const localItFn = function (title: string, opts: ItOptions) {
     const testTitle = `${title} [${browser}]`
 
     return mochaItFn(testTitle, function () {
+      this.retries(options.retries)
+
       if (options.useSeparateBrowserSnapshots) {
         title = testTitle
       }

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -505,7 +505,6 @@ const localItFn = function (title: string, opts: ItOptions) {
   const DEFAULT_OPTIONS = {
     only: false,
     skip: false,
-    retries: 0,
     browser: [],
     snapshot: false,
     onStdout: _.noop,

--- a/system-tests/test/downloads_spec.ts
+++ b/system-tests/test/downloads_spec.ts
@@ -60,7 +60,7 @@ describe('e2e downloads', () => {
   })
 
   it('does not trash downloads between runs if trashAssetsBeforeRuns: false', async function () {
-    this.retries(5)
+    this.retries(10)
 
     await systemTests.exec(this, {
       project: 'downloads',

--- a/system-tests/test/downloads_spec.ts
+++ b/system-tests/test/downloads_spec.ts
@@ -60,6 +60,8 @@ describe('e2e downloads', () => {
   })
 
   it('does not trash downloads between runs if trashAssetsBeforeRuns: false', async function () {
+    this.retries(5)
+
     await systemTests.exec(this, {
       project: 'downloads',
       spec: 'download_csv.cy.ts',

--- a/system-tests/test/service_worker_protocol_spec.js
+++ b/system-tests/test/service_worker_protocol_spec.js
@@ -27,6 +27,8 @@ describe('capture-protocol', () => {
   describe('service worker', () => {
     BROWSERS.forEach((browser) => {
       it(`verifies the types of requests match - ${browser}`, function () {
+        this.retries(10)
+
         return systemTests.exec(this, {
           key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
           project: 'protocol',

--- a/system-tests/test/service_worker_spec.js
+++ b/system-tests/test/service_worker_spec.js
@@ -49,6 +49,7 @@ describe('e2e service worker', () => {
     spec: 'service_worker.cy.js',
     retries: 10,
     onRun: async (exec, browser) => {
+      requestsForServiceWorkerCache = 0
       await exec()
       // Ensure that we only called this once even though we loaded the
       // service worker twice

--- a/system-tests/test/service_worker_spec.js
+++ b/system-tests/test/service_worker_spec.js
@@ -47,6 +47,7 @@ describe('e2e service worker', () => {
   systemTests.it('executes one spec with a cached call', {
     project: 'e2e',
     spec: 'service_worker.cy.js',
+    retries: 10,
     onRun: async (exec, browser) => {
       await exec()
       // Ensure that we only called this once even though we loaded the

--- a/system-tests/test/vite_dev_server_fresh_spec.ts
+++ b/system-tests/test/vite_dev_server_fresh_spec.ts
@@ -13,6 +13,8 @@ describe('@cypress/vite-dev-server', function () {
   describe('react', () => {
     for (const project of VITE_REACT) {
       it(`executes all of the specs for ${project}`, function () {
+        this.retries(10)
+
         return systemTests.exec(this, {
           project,
           configFile: 'cypress-vite.config.ts',


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes N/A (no linked issue)

### Additional details
- Adds optional `retries` support to the system test runner (`ItOptions` and `localItFn` default options) so individual tests can be retried on failure.
- Applies retries to known flaky system tests: downloads (5 retries), service worker / protocol (10 retries), and Vite dev server fresh (10 retries).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the system test harness and test specs, adding optional Mocha retry configuration to reduce CI flake without affecting product/runtime code.
> 
> **Overview**
> Adds optional `retries` support to `systemTests.it` (`ItOptions`) and applies it only when explicitly provided so suites can still inherit Mocha defaults.
> 
> Updates several known-flaky system tests to retry up to 10 times (downloads, service worker/protocol, and Vite dev server fresh runs) and resets `requestsForServiceWorkerCache` inside the retried `onRun` to avoid cross-attempt leakage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59fc4106d8f8070e28fa1e250cfb135cff6eb232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
- Run the affected system tests (e.g. `yarn test-system` scoped to downloads, service worker, or vite dev server specs) and confirm they run with retries on failure where configured.

### How has the user experience changed?
- No user-facing change. CI/system test stability only.

### PR Tasks
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?