### PR TITLE
test: fix primaryOriginCommunicator cleanup test

### DIFF
--- a/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
+++ b/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
@@ -66,9 +66,12 @@ describe('Cypress In Cypress Origin Communicator', () => {
 
       cy.get('[aria-controls="reporter-inline-specs-list"]').type('{enter}')
       cy.get('[data-cy="spec-row-item"]').contains('123').click()
+      cy.waitForSpecToFinish()
 
       cy.then(() => {
-        expect(removeAllListenersSpy).to.be.calledOnce
+        const noArgCalls = removeAllListenersSpy.getCalls().filter((c) => c.args.length === 0)
+
+        expect(noArgCalls).to.have.length(1)
       })
     })
   })


### PR DESCRIPTION
- Closes n/a

### Additional details

The third test in the `Cypress In Cypress Origin Communicator > primary origin memory leak prevention` suite (`cleans up the primaryOriginCommunicator events when navigating to run a different spec`) has been flaky on CI. Example failures:

- [Pipeline 80679 — called thrice](https://app.circleci.com/pipelines/github/cypress-io/cypress/80679/workflows/278e0a43-c64f-4f38-ae7b-f0e79aac51d2/jobs/3562500/tests#failed-test-3)
- [Pipeline 80659 — never called](https://app.circleci.com/pipelines/github/cypress-io/cypress/80659/workflows/0b35ecd2-3bba-49cc-b519-dca3919ee52f/jobs/3561181/tests#failed-test-4)

**Root cause:** two compounding timing issues.

1. The assertion ran immediately after clicking the new spec row with no wait for the new spec to take over. The intended cleanup call (`Cypress.primaryOriginCommunicator.removeAllListeners()` in `event-manager.ts`) happens when Cypress is re-run for the new spec. If the `cy.then` assertion beat that, the spy saw zero calls.
2. The spy caught all `removeAllListeners` calls, including the event-specific ones that `initializeCloudCyPrompt` makes during cy-prompt re-init on the new spec (`removeAllListeners('prompt:more-info-needed')` and `removeAllListeners('get:source:details:for:line')` in `packages/driver/src/cy/commands/prompt/index.ts`). If cy-prompt's async `loadRemote` resolved before the assertion, the spy saw three calls.

The sweet spot of exactly one call was non-deterministic, so the test was observed failing in both directions (0 and 3).

**Fix:**
- Add `cy.waitForSpecToFinish()` after clicking the new spec so the new spec run is established before asserting.
- Filter the spy's calls to those made with zero arguments, since the memory-leak assertion is only about the global no-arg cleanup. Incidental event-specific removals from cy-prompt initialization are not what this test is verifying.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add an explicit wait and narrow an assertion to a specific `removeAllListeners()` call signature to avoid timing-related flakes.
> 
> **Overview**
> Deflakes the `primaryOriginCommunicator` cleanup E2E test when switching specs by waiting for the newly selected spec to finish before asserting.
> 
> Tightens the assertion to count only zero-argument `removeAllListeners()` calls, avoiding incidental event-specific `removeAllListeners(name)` calls that could make the spy appear over-called.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21b40ab8dc42bb669841d37cdea0eb4979cd0b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Check out this branch.
2. Run the spec repeatedly to confirm stability:
   ```
   yarn workspace @packages/app cypress:run:e2e -- --spec cypress/e2e/cypress-origin-communicator.cy.ts
   ```
3. Test should consistently pass across runs.

### How has the user experience changed?

No user-facing change. Test-only fix.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?