### PR TITLE
refactor: send browserFamily when creating run

### DIFF
--- a/packages/server/lib/modes/record.ts
+++ b/packages/server/lib/modes/record.ts
@@ -510,6 +510,7 @@ interface InstanceOptions {
     osVersion: any
     browserName: any
     browserVersion: any
+    browserFamily: any
   }
   parallel?: any
   ciBuildId?: any

--- a/packages/server/lib/modes/record.ts
+++ b/packages/server/lib/modes/record.ts
@@ -602,6 +602,7 @@ const createRunAndRecordSpecs = (options: any = {}) => {
       osVersion: sys.osVersion,
       browserName: browser.displayName,
       browserVersion: browser.version,
+      browserFamily: browser.family,
     }
 
     telemetry.startSpan({ name: 'record:createRun' })

--- a/packages/server/test/unit/modes/record_spec.js
+++ b/packages/server/test/unit/modes/record_spec.js
@@ -212,6 +212,7 @@ describe('lib/modes/record', () => {
         const browser = {
           displayName: 'chrome',
           version: '59',
+          family: 'chromium',
         }
         const tag = 'nightly,develop'
         const testingType = 'e2e'
@@ -267,6 +268,7 @@ describe('lib/modes/record', () => {
             osVersion: 4,
             browserName: 'chrome',
             browserVersion: '59',
+            browserFamily: 'chromium',
           },
           ci: {
             params: {
@@ -293,8 +295,52 @@ describe('lib/modes/record', () => {
 
         await beforeSpecRun()
 
-        expect(api.createInstance).to.have.been.called
+        expect(api.createInstance).to.have.been.calledWith('run-id', sinon.match({
+          platform: sinon.match({
+            browserFamily: 'chromium',
+            browserName: 'chrome',
+            browserVersion: '59',
+          }),
+        }))
+
         expect(ctx.actions.currentRecording.startInstance).to.have.been.calledWith('instance-id')
+      })
+
+      it('passes browser.family as platform.browserFamily for non-chromium browsers', async () => {
+        const runAllSpecs = sinon.stub()
+        const sys = { osCpus: 1, osName: 'linux', osMemory: 8, osVersion: '1' }
+        const browser = {
+          displayName: 'firefox',
+          version: '120',
+          family: 'firefox',
+        }
+        const project = { setOnTestsReceived: sinon.stub() }
+        const ctx = {
+          actions: {
+            currentRecording: { startRun: sinon.stub(), startInstance: sinon.stub() },
+          },
+        }
+
+        await recordMode.createRunAndRecordSpecs({
+          key: 'k',
+          sys,
+          specs,
+          browser,
+          projectRoot: 'root',
+          specPattern: ['a'],
+          runAllSpecs,
+          testingType: 'e2e',
+          project,
+          ctx,
+        })
+
+        expect(api.createRun).to.have.been.calledWith(sinon.match({
+          platform: sinon.match({
+            browserFamily: 'firefox',
+            browserName: 'firefox',
+            browserVersion: '120',
+          }),
+        }))
       })
     })
   })

--- a/system-tests/test/record_spec.js
+++ b/system-tests/test/record_spec.js
@@ -504,6 +504,50 @@ describe('e2e record', () => {
     })
   })
 
+  context('platform.browserFamily', () => {
+    setupStubbedServer(createRoutes())
+
+    const familyByBrowser = {
+      electron: 'chromium',
+      chrome: 'chromium',
+      'chrome-for-testing': 'chromium',
+      firefox: 'firefox',
+      webkit: 'webkit',
+    }
+
+    systemTests.it('is sent on POST /runs and instance create matching the launched browser', {
+      key: 'f858a2bc-b469-4e48-be67-0876339ee7e1',
+      configFile: 'cypress-with-project-id.config.js',
+      config: {
+        experimentalWebKitSupport: true,
+      },
+      spec: 'record_pass.cy.js',
+      record: true,
+      snapshot: false,
+      expectedExitCode: 0,
+      onRun (execFn, browser) {
+        return execFn().then(() => {
+          const expectedFamily = familyByBrowser[browser]
+
+          expect(expectedFamily, `no browserFamily mapping for browser: ${browser}`).to.exist
+
+          const requests = getRequests()
+          const postRun = requests.find((r) => r.url === 'POST /runs')
+
+          expect(postRun, 'POST /runs').to.exist
+          expect(postRun.body.platform.browserFamily).to.eq(expectedFamily)
+
+          const instanceCreate = requests.find((r) => {
+            return r.url.startsWith('POST /runs/') && r.url.endsWith('/instances')
+          })
+
+          expect(instanceCreate, 'POST /runs/:id/instances').to.exist
+          expect(instanceCreate.body.platform.browserFamily).to.eq(expectedFamily)
+        })
+      },
+    })
+  })
+
   context('recordKey', () => {
     setupStubbedServer(createRoutes())
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/7574

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new field to the Cloud API payload and tightens/extends coverage with unit + system tests; primary risk is backend schema/compat expectations for the new `platform.browserFamily` property.
> 
> **Overview**
> Adds `platform.browserFamily` (sourced from `browser.family`) to the payload sent when creating Cloud runs and instances in `record` mode.
> 
> Updates unit assertions to verify `api.createRun`/`api.createInstance` receive `browserFamily`, and adds a system test ensuring `POST /runs` and `POST /runs/:id/instances` include the expected family for multiple browsers (Chromium variants, Firefox, WebKit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3b2241ecc9a13cd955fd7e275e264c6d9a21407. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
To be tested with https://github.com/cypress-io/cypress-services/pull/13032

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
