### PR TITLE
test: de-flake proxy correlation timing test

### DIFF
--- a/packages/server/test/integration/http_requests_spec.js
+++ b/packages/server/test/integration/http_requests_spec.js
@@ -1022,10 +1022,9 @@ describe('Routes', () => {
       })
 
       it('properly correlates when proxy failure come first', function () {
+        const followupPreRequestTimeout = 1000
+
         this.networkProxy.setPreRequestTimeout(50)
-        // If this takes longer than the Promise.delay and the prerequest timeout then the second
-        // call has hit the prerequest timeout which is a problem
-        this.timeout(900)
 
         nock(this.server.remoteStates.current().origin)
         .get('/')
@@ -1047,7 +1046,7 @@ describe('Routes', () => {
 
         // Wait 100 ms to make sure the request times out
         return Promise.delay(100).then(() => {
-          this.networkProxy.setPreRequestTimeout(1000)
+          this.networkProxy.setPreRequestTimeout(followupPreRequestTimeout)
           nock(this.server.remoteStates.current().origin)
           .get('/')
           .once()
@@ -1062,6 +1061,7 @@ describe('Routes', () => {
             url: 'http://www.github.com/',
           })
 
+          const followupStart = Date.now()
           const followupRequestPromise = this.rp({
             url: 'http://www.github.com/',
             headers: {
@@ -1071,6 +1071,9 @@ describe('Routes', () => {
           })
 
           return followupRequestPromise.then((res) => {
+            // If the followup hit the pre-request timeout, the proxy incorrectly correlated
+            // with the stale pre-request from the first (timed-out) request.
+            expect(Date.now() - followupStart, 'followup request hit the pre-request timeout').to.be.lessThan(followupPreRequestTimeout)
             expect(res.statusCode).to.eq(200)
 
             expect(res.body).to.include('hello from baz!')


### PR DESCRIPTION
- Closes [n/a]

### Additional details

The `properly correlates when proxy failure come first` integration test in [http_requests_spec.js](packages/server/test/integration/http_requests_spec.js) was using a tight `this.timeout(900)` Mocha timeout as its bug-detection mechanism. The reasoning was: if the proxy incorrectly correlates a new request with a stale pre-request from a previously timed-out request, the followup will hit the 1000ms pre-request timeout, making total wall time exceed 900ms.

The problem: the legitimate (non-bug) path can also exceed 900ms under CI load — there's only ~675ms of headroom for Node event-loop processing, nock interception, proxy correlation, and the second request's full lifecycle, after subtracting the explicit 50ms + 75ms + 100ms waits. A recent CircleCI run ([job 3592058](https://app.circleci.com/pipelines/github/cypress-io/cypress/81098/workflows/dd852a15-b3a5-4849-9e2d-9e04d382b341/jobs/3592058/tests#failed-test-0)) failed exactly this way.

This change replaces the Mocha-timeout-as-assertion with an **explicit elapsed-time assertion** on just the followup request. The bug condition (proxy correlated incorrectly → followup hit pre-request timeout) is now detected directly:

```js
expect(Date.now() - followupStart, 'followup request hit the pre-request timeout')
  .to.be.lessThan(followupPreRequestTimeout)
```

This decouples bug detection from CI scheduling jitter on the rest of the test, and produces a clearer failure message when the bug does occur.

### Steps to test

1. `yarn workspace @packages/server test-integration -- packages/server/test/integration/http_requests_spec.js --grep "properly correlates when proxy failure come first"`
2. Test should pass.

### How has the user experience changed?

No user-facing changes — test-only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces a brittle Mocha timeout with an explicit elapsed-time assertion, with no production code impact.
> 
> **Overview**
> Updates the `properly correlates when proxy failure come first` integration test to stop using a tight Mocha `this.timeout()` as a proxy-correlation bug detector.
> 
> The test now captures the start time of the follow-up request and **explicitly asserts** it completes in less than the configured pre-request timeout, making the failure mode deterministic and producing a clearer error when stale pre-request correlation occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6957a16c18b80e73d3030d15deeeecd82aaf082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->