### PR TITLE
chore: open auto-update PRs as cypress-bot via App installation token

### DIFF
--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -15,11 +15,17 @@ jobs:
     # Prevent from running this workflow on forks
     if: github.repository == 'cypress-io/cypress'
     steps:
+      - name: Generate Cypress Bot App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup CircleCI CLI
         run: |
           sudo snap install circleci
@@ -105,6 +111,7 @@ jobs:
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { updatePRTitle } = require('./scripts/github-actions/update-browser-versions.js')
 
@@ -121,6 +128,7 @@ jobs:
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')
 

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -115,6 +115,16 @@ jobs:
         run: |
           echo "has_changes=$(test "$(git status --porcelain -- ${{ env.SNAPSHOT_FILES }})" && echo 'true')" >> $GITHUB_OUTPUT
         shell: bash
+      ## The build steps above can run for >1h on a from-scratch / Windows pass,
+      ## which is longer than the App installation token's lifetime. Mint a
+      ## fresh token here so all subsequent auth-requiring steps (gh api, git
+      ## push, github-script) use a token that's guaranteed to still be valid.
+      - name: Refresh Cypress Bot App token
+        id: app-token-refresh
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
       - name: Determine branch name - commit directly to branch
         if: ${{ inputs.commit_directly_to_branch == true }}
         run: |
@@ -132,7 +142,7 @@ jobs:
         run: |
           echo "number_of_prs_for_branch=$(gh api '/repos/cypress-io/cypress/pulls?head=cypress-io:${{ env.BRANCH_NAME }}' --jq length)" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
         shell: bash
       - name: Check need for PR or branch update
         id: check-need-for-pr
@@ -140,7 +150,7 @@ jobs:
           echo "needs_pr=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_NAME != env.BASE_BRANCH && steps.check-number-of-existing-prs.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
           echo "needs_branch_update=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_EXISTS == 'true' }}" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
         shell: bash
       ## Update available and a branch/PR already exists
       - name: Checkout existing branch
@@ -160,16 +170,17 @@ jobs:
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
         run: |
           git diff-index --quiet HEAD || git commit -am "chore: updating v8 snapshot cache"
-      ## Push branch
+      ## Push branch — use the refreshed App token explicitly. The persisted
+      ## credential from the initial checkout may have expired during the build.
       - name: Push branch to remote
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: git push origin ${{ env.BRANCH_NAME }}
+        run: git push "https://x-access-token:${{ steps.app-token-refresh.outputs.token }}@github.com/${{ github.repository }}.git" "${{ env.BRANCH_NAME }}"
       # PR needs to be created
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token-refresh.outputs.token }}
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')
 

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -53,7 +53,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      CYPRESS_BOT_APP_ID: ${{ secrets.RAM_APP }}
+      CYPRESS_BOT_APP_ID: ${{ secrets.CYPRESS_BOT_APP_ID }}
       BASE_BRANCH: ${{ inputs.branch || github.ref_name }}
       # Flex the generate from scratch option based on manual input or if we are on the weekly schedule
       GENERATE_FROM_SCRATCH: ${{ inputs.generate_from_scratch == true || (github.event_name == 'schedule' && github.event.schedule == '0 0 * * 3') }}
@@ -77,11 +77,17 @@ jobs:
       - name: Install setuptools - Mac
         if: ${{ matrix.platform == 'macos-latest' }}
         run: sudo -H pip install setuptools
+      - name: Generate Cypress Bot App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
+          private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ env.BASE_BRANCH }}
       - name: Set committer info
         ## attribute the commit to cypress-bot: https://github.community/t/logging-into-git-as-a-github-app/115916
@@ -126,7 +132,7 @@ jobs:
         run: |
           echo "number_of_prs_for_branch=$(gh api '/repos/cypress-io/cypress/pulls?head=cypress-io:${{ env.BRANCH_NAME }}' --jq length)" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
       - name: Check need for PR or branch update
         id: check-need-for-pr
@@ -134,7 +140,7 @@ jobs:
           echo "needs_pr=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_NAME != env.BASE_BRANCH && steps.check-number-of-existing-prs.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
           echo "needs_branch_update=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_EXISTS == 'true' }}" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
       ## Update available and a branch/PR already exists
       - name: Checkout existing branch
@@ -163,6 +169,7 @@ jobs:
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { createPullRequest } = require('./scripts/github-actions/create-pull-request.js')
 


### PR DESCRIPTION
- Closes n/a

### Additional details

The `update-browser-versions` and `update_v8_snapshot_cache` workflows push commits as `cypress-bot[bot]`, but their `actions/github-script@v7` steps for opening / updating PRs did not pass a `github-token:`. As a result, those steps fell back to the default `GITHUB_TOKEN` and the PRs were authored by `github-actions[bot]`, which is **not** in the security groups for the CircleCI contexts the `pull-request` workflow consumes — producing the "user who triggered the build may not have permission to a context being used" / "Unauthorized" failure on the PR pipeline (e.g. `update-v8-snapshot-cache-on-release/16.0.0-linux`).

This change:

- Adds an `actions/create-github-app-token@v2` step to each workflow that mints a short-lived (~1 hour) Cypress Bot App installation access token from `secrets.CYPRESS_BOT_APP_ID` + `secrets.CYPRESS_BOT_APP_PRIVATE_KEY`.
- Replaces every reference to `secrets.BOT_GITHUB_ACTION_TOKEN` (in `actions/checkout`, `gh` CLI `GH_TOKEN`, and `actions/github-script`) with the minted token.
- Adds `github-token: ${{ steps.app-token.outputs.token }}` to the PR-mutating `github-script` steps (`Update PR Title`, `Create Pull Request`) so the resulting PRs are authored by `cypress-bot[bot]`.
- Renames the `RAM_APP` secret reference to `CYPRESS_BOT_APP_ID` in `update_v8_snapshot_cache.yml` so both workflows reference the same App-ID secret name.

#### Required prerequisites before merge

1. Add `CYPRESS_BOT_APP_PRIVATE_KEY` as a repository secret (the Cypress Bot GitHub App's `.pem` private key).
2. Confirm `CYPRESS_BOT_APP_ID` repo secret is set (same value as the existing `RAM_APP`).
3. CircleCI: add `cypress-bot` to the security groups for the contexts consumed by `.circleci/src/pipeline/workflows/pull-request.yml`: `test-runner:env-canary`, `test-runner:percy`, `test-runner:npm-release`, `org-npm-credentials`, `test-runner:performance-tracking`, `test-runner:cypress-record-key`, `test-runner:launchpad-tests`, `test-runner:upload`, `test-runner:build-binary`, `publish-binary`, `test-runner:commit-status-checks`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI automation authentication and push/PR creation paths; mistakes could break scheduled update workflows or PR creation, but it does not affect runtime product code.
> 
> **Overview**
> Ensures the auto-update workflows (`update-browser-versions` and `update_v8_snapshot_cache`) authenticate as `cypress-bot` by minting a GitHub App installation token and using it for `actions/checkout`, `gh` CLI calls, and `actions/github-script` steps that create/update PRs.
> 
> In `update_v8_snapshot_cache`, adds a token refresh after long-running build steps and switches the `git push` to explicitly use the refreshed token URL to avoid expiration-related failures; also standardizes the App ID secret to `CYPRESS_BOT_APP_ID`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5af6461c1c1c95630935a1a6fbf6ad6545e7979f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

After the prerequisites above are in place:

1. Manually trigger `Update Browser Versions` via the Actions UI (`workflow_dispatch`). Confirm the `Generate Cypress Bot App token` step succeeds and downstream `gh` / checkout calls authenticate.
2. To exercise the PR-author path end-to-end without waiting for an actual Chrome bump, temporarily seed a stale `browsers.json` so `has_update == 'true'`. On the resulting PR, confirm:
   - PR author is `cypress-bot[bot]`, not `github-actions[bot]`.
   - The CircleCI `pull-request` workflow runs without the "Unauthorized" / context-permission error on the `internal-pr-build` job.
3. Repeat for `Update V8 Snapshot Cache` via `workflow_dispatch`.
4. Close any synthetic test PR.

### How has the user experience changed?

No user-facing change. Internal CI/release automation only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
