### PR TITLE
test: stabilize flaky 'Your tests are loading...' waits

### DIFF
--- a/packages/app/cypress/e2e/run-all-specs-ct.cy.ts
+++ b/packages/app/cypress/e2e/run-all-specs-ct.cy.ts
@@ -36,7 +36,7 @@ describe('run-all-specs-ct', () => {
         // in cy-in-cy only, runAllSpecs is always set AFTER initCypressTests is called inside the vite dev server, meaning that __RUN_ALL_SPECS__ on the window is out of date.
         // to hack around this, we reload the page to force the vite dev server to process the runAllSpecs again when the value is set properly.
         if (bundler === 'vite') {
-          cy.get('.runnable-loading-title').should('not.be.visible')
+          cy.contains('Your tests are loading...').should('not.exist')
           cy.reload()
         }
 
@@ -54,7 +54,7 @@ describe('run-all-specs-ct', () => {
         // in cy-in-cy only, runAllSpecs is always set AFTER initCypressTests is called inside the vite dev server, meaning that __RUN_ALL_SPECS__ on the window is out of date.
         // to hack around this, we reload the page to force the vite dev server to process the runAllSpecs again when the value is set properly.
         if (bundler === 'vite') {
-          cy.get('.runnable-loading-title').should('not.be.visible')
+          cy.contains('Your tests are loading...').should('not.exist')
           cy.reload()
         }
 
@@ -72,7 +72,7 @@ describe('run-all-specs-ct', () => {
         // in cy-in-cy only, runAllSpecs is always set AFTER initCypressTests is called inside the vite dev server, meaning that __RUN_ALL_SPECS__ on the window is out of date.
         // to hack around this, we reload the page to force the vite dev server to process the runAllSpecs again when the value is set properly.
         if (bundler === 'vite') {
-          cy.get('.runnable-loading-title').should('not.be.visible')
+          cy.contains('Your tests are loading...').should('not.exist')
           cy.reload()
         }
 

--- a/packages/app/cypress/e2e/specs_list_e2e.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_e2e.cy.ts
@@ -119,7 +119,7 @@ describe('App: Spec List (E2E)', () => {
       cy.findAllByTestId('spec-item-link').should('have.attr', 'href')
       cy.findAllByTestId('spec-item-link').contains('dom-content.spec.js').click()
 
-      cy.findByText('Your tests are loading...').should('not.be.visible')
+      cy.contains('Your tests are loading...').should('not.exist')
       cy.get('[data-cy="runnable-header"]').should('be.visible')
       cy.get('body').type('f')
 
@@ -132,7 +132,7 @@ describe('App: Spec List (E2E)', () => {
       cy.findAllByTestId('spec-item-link').contains('accounts_list.spec.js').click()
 
       // ensure the tests are loaded
-      cy.findByText('Your tests are loading...').should('not.be.visible')
+      cy.contains('Your tests are loading...').should('not.exist')
 
       cy.get('[data-cy="runnable-header"]').should('be.visible')
       // open the inline spec list


### PR DESCRIPTION
- Closes n/a

### Additional details

Investigated a flake in `windows-run-app-integration-tests-chrome` ([job 3579743](https://app.circleci.com/pipelines/github/cypress-io/cypress/80924/workflows/fb265f86-f812-467c-b3cc-4d233a7bcd10/jobs/3579743/tests)):

```
AssertionError: Timed out retrying after 4000ms:
Expected to find element: `.runnable-loading-title`, but never found it.
    at Context.eval (webpack://@packages/app/./cypress/e2e/run-all-specs-ct.cy.ts:57:44)
```

The loader title (`<div className="runnable-loading-title">Your tests are loading...</div>` in `packages/reporter/src/runnables/runnables.tsx`) only exists in the DOM during a brief loading window. The original `cy.get('.runnable-loading-title').should('not.be.visible')` (and the `cy.findByText(...).should('not.be.visible')` variant in `specs_list_e2e.cy.ts`) requires that element to exist *at query time*: if the runner finishes loading before the assertion runs, `cy.get`/`cy.findByText` keeps retrying for an element that never reappears, and the assertion times out instead of passing.

This swaps all five callsites to the canonical pattern already used by `waitForSpecToFinish` (`packages/app/cypress/e2e/support/execute-spec.ts:31`), `npm/vite-dev-server/cypress/support/commands.ts:28`, and `packages/app/cypress/e2e/runner/ct-framework-errors.cy.ts:42`:

```ts
cy.contains('Your tests are loading...').should('not.exist')
```

`.should('not.exist')` is satisfied whether the loader briefly appeared and was removed, or never appeared at all — eliminating the race.

Files updated:
- `packages/app/cypress/e2e/run-all-specs-ct.cy.ts` (3 callsites — the one that flaked)
- `packages/app/cypress/e2e/specs_list_e2e.cy.ts` (2 callsites with the same pattern)

Other usages of the same string were audited and left alone:
- `runnables.cy.ts:57` uses `.should('be.visible')` intentionally (test is *about* the loader).
- `sessions.ui.cy.ts:801` only asserts the loader appeared during session restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only E2E test assertions to avoid a race on a transient loading element; no production code paths are modified.
> 
> **Overview**
> Stabilizes cy-in-cy E2E specs by replacing waits that required the loading title element to exist (e.g. `.runnable-loading-title` / `findByText(...).should('not.be.visible')`) with `cy.contains('Your tests are loading...').should('not.exist')`.
> 
> This updates the `vite` reload workaround in `run-all-specs-ct.cy.ts` and the spec-selection flows in `specs_list_e2e.cy.ts` to avoid flaking when the loader appears only briefly or not at all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d2b04f72c652aa2ed082c421152e029bb125f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Existing E2E tests cover this — `packages/app/cypress/e2e/run-all-specs-ct.cy.ts` and `packages/app/cypress/e2e/specs_list_e2e.cy.ts` should continue to pass without flakes.

### How has the user experience changed?

No user-facing change — test stability only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?