### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -12,6 +12,8 @@ on:
     branches:
       - develop
       - release/*
+permissions:
+  contents: read
 jobs:
   Snyk_SCA_Scan:
     # Skip this job on PRs from forks
@@ -25,7 +27,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - develop
       - release/*
+permissions:
+  contents: read
 jobs:
   Snyk_SAST_Scan:
     # Skip this job on PRs from forks
@@ -18,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_GITHUB_ACTION_TOKEN }}
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -17,12 +17,12 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   add-to-triage-project:
     name: Add to triage project
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     env:
       PROJECT_NUMBER: 9
       GITHUB_TOKEN: ${{ secrets.ADD_TO_TRIAGE_BOARD_TOKEN }}

--- a/.github/workflows/triage_add_to_routed_project.yml
+++ b/.github/workflows/triage_add_to_routed_project.yml
@@ -8,6 +8,7 @@ on:
   issues:
     types:
       - labeled
+permissions: {}
 jobs:
   route-to-e2e:
     if: github.event.label.name == 'routed-to-e2e'

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -9,6 +9,8 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   handle-comment-scenarios:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage_update_status.yml
+++ b/.github/workflows/triage_update_status.yml
@@ -12,6 +12,8 @@ on:
       ADD_TO_TRIAGE_BOARD_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   move-to-requested-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -23,7 +23,6 @@ jobs:
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-          repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -21,9 +21,8 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
-          permissions: |-
-            contents: write
-            pull-requests: write
+          permission-contents: write
+          permission-pull-requests: write
           repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
+          permissions: |-
+            contents: write
+            pull-requests: write
+          repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
+          permissions: |-
+            contents: read
+          repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -125,6 +128,32 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
+          permissions: |-
+            contents: write
+            pull-requests: write
+          repositories: cypress
+      ## actions/checkout persisted the *initial* token in git's config. On
+      ## Windows the build can exceed the App token's 1h lifetime, so that
+      ## persisted credential expires before we push. Re-run checkout with
+      ## the refreshed token to overwrite the persisted credential. The action
+      ## does a force-checkout, so stash the freshly-generated snapshot file
+      ## first and restore it afterward.
+      - name: Stash snapshot changes for credential refresh
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
+        run: git stash push -- ${{ env.SNAPSHOT_FILES }}
+        shell: bash
+      - name: Refresh persisted git credentials
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token-refresh.outputs.token }}
+          ref: ${{ env.BASE_BRANCH }}
+          clean: false
+      - name: Restore snapshot changes
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
+        run: git stash pop
+        shell: bash
       - name: Determine branch name - commit directly to branch
         if: ${{ inputs.commit_directly_to_branch == true }}
         run: |
@@ -170,11 +199,9 @@ jobs:
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
         run: |
           git diff-index --quiet HEAD || git commit -am "chore: updating v8 snapshot cache"
-      ## Push branch — use the refreshed App token explicitly. The persisted
-      ## credential from the initial checkout may have expired during the build.
       - name: Push branch to remote
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: git push "https://x-access-token:${{ steps.app-token-refresh.outputs.token }}@github.com/${{ github.repository }}.git" "${{ env.BRANCH_NAME }}"
+        run: git push origin "${{ env.BRANCH_NAME }}"
       # PR needs to be created
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -83,8 +83,7 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
-          permissions: |-
-            contents: read
+          permission-contents: read
           repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6
@@ -128,9 +127,8 @@ jobs:
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
-          permissions: |-
-            contents: write
-            pull-requests: write
+          permission-contents: write
+          permission-pull-requests: write
           repositories: cypress
       ## actions/checkout persisted the *initial* token in git's config. On
       ## Windows the build can exceed the App token's 1h lifetime, so that

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -84,7 +84,6 @@ jobs:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: read
-          repositories: cypress
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -129,7 +128,6 @@ jobs:
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-          repositories: cypress
       ## actions/checkout persisted the *initial* token in git's config. On
       ## Windows the build can exceed the App token's 1h lifetime, so that
       ## persisted credential expires before we push. Re-run checkout with


### PR DESCRIPTION
- Closes n/a

### Additional details

Fix Windows issue when token expires in the v8 snapshot update workflow. Explicitly declare workflow permissions.

### Steps to test

Trigger each affected workflow via `workflow_dispatch` and confirm runs succeed across all platforms.

### How has the user experience changed?

No user-facing change — CI hardening only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow permission and authentication changes can break CI automation (especially branch/PR pushing) if mis-scoped, but are limited to GitHub Actions configuration with no runtime product impact.
> 
> **Overview**
> Hardens several GitHub Actions workflows by explicitly setting top-level `permissions` and removing the custom checkout token from the Snyk PR scans.
> 
> Fixes long-running `update_v8_snapshot_cache.yml` runs (notably Windows) by minting a refreshed GitHub App token, re-checking out to update persisted git credentials while stashing/restoring snapshot changes, and switching the push step to `git push origin` using the updated credentials.
> 
> Updates token scopes for `actions/create-github-app-token` (e.g., adding `contents`/`pull-requests` permissions where required) and locks down triage workflows with `permissions: {}` at the workflow level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7809f06692266fab77ceb2b8ef5d4895a04992be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->