### PR TITLE
chore(ci): re-enable pre-release install comment

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1026,10 +1026,9 @@ commands:
       - run:
           name: Post pre-release install comment
           command: |
-            # TODO: Uncomment when the issue with github app permissions is resolved
-            # node scripts/add-install-comment.js \
-            #   --npm << parameters.package_url_path >> \
-            #   --binary << parameters.binary_url_path >>
+            node scripts/add-install-comment.js \
+              --npm << parameters.package_url_path >> \
+              --binary << parameters.binary_url_path >>
 
   sanitize-verify-and-store-mocha-results:
     description: Double-check that Mocha tests ran as expected.


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details

The CircleCI command `post-pre-release-install-comment` had the `node scripts/add-install-comment.js` invocation commented out with a note about GitHub App permissions. This change restores that step so CI can post install instructions (npm package URL and binary URL) on the relevant commit via the Cypress GitHub App.

Affected code: `.circleci/src/pipeline/@pipeline.yml` — the run step now executes `add-install-comment.js` with `--npm` and `--binary` parameters again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that re-enables a previously disabled GitHub-commenting step; main risk is unexpected failures if GitHub App credentials/permissions are still misconfigured.
> 
> **Overview**
> Re-enables the CircleCI `post-install-comment` command to execute `scripts/add-install-comment.js`, posting pre-release install instructions (npm package and binary URLs) back to GitHub instead of leaving the step commented out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67144379f7d42707a978d22a0b295d600669f2a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run the CircleCI workflow path that invokes `post-pre-release-install-comment` with valid `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, and `GITHUB_APP_CYPRESS_INSTALLATION_ID` (and the npm/binary URL parameters passed through from the job).
2. Confirm a comment appears on the expected GitHub commit with pre-release install instructions.

### How has the user experience changed?

**Before:** No automated install comment from this step (script was disabled in CI).

**After:** Reviewers and testers get an automated comment with how to install the pre-release npm package and binary when the pipeline succeeds.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?