### PR TITLE
internal: add placeholder v16 on MajorVersionWelcome

### DIFF
--- a/packages/launchpad/src/welcome/MajorVersionWelcome.cy.tsx
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.cy.tsx
@@ -15,11 +15,12 @@ describe('<MajorVersionWelcome />', { viewportWidth: 1280, viewportHeight: 1400 
     cy.contains('h1', 'What\'s New in Cypress').should('be.visible')
 
     cy.get('[data-cy="release-highlights"]').within(() => {
-      cy.contains('a[href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v15#15-0-0"]', '15.0.0')
-      cy.contains('a[href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v15#15-0-0"]', 'changelog')
+      cy.contains('a[href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v16#16-0-0"]', '16.0.0')
+      cy.contains('a[href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v16#16-0-0"]', 'changelog')
     })
 
     cy.get('[data-cy="previous-release-highlights"]').within(() => {
+      cy.contains('a[href="https://on.cypress.io/changelog#15-0-0"]', '15.0.0')
       cy.contains('a[href="https://on.cypress.io/changelog#14-0-0"]', '14.0.0')
       cy.contains('a[href="https://on.cypress.io/changelog#13-0-0"]', '13.0.0')
       cy.contains('a[href="https://on.cypress.io/changelog#12-0-0"]', '12.0.0')
@@ -35,17 +36,18 @@ describe('<MajorVersionWelcome />', { viewportWidth: 1280, viewportHeight: 1400 
   })
 
   it('renders correct time for releases and overflows correctly', () => {
-    cy.clock(Date.UTC(2025, 7, 20))
+    cy.clock(Date.UTC(2026, 4, 5))
     cy.mount(<MajorVersionWelcome />)
-    cy.contains('15.0.0 Released just now')
-    cy.contains('14.0.0 Released 7 months ago')
-    cy.contains('13.0.0 Released 2 years ago')
+    cy.contains('16.0.0 Released just now')
+    cy.contains('15.0.0 Released 9 months ago')
+    cy.contains('14.0.0 Released last year')
+    cy.contains('13.0.0 Released 3 years ago')
     cy.contains('12.0.0 Released 3 years ago')
     cy.tick(interval('1 minute'))
-    cy.contains('15.0.0 Released 1 minute ago')
+    cy.contains('16.0.0 Released 1 minute ago')
     cy.tick(interval('1 month'))
-    cy.contains('15.0.0 Released last month')
-    cy.contains('14.0.0 Released 8 months ago')
+    cy.contains('16.0.0 Released last month')
+    cy.contains('15.0.0 Released 10 months ago')
 
     cy.viewport(1280, 500)
 

--- a/packages/launchpad/src/welcome/MajorVersionWelcome.vue
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.vue
@@ -43,7 +43,7 @@
               </span>
             </div>
             <div class="children:mb-[16px]">
-              <!-- TODO: Replace with approved v16 launch copy. Approval process documented in prod-eng-docs. -->
+              <!-- TODO: Replace with approved v16 launch copy. -->
               <p>
                 Cypress 16 is here. This version includes breaking changes that may require updates to your project.
               </p>
@@ -74,8 +74,7 @@
               </span>
             </div>
             <p class="text-[14px] leading-[20px]">
-              <!-- TODO: Replace with approved v15 summary copy. -->
-              v15 advanced Cypress Studio with AI-assisted authoring and added cross-origin support improvements.
+              This release prepared Cypress Studio for the next era of AI-assisted test creation, with right-click assertions and inline test editing. It also made changes to improve reliability, future compatibility, and cross-origin support.
               <br>
               <br>
               Read about the v15.0.0 changes in our
@@ -212,7 +211,6 @@ const versionReleaseDates = computed(() => {
     '13': useTimeAgo(Date.UTC(2023, 7, 29)).value,
     '14': useTimeAgo(Date.UTC(2025, 0, 16)).value,
     '15': useTimeAgo(Date.UTC(2025, 7, 20)).value,
-    // TODO: replace placeholder with the real v16 release date before merging to release/16.0.0.
     '16': useTimeAgo(Date.UTC(2026, 4, 5)).value,
   }
 })

--- a/packages/launchpad/src/welcome/MajorVersionWelcome.vue
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.vue
@@ -74,7 +74,7 @@
               </span>
             </div>
             <p class="text-[14px] leading-[20px]">
-              This release prepared Cypress Studio for the next era of AI-assisted test creation, with right-click assertions and inline test editing. It also made changes to improve reliability, future compatibility, and cross-origin support.
+              This release prepares Cypress Studio for the next era of AI-assisted test creation. You can record interactions, add assertions by right-clicking, and now edit tests inline without leaving Cypress. Turn on <InlineCodeFragment>experimentalStudio</InlineCodeFragment> in your config to try it out and share your feedback.
               <br>
               <br>
               Read about the v15.0.0 changes in our

--- a/packages/launchpad/src/welcome/MajorVersionWelcome.vue
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.vue
@@ -33,25 +33,22 @@
 
             <div class="mb-[16px]">
               <ExternalLink
-                href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v15#15-0-0"
+                href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v16#16-0-0"
                 class="font-bold text-indigo-500"
               >
-                15.0.0
+                16.0.0
               </ExternalLink>
               <span class="font-light pl-[10px] text-gray-500 text-[14px]">
-                Released {{ versionReleaseDates['15'] }}
+                Released {{ versionReleaseDates['16'] }}
               </span>
             </div>
             <div class="children:mb-[16px]">
+              <!-- TODO: Replace with approved v16 launch copy. Approval process documented in prod-eng-docs. -->
               <p>
-                This release prepares Cypress Studio for the next era of AI-assisted test creation. You can record interactions, add assertions by right-clicking, and now edit tests inline without leaving Cypress. Turn on <InlineCodeFragment>experimentalStudio</InlineCodeFragment> in your config to try it out and share your feedback.
+                Cypress 16 is here. This version includes breaking changes that may require updates to your project.
               </p>
               <p>
-                We’ve also made important changes to improve reliability, future compatibility, and cross-origin support. Several older versions of Node.js, browser protocols, and Webpack integrations are no longer supported.
-                This version includes breaking changes that may require updates to your project.
-              </p>
-              <p>
-                For a complete list of updates, please review our <ExternalLink href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v15#15-0-0">
+                For a complete list of updates, please review our <ExternalLink href="https://on.cypress.io/changelog?utm_source=Binary%3A+App&utm_medium=splash-page&utm_campaign=v16#16-0-0">
                   <!--eslint-disable-next-line vue/multiline-html-element-content-newline-->
                   changelog</ExternalLink>.
               </p>
@@ -65,6 +62,28 @@
             <h2 class="font-bold mt-[24px] mb-[12px] text-[14px] text-gray-600">
               Previous release highlights
             </h2>
+            <div class="pb-[8px]">
+              <ExternalLink
+                href="https://on.cypress.io/changelog#15-0-0"
+                class="font-bold text-indigo-500"
+              >
+                15.0.0
+              </ExternalLink>
+              <span class="font-light pl-[10px] text-gray-500 text-[14px]">
+                Released {{ versionReleaseDates['15'] }}
+              </span>
+            </div>
+            <p class="text-[14px] leading-[20px]">
+              <!-- TODO: Replace with approved v15 summary copy. -->
+              v15 advanced Cypress Studio with AI-assisted authoring and added cross-origin support improvements.
+              <br>
+              <br>
+              Read about the v15.0.0 changes in our
+              <ExternalLink href="https://on.cypress.io/changelog#15-0-0">
+                <!--eslint-disable-next-line vue/multiline-html-element-content-newline-->
+                changelog</ExternalLink>.
+            </p>
+            <br>
             <div class="pb-[8px]">
               <ExternalLink
                 href="https://on.cypress.io/changelog#14-0-0"
@@ -193,6 +212,8 @@ const versionReleaseDates = computed(() => {
     '13': useTimeAgo(Date.UTC(2023, 7, 29)).value,
     '14': useTimeAgo(Date.UTC(2025, 0, 16)).value,
     '15': useTimeAgo(Date.UTC(2025, 7, 20)).value,
+    // TODO: replace placeholder with the real v16 release date before merging to release/16.0.0.
+    '16': useTimeAgo(Date.UTC(2026, 4, 5)).value,
   }
 })
 


### PR DESCRIPTION
- Closes n/a

### Additional details

Adds a placeholder v16 entry to the `MajorVersionWelcome` splash page so the canary test (`makes sure there is an entry for the current major release in the monorepo package.json version`) passes on `release/16.0.0`. The real v16 launch copy and release date will land in a follow-up PR closer to release.

- Promotes `16.0.0` to the featured release block with placeholder body copy.
- Demotes `15.0.0` into `previous-release-highlights` (verbatim copy, matching the v14 demotion precedent in [a018700da3](https://github.com/cypress-io/cypress/commit/a018700da3)).
- Adds `versionReleaseDates['16']` with a placeholder date.
- Updates the two existing component tests to match the new structure.

### Steps to test

1. `yarn workspace @packages/launchpad cypress:run:ct -- --spec packages/launchpad/src/welcome/MajorVersionWelcome.cy.tsx`
2. All three `<MajorVersionWelcome />` specs should pass.

### How has the user experience changed?

Users upgrading to v16 see a placeholder v16 entry at the top of the welcome screen. The Percy snapshot `'content overflows inside box'` needs a new baseline since `previous-release-highlights` now has four entries instead of three.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?