### PR TITLE
misc: add lerna concurrency flag to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run build --stream && yarn workspace @packages/electron build-binary && lerna run build-cli --stream",
+    "build": "lerna run build --stream --concurrency=4 && yarn workspace @packages/electron build-binary && lerna run build-cli --stream",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",
     "check-binary-on-cdn": "node ./scripts/binary.js checkIfBinaryExistsOnCdn",


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
Lerna (or Nx) was kicking off too many parallel processes during the build phase that was sometimes overwhelming a build instance and causing hangs or out of memory issues.  This adds a concurrency limit to the Lerna build phase.

Build with additional flag
- time for first part of build script: 1m 34s
- [CircleCI](https://app.circleci.com/pipelines/github/cypress-io/cypress/79766/workflows/071d787f-2fe5-4e95-8b4d-58201244120d/jobs/3498534/parallel-runs/0/steps/0-112)

Example without the flag
- time for first part of build script: 1m 50s
- [CircleCI](https://app.circleci.com/pipelines/github/cypress-io/cypress/79764/workflows/af68d3d4-94b5-4fc1-93e6-eb7da25d2377/jobs/3498356/parallel-runs/0/steps/0-112)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to build tooling, but it can affect build time/ordering and CI behavior if any packages implicitly relied on higher concurrency.
> 
> **Overview**
> **Build tooling update:** the root `package.json` `build` script now runs `lerna run build` with `--concurrency=4` (while keeping the existing electron binary build and `build-cli` steps), to cap parallel package builds and reduce CI hangs/OOM from too many simultaneous processes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bc2ae03a55855c1f0ff4f63667def6344256ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
Validate build step in CI works and takes about the same about of time.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
