### PR TITLE
test: scrub non-deterministic Vite client log lines from stdout snapshots

### DIFF
--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -167,6 +167,9 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   // Replaces "new dependencies optimized" message from vite as it does not respect the logLevel='silent' option
   .replace(/^.*Re-optimizing dependencies.*?\n$/gm, '')
   .replace(/\).*new dependencies optimized.*?\n/gm, ')\n')
+  // Strip non-deterministic Vite timestamped log lines (e.g. "2:59:36 PM [vite] (client) ...")
+  // that occasionally leak into stdout despite logLevel='silent'
+  .replace(/^\d{1,2}:\d{2}:\d{2}\s(?:AM|PM)\s\[vite\].*\n/gm, '')
 
   if (options.browser === 'webkit') {
     // WebKit throws for lookups on undefined refs with "Can't find variable: <var>"

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -138,6 +138,10 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   .replace(/\s\(\d+([ms]|ms)\)/g, '')
   // escape "Timed out retrying" messages
   .replace(retryDuration, 'TORA$1')
+  // Strip non-deterministic Vite timestamped log lines (e.g. "2:59:36 PM [vite] (client) ...")
+  // that occasionally leak into stdout despite logLevel='silent'.
+  // Must run before STDOUT_DURATION_IN_TABLES_RE, which would otherwise consume the timestamp.
+  .replace(/^\d{1,2}:\d{2}:\d{2}\s(?:AM|PM)\s\[vite\].*\n/gm, '')
   // 12:35 -> XX:XX
   .replace(STDOUT_DURATION_IN_TABLES_RE, replaceDurationInTables)
   // restore "Timed out retrying" messages
@@ -167,9 +171,6 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   // Replaces "new dependencies optimized" message from vite as it does not respect the logLevel='silent' option
   .replace(/^.*Re-optimizing dependencies.*?\n$/gm, '')
   .replace(/\).*new dependencies optimized.*?\n/gm, ')\n')
-  // Strip non-deterministic Vite timestamped log lines (e.g. "2:59:36 PM [vite] (client) ...")
-  // that occasionally leak into stdout despite logLevel='silent'
-  .replace(/^\d{1,2}:\d{2}:\d{2}\s(?:AM|PM)\s\[vite\].*\n/gm, '')
 
   if (options.browser === 'webkit') {
     // WebKit throws for lookups on undefined refs with "Can't find variable: <var>"


### PR DESCRIPTION
- Closes n/a

### Additional details

Fixes a flaky failure in the `@cypress/vite-dev-server react executes all of the specs for vite8.0.0-react` system test (and likely the other Vite variants).

The test compares stdout against a saved snapshot. Vite's logger occasionally writes a timestamped line such as `2:59:36 PM [vite] (client) ...` to stdout — despite `logLevel: 'silent'` — before the Cypress `(Run Starting)` banner, which produces a snapshot diff that fails the test non-deterministically.

Observed failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/80679/workflows/e56bacac-95b8-467e-ba43-463928860150/jobs/3562452/tests#failed-test-0

This change adds a scrub in `normalizeStdout` that strips any line matching `^<H:MM:SS> (AM|PM) [vite] ...`, mirroring the existing scrubs just above it for Vite's `Re-optimizing dependencies` and `new dependencies optimized` leaks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only stdout snapshot normalization change that strips specific Vite log lines; main risk is accidentally removing legitimate stdout lines that match the timestamped `[vite]` pattern.
> 
> **Overview**
> Reduces system test flakiness by extending `normalizeStdout` to strip non-deterministic, timestamped Vite client log lines (e.g. `2:59:36 PM [vite] ...`) that can leak into stdout even with `logLevel: 'silent'`.
> 
> The scrub runs *before* `STDOUT_DURATION_IN_TABLES_RE` normalization to avoid the timestamp being mistaken for a duration in snapshot output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e974e95bbe98a54aaa4707827bc17b1f17472438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Re-run the `vite_dev_server_fresh_spec` system tests in CI; they should no longer fail when Vite emits a stray client log line.

### How has the user experience changed?

No user-facing change — system-tests-only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?