### PR TITLE
test: deflake primaryOriginCommunicator map-clearing test

### DIFF
--- a/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
+++ b/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
@@ -1,4 +1,4 @@
-describe('Cypress In Cypress Origin Communicator', () => {
+describe('Cypress In Cypress Origin Communicator', { defaultCommandTimeout: 10000 }, () => {
   describe('primary origin memory leak prevention', () => {
     let spies: Array<ReturnType<typeof cy.spy>>
 

--- a/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
+++ b/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
@@ -66,7 +66,7 @@ describe('Cypress In Cypress Origin Communicator', () => {
 
       cy.window().then((win) => {
         // @ts-ignore
-        const comm = win.Cypress.primaryOriginCommunicator
+        const comm = win.Cypress.primaryOriginCommunicator as any
 
         // @ts-ignore — hold stub across navigation for the assertion below
         window.__cyCommunicatorMapTest = { postMessage: cy.stub() }
@@ -85,7 +85,7 @@ describe('Cypress In Cypress Origin Communicator', () => {
 
       cy.window().then((win) => {
         // @ts-ignore
-        const comm = win.Cypress.primaryOriginCommunicator
+        const comm = win.Cypress.primaryOriginCommunicator as any
         // @ts-ignore
         const stub = window.__cyCommunicatorMapTest
 

--- a/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
+++ b/packages/app/cypress/e2e/cypress-origin-communicator.cy.ts
@@ -1,7 +1,6 @@
 describe('Cypress In Cypress Origin Communicator', () => {
   describe('primary origin memory leak prevention', () => {
     let spies: Array<ReturnType<typeof cy.spy>>
-    let removeAllListenersSpy: ReturnType<typeof cy.spy>
 
     beforeEach(() => {
       spies = []
@@ -63,10 +62,11 @@ describe('Cypress In Cypress Origin Communicator', () => {
       cy.specsPageIsVisible()
       cy.contains('dom-content.spec').click()
       cy.waitForSpecToFinish()
+      trackRemoveAllListenersOnAllCypressInstances()
 
-      cy.then(() => {
+      cy.window().then((win) => {
         // @ts-ignore
-        const comm = window.top[0].Cypress.primaryOriginCommunicator
+        const comm = win.Cypress.primaryOriginCommunicator
 
         // @ts-ignore — hold stub across navigation for the assertion below
         window.__cyCommunicatorMapTest = { postMessage: cy.stub() }
@@ -76,21 +76,16 @@ describe('Cypress In Cypress Origin Communicator', () => {
           // @ts-ignore
           source: window.__cyCommunicatorMapTest,
         })
-
-        // @ts-ignore
-        removeAllListenersSpy = cy.spy(comm, 'removeAllListeners')
       })
 
       cy.get('a[href="#/runs"]').click()
       cy.location('hash').should('include', '/runs')
 
-      cy.wrap(null).should(() => {
-        const noArgCalls = removeAllListenersSpy.getCalls().filter((c) => c.args.length === 0)
+      assertZeroArgCleanupFired()
 
-        expect(noArgCalls.length).to.be.at.least(1)
-
+      cy.window().then((win) => {
         // @ts-ignore
-        const comm = window.top[0].Cypress.primaryOriginCommunicator
+        const comm = win.Cypress.primaryOriginCommunicator
         // @ts-ignore
         const stub = window.__cyCommunicatorMapTest
 


### PR DESCRIPTION
- Closes n/a

### Additional details

The test "clears cached spec bridge window targets when `primaryOriginCommunicator.removeAllListeners()` runs without an event" was flaking on Windows CI (Chrome) with:

```
AssertionError: Timed out retrying after 4000ms: expected 0 to be at least 1
```

The other three tests in the same describe block were deflaked over prior PRs and now use shared helpers (`trackRemoveAllListenersOnAllCypressInstances()` + `assertZeroArgCleanupFired()`). This test was added later in #33704 with a direct spy approach that doesn't use those proven helpers.

**Fix**: Align the test with the established pattern:
- Replace the direct `cy.spy(window.top[0].Cypress.primaryOriginCommunicator, 'removeAllListeners')` with `trackRemoveAllListenersOnAllCypressInstances()`, which retries across any Cypress instance and absorbs transition delays
- Use `cy.window()` instead of `window.top[0]` for reliable frame access
- Split the assertion into `assertZeroArgCleanupFired()` (retryable wait for teardown) + a separate `cy.window().then()` for verifying the map was cleared
- Remove the now-unused `removeAllListenersSpy` variable

### Steps to test

1. Run the spec on Windows or simulate CI conditions:
   ```
   yarn workspace @packages/app cypress:run:e2e -- --spec cypress/e2e/cypress-origin-communicator.cy.ts
   ```
2. Confirm all 4 tests in `primary origin memory leak prevention` pass

### How has the user experience changed?

No user-facing change. Test-only fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust how Cypress instances/windows are accessed and how teardown assertions are retried; low product risk but could mask regressions if assertions become too permissive.
> 
> **Overview**
> Deflakes the e2e that verifies spec-bridge window targets are cleared on `primaryOriginCommunicator.removeAllListeners()` by switching from a single direct spy to the shared cross-instance spying + retryable assertion helpers.
> 
> The test now uses `cy.window()` for communicator access, asserts teardown via `assertZeroArgCleanupFired()`, and only then validates the cached bridge target no longer receives messages; removes the unused per-test `removeAllListenersSpy` variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f6a5899722e7279d1bdb24b3aea0e43c9da670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->