### PR TITLE
test: stabilize flaky 'passes with experimentalSourceRewriting' in visit_spec

### DIFF
--- a/system-tests/__snapshots__/visit_spec.js
+++ b/system-tests/__snapshots__/visit_spec.js
@@ -522,7 +522,7 @@ exports['e2e visit / low response timeout / calls onBeforeLoad when overwriting 
 
 `
 
-exports['e2e visit / low response timeout / passes with experimentalSourceRewriting'] = `
+exports['e2e visit / source rewriting / passes with experimentalSourceRewriting'] = `
 
 ====================================================================================================
 

--- a/system-tests/test/visit_spec.js
+++ b/system-tests/test/visit_spec.js
@@ -147,24 +147,6 @@ describe('e2e visit', () => {
       },
     })
 
-    systemTests.it('passes with experimentalSourceRewriting', {
-      browser: '!webkit', // TODO(webkit): fix+unskip
-      spec: 'source_rewriting.cy.js',
-      config: {
-        experimentalSourceRewriting: true,
-      },
-      snapshot: true,
-      onRun (exec) {
-        return startTlsV1Server(6776)
-        .then((serv) => {
-          return exec()
-          .then(() => {
-            return serv.destroy()
-          })
-        })
-      },
-    })
-
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23252
     systemTests.it.skip('fails when network connection immediately fails', {
       spec: 'visit_http_network_error_failing.cy.js',
@@ -219,6 +201,30 @@ describe('e2e visit', () => {
       spec: 'visit_response_never_ends_failing.cy.js',
       snapshot: true,
       expectedExitCode: 3,
+    })
+  })
+
+  context('source rewriting', () => {
+    systemTests.setup({
+      servers: {
+        port: 3434,
+        static: true,
+        onServer,
+      },
+      settings: {
+        e2e: {
+          allowCypressEnv: false,
+        },
+      },
+    })
+
+    systemTests.it('passes with experimentalSourceRewriting', {
+      browser: '!webkit', // TODO(webkit): fix+unskip
+      spec: 'source_rewriting.cy.js',
+      config: {
+        experimentalSourceRewriting: true,
+      },
+      snapshot: true,
     })
   })
 


### PR DESCRIPTION
- Closes [no issue]

### Additional details

`source_rewriting.cy.js` was running under the `low response timeout` context in `visit_spec.js`, which set `responseTimeout: 500ms` and `pageLoadTimeout: 1000ms`. That spec runs ~18 sequential redirect tests against static HTML and never hits any timeout-sensitive endpoint, so the tight timeouts added no test value but caused intermittent CI flakes when a slow runner exceeded the 1s page-load budget on any one of the 18 visits.

Observed flake (this PR's motivating example):
- CircleCI job [3612248](https://app.circleci.com/pipelines/github/cypress-io/cypress/81374/workflows/420280f2-767e-46a8-95f3-ad6c43b439fe/jobs/3612248/tests) — `Process errored: Exit code 1: expected 1 to equal 0` from `system-tests/lib/system-tests.ts:463`. CircleCI's flaky test database confirms this test (and the analogous Firefox `passes` variant) has been flaky historically.

What changed:
- Moved `passes with experimentalSourceRewriting` to a new `source rewriting` context with default timeouts, leaving the original `passes` test (which legitimately exercises low timeouts and TLSv1 against `visit.cy.js`) untouched.
- Dropped the `startTlsV1Server(6776)` wrapper from the moved test — `source_rewriting.cy.js` never visits `https://localhost:6776`, so it was vestigial.
- Updated the snapshot key in `system-tests/__snapshots__/visit_spec.js` to match the new context path. Snapshot body is unchanged.

### Steps to test

1. `yarn workspace @tooling/system-tests build`
2. `node system-tests/scripts/run.js --glob-in-dir="visit_spec"` — `passes with experimentalSourceRewriting [electron]` should now appear under the `source rewriting` context and pass consistently.

### How has the user experience changed?

No user-facing change. CI-only stability fix.

### PR Tasks

- [x] Have tests been added/updated? (Test stability change — same coverage, more reliable.)
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only reorganization that changes timeouts and removes an unused TLS server wrapper, with no product code impact.
> 
> **Overview**
> Stabilizes the `passes with experimentalSourceRewriting` system test by moving it out of the `low response timeout` context into a new `source rewriting` context that uses default timeouts.
> 
> Removes the per-test TLSv1 server setup from this spec (it no longer wraps execution), and updates the snapshot key in `system-tests/__snapshots__/visit_spec.js` to match the new context path (snapshot output content is otherwise unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d92b161695564e98ffe9ce6bc86a81dc5e4a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->