### PR TITLE
test(e2e): mock studio telemetry and metrics in e2e tests

### DIFF
--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -18,8 +18,9 @@ beforeEach(() => {
 })
 
 beforeEach(() => {
-  // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data
-  cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, allowUnmocked: false })
+  // Stub Studio Honeycomb-style posts only (default allowUnmocked: true leaves other cloud traffic alone).
+  cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, persist: true })
+  cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
 })
 
 function e2eTestingTypeIsSelected () {

--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -1,6 +1,7 @@
 import '@packages/frontend-shared/cypress/support/e2e'
 import 'cypress-real-events/support'
 import './execute-spec'
+import nock from 'nock'
 
 Cypress.on('window:before:load', (win) => {
   // Can set this in a spec-by-spec basis to 'true' to use
@@ -21,6 +22,10 @@ beforeEach(() => {
   // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data
   cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, persist: true })
   cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
+})
+
+afterEach(() => {
+  nock.cleanAll()
 })
 
 function e2eTestingTypeIsSelected () {

--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
 })
 
 beforeEach(() => {
-  // Mock out all studio telemetry/metrics // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data requests so that our tests don't pollute our telemetry data
+  // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data
   cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, persist: true })
   cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
 })

--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -17,6 +17,11 @@ beforeEach(() => {
   expect(window.top?.getEventManager().autDestroyedCount).to.be.undefined
 })
 
+beforeEach(() => {
+  // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data
+  cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, allowUnmocked: false })
+})
+
 function e2eTestingTypeIsSelected () {
   cy.findByTestId('specs-testing-type-header').within(() => {
     cy.findByTestId('testing-type-switch').contains('button', 'E2E').should('have.attr', 'aria-selected', 'true')

--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -1,7 +1,6 @@
 import '@packages/frontend-shared/cypress/support/e2e'
 import 'cypress-real-events/support'
 import './execute-spec'
-import nock from 'nock'
 
 Cypress.on('window:before:load', (win) => {
   // Can set this in a spec-by-spec basis to 'true' to use
@@ -22,10 +21,6 @@ beforeEach(() => {
   // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data
   cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, persist: true })
   cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
-})
-
-afterEach(() => {
-  nock.cleanAll()
 })
 
 function e2eTestingTypeIsSelected () {

--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -18,7 +18,7 @@ beforeEach(() => {
 })
 
 beforeEach(() => {
-  // Stub Studio Honeycomb-style posts only (default allowUnmocked: true leaves other cloud traffic alone).
+  // Mock out all studio telemetry/metrics // Mock out all studio telemetry requests so that our tests don't pollute Honeycomb data requests so that our tests don't pollute our telemetry data
   cy.mockNodeCloudRequest({ url: '/studio/telemetry', method: 'post', body: {}, persist: true })
   cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
 })

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -472,10 +472,14 @@ async function makeE2ETasks () {
 
       return null
     },
-    __internal_mockNodeCloudRequest ({ url, method, body, allowUnmocked = true }: MockNodeCloudRequestOptions) {
+    __internal_mockNodeCloudRequest ({ url, method, body, persist = false }: MockNodeCloudRequestOptions) {
       const nocked = nock('https://cloud.cypress.io', {
-        allowUnmocked,
+        allowUnmocked: true,
       })
+
+      if (persist) {
+        nocked.persist()
+      }
 
       nocked[method](url).reply(200, body)
 

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -472,9 +472,9 @@ async function makeE2ETasks () {
 
       return null
     },
-    __internal_mockNodeCloudRequest ({ url, method, body }: MockNodeCloudRequestOptions) {
+    __internal_mockNodeCloudRequest ({ url, method, body, allowUnmocked = true }: MockNodeCloudRequestOptions) {
       const nocked = nock('https://cloud.cypress.io', {
-        allowUnmocked: true,
+        allowUnmocked,
       })
 
       nocked[method](url).reply(200, body)

--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -85,7 +85,7 @@ export interface MockNodeCloudRequestOptions {
   url: string
   method: string
   body: nock.Body
-  allowUnmocked?: boolean
+  persist?: boolean
 }
 
 export interface MockNodeCloudStreamingRequestOptions {
@@ -207,7 +207,7 @@ declare global {
       /**
        * Mocks a node cloud request
        */
-      mockNodeCloudRequest(options: { url: string, method: string, body: nock.Body, allowUnmocked?: boolean }): void
+      mockNodeCloudRequest(options: { url: string, method: string, body: nock.Body, persist?: boolean }): void
       /**
        * Mocks a node cloud streaming request
        */

--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -85,6 +85,7 @@ export interface MockNodeCloudRequestOptions {
   url: string
   method: string
   body: nock.Body
+  allowUnmocked?: boolean
 }
 
 export interface MockNodeCloudStreamingRequestOptions {
@@ -206,7 +207,7 @@ declare global {
       /**
        * Mocks a node cloud request
        */
-      mockNodeCloudRequest(options: { url: string, method: string, body: nock.Body }): void
+      mockNodeCloudRequest(options: { url: string, method: string, body: nock.Body, allowUnmocked?: boolean }): void
       /**
        * Mocks a node cloud streaming request
        */


### PR DESCRIPTION


<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
https://github.com/cypress-io/cypress-services/issues/12925

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->
- Mock studio telemetry calls so that we don't log calls for Cypress tests in Honeycomb.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adds persistent nock stubbing for Studio telemetry/metrics endpoints; main risk is inadvertently masking real network behavior in studio-related e2e tests if those requests should be asserted on.
> 
> **Overview**
> Prevents Cypress-in-Cypress Studio e2e runs from emitting real telemetry by adding global `beforeEach` mocks for `/studio/telemetry` and `/studio/metrics`.
> 
> Extends `mockNodeCloudRequest` to support a `persist` option (plumbed through types and the plugin task) so these mocks can survive multiple requests without needing duplicate setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cea91c5313c5fa22a3c4450bda0cc2106792c0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

- Before this PR, if you go to [Honeycomb](https://ui.honeycomb.io/cypress/environments/cypress-app/datasets/studio/result/ZPeSiL6m97) and pick any of the tests under `packages/app/cypress/e2e/studio`, for example `studio-new-tests.cy.ts`, you would see the traces for the test. With this PR, you shouldn't see the traces get logged anymore. To see the change more easily, you could change the `projectId` in `system-tests/projects/studio/cypress.config.js` to something else use that in the `projectSlug` in Honeycomb to check that no traces are coming in anymore

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
