### PR TITLE
test(electron-mksnapshot): retry mksnapshot spawns to deflake Windows CI

### DIFF
--- a/tooling/electron-mksnapshot/src/mksnapshot-run.ts
+++ b/tooling/electron-mksnapshot/src/mksnapshot-run.ts
@@ -10,6 +10,46 @@ const logInfo = debug('cypress:mksnapshot:info')
 const logDebug = debug('cypress:mksnapshot:debug')
 const logError = debug('cypress:mksnapshot:error')
 
+// The mksnapshot/v8_context_snapshot_generator binaries occasionally crash
+// with a V8 fatal error on Windows CI runners. The crash is non-deterministic
+// and a fresh process invocation typically succeeds, so we retry on failure.
+const SPAWN_MAX_ATTEMPTS = 2
+const SPAWN_TIMEOUT_MS = 20_000
+
+function spawnWithRetry (
+  command: string,
+  args: string[],
+  options: Parameters<typeof spawnSync>[2],
+  description: string,
+) {
+  let result: ReturnType<typeof spawnSync> | undefined
+
+  for (let attempt = 1; attempt <= SPAWN_MAX_ATTEMPTS; attempt++) {
+    result = spawnSync(command, args, { ...options, timeout: SPAWN_TIMEOUT_MS })
+
+    if (result.status === 0) {
+      if (attempt > 1) {
+        logInfo('%s succeeded on attempt %d', description, attempt)
+      }
+
+      return result
+    }
+
+    if (attempt < SPAWN_MAX_ATTEMPTS) {
+      logError(
+        '%s failed on attempt %d/%d (status: %s, signal: %s); retrying',
+        description,
+        attempt,
+        SPAWN_MAX_ATTEMPTS,
+        result.status,
+        result.signal,
+      )
+    }
+  }
+
+  return result!
+}
+
 const workingDir = path.join(tempDir, 'mksnapshot-workdir')
 
 fs.ensureDirSync(workingDir)
@@ -123,10 +163,11 @@ function createSnapshotBlob (
   logDebug({ mksnapshotBinaryDir, mksnapshotCommand, mksnapshotArgs })
   logDebug(cmd)
 
-  const mksnapshotProcess = spawnSync(
+  const mksnapshotProcess = spawnWithRetry(
     mksnapshotCommand,
     mksnapshotArgs,
     snapshotBlobOptions,
+    'mksnapshot',
   )
 
   if (mksnapshotProcess.status !== 0) {
@@ -179,10 +220,11 @@ function createV8ContextSnapshot (
   logInfo(`Generating ${v8ContextFile}`)
   logDebug(cmd)
 
-  const v8ContextGenProcess = spawnSync(
+  const v8ContextGenProcess = spawnWithRetry(
     v8ContextGenCommand,
     v8ContextGenArgs,
     v8ContextGenOptions,
+    'v8_context_snapshot_generator',
   )
 
   if (v8ContextGenProcess.status !== 0) {

--- a/tooling/electron-mksnapshot/src/mksnapshot-run.ts
+++ b/tooling/electron-mksnapshot/src/mksnapshot-run.ts
@@ -14,18 +14,25 @@ const logError = debug('cypress:mksnapshot:error')
 // with a V8 fatal error on Windows CI runners. The crash is non-deterministic
 // and a fresh process invocation typically succeeds, so we retry on failure.
 const SPAWN_MAX_ATTEMPTS = 2
-const SPAWN_TIMEOUT_MS = 20_000
+
+export interface RunMksnapshotOptions {
+  // Per-attempt timeout in milliseconds. Disabled by default — production
+  // snapshot builds bundle the whole Cypress app and routinely exceed any
+  // small timeout. Tests set this to bound a hung child process.
+  spawnTimeoutMs?: number
+}
 
 function spawnWithRetry (
   command: string,
   args: string[],
   options: Parameters<typeof spawnSync>[2],
   description: string,
+  spawnTimeoutMs?: number,
 ) {
   let result: ReturnType<typeof spawnSync> | undefined
 
   for (let attempt = 1; attempt <= SPAWN_MAX_ATTEMPTS; attempt++) {
-    result = spawnSync(command, args, { ...options, timeout: SPAWN_TIMEOUT_MS })
+    result = spawnSync(command, args, { ...options, timeout: spawnTimeoutMs })
 
     if (result.status === 0) {
       if (attempt > 1) {
@@ -149,6 +156,7 @@ function createSnapshotBlob (
   mksnapshotCommand: string,
   mksnapshotArgs: string[],
   outputDir: string,
+  spawnTimeoutMs?: number,
 ) {
   const stdio: StdioOptions = 'inherit'
   const snapshotBlobOptions = {
@@ -168,6 +176,7 @@ function createSnapshotBlob (
     mksnapshotArgs,
     snapshotBlobOptions,
     'mksnapshot',
+    spawnTimeoutMs,
   )
 
   if (mksnapshotProcess.status !== 0) {
@@ -196,6 +205,7 @@ function createSnapshotBlob (
 function createV8ContextSnapshot (
   mksnapshotBinaryDir: string,
   outputDir: string,
+  spawnTimeoutMs?: number,
 ) {
   const v8ContextGenCommand = path.join(
     mksnapshotBinaryDir,
@@ -225,6 +235,7 @@ function createV8ContextSnapshot (
     v8ContextGenArgs,
     v8ContextGenOptions,
     'v8_context_snapshot_generator',
+    spawnTimeoutMs,
   )
 
   if (v8ContextGenProcess.status !== 0) {
@@ -240,7 +251,7 @@ function createV8ContextSnapshot (
   }
 }
 
-export function runMksnapshot (args: string[]) {
+export function runMksnapshot (args: string[], options: RunMksnapshotOptions = {}) {
   logDebug('Provided args: %o', args)
   checkArgs(args)
   let { outputDir, mksnapshotArgs } = extractOutdir(args)
@@ -257,7 +268,8 @@ export function runMksnapshot (args: string[]) {
     mksnapshotCommand,
     mksnapshotArgs,
     outputDir,
+    options.spawnTimeoutMs,
   )
 
-  createV8ContextSnapshot(mksnapshotBinaryDir, outputDir)
+  createV8ContextSnapshot(mksnapshotBinaryDir, outputDir, options.spawnTimeoutMs)
 }

--- a/tooling/electron-mksnapshot/src/mksnapshot.ts
+++ b/tooling/electron-mksnapshot/src/mksnapshot.ts
@@ -2,14 +2,14 @@ import { attemptDownload } from './mksnapshot-download'
 import { Metadata } from './metadata'
 
 import debug from 'debug'
-import { runMksnapshot } from './mksnapshot-run'
+import { runMksnapshot, type RunMksnapshotOptions } from './mksnapshot-run'
 import type { VersionMeta } from './config'
 
 const logInfo = debug('cypress:mksnapshot:info')
 const logDebug = debug('cypress:mksnapshot:debug')
 const logError = debug('cypress:mksnapshot:error')
 
-export async function syncAndRun (version: string, args: string[]) {
+export async function syncAndRun (version: string, args: string[], options: RunMksnapshotOptions = {}) {
   const metadata = new Metadata(version)
 
   if (metadata.matchesCurrentConfig()) {
@@ -37,7 +37,7 @@ export async function syncAndRun (version: string, args: string[]) {
     }
   }
 
-  runMksnapshot(args)
+  runMksnapshot(args, options)
 
   return metadata.current()
 }

--- a/tooling/electron-mksnapshot/test/.mocharc.js
+++ b/tooling/electron-mksnapshot/test/.mocharc.js
@@ -4,6 +4,6 @@ module.exports = {
   reporterOptions: {
     configFile: '../../mocha-reporter-config.json',
   },
-  timeout: 30000,
+  timeout: 90000,
   watchFiles: ['test/**/*.ts', 'src/**/*.ts'],
 }

--- a/tooling/electron-mksnapshot/test/integration/mksnapshot.spec.ts
+++ b/tooling/electron-mksnapshot/test/integration/mksnapshot.spec.ts
@@ -19,6 +19,7 @@ describe('mksnapshot', () => {
     const { version, snapshotBlobFile, v8ContextFile } = await syncAndRun(
       providedVersion,
       args,
+      { spawnTimeoutMs: 20_000 },
     )
 
     expect(version).to.equal(providedVersion)
@@ -31,7 +32,7 @@ describe('mksnapshot', () => {
     const args = [invalidSnapshot, '--output_dir', outputDir]
 
     try {
-      await syncAndRun(providedVersion, args)
+      await syncAndRun(providedVersion, args, { spawnTimeoutMs: 20_000 })
       assert.fail('should fail making invalid snapshot')
     } catch (err) {
       expect(err.message.includes('Failed to create snapshot blob'), 'fails with helpful error message').to.be.true
@@ -44,6 +45,7 @@ describe('mksnapshot', () => {
     const { version, snapshotBlobFile, v8ContextFile } = await syncAndRun(
       providedVersion,
       args,
+      { spawnTimeoutMs: 20_000 },
     )
 
     expect(version).to.equal(providedVersion)


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `windows-v8-integration-tests` job has been flaking on the `mksnapshot` integration tests (e.g. [job 3612271](https://app.circleci.com/pipelines/github/cypress-io/cypress/81374/workflows/9c7c74f6-2f95-4a3d-88ce-63bd01244cf3/jobs/3612271)). All three tests in `tooling/electron-mksnapshot/test/integration/mksnapshot.spec.ts` time out at 30s with the same underlying cause: the prebuilt `mksnapshot` / `v8_context_snapshot_generator` binaries crash with a V8 fatal error during snapshot creation:

```
# Fatal error in , line 0
# ignored
==== C stack trace ===============================
    v8_inspector::protocol::Binary::~Binary [...]
```

The crash is non-deterministic — the binaries are external Electron releases, so we can't fix the crash itself. Re-invoking the binary in a fresh process typically succeeds.

This PR wraps both `spawnSync` calls in `mksnapshot-run.ts` with a small retry helper:
- Retries once on non-zero exit (2 attempts total). Enabled by default for both tests and production builds.
- Logs each attempt so the retry behavior is visible in CI output.
- Optional per-attempt timeout via `RunMksnapshotOptions.spawnTimeoutMs`. Disabled by default (the production v8-snapshot build bundles the whole Cypress app and can legitimately exceed any small timeout). The integration tests pass `spawnTimeoutMs: 20_000` explicitly so a hung crashed child gets killed before mocha's outer timeout fires.

The mocha test timeout in `tooling/electron-mksnapshot/test/.mocharc.js` is bumped from 30s → 90s to accommodate the retry worst case (~80s of spawn time + download + setup).

This benefits the production V8 snapshot build path too, not just the tests, since the same `runMksnapshot` function is invoked by `@tooling/v8-snapshot` during CI binary builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds retry/timeout behavior around external `mksnapshot` process execution; while scoped, it changes build/test reliability and could mask persistent failures or affect timing-sensitive CI runs.
> 
> **Overview**
> Improves resilience of Electron snapshot generation by wrapping `mksnapshot` and `v8_context_snapshot_generator` executions in a **retry-on-failure** helper (2 attempts) with additional debug/error logging.
> 
> Extends the `runMksnapshot`/`syncAndRun` APIs to accept an optional per-attempt `spawnTimeoutMs` (used by integration tests), and increases the mocha test timeout (30s  90s) to accommodate retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 008c383eabf4a08810f6bacf0d48c6934a3d045c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Run `yarn workspace @tooling/electron-mksnapshot test-integration` (slow — downloads real Electron releases). All three tests should pass.
- On Windows CI, observe that transient `mksnapshot` V8 crashes now produce a fast-failed first attempt followed by a successful retry (visible in `cypress:mksnapshot:*` debug output) instead of a 30s timeout.

### How has the user experience changed?

No user-facing change. Internal CI/build reliability improvement.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?