### PR TITLE
fixed issue #32779

### DIFF
--- a/packages/reporter/src/runnables/runnable-popover-options.tsx
+++ b/packages/reporter/src/runnables/runnable-popover-options.tsx
@@ -6,7 +6,7 @@ import cs from 'classnames'
 
 import Tooltip from '@cypress/react-tooltip'
 import Button from '@cypress-design/react-button'
-import { IconActionAddMedium, IconWindowCodeEditor, IconMenuDotsVertical } from '@cypress-design/react-icon'
+import { IconActionAddMedium, IconWindowCodeEditorSmall, IconMenuDotsVertical } from '@cypress-design/react-icon'
 import defaultEvents, { Events } from '../lib/events'
 import Switch from '../lib/switch'
 import appState from '../lib/app-state'
@@ -142,7 +142,7 @@ export const RunnablePopoverOptions: React.FC<Props> = observer(({
           onClick={handleOpenInIDE}
           data-cy="runnable-popover-open-ide"
         >
-          <IconWindowCodeEditor strokeColor="gray-500" fillColor="gray-500" />
+          <IconWindowCodeEditorSmall strokeColor="gray-500" fillColor="gray-500" />
           <span>Open in IDE</span>
         </button>
 


### PR DESCRIPTION
​This PR fixes #32779 
Adjusted the icon size in runnable-popover-options.tsx to match the UI requirements.

Note: ​I had some trouble running the full environment locally for screenshots, but the change is a straightforward component rename which is clear in the code.

​Closes #32779