### PR TITLE
breaking: remove `@angular/platform-browser-dynamic` in favor of `@angular/platform-browser` for `@cypress/angular`

### DIFF
--- a/npm/angular/package.json
+++ b/npm/angular/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@angular/common": "^21.0.0",
     "@angular/core": "^21.0.0",
-    "@angular/platform-browser-dynamic": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
     "@cypress/mount-utils": "0.0.0-development",
     "rollup": "^4.60.2",
     "typescript": "~5.9.2"
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@angular/common": ">=21.0.0",
     "@angular/core": ">=21.0.0",
-    "@angular/platform-browser-dynamic": ">=21.0.0",
+    "@angular/platform-browser": ">=21.0.0",
     "rxjs": ">=7.8.0"
   },
   "files": [

--- a/npm/angular/rollup.config.mjs
+++ b/npm/angular/rollup.config.mjs
@@ -5,7 +5,7 @@ const config = {
     '@angular/core',
     '@angular/core/testing',
     '@angular/common',
-    '@angular/platform-browser-dynamic/testing',
+    '@angular/platform-browser/testing',
     '@angular/core/rxjs-interop',
   ],
 }

--- a/npm/angular/src/mount.ts
+++ b/npm/angular/src/mount.ts
@@ -8,12 +8,10 @@ import {
   TestBed,
   TestComponentRenderer,
 } from '@angular/core/testing'
-// NOTE: @angular/platform-browser-dynamic is deprecated and needs to be updated to @angular/platform-browser in a breaking change of Cypress.
-// @see https://github.com/cypress-io/cypress/issues/33006
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing'
+  BrowserTestingModule,
+  platformBrowserTesting,
+} from '@angular/platform-browser/testing'
 import {
   setupHooks,
   getContainerEl,
@@ -551,8 +549,8 @@ export const createOutputSpy = <T>(alias: string) => {
 
 // Only needs to run once, we reset before each test
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
+  BrowserTestingModule,
+  platformBrowserTesting(),
   {
     teardown: { destroyAfterEach: false },
   },

--- a/npm/cypress-schematic/README.md
+++ b/npm/cypress-schematic/README.md
@@ -33,7 +33,7 @@
 
 - Cypress `^16.0.0`
 - Angular `>=21.0.0` 
-    - `@cypress/schematic@5` supports Angular 20 - 21 on Cypress <= `15.0.0`
+    - `@cypress/schematic@5` supports Angular 20 - 21 on Cypress `^15.0.0`
     - `@cypress/schematic@4` supports Angular 18 - 19
     - `@cypress/schematic@3` supports Angular 17
     - `@cypress/schematic@2` supports Angular 13 - 16

--- a/packages/scaffold-config/src/dependencies.ts
+++ b/packages/scaffold-config/src/dependencies.ts
@@ -100,12 +100,12 @@ export const WIZARD_DEPENDENCY_ANGULAR_COMMON = {
   minVersion: '^21.0.0',
 } as const
 
-export const WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER_DYNAMIC = {
+export const WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER = {
   type: 'angular',
-  name: 'Angular Platform Browser Dynamic',
-  package: '@angular/platform-browser-dynamic',
-  installer: '@angular/platform-browser-dynamic',
-  description: 'Library for using Angular in a web browser with JIT compilation',
+  name: 'Angular Platform Browser',
+  package: '@angular/platform-browser',
+  installer: '@angular/platform-browser',
+  description: 'Library for using Angular in a web browser',
   minVersion: '^21.0.0',
 } as const
 
@@ -130,7 +130,7 @@ export const WIZARD_DEPENDENCIES = [
   WIZARD_DEPENDENCY_ANGULAR_DEVKIT_BUILD_ANGULAR,
   WIZARD_DEPENDENCY_ANGULAR_CORE,
   WIZARD_DEPENDENCY_ANGULAR_COMMON,
-  WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER_DYNAMIC,
+  WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER,
   WIZARD_DEPENDENCY_SVELTE,
 ] as const
 
@@ -144,7 +144,7 @@ const componentDependenciesOfInterest = [
   '@angular-devkit/build-angular',
   '@angular/core',
   '@angular/common',
-  '@angular/platform-browser-dynamic',
+  '@angular/platform-browser',
   'react',
   'react-dom',
   'vue',

--- a/packages/scaffold-config/src/frameworks.ts
+++ b/packages/scaffold-config/src/frameworks.ts
@@ -183,7 +183,7 @@ export const CT_FRAMEWORKS: Cypress.ComponentFrameworkDefinition[] = [
         dependencies.WIZARD_DEPENDENCY_ANGULAR_DEVKIT_BUILD_ANGULAR,
         dependencies.WIZARD_DEPENDENCY_ANGULAR_CORE,
         dependencies.WIZARD_DEPENDENCY_ANGULAR_COMMON,
-        dependencies.WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER_DYNAMIC,
+        dependencies.WIZARD_DEPENDENCY_ANGULAR_PLATFORM_BROWSER,
       ]
     },
     codeGenFramework: 'angular',

--- a/system-tests/projects/angular-21/cypress.config.ts
+++ b/system-tests/projects/angular-21/cypress.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
             '@angular/core': require.resolve('@angular/core'),
             '@angular/platform-browser/testing': require.resolve('@angular/platform-browser/testing'),
             '@angular/platform-browser': require.resolve('@angular/platform-browser'),
-            '@angular/platform-browser-dynamic/testing': require.resolve('@angular/platform-browser-dynamic/testing'),
-            '@angular/platform-browser-dynamic': require.resolve('@angular/platform-browser-dynamic'),
           },
         },
       },

--- a/system-tests/projects/angular-21/package.json
+++ b/system-tests/projects/angular-21/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.0",
     "@angular/cli": "^21.2.0",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.0",
     "jsdom": "^27.1.0",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"

--- a/system-tests/projects/angular-21/yarn.lock
+++ b/system-tests/projects/angular-21/yarn.lock
@@ -344,13 +344,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.0":
-  version "21.2.2"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.2.tgz#7c82b40f6fc642887066aca3e91db0365ad99f99"
-  integrity sha512-xhagOxT/2Z66DNR/2mXp94yRXod3AZCpeyeIgluiuUWyDyBzqn1dd7Kdkpae5FYkoDDbYqWvjbGgtoFrRhm0+A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.2"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.2.tgz#1625da40a26dae4c9b91797d4385d0b563dc7772"

--- a/system-tests/projects/angular-cli-configured/cypress.config.ts
+++ b/system-tests/projects/angular-cli-configured/cypress.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
             '@angular/core': require.resolve('@angular/core'),
             '@angular/platform-browser/testing': require.resolve('@angular/platform-browser/testing'),
             '@angular/platform-browser': require.resolve('@angular/platform-browser'),
-            '@angular/platform-browser-dynamic/testing': require.resolve('@angular/platform-browser-dynamic/testing'),
-            '@angular/platform-browser-dynamic': require.resolve('@angular/platform-browser-dynamic'),
           },
         },
       },

--- a/system-tests/projects/angular-cli-configured/package.json
+++ b/system-tests/projects/angular-cli-configured/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.7",
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.9",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"
   }

--- a/system-tests/projects/angular-cli-configured/yarn.lock
+++ b/system-tests/projects/angular-cli-configured/yarn.lock
@@ -339,13 +339,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.9":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.9.tgz#178c808d4329e29860b08d8fd65a9bbcb639ae21"
-  integrity sha512-Z+2vefW4GUSuTC4BOKNiyftqecLSjxOKwe1ZNljBsjesLzywIXi+v+tyEm8ODHHlf7bz/0HwXvc9OYZmfjt95A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.9"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"

--- a/system-tests/projects/angular-cli-unconfigured/package.json
+++ b/system-tests/projects/angular-cli-unconfigured/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.7",
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.9",
     "jsdom": "^28.0.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",

--- a/system-tests/projects/angular-cli-unconfigured/yarn.lock
+++ b/system-tests/projects/angular-cli-unconfigured/yarn.lock
@@ -344,13 +344,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.9":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.9.tgz#178c808d4329e29860b08d8fd65a9bbcb639ae21"
-  integrity sha512-Z+2vefW4GUSuTC4BOKNiyftqecLSjxOKwe1ZNljBsjesLzywIXi+v+tyEm8ODHHlf7bz/0HwXvc9OYZmfjt95A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.9"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"

--- a/system-tests/projects/angular-custom-config/cypress.config.ts
+++ b/system-tests/projects/angular-custom-config/cypress.config.ts
@@ -32,8 +32,6 @@ export default defineConfig({
             '@angular/core': require.resolve('@angular/core'),
             '@angular/platform-browser/testing': require.resolve('@angular/platform-browser/testing'),
             '@angular/platform-browser': require.resolve('@angular/platform-browser'),
-            '@angular/platform-browser-dynamic/testing': require.resolve('@angular/platform-browser-dynamic/testing'),
-            '@angular/platform-browser-dynamic': require.resolve('@angular/platform-browser-dynamic'),
           },
         },
       },

--- a/system-tests/projects/angular-custom-config/package.json
+++ b/system-tests/projects/angular-custom-config/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.7",
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.9",
     "typescript": "~5.9.2"
   }
 }

--- a/system-tests/projects/angular-custom-config/yarn.lock
+++ b/system-tests/projects/angular-custom-config/yarn.lock
@@ -339,13 +339,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.9":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.9.tgz#178c808d4329e29860b08d8fd65a9bbcb639ae21"
-  integrity sha512-Z+2vefW4GUSuTC4BOKNiyftqecLSjxOKwe1ZNljBsjesLzywIXi+v+tyEm8ODHHlf7bz/0HwXvc9OYZmfjt95A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.9"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"

--- a/system-tests/projects/angular-custom-root/cypress.config.ts
+++ b/system-tests/projects/angular-custom-root/cypress.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
             '@angular/core': require.resolve('@angular/core'),
             '@angular/platform-browser/testing': require.resolve('@angular/platform-browser/testing'),
             '@angular/platform-browser': require.resolve('@angular/platform-browser'),
-            '@angular/platform-browser-dynamic/testing': require.resolve('@angular/platform-browser-dynamic/testing'),
-            '@angular/platform-browser-dynamic': require.resolve('@angular/platform-browser-dynamic'),
           },
         },
       },

--- a/system-tests/projects/angular-custom-root/package.json
+++ b/system-tests/projects/angular-custom-root/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.7",
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.9",
     "typescript": "~5.9.2"
   }
 }

--- a/system-tests/projects/angular-custom-root/yarn.lock
+++ b/system-tests/projects/angular-custom-root/yarn.lock
@@ -339,13 +339,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.9":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.9.tgz#178c808d4329e29860b08d8fd65a9bbcb639ae21"
-  integrity sha512-Z+2vefW4GUSuTC4BOKNiyftqecLSjxOKwe1ZNljBsjesLzywIXi+v+tyEm8ODHHlf7bz/0HwXvc9OYZmfjt95A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.9"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"

--- a/system-tests/projects/angular-signals/cypress.config.ts
+++ b/system-tests/projects/angular-signals/cypress.config.ts
@@ -22,8 +22,6 @@ export default defineConfig({
             '@angular/core': require.resolve('@angular/core'),
             '@angular/platform-browser/testing': require.resolve('@angular/platform-browser/testing'),
             '@angular/platform-browser': require.resolve('@angular/platform-browser'),
-            '@angular/platform-browser-dynamic/testing': require.resolve('@angular/platform-browser-dynamic/testing'),
-            '@angular/platform-browser-dynamic': require.resolve('@angular/platform-browser-dynamic'),
           },
         },
       },

--- a/system-tests/projects/angular-signals/package.json
+++ b/system-tests/projects/angular-signals/package.json
@@ -24,7 +24,6 @@
     "@angular/build": "^21.2.7",
     "@angular/cli": "^21.2.7",
     "@angular/compiler-cli": "^21.2.0",
-    "@angular/platform-browser-dynamic": "^21.2.9",
     "@types/lodash": "~4.17.24",
     "lodash": "~4.18.1",
     "typescript": "~5.9.2"

--- a/system-tests/projects/angular-signals/yarn.lock
+++ b/system-tests/projects/angular-signals/yarn.lock
@@ -339,13 +339,6 @@
     "@standard-schema/spec" "^1.0.0"
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.2.9":
-  version "21.2.9"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.9.tgz#178c808d4329e29860b08d8fd65a9bbcb639ae21"
-  integrity sha512-Z+2vefW4GUSuTC4BOKNiyftqecLSjxOKwe1ZNljBsjesLzywIXi+v+tyEm8ODHHlf7bz/0HwXvc9OYZmfjt95A==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/platform-browser@^21.2.0":
   version "21.2.9"
   resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/platform-browser-dynamic@^21.0.0":
-  version "21.0.1"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.0.1.tgz#6b044e60ac2d5926525f0688e9e53bf45f3f3b43"
-  integrity sha512-TzCKf3p1NBK1NYoPJXLScSjVeiQ52DaXf9gweNUGtCmX3EkVKf1sx4Ny1x4DxaTwB5XZn+O+L3nVLstPBj7UGA==
+"@angular/platform-browser@^21.0.0":
+  version "21.2.9"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-21.2.9.tgz#361232ec68fe12cf2be626c2d9855aaeb4e654fe"
+  integrity sha512-MjEtFvoFtsjsAeu2yzauqGgwwEHV4ml25c9vGFmw4OmSoNme4yp41f2DegwOkn1TTHL3OF3GE65ng2U2feJU4Q==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
- Closes #33006

## NOTE: rebase merge into `release/16.0.0`

## Summary

This PR removes `@angular/platform-browser-dynamic` as a dependency of `@cypress/angular`, replacing it with `@angular/platform-browser`. This stacks on top of [#33660](https://github.com/cypress-io/cypress/pull/33660) (`breaking/remove_angular_18_19_20`), which merged `@cypress/angular-zoneless` upstream and dropped Angular 18–20 support.

`@angular/platform-browser-dynamic` was previously required for JIT (Just-In-Time) compilation. With Angular 21 and the shift to fully standalone / zoneless components, JIT compilation is no longer needed — `@angular/platform-browser` is sufficient and is already a direct Angular dependency.

## Breaking changes

### `@cypress/angular`
- `@angular/platform-browser-dynamic` is no longer a peer dependency or imported at runtime
- `@angular/platform-browser` is used directly instead
- `npm/angular/src/mount.ts` updated to remove the `platform-browser-dynamic` import
- `npm/angular/rollup.config.mjs` updated to reflect the changed external dependency

### `@cypress/scaffold-config`
- `dependencies.ts` updated — `@angular/platform-browser-dynamic` removed from the Angular dependency list

### System-test projects
- `@angular/platform-browser-dynamic` removed from `package.json` and `yarn.lock` in all surviving Angular projects (`angular-21`, `angular-cli-configured`, `angular-cli-unconfigured`, `angular-custom-config`, `angular-custom-root`, `angular-signals`)
- `cypress.config.ts` files updated to remove any references to the old dynamic platform

## PR stack

```
breaking/update_npm_package_targets          ← base
  └── chore/remove_angular_tests_before_break  (#33659)
        └── breaking/remove_angular_18_19_20   (#33660)
              └── breaking/remove_platform_browser_dynamic  ← this PR
```

## Test plan

- [ ] All Angular 21 system-test projects pass CI without `@angular/platform-browser-dynamic` installed
- [ ] `@cypress/angular` mount works correctly for both zone.js and zoneless component setups
- [ ] Scaffold-config dependency detection no longer lists `@angular/platform-browser-dynamic`

Made with [Cursor](https://cursor.com)

Documentation updates for Cypress 16 Angular related changes are on https://github.com/cypress-io/cypress-documentation/pull/6423

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Angular component testbed initialization and removes a previously required peer dependency, which can break projects still relying on `@angular/platform-browser-dynamic` or older Angular testing setups.
> 
> **Overview**
> Removes `@angular/platform-browser-dynamic` from `@cypress/angular` (dev + peer deps) and switches the mount implementation and Rollup externals to use `@angular/platform-browser/testing` (`BrowserTestingModule` + `platformBrowserTesting`) instead.
> 
> Updates scaffolding/dependency detection to require `@angular/platform-browser` for Angular projects, and cleans all Angular system-test projects/configs/locks to drop `platform-browser-dynamic` aliases and packages. Also tweaks the schematic README compatibility note for `@cypress/schematic@5` on Cypress `^15.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0bc7a8a838fe83e8059c138a6dba785d64f7dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->