### PR TITLE
chore: Add links to open login, setup project modals when throwing er…

### DIFF
--- a/packages/app/cypress/e2e/runner/event-manager.cy.ts
+++ b/packages/app/cypress/e2e/runner/event-manager.cy.ts
@@ -84,4 +84,22 @@ describe('event-manager', () => {
 
     cy.get('@resetDirtyState').should('have.been.calledOnce')
   })
+
+  it('forwards open:login:connect:modal from reporter to local bus', () => {
+    loadSpec({
+      filePath: 'hooks/basic.cy.js',
+      passCount: 2,
+    })
+
+    cy.window().then((win) => {
+      const eventManager = win.getEventManager()
+      const args = { utmMedium: 'test-medium', utmContent: 'test-content' }
+
+      cy.spy(eventManager.localBus, 'emit').as('localBusEmit')
+
+      eventManager.reporterBus.emit('open:login:connect:modal', args)
+
+      expect(eventManager.localBus.emit).to.have.been.calledWith('open:login:connect:modal', args)
+    })
+  })
 })

--- a/packages/app/src/runner/SpecRunnerOpenMode.vue
+++ b/packages/app/src/runner/SpecRunnerOpenMode.vue
@@ -438,6 +438,13 @@ onMounted(() => {
     preferences.update('showFetchRequests', state.showFetchRequests)
     preferences.update('codeEditorLineWrap', state.codeEditorLineWrap)
   })
+
+  eventManager.on('open:login:connect:modal', ({ utmMedium, utmContent }) => {
+    userProjectStatusStore.openLoginConnectModal({
+      utmMedium,
+      utmContent,
+    })
+  })
 })
 
 onBeforeUnmount(() => {

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -262,6 +262,10 @@ export class EventManager {
       this.ws.emit('external:open', url)
     })
 
+    this.reporterBus.on('open:login:connect:modal', (args) => {
+      this.localBus.emit('open:login:connect:modal', args)
+    })
+
     this.reporterBus.on('get:user:editor', (cb) => {
       this.ws.emit('get:user:editor', cb)
     })

--- a/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
@@ -127,10 +127,10 @@ describe('driver/src/cypress/error_utils', () => {
         obj_with_trigger_action: {
           message: 'Error with trigger action',
           docsUrl: 'https://on.link.io',
-          triggerAction: 'login',
+          triggerAction: 'loginModal',
         },
         parent_has_trigger: {
-          triggerAction: 'connectProject',
+          triggerAction: 'projectConnectModal',
           child: {
             message: 'Child error inherits trigger from parent',
           },
@@ -210,14 +210,14 @@ describe('driver/src/cypress/error_utils', () => {
         const err = $errUtils.errByPath('__test_errors.obj_with_trigger_action') as CypressError
 
         expect(err.message).to.include('Error with trigger action')
-        expect(err.triggerAction).to.eq('login')
+        expect(err.triggerAction).to.eq('loginModal')
       })
 
       it('inherits triggerAction from parent when not set on the message object', () => {
         const err = $errUtils.errByPath('__test_errors.parent_has_trigger.child') as CypressError
 
         expect(err.message).to.include('Child error inherits trigger from parent')
-        expect(err.triggerAction).to.eq('connectProject')
+        expect(err.triggerAction).to.eq('projectConnectModal')
       })
 
       it('uses args provided for the error', () => {

--- a/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
+++ b/packages/driver/cypress/e2e/cypress/error_utils.cy.ts
@@ -124,6 +124,17 @@ describe('driver/src/cypress/error_utils', () => {
           message: 'This is a simple error message',
           docsUrl: 'https://on.link.io',
         },
+        obj_with_trigger_action: {
+          message: 'Error with trigger action',
+          docsUrl: 'https://on.link.io',
+          triggerAction: 'login',
+        },
+        parent_has_trigger: {
+          triggerAction: 'connectProject',
+          child: {
+            message: 'Child error inherits trigger from parent',
+          },
+        },
         obj_with_args: {
           message: `This has args like '{{foo}}' and {{bar}}`,
           docsUrl: 'https://on.link.io',
@@ -193,6 +204,20 @@ describe('driver/src/cypress/error_utils', () => {
         expect(err.name).to.eq('CypressError')
         expect(err.message).to.include('This is a simple error message')
         expect(err.docsUrl).to.include('https://on.link.io')
+      })
+
+      it('includes triggerAction when present on the error message object', () => {
+        const err = $errUtils.errByPath('__test_errors.obj_with_trigger_action') as CypressError
+
+        expect(err.message).to.include('Error with trigger action')
+        expect(err.triggerAction).to.eq('login')
+      })
+
+      it('inherits triggerAction from parent when not set on the message object', () => {
+        const err = $errUtils.errByPath('__test_errors.parent_has_trigger.child') as CypressError
+
+        expect(err.message).to.include('Child error inherits trigger from parent')
+        expect(err.triggerAction).to.eq('connectProject')
       })
 
       it('uses args provided for the error', () => {

--- a/packages/driver/src/cy/commands/querying/querying.ts
+++ b/packages/driver/src/cy/commands/querying/querying.ts
@@ -306,11 +306,12 @@ export default (Commands, Cypress, cy, state) => {
       switch (err.type) {
         case 'length':
           if (err.expected > 1) {
-            const { message, docsUrl, docsUrlTitle } = $errUtils.cypressErrByPath('contains.length_option')
+            const { message, docsUrl, docsUrlTitle, triggerAction } = $errUtils.cypressErrByPath('contains.length_option')
 
             err.message = message
             err.docsUrl = docsUrl
             err.docsUrlTitle = docsUrlTitle
+            err.triggerAction = triggerAction
             err.retry = false
           }
 
@@ -382,11 +383,12 @@ export default (Commands, Cypress, cy, state) => {
     this.set('onFail', (err) => {
       switch (err.type) {
         case 'existence': {
-          const { message, docsUrl, docsUrlTitle } = $errUtils.cypressErrByPath('shadow.no_shadow_root')
+          const { message, docsUrl, docsUrlTitle, triggerAction } = $errUtils.cypressErrByPath('shadow.no_shadow_root')
 
           err.message = message
           err.docsUrl = docsUrl
           err.docsUrlTitle = docsUrlTitle
+          err.triggerAction = triggerAction
           break
         }
         default:

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -17,7 +17,7 @@ import $stackUtils, { StackAndCodeFrameIndex } from './stack_utils'
 import $utils from './utils'
 import type { HandlerType } from './runner'
 
-const ERROR_PROPS = ['message', 'type', 'name', 'stack', 'parsedStack', 'fileName', 'lineNumber', 'columnNumber', 'host', 'uncaught', 'actual', 'expected', 'showDiff', 'isPending', 'isRecovered', 'docsUrl', 'codeFrame', 'docsUrlTitle'] as const
+const ERROR_PROPS = ['message', 'type', 'name', 'stack', 'parsedStack', 'fileName', 'lineNumber', 'columnNumber', 'host', 'uncaught', 'actual', 'expected', 'showDiff', 'isPending', 'isRecovered', 'docsUrl', 'codeFrame', 'docsUrlTitle', 'triggerAction'] as const
 const ERR_PREPARED_FOR_SERIALIZATION = Symbol('ERR_PREPARED_FOR_SERIALIZATION')
 
 const crossOriginScriptRe = /^script error/i
@@ -330,6 +330,7 @@ export class InternalCypressError extends Error {
 export class CypressError extends Error {
   docsUrl?: string
   docsUrlTitle?: string | null
+  triggerAction?: 'login' | 'connectProject' | null
   retry?: boolean
   userInvocationStack?: any
   onFail?: Function
@@ -425,6 +426,22 @@ const docsUrlTitleByParents = (msgPath) => {
   return docsUrlTitleByParents(msgPath)
 }
 
+const triggerActionByParents = (msgPath) => {
+  msgPath = msgPath.split('.').slice(0, -1).join('.')
+
+  if (!msgPath) {
+    return // reached root
+  }
+
+  const obj = _.get(allErrorMessages, msgPath)
+
+  if (obj.hasOwnProperty('triggerAction')) {
+    return obj.triggerAction
+  }
+
+  return triggerActionByParents(msgPath)
+}
+
 const errByPath = (msgPath, args?) => {
   let msgValue = _.get(allErrorMessages, msgPath)
 
@@ -446,11 +463,13 @@ const errByPath = (msgPath, args?) => {
 
   const docsUrl = (msgObj.hasOwnProperty('docsUrl') && msgObj.docsUrl) || docsUrlByParents(msgPath)
   const docsUrlTitle = (msgObj.hasOwnProperty('docsUrlTitle') && msgObj.docsUrlTitle) || docsUrlTitleByParents(msgPath)
+  const triggerAction = (msgObj.hasOwnProperty('triggerAction') && msgObj.triggerAction) || triggerActionByParents(msgPath)
 
   return cypressErr({
     message: replaceErrMsgTokens(msgObj.message, args),
     docsUrl: docsUrl ? replaceErrMsgTokens(docsUrl, args) : undefined,
     docsUrlTitle: docsUrlTitle ? replaceErrMsgTokens(docsUrlTitle, args) : undefined,
+    triggerAction: triggerAction ? replaceErrMsgTokens(triggerAction, args) : undefined,
   })
 }
 
@@ -565,6 +584,7 @@ const errorFromErrorEvent = (event): ErrorFromErrorEvent => {
   let { message, filename, lineno, colno, error } = event
   let docsUrl = error?.docsUrl
   let docsUrlTitle = error?.docsUrlTitle
+  let triggerAction = error?.triggerAction
 
   // reset the message on a cross origin script error
   // since no details are accessible
@@ -574,6 +594,7 @@ const errorFromErrorEvent = (event): ErrorFromErrorEvent => {
     message = crossOriginErr.message
     docsUrl = crossOriginErr.docsUrl
     docsUrlTitle = crossOriginErr.docsUrlTitle
+    triggerAction = crossOriginErr.triggerAction
   }
 
   // it's possible the error was thrown as a string (throw 'some error')
@@ -584,6 +605,7 @@ const errorFromErrorEvent = (event): ErrorFromErrorEvent => {
 
   err.docsUrl = docsUrl
   err.docsUrlTitle = docsUrlTitle
+  err.triggerAction = triggerAction
 
   // makeErrFromObj clones the error, so the original doesn't get mutated
   return {

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -330,7 +330,7 @@ export class InternalCypressError extends Error {
 export class CypressError extends Error {
   docsUrl?: string
   docsUrlTitle?: string | null
-  triggerAction?: 'login' | 'connectProject' | null
+  triggerAction?: 'loginModal' | 'projectConnectModal' | null
   retry?: boolean
   userInvocationStack?: any
   onFail?: Function

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -465,11 +465,16 @@ const errByPath = (msgPath, args?) => {
   const docsUrlTitle = (msgObj.hasOwnProperty('docsUrlTitle') && msgObj.docsUrlTitle) || docsUrlTitleByParents(msgPath)
   const triggerAction = (msgObj.hasOwnProperty('triggerAction') && msgObj.triggerAction) || triggerActionByParents(msgPath)
 
+  const resolvedTriggerAction =
+    triggerAction === 'loginModal' || triggerAction === 'projectConnectModal'
+      ? triggerAction
+      : undefined
+
   return cypressErr({
     message: replaceErrMsgTokens(msgObj.message, args),
     docsUrl: docsUrl ? replaceErrMsgTokens(docsUrl, args) : undefined,
     docsUrlTitle: docsUrlTitle ? replaceErrMsgTokens(docsUrlTitle, args) : undefined,
-    triggerAction: triggerAction ? replaceErrMsgTokens(triggerAction, args) : undefined,
+    triggerAction: resolvedTriggerAction,
   })
 }
 

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -392,8 +392,9 @@ const replaceErrMsgTokens = (errMessage, args) => {
   return $utils.normalizeNewLines(getMsg(args), 2)
 }
 
-// recursively try for a default docsUrl
-const docsUrlByParents = (msgPath) => {
+// Walk up the error message path (e.g. foo.bar.baz -> foo.bar -> foo) and return
+// the first ancestor object in allErrorMessages that defines `propName`.
+const findPropByParents = (msgPath, propName) => {
   msgPath = msgPath.split('.').slice(0, -1).join('.')
 
   if (!msgPath) {
@@ -402,44 +403,11 @@ const docsUrlByParents = (msgPath) => {
 
   const obj = _.get(allErrorMessages, msgPath)
 
-  if (obj.hasOwnProperty('docsUrl')) {
-    return obj.docsUrl
+  if (obj.hasOwnProperty(propName)) {
+    return obj[propName]
   }
 
-  return docsUrlByParents(msgPath)
-}
-
-// recursively try for a default docsUrlTitle
-const docsUrlTitleByParents = (msgPath) => {
-  msgPath = msgPath.split('.').slice(0, -1).join('.')
-
-  if (!msgPath) {
-    return // reached root
-  }
-
-  const obj = _.get(allErrorMessages, msgPath)
-
-  if (obj.hasOwnProperty('docsUrlTitle')) {
-    return obj.docsUrlTitle
-  }
-
-  return docsUrlTitleByParents(msgPath)
-}
-
-const triggerActionByParents = (msgPath) => {
-  msgPath = msgPath.split('.').slice(0, -1).join('.')
-
-  if (!msgPath) {
-    return // reached root
-  }
-
-  const obj = _.get(allErrorMessages, msgPath)
-
-  if (obj.hasOwnProperty('triggerAction')) {
-    return obj.triggerAction
-  }
-
-  return triggerActionByParents(msgPath)
+  return findPropByParents(msgPath, propName)
 }
 
 const errByPath = (msgPath, args?) => {
@@ -461,9 +429,9 @@ const errByPath = (msgPath, args?) => {
     }
   }
 
-  const docsUrl = (msgObj.hasOwnProperty('docsUrl') && msgObj.docsUrl) || docsUrlByParents(msgPath)
-  const docsUrlTitle = (msgObj.hasOwnProperty('docsUrlTitle') && msgObj.docsUrlTitle) || docsUrlTitleByParents(msgPath)
-  const triggerAction = (msgObj.hasOwnProperty('triggerAction') && msgObj.triggerAction) || triggerActionByParents(msgPath)
+  const docsUrl = (msgObj.hasOwnProperty('docsUrl') && msgObj.docsUrl) || findPropByParents(msgPath, 'docsUrl')
+  const docsUrlTitle = (msgObj.hasOwnProperty('docsUrlTitle') && msgObj.docsUrlTitle) || findPropByParents(msgPath, 'docsUrlTitle')
+  const triggerAction = (msgObj.hasOwnProperty('triggerAction') && msgObj.triggerAction) || findPropByParents(msgPath, 'triggerAction')
 
   const resolvedTriggerAction =
     triggerAction === 'loginModal' || triggerAction === 'projectConnectModal'

--- a/packages/reporter/cypress/e2e/test_errors.cy.ts
+++ b/packages/reporter/cypress/e2e/test_errors.cy.ts
@@ -326,4 +326,34 @@ describe('test errors', () => {
       cy.get('.runnable-err-docs-url').should('have.text', 'Custom title')
     })
   })
+
+  describe('trigger action', () => {
+    it('shows "Log in to Cypress Cloud." when triggerAction is loginModal', () => {
+      setError({ ...commandErr, triggerAction: 'loginModal' })
+
+      cy.get('.runnable-err-trigger-action').should('be.visible')
+      cy.get('.runnable-err-trigger-action').contains('Log in to Cypress Cloud.')
+    })
+
+    it('shows "Connect project to Cypress Cloud." when triggerAction is projectConnectModal', () => {
+      setError({ ...commandErr, triggerAction: 'projectConnectModal' })
+
+      cy.get('.runnable-err-trigger-action').should('be.visible')
+      cy.get('.runnable-err-trigger-action').contains('Connect project to Cypress Cloud.')
+    })
+
+    it('does not show trigger action when triggerAction is not set', () => {
+      setError(commandErr)
+
+      cy.get('.runnable-err-trigger-action').should('not.exist')
+    })
+
+    it('emits open:login:connect:modal when trigger action link is clicked', () => {
+      setError({ ...commandErr, triggerAction: 'loginModal' })
+
+      cy.spy(runner, 'emit')
+      cy.get('.runnable-err-trigger-action a').click()
+      cy.wrap(runner.emit).should('be.calledWith', 'open:login:connect:modal', { utmMedium: 'Reporter Error Learn More' })
+    })
+  })
 })

--- a/packages/reporter/src/errors/err-model.ts
+++ b/packages/reporter/src/errors/err-model.ts
@@ -32,6 +32,7 @@ export interface ErrProps {
   templateType: string
   codeFrame: CodeFrame
   docsUrlTitle: string | null
+  triggerAction: 'loginModal' | 'projectConnectModal' | null
 }
 
 export default class Err {
@@ -45,7 +46,7 @@ export default class Err {
   codeFrame: CodeFrame
   isRecovered: boolean = false
   docsUrlTitle: string | null = null
-
+  triggerAction: 'loginModal' | 'projectConnectModal' | null = null
   constructor (props?: Partial<ErrProps>) {
     makeObservable(this, {
       name: observable,
@@ -59,6 +60,7 @@ export default class Err {
       displayMessage: computed,
       isCommandErr: computed,
       docsUrlTitle: observable,
+      triggerAction: observable,
     })
 
     this.update(props)
@@ -83,6 +85,7 @@ export default class Err {
     if (props.templateType) this.templateType = props.templateType
     if (props.codeFrame) this.codeFrame = props.codeFrame
     if (props.docsUrlTitle) this.docsUrlTitle = props.docsUrlTitle
+    if (props.triggerAction) this.triggerAction = props.triggerAction
     this.isRecovered = !!props.isRecovered
   }
 }

--- a/packages/reporter/src/errors/errors.scss
+++ b/packages/reporter/src/errors/errors.scss
@@ -142,6 +142,14 @@ $code-border-radius: 4px;
     font-family: $font-system;
   }
 
+  .runnable-err-trigger-action {
+    margin-top: 14px;
+    font-family: $font-system;
+    a {
+      cursor: pointer;
+    }
+  }
+
   .runnable-err-message {
     font-family: $font-system;
     font-size: 14px;

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -41,6 +41,18 @@ const DocsUrl = ({ url, title }: DocsUrlProps) => {
   ))
 }
 
+const TriggerAction = ({ triggerAction }: { triggerAction: 'loginModal' | 'projectConnectModal' }) => {
+  const openTriggerActionModal = () => {
+    events.emit('open:login:connect:modal', {
+      utmMedium: 'Reporter Error Learn More',
+    })
+  }
+
+  return <div className='runnable-err-trigger-action'><a onClick={openTriggerActionModal}>
+    {triggerAction === 'loginModal' ? 'Log in to Cypress Cloud.' : 'Connect project to Cypress Cloud.'}
+  </a></div>
+}
+
 interface TestErrorProps {
   err: Err
   testId?: string
@@ -95,6 +107,7 @@ const TestError: React.FC<TestErrorProps> = ({ err, groupLevel = 0, testId, comm
           <div className='runnable-err-message'>
             <span dangerouslySetInnerHTML={{ __html: formattedMessage(err.message) }} />
             <DocsUrl url={err.docsUrl} title={err.docsUrlTitle} />
+            {err.triggerAction && <TriggerAction triggerAction={err.triggerAction} />}
           </div>
           {codeFrame && <ErrorCodeFrame codeFrame={codeFrame} />}
           {err.stack &&

--- a/packages/reporter/src/lib/events.ts
+++ b/packages/reporter/src/lib/events.ts
@@ -213,6 +213,10 @@ const events: Events = {
       runner.emit('external:open', url)
     })
 
+    localBus.on('open:login:connect:modal', (args) => {
+      runner.emit('open:login:connect:modal', args)
+    })
+
     localBus.on('open:file', (fileDetails) => {
       runner.emit('open:file', fileDetails)
     })


### PR DESCRIPTION
…rors for cy.prompt

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> https://github.com/cypress-io/cypress-services/issues/12883

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-package error serialization/rendering and introduces a new runner/reporter event, so regressions could affect how errors display/propagate in interactive runs. Changes are scoped to additional optional fields and a single new event forwarder.
> 
> **Overview**
> Adds an optional `triggerAction` field to Cypress errors, including inheritance from parent error-message definitions and propagation through error serialization (`error_utils.ts`) into the reporter error model.
> 
> The reporter UI now conditionally renders a call-to-action link for `loginModal` or `projectConnectModal`, emitting `open:login:connect:modal` when clicked; the event is forwarded reporter→local bus→app runner and handled in `SpecRunnerOpenMode.vue` to open the login/connect modal.
> 
> Updates querying command failures to carry `triggerAction`, and adds/extends Cypress e2e coverage across driver error utils, reporter error rendering, and event-manager forwarding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cefba74f2ecdfc63de26ec7c1ff75f2b483fc5c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
