### PR TITLE
dependency: upgrade simple-git to 3.36.0 to fix RCE vulnerability

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 **Dependency Updates:**
 
 - Upgraded `cachedir` from `^2.3.0` to `^2.4.0`. Addressed in [#33608](https://github.com/cypress-io/cypress/pull/33608).
+- Upgraded `simple-git` from `3.33.0` to `3.36.0` to address a [Remote Code Execution](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15456078) vulnerability reported in security scans. Addressed in [#33680](https://github.com/cypress-io/cypress/pull/33680).
 
 ## 15.14.1
 

--- a/patches/simple-git+3.36.0.patch
+++ b/patches/simple-git+3.36.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/simple-git/dist/cjs/index.js b/node_modules/simple-git/dist/cjs/index.js
-index 027f227..f0e3828 100644
+index 311a792..e8040ea 100644
 --- a/node_modules/simple-git/dist/cjs/index.js
 +++ b/node_modules/simple-git/dist/cjs/index.js
-@@ -1805,10 +1805,8 @@ var init_tasks_pending_queue = __esm({
+@@ -1729,10 +1729,8 @@ var init_tasks_pending_queue = __esm({
        static getName(name = "empty") {
          return `task:${name}:${++_TasksPendingQueue.counter}`;
        }
@@ -15,10 +15,10 @@ index 027f227..f0e3828 100644
  });
  
 diff --git a/node_modules/simple-git/dist/esm/index.js b/node_modules/simple-git/dist/esm/index.js
-index ee39dec..44fe293 100644
+index bc6ff91..7ddd754 100644
 --- a/node_modules/simple-git/dist/esm/index.js
 +++ b/node_modules/simple-git/dist/esm/index.js
-@@ -1231,10 +1231,8 @@ var init_tasks_pending_queue = __esm({
+@@ -1210,10 +1210,8 @@ var init_tasks_pending_queue = __esm({
        static getName(name = "empty") {
          return `task:${name}:${++_TasksPendingQueue.counter}`;
        }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7445,6 +7445,18 @@
     "@sigstore/core" "^2.0.0"
     "@sigstore/protobuf-specs" "^0.3.2"
 
+"@simple-git/args-pathspec@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz#9ef4a2ad5f49ab4056362d03f93f775b93118ca5"
+  integrity sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==
+
+"@simple-git/argv-parser@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz#275b839c6eeb5030872c73b1ea839a416885da9d"
+  integrity sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==
+  dependencies:
+    "@simple-git/args-pathspec" "^1.0.3"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -28823,12 +28835,14 @@ simple-get@^4.0.0:
     simple-concat "^1.0.0"
 
 simple-git@^3.32.3:
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.33.0.tgz#b903dc70f5b93535a4f64ff39172da43058cfb88"
-  integrity sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==
+  version "3.36.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.36.0.tgz#019b28c0a35847ee34299c6fb63770ab1b2dffb7"
+  integrity sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==
   dependencies:
     "@kwsites/file-exists" "^1.1.1"
     "@kwsites/promise-deferred" "^1.1.1"
+    "@simple-git/args-pathspec" "^1.0.3"
+    "@simple-git/argv-parser" "^1.1.0"
     debug "^4.4.0"
 
 simple-swizzle@^0.2.2:


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

Resolves [SNYK-JS-SIMPLEGIT-15456078](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15456078) — a **Critical** Remote Code Execution in `simple-git@3.33.0`.

**Fix strategy:** relock only. The `^3.32.3` ranges declared in `packages/data-context/package.json` and `packages/app/package.json` already cover the fixed version 3.36.0, so no `package.json` bumps were needed — deleting the lockfile stanza and reinstalling was sufficient to land 3.36.0.

**Patch forward:** the existing `patches/simple-git+3.33.0.patch` (which converts a `static { this.counter = 0 }` class block into a post-class assignment on `TasksPendingQueue`) was re-applied cleanly against 3.36.0 and regenerated as `patches/simple-git+3.36.0.patch`.

**Validation:** Snyk rescan at `--severity-threshold=critical` reports 0 vulnerabilities; simple-git is no longer in the vulnerability list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency relock upgrades `simple-git`, which can affect any code paths that shell out to git; while intended as a security-only change, subtle behavior differences in git interactions are possible.
> 
> **Overview**
> Upgrades the `simple-git` dependency from `3.33.0` to `3.36.0` via `yarn.lock` to address a critical RCE vulnerability, including new transitive `@simple-git/*` packages.
> 
> Updates the existing `patch-package` override by regenerating it as `patches/simple-git+3.36.0.patch`, and documents the security upgrade in `cli/CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3eafebec89e1e5730d8357e871375549862bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- `yarn install` and confirm `simple-git` resolves to `3.36.0` in `yarn.lock`.
- Confirm `patches/simple-git+3.36.0.patch` applies cleanly during postinstall.
- Existing CI / unit tests exercising `packages/data-context` and `packages/app` git integrations should continue to pass.

### How has the user experience changed?

No user-facing change — dependency security fix only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?