### PR TITLE
test: stabilize flaky 'fails when content type isnt html' in visit_spec

### DIFF
--- a/system-tests/__snapshots__/visit_spec.js
+++ b/system-tests/__snapshots__/visit_spec.js
@@ -209,17 +209,11 @@ However, you can likely use \`cy.request()\` instead of \`cy.visit()\`.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     visit_non_html_content_type_failing.cy.js                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_non_html_content_type_failing.cy.js/when      (1280x720)
-     content type is plaintext -- fails (failed).png                                                
 
 
 ====================================================================================================

--- a/system-tests/test/visit_spec.js
+++ b/system-tests/test/visit_spec.js
@@ -189,6 +189,9 @@ describe('e2e visit', () => {
       spec: 'visit_non_html_content_type_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: {
+        screenshotOnRunFailure: false,
+      },
     })
 
     systemTests.it('calls onBeforeLoad when overwriting cy.visit', {


### PR DESCRIPTION
- Closes n/a

### Additional details

The system test `e2e visit / low response timeout / fails when content type isnt html` (in `system-tests/test/visit_spec.js`) is flaky in CI. Example failure: [CircleCI job 3587493](https://app.circleci.com/pipelines/github/cypress-io/cypress/81034/workflows/c49b9d76-2b3e-452f-8b19-330ee9f83994/jobs/3587493/tests#failed-test-0).

**Root cause:** The "low response timeout" context sets `responseTimeout: 500`. When the test fails (as expected, due to a non-HTML content type), Cypress automatically takes a failure screenshot using `config('responseTimeout')` as the timeout — see [`packages/driver/src/cy/commands/screenshot.ts`](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/commands/screenshot.ts) (`runnable:after:run:async` listener). In CI, 500ms is sometimes not enough to take the screenshot, so a `cy.screenshot() timed out waiting 500ms to complete` error replaces the original `cy.visit()` content-type error in the output, breaking the snapshot comparison.

**Fix:** Disable `screenshotOnRunFailure` for this specific test, since it is verifying the `cy.visit()` error message — not screenshot behavior. The snapshot is updated accordingly (Screenshots: 0, no `(Screenshots)` section). This follows an established pattern used across other system tests (`config_spec.js`, `reporters_spec.js`, `ci_failure_spec.ts`, `experimental_retries.spec.ts`).

### Steps to test

1. Run the system test: `node system-tests/scripts/run.js --glob-in-dir="visit_spec"` and verify the "fails when content type isnt html" test passes.
2. Verify other tests in the "low response timeout" context still pass.

### How has the user experience changed?

No user-facing change — this is a test stabilization.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to system test configuration and snapshot output, with no product/runtime code impact.
> 
> **Overview**
> Stabilizes the `visit_non_html_content_type_failing` system test by disabling `screenshotOnRunFailure` for that single failing-run scenario (so the test asserts the `cy.visit()` error without competing screenshot timeouts).
> 
> Updates the corresponding `visit_spec` snapshot to reflect **no screenshot captured** (Screenshots: 0 and removal of the `(Screenshots)` section).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f5783b3ce5d9f65e1bb5ba1c77dfdf90ddd933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->