### PR TITLE
chore(ci): commit v8 snapshot updates via GitHub API

### DIFF
--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -90,11 +90,6 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ env.BASE_BRANCH }}
-      - name: Set committer info
-        ## attribute the commit to cypress-bot: https://github.community/t/logging-into-git-as-a-github-app/115916
-        run: |
-          git config --local user.email "${{ env.CYPRESS_BOT_APP_ID }}+cypress-bot[bot]@users.noreply.github.com"
-          git config --local user.name "cypress-bot[bot]"
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
@@ -118,86 +113,66 @@ jobs:
         shell: bash
       ## The build steps above can run for >1h on a from-scratch / Windows pass,
       ## which is longer than the App installation token's lifetime. Mint a
-      ## fresh token here so all subsequent auth-requiring steps (gh api, git
-      ## push, github-script) use a token that's guaranteed to still be valid.
+      ## fresh token here so the API-driven commit and PR steps below use a
+      ## token that's guaranteed to still be valid.
       - name: Refresh Cypress Bot App token
         id: app-token-refresh
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-      ## actions/checkout persisted the *initial* token in git's config. On
-      ## Windows the build can exceed the App token's 1h lifetime, so that
-      ## persisted credential expires before we push. Re-run checkout with
-      ## the refreshed token to overwrite the persisted credential. The action
-      ## does a force-checkout, so stash the freshly-generated snapshot file
-      ## first and restore it afterward.
-      - name: Stash snapshot changes for credential refresh
-        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: git stash push -- ${{ env.SNAPSHOT_FILES }}
-        shell: bash
-      - name: Refresh persisted git credentials
-        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token-refresh.outputs.token }}
-          ref: ${{ env.BASE_BRANCH }}
-          clean: false
-      - name: Restore snapshot changes
-        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: git stash pop
-        shell: bash
       - name: Determine branch name - commit directly to branch
         if: ${{ inputs.commit_directly_to_branch == true }}
-        run: |
-          echo "BRANCH_NAME=${{ env.BASE_BRANCH }}" >> $GITHUB_ENV
-          echo "BRANCH_EXISTS=true" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=${{ env.BASE_BRANCH }}" >> $GITHUB_ENV
         shell: bash
       - name: Determine branch name - commit to separate branch
         if: ${{ inputs.commit_directly_to_branch != true }}
-        run: |
-          echo "BRANCH_NAME=update-v8-snapshot-cache-on-${{ env.BASE_BRANCH }}-${{ env.PLATFORM }}" >> $GITHUB_ENV
-          echo "BRANCH_EXISTS=$(git show-ref --verify --quiet refs/remotes/origin/update-v8-snapshot-cache-on-${{ env.BASE_BRANCH }}-${{ env.PLATFORM }} && echo 'true')" >> $GITHUB_ENV
+        run: echo "BRANCH_NAME=update-v8-snapshot-cache-on-${{ env.BASE_BRANCH }}-${{ env.PLATFORM }}" >> $GITHUB_ENV
         shell: bash
       - name: Check number of existing prs
         id: check-number-of-existing-prs
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
         run: |
           echo "number_of_prs_for_branch=$(gh api '/repos/cypress-io/cypress/pulls?head=cypress-io:${{ env.BRANCH_NAME }}' --jq length)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
         shell: bash
-      - name: Check need for PR or branch update
+      - name: Check need for PR
         id: check-need-for-pr
+        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
         run: |
-          echo "needs_pr=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_NAME != env.BASE_BRANCH && steps.check-number-of-existing-prs.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
-          echo "needs_branch_update=${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' && env.BRANCH_EXISTS == 'true' }}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
+          echo "needs_pr=${{ env.BRANCH_NAME != env.BASE_BRANCH && steps.check-number-of-existing-prs.outputs.number_of_prs_for_branch == '0' }}" >> $GITHUB_OUTPUT
         shell: bash
-      ## Update available and a branch/PR already exists
-      - name: Checkout existing branch
-        if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
-        run: |
-          git stash push -- ${{ env.SNAPSHOT_FILES }}
-          git reset --hard
-          git checkout ${{ env.BRANCH_NAME }}
-          git pull origin ${{ env.BRANCH_NAME }}
-          git merge -Xtheirs stash
-      ## Update available and a PR doesn't already exist
-      - name: Checkout new branch
-        if: ${{ steps.check-need-for-pr.outputs.needs_branch_update != 'true' }}
-        run: git checkout -b ${{ env.BRANCH_NAME }} ${{ env.BASE_BRANCH }}
-      ## Commit changes if present
-      - name: Commit the changes
+      - name: Commit snapshot update via API
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: |
-          git diff-index --quiet HEAD || git commit -am "chore: updating v8 snapshot cache"
-      - name: Push branch to remote
-        if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        run: git push origin "${{ env.BRANCH_NAME }}"
+        uses: actions/github-script@v7
+        env:
+          SNAPSHOT_FILES: ${{ env.SNAPSHOT_FILES }}
+          BASE_BRANCH: ${{ env.BASE_BRANCH }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+        with:
+          github-token: ${{ steps.app-token-refresh.outputs.token }}
+          script: |
+            const { commitViaApi } = require('./scripts/github-actions/commit-via-api.js')
+
+            // SNAPSHOT_FILES is wrapped in single quotes for shell consumers;
+            // strip them before handing the path to Node.
+            const filePaths = process.env.SNAPSHOT_FILES
+              .split(/\s+/)
+              .map((p) => p.replace(/^'|'$/g, ''))
+              .filter(Boolean)
+
+            await commitViaApi({
+              context,
+              github,
+              baseBranch: process.env.BASE_BRANCH,
+              branchName: process.env.BRANCH_NAME,
+              filePaths,
+              message: 'chore: updating v8 snapshot cache',
+            })
       # PR needs to be created
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -156,7 +156,10 @@ jobs:
         with:
           github-token: ${{ steps.app-token-refresh.outputs.token }}
           script: |
-            const { commitViaApi } = await import('./scripts/github-actions/commit-via-api.mjs')
+            const path = require('node:path')
+            const { pathToFileURL } = require('node:url')
+            const moduleUrl = pathToFileURL(path.join(process.cwd(), 'scripts/github-actions/commit-via-api.mjs')).href
+            const { commitViaApi } = await import(moduleUrl)
 
             // SNAPSHOT_FILES is wrapped in single quotes for shell consumers;
             // strip them before handing the path to Node.

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           github-token: ${{ steps.app-token-refresh.outputs.token }}
           script: |
-            const { commitViaApi } = require('./scripts/github-actions/commit-via-api.js')
+            const { commitViaApi } = await import('./scripts/github-actions/commit-via-api.mjs')
 
             // SNAPSHOT_FILES is wrapped in single quotes for shell consumers;
             // strip them before handing the path to Node.

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -156,9 +156,9 @@ jobs:
         with:
           github-token: ${{ steps.app-token-refresh.outputs.token }}
           script: |
-            const path = require('node:path')
-            const { pathToFileURL } = require('node:url')
-            const moduleUrl = pathToFileURL(path.join(process.cwd(), 'scripts/github-actions/commit-via-api.mjs')).href
+            const { join } = await import('node:path')
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(join(process.cwd(), 'scripts/github-actions/commit-via-api.mjs')).href
             const { commitViaApi } = await import(moduleUrl)
 
             // SNAPSHOT_FILES is wrapped in single quotes for shell consumers;

--- a/scripts/github-actions/commit-via-api.js
+++ b/scripts/github-actions/commit-via-api.js
@@ -1,0 +1,68 @@
+const fs = require('fs')
+
+const commitViaApi = async ({ context, github, baseBranch, branchName, filePaths, message }) => {
+  const owner = context.repo.owner
+  const repo = context.repo.repo
+  const repositoryNameWithOwner = `${owner}/${repo}`
+
+  // The GitHub API requires POSIX paths even on Windows runners.
+  const additions = filePaths.map((rawPath) => {
+    const path = rawPath.split('\\').join('/')
+
+    return {
+      path,
+      contents: fs.readFileSync(rawPath).toString('base64'),
+    }
+  })
+
+  let expectedHeadOid
+
+  try {
+    const { data } = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${branchName}`,
+    })
+
+    expectedHeadOid = data.object.sha
+  } catch (err) {
+    if (err.status !== 404) throw err
+
+    const { data: baseRef } = await github.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${baseBranch}`,
+    })
+
+    expectedHeadOid = baseRef.object.sha
+
+    await github.rest.git.createRef({
+      owner,
+      repo,
+      ref: `refs/heads/${branchName}`,
+      sha: expectedHeadOid,
+    })
+  }
+
+  const mutation = `
+    mutation ($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit { oid url }
+      }
+    }`
+
+  const { createCommitOnBranch } = await github.graphql(mutation, {
+    input: {
+      branch: { repositoryNameWithOwner, branchName },
+      message: { headline: message },
+      expectedHeadOid,
+      fileChanges: { additions },
+    },
+  })
+
+  return createCommitOnBranch.commit
+}
+
+module.exports = {
+  commitViaApi,
+}

--- a/scripts/github-actions/commit-via-api.mjs
+++ b/scripts/github-actions/commit-via-api.mjs
@@ -1,6 +1,6 @@
-const fs = require('fs')
+import fs from 'node:fs'
 
-const commitViaApi = async ({ context, github, baseBranch, branchName, filePaths, message }) => {
+export const commitViaApi = async ({ context, github, baseBranch, branchName, filePaths, message }) => {
   const owner = context.repo.owner
   const repo = context.repo.repo
   const repositoryNameWithOwner = `${owner}/${repo}`
@@ -61,8 +61,4 @@ const commitViaApi = async ({ context, github, baseBranch, branchName, filePaths
   })
 
   return createCommitOnBranch.commit
-}
-
-module.exports = {
-  commitViaApi,
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "echo 'internal-scripts build: no build necessary'",
-    "lint": "eslint --ext .js,.ts,.json, ."
+    "lint": "eslint --ext .js,.mjs,.ts,.json, ."
   },
   "dependencies": {
     "@packages/electron": "0.0.0-development"


### PR DESCRIPTION
- Closes #33772 (the existing snapshot-update PR with bookkeeping commits will be superseded once this lands and the workflow re-runs)

### Additional details

The `update-v8-snapshot-cache` workflow has been producing PRs polluted with stash-bookkeeping commits, e.g. [#33772](https://github.com/cypress-io/cypress/pull/33772). The root cause was [`git merge -Xtheirs stash`](https://github.com/cypress-io/cypress/blob/develop/.github/workflows/update_v8_snapshot_cache.yml#L188) on the existing branch path: that pulled the stash's internal WIP/index commits into the branch history, producing a triplet of `index on develop:`, `WIP on develop:`, and `Merge commit 'stash' into …` commits every time the workflow ran. The bot's commits are also unsigned because `git commit` from a runner has no GPG key configured.

This change replaces the local `git stash` / `git merge` / `git commit` / `git push` sequence with the GitHub GraphQL [`createCommitOnBranch`](https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch) mutation:

- New helper `scripts/github-actions/commit-via-api.js` — looks up the target branch's HEAD (creating the branch from `BASE_BRANCH` if it doesn't exist), then posts the snapshot file change via GraphQL.
- Workflow simplification — drops the credential-refresh stash dance, the existing-branch checkout/merge step, the new-branch checkout step, and the local `git commit` / `git push` steps. Net **35 added / 60 removed** lines in the workflow.

Commits made through `createCommitOnBranch` with an App-authenticated token are auto-verified by GitHub under the `cypress-bot[bot]` identity, so the resulting PRs will show signed commits going forward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automated snapshot-update workflow to write commits/branches via GitHub’s API instead of local `git` operations, which could break the bot update flow if the GraphQL mutation/branch handling behaves differently across platforms. No production/runtime code paths are affected.
> 
> **Overview**
> Updates the `update_v8_snapshot_cache` GitHub Actions workflow to **stop using local `git stash/merge/commit/push`** and instead commit snapshot file updates via an API call.
> 
> Adds `scripts/github-actions/commit-via-api.mjs`, which ensures the target branch exists (creating it from `BASE_BRANCH` if needed) and uses the GraphQL `createCommitOnBranch` mutation to upload the updated snapshot file contents, avoiding stash bookkeeping commits and enabling verified bot commits.
> 
> Also tightens workflow execution so token refresh/API steps only run when snapshot files actually changed, and extends `scripts` linting to include `.mjs` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c571f14dad7404cb733826d74e3c9c861663c298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This workflow only runs on the default branch / release branches, so it can't be exercised pre-merge. After merge, the next scheduled run (or a manual `workflow_dispatch`) will produce a PR; verify:

1. The PR contains exactly one commit titled `chore: updating v8 snapshot cache` per platform.
2. The commit shows the green **Verified** badge in the GitHub UI.
3. The PR's diff contains only the platform's `tooling/v8-snapshot/cache/<platform>/snapshot-meta.json`.
4. Re-running the workflow against an existing open PR stacks one new clean commit on top (no `index on develop:` / `WIP on develop:` / `Merge commit 'stash'` commits).

To force a clean test, delete the existing branch `update-v8-snapshot-cache-on-develop-darwin` (and the linux/windows equivalents if they exist) before triggering the workflow so it exercises the create-branch path.

### How has the user experience changed?

Internal CI workflow only — no user-facing change. The bot's automated PRs (e.g. [#33772](https://github.com/cypress-io/cypress/pull/33772)) will now contain a single signed commit instead of ~22 unsigned commits.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?