### PR TITLE
misc: Capture additional env vars for retrying failed tests

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.14.3
+
+**Misc:**
+
+- Additional CI environment variables are now captured to support a future failed test retry feature. Addressed in [#33714](https://github.com/cypress-io/cypress/pull/33714).
+
 ## 15.14.2
 
 **Performance:**
@@ -49,7 +55,7 @@
 
 - Upgraded `axios` to `1.15.0` to address [CVE-2025-62718](https://www.cve.org/CVERecord?id=CVE-2025-62718) and [CVE-2026-40175](https://www.cve.org/CVERecord?id=CVE-2026-40175) vulnerabilities reported in security scans. Fixes [#33590](https://github.com/cypress-io/cypress/issues/33590).
 
-## 15.13.1 
+## 15.13.1
 
 **Performance:**
 

--- a/packages/server/lib/util/ci_provider.ts
+++ b/packages/server/lib/util/ci_provider.ts
@@ -187,6 +187,8 @@ const _providerCiParams = () => {
       'SYSTEM_PULLREQUEST_PULLREQUESTNUMBER',
       'SYSTEM_PULLREQUEST_TARGETBRANCH',
       'SYSTEM_PULLREQUEST_TARGETBRANCHNAME',
+      'SYSTEM_TEAMPROJECT',
+      'BUILD_DEFINITIONNAME',
     ]),
     awsCodeBuild: extract([
       'CODEBUILD_BUILD_ID',
@@ -259,6 +261,7 @@ const _providerCiParams = () => {
       'BITBUCKET_PR_ID',
       'BITBUCKET_PR_DESTINATION_BRANCH',
       'BITBUCKET_PR_DESTINATION_COMMIT',
+      'BITBUCKET_PIPELINE_UUID',
     ]),
     // https://buildkite.com/docs/pipelines/configure/environment-variables
     buildkite: extract([
@@ -288,6 +291,8 @@ const _providerCiParams = () => {
       'CIRCLE_PULL_REQUEST',
       'CIRCLE_REPOSITORY_URL',
       'CI_PULL_REQUEST',
+      'CIRCLE_PROJECT_REPONAME',
+      'CIRCLE_WORKFLOW_WORKSPACE_ID',
     ]),
     cloudbeesUnify: extract([
       'CLOUDBEES_WORKSPACE',

--- a/packages/server/test/unit/util/ci_provider_spec.ts
+++ b/packages/server/test/unit/util/ci_provider_spec.ts
@@ -395,6 +395,7 @@ describe('lib/util/ci_provider', () => {
       BITBUCKET_PR_ID: 'bitbucketPrId',
       BITBUCKET_PR_DESTINATION_BRANCH: 'bitbucketPrDestinationBranch',
       BITBUCKET_PR_DESTINATION_COMMIT: 'bitbucketPrDestinationCommit',
+      BITBUCKET_PIPELINE_UUID: 'bitbucketPipelineUuid',
     }, { clear: true })
 
     expectsName('bitbucket')
@@ -407,6 +408,7 @@ describe('lib/util/ci_provider', () => {
       bitbucketPrId: 'bitbucketPrId',
       bitbucketPrDestinationBranch: 'bitbucketPrDestinationBranch',
       bitbucketPrDestinationCommit: 'bitbucketPrDestinationCommit',
+      bitbucketPipelineUuid: 'bitbucketPipelineUuid',
     })
 
     expectsCommitParams({
@@ -588,6 +590,8 @@ describe('lib/util/ci_provider', () => {
       CIRCLE_PULL_REQUEST: 'circlePullRequest',
       CIRCLE_REPOSITORY_URL: 'circleRepositoryUrl',
       CI_PULL_REQUEST: 'ciPullRequest',
+      CIRCLE_PROJECT_REPONAME: 'circleProjectReponame',
+      CIRCLE_WORKFLOW_WORKSPACE_ID: 'circleWorkflowWorkspaceId',
 
       CIRCLE_SHA1: 'circleSha',
       CIRCLE_BRANCH: 'circleBranch',
@@ -609,6 +613,8 @@ describe('lib/util/ci_provider', () => {
       circlePullRequest: 'circlePullRequest',
       circleRepositoryUrl: 'circleRepositoryUrl',
       ciPullRequest: 'ciPullRequest',
+      circleProjectReponame: 'circleProjectReponame',
+      circleWorkflowWorkspaceId: 'circleWorkflowWorkspaceId',
     })
 
     return expectsCommitParams({
@@ -1283,6 +1289,8 @@ describe('lib/util/ci_provider', () => {
       SYSTEM_STAGEATTEMPT: 'stageAttempt',
       SYSTEM_PHASEATTEMPT: 'phaseAttempt',
       SYSTEM_JOBATTEMPT: 'jobAttempt',
+      SYSTEM_TEAMPROJECT: 'teamProject',
+      BUILD_DEFINITIONNAME: 'buildDefinitionName',
 
       BUILD_SOURCEVERSION: 'commit',
       BUILD_SOURCEBRANCHNAME: 'branch',
@@ -1305,6 +1313,8 @@ describe('lib/util/ci_provider', () => {
       systemStageattempt: 'stageAttempt',
       systemPhaseattempt: 'phaseAttempt',
       systemJobattempt: 'jobAttempt',
+      systemTeamproject: 'teamProject',
+      buildDefinitionname: 'buildDefinitionName',
     })
 
     return expectsCommitParams({


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes [RAP-74](https://cypress-io.atlassian.net/browse/RAP-74)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends CI metadata collection, which can affect what environment/commit data is captured and sent (or stored) for CI runs across multiple providers. Risk is moderate due to potential downstream assumptions about available CI params and their naming/casing.
> 
> **Overview**
> Adds capture of additional CI-provider environment variables in `ci_provider.ts` (Azure: `SYSTEM_TEAMPROJECT`, `BUILD_DEFINITIONNAME`; Bitbucket: `BITBUCKET_PIPELINE_UUID`; CircleCI: `CIRCLE_PROJECT_REPONAME`, `CIRCLE_WORKFLOW_WORKSPACE_ID`) and updates unit tests to assert the new extracted fields.
> 
> Updates the CLI changelog to note the expanded CI env var capture in support of a future failed test retry feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9171ffe3554a45ac17dbf78bc5380422fb70d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[RAP-74]: https://cypress-io.atlassian.net/browse/RAP-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ