### PR TITLE
fix(cy.wrap): preserve custom onFail when wrapping rejected promises

### DIFF
--- a/packages/driver/cypress/e2e/commands/misc.cy.js
+++ b/packages/driver/cypress/e2e/commands/misc.cy.js
@@ -321,6 +321,28 @@ describe('src/cy/commands/misc', () => {
 
         cy.wrap(rejectedPromise)
       })
+
+      // https://github.com/cypress-io/cypress/issues/FIXME
+      // When a rejected promise error already has a custom `onFail` handler
+      // (e.g. set by throwErrByPath in cy.prompt's throwPromptError),
+      // cy.wrap's catch must not overwrite it — the log handler is a fallback only.
+      it('preserves a custom onFail already attached to the rejected error', function (done) {
+        const customOnFail = cy.stub()
+
+        const err = new Error('error with custom onFail')
+
+        err.onFail = customOnFail
+
+        const rejectedPromise = Promise.reject(err)
+
+        cy.on('fail', () => {
+          expect(customOnFail).to.have.been.calledOnce
+          expect(customOnFail).to.have.been.calledWith(err)
+          done()
+        })
+
+        cy.wrap(rejectedPromise)
+      })
     })
 
     describe('circular references', () => {

--- a/packages/driver/cypress/e2e/commands/misc.cy.js
+++ b/packages/driver/cypress/e2e/commands/misc.cy.js
@@ -322,7 +322,6 @@ describe('src/cy/commands/misc', () => {
         cy.wrap(rejectedPromise)
       })
 
-      // https://github.com/cypress-io/cypress/issues/FIXME
       // When a rejected promise error already has a custom `onFail` handler
       // (e.g. set by throwErrByPath in cy.prompt's throwPromptError),
       // cy.wrap's catch must not overwrite it — the log handler is a fallback only.

--- a/packages/driver/src/cy/commands/misc.ts
+++ b/packages/driver/src/cy/commands/misc.ts
@@ -53,7 +53,9 @@ export default (Commands, Cypress, cy, state) => {
       })
       .catch((err) => {
         $errUtils.throwErr(err, {
-          onFail: options._log,
+          // Don't overwrite a custom onFail already set on the error (e.g. by throwErrByPath
+          // in cy.prompt's throwPromptError). cy.wrap's log handler is a fallback only.
+          onFail: err.onFail ? undefined : options._log,
         })
       })
       .then((subject) => {


### PR DESCRIPTION
### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `cy.wrap` error-handling for rejected promises, which can affect how failures are surfaced/logged across many tests. Scope is small but touches a core command and could alter failure reporting behavior in edge cases.
> 
> **Overview**
> `cy.wrap()` no longer overwrites an existing `err.onFail` when wrapping a rejected promise; it only supplies its log-based `onFail` fallback when the error doesn’t already define one.
> 
> Adds an e2e test ensuring a rejected error with a pre-attached custom `onFail` is preserved and invoked during failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43095682963d6f5e891f01d4673b674439dbf9a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?