### PR TITLE
fix(reporter): escape HTML in spy assertion arguments

### DIFF
--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -93,6 +93,14 @@ describe('formattedMessage', () => {
       expect(result).to.equal('expected <strong>&lt;button#increment&gt;</strong> to be enabled')
     })
 
+    it('escapes HTML in spy assertion arguments', () => {
+      // Spy assertions like calledOnceWith can contain HTML strings
+      const specialMessage = 'expected **method** to have been called once with **<svg viewBox="0 0 10 10"></svg>**'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected <strong>method</strong> to have been called once with <strong>&lt;svg viewBox=&quot;0 0 10 10&quot;&gt;&lt;/svg&gt;</strong>')
+    })
+
     it('renders the custom message properly with the assertion message', () => {
       const specialMessage = 'My Custom Message: expected **abcdef** to equal **abcdef**'
       const result = formattedMessage(specialMessage, 'assert')

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -33,6 +33,8 @@ const nameClassName = (name: string) => name.replace(/(\s+)/g, '-')
 
 const md = new Markdown()
 const mdOnlyHTML = new Markdown('zero').enable(['html_inline', 'html_block'])
+// Instance for escaping HTML - no HTML parsing enabled so tags are escaped
+const mdEscapeHTML = new Markdown('zero')
 
 const asterisksRegex = /^\*\*(.+?)\*\*$/gs
 // regex to match everything outside of expected/actual values like:
@@ -66,7 +68,7 @@ export const formattedMessage = (message: string, name?: string) => {
       return splitTrim.map((s) => {
         // we want to escape HTML chars so that they display
         // correctly in the command log: <p> -> &lt;p&gt;
-        const HTMLEscapedString = mdOnlyHTML.renderInline(s)
+        const HTMLEscapedString = mdEscapeHTML.renderInline(s)
 
         return HTMLEscapedString.replace(asterisksRegex, `<strong>$1</strong>`)
       })


### PR DESCRIPTION
## Description

HTML content in spy assertion arguments (like `calledOnceWith`) was not being properly escaped, causing the HTML to be rendered in the command log instead of being displayed as text.

### Current Behavior
When using spy assertions with HTML string arguments, the HTML is rendered in the command log, breaking the markup:

```js
const markup = `<svg viewBox="0 0 10 10" width="10" height="10"></svg>`;
expect(obj.method).to.have.been.calledOnceWith(markup);
```

The SVG HTML would be rendered instead of displayed as text.

### Desired Behavior
HTML should be properly escaped and displayed as text in the command log.

### Changes
- Added `mdEscapeHTML` markdown-it instance without HTML parsing enabled to properly escape HTML tags
- Added test case for spy assertion HTML escaping

Fixes #33416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to reporter message formatting; main risk is minor regressions in assertion string rendering/escaping.
> 
> **Overview**
> Prevents HTML from being interpreted in assertion messages by switching assertion value formatting to use a markdown-it instance with *no HTML parsing enabled*, ensuring tags like `<svg ...>` are escaped before being wrapped in `<strong>`.
> 
> Adds a Cypress unit test covering spy assertions (e.g. `calledOnceWith`) to verify HTML arguments are rendered as escaped text in the command log.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b0840864ac7d192913a52656fc80180448b572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->