### PR TITLE
chore(deps): update dependency cypress-example-kitchensink to 5.2.6

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
     "test-unit": "echo 'no unit tests'"
   },
   "devDependencies": {
-    "cypress-example-kitchensink": "5.2.5",
+    "cypress-example-kitchensink": "5.2.6",
     "gh-pages": "5.0.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14036,10 +14036,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-cypress-example-kitchensink@5.2.5:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-5.2.5.tgz#7b17921b169d07cc7b9fcf74f5e44c62c3a967bc"
-  integrity sha512-j2lI1rzk0jlcJZM90YbJGSiiW5oirqR5+JON4iTX1HoR8Fx8rx1fZWIwWZtvT8ffcYjDkBbhBF8qQ1wAnDu22g==
+cypress-example-kitchensink@5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-5.2.6.tgz#46d975215da370e5eab98fb0a0f803d85e6b1851"
+  integrity sha512-BjCzESv3DPYZNCmRXuLqDpdsLrthXQa+21XzFAhsb0PSmO064kRqhXA10L4UFVnpMrRZNepmJ4HY4zP7+Anshg==
   dependencies:
     npm-run-all2 "8.0.4"
     serve "14.2.6"


### PR DESCRIPTION
### Additional details

Updates [packages/example/package.json](https://github.com/cypress-io/cypress/blob/develop/packages/example/package.json) from `cypress-example-kitchensink@5.2.5` to [cypress-example-kitchensink@5.2.6](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v5.2.6)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the `@packages/example` workspace; main impact is potential changes in the example app build/output.
> 
> **Overview**
> Updates `@packages/example` to use `cypress-example-kitchensink@5.2.6` (from `5.2.5`).
> 
> Refreshes the corresponding `yarn.lock` entry to the new tarball/integrity values for that package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5aeb5980e74316b0557ef64bc83534c3ee1cb7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```shell
yarn
yarn workspace @packages/example build
```

### How has the user experience changed?

Provides linted html code for publication to https://example.cypress.io/
No changes to presentation on this site however. Changes are only apparent when using "view page source" or similar in web browser.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
