### PR TITLE
dependency: update basic-ftp to 5.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,5 @@ system-tests/lib/validations
 !.cursor/BUGBOT.md
 
 settings.local.json
+
+.claude/*

--- a/yarn.lock
+++ b/yarn.lock
@@ -11544,9 +11544,9 @@ basic-auth@2.0.1, basic-auth@~2.0.0:
     safe-buffer "5.1.2"
 
 basic-ftp@^5.0.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.0.tgz#7c2dff63c918bde60e6bad1f2ff93dcf5137a40a"
-  integrity sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.2.tgz#4cb2422deddf432896bdb3c9b8f13b944ad4842c"
+  integrity sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==
 
 batch@0.6.1:
   version "0.6.1"


### PR DESCRIPTION
- Closes n/a

### Additional details

Updates the `basic-ftp` dependency from 5.2.0 to 5.2.2. This is a patch version bump that picks up bug fixes and improvements in the upstream package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch-level dependency lockfile update plus a minor `.gitignore` tweak; any impact is limited to FTP code paths and local developer files.
> 
> **Overview**
> Updates the lockfile to use `basic-ftp@5.2.2`.
> 
> Tweaks `.gitignore` to ignore `.claude/*` and normalizes the `settings.local.json` entry (newline/formatting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83269d5893faf5d574e6d5e781e62eae7e7ff74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Verify `yarn.lock` reflects `basic-ftp@5.2.2`

### How has the user experience changed?

No user-facing behavior change expected. This is a patch-level dependency update.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?