### PR TITLE
test: stabilize flaky cookie override cy.origin test

### DIFF
--- a/packages/driver/cypress/e2e/e2e/origin/cookie_login.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/cookie_login.cy.ts
@@ -117,7 +117,9 @@ describe('cy.origin - cookie login', { browser: '!webkit' }, () => {
       cy.visit('https://localhost:3502/fixtures/primary-origin.html')
       cy.get('[data-cy="cookie-login-override"]').click()
       cy.origin('https://www.foobar.com:3502', { args: { username } }, ({ username }) => {
-        cy.get('[data-cy="username"]').type(username)
+        // the https prelogin -> foobar.com redirect can exceed the default 4s
+        // timeout, so wait longer for the cross-origin page to be ready
+        cy.get('[data-cy="username"]', { timeout: 10000 }).type(username)
         cy.get('[data-cy="login"]').click()
       })
 


### PR DESCRIPTION
- Closes n/a

### Additional details

The `cy.origin - cookie login general behavior handles browser-sent cookies being overridden by server-kept cookies` test is flaky in CI ([example failure](https://app.circleci.com/pipelines/github/cypress-io/cypress/80694/workflows/96b5db12-96a8-4b70-9d65-07e295c6f6ca/jobs/3563311/tests#failed-test-0)).

After clicking `[data-cy="cookie-login-override"]`, the browser navigates to `https://localhost:3502/prelogin` which server-redirects to `https://www.foobar.com:3502/fixtures/auth/cookie-login.html`. Occasionally this https redirect chain takes longer than the default 4s command timeout, so the first `cy.get` inside `cy.origin` fails with:

> The command was expected to run against origin `https://www.foobar.com:3502` but the application is at origin `https://localhost:3502`.

Scoping a longer timeout to just that first `cy.get` inside the `cy.origin` block gives the cross-origin page time to be ready without masking real regressions on any subsequent commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that increases a single command timeout to reduce CI flakiness; no product/runtime logic is modified.
> 
> **Overview**
> Stabilizes the `cy.origin` cookie-login override E2E by extending the timeout on the first cross-origin `cy.get('[data-cy="username"]')` to tolerate occasional slow `https` redirect chains.
> 
> Adds a brief comment explaining the longer wait is scoped to the initial readiness check so subsequent assertions still fail quickly on real regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35734c29ed98ed5030bbd22f952007034121dd51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Run `packages/driver/cypress/e2e/e2e/origin/cookie_login.cy.ts` and confirm the `handles browser-sent cookies being overridden by server-kept cookies` test passes consistently.

### How has the user experience changed?

No user-facing change — test-only stability fix.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?