### PR TITLE
test(studio): reset studio after each studio e2e test

### DIFF
--- a/packages/app/cypress/e2e/support/e2eSupport.ts
+++ b/packages/app/cypress/e2e/support/e2eSupport.ts
@@ -23,6 +23,26 @@ beforeEach(() => {
   cy.mockNodeCloudRequest({ url: '/studio/metrics', method: 'post', body: {}, persist: true })
 })
 
+afterEach(() => {
+  const specPath = Cypress.spec.relative.replace(/\\/g, '/')
+
+  if (!specPath.includes('e2e/studio/')) {
+    return
+  }
+
+  // reset studio after each test to avoid triggering the browser's unsaved changes dialog in between tests
+  cy.get('body').then(($body) => {
+    const $btn = $body.find('[data-cy="studio-reset-button"]')
+    const isEnabled = $btn.length > 0
+      && !$btn.is(':disabled')
+      && $btn.attr('aria-disabled') !== 'true'
+
+    if (isEnabled) {
+      cy.wrap($btn).click({ force: true })
+    }
+  })
+})
+
 function e2eTestingTypeIsSelected () {
   cy.findByTestId('specs-testing-type-header').within(() => {
     cy.findByTestId('testing-type-switch').contains('button', 'E2E').should('have.attr', 'aria-selected', 'true')


### PR DESCRIPTION
- After each studio e2e spec, click the reset control when enabled so Studio state does not carry between tests and the browser unsaved-changes prompt does not appear between tests.

<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds cleanup between Studio E2E tests; main risk is potential test flake if the reset button is missing or temporarily disabled.
> 
> **Overview**
> Adds an `afterEach` hook for Studio E2E specs that clicks the `studio-reset-button` when present and enabled, clearing Studio state between tests to prevent unsaved-changes dialogs from interrupting runs.
> 
> The cleanup is scoped to specs under `e2e/studio/` and no-ops for other E2E tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6403dea72053721c2739e0863568aea37287cabe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
