### PR TITLE
chore: Capture more env vars

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,10 +13,6 @@
 - Fixed an issue where a CSS selector built internally from element attributes could throw an uncaught `Syntax error, unrecognized expression` and crash the runner when an attribute value contained CSS-special characters (for example, an `<input>` with a `pattern` attribute containing regex metacharacters). Fixes [#26967](https://github.com/cypress-io/cypress/issues/26967) and [#29345](https://github.com/cypress-io/cypress/issues/29345).
 - Fixed an issue where transient HTTP 500 responses from Cypress Cloud were not retried for idempotent requests. Fixed in [#33718](https://github.com/cypress-io/cypress/pull/33718).
 
-**Misc:**
-
-- Additional CI environment variables are now captured to support a future failed test retry feature. Addressed in [#33714](https://github.com/cypress-io/cypress/pull/33714).
-
 **Dependency Updates:**
 
 - Upgraded `socket.io` from `4.0.1` to `4.8.3`, `socket.io-client` from `4.0.1` to `4.8.3`, and `socket.io-parser` from `4.0.5` to `4.2.6` to address a [Denial of Service](https://github.com/advisories/GHSA-677m-j7p3-52f9) vulnerability reported in security scans. The `engine.io`, `engine.io-client`, and `engine.io-parser` direct deps in `@packages/socket` were also bumped to keep transitive copies aligned and the existing browser-side patches applied. Addressed in [#33719](https://github.com/cypress-io/cypress/pull/33719).

--- a/packages/server/lib/util/ci_provider.ts
+++ b/packages/server/lib/util/ci_provider.ts
@@ -157,6 +157,10 @@ const _userProvidedProviderCiParams = () => {
     'CYPRESS_PULL_REQUEST_ID',
     'CYPRESS_PULL_REQUEST_URL',
     'CYPRESS_CI_BUILD_URL',
+    // Users can set these to override automatic detection of a rerun or enable
+    // it for unsupported CI providers
+    'CYPRESS_RERUN_GROUP_ID', // ID shared by a run and its retries
+    'CYPRESS_RERUN_ALL_TESTS', // Opt out of only rerunning failed tests and force all tests to be rerun
   ])
 }
 // TODO: don't forget about buildNumber!

--- a/packages/server/test/unit/util/ci_provider_spec.ts
+++ b/packages/server/test/unit/util/ci_provider_spec.ts
@@ -44,6 +44,8 @@ describe('lib/util/ci_provider', () => {
       CYPRESS_PULL_REQUEST_ID: 'cypressPullRequestId',
       CYPRESS_PULL_REQUEST_URL: 'cypressPullRequestUrl',
       CYPRESS_CI_BUILD_URL: 'cypressCiBuildUrl',
+      CYPRESS_RERUN_GROUP_ID: 'cypressRerunGroupId',
+      CYPRESS_RERUN_ALL_TESTS: 'cypressRerunAllTests',
     }, { clear: true })
 
     expectsName(null)
@@ -51,6 +53,8 @@ describe('lib/util/ci_provider', () => {
       cypressPullRequestId: 'cypressPullRequestId',
       cypressPullRequestUrl: 'cypressPullRequestUrl',
       cypressCiBuildUrl: 'cypressCiBuildUrl',
+      cypressRerunGroupId: 'cypressRerunGroupId',
+      cypressRerunAllTests: 'cypressRerunAllTests',
     })
 
     return expectsCommitParams(null)
@@ -1112,6 +1116,8 @@ describe('lib/util/ci_provider', () => {
         CYPRESS_PULL_REQUEST_ID: 'cypressPullRequestId',
         CYPRESS_PULL_REQUEST_URL: 'cypressPullRequestUrl',
         CYPRESS_CI_BUILD_URL: 'cypressCiBuildUrl',
+        CYPRESS_RERUN_GROUP_ID: 'cypressRerunGroupId',
+        CYPRESS_RERUN_ALL_TESTS: 'cypressRerunAllTests',
 
         GIT_COMMIT: 'gitCommit',
         GIT_BRANCH: 'gitBranch',
@@ -1124,6 +1130,8 @@ describe('lib/util/ci_provider', () => {
         cypressPullRequestId: 'cypressPullRequestId',
         cypressPullRequestUrl: 'cypressPullRequestUrl',
         cypressCiBuildUrl: 'cypressCiBuildUrl',
+        cypressRerunGroupId: 'cypressRerunGroupId',
+        cypressRerunAllTests: 'cypressRerunAllTests',
       })
 
       return expectsCommitParams({


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/RAP-73

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends CI metadata extraction to include two additional user-provided environment variables and updates unit tests/changelog accordingly.
> 
> **Overview**
> Adds extraction of `CYPRESS_RERUN_GROUP_ID` and `CYPRESS_RERUN_ALL_TESTS` as user-provided CI parameters in `ci_provider`, allowing runs to explicitly signal retry/rerun behavior even on unsupported CI providers.
> 
> Updates unit tests to assert the new fields are included (including when merged with provider-detected params), and removes the corresponding “Misc” changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1860dbb2d4aba688059a73d7c117b97ec8956ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!-- Provide before and after examples of the change.
Screenshots or GIFs are preferred. -->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
