### PR TITLE
perf: trimmed config on instance test payloads instead of the full runtime object during Cloud recording

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@ _Released 04/07/2026 (PENDING)_
 
 **Performance:**
 
-- When recording to Cypress Cloud, the App now sends a smaller, sanitized snapshot of your project config (supported options only with bulky fields redacted), which reduces payload size and can make Cloud recording faster. Addressed in [#33517](https://github.com/cypress-io/cypress/pull/33517).
+- When recording to Cypress Cloud, the App now sends a smaller snapshot of your project config, which reduces payload size and can make Cloud recording faster. Addressed in [#33517](https://github.com/cypress-io/cypress/pull/33517).
 
 ## 15.13.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.13.1 
+
+_Released 04/07/2026 (PENDING)_
+
+**Performance:**
+
+- When recording to Cypress Cloud, the App now sends a smaller, sanitized snapshot of your project config (supported options only with bulky fields redacted), which reduces payload size and can make Cloud recording faster. Addressed in [#33517](https://github.com/cypress-io/cypress/pull/33517).
+
 ## 15.13.0
 
 _Released 03/24/2026_

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.13.1 
 
-_Released 04/07/2026 (PENDING)_
+_Released 03/31/2026 (PENDING)_
 
 **Performance:**
 

--- a/packages/config/src/browser.ts
+++ b/packages/config/src/browser.ts
@@ -134,6 +134,23 @@ export const getPublicConfigKeys = () => {
   return publicConfigKeys
 }
 
+/**
+ * Keys allowed on Cypress Cloud recording payloads: public config options (same basis as
+ * config.resolved) plus flattened component-testing-only fields not listed as top-level
+ * `options[].name` entries (see mergeDefaults in project/utils).
+ */
+const cloudRecordingConfigExtraKeys = ['devServer', 'devServerConfig', 'indexHtmlFile'] as const
+
+let cloudRecordingConfigKeysCache: string[] | undefined
+
+export const getCloudRecordingConfigKeys = (): string[] => {
+  if (!cloudRecordingConfigKeysCache) {
+    cloudRecordingConfigKeysCache = [...publicConfigKeys, ...cloudRecordingConfigExtraKeys]
+  }
+
+  return cloudRecordingConfigKeysCache
+}
+
 export const matchesConfigKey = (key: string) => {
   if (_.has(defaultValues, key)) {
     return key

--- a/packages/config/test/index.spec.ts
+++ b/packages/config/test/index.spec.ts
@@ -88,6 +88,25 @@ describe('config/src/index', () => {
     })
   })
 
+  describe('.getCloudRecordingConfigKeys', () => {
+    it('includes every public config key plus component recording extras', () => {
+      const cloudKeys = configUtil.getCloudRecordingConfigKeys()
+      const publicKeys = configUtil.getPublicConfigKeys()
+
+      for (const key of publicKeys) {
+        expect(cloudKeys).toContain(key)
+      }
+
+      expect(cloudKeys).toContain('devServer')
+      expect(cloudKeys).toContain('devServerConfig')
+      expect(cloudKeys).toContain('indexHtmlFile')
+    })
+
+    it('returns the same array instance on each call', () => {
+      expect(configUtil.getCloudRecordingConfigKeys()).toBe(configUtil.getCloudRecordingConfigKeys())
+    })
+  })
+
   describe('.matchesConfigKey', () => {
     it('returns normalized key when config key has a default value', () => {
       let normalizedKey = configUtil.matchesConfigKey('EXEC_TIMEOUT')

--- a/packages/server/lib/config.ts
+++ b/packages/server/lib/config.ts
@@ -1,17 +1,45 @@
 import _ from 'lodash'
-import * as configUtils from '@packages/config'
+import { getCloudRecordingConfigKeys, setUrls } from '@packages/config'
 
-export const setUrls = configUtils.setUrls
+export { setUrls }
+
+const devServerConfigRecordingPreservedKeys = ['bundler', 'framework'] as const
+
+function sanitizeDevServerConfigForRecording (devServerConfig: Record<string, unknown>) {
+  const preserved = _.pick(devServerConfig, devServerConfigRecordingPreservedKeys)
+  const rest = _.omit(devServerConfig, devServerConfigRecordingPreservedKeys)
+
+  return {
+    ...preserved,
+    ..._.mapValues(rest, (val) => `omitted: ${typeof val}`),
+  }
+}
+
+function sanitizeEnvLikeForRecording (obj: Record<string, unknown>) {
+  return _.mapValues(obj ?? {}, (val) => `omitted: ${typeof val}`)
+}
 
 // Strips out values that can be aribitrarily sized / are duplicated from config
-// payload sent for recording
+// payload sent for recording (env and expose values replaced with typeof placeholders)
 export function filterRuntimeConfigForRecording (config) {
-  const { rawJson, devServer, env, resolved, ...configRest } = config
+  const { rawJson, devServer, devServerConfig, env, expose, resolved, ...configRest } = config
   const { webpackConfig, viteConfig, ...devServerRest } = devServer ?? {}
   const resultConfig = { ...configRest }
 
   if (env) {
-    resultConfig.env = _.mapValues(env ?? {}, (val, key) => `omitted: ${typeof val}`)
+    resultConfig.env = sanitizeEnvLikeForRecording(env)
+  }
+
+  if (expose) {
+    resultConfig.expose = sanitizeEnvLikeForRecording(expose)
+  }
+
+  if (devServerConfig !== undefined) {
+    if (_.isPlainObject(devServerConfig)) {
+      resultConfig.devServerConfig = sanitizeDevServerConfigForRecording(devServerConfig)
+    } else {
+      resultConfig.devServerConfig = `omitted: ${typeof devServerConfig}`
+    }
   }
 
   if (devServer) {
@@ -25,5 +53,5 @@ export function filterRuntimeConfigForRecording (config) {
     }
   }
 
-  return resultConfig
+  return _.pick(resultConfig, getCloudRecordingConfigKeys())
 }

--- a/packages/server/test/unit/cloud/api/api_spec.js
+++ b/packages/server/test/unit/cloud/api/api_spec.js
@@ -1007,6 +1007,8 @@ describe('lib/cloud/api', () => {
     it('POSTs /instances/:id/tests strips arbitrarily large config values', function () {
       this.props.config = {
         projectId: 'abcd1234',
+        customBloat: { nested: 'x'.repeat(5000) },
+        _myPluginState: { foo: 'bar' },
         devServer: {
           bundler: 'webpack',
           framework: 'react',
@@ -1053,6 +1055,46 @@ describe('lib/cloud/api', () => {
       expect(expectedConfig.resolved).to.be.undefined
       expect(expectedConfig.devServer.webpackConfig).to.equal('omitted')
       expect(expectedConfig.devServer.viteConfig).to.equal('omitted')
+      expect(expectedConfig.customBloat).to.be.undefined
+      expect(expectedConfig._myPluginState).to.be.undefined
+
+      return api.postInstanceTests(this.props)
+    })
+
+    it('POSTs /instances/:id/tests keeps allowlisted component config keys', function () {
+      this.props.config = {
+        projectId: 'abcd1234',
+        indexHtmlFile: 'cypress/support/component-index.html',
+        devServerConfig: {
+          framework: 'react',
+          bundler: 'webpack',
+          mode: 'development',
+          webpackConfig: { entry: 'app' },
+        },
+      }
+
+      const expectedConfig = filterRuntimeConfigForRecording(this.props.config)
+
+      expect(expectedConfig.projectId).to.eq('abcd1234')
+      expect(expectedConfig.indexHtmlFile).to.eq('cypress/support/component-index.html')
+      expect(expectedConfig.devServerConfig).to.eql({
+        framework: 'react',
+        bundler: 'webpack',
+        mode: 'omitted: string',
+        webpackConfig: 'omitted: object',
+      })
+
+      nock(API_BASEURL)
+      .matchHeader('x-route-version', '1')
+      .matchHeader('x-cypress-run-id', this.props.runId)
+      .matchHeader('x-cypress-request-attempt', '0')
+      .matchHeader('x-os-name', OS_PLATFORM)
+      .matchHeader('x-cypress-version', pkg.version)
+      .post('/instances/instance-id-123/tests', {
+        ...this.bodyProps,
+        config: expectedConfig,
+      })
+      .reply(200)
 
       return api.postInstanceTests(this.props)
     })

--- a/packages/server/test/unit/filter_runtime_config_for_recording_spec.js
+++ b/packages/server/test/unit/filter_runtime_config_for_recording_spec.js
@@ -1,0 +1,147 @@
+require('../spec_helper')
+
+const _ = require('lodash')
+const { filterRuntimeConfigForRecording } = require('../../lib/config')
+const { getCloudRecordingConfigKeys } = require('@packages/config')
+
+describe('lib/config filterRuntimeConfigForRecording', () => {
+  it('returns an empty object for an empty config', () => {
+    expect(filterRuntimeConfigForRecording({})).to.eql({})
+  })
+
+  it('removes rawJson, resolved, and keys not in the cloud recording allowlist', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      projectId: 'abc',
+      baseUrl: 'http://localhost',
+      rawJson: { huge: 'x'.repeat(1000) },
+      resolved: { baseUrl: { value: 'x', from: 'config' } },
+      socketId: 'sock-1',
+      clientRoute: '/__/',
+      arbitraryUserKey: { nested: true },
+    })
+
+    expect(filtered.rawJson).to.be.undefined
+    expect(filtered.resolved).to.be.undefined
+    expect(filtered.socketId).to.be.undefined
+    expect(filtered.clientRoute).to.be.undefined
+    expect(filtered.arbitraryUserKey).to.be.undefined
+    expect(filtered.projectId).to.eq('abc')
+    expect(filtered.baseUrl).to.eq('http://localhost')
+  })
+
+  it('replaces env values with type placeholders', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      env: {
+        STR: 'secret',
+        NUM: 42,
+        BOOL: false,
+        OBJ: { a: 1 },
+      },
+    })
+
+    expect(filtered.env).to.eql({
+      STR: 'omitted: string',
+      NUM: 'omitted: number',
+      BOOL: 'omitted: boolean',
+      OBJ: 'omitted: object',
+    })
+  })
+
+  it('replaces expose values with type placeholders like env', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      expose: {
+        API_URL: 'https://secret.example',
+        FLAG: true,
+      },
+    })
+
+    expect(filtered.expose).to.eql({
+      API_URL: 'omitted: string',
+      FLAG: 'omitted: boolean',
+    })
+  })
+
+  it('omits devServer webpackConfig and viteConfig but keeps other devServer fields', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      devServer: {
+        bundler: 'webpack',
+        framework: 'react',
+        webpackConfig: { entry: 'app' },
+        viteConfig: { root: '/tmp' },
+      },
+    })
+
+    expect(filtered.devServer).to.eql({
+      bundler: 'webpack',
+      framework: 'react',
+      webpackConfig: 'omitted',
+      viteConfig: 'omitted',
+    })
+  })
+
+  it('preserves bundler and framework on devServerConfig and redacts other fields', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      devServerConfig: {
+        bundler: 'vite',
+        framework: 'vue',
+        viteConfig: { build: { target: 'esnext' } },
+        mode: 'development',
+      },
+    })
+
+    expect(filtered.devServerConfig).to.eql({
+      bundler: 'vite',
+      framework: 'vue',
+      viteConfig: 'omitted: object',
+      mode: 'omitted: string',
+    })
+  })
+
+  it('redacts non-object devServerConfig with a type placeholder string', () => {
+    expect(filterRuntimeConfigForRecording({ devServerConfig: null }).devServerConfig)
+    .to.eq('omitted: object')
+
+    expect(filterRuntimeConfigForRecording({ devServerConfig: 'oops' }).devServerConfig)
+    .to.eq('omitted: string')
+
+    expect(filterRuntimeConfigForRecording({ devServerConfig: [] }).devServerConfig)
+    .to.eq('omitted: object')
+  })
+
+  it('does not set devServerConfig when undefined', () => {
+    const filtered = filterRuntimeConfigForRecording({ projectId: 'x' })
+
+    expect(filtered).not.to.have.property('devServerConfig')
+  })
+
+  it('keeps indexHtmlFile and allowlisted public keys only', () => {
+    const filtered = filterRuntimeConfigForRecording({
+      indexHtmlFile: 'cypress/support/component-index.html',
+      specPattern: '**/*.cy.ts',
+      video: true,
+      notARealOption: 'drop-me',
+    })
+
+    expect(filtered.indexHtmlFile).to.eq('cypress/support/component-index.html')
+    expect(filtered.specPattern).to.eq('**/*.cy.ts')
+    expect(filtered.video).to.eq(true)
+    expect(filtered.notARealOption).to.be.undefined
+  })
+
+  it('output keys are a subset of getCloudRecordingConfigKeys()', () => {
+    const allow = new Set(getCloudRecordingConfigKeys())
+    const filtered = filterRuntimeConfigForRecording({
+      projectId: 'p',
+      devServer: { bundler: 'webpack', framework: 'react' },
+      devServerConfig: { bundler: 'webpack', framework: 'react' },
+      env: { K: 1 },
+      expose: { X: 'y' },
+      indexHtmlFile: 'index.html',
+      extra: 'should-not-appear',
+    })
+
+    _.each(_.keys(filtered), (key) => {
+      expect(allow.has(key), `unexpected key on filtered config: ${key}`).to.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
### Additional details

Users can attach **large** values to config. Smaller requests **speed up recording in Cypress Cloud**. [Linking to previous research that showed this as truth.](https://app.clickup.com/18033298/docs/h6amj-41967/h6amj-37147)

I cross referenced what is used in the Cloud code and confirmed anything stripped is not actively used. Also have confirmation that this is not useful to store as a company.

- **Allowlisted keys only** — Payloads include public Cypress config keys (`getPublicConfigKeys()`), plus component-only top-level fields used after flattening (`devServer`, `devServerConfig`, `indexHtmlFile`). Arbitrary keys are omitted so they are not sent, stored or processed in the Cloud.
- **Sanitization** — `rawJson` and `resolved` remain stripped; `devServer.webpackConfig` / `viteConfig` remain placeholders; **`env` and `expose`** use `omitted: <type>` placeholders; **`devServerConfig`** keeps **`bundler`** and **`framework`** and redacts other properties the same way.
- **`getCloudRecordingConfigKeys()`** - New `@packages/config` helper defines the recording allowlist.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape/content of config data sent to Cypress Cloud during recording by aggressively allowlisting keys and redacting values, which could break Cloud-side expectations or diagnostics if any required fields are missed.
> 
> **Overview**
> **Reduces Cypress Cloud recording payload size** by replacing the full runtime config sent on `POST /instances/:id/tests` with an allowlisted snapshot.
> 
> Introduces `getCloudRecordingConfigKeys()` (public config keys + component extras like `devServer`, `devServerConfig`, `indexHtmlFile`) and updates `filterRuntimeConfigForRecording` to (a) drop non-allowlisted/arbitrary keys, `rawJson`, and `resolved`, (b) redact `env`/`expose` values to `omitted: <type>`, and (c) keep only `bundler`/`framework` in `devServerConfig` while redacting the rest.
> 
> Adds/updates unit coverage for the new allowlist behavior and includes a changelog entry for the performance improvement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f928ceb69be043653d9b8c6b92b296e2a2507e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
