### PR TITLE
perf: skip git status and git log calls in run mode

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ _Released 03/31/2026 (PENDING)_
 **Performance:**
 
 - When recording to Cypress Cloud, the App now sends a smaller snapshot of your project config, which reduces payload size and can make Cloud recording faster. Addressed in [#33517](https://github.com/cypress-io/cypress/pull/33517).
+- Eliminated unnecessary `git status` and `git log` subprocess calls during `cypress run`, which were collecting spec file git metadata only used in the interactive GUI. Fixed in [#33552](https://github.com/cypress-io/cypress/pull/33552).
 
 **Bugfixes:**
 

--- a/packages/data-context/src/sources/GitDataSource.ts
+++ b/packages/data-context/src/sources/GitDataSource.ts
@@ -157,7 +157,7 @@ export class GitDataSource {
   }
 
   setSpecs (specs: string[]) {
-    if (this.#destroyed) {
+    if (this.#destroyed || this.config.isRunMode) {
       return
     }
 

--- a/packages/data-context/test/unit/sources/GitDataSource_unit.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource_unit.spec.ts
@@ -50,6 +50,39 @@ describe('GitDataSource', () => {
   })
 
   describe('Unit', () => {
+    describe('in run mode', () => {
+      it('does not load git info when setSpecs is called', async () => {
+        const revparseP = pDefer<void>()
+
+        stubbedSimpleGit.revparse.mockImplementationOnce((opts: string) => {
+          revparseP.resolve()
+
+          return Promise.resolve('/root') as unknown as R<'revparse'>
+        })
+
+        const onGitInfoChange = jest.fn()
+
+        const gds = new GitDataSource({
+          isRunMode: true,
+          projectRoot: '/root',
+          onBranchChange: jest.fn(),
+          onGitInfoChange,
+          onError: jest.fn(),
+          onGitLogChange: jest.fn(),
+        })
+
+        await revparseP.promise
+
+        gds.setSpecs(['/root/cypress/e2e/spec.cy.ts'])
+
+        // In run mode, setSpecs should be a no-op — no git status or git log calls
+        expect(stubbedSimpleGit.status).not.toHaveBeenCalled()
+        expect(onGitInfoChange).not.toHaveBeenCalled()
+
+        await gds.destroy()
+      })
+    })
+
     describe('in open mode', () => {
       let gds: GitDataSource
       let projectRoot: string


### PR DESCRIPTION
### Additional details

`GitDataSource.setSpecs()` calls `git status --porcelain` (via `simple-git`) and `git log` for every spec file, even during `cypress run`. The constructor already skips the 60-second git polling loop when `isRunMode` is true, but `setSpecs()` is a separate entry point that was missing the same guard.

Since the git info (modified/created badges, last author, commit hash) is only displayed in the spec list UI during `cypress open`, these calls are pure overhead in run mode — spawning git subprocesses in CI for data that is never consumed.

The fix adds `this.config.isRunMode` to the existing early-return check in `setSpecs()`. Other run-mode-critical data (`gitBaseDir`, used as `repoRoot` for Cloud recording) is already populated by the constructor's `#verifyGitRepo()` call and is unaffected.

### Steps to test

1. Run `cypress run --spec <any-spec>` with `DEBUG=cypress:data-context:sources:GitDataSource`
2. Confirm there are no `git log` or `git status` calls logged after initialization
3. Confirm Cloud recording (if enabled) still reports the correct `repoRoot`

### How has the user experience changed?

No user-facing behavior change. `cypress run` no longer spawns unnecessary `git status` and `git log` subprocesses, reducing CI overhead.

This isn't a super large perf win or anything, just something that was noted as odd when experimenting with some stuff for task sandboxing.

  ### PR Tasks

  - [x] Have tests been added/updated?
  - [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
  - [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early return in `GitDataSource.setSpecs()` when `isRunMode` is enabled, preventing extra git subprocesses without affecting run-mode repo root detection. Main risk is missing spec git metadata if any run-mode code path unexpectedly relied on it.
> 
> **Overview**
> Avoids per-spec git metadata collection during `cypress run` by making `GitDataSource.setSpecs()` a no-op when `isRunMode` is true, eliminating unnecessary `git status`/`git log` work.
> 
> Adds a unit test asserting `setSpecs()` does not trigger git info loading in run mode, and documents the performance improvement in the `15.13.1` changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 462380bb3c733369e85527c77a58846c0229d99b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->