### PR TITLE
dependency: update flatted to 3.4.2

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-03-10-2026
+03-20-2026

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -21,6 +21,7 @@ _Released 03/24/2026 (PENDING)_
 - Upgraded `simple-git` from `3.27.0` to `3.32.3` to address [Improper Handling of Case Sensitivity](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15457646) (CVE-2026-28292) vulnerability reported in security scans. Addressed in [#33470](https://github.com/cypress-io/cypress/pull/33470)
 - Upgraded `minimatch` to `3.1.3` to address [CVE-2026-26996](https://nvd.nist.gov/vuln/detail/CVE-2026-26996), [CVE-2026-27903](https://nvd.nist.gov/vuln/detail/CVE-2026-27903), and [CVE-2026-27904](https://nvd.nist.gov/vuln/detail/CVE-2026-27904) ReDoS vulnerabilities reported in security scans. Addressed in [#33461](https://github.com/cypress-io/cypress/pull/33461).
 - Upgraded `serialize-javascript` to `7.0.3` to address [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) vulnerability reported in security scans. Addressed in [#33461](https://github.com/cypress-io/cypress/pull/33461).
+- Upgraded `flatted` from `3.2.9` to `3.4.2` to address [Prototype Pollution](https://security.snyk.io/vuln/SNYK-JS-FLATTED-15700433) (CVE-2026-33228) vulnerability reported in security scans. Addressed in [#33501](https://github.com/cypress-io/cypress/pull/33501)
 
 ## 15.12.0
 

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -26,7 +26,7 @@
     "engine.io": "6.4.2",
     "engine.io-client": "~5.0.0",
     "engine.io-parser": "4.0.2",
-    "flatted": "3.2.9",
+    "flatted": "3.4.2",
     "socket.io": "4.0.1",
     "socket.io-client": "4.0.1",
     "socket.io-parser": "4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17108,15 +17108,10 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
-  integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
-
-flatted@^3.1.0, flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+flatted@3.4.2, flatted@^3.1.0, flatted@^3.2.9:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 floating-vue@5.2.2:
   version "5.2.2"


### PR DESCRIPTION


- Closes 

### Additional details

This change addresses [**SNYK-JS-FLATTED-15700433**](https://security.snyk.io/vuln/SNYK-JS-FLATTED-15700433) (**CVE-2026-33228**). Affected `flatted` versions **before 3.4.2** are vulnerable to **prototype pollution** via `parse` when given malicious input (e.g. crafted strings that manipulate the prototype chain). Snyk’s remediation is to upgrade **`flatted` to 3.4.2 or higher** — see the [Snyk advisory](https://security.snyk.io/vuln/SNYK-JS-FLATTED-15700433) for full details, PoC context, and CVSS.

We bump the direct `flatted` dependency in `@packages/socket` from `3.2.9` to `3.4.2`, refresh `yarn.lock` so resolved `flatted` versions converge on `3.4.2`, and record the upgrade in `cli/CHANGELOG.md` for the pending release notes.


---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update, but it affects socket payload serialization via the patched `socket.io-parser` use of `flatted`, so regressions would show up as connection/encode/decode issues.
> 
> **Overview**
> Updates the `@packages/socket` direct dependency on `flatted` from `3.2.9` to `3.4.2` and refreshes `yarn.lock` so all `flatted` resolutions converge on `3.4.2`.
> 
> Adds a changelog entry noting the `flatted` upgrade as a security-motivated fix for a prototype pollution CVE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da86dbdaea491490f311fc7dd2cf5c79b47aad8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>


### Steps to test

1. `yarn` (verify lockfile installs cleanly).
2. Optionally: `yarn test --scope @packages/socket` if you want extra confidence around socket serialization paths.

### How has the user experience changed?

No intentional user-facing change; dependency-only update.

### PR Tasks


- [ ] Have tests been added/updated? [na]
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?  [na]
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? [na]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency bump to address a prototype pollution CVE, with the main potential impact being regressions in socket payload encode/decode paths that rely on `flatted`. CI cache is invalidated, so build/install behavior may change only in CI caching.
> 
> **Overview**
> Updates `@packages/socket` to use `flatted@3.4.2` and refreshes `yarn.lock` so `flatted` resolutions converge on `3.4.2`.
> 
> Adds a `cli/CHANGELOG.md` entry documenting the security-driven upgrade (CVE-2026-33228) and bumps `.circleci/cache-version.txt` to force a clean CI cache rebuild.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f649af40492b75d9f77ae64690574acbca5e67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->