### PR TITLE
chore(ci): enable Snyk scans on fork PRs via approval-gated environment

### DIFF
--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -8,6 +8,10 @@ name: Snyk Software Composition Analysis Scan
 # implemented PAT token for actions to resolve an issue with the action not
 # running and reporting back to the PR status checks
 on:
+  pull_request:
+    branches:
+      - develop
+      - release/*
   pull_request_target:
     branches:
       - develop
@@ -17,9 +21,11 @@ permissions:
 jobs:
   Snyk_SCA_Scan:
     runs-on: ubuntu-latest
-    # Fork PRs require manual approval via the fork-pr-review environment.
-    # Internal PRs run without an environment gate.
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
+    # Route each PR to exactly one event: internal -> pull_request, fork -> pull_request_target.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr-review' || '' }}
     strategy:
       matrix:
         node-version: [22.x]

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -8,7 +8,7 @@ name: Snyk Software Composition Analysis Scan
 # implemented PAT token for actions to resolve an issue with the action not
 # running and reporting back to the PR status checks
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
       - release/*
@@ -16,9 +16,10 @@ permissions:
   contents: read
 jobs:
   Snyk_SCA_Scan:
-    # Skip this job on PRs from forks
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Fork PRs require manual approval via the fork-pr-review environment.
+    # Internal PRs run without an environment gate.
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
     strategy:
       matrix:
         node-version: [22.x]
@@ -26,6 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          # Cache only on pull_request (internal PRs) — pull_request_target writes scope to the base branch and could be poisoned by an approved fork PR.
+          cache: ${{ github.event_name == 'pull_request' && 'yarn' || '' }}
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -33,9 +33,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-        # Yarn caching intentionally disabled: with `pull_request_target`,
-        # cache writes are scoped to the base branch, so an approved fork
-        # PR could poison the develop cache. See actions/setup-node#1358.
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -33,7 +33,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'yarn'
+        # Yarn caching intentionally disabled: with `pull_request_target`,
+        # cache writes are scoped to the base branch, so an approved fork
+        # PR could poison the develop cache. See actions/setup-node#1358.
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -47,3 +47,4 @@ jobs:
           snyk test --all-projects --strict-out-of-sync=false --detection-depth=6 --exclude=.nx,system-tests,tooling,docker,Dockerfile --severity-threshold=critical --org=cypress-opensource
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_API: https://api.snyk.io

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -4,6 +4,10 @@ name: Snyk Static Analysis Scan
 # "develop" branch. We use this as a control to prevent vulnerabilities
 # from being introduced into the codebase.
 on:
+  pull_request:
+    branches:
+      - develop
+      - release/*
   pull_request_target:
     branches:
       - develop
@@ -13,9 +17,11 @@ permissions:
 jobs:
   Snyk_SAST_Scan:
     runs-on: ubuntu-latest
-    # Fork PRs require manual approval via the fork-pr-review environment.
-    # Internal PRs run without an environment gate.
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
+    # Route each PR to exactly one event: internal -> pull_request, fork -> pull_request_target.
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr-review' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          # Cache only on pull_request (internal PRs) — pull_request_target writes scope to the base branch and could be poisoned by an approved fork PR.
+          cache: ${{ github.event_name == 'pull_request' && 'yarn' || '' }}
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-          cache: 'yarn'
+        # Yarn caching intentionally disabled: with `pull_request_target`,
+        # cache writes are scoped to the base branch, so an approved fork
+        # PR could poison the develop cache. See actions/setup-node#1358.
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -26,9 +26,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
-        # Yarn caching intentionally disabled: with `pull_request_target`,
-        # cache writes are scoped to the base branch, so an approved fork
-        # PR could poison the develop cache. See actions/setup-node#1358.
       - name: Run yarn
         run: yarn
       - name: Run build

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -38,6 +38,7 @@ jobs:
           snyk code test --yarn-workspaces --strict-out-of-sync=false --detection-depth=6 --exclude=docker,Dockerfile --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_API: https://api.snyk.io
       # The Following Requires Advanced Security License
       # - name: Upload results to Github Code Scanning
       #   uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -4,7 +4,7 @@ name: Snyk Static Analysis Scan
 # "develop" branch. We use this as a control to prevent vulnerabilities
 # from being introduced into the codebase.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
       - release/*
@@ -12,13 +12,15 @@ permissions:
   contents: read
 jobs:
   Snyk_SAST_Scan:
-    # Skip this job on PRs from forks
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Fork PRs require manual approval via the fork-pr-review environment.
+    # Internal PRs run without an environment gate.
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Set up Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The Snyk SCA and SAST workflows previously skipped any pull request opened from a fork (`if: github.event.pull_request.head.repo.full_name == github.repository`) because `pull_request` triggers don't grant secret access to fork-originated runs, and Snyk requires `SNYK_TOKEN`. As a result, contributor PRs from forks shipped without our SCA/SAST coverage.

This change enables Snyk scans on fork PRs while keeping the security boundary intact:

- **Dual triggers, single run per PR:** workflows fire on both `pull_request` and `pull_request_target`. A job-level `if:` routes each PR to exactly one event — internal PRs run via `pull_request`, fork PRs run via `pull_request_target` (where secrets are available). No double runs.
- **Approval gate for forks:** the fork-only `pull_request_target` path runs inside a new `fork-pr-review` GitHub Environment that requires maintainer approval before any fork code executes. Internal PRs evaluate the environment expression to an empty string and run without the gate, so the existing developer workflow is unchanged.
- **Explicit fork checkout:** under `pull_request_target`, `actions/checkout` defaults to the base branch, so the step now passes `ref: ${{ github.event.pull_request.head.sha }}` to scan the PR's actual code.
- **Workflow-file tampering blocked:** because `pull_request_target` reads the workflow definition from the base branch, fork-side edits to these files cannot take effect until merged.
- **Defense-in-depth hardening on fork-PR runs:**
  - `persist-credentials: false` on the checkout step keeps `GITHUB_TOKEN` out of the runner's git credential store, so fork-controlled lifecycle scripts during `yarn`/`yarn build` can't read it.
  - `cache: 'yarn'` removed from `actions/setup-node`. Under `pull_request_target`, cache writes are scoped to the base branch, so an approved fork PR could otherwise poison the develop cache.
  - `SNYK_API: https://api.snyk.io` pinned at the scan step's env block. Step-level env overrides anything fork code wrote into `$GITHUB_ENV` during install/build, so a fork can't redirect Snyk traffic to an attacker-controlled endpoint.

The `fork-pr-review` environment was named generically so other workflows that need to run privileged steps on fork PRs can reuse the same approval gate.

#### Required GitHub configuration (already done)

A `fork-pr-review` environment must exist in repo Settings → Environments with required reviewers configured and deployment branches restricted to `develop` and `release/*`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI trigger context and secret exposure boundaries for Snyk workflows; misconfiguration could either block scans or unintentionally run privileged steps on untrusted code.
> 
> **Overview**
> Enables `Snyk_SCA_Scan` and `Snyk_SAST_Scan` to run for *both* internal and fork PRs by adding a `pull_request_target` trigger and routing execution via a job-level `if:` so each PR runs exactly once.
> 
> For the fork (`pull_request_target`) path, the workflows now **gate execution** behind the `fork-pr-review` environment, explicitly checkout the PR head SHA, disable persisted git credentials, and disable yarn caching (cache only on internal `pull_request` runs). Both scan steps also pin `SNYK_API` to `https://api.snyk.io`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a9a9b009b9a282966605eeae685e8fb28562d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Internal PR path:
1. Open a PR from a branch inside `cypress-io/cypress` targeting `develop`.
2. Confirm both `Snyk_SCA_Scan` and `Snyk_SAST_Scan` workflows start immediately under the `pull_request` event with no approval prompt.

Fork PR path:
1. Have a contributor open a PR from their fork targeting `develop`.
2. Confirm both Snyk workflows enter a "Waiting for review" state under the `pull_request_target` event.
3. As a designated reviewer, click **Review deployments** → **Approve and deploy** for each workflow.
4. Confirm the scans run and report status back to the PR check list.

### How has the user experience changed?

No user-facing Cypress behavior changes. CI behavior change only: contributor (fork) PRs now get Snyk SCA + SAST coverage after a maintainer approves the gated workflow runs.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?