### PR TITLE
feat: studio - allow for new test to be added when focused on single test

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 _Released 03/24/2026 (PENDING)_
 
+**Features:**
+
+- Studio now allows adding a new test when focused on a single test. Addressed in [#33481](https://github.com/cypress-io/cypress/pull/33481)
+
 **Bugfixes:**
 
 - Fixed an issue where Cypress may hang when running component tests and a connection to the dev server can no longer be made. Addressed in [#33469](https://github.com/cypress-io/cypress/pull/33469)

--- a/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-new-tests.cy.ts
@@ -12,27 +12,13 @@ describe('Cypress Studio - New Test Creation', () => {
     cy.get('.runnable-title').its(3).should('contain.text', 'visits a basic html page 3')
   })
 
-  it('creates a new test from spec header', () => {
-    launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSpecHeader: true })
+  describe('from spec header', () => {
+    const assertRootCreatedTest = () => {
+      // we should have the commands we executed after we save
+      cy.withCtx(async (ctx) => {
+        const spec = await ctx.actions.file.readFileInProject('cypress/e2e/spec-w-visit.cy.js')
 
-    inputNewTestName()
-
-    cy.contains('new-test').click()
-
-    cy.percySnapshot()
-
-    cy.get('.cm-content').invoke('text', 'cy.visit("cypress/e2e/index.html")')
-
-    cy.findByTestId('studio-save-button').click()
-
-    // verify recording is enabled to ensure the panel is fully ready
-    cy.findByTestId('record-button-recording').should('have.text', 'Recording...')
-
-    // we should have the commands we executed after we save
-    cy.withCtx(async (ctx) => {
-      const spec = await ctx.actions.file.readFileInProject('cypress/e2e/spec-w-visit.cy.js')
-
-      expect(spec.trim().replace(/\r/g, '')).to.equal(`
+        expect(spec.trim().replace(/\r/g, '')).to.equal(`
 describe('studio functionality', () => {
   beforeEach(() => {
     cy.visit('cypress/e2e/index.html')
@@ -46,6 +32,70 @@ describe('studio functionality', () => {
 it('new-test', function() {
   cy.visit("cypress/e2e/index.html")
 });`.trim())
+      })
+    }
+
+    const saveNewTest = () => {
+      inputNewTestName()
+
+      cy.contains('new-test').click()
+
+      cy.percySnapshot()
+
+      cy.get('.cm-content').invoke('text', 'cy.visit("cypress/e2e/index.html")')
+
+      cy.findByTestId('studio-save-button').click()
+
+      // verify recording is enabled to ensure the panel is fully ready
+      cy.findByTestId('record-button-recording').should('have.text', 'Recording...')
+    }
+
+    it('outside of studio', () => {
+      loadProjectAndRunSpec({ specName: 'spec-w-visit.cy.js' })
+      openNewTestFromSpecHeader()
+
+      saveNewTest()
+
+      assertRootCreatedTest()
+    })
+
+    it('in studio welcome screen', () => {
+      launchStudio({ specName: 'spec-w-visit.cy.js', createNewTestFromSpecHeader: true })
+
+      saveNewTest()
+
+      assertRootCreatedTest()
+    })
+
+    it('in studio single test mode', () => {
+      launchStudio({ specName: 'spec-w-visit.cy.js' })
+
+      openNewTestFromSpecHeader()
+
+      saveNewTest()
+
+      // we should have the commands we executed after we save
+      cy.withCtx(async (ctx) => {
+        const spec = await ctx.actions.file.readFileInProject('cypress/e2e/spec-w-visit.cy.js')
+
+        return spec.trim().replace(/\r/g, '')
+      }).then((normalizedSpec) => {
+        expect(normalizedSpec).to.equal(`
+describe('studio functionality', () => {
+  beforeEach(() => {
+    cy.visit('cypress/e2e/index.html')
+  });
+
+  it('visits a basic html page', () => {
+    cy.get('h1').should('have.text', 'Hello, Studio!')
+  })
+
+  it('new-test', function() {
+    cy.visit("cypress/e2e/index.html")
+  });
+})
+`.trim())
+      })
     })
   })
 

--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -146,14 +146,14 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
           <span>Open in IDE</span>
         </button>
 
-        {<button
+        <button
           className="runnable-popover-item"
           onClick={handleNewTest}
           data-cy="runnable-popover-new-test"
         >
           <IconActionAddMedium strokeColor="gray-500" />
           <span>New test</span>
-        </button>}
+        </button>
       </div>
 
       <div className="runnable-popover-section">

--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -22,8 +22,6 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
 }: Props) => {
   const relativeSpecPath = spec.relative
 
-  const isStudioSingleTest = appState?.studioActive && appState.studioSingleTestActive
-
   const fileDetails = {
     absoluteFile: spec.absolute,
     column: 0,
@@ -56,8 +54,21 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
     setIsOpen(false)
   }
 
+  const getSuiteIdForNewTest = (): string => {
+    const test = Cypress.state('test')
+    const parent = test && test?.parent
+
+    if (parent && parent.id && parent.type === 'suite') {
+      return parent.id
+    }
+
+    return 'r1'
+  }
+
   const handleNewTest = () => {
-    events.emit('studio:init:suite', { suiteId: 'r1', entrySource: 'new-test-root' })
+    const suiteId = getSuiteIdForNewTest()
+
+    events.emit('studio:init:suite', { suiteId, entrySource: suiteId === 'r1' ? 'new-test-root' : 'new-test-suite' })
     setIsOpen(false)
   }
 
@@ -129,7 +140,7 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
           <span>Open in IDE</span>
         </button>
 
-        {!isStudioSingleTest && <button
+        {<button
           className="runnable-popover-item"
           onClick={handleNewTest}
           data-cy="runnable-popover-new-test"

--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -22,6 +22,8 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
 }: Props) => {
   const relativeSpecPath = spec.relative
 
+  const isStudioSingleTest = appState?.studioActive && appState.studioSingleTestActive
+
   const fileDetails = {
     absoluteFile: spec.absolute,
     column: 0,
@@ -58,11 +60,15 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
     const test = Cypress.state('test')
     const parent = test && test?.parent
 
-    if (parent && parent.id && parent.type === 'suite') {
-      return parent.id
+    let suiteId = 'r1'
+
+    if (isStudioSingleTest) {
+      if (parent && parent.id && parent.type === 'suite') {
+        suiteId = parent.id
+      }
     }
 
-    return 'r1'
+    return suiteId
   }
 
   const handleNewTest = () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/12648

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- Show the 'new test' button when focused on test.
- When new test created, add the test directly after the previous focused test - in the same suite.

https://github.com/user-attachments/assets/8b2a7f28-6c4e-43d5-bf17-8f8e46d760b4



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Studio entry behavior by emitting `studio:init:suite` with a dynamically chosen `suiteId` when in single-test mode, which could route new tests to the wrong suite if runner state is unexpected. Impact is limited to Studio UI flows and covered by updated e2e tests.
> 
> **Overview**
> **Studio now supports creating a new test while focused on a single test.** The reporter runnable popover always shows *New test* and, in Studio single-test mode, derives the target `suiteId` from the currently running test’s parent suite before emitting `studio:init:suite` (choosing `entrySource` as root vs suite).
> 
> E2E coverage for Studio new-test creation was refactored/expanded to validate creating from the spec header in multiple entry contexts (outside Studio, welcome screen, and single-test mode), and the CLI changelog was updated to announce the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84c80a3dcadeed1f1453b77c01e0eadc3bb90508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
