### PR TITLE
test: deflake windows launchpad integration tests

### DIFF
--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -657,7 +657,7 @@ describe('Launchpad: Setup Project', () => {
 
       cy.findByRole('button', { name: 'Skip' }).click()
       cy.intercept('POST', 'mutation-ExternalLink_OpenExternal', { 'data': { 'openExternal': true } }).as('OpenExternal')
-      cy.findByText('Learn more').click()
+      cy.findByText('Learn more', { timeout: 10000 }).click()
       cy.wait('@OpenExternal')
       .its('request.body.variables.url')
       .should('equal', 'https://on.cypress.io/guides/configuration')
@@ -693,7 +693,7 @@ describe('Launchpad: Setup Project', () => {
       verifyWelcomePage({ e2eIsConfigured: true, ctIsConfigured: false })
 
       cy.get('[data-cy-testingtype="e2e"]').click()
-      cy.contains('h1', 'Choose a browser')
+      cy.contains('h1', 'Choose a browser', { timeout: 10000 })
 
       // Execute same function that is called in the browser to switch testing types
       cy.withCtx(async (ctx, { sinon }) => {

--- a/packages/launchpad/cypress/e2e/slow-network.cy.ts
+++ b/packages/launchpad/cypress/e2e/slow-network.cy.ts
@@ -40,7 +40,9 @@ describe('slow network: launchpad', () => {
     cy.visitLaunchpad()
     cy.get('[data-cy=top-nav-cypress-version-current-link]').should('not.exist')
     cy.contains('E2E Testing').click()
-    cy.get('h1').should('contain', 'Choose a browser')
+    // Spec stubs ctx.util.fetch with a 60s delay, so the default 4s timeout
+    // is too short for the route transition under slow-network conditions.
+    cy.get('h1', { timeout: 30000 }).should('contain', 'Choose a browser')
   })
 
   // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/21897


### PR DESCRIPTION
- Closes n/a — flaky test fix

### Additional details

Three tests in `windows-run-launchpad-integration-tests-chrome` flaked on a recent `develop` run ([pipeline 80755](https://app.circleci.com/pipelines/github/cypress-io/cypress/80755/workflows/8563c497-0054-4b1a-8270-b3bcba0fe1d2/jobs/3567956/tests)). All three hit the default 4s timeout waiting for launchpad route transitions that are slower on Windows + Chrome. These are timeout bumps only — no behavioral change.

- `slow-network.cy.ts` — the spec stubs `ctx.util.fetch` with a 60s delay, so the default 4s `Choose a browser` assertion is always racy. Bumped to 30s.
- `project-setup.cy.ts` "switch testing types takes the user to first step of ct setup…" — already flagged by CircleCI flaky-tests insights. Bumped `Choose a browser` to 10s, matching the 10s timeout already used elsewhere on the same page.
- `project-setup.cy.ts` "openLink opens docs link in the default browser" — the DOM snapshot in the failure showed the scaffold → external-link screen transition hadn't landed within 4s. Bumped `findByText('Learn more')` to 10s.

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

Not applicable — timeout-only change. CI should exercise the same specs.

### How has the user experience changed?

No user-facing change. Internal test reliability only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)