### PR TITLE
chore: drop verify-release-readiness from PR workflow

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -70,12 +70,6 @@ jobs:
         - internal-pr-build
         - external-pr-build
         - approve-contributor-pr
-  - verify-release-readiness:
-      context: [test-runner:npm-release, org-npm-credentials]
-      requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
   - server-unit-tests:
       requires:
         - internal-pr-build
@@ -443,7 +437,6 @@ jobs:
         # Conditional jobs (halt early when not needed)
         - cli-visual-tests
         - unit-tests
-        - verify-release-readiness
         - server-unit-tests
         - server-integration-tests
         - server-performance-tests


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

Remove the `verify-release-readiness` job from the pull-request CircleCI workflow. The job ran two things:

1. `yarn test-npm-package-release-script` — `semantic-release --dry-run` across all `@cypress/*` packages.
2. `node ./scripts/semantic-commits/validate-binary-changelog.js` — a changelog validator that already self-skips on any branch other than `develop`, `release/X.Y.Z`, or a version-bump branch (`scripts/semantic-commits/validate-binary-changelog.js:17-21`), so it does effectively nothing on a typical PR.

The actual publish happens in the `npm-release` job (`.circleci/src/pipeline/@pipeline.yml:2712`), which is filtered to `develop` / `release/*` in `@main.yml`, requires `ready-to-release`, and itself starts with the same `semantic-release --dry-run` per package via `scripts/npm-release.js`. So release-config breakage is still caught on develop/release branches before anything is published — we just no longer pay for the dry-run on every PR.

The job remains in the develop/release `@main.yml` workflow and as a gate on `ready-to-release` there; only the `pull-request` workflow invocation and the corresponding entry in the `all-jobs-passed` aggregator's `requires` list were removed.

### Steps to test

- Open this PR and confirm CircleCI's `pull-request` workflow no longer schedules `verify-release-readiness`, while `all-jobs-passed` still completes.
- Confirm the develop branch workflow (`linux-x64` in `@main.yml`) still includes `verify-release-readiness` upstream of `ready-to-release`/`npm-release`.

### How has the user experience changed?

No user-facing change. CI-only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration-only change that reduces PR coverage for release-readiness checks; main build/release workflows remain unaffected but misconfigurations may be caught later.
> 
> **Overview**
> Removes the `verify-release-readiness` job from the CircleCI `pull-request` workflow so PRs no longer run the release-readiness dry-run checks.
> 
> Updates the `all-jobs-passed` fan-in aggregator to stop requiring `verify-release-readiness`, keeping the PR required status check unblocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061078f4c13217b944d0f55ec373f3a61bdb5aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->