### PR TITLE
test(system-tests): add Node.js 26 binary smoke coverage

### DIFF
--- a/system-tests/test-binary/node_versions_spec.ts
+++ b/system-tests/test-binary/node_versions_spec.ts
@@ -34,6 +34,7 @@ describe('binary node versions', () => {
     'cypress/base:22.19.0',
     'cypress/base:24.0.0',
     'cypress/base:25.0.0',
+    'cypress/base:26.0.0',
   ].forEach(smokeTestDockerImage)
 })
 
@@ -47,6 +48,7 @@ describe('type: module', () => {
     'cypress/base:22.19.0',
     'cypress/base:24.0.0',
     'cypress/base:25.0.0',
+    'cypress/base:26.0.0',
   ].forEach((dockerImage) => {
     systemTests.it(`can run in ${dockerImage}`, {
       withBinary: true,


### PR DESCRIPTION
## Summary

Extends `test-binary/node_versions_spec.ts` to run e2e, component, and `type: module` binary system tests against `cypress/base:26.0.0`.

## Related

- Closes / addresses https://github.com/cypress-io/cypress/issues/33693

## Notes

- CI must have access to the `cypress/base:26.0.0` image (published from cypress-docker-images when available).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands system test coverage by adding a new Docker image tag; main risk is CI failures if `cypress/base:26.0.0` is unavailable or behaves differently.
> 
> **Overview**
> Extends the binary system-test matrix to include **Node.js 26** by adding `cypress/base:26.0.0` to the Docker image lists.
> 
> This makes the existing binary smoke runs execute against Node 26 for both the `binary node versions` (e2e + component) suite and the `type: module` e2e suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc453cc527c29930a14e75d8ec6536bc6a8574e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->