### PR TITLE
fix: reduce size of 'Open in IDE' icon for better UI consistency

### DIFF
--- a/packages/app/src/debug/DebugSpec.vue
+++ b/packages/app/src/debug/DebugSpec.vue
@@ -36,7 +36,7 @@
                     fill-color="gray-100"
                     hocus-stroke-color="indigo-400"
                     hocus-fill-color="indigo-200"
-                    size="16"
+                    size="14"
                     interactive-colors-on-group
                     class="min-w-[16px]"
                   />


### PR DESCRIPTION
Fixes #32779

Reduced the size of the "Open in IDE" icon from 16 to 14 to improve UI consistency and alignment with surrounding elements.

This is a minimal UI change affecting only the icon size.