### PR TITLE
fix(vite-dev-server): exclude CT specs from Vite 8 JSX refresh

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where component specs that defined local React components could register every `describe` / `it` block twice in `cypress open` when using Vite 8, because React refresh treated those specs as HMR self-accepting modules. `@cypress/vite-dev-server` now excludes component spec files from JSX refresh while leaving Fast Refresh enabled for application source. Fixes [#33750](https://github.com/cypress-io/cypress/issues/33750).
 - Fixed an issue where multi-origin tests using [`cy.origin`](https://docs.cypress.io/api/commands/origin) could fail to talk to a secondary origin after test isolation, when the spec-bridge iframe was already present, or when more than one secondary origin became ready around the same time. Cached spec-bridge window targets are now cleared at the correct lifecycle points, improving performance of specs with cy.origin calls. Addressed in [#33704](https://github.com/cypress-io/cypress/pull/33704).
 - Fixed an issue where a CSS selector built internally from element attributes could throw an uncaught `Syntax error, unrecognized expression` and crash the runner when an attribute value contained CSS-special characters (for example, an `<input>` with a `pattern` attribute containing regex metacharacters). Fixes [#26967](https://github.com/cypress-io/cypress/issues/26967) and [#29345](https://github.com/cypress-io/cypress/issues/29345).
 

--- a/npm/vite-dev-server/src/resolveConfig.ts
+++ b/npm/vite-dev-server/src/resolveConfig.ts
@@ -18,6 +18,12 @@ import type { Vite_7, Vite_8 } from './getVite.js'
 
 const debug = debugFn('cypress:vite-dev-server:resolve-config')
 
+// Limit jsxRefreshInclude/exclude matching to scripts. With only jsxRefreshExclude set, Vite builds
+// createFilter(undefined, exclude) which matches every non-excluded path — CSS would hit transformWithOxc and fail.
+// @see https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/oxc.ts (transform + jsxRefreshFilter)
+/** Passed as `oxc.jsxRefreshInclude` so JSX refresh excludes do not match CSS or other assets. */
+export const JSX_REFRESH_SCRIPT_RE = /\.(?:[cm]?js|[cm]?ts|[jt]sx)$/
+
 export const isVite8 = (vite: Vite_7 | Vite_8): boolean => {
   const isVite8 = vite.version && semverGte(vite.version, '8.0.0') || false
 
@@ -143,6 +149,7 @@ function makeCypressViteConfig (config: ViteDevServerConfig, vite: Vite_7 | Vite
     // @see https://github.com/cypress-io/cypress/issues/33750
     ...(isVite8(vite) ? {
       oxc: {
+        jsxRefreshInclude: JSX_REFRESH_SCRIPT_RE,
         jsxRefreshExclude: specs.map((s) => s.absolute),
       },
     } : {}),

--- a/npm/vite-dev-server/src/resolveConfig.ts
+++ b/npm/vite-dev-server/src/resolveConfig.ts
@@ -138,6 +138,14 @@ function makeCypressViteConfig (config: ViteDevServerConfig, vite: Vite_7 | Vite
   const viteConfig: InlineConfig_7 | InlineConfig_8 = {
     root: projectRoot,
     base: `${devServerPublicPathRoute}/`,
+    // Vite 8 Rolldown/react-plugin can wrap JSX specs with `import.meta.hot.accept`, re-evaluating
+    // the module in headed mode and registering describe/it twice. Excluding CT specs from JSX refresh fixes it.
+    // @see https://github.com/cypress-io/cypress/issues/33750
+    ...(isVite8(vite) ? {
+      oxc: {
+        jsxRefreshExclude: specs.map((s) => s.absolute),
+      },
+    } : {}),
     optimizeDeps: {
       ...options,
       entries: [

--- a/npm/vite-dev-server/test/resolveConfig.spec.ts
+++ b/npm/vite-dev-server/test/resolveConfig.spec.ts
@@ -7,7 +7,7 @@ import * as vite6 from 'vite-6'
 import * as vite7 from 'vite-7'
 import * as vite8 from 'vite-8'
 import { scaffoldSystemTestProject } from './test-helpers/scaffoldProject'
-import { createViteDevServerConfig } from '../src/resolveConfig'
+import { createViteDevServerConfig, JSX_REFRESH_SCRIPT_RE } from '../src/resolveConfig'
 import type { ViteDevServerConfig } from '../src/devServer'
 
 const getViteDevServerConfig = (projectRoot: string) => {
@@ -122,7 +122,7 @@ describe('resolveConfig', function () {
     // Real package root so createRequire can resolve `vite` like a consumer project; inline viteConfig skips fixture scaffolding.
     const viteDevServerPackageRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-    it('sets oxc.jsxRefreshExclude from the Cypress specs list (Vite 8)', async () => {
+    it('sets oxc.jsxRefreshInclude and jsxRefreshExclude from Cypress specs (Vite 8)', async () => {
       const specAbsolutes = [
         path.join(viteDevServerPackageRoot, 'src', 'Hello.cy.tsx'),
         path.join(viteDevServerPackageRoot, 'src', 'Other.cy.tsx'),
@@ -138,10 +138,11 @@ describe('resolveConfig', function () {
 
       const viteConfig = await createViteDevServerConfig(viteDevServerConfig, vite8)
 
+      expect(viteConfig.oxc?.jsxRefreshInclude).to.equal(JSX_REFRESH_SCRIPT_RE)
       expect(viteConfig.oxc?.jsxRefreshExclude).to.eql(specAbsolutes)
     })
 
-    it('does not set oxc.jsxRefreshExclude for Vite 7', async () => {
+    it('does not set oxc overrides for Vite 7', async () => {
       const specAbsolute = path.join(viteDevServerPackageRoot, 'components', 'Card.cy.tsx')
       const viteDevServerConfig = {
         ...getViteDevServerConfig(viteDevServerPackageRoot),
@@ -152,6 +153,11 @@ describe('resolveConfig', function () {
       const viteConfig = await createViteDevServerConfig(viteDevServerConfig, vite7)
 
       expect(viteConfig.oxc).to.be.undefined
+    })
+
+    it('matches only script-like paths so imported CSS (e.g. support files) is not run through transformWithOxc', () => {
+      expect(JSX_REFRESH_SCRIPT_RE.test('/project/cypress/support/backgroundColor.css')).to.be.false
+      expect(JSX_REFRESH_SCRIPT_RE.test('/project/src/App.cy.tsx')).to.be.true
     })
   })
 }, 1000 * 60)

--- a/npm/vite-dev-server/test/resolveConfig.spec.ts
+++ b/npm/vite-dev-server/test/resolveConfig.spec.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+import { fileURLToPath } from 'node:url'
 import { vi, describe, it, beforeEach, expect } from 'vitest'
 import { EventEmitter } from 'events'
 import * as vite5 from 'vite-5'
@@ -113,6 +115,43 @@ describe('resolveConfig', function () {
         expect(viteConfig.server?.watch?.ignored).to.be.undefined
         expect(viteConfig.server?.hmr).to.be.undefined
       })
+    })
+  })
+
+  describe('Vite 8 JSX refresh excludes component specs', () => {
+    // Real package root so createRequire can resolve `vite` like a consumer project; inline viteConfig skips fixture scaffolding.
+    const viteDevServerPackageRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+    it('sets oxc.jsxRefreshExclude from the Cypress specs list (Vite 8)', async () => {
+      const specAbsolutes = [
+        path.join(viteDevServerPackageRoot, 'src', 'Hello.cy.tsx'),
+        path.join(viteDevServerPackageRoot, 'src', 'Other.cy.tsx'),
+      ]
+      const viteDevServerConfig = {
+        ...getViteDevServerConfig(viteDevServerPackageRoot),
+        viteConfig: {},
+        specs: [
+          { absolute: specAbsolutes[0], relative: 'src/Hello.cy.tsx' },
+          { absolute: specAbsolutes[1], relative: 'src/Other.cy.tsx' },
+        ],
+      } as unknown as ViteDevServerConfig
+
+      const viteConfig = await createViteDevServerConfig(viteDevServerConfig, vite8)
+
+      expect(viteConfig.oxc?.jsxRefreshExclude).to.eql(specAbsolutes)
+    })
+
+    it('does not set oxc.jsxRefreshExclude for Vite 7', async () => {
+      const specAbsolute = path.join(viteDevServerPackageRoot, 'components', 'Card.cy.tsx')
+      const viteDevServerConfig = {
+        ...getViteDevServerConfig(viteDevServerPackageRoot),
+        viteConfig: {},
+        specs: [{ absolute: specAbsolute, relative: 'components/Card.cy.tsx' }],
+      } as unknown as ViteDevServerConfig
+
+      const viteConfig = await createViteDevServerConfig(viteDevServerConfig, vite7)
+
+      expect(viteConfig.oxc).to.be.undefined
     })
   })
 }, 1000 * 60)


### PR DESCRIPTION
### Summary

Fixes duplicate `describe` / `it` registration in **headed** component testing when using **Vite 8** and specs that define **local React components** (JSX in the spec file). Headless runs were unaffected because HMR is disabled there.

Closes https://github.com/cypress-io/cypress/issues/33750

### Problem

With Vite 8, `@vitejs/plugin-react` can treat modules that contain JSX as React Refresh boundaries and inject `import.meta.hot.accept(...)`. Cypress loads specs via dynamic `import()`; when the spec becomes a self-accepting HMR module, the module can be evaluated again after the initial load, so Mocha registers the same suite twice (duplicated sidebar entries and double test execution).

### Solution

In `@cypress/vite-dev-server`, when resolving config for Vite 8, set `oxc.jsxRefreshExclude` to the absolute paths of all component **spec** files passed in `specs`. That keeps JSX transformation for specs but stops React Refresh from wrapping them as HMR self-acceptors. Application source still gets Fast Refresh as before.

### Changes

- `npm/vite-dev-server/src/resolveConfig.ts` — conditional `oxc.jsxRefreshExclude` for `isVite8`
- `npm/vite-dev-server/test/resolveConfig.spec.ts` — asserts `jsxRefreshExclude` for Vite 8 and no `oxc` override for Vite 7
- `cli/CHANGELOG.md` — user-facing note under the pending release

### Verification

- `yarn workspace @cypress/vite-dev-server test -- test/resolveConfig.spec.ts -t "Vite 8 JSX"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the generated Vite 8 dev-server config (`oxc` JSX refresh filters), which could affect HMR/transform behavior for component testing projects on Vite 8.
> 
> **Overview**
> Fixes a Vite 8 headed component-testing regression where spec files containing local React components could be re-evaluated by HMR and register Mocha `describe`/`it` blocks twice.
> 
> When Vite 8 is detected, `@cypress/vite-dev-server` now sets `oxc.jsxRefreshExclude` to the absolute component spec paths and constrains matching via a new `JSX_REFRESH_SCRIPT_RE` include filter so non-script assets (like CSS) aren’t affected. Adds targeted tests for the Vite 8 `oxc` config (and ensures no override on Vite 7) and documents the fix in the CLI changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaf3c3b9ed8455589eb31e9a10a6f76b76df2de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->