### PR TITLE
chore(ci): remove conflicting declarations from generated pipeline parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ parameters:
   publish-binary-branch:
     type: string
     default: main
-  # set to true when triggering the pipeline manually to have CI comment on the commit
-  # with links to published binaries
   force-persist-artifacts:
     type: boolean
     default: false
@@ -171,6 +169,8 @@ jobs:
                 fi
           - run:
               name: Generate path-filtered pipeline parameters
+              environment:
+                RUN_ALL_JOBS: << pipeline.parameters.run-all-jobs >>
               command: |
                 bash .circleci/scripts/generate-pipeline-parameters.sh \
                   > /tmp/pipeline-parameters.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ parameters:
   publish-binary-branch:
     type: string
     default: main
+  # set to true when triggering the pipeline manually to have CI comment on the commit
+  # with links to published binaries
   force-persist-artifacts:
     type: boolean
     default: false
@@ -169,10 +171,6 @@ jobs:
                 fi
           - run:
               name: Generate path-filtered pipeline parameters
-              environment:
-                PUBLISH_BINARY_BRANCH: << pipeline.parameters.publish-binary-branch >>
-                FORCE_PERSIST_ARTIFACTS: << pipeline.parameters.force-persist-artifacts >>
-                RUN_ALL_JOBS: << pipeline.parameters.run-all-jobs >>
               command: |
                 bash .circleci/scripts/generate-pipeline-parameters.sh \
                   > /tmp/pipeline-parameters.json

--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -5,7 +5,7 @@
 # Output: JSON written to stdout, consumed by continuation/continue pipeline_parameters.
 #
 # Only path-filtering run-* keys belong here. publish-binary-branch,
-# force-persist-artifacts, and run-all-jobs live on the setup workflow trigger;
+# force-persist-artifacts, live on the setup workflow trigger;
 # including them again in this payload conflicts with CircleCI’s continuation API.
 #
 # All run-* params default to true so that develop/release branches and

--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -4,6 +4,10 @@
 #
 # Output: JSON written to stdout, consumed by continuation/continue pipeline_parameters.
 #
+# Only path-filtering run-* keys belong here. publish-binary-branch,
+# force-persist-artifacts, and run-all-jobs live on the setup workflow trigger;
+# including them again in this payload conflicts with CircleCI’s continuation API.
+#
 # All run-* params default to true so that develop/release branches and
 # API-triggered pipelines run everything without needing to pass explicit params.
 
@@ -34,12 +38,8 @@ npm_eslint_plugin_tests=false
 npm_schematic_tests=false
 
 emit_json() {
-  local pb="${PUBLISH_BINARY_BRANCH:-main}"
-  # CircleCI converts boolean pipeline params to "0"/"1" in env vars; normalize to JSON boolean
-  local fpa_raw="${FORCE_PERSIST_ARTIFACTS:-false}"
-  local fpa; [[ "$fpa_raw" == "true" || "$fpa_raw" == "1" ]] && fpa=true || fpa=false
   cat <<EOF
-{"publish-binary-branch": "$pb", "force-persist-artifacts": $fpa, "run-driver-tests": $driver_tests, "run-server-tests": $server_tests, "run-app-ui-tests": $app_ui_tests, "run-launchpad-tests": $launchpad_tests, "run-reporter-tests": $reporter_tests, "run-frontend-shared-tests": $frontend_shared_tests, "run-system-tests": $system_tests, "run-v8-tests": $v8_tests, "run-cli-tests": $cli_tests, "run-unit-tests": $unit_tests, "run-npm-webpack-dev-server-tests": $npm_webpack_dev_server_tests, "run-npm-vite-dev-server-tests": $npm_vite_dev_server_tests, "run-npm-webpack-preprocessor-tests": $npm_webpack_preprocessor_tests, "run-npm-webpack-batteries-tests": $npm_webpack_batteries_tests, "run-npm-vue-tests": $npm_vue_tests, "run-npm-react-tests": $npm_react_tests, "run-npm-angular-tests": $npm_angular_tests, "run-npm-puppeteer-tests": $npm_puppeteer_tests, "run-npm-vite-plugin-esm-tests": $npm_vite_plugin_esm_tests, "run-npm-mount-utils-tests": $npm_mount_utils_tests, "run-npm-grep-tests": $npm_grep_tests, "run-npm-eslint-plugin-tests": $npm_eslint_plugin_tests, "run-npm-schematic-tests": $npm_schematic_tests}
+{"run-driver-tests": $driver_tests, "run-server-tests": $server_tests, "run-app-ui-tests": $app_ui_tests, "run-launchpad-tests": $launchpad_tests, "run-reporter-tests": $reporter_tests, "run-frontend-shared-tests": $frontend_shared_tests, "run-system-tests": $system_tests, "run-v8-tests": $v8_tests, "run-cli-tests": $cli_tests, "run-unit-tests": $unit_tests, "run-npm-webpack-dev-server-tests": $npm_webpack_dev_server_tests, "run-npm-vite-dev-server-tests": $npm_vite_dev_server_tests, "run-npm-webpack-preprocessor-tests": $npm_webpack_preprocessor_tests, "run-npm-webpack-batteries-tests": $npm_webpack_batteries_tests, "run-npm-vue-tests": $npm_vue_tests, "run-npm-react-tests": $npm_react_tests, "run-npm-angular-tests": $npm_angular_tests, "run-npm-puppeteer-tests": $npm_puppeteer_tests, "run-npm-vite-plugin-esm-tests": $npm_vite_plugin_esm_tests, "run-npm-mount-utils-tests": $npm_mount_utils_tests, "run-npm-grep-tests": $npm_grep_tests, "run-npm-eslint-plugin-tests": $npm_eslint_plugin_tests, "run-npm-schematic-tests": $npm_schematic_tests}
 EOF
 }
 

--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -4,10 +4,6 @@
 #
 # Output: JSON written to stdout, consumed by continuation/continue pipeline_parameters.
 #
-# Only path-filtering run-* keys belong here. publish-binary-branch,
-# force-persist-artifacts, live on the setup workflow trigger;
-# including them again in this payload conflicts with CircleCI’s continuation API.
-#
 # All run-* params default to true so that develop/release branches and
 # API-triggered pipelines run everything without needing to pass explicit params.
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change limited to how CircleCI continuation parameters are generated; risk is mainly accidental omission of expected params causing pipeline triggers or artifact persistence behavior to differ.
> 
> **Overview**
> The setup workflow no longer passes `publish-binary-branch` or `force-persist-artifacts` into `generate-pipeline-parameters.sh`, and the script no longer emits those keys in its JSON output.
> 
> As a result, the continuation pipeline parameters file now contains only the `run-*` booleans used for path-filtered job selection, avoiding conflicting/duplicate parameter declarations in the generated pipeline parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c180d494a66132bf781c4b0e6543d00006b1b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Trigger a pipeline execution from CircleCI with force-persist-artifacts=true. The full workflow matrix should run and comment on the commit.

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
