### PR TITLE
fix(deps): support tsconfig paths without baseUrl (TS6+) in webpack-batteries-included-preprocessor

### DIFF
--- a/npm/webpack-batteries-included-preprocessor/index.ts
+++ b/npm/webpack-batteries-included-preprocessor/index.ts
@@ -138,10 +138,17 @@ const addTypeScriptConfig = (file: { filePath: string }, options: {
 
   webpackOptions.resolve.extensions = webpackOptions.resolve.extensions.concat(['.ts', '.tsx'])
   webpackOptions.resolve.extensionAlias = webpackOptions.resolve.extensionAlias || { '.js': ['.ts', '.js'], '.mjs': ['.mts', '.mjs'] }
-  webpackOptions.resolve.plugins = [new TsconfigPathsPlugin({
-    configFile: configFile?.path,
-    silent: true,
-  })]
+
+  // Only register the paths plugin when we actually located a tsconfig.json.
+  // tsconfig-paths-webpack-plugin v4 no longer early-returns when its internal
+  // loadConfig fails, so passing an undefined configFile causes it to walk up
+  // from process.cwd() and crash with "matchPath is not a function" on resolve.
+  if (configFile?.path) {
+    webpackOptions.resolve.plugins = [new TsconfigPathsPlugin({
+      configFile: configFile.path,
+      silent: true,
+    })]
+  }
 
   // @ts-expect-error - not typed intentionally
   options.__typescriptSupportAdded = true

--- a/npm/webpack-batteries-included-preprocessor/index.ts
+++ b/npm/webpack-batteries-included-preprocessor/index.ts
@@ -111,12 +111,10 @@ const addTypeScriptConfig = (file: { filePath: string }, options: {
     isGreaterThanOrEqualToTs6 = !isLessThanTs6
   }
 
-  // tsconfig-paths-webpack-plugin v4 tolerates a missing baseUrl (the TS 6+ recommended
-  // shape, see https://github.com/cypress-io/cypress/issues/33733), but v3 rejects it.
-  // For TS < 6 we keep v3 to preserve resolution behavior in projects whose tsconfigs
-  // had paths without baseUrl and were unintentionally relying on the plugin no-oping.
-  const TsconfigPathsPlugin = isGreaterThanOrEqualToTs6
-    ? require('tsconfig-paths-webpack-plugin-v4')
+  // Use the v3 plugin for TS < 6 to remain passive; TS 6+ uses v4, which
+  // tolerates the missing-baseUrl shape recommended by TypeScript 6+.
+  const TsconfigPathsPlugin = isLessThanTs6
+    ? require('tsconfig-paths-webpack-plugin-v3')
     : require('tsconfig-paths-webpack-plugin')
 
   webpackOptions.module.rules.push({

--- a/npm/webpack-batteries-included-preprocessor/index.ts
+++ b/npm/webpack-batteries-included-preprocessor/index.ts
@@ -94,9 +94,6 @@ const addTypeScriptConfig = (file: { filePath: string }, options: {
     return options
   }
 
-  const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
-  // node will try to load a projects tsconfig.json instead of the node
-
   // tsx parses the moduleResolution default to node10 as well as moduleResolution="node" to node10
   // ts-loader struggles to validate the node10 moduleResolution option depending on the version of typescript used,
   // so we set it to node which is the same as node 10. @see https://www.typescriptlang.org/tsconfig/#moduleResolution.
@@ -113,6 +110,14 @@ const addTypeScriptConfig = (file: { filePath: string }, options: {
     isLessThanTs6 = semver.lt(tsVersion, '6.0.0-0')
     isGreaterThanOrEqualToTs6 = !isLessThanTs6
   }
+
+  // tsconfig-paths-webpack-plugin v4 tolerates a missing baseUrl (the TS 6+ recommended
+  // shape, see https://github.com/cypress-io/cypress/issues/33733), but v3 rejects it.
+  // For TS < 6 we keep v3 to preserve resolution behavior in projects whose tsconfigs
+  // had paths without baseUrl and were unintentionally relying on the plugin no-oping.
+  const TsconfigPathsPlugin = isGreaterThanOrEqualToTs6
+    ? require('tsconfig-paths-webpack-plugin-v4')
+    : require('tsconfig-paths-webpack-plugin')
 
   webpackOptions.module.rules.push({
     test: typescriptExtensionRegex,

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -34,8 +34,8 @@
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.5.7",
-    "tsconfig-paths-webpack-plugin": "^3.5.2",
-    "tsconfig-paths-webpack-plugin-v4": "npm:tsconfig-paths-webpack-plugin@^4.2.0",
+    "tsconfig-paths-webpack-plugin": "^4.2.0",
+    "tsconfig-paths-webpack-plugin-v3": "npm:tsconfig-paths-webpack-plugin@^3.5.2",
     "webpack": "^5.88.2",
     "webpack-bundle-analyzer": "4.10.2"
   },
@@ -48,8 +48,8 @@
     "globals": "^15.12.0",
     "jiti": "^2.4.2",
     "react": "^16.13.1",
-    "typescript": "~5.4.5",
-    "typescript-v6": "npm:typescript@^6.0.0",
+    "typescript": "^6.0.0",
+    "typescript-v5": "npm:typescript@~5.4.5",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -34,7 +34,8 @@
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.5.7",
-    "tsconfig-paths-webpack-plugin": "^4.2.0",
+    "tsconfig-paths-webpack-plugin": "^3.5.2",
+    "tsconfig-paths-webpack-plugin-v4": "npm:tsconfig-paths-webpack-plugin@^4.2.0",
     "webpack": "^5.88.2",
     "webpack-bundle-analyzer": "4.10.2"
   },
@@ -48,6 +49,7 @@
     "jiti": "^2.4.2",
     "react": "^16.13.1",
     "typescript": "~5.4.5",
+    "typescript-v6": "npm:typescript@^6.0.0",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {

--- a/npm/webpack-batteries-included-preprocessor/package.json
+++ b/npm/webpack-batteries-included-preprocessor/package.json
@@ -34,7 +34,7 @@
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.5.7",
-    "tsconfig-paths-webpack-plugin": "^3.5.2",
+    "tsconfig-paths-webpack-plugin": "^4.2.0",
     "webpack": "^5.88.2",
     "webpack-bundle-analyzer": "4.10.2"
   },

--- a/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
@@ -78,15 +78,8 @@ describe('webpack-batteries-included-preprocessor features', () => {
       await runAndEval('ts_spec.ts', { ...options })
     })
 
-    // https://github.com/cypress-io/cypress/issues/33733
-    // TS 6 deprecates `baseUrl` for path-only setups; the v3 plugin rejects this
-    // shape, so we route TS 6+ to v4 (npm-aliased as tsconfig-paths-webpack-plugin-v4).
-    // Force the TS 6 install here so this test actually exercises the v4 branch
-    // regardless of the package's default `typescript` devDep.
     it('handles tsconfig paths without baseUrl (TypeScript 6+ style)', async () => {
-      const typescriptV6 = require.resolve('typescript-v6/lib/typescript.js')
-
-      await runAndEval('paths-no-baseurl/spec.ts', { typescript: typescriptV6 })
+      await runAndEval('paths-no-baseurl/spec.ts', { ...options })
     })
 
     it('handles tsx', async () => {

--- a/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
@@ -79,8 +79,14 @@ describe('webpack-batteries-included-preprocessor features', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/33733
+    // TS 6 deprecates `baseUrl` for path-only setups; the v3 plugin rejects this
+    // shape, so we route TS 6+ to v4 (npm-aliased as tsconfig-paths-webpack-plugin-v4).
+    // Force the TS 6 install here so this test actually exercises the v4 branch
+    // regardless of the package's default `typescript` devDep.
     it('handles tsconfig paths without baseUrl (TypeScript 6+ style)', async () => {
-      await runAndEval('paths-no-baseurl/spec.ts', { ...options })
+      const typescriptV6 = require.resolve('typescript-v6/lib/typescript.js')
+
+      await runAndEval('paths-no-baseurl/spec.ts', { typescript: typescriptV6 })
     })
 
     it('handles tsx', async () => {

--- a/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/e2e/features.spec.ts
@@ -78,6 +78,11 @@ describe('webpack-batteries-included-preprocessor features', () => {
       await runAndEval('ts_spec.ts', { ...options })
     })
 
+    // https://github.com/cypress-io/cypress/issues/33733
+    it('handles tsconfig paths without baseUrl (TypeScript 6+ style)', async () => {
+      await runAndEval('paths-no-baseurl/spec.ts', { ...options })
+    })
+
     it('handles tsx', async () => {
       await runAndEval('tsx_spec.tsx', { ...options })
     })

--- a/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/paths-example-dir/paths-example-file.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/paths-example-dir/paths-example-file.ts
@@ -1,0 +1,1 @@
+export const pathed = true

--- a/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/spec.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/spec.ts
@@ -1,0 +1,4 @@
+import { expect } from 'chai'
+import { pathed } from '@paths/paths-example-file'
+
+expect(pathed).to.be.true

--- a/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/tsconfig.json
+++ b/npm/webpack-batteries-included-preprocessor/test/fixtures/paths-no-baseurl/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "paths": {
+      "@paths/*": ["./paths-example-dir/*"]
+    }
+  }
+}

--- a/npm/webpack-batteries-included-preprocessor/test/fixtures/tsconfig.json
+++ b/npm/webpack-batteries-included-preprocessor/test/fixtures/tsconfig.json
@@ -2,6 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "jsx": "react",
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@paths/*": ["paths-example-dir/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -30974,7 +30974,16 @@ ts-node@^9:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-"tsconfig-paths-webpack-plugin-v4@npm:tsconfig-paths-webpack-plugin@^4.2.0":
+"tsconfig-paths-webpack-plugin-v3@npm:tsconfig-paths-webpack-plugin@^3.5.2":
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
+  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^3.9.0"
+
+tsconfig-paths-webpack-plugin@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz#f7459a8ed1dd4cf66ad787aefc3d37fff3cf07fc"
   integrity sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==
@@ -30983,15 +30992,6 @@ ts-node@^9:
     enhanced-resolve "^5.7.0"
     tapable "^2.2.1"
     tsconfig-paths "^4.1.2"
-
-tsconfig-paths-webpack-plugin@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
-  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
-  dependencies:
-    chalk "^4.1.0"
-    enhanced-resolve "^5.7.0"
-    tsconfig-paths "^3.9.0"
 
 tsconfig-paths@3.10.1:
   version "3.10.1"
@@ -31330,10 +31330,10 @@ typescript-eslint@^8.37.0:
     "@typescript-eslint/typescript-estree" "8.37.0"
     "@typescript-eslint/utils" "8.37.0"
 
-"typescript-v6@npm:typescript@^6.0.0":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
-  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+"typescript-v5@npm:typescript@~5.4.5":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
 typescript@5.3.3:
   version "5.3.3"
@@ -31354,6 +31354,11 @@ typescript@5.6.3:
   version "5.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+
+typescript@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 ua-parser-js@0.7.33, ua-parser-js@^0.7.18:
   version "0.7.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30974,7 +30974,7 @@ ts-node@^9:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tsconfig-paths-webpack-plugin@^4.2.0:
+"tsconfig-paths-webpack-plugin-v4@npm:tsconfig-paths-webpack-plugin@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz#f7459a8ed1dd4cf66ad787aefc3d37fff3cf07fc"
   integrity sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==
@@ -30983,6 +30983,15 @@ tsconfig-paths-webpack-plugin@^4.2.0:
     enhanced-resolve "^5.7.0"
     tapable "^2.2.1"
     tsconfig-paths "^4.1.2"
+
+tsconfig-paths-webpack-plugin@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
+  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^3.9.0"
 
 tsconfig-paths@3.10.1:
   version "3.10.1"
@@ -30993,7 +31002,7 @@ tsconfig-paths@3.10.1:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^3.12.0, tsconfig-paths@^3.15.0:
+tsconfig-paths@^3.12.0, tsconfig-paths@^3.15.0, tsconfig-paths@^3.9.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
   integrity sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==
@@ -31320,6 +31329,11 @@ typescript-eslint@^8.37.0:
     "@typescript-eslint/parser" "8.37.0"
     "@typescript-eslint/typescript-estree" "8.37.0"
     "@typescript-eslint/utils" "8.37.0"
+
+"typescript-v6@npm:typescript@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 typescript@5.3.3:
   version "5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30974,14 +30974,15 @@ ts-node@^9:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tsconfig-paths-webpack-plugin@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
-  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+tsconfig-paths-webpack-plugin@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz#f7459a8ed1dd4cf66ad787aefc3d37fff3cf07fc"
+  integrity sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.7.0"
-    tsconfig-paths "^3.9.0"
+    tapable "^2.2.1"
+    tsconfig-paths "^4.1.2"
 
 tsconfig-paths@3.10.1:
   version "3.10.1"
@@ -30992,7 +30993,7 @@ tsconfig-paths@3.10.1:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^3.12.0, tsconfig-paths@^3.15.0, tsconfig-paths@^3.9.0:
+tsconfig-paths@^3.12.0, tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
   integrity sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==


### PR DESCRIPTION
- Closes #33733

### Additional details

TypeScript 6 deprecates the `baseUrl` compiler option for path-alias use cases and recommends omitting `baseUrl` and prefixing `paths` mappings with `./` (e.g. `"@/*": ["./src/*"]`). With Cypress 15.14.2, tsconfigs in this shape fail webpack compilation:

```
Module not found: Error: Can't resolve '@/example'
```

**Root cause.** `@cypress/webpack-batteries-included-preprocessor` configures `TsconfigPathsPlugin` and pinned `tsconfig-paths-webpack-plugin@^3.5.2`. That version depends on `tsconfig-paths@3.x`, whose `loadConfig` returns `resultType: "failed"` with `"Missing baseUrl in compilerOptions"` for any tsconfig that omits `baseUrl`. The plugin then sets neither `matchPath` nor `baseUrl`, so its `apply()` short-circuits and webpack never sees the alias.

**Fix.** Flex `TsconfigPathsPlugin` between v3 and v4 based on the user's TypeScript version:

- **TS < 6** → keep `tsconfig-paths-webpack-plugin@^3.5.2`. Preserves resolution behavior for projects whose tsconfigs had `paths` without `baseUrl` and were unintentionally relying on the plugin no-oping (e.g. the cypress monorepo's launchpad e2e setup, where `@packages/*` aliases silently fall through to yarn-workspace symlinks at `node_modules/@packages/*`, which then match the ts-loader `node_modules` exclusion and behave as pre-built workspace packages).
- **TS ≥ 6** → use `tsconfig-paths-webpack-plugin@^4.2.0`. v4 was specifically updated to tolerate a missing `baseUrl` (it falls back to the tsconfig directory, matching TypeScript 4.1+ behavior), which is what the TS 6 paths-only shape needs.

Both plugin versions are installed side-by-side via yarn's `npm:` package alias (`tsconfig-paths-webpack-plugin-v4: "npm:tsconfig-paths-webpack-plugin@^4.2.0"`); the right one is selected at runtime in `index.ts` from the existing `isGreaterThanOrEqualToTs6` flag.

A defensive guard around the plugin construction was also added: when `get-tsconfig` returns no config (a JS-only project), v4 of the plugin would otherwise walk up from `process.cwd()`, fail to load, leave `matchPath` undefined, and crash on the first webpack resolve with `TypeError: matchPath is not a function`. Now the plugin is only registered when a tsconfig is actually located.

**Why not bump everything to v4?** v4 changes resolution semantics for the no-baseUrl case in a way that's load-bearing for at least one in-repo consumer (launchpad e2e) and — importantly — for any external project with a similarly-shaped legacy tsconfig. Gating on the TS version targets the fix at the population that actually wants the new behavior (TS 6+ users following the deprecation guidance) without changing what TS 5 users see.

**Regression coverage.** New fixture under `test/fixtures/paths-no-baseurl/` (a tsconfig with `paths` and no `baseUrl`, plus a spec that imports through the alias). The test points at a real `typescript@6` install (installed as an aliased devDep, `typescript-v6: "npm:typescript@^6.0.0"`) so it actually exercises the v4 branch rather than running under the package's `typescript@5.4` default. The existing `handles typescript (and tsconfig paths)` test (which uses `baseUrl` under TS 5) still passes against v3.

### Steps to test

From `npm/webpack-batteries-included-preprocessor/`:

1. `yarn build`
2. `yarn test -- features.spec.ts` — confirm all 18 tests pass (including the new `handles tsconfig paths without baseUrl (TypeScript 6+ style)`).

End-to-end against the reporter's repro (https://github.com/DCzajkowski/cypress-typescript-6-import-aliases-reproduction, which uses TS 6.0.3):

1. Clone the repro and `npm install` (this pulls Cypress 15.14.2).
2. In `cypress.config.js`, override `file:preprocessor` to load this branch's local build of `@cypress/webpack-batteries-included-preprocessor`.
3. With the bare `paths`-only tsconfig (no `baseUrl`): `npx cypress run` — passes.
4. With the legacy `baseUrl: "."` + `paths` tsconfig: `npx cypress run` — still passes.

### How has the user experience changed?

Users on TypeScript 6 can now omit `baseUrl` from their tsconfig and use `./`-prefixed `paths` (the modern, non-deprecated TypeScript style) without webpack failing to resolve the alias. TS 5 users see no change — the existing v3 plugin continues to handle their tsconfigs exactly as before. JS-only projects with no tsconfig are unaffected (the plugin is now only registered when a tsconfig is found).

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TypeScript/webpack module resolution by conditionally swapping `tsconfig-paths-webpack-plugin` versions and changing when the plugin is registered; mis-detection of TS version or tsconfig discovery could break path alias resolution for some projects.
> 
> **Overview**
> Fixes TS6+ projects whose `tsconfig.json` uses `paths` without `baseUrl` by selecting `tsconfig-paths-webpack-plugin` **v4 for TS ≥ 6** and an aliased **v3 for TS < 6**, and by only registering the paths plugin when a `tsconfig` is actually found.
> 
> Updates dependencies to include both plugin versions and bumps dev `typescript` to `^6`, adds an e2e fixture/test covering the *no-`baseUrl`* tsconfig shape, and tweaks the existing fixture tsconfig for TS6 deprecation handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 838749ad38dc568c0fe27c394f4aa9ce00db9fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->