### PR TITLE
test: stabilize flaky 'can delay and wait on XHR' in @cypress/vue

### DIFF
--- a/npm/vue/cypress/component/xhr/ajax-list.cy.js
+++ b/npm/vue/cypress/component/xhr/ajax-list.cy.js
@@ -49,7 +49,7 @@ describe('AjaxList', () => {
         method: 'GET',
         url: '/users?_limit=3',
       }, {
-        delayMs: 1000,
+        delayMs: 5000,
         body: users,
       }).as('users')
 

--- a/npm/vue/cypress/component/xhr/ajax-list.cy.js
+++ b/npm/vue/cypress/component/xhr/ajax-list.cy.js
@@ -49,7 +49,7 @@ describe('AjaxList', () => {
         method: 'GET',
         url: '/users?_limit=3',
       }, {
-        delayMs: 5000,
+        delay: 1000,
         body: users,
       }).as('users')
 


### PR DESCRIPTION
- Closes n/a

### Additional details

The `AjaxList > using cy.intercept() > can delay and wait on XHR` test in `@cypress/vue` was flaking on CI with:

```
AssertionError: Timed out retrying after 4000ms: Too many elements found. Found '1', expected '0'.
    at Context.<anonymous> (/root/cypress/npm/vue/cypress/component/xhr/ajax-list.cy.js:58:19)
```

**Failure observed:** [npm-vue job 3586248](https://app.circleci.com/pipelines/github/cypress-io/cypress/81014/workflows/3ee0d36e-de07-4868-92c6-7edc3baec776/jobs/3586248/steps)

**Root cause:** The test was using a `delayMs` property on `cy.intercept`'s `StaticResponse`, but `delayMs` was removed in #30463 (renamed to `delay`) and is silently ignored. The mocked response was therefore returned with **no delay at all**, and the loading-state assertion (`cy.get('li').should('have.length', 0)`) was racing against Vue's reactivity tick — the brief window between the axios promise resolving and Vue rendering the `<li>` items. Under CI load, Vue would render before the assertion ran, finding `1` element instead of `0`.

**Fix:** Renamed `delayMs` → `delay` so an actual 1s delay is applied to the response. With a real delay in place, the loading-state assertion reliably runs before the response arrives, and `cy.wait('@users')` resolves once the delay completes.

### Steps to test

```sh
yarn workspace @cypress/vue cy:run -- --spec cypress/component/xhr/ajax-list.cy.js
```

All five `AjaxList` tests should pass.

### How has the user experience changed?

No user-facing changes — internal test stability fix only.

### PR Tasks

- [na] Have tests been added/updated? (test stability fix only)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?