### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -974,7 +974,7 @@ _Released 07/16/2024_
 
 - Fixed an issue where unhandled `WebSocket connection closed` exceptions would be thrown when CDP connections rapidly connect, disconnect, and connect again while there are pending commands. Fixes [#29572](https://github.com/cypress-io/cypress/issues/29572).
 - CLI output properly displays non-JSON response bodies when a Test Replay upload attempt returns a non-JSON response body for a non-200 status code. Addressed in [#29801](https://github.com/cypress-io/cypress/pull/29801).
-- Fixed an issue where the ReadStream used to upload a Test Replay recording could erroneously be re-used when retrying in cases of retryable upload failures. Fixes [#29227](https://github.com/cypress-io/cypress/issues/29227).
+- Fixed an issue where the ReadStream used to upload a Test Replay recording could erroneously be reused when retrying in cases of retryable upload failures. Fixes [#29227](https://github.com/cypress-io/cypress/issues/29227).
 - Fixed an issue where command snapshots were not being captured within the `cy.origin()` command within Test Replay. Addressed in [#29828](https://github.com/cypress-io/cypress/pull/29828).
 
 **Dependency Updates:**

--- a/npm/angular/CHANGELOG.md
+++ b/npm/angular/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 * update changelog references to make it clearer on where angular 17 packages live historically
 
-* fix cy framework errors app test to use angualr 18 and 19
+* fix cy framework errors app test to use angular 18 and 19
 
 * fix issue where di was not discoverable in resolved system tests config
 
@@ -203,7 +203,7 @@
 * support webpack-dev-server v4 ([#17918](https://github.com/cypress-io/cypress/issues/17918)) ([16e4759](https://github.com/cypress-io/cypress/commit/16e4759e0196f68c5f0525efb020211337748f94))
 * swap the #__cy_root id selector to become data-cy-root for component mounting ([#20951](https://github.com/cypress-io/cypress/issues/20951)) ([0e7b555](https://github.com/cypress-io/cypress/commit/0e7b555f93fb403f431c5de4a07ae7ad6ac89ba2))
 * Use .config files ([#18578](https://github.com/cypress-io/cypress/issues/18578)) ([081dd19](https://github.com/cypress-io/cypress/commit/081dd19cc6da3da229a7af9c84f62730c85a5cd6))
-* use devServer instad of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
+* use devServer instead of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
 * use hoisted yarn install in binary build ([#17285](https://github.com/cypress-io/cypress/issues/17285)) ([e4f5b10](https://github.com/cypress-io/cypress/commit/e4f5b106d49d6ac0857c5fdac886f83b99558c88))
 * Use plugins on config files ([#18798](https://github.com/cypress-io/cypress/issues/18798)) ([bb8251b](https://github.com/cypress-io/cypress/commit/bb8251b752ac44f1184f9160194cf12d41fc867f))
 * use supportFile by testingType ([#19364](https://github.com/cypress-io/cypress/issues/19364)) ([0366d4f](https://github.com/cypress-io/cypress/commit/0366d4fa8971e5e5189c6fd6450cc3c8d72dcfe1))
@@ -231,7 +231,7 @@
 * support webpack-dev-server v4 ([#17918](https://github.com/cypress-io/cypress/issues/17918)) ([16e4759](https://github.com/cypress-io/cypress/commit/16e4759e0196f68c5f0525efb020211337748f94))
 * swap the #__cy_root id selector to become data-cy-root for component mounting ([#20951](https://github.com/cypress-io/cypress/issues/20951)) ([0e7b555](https://github.com/cypress-io/cypress/commit/0e7b555f93fb403f431c5de4a07ae7ad6ac89ba2))
 * Use .config files ([#18578](https://github.com/cypress-io/cypress/issues/18578)) ([081dd19](https://github.com/cypress-io/cypress/commit/081dd19cc6da3da229a7af9c84f62730c85a5cd6))
-* use devServer instad of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
+* use devServer instead of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
 * use hoisted yarn install in binary build ([#17285](https://github.com/cypress-io/cypress/issues/17285)) ([e4f5b10](https://github.com/cypress-io/cypress/commit/e4f5b106d49d6ac0857c5fdac886f83b99558c88))
 * Use plugins on config files ([#18798](https://github.com/cypress-io/cypress/issues/18798)) ([bb8251b](https://github.com/cypress-io/cypress/commit/bb8251b752ac44f1184f9160194cf12d41fc867f))
 * use supportFile by testingType ([#19364](https://github.com/cypress-io/cypress/issues/19364)) ([0366d4f](https://github.com/cypress-io/cypress/commit/0366d4fa8971e5e5189c6fd6450cc3c8d72dcfe1))
@@ -259,7 +259,7 @@
 * support webpack-dev-server v4 ([#17918](https://github.com/cypress-io/cypress/issues/17918)) ([16e4759](https://github.com/cypress-io/cypress/commit/16e4759e0196f68c5f0525efb020211337748f94))
 * swap the #__cy_root id selector to become data-cy-root for component mounting ([#20951](https://github.com/cypress-io/cypress/issues/20951)) ([0e7b555](https://github.com/cypress-io/cypress/commit/0e7b555f93fb403f431c5de4a07ae7ad6ac89ba2))
 * Use .config files ([#18578](https://github.com/cypress-io/cypress/issues/18578)) ([081dd19](https://github.com/cypress-io/cypress/commit/081dd19cc6da3da229a7af9c84f62730c85a5cd6))
-* use devServer instad of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
+* use devServer instead of startDevServer ([#20092](https://github.com/cypress-io/cypress/issues/20092)) ([8a6768f](https://github.com/cypress-io/cypress/commit/8a6768fee6f46b908c5a9daf23da8b804a6c627f))
 * use hoisted yarn install in binary build ([#17285](https://github.com/cypress-io/cypress/issues/17285)) ([e4f5b10](https://github.com/cypress-io/cypress/commit/e4f5b106d49d6ac0857c5fdac886f83b99558c88))
 * Use plugins on config files ([#18798](https://github.com/cypress-io/cypress/issues/18798)) ([bb8251b](https://github.com/cypress-io/cypress/commit/bb8251b752ac44f1184f9160194cf12d41fc867f))
 * use supportFile by testingType ([#19364](https://github.com/cypress-io/cypress/issues/19364)) ([0366d4f](https://github.com/cypress-io/cypress/commit/0366d4fa8971e5e5189c6fd6450cc3c8d72dcfe1))

--- a/npm/cypress-schematic/CHANGELOG.md
+++ b/npm/cypress-schematic/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 * update changelog references to make it clearer on where angular 17 packages live historically
 
-* fix cy framework errors app test to use angualr 18 and 19
+* fix cy framework errors app test to use angular 18 and 19
 
 * fix issue where di was not discoverable in resolved system tests config
 

--- a/npm/eslint-plugin-dev/CHANGELOG.md
+++ b/npm/eslint-plugin-dev/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
-* allow for versions greater than 4 for eslint-plugin-mocha to prevent force installing dependencies when eslint-plugin-mocha is bumbed in comsumer packages ([#27944](https://github.com/cypress-io/cypress/issues/27944)) ([bf05978](https://github.com/cypress-io/cypress/commit/bf0597847e71f34303364929f9c34cdd6c0e7ad8))
+* allow for versions greater than 4 for eslint-plugin-mocha to prevent force installing dependencies when eslint-plugin-mocha is bumbed in consumer packages ([#27944](https://github.com/cypress-io/cypress/issues/27944)) ([bf05978](https://github.com/cypress-io/cypress/commit/bf0597847e71f34303364929f9c34cdd6c0e7ad8))
 
 # [@cypress/eslint-plugin-dev-v5.3.2](https://github.com/cypress-io/cypress/compare/@cypress/eslint-plugin-dev-v5.3.1...@cypress/eslint-plugin-dev-v5.3.2) (2022-08-15)
 

--- a/npm/mount-utils/README.md
+++ b/npm/mount-utils/README.md
@@ -80,7 +80,7 @@ export function mount(
   // Render HTML containing component.
   $root.innerHTML = `<${name} id="root"></${name}>`;
 
-  // Log a messsage in the Command Log.
+  // Log a message in the Command Log.
   Cypress.log({
     name: "mount",
     message: [`<${name} ... />`],

--- a/npm/react/CHANGELOG.md
+++ b/npm/react/CHANGELOG.md
@@ -392,7 +392,7 @@
 
 ### Bug Fixes
 
-* removing test for previous undesireable behavior ([#15458](https://github.com/cypress-io/cypress/issues/15458)) ([35dde75](https://github.com/cypress-io/cypress/commit/35dde753560e9d53d1c49131187ff30d8e31fc75))
+* removing test for previous undesirable behavior ([#15458](https://github.com/cypress-io/cypress/issues/15458)) ([35dde75](https://github.com/cypress-io/cypress/commit/35dde753560e9d53d1c49131187ff30d8e31fc75))
 * **@cypress/react:** Correctly unmount react components ([#15250](https://github.com/cypress-io/cypress/issues/15250)) ([6b515c7](https://github.com/cypress-io/cypress/commit/6b515c777ca2fa599f21dc47d181fd28a7eb6db0))
 * **component-testing:** ensure to call unmount after each test ([#15385](https://github.com/cypress-io/cypress/issues/15385)) ([153fc51](https://github.com/cypress-io/cypress/commit/153fc515a53343758393db795879a64494374551))
 * make webpack-dev-server a peer dependency ([#15163](https://github.com/cypress-io/cypress/issues/15163)) ([fa969fb](https://github.com/cypress-io/cypress/commit/fa969fba78d86494b5d920f573768677301fad13))

--- a/npm/webpack-dev-server/CHANGELOG.md
+++ b/npm/webpack-dev-server/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ### Bug Fixes
 
-* extranous angular warnings ([#32251](https://github.com/cypress-io/cypress/issues/32251)) ([c8606c2](https://github.com/cypress-io/cypress/commit/c8606c21ae148459fe54d74e040fd2ec5bdc3d08))
+* extraneous angular warnings ([#32251](https://github.com/cypress-io/cypress/issues/32251)) ([c8606c2](https://github.com/cypress-io/cypress/commit/c8606c21ae148459fe54d74e040fd2ec5bdc3d08))
 
 # [@cypress/webpack-dev-server-v5.1.0](https://github.com/cypress-io/cypress/compare/@cypress/webpack-dev-server-v5.0.0...@cypress/webpack-dev-server-v5.1.0) (2025-08-14)
 
@@ -95,7 +95,7 @@
 
 * update changelog references to make it clearer on where angular 17 packages live historically
 
-* fix cy framework errors app test to use angualr 18 and 19
+* fix cy framework errors app test to use angular 18 and 19
 
 * fix issue where di was not discoverable in resolved system tests config
 

--- a/packages/packherd-require/README.md
+++ b/packages/packherd-require/README.md
@@ -65,7 +65,7 @@ To enable this feature the [packherdRequire][require fn] has to be invoked in or
 have it hook into Node.js `require` calls via a `Module._extension`. Particularly the
 [`transpileOpts`][transpile opts] field of the [opts][require opts] needs to be configured as follows.
 
-- `supportTS`: `true`
+- `supports`: `true`
 - `initTranspileCache`: needs to be a function matching [InitTranspileCache][init transpile cache fn]
 
 ### Transpile Cache


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; no runtime code or behavior is modified.
> 
> **Overview**
> **Documentation polish:** fixes a handful of typos and wording issues across various package changelogs/READMEs (e.g. spelling corrections, minor grammar tweaks).
> 
> Also corrects an option name in `packages/packherd-require/README.md` (documents `supports` instead of `supportTS`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a74fb6bcfd58836240ae4716408c2b019a8d17f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->