### PR TITLE
chore: clear stale dest in circle-cache unpack on self-hosted M1

### DIFF
--- a/scripts/circle-cache.js
+++ b/scripts/circle-cache.js
@@ -87,12 +87,13 @@ async function unpackCircleCache () {
 
   await Promise.all(
     paths.map(async (src) => {
-      await fsExtra.move(
-        src,
-        src
-        .replace(CACHE_DIR, BASE_DIR)
-        .replace(/(.*?)_node_modules/, `$1/node_modules`),
-      )
+      const dest = src
+      .replace(CACHE_DIR, BASE_DIR)
+      .replace(/(.*?)_node_modules/, `$1/node_modules`)
+
+      // self-hosted M1 doesn't always clear this directory between runs, so remove it
+      await fsExtra.remove(dest)
+      await fsExtra.move(src, dest)
     }),
   )
 


### PR DESCRIPTION
- Closes n/a

### Additional details

CI job [3563442](https://app.circleci.com/pipelines/github/cypress-io/cypress/80696/workflows/eee80b4c-1f19-4fc9-b8ff-044938aee786/jobs/3563442/steps) failed during `node scripts/circle-cache.js --action unpack` with:

```
Error: dest already exists.
    at /Users/person/cypress/node_modules/fs-extra/lib/move/move.js:41:31
```

The `/Users/person/cypress/...` path indicates this ran on a self-hosted darwin-arm64 (M1) runner. These runners don't reliably clear the workspace between jobs — which is exactly why `prepareCircleCache` already calls `fsExtra.remove(dest)` before the move (see the comment at `scripts/circle-cache.js:73`: *"self-hosted M1 doesn't always clear this directory between runs, so remove it"*).

The symmetric call in `unpackCircleCache` was missing that guard, so a stale `<pkg>/node_modules` from a previous run caused `fsExtra.move` to throw.

This PR mirrors the existing `prepareCircleCache` pattern: compute `dest`, `fsExtra.remove(dest)`, then `fsExtra.move(src, dest)`. Keeps the two halves of the cache dance symmetric.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-script change that only adds a defensive `fsExtra.remove(dest)` before `move` during cache unpacking to avoid failures on runners with stale workspaces.
> 
> **Overview**
> Fixes CircleCI cache unpacking by computing the destination path up front in `unpackCircleCache()` and **removing any existing destination directory** before calling `fsExtra.move()`.
> 
> This mirrors the existing guard used in `prepareCircleCache()` and avoids `dest already exists` errors on self-hosted M1 runners where workspaces may not be fully cleaned between jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e699359c035b63e6086704dc958ed9c5dc09879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This only triggers on self-hosted darwin-arm64 CI runners when a prior job left a stale `node_modules` directory on disk. To validate locally:

1. Create `globbed_node_modules/<pkg>_node_modules/<subpkg>/` with some dummy content.
2. Create a pre-existing `<pkg>/node_modules/` directory.
3. Run `node scripts/circle-cache.js --action unpack`.
4. Before this fix: fails with "dest already exists". After: succeeds.

Also confirm darwin-arm64 CI jobs that use `restore_cached_workspace` no longer flake on the unpack step.

### How has the user experience changed?

No user-facing change — CI tooling only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?