### PR TITLE
test: reduce flake in experimental retries mochaEvents tests

### DIFF
--- a/packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.cy.ts
+++ b/packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.cy.ts
@@ -14,7 +14,7 @@ import { runCypressInCypressMochaEventsTest } from './support/mochaEventsUtils'
  * 'detect-flake-and-pass-on-threshold' will have a passed test as long as the config passesRequired is satisfied on retries.
  * 'detect-flake-but-always-fail' projects should have the same passed/failed tests, but different number of attempts depending on stopIfAnyPassed
  */
-describe('Experimental retries: mochaEvents & test status tests', { retries: 0, defaultCommandTimeout: 7500 }, () => {
+describe('Experimental retries: mochaEvents & test status tests', { retries: 0, defaultCommandTimeout: 30000 }, () => {
   const projects: ['detect-flake-and-pass-on-threshold', 'detect-flake-but-always-fail', 'detect-flake-but-always-fail-stop-any-passed'] = ['detect-flake-and-pass-on-threshold', 'detect-flake-but-always-fail', 'detect-flake-but-always-fail-stop-any-passed']
 
   projects.forEach((project) => {
@@ -380,7 +380,7 @@ describe('Experimental retries: mochaEvents & test status tests', { retries: 0, 
       // 'detect-flake-and-pass-on-threshold': will run a total of 6 times. All attempts fail. The test fails
       // 'detect-flake-but-always-fail': will run a total of 10 times. All attempts fail. The test fails.
       // 'detect-flake-but-always-fail-stop-any-passed': will run a total of 10 times. All attempts fail. The test fails.
-      describe('cleanses errors before emitting', { defaultCommandTimeout: 15000 }, () => {
+      describe('cleanses errors before emitting', () => {
         it('does not try to serialize error with err.actual as DOM node', function (done) {
           // because there are more attempts for 'detect-flake-but-always-fail', the timeout needs to be increased
           this.timeout(20000)


### PR DESCRIPTION
- Closes n/a

### Additional details

Several tests in `packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.cy.ts` have been observed flaking in CI, e.g. [this run](https://app.circleci.com/pipelines/github/cypress-io/cypress/80638/workflows/092c9cf5-c87e-4f83-9619-7e043d0145f7/jobs/3560896/tests#failed-test-2):

- `detect-flake-but-always-fail can retry from [afterEach] matches mocha snapshot`
- `detect-flake-but-always-fail three tests with retry matches mocha snapshot`
- `detect-flake-but-always-fail cleanses errors before emitting does not try to serialize error with err.actual as DOM node`
- `detect-flake-but-always-fail-stop-any-passed cleanses errors before emitting does not try to serialize error with err.actual as DOM node`

Each test runs an inner cypress-in-cypress spec and waits on a promise that resolves when the inner run fires `cypress:in:cypress:run:complete` (see `support/mochaEventsUtils.ts`). The outer `cy.then((win) => assertMatchingSnapshot(win))` waits for that promise using `defaultCommandTimeout`.

For the `detect-flake-but-always-fail` project, the failing spec is retried 10 times (`maxRetries: 9`, `stopIfAnyPassed: false`). Under CI load, 10 inner attempts plus runner bootstrap regularly exceeds the previous 7500ms command timeout, so the outer `cy.then` times out before the inner run completes — producing the `cy.then() timed out after waiting 15000ms` / equivalent failures.

This PR raises the outer describe's `defaultCommandTimeout` from 7500ms to 30000ms to give the 10-attempt cases enough headroom, and drops the now-redundant 15000ms override on the `cleanses errors before emitting` inner describe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only timeout adjustments to reduce CI flake; no production logic or runtime behavior changes.
> 
> **Overview**
> Reduces CI flake in `retries.experimentalRetries.mochaEvents.cy.ts` by increasing the suite-level `defaultCommandTimeout` from `7500` to `30000` to accommodate slower cypress-in-cypress runs with many retry attempts.
> 
> Removes the now-redundant per-suite `defaultCommandTimeout` override on `cleanses errors before emitting`, relying on the higher top-level timeout instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf02535ec675f0a9d2ba08456b07c7cfdacb1ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Re-run the affected suite in CI and confirm the four tests above no longer flake.
- Locally: \`yarn workspace @packages/app cypress:run:e2e -- --spec packages/app/cypress/e2e/runner/retries.experimentalRetries.mochaEvents.cy.ts\`

### How has the user experience changed?

No user-facing changes — test-only fix.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?