### PR TITLE
test: stabilize flaky readFile 'retries assertions until they pass'

### DIFF
--- a/packages/driver/cypress/e2e/commands/files.cy.js
+++ b/packages/driver/cypress/e2e/commands/files.cy.js
@@ -109,12 +109,6 @@ describe('src/cy/commands/files', () => {
     })
 
     it('retries assertions until they pass', () => {
-      let retries = 0
-
-      cy.on('command:retry', () => {
-        retries += 1
-      })
-
       Cypress.backend.withArgs('run:privileged')
       .onFirstCall()
       .resolves({
@@ -126,9 +120,13 @@ describe('src/cy/commands/files', () => {
       })
 
       cy.readFile('foo.json').should('eq', 'quux').then(() => {
-        // Two retries: The first one triggers a backend request and throws a 'not ready' error.
-        // The second gets foobarbaz, triggering another request to the backend.
-        expect(retries).to.eq(2)
+        // Verify two calls were made: the first returns foobarbaz (failing the
+        // assertion), and the second returns quux (passing the assertion).
+        const readFilePrivilegedCalls = Cypress.backend.getCalls().filter(
+          (c) => c.args[0] === 'run:privileged' && c.args[1]?.commandName === 'readFile',
+        )
+
+        expect(readFilePrivilegedCalls.length).to.eq(2)
       })
     })
 


### PR DESCRIPTION
- Closes [n/a — flake]

### Additional details

The `src/cy/commands/files #readFile retries assertions until they pass` test in [files.cy.js](packages/driver/cypress/e2e/commands/files.cy.js) failed in Firefox in [job 3582731](https://app.circleci.com/pipelines/github/cypress-io/cypress/80964/workflows/adc75dd5-fe7a-4cd2-b449-6688577379aa/jobs/3582731/tests#failed-test-0) with `expected 3 to equal 2` on `expect(retries).to.eq(2)`.

The test was counting `command:retry` events to assert the retry loop ran exactly twice. That count is timing-dependent — under load the retry loop can poll the query function once more before the stubbed backend promise resolves, producing 3 retries instead of 2. The retry count was an indirect proxy; the deterministic contract is "the backend was called twice" (since the test stubs `onFirstCall` and `onSecondCall`).

Replaces the brittle `command:retry` counter with a count of `run:privileged` backend calls, exactly as was done for the sibling `retries to read when ENOENT` test in #33510.

### Steps to test

Run the driver test locally — should remain stable across browsers:

```
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/files.cy.js
```

### How has the user experience changed?

No user-facing change — test-only stability fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces timing-sensitive retry counting with a deterministic assertion on backend call count.
> 
> **Overview**
> Stabilizes the `#readFile` test `retries assertions until they pass` by removing reliance on counting `command:retry` events.
> 
> The test now asserts deterministically that `Cypress.backend('run:privileged', { commandName: 'readFile' })` was invoked exactly twice (first response fails the assertion, second passes), matching the approach used in the related ENOENT retry test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce61935fb4eb18a62a9f79422caa300bbe07660a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->