### PR TITLE
breaking: remove cy.end command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Upgraded bundled Node.js version from `22.19.0` to `24.14.0`. Addressed in [#33494](https://github.com/cypress-io/cypress/pull/33494).
 - Removed built-in CoffeeScript support. The default `@cypress/webpack-batteries-included-preprocessor` no longer bundles `coffee-loader` or `coffeescript`. Use JavaScript/TypeScript for specs, fixtures, and support files, or add CoffeeScript to your own webpack config via `@cypress/webpack-preprocessor`. Addressed in [#33654](https://github.com/cypress-io/cypress/pull/33654).
+- Removed the `cy.end()` command, which ended a chain of commands by yielding `null`. The same result can be achieved by starting a new chain or by using `cy.then(() => null)` / `cy.wrap(null)`.
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - Upgraded bundled Node.js version from `22.19.0` to `24.14.0`. Addressed in [#33494](https://github.com/cypress-io/cypress/pull/33494).
 - Removed built-in CoffeeScript support. The default `@cypress/webpack-batteries-included-preprocessor` no longer bundles `coffee-loader` or `coffeescript`. Use JavaScript/TypeScript for specs, fixtures, and support files, or add CoffeeScript to your own webpack config via `@cypress/webpack-preprocessor`. Addressed in [#33654](https://github.com/cypress-io/cypress/pull/33654).
-- Removed the `cy.end()` command, which ended a chain of commands by yielding `null`. The same result can be achieved by starting a new chain or by using `cy.then(() => null)` / `cy.wrap(null)`.
+- Removed the `cy.end()` command, which ended a chain of commands by yielding `null`. The same result can be achieved by starting a new chain or by using `cy.then(() => null)` / `cy.wrap(null)`. Addressed in [#33696](https://github.com/cypress-io/cypress/pull/33696).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - Upgraded bundled Node.js version from `22.19.0` to `24.14.0`. Addressed in [#33494](https://github.com/cypress-io/cypress/pull/33494).
 - Removed built-in CoffeeScript support. The default `@cypress/webpack-batteries-included-preprocessor` no longer bundles `coffee-loader` or `coffeescript`. Use JavaScript/TypeScript for specs, fixtures, and support files, or add CoffeeScript to your own webpack config via `@cypress/webpack-preprocessor`. Addressed in [#33654](https://github.com/cypress-io/cypress/pull/33654).
-- Removed the `cy.end()` command, which ended a chain of commands by yielding `null`. The same result can be achieved by starting a new chain or by using `cy.then(() => null)` / `cy.wrap(null)`. Addressed in [#33696](https://github.com/cypress-io/cypress/pull/33696).
+- Removed the `cy.end()` command, which ended a chain of commands by yielding `null`. A Cypress chain is already terminated when the next `cy.<command>()` starts a new chain, so existing `.end()` calls can simply be removed. Addressed in [#33696](https://github.com/cypress-io/cypress/pull/33696).
 
 **Dependency Updates:**
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1370,13 +1370,6 @@ declare namespace Cypress {
     each(fn: (item: any, index: number, $list: any[]) => void): Chainable<Subject>
 
     /**
-     * End a chain of commands
-     *
-     * @see https://on.cypress.io/end
-     */
-    end(): Chainable<null>
-
-    /**
      * Get A DOM element at a specific index in an array of elements.
      *
      * @see https://on.cypress.io/eq

--- a/packages/driver/cypress/e2e/commands/command_option_immutability.cy.js
+++ b/packages/driver/cypress/e2e/commands/command_option_immutability.cy.js
@@ -83,7 +83,7 @@ describe('command log', () => {
         cy.document(options)
       })
 
-      // Ignore cy.each(), cy.end() because they don't have options.
+      // Ignore cy.each() because it doesn't have options.
 
       testOptions('eq', { timeout: 1111 }, 1, (options) => {
         cy.get('input').eq(0, options)

--- a/packages/driver/cypress/e2e/commands/misc.cy.js
+++ b/packages/driver/cypress/e2e/commands/misc.cy.js
@@ -6,27 +6,14 @@ describe('src/cy/commands/misc', () => {
     cy.visit('/fixtures/jquery.html')
   })
 
-  context('#end', () => {
-    it('nulls out the subject', () => {
-      cy.noop({}).end().then((subject) => {
-        expect(subject).to.be.null
-
-        // We want cy.end() to break the subject chain - any previous entries
-        // (in this case `{}`) should be discarded. No re-running any previous
-        // query functions once you've used `.end()` on a chain.
-        expect(cy.subjectChain()).to.eql([null])
-      })
-    })
-  })
-
   context('#log', () => {
     it('nulls out the subject', () => {
       cy.wrap({}).log('foo').then((subject) => {
         expect(subject).to.be.null
 
-        // We want cy.end() to break the subject chain - any previous entries
+        // We want cy.log() to break the subject chain - any previous entries
         // (in this case `{}`) should be discarded. No re-running any previous
-        // query functions once you've used `.end()` on a chain.
+        // query functions once you've used `.log()` on a chain.
         expect(cy.subjectChain()).to.eql([null])
       })
     })

--- a/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
@@ -221,7 +221,7 @@ it('verifies number of cy commands', () => {
     'check', 'uncheck', 'click', 'env', 'dblclick', 'rightclick', 'focus', 'blur', 'hover', 'scrollIntoView', 'scrollTo', 'select',
     'selectFile', 'submit', 'type', 'clear', 'trigger', 'should', 'and', 'clock', 'tick', 'spread', 'each', 'then',
     'invoke', 'its', 'getCookie', 'getCookies', 'setCookie', 'clearCookie', 'clearCookies', 'pause', 'debug', 'exec', 'readFile',
-    'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'end', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
+    'writeFile', 'fixture', 'clearLocalStorage', 'url', 'hash', 'location', 'noop', 'log', 'wrap', 'reload', 'go', 'visit',
     'focused', 'get', 'contains', 'shadow', 'within', 'request', 'session', 'screenshot', 'task', 'find', 'filter', 'not',
     'children', 'eq', 'closest', 'first', 'last', 'next', 'nextAll', 'nextUntil', 'parent', 'parents', 'parentsUntil', 'prev', 'press',
     'prevAll', 'prevUntil', 'prompt', 'siblings', 'wait', 'title', 'window', 'document', 'viewport', 'server', 'route', 'intercept', 'origin',

--- a/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts
@@ -6,12 +6,6 @@ context('cy.origin misc', { browser: '!webkit' }, () => {
     cy.get('a[data-cy="dom-link"]').click()
   })
 
-  it('.end()', () => {
-    cy.origin('http://www.foobar.com:3500', () => {
-      cy.get('#button').end().should('be.null')
-    })
-  })
-
   it('.exec()', () => {
     cy.origin('http://www.foobar.com:3500', () => {
       cy.exec('echo foobar').its('stdout').should('contain', 'foobar')

--- a/packages/driver/src/cy/commands/misc.ts
+++ b/packages/driver/src/cy/commands/misc.ts
@@ -11,7 +11,6 @@ interface InternalWrapOptions extends Partial<Cypress.Loggable & Cypress.Timeout
 }
 
 export default (Commands, Cypress, cy, state) => {
-  Commands.add('end', () => null)
   Commands.add('noop', (arg) => arg)
 
   Commands.add('log', (msg, ...args) => {

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/ui-states/commands.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/ui-states/commands.cy.js
@@ -14,7 +14,7 @@ describe('Command Options and UI Display Tests', () => {
       cy.log(obj)
     })
 
-    cy.get('div').each(($div) => { }).end()
+    cy.get('div').each(($div) => { })
 
     cy.fixture('uiStates')
 


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

`cy.end()` was a one-line command (`Commands.add('end', () => null)`) whose only job was to terminate a chain of commands by yielding `null`. The same result is achievable by starting a new chain or by using `cy.then(() => null)` / `cy.wrap(null)`, so the command no longer pulls its weight in the public API and is being removed.

This is a breaking change and is targeted at the in-progress 16.0.0 release branch alongside the existing breaking entries.

Changes:
- Removed the `Commands.add('end', ...)` registration in `packages/driver/src/cy/commands/misc.ts`.
- Removed the `end(): Chainable<null>` signature from `cli/types/cypress.d.ts`.
- Deleted the `#end` driver e2e test block in `packages/driver/cypress/e2e/commands/misc.cy.js` and reworded the adjacent `#log` test comments that referenced `cy.end`.
- Removed `'end'` from the cross-origin `expectedCommands` roster assertion in `packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts`.
- Updated the option-immutability ignore-list comment in `packages/driver/cypress/e2e/commands/command_option_immutability.cy.js`.
- Added a Breaking Changes entry to `cli/CHANGELOG.md` under 16.0.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API removal that will fail existing tests/types relying on `cy.end()`, though the implementation change is small and localized to command registration and coverage updates.
> 
> **Overview**
> Removes the `cy.end()` command from the driver by deleting its command registration and eliminating its `Chainable<null>` TypeScript definition.
> 
> Updates and prunes e2e/system tests that asserted `cy.end()` behavior (including cross-origin command roster expectations) and adds a Cypress v16.0.0 changelog entry calling out the breaking change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f7f34639928fdd8a140b525801537c425612c10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. In a project on this branch, write a spec that tries to call `cy.end()` — TypeScript should now report that `end` does not exist on `Chainable`, and at runtime the command queue should reject the call as an unknown command.
2. Run the touched driver specs to confirm they still pass:
   - `yarn cypress:run -- --spec packages/driver/cypress/e2e/commands/misc.cy.js`
   - `yarn cypress:run -- --spec packages/driver/cypress/e2e/commands/command_option_immutability.cy.js`
   - `yarn cypress:run -- --spec packages/driver/cypress/e2e/e2e/origin/commands/misc.cy.ts` (the `expectedCommands` assertion in this spec is the canary for command-roster drift)

### How has the user experience changed?

`cy.end()` is no longer available. Users who relied on it should switch to `cy.then(() => null)`, `cy.wrap(null)`, or simply start a new `cy.<command>()` chain. This is captured in the 16.0.0 Breaking Changes section of the changelog.

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?