### PR TITLE
fix: truncate long strings in chai inspect (#33512)

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -69,6 +69,7 @@
         "titleize",
         "topnav",
         "Transpiling",
+        "truncator",
         "uncategorized",
         "unconfigured",
         "unplugin",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,6 +15,7 @@ _Released 04/16/2026_
 **Bugfixes:**
 
 - Fixed an issue where Cypress tests in open mode would not pick up on modified `env` values in the user's config file. Fixed in [#33567](https://github.com/cypress-io/cypress/pull/33567). Fixes [#33372](https://github.com/cypress-io/cypress/issues/33372).
+- Fixed an issue where `cy.readFile(..., 'base64')` assertions against large mismatched strings could appear to hang because assertion messages were not being truncated. Fixes [#25443](https://github.com/cypress-io/cypress/issues/25443).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 <!-- See the ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.14.1
+
+_Released 12/31/2026_ (PENDING)
+
+**Bugfixes:**
+
+- Fixed an issue where `cy.readFile(..., 'base64')` assertions against large mismatched strings could appear to hang because assertion messages were not being truncated. Fixes [#25443](https://github.com/cypress-io/cypress/issues/25443).
+
 ## 15.14.0
 
 _Released 04/16/2026_
@@ -15,7 +23,6 @@ _Released 04/16/2026_
 **Bugfixes:**
 
 - Fixed an issue where Cypress tests in open mode would not pick up on modified `env` values in the user's config file. Fixed in [#33567](https://github.com/cypress-io/cypress/pull/33567). Fixes [#33372](https://github.com/cypress-io/cypress/issues/33372).
-- Fixed an issue where `cy.readFile(..., 'base64')` assertions against large mismatched strings could appear to hang because assertion messages were not being truncated. Fixes [#25443](https://github.com/cypress-io/cypress/issues/25443).
 
 **Dependency Updates:**
 

--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -1316,8 +1316,8 @@ describe('src/cy/commands/assertions', () => {
     describe('escape markdown', () => {
       // https://github.com/cypress-io/cypress/issues/17357
       it('images', (done) => {
-        const text = 'hello world ![JSDoc example](/slides/img/jsdoc.png)'
-        const result = 'hello world ``![JSDoc example](/slides/img/jsdoc.png)``'
+        const text = 'hello ![JSDoc example](/jsdoc.png)'
+        const result = 'hello ``![JSDoc example](/jsdoc.png)``'
 
         expectMarkdown(
           () => expect(text).to.equal(text),

--- a/packages/driver/src/cy/chai/inspect.ts
+++ b/packages/driver/src/cy/chai/inspect.ts
@@ -13,6 +13,9 @@ import getEnumerableProperties from 'chai/lib/chai/utils/getEnumerableProperties
 export function create (chai) {
   const { getName, getProperties } = chai.util
   const { config } = chai
+  // Match `loupe`'s ellipsis truncation marker (kept ASCII only in source).
+  // https://github.com/chaijs/loupe/blob/4386081e3302476af38f6fe64786a3f9c5a30ad4/src/helpers.ts#L48
+  const truncator = '\u2026'
 
   /**
    * ### .inspect(obj, [showHidden], [depth], [colors])
@@ -20,16 +23,15 @@ export function create (chai) {
    * Echoes the value of a value. Tries to print the value out
    * in the best way possible given the different types.
    *
-   * @param {Object} obj The object to print out.
-   * @param {Boolean} showHidden Flag that shows hidden (not enumerable)
+   * @param obj The object to print out.
+   * @param showHidden Flag that shows hidden (not enumerable)
    *    properties of objects. Default is false.
-   * @param {Number} depth Depth in which to descend in object. Default is 2.
-   * @param {Boolean} colors Flag to turn on ANSI escape codes to color the
+   * @param depth Depth in which to descend in object. Default is 2.
+   * @param colors Flag to turn on ANSI escape codes to color the
    *    output. Default is false (no coloring).
    * @namespace Utils
-   * @name inspect
    */
-  function inspect (obj, showHidden, depth, colors) {
+  function inspect (obj: any, showHidden?: boolean, depth?: number, _colors?: boolean) {
     let ctx = {
       showHidden,
       seen: [],
@@ -69,6 +71,35 @@ export function create (chai) {
   let formatValueHook
 
   const setFormatValueHook = (fn) => formatValueHook = fn
+
+  const isHighSurrogate = (char: string) => char >= '\ud800' && char <= '\udbff'
+
+  const truncate = (string: string, length: number, tail?: string) => {
+    string = String(string)
+    tail = tail ?? truncator
+
+    const tailLength = tail.length
+    const stringLength = string.length
+
+    // If the truncation marker is longer than the requested output, return only
+    // the marker.
+    if (tailLength > length && stringLength > tailLength) {
+      return tail
+    }
+
+    if (stringLength > length && stringLength > tailLength) {
+      let end = length - tailLength
+
+      // Avoid splitting a UTF-16 surrogate pair at the truncation boundary.
+      if (end > 0 && isHighSurrogate(string[end - 1])) {
+        end -= 1
+      }
+
+      return `${string.slice(0, end)}${tail}`
+    }
+
+    return string
+  }
 
   function formatValue (ctx, value, recurseTimes) {
     // Provide a hook for user-specified inspect functions.
@@ -253,11 +284,14 @@ export function create (chai) {
         return ctx.stylize('undefined', 'undefined')
 
       case 'string': {
-        const simple = `'${JSON.stringify(value).replace(/^"|"$/g, '')
+        const simple = JSON.stringify(value).replace(/^"|"$/g, '')
         .replace(/'/g, '\\\'')
-        .replace(/\\"/g, '"')}'`
+        .replace(/\\"/g, '"')
+        const truncated = config.truncateThreshold
+          ? truncate(simple, config.truncateThreshold - 2)
+          : simple
 
-        return ctx.stylize(simple, 'string')
+        return ctx.stylize(`'${truncated}'`, 'string')
       }
 
       case 'number':

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -21,8 +21,71 @@ const ERROR_PROPS = ['message', 'type', 'name', 'stack', 'parsedStack', 'fileNam
 const ERR_PREPARED_FOR_SERIALIZATION = Symbol('ERR_PREPARED_FOR_SERIALIZATION')
 
 const crossOriginScriptRe = /^script error/i
+const truncator = '\u2026'
+const NO_DIFFERENCE = -1
 
 let allErrorMessages = $errorMessages
+
+/**
+ * Returns the index of the first character where two strings differ, or
+ * `NO_DIFFERENCE` if identical.
+ */
+const getFirstDifferenceIndex = (a: string, b: string) => {
+  const len = Math.min(a.length, b.length)
+  let i = 0
+
+  while (i < len && a[i] === b[i]) i++
+
+  return i === a.length && i === b.length ? NO_DIFFERENCE : i
+}
+
+/**
+ * Returns a truncated view of `value` centered around `differenceIndex`.
+ */
+const getDiffWindow = (value: string, differenceIndex: number) => {
+  const { truncateThreshold: threshold } = chai.config
+
+  if (threshold <= 0 || value.length <= threshold) return value
+
+  const halfWindow = Math.floor(threshold / 2)
+  const start = Math.max(
+    0,
+    Math.min(differenceIndex - halfWindow, value.length - threshold),
+  )
+  const end = start + threshold
+
+  const prefix = start > 0 ? truncator : ''
+  const suffix = end < value.length ? truncator : ''
+
+  const visibleStart = start + (prefix ? 1 : 0)
+  const visibleEnd = end - (suffix ? 1 : 0)
+
+  return `${prefix}${value.slice(visibleStart, visibleEnd)}${suffix}`
+}
+
+/**
+ * Returns `actual` and `expected` truncated around their first difference, or
+ * unchanged if either is not a string.
+ */
+const getDiffFriendlyStringValues = (
+  actual: unknown,
+  expected: unknown,
+) => {
+  if (typeof actual !== 'string' || typeof expected !== 'string') {
+    return { actual, expected }
+  }
+
+  const differenceIndex = getFirstDifferenceIndex(actual, expected)
+
+  if (differenceIndex === NO_DIFFERENCE) {
+    return { actual, expected }
+  }
+
+  return {
+    actual: getDiffWindow(actual, differenceIndex),
+    expected: getDiffWindow(expected, differenceIndex),
+  }
+}
 
 if (!Error.captureStackTrace) {
   Error.captureStackTrace = (err, fn) => {
@@ -46,12 +109,14 @@ const prepareErrorForSerialization = (err) => {
   }
 
   if (err.showDiff === true) {
+    const diffFriendlyValues = getDiffFriendlyStringValues(err.actual, err.expected)
+
     if (err.actual) {
-      err.actual = chai.util.inspect(err.actual)
+      err.actual = chai.util.inspect(diffFriendlyValues.actual)
     }
 
     if (err.expected) {
-      err.expected = chai.util.inspect(err.expected)
+      err.expected = chai.util.inspect(diffFriendlyValues.expected)
     }
   } else {
     delete err.actual

--- a/packages/driver/src/cypress/error_utils.ts
+++ b/packages/driver/src/cypress/error_utils.ts
@@ -23,8 +23,17 @@ const ERR_PREPARED_FOR_SERIALIZATION = Symbol('ERR_PREPARED_FOR_SERIALIZATION')
 const crossOriginScriptRe = /^script error/i
 const truncator = '\u2026'
 const NO_DIFFERENCE = -1
+const STRING_INSPECT_OVERHEAD = 2
 
 let allErrorMessages = $errorMessages
+
+const getStringDiffWindowSize = () => {
+  const { truncateThreshold: threshold } = chai.config
+
+  if (threshold <= 0) return threshold
+
+  return Math.max(1, threshold - STRING_INSPECT_OVERHEAD)
+}
 
 /**
  * Returns the index of the first character where two strings differ, or
@@ -43,16 +52,16 @@ const getFirstDifferenceIndex = (a: string, b: string) => {
  * Returns a truncated view of `value` centered around `differenceIndex`.
  */
 const getDiffWindow = (value: string, differenceIndex: number) => {
-  const { truncateThreshold: threshold } = chai.config
+  const windowSize = getStringDiffWindowSize()
 
-  if (threshold <= 0 || value.length <= threshold) return value
+  if (windowSize <= 0 || value.length <= windowSize) return value
 
-  const halfWindow = Math.floor(threshold / 2)
+  const halfWindow = Math.floor(windowSize / 2)
   const start = Math.max(
     0,
-    Math.min(differenceIndex - halfWindow, value.length - threshold),
+    Math.min(differenceIndex - halfWindow, value.length - windowSize),
   )
-  const end = start + threshold
+  const end = start + windowSize
 
   const prefix = start > 0 ? truncator : ''
   const suffix = end < value.length ? truncator : ''

--- a/packages/driver/test/unit/cy/chai/inspect.spec.ts
+++ b/packages/driver/test/unit/cy/chai/inspect.spec.ts
@@ -1,0 +1,14 @@
+import chai from 'chai'
+import { describe, expect, it } from 'vitest'
+
+import { create } from '../../../../src/cy/chai/inspect'
+
+describe('cy/chai/inspect', () => {
+  it('should truncate long strings the same way as chai', () => {
+    const { inspect } = create(chai)
+    const value = 'a'.repeat(10000)
+    const expected = `'${'a'.repeat(chai.config.truncateThreshold - 3)}\u2026'`
+
+    expect(inspect(value)).to.equal(expected)
+  })
+})

--- a/packages/driver/test/unit/cypress/err_utils.spec.ts
+++ b/packages/driver/test/unit/cypress/err_utils.spec.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { vi, describe, it, expect, beforeEach } from 'vitest'
+import chai from 'chai'
 
 // source_map_utils must be included in order for vite to mock it, even
 // if it isn't referenced.
@@ -63,5 +64,89 @@ describe('err_utils', () => {
         })
       })
     }
+  })
+
+  describe('wrapErr', () => {
+    const { truncateThreshold: threshold } = chai.config
+    const baseErr = {
+      message: 'expected values to be equal',
+      name: 'AssertionError',
+      showDiff: true,
+    }
+
+    const makeWrapped = (actual: unknown, expected: unknown) => {
+      return errUtils.wrapErr({ ...baseErr, actual, expected })
+    }
+
+    const makeExpected = (actual: unknown, expected: unknown) => {
+      return { ...baseErr, actual, expected }
+    }
+
+    it('should return non-string values unchanged', () => {
+      const wrapped = makeWrapped({ a: 1 }, { a: 2 })
+
+      expect(wrapped).to.deep.eq(
+        makeExpected('{ a: 1 }', '{ a: 2 }'),
+      )
+    })
+
+    it('should return identical strings unchanged', () => {
+      const value = 'identical'
+      const wrapped = makeWrapped(value, value)
+
+      expect(wrapped).to.deep.eq(
+        makeExpected('\'identical\'', '\'identical\''),
+      )
+    })
+
+    it('should return short strings unchanged', () => {
+      const actual = 'short-X'
+      const expected = 'short-Y'
+      const wrapped = makeWrapped(actual, expected)
+
+      expect(wrapped).to.deep.eq(
+        makeExpected('\'short-X\'', '\'short-Y\''),
+      )
+    })
+
+    it('should truncate long strings around the diff with both markers', () => {
+      const samePrefix = 'a'.repeat(threshold + 10)
+      const actual = `${samePrefix}X${'b'.repeat(50)}`
+      const expected = `${samePrefix}Y${'b'.repeat(50)}`
+      const wrapped = makeWrapped(actual, expected)
+
+      expect(wrapped).to.deep.eq(
+        makeExpected(
+          '\'…aaaaaaaaaaaaaaaaaaaXbbbbbbbbbbbbbbbbbb…\'',
+          '\'…aaaaaaaaaaaaaaaaaaaYbbbbbbbbbbbbbbbbbb…\'',
+        ),
+      )
+    })
+
+    it('should omit leading marker when difference is near the start', () => {
+      const actual = `X${'a'.repeat(threshold + 10)}`
+      const expected = `Y${'a'.repeat(threshold + 10)}`
+      const wrapped = makeWrapped(actual, expected)
+
+      expect(wrapped).to.deep.eq(
+        makeExpected(
+          '\'Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
+          '\'Yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
+        ),
+      )
+    })
+
+    it('should omit trailing marker when difference is near the end', () => {
+      const actual = `${'a'.repeat(threshold + 10)}X`
+      const expected = `${'a'.repeat(threshold + 10)}Y`
+      const wrapped = makeWrapped(actual, expected)
+
+      expect(wrapped).to.deep.eq(
+        makeExpected(
+          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX\'',
+          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaY\'',
+        ),
+      )
+    })
   })
 })

--- a/packages/driver/test/unit/cypress/err_utils.spec.ts
+++ b/packages/driver/test/unit/cypress/err_utils.spec.ts
@@ -117,8 +117,8 @@ describe('err_utils', () => {
 
       expect(wrapped).to.deep.eq(
         makeExpected(
-          '\'…aaaaaaaaaaaaaaaaaaaXbbbbbbbbbbbbbbbbbb…\'',
-          '\'…aaaaaaaaaaaaaaaaaaaYbbbbbbbbbbbbbbbbbb…\'',
+          '\'…aaaaaaaaaaaaaaaaaaXbbbbbbbbbbbbbbbbb…\'',
+          '\'…aaaaaaaaaaaaaaaaaaYbbbbbbbbbbbbbbbbb…\'',
         ),
       )
     })
@@ -130,8 +130,8 @@ describe('err_utils', () => {
 
       expect(wrapped).to.deep.eq(
         makeExpected(
-          '\'Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
-          '\'Yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
+          '\'Xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
+          '\'Yaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…\'',
         ),
       )
     })
@@ -143,10 +143,58 @@ describe('err_utils', () => {
 
       expect(wrapped).to.deep.eq(
         makeExpected(
-          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX\'',
-          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaY\'',
+          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX\'',
+          '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaY\'',
         ),
       )
+    })
+
+    it('should keep the differing character when it is near the right edge after inspect truncation', () => {
+      const { truncateThreshold: threshold } = chai.config
+      const { inspect: originalInspect } = chai.util
+
+      const truncator = '\u2026'
+
+      const truncate = (string: string, length: number, tail: string) => {
+        if (string.length > length && string.length > tail.length) {
+          return `${string.slice(0, length - tail.length)}${tail}`
+        }
+
+        return string
+      }
+
+      chai.util.inspect = (value: unknown) => {
+        if (typeof value !== 'string') {
+          return originalInspect(value)
+        }
+
+        const simple = JSON.stringify(value)
+        .replace(/^"|"$/g, '')
+        .replace(/'/g, '\\\'')
+        .replace(/\\"/g, '"')
+
+        const truncated = threshold
+          ? truncate(simple, threshold - 2, truncator)
+          : simple
+
+        return `'${truncated}'`
+      }
+
+      try {
+        const samePrefix = 'a'.repeat(threshold + 10)
+        const actual = `${samePrefix}X`
+        const expected = `${samePrefix}Y`
+        const wrapped = makeWrapped(actual, expected)
+
+        expect(wrapped).to.deep.eq(
+          makeExpected(
+            '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaX\'',
+            '\'…aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaY\'',
+          ),
+        )
+      } finally {
+        chai.util.inspect = originalInspect
+      }
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/25443
- Follow-up to https://github.com/cypress-io/cypress/pull/33512 and https://github.com/cypress-io/cypress/pull/33611

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

- The reverted changes improved performance by truncating long strings. However, they also led to missing string diffs in `run` mode for large values. The issue came from serializing `err.actual` and `err.expected` with truncated inspect output that could become identical when the mismatch was outside the displayed prefix.
- I updated error processing to keep a window around the first differing character when both values are strings, then inspect those values. This change should keep payloads compact while preserving output diff context.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches assertion string formatting and error serialization paths used widely across failures; logic is well-tested but could subtly affect displayed assertion output and truncation boundaries.
> 
> **Overview**
> Fixes long-string assertion output truncation so large mismatched string assertions no longer appear to hang or lose diff context.
> 
> This updates the custom `chai` `inspect` implementation to truncate string primitives using the same ellipsis marker as `loupe` while avoiding surrogate-pair splits, and adjusts error serialization (`wrapErr`) to window `actual`/`expected` strings around their first differing character before calling `chai.util.inspect`, preventing both sides from truncating to identical prefixes.
> 
> Adds focused unit tests covering `inspect` truncation and diff-window behavior, tweaks an e2e markdown-escape fixture, and records the bugfix in `cli/CHANGELOG.md` (plus a `cspell` word add).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f828eb1321c31b0e77e4fd764ce748595e585e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

```sh
yarn workspace @packages/driver test test/unit/cy/chai/inspect.spec.ts test/unit/cypress/err_utils.spec.ts
```

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

Before this follow-up, the previous truncation only approach could hide the first differing character for long strings, so `run` mode could show:

```text
Timed out retrying after 4000ms
+ expected - actual
```

After this change, long strings should still be condensed. However, the output should include context around the first mismatch so it's actionable.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
