### PR TITLE
chore(ci): use node wrapper for lerna build concurrency to unbreak Windows CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@ loglevel=warn
 progress=false
 package-lock=false
 save-exact=true
-script-shell=bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,11 +283,9 @@ The project utilizes [yarn workspaces](https://yarnpkg.com/lang/en/docs/workspac
 
 > **⚠ Running on Windows?**
 >
-> The project's `.npmrc` sets `script-shell=bash` so npm scripts behave the same on every platform. You'll need `bash` on your `PATH` — Git Bash (ships with [Git for Windows](https://gitforwindows.org/)) is the easiest option.
->
-> If you previously ran `yarn config set script-shell "C:\\Windows\\system32\\cmd.exe"` per older instructions, that setting in your `~/.yarnrc` will override the project's `.npmrc`. Remove it with:
+> If you are running a Windows operating system, you may encounter some commands that are not working. In order to resolve paths correctly during the development build process, you may need to explicitly set your default `yarn` shell script to Command Prompt by using the following command:
 >```bash
-> yarn config delete script-shell
+> yarn config set script-shell "C:\\Windows\\system32\\cmd.exe"
 >```
 
 **Install all dependencies:**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "binary-smoke-test": "node ./scripts/binary.js smoke",
     "binary-upload": "node ./scripts/binary.js upload",
     "binary-zip": "node ./scripts/binary.js zip",
-    "build": "lerna run build --stream --concurrency=$(node -p \"Math.min(4, require('os').availableParallelism())\") && yarn workspace @packages/electron build-binary && lerna run build-cli --stream",
+    "build": "node ./scripts/lerna-build.js && yarn workspace @packages/electron build-binary && lerna run build-cli --stream",
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",
     "check-binary-on-cdn": "node ./scripts/binary.js checkIfBinaryExistsOnCdn",

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Cap lerna build concurrency at 4 (per #33483, to avoid CI hangs/OOM on big
+// runners) but never exceed available parallelism. Without the lower bound,
+// arm.medium (2 CPU) runs 4 simultaneous tsc startups and intermittently
+// segfaults inside V8's bytecode-cache deserializer (#33730).
+const { spawn } = require('child_process')
+const os = require('os')
+
+const concurrency = Math.min(4, os.availableParallelism())
+
+const child = spawn(
+  'lerna',
+  ['run', 'build', '--stream', `--concurrency=${concurrency}`],
+  { stdio: 'inherit', shell: true },
+)
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+  } else {
+    process.exit(code ?? 1)
+  }
+})


### PR DESCRIPTION
- Closes nothing yet; fixes Windows CI breakage introduced by #33730 ([failing job 3597633](http://app.circleci.com/pipelines/github/cypress-io/cypress/81179/workflows/9ed5105b-09a4-46df-b150-3b5bbc5b5616/jobs/3597633)).

### Additional details

#33730 capped lerna build concurrency at `Math.min(4, os.availableParallelism())` to fix arm64 V8 segfaults on `arm.medium` (2-CPU) runners. To express that in `package.json` it used `$(node -p "...")` shell substitution and set `script-shell=bash` in `.npmrc` so the substitution would work on Windows.

That `.npmrc` change triggers a long-standing, unfixed Yarn 1 bug ([yarnpkg/yarn#7732](https://github.com/yarnpkg/yarn/issues/7732), [#5717](https://github.com/yarnpkg/yarn/issues/5717), [#5349](https://github.com/yarnpkg/yarn/issues/5349)): with `script-shell=bash`, Yarn 1 passes Windows-style `node_modules\.bin\X` paths to `bash -c` without escaping the backslashes. Bash treats `\` as escape characters, so the path is mangled and any `.bin/` invocation fails with exit 127. We hit this on `windows-build`:

```
$ C:\Users\circleci\cypress\node_modules\.bin\gulp syncCloudValidations
bash: line 1: C:Userscirclecicypressnode_modules.bingulp: command not found
```

A targeted patch wouldn't be enough — auditing the Windows CI graph shows the bug would impact roughly 7 of ~10 Windows jobs (every one runs at least one yarn script that resolves a `.bin/` binary: `lerna`, `gulp`, `mocha`, `vitest`, `cypress`, `electron-builder`, …).

This PR restores the `scripts/lerna-build.js` Node wrapper (originally landed in #33730 then reverted in favor of `script-shell=bash`) so the concurrency calculation runs in plain Node — no shell features needed, no Windows path mangling. The cap-at-4 / floor-at-`os.availableParallelism()` behavior is preserved exactly.

Changes:
- Remove `script-shell=bash` from `.npmrc`
- Revert root `build` script in `package.json` to `node ./scripts/lerna-build.js && …`
- Re-create `scripts/lerna-build.js`
- Revert the Windows section of `CONTRIBUTING.md` to the prior cmd.exe guidance

### Steps to test

1. CI: confirm `windows-build` passes the **Sync Cloud Validations** step and downstream Windows jobs (`windows-create-build-artifacts`, `windows-unit-tests`, `windows-server-unit-tests-*`, `windows-driver-*`, etc.) build/test as before.
2. CI: confirm `linux-arm64` build still passes (the arm64 V8 segfault target from #33730).
3. Locally: `yarn build` still completes on macOS / Linux / Windows; effective concurrency is `Math.min(4, os.availableParallelism())`.

### How has the user experience changed?

No user-facing change. Internal CI/build-orchestration only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the root build orchestration and Windows developer/CI setup; mistakes could break builds across platforms, though changes are isolated to scripts/docs.
> 
> **Overview**
> Restores a Node-based wrapper (`scripts/lerna-build.js`) for `lerna run build` so build concurrency is computed in Node (`Math.min(4, os.availableParallelism())`) instead of via shell substitution.
> 
> Removes `script-shell=bash` from `.npmrc` and updates the root `build` script to call the wrapper, avoiding Yarn-on-Windows path mangling; `CONTRIBUTING.md` is updated to reflect the Windows `yarn config set script-shell "C:\\Windows\\system32\\cmd.exe"` guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e688bcc0720d30b0ce274a462ab9d8794e5e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->