### PR TITLE
fix: upgrade growl to 1.10.0 (CVE-2017-16042)

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
     "**/editorconfig/minimatch": "9.0.7",
     "**/form-data": "^4.0.5",
     "**/graphql-config/minimatch": "3.1.3",
+    "**/growl": "1.10.0",
     "**/jquery": "3.7.1",
     "**/lerna/minimatch": "3.1.3",
     "**/mocha-7.2.0/minimatch": "3.1.3",


### PR DESCRIPTION
## Summary
Upgrade growl from 1.9.2 to 1.10.0 to fix CVE-2017-16042.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2017-16042 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2017-16042` |
| **File** | `yarn.lock` |

**Description**: nodejs-growl: Does not properly sanitize input before passing it to exec

## Changes
- `package.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
