### PR TITLE
test: stabilize flaky 'responds to a cypress.config.js file change' spec

### DIFF
--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -487,7 +487,7 @@ module.exports = {
 }`)
       })
 
-      cy.get('[data-cy="create-spec-page-title"]')
+      cy.get('[data-cy="create-spec-page-title"]', { timeout: 10000 })
       .should('contain', defaultMessages.createSpec.page.customPatternNoSpecs.title)
     })
   })


### PR DESCRIPTION
- Closes [no linked issue]

### Additional details

The `specChange subscription > spec pattern modal > responds to a cypress.config.js file change` test in [specChange-subscription.cy.ts](packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts) has been failing intermittently on Windows CI. Example failure: [job 3592689](https://app.circleci.com/pipelines/github/cypress-io/cypress/81107/workflows/4853cac3-2c73-4778-8010-3a126ad5126d/jobs/3592689/tests).

The error:
```
AssertionError: Timed out retrying after 4000ms: Expected to find element: `[data-cy="create-spec-page-title"]`, but never found it.
```

The test rewrites `cypress.config.js` twice in succession. The second rewrite is the more demanding one — it adds a `setupNodeEvents` that mutates `config.specPattern = []`, which exercises this chain:

1. File written via `ctx.actions.file.writeFileInProject`
2. File watcher fires
3. Config is re-evaluated
4. `setupNodeEvents` runs and mutates the spec pattern
5. GraphQL subscription pushes the update
6. UI re-renders the "no specs found" page

On Windows CI, this can exceed the default 4000ms `cy.get` timeout — especially since the test had just executed a similar (simpler) flow that the test author already gave a 7500ms timeout to (line 456). The final assertion was left on the default, which is the inconsistency this PR fixes.

Bumping the timeout on the final `cy.get('[data-cy=\"create-spec-page-title\"]')` to 10s gives the slowest path enough headroom without masking real regressions (the assertion still uses Cypress's retry logic and will pass quickly on healthy runs).

### Steps to test

1. Run `packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts` and confirm the `responds to a cypress.config.js file change` test still passes locally.
2. Re-run the previously failing Windows CI job — the assertion should no longer time out.

### How has the user experience changed?

No user-facing change. Test stabilization only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that increases a single `cy.get` timeout to reduce CI flake without affecting production behavior.
> 
> **Overview**
> Stabilizes the flaky `specChange subscription > spec pattern modal > responds to a cypress.config.js file change` Cypress E2E by increasing the timeout on the final `cy.get('[data-cy="create-spec-page-title"]')` assertion to 10s, giving the UI more time to re-render after the second `cypress.config.js` rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc0fd748db7cb8f1c12730e7df8be971b49014e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->