### PR TITLE
chore: narrow CYPRESS_COMMERCIAL_RECOMMENDATIONS override; deflake no-branch test

### DIFF
--- a/packages/app/cypress/e2e/cloud_message_banner.cy.ts
+++ b/packages/app/cypress/e2e/cloud_message_banner.cy.ts
@@ -68,8 +68,6 @@ Cypress.on('window:before:load', (win) => {
 })
 
 describe('App - Cloud Message Banner', () => {
-  // Tasks (not cy.withCtx) because webpack rewrites process.env in spec code
-  // and the rewritten access fails when serialized into a withCtx callback.
   before(() => {
     cy.task('__internal_optInToCloudAppMessages')
   })

--- a/packages/app/cypress/e2e/cloud_message_banner.cy.ts
+++ b/packages/app/cypress/e2e/cloud_message_banner.cy.ts
@@ -68,6 +68,20 @@ Cypress.on('window:before:load', (win) => {
 })
 
 describe('App - Cloud Message Banner', () => {
+  // CI sets CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide and that short-
+  // circuits the cloudAppMessages stitching executor to []. This spec
+  // exercises the channel — clear the env var for the duration of the suite
+  // (in the plain-Node plugin process; can't use cy.withCtx here because
+  // webpack rewrites process.env references in spec code) and restore it
+  // after so we don't leak the deletion into sibling specs.
+  before(() => {
+    cy.task('__internal_optInToCloudAppMessages')
+  })
+
+  after(() => {
+    cy.task('__internal_restoreCommercialRecommendations')
+  })
+
   beforeEach(() => {
     cy.scaffoldProject('cypress-in-cypress')
     cy.openProject('cypress-in-cypress')

--- a/packages/app/cypress/e2e/cloud_message_banner.cy.ts
+++ b/packages/app/cypress/e2e/cloud_message_banner.cy.ts
@@ -68,12 +68,8 @@ Cypress.on('window:before:load', (win) => {
 })
 
 describe('App - Cloud Message Banner', () => {
-  // CI sets CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide and that short-
-  // circuits the cloudAppMessages stitching executor to []. This spec
-  // exercises the channel — clear the env var for the duration of the suite
-  // (in the plain-Node plugin process; can't use cy.withCtx here because
-  // webpack rewrites process.env references in spec code) and restore it
-  // after so we don't leak the deletion into sibling specs.
+  // Tasks (not cy.withCtx) because webpack rewrites process.env in spec code
+  // and the rewritten access fails when serialized into a withCtx callback.
   before(() => {
     cy.task('__internal_optInToCloudAppMessages')
   })

--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -584,13 +584,9 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
   })
 })
 
-// Standalone describe: the "no branch" scenario can't live inside the suite
-// above because that suite's beforeEach calls startAppServer and *then* stubs
-// the branch to 'fakeBranch' with git hashes set. By the time a nested
-// override runs, the binary has already booted with the populated git state
-// and the urql cache holds runs derived from it — re-stubbing branch to
-// undefined races against cached state. Installing the stub before
-// startAppServer makes the binary boot with no branch and no cached runs.
+// Separate describe so the branch stub installs before startAppServer.
+// Nesting under the suite above means the binary boots with git state and
+// urql caches runs from it; a later override races against the cache.
 describe('App/Cloud Integration - Latest runs (no branch)', { viewportWidth: 1200, viewportHeight: 900 }, () => {
   beforeEach(() => {
     cy.scaffoldProject('cypress-in-cypress')

--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -305,24 +305,6 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
     })
   })
 
-  context('when not using a branch', () => {
-    beforeEach(() => {
-      cy.withCtx((ctx, o) => {
-        o.sinon.stub(ctx.lifecycleManager.git!, 'currentBranch').value(undefined)
-      })
-
-      cy.loginUser()
-
-      cy.visitApp()
-      cy.specsPageIsVisible()
-      cy.findByTestId('sidebar-link-specs-page').click()
-    })
-
-    it('shows placeholders for all visible specs', () => {
-      allVisibleSpecsShouldBePlaceholders()
-    })
-  })
-
   context('when runs are recorded', () => {
     beforeEach(() => {
       cy.loginUser()
@@ -599,6 +581,35 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
       cy.get(dotSelector('accounts_new.spec.js', 'latest')).trigger('mouseleave')
       cy.get(averageDurationSelector('accounts_list.spec.js')).contains('0:13')
     })
+  })
+})
+
+// Standalone describe: the "no branch" scenario can't live inside the suite
+// above because that suite's beforeEach calls startAppServer and *then* stubs
+// the branch to 'fakeBranch' with git hashes set. By the time a nested
+// override runs, the binary has already booted with the populated git state
+// and the urql cache holds runs derived from it — re-stubbing branch to
+// undefined races against cached state. Installing the stub before
+// startAppServer makes the binary boot with no branch and no cached runs.
+describe('App/Cloud Integration - Latest runs (no branch)', { viewportWidth: 1200, viewportHeight: 900 }, () => {
+  beforeEach(() => {
+    cy.scaffoldProject('cypress-in-cypress')
+    cy.openProject('cypress-in-cypress')
+
+    cy.withCtx((ctx, o) => {
+      o.sinon.stub(ctx.lifecycleManager.git!, 'currentBranch').value(undefined)
+    })
+
+    cy.startAppServer()
+    cy.loginUser()
+
+    cy.visitApp()
+    cy.specsPageIsVisible()
+    cy.findByTestId('sidebar-link-specs-page').click()
+  })
+
+  it('shows placeholders for all visible specs', () => {
+    allVisibleSpecsShouldBePlaceholders()
   })
 })
 

--- a/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
+++ b/packages/app/cypress/e2e/specs_list_latest_runs.cy.ts
@@ -584,9 +584,6 @@ describe('App/Cloud Integration - Latest runs and Average duration', { viewportW
   })
 })
 
-// Separate describe so the branch stub installs before startAppServer.
-// Nesting under the suite above means the binary boots with git state and
-// urql caches runs from it; a later override races against the cache.
 describe('App/Cloud Integration - Latest runs (no branch)', { viewportWidth: 1200, viewportHeight: 900 }, () => {
   beforeEach(() => {
     cy.scaffoldProject('cypress-in-cypress')

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -384,8 +384,6 @@ async function makeE2ETasks () {
 
       return null
     },
-    // CI sets CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide; cloud_message_banner.cy.ts
-    // needs the cloudAppMessages channel live, other specs keep the short-circuit.
     __internal_optInToCloudAppMessages () {
       cachedCommercialRecommendations = process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS
       delete process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -77,12 +77,6 @@ export async function e2ePluginSetup (on: Cypress.PluginEvents, config: Cypress.
   delete process.env.CYPRESS_INTERNAL_VITE_DEV
   delete process.env.CYPRESS_INTERNAL_VITE_APP_PORT
   delete process.env.CYPRESS_INTERNAL_VITE_LAUNCHPAD_PORT
-  // CI sets this org-wide to '0' to silence the end-of-run commercial-
-  // recommendations message. That same flag also short-circuits the
-  // cloudAppMessages stitching executor, which breaks any E2E spec that
-  // exercises the channel. The cypress-in-cypress AUT is a test environment;
-  // the opt-out doesn't apply.
-  delete process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS
 
   // Set this to a dedicate port so we can debug the state of the tests
   process.env.CYPRESS_INTERNAL_GRAPHQL_PORT = '5555'
@@ -145,6 +139,8 @@ async function makeE2ETasks () {
   let remoteGraphQLOptions: Record<string, any> | undefined
   let remoteGraphQLInterceptBatched: RemoteGraphQLBatchInterceptor | undefined
   let scaffoldedProjects = new Set<string>()
+  // Spec-scoped opt-in (see __internal_optInToCloudAppMessages task below).
+  let cachedCommercialRecommendations: string | undefined
 
   const cachedCwd = process.cwd()
 
@@ -386,6 +382,27 @@ async function makeE2ETasks () {
     },
     __internal_remoteGraphQLInterceptBatched (fn: string) {
       remoteGraphQLInterceptBatched = new Function('console', 'obj', 'testState', `return (${fn})(obj, testState)`).bind(null, console) as RemoteGraphQLBatchInterceptor
+
+      return null
+    },
+    // Targeted at cloud_message_banner.cy.ts: CI sets
+    // CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide to silence the end-of-run
+    // commercial-recommendations message. The same flag short-circuits the
+    // cloudAppMessages stitching executor — that spec is the one place we need
+    // to defeat it. Other specs keep the flag and short-circuit as before, so
+    // we don't introduce extra cloudAppMessages traffic into unrelated suites.
+    __internal_optInToCloudAppMessages () {
+      cachedCommercialRecommendations = process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS
+      delete process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS
+
+      return null
+    },
+    __internal_restoreCommercialRecommendations () {
+      if (cachedCommercialRecommendations !== undefined) {
+        process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS = cachedCommercialRecommendations
+      }
+
+      cachedCommercialRecommendations = undefined
 
       return null
     },

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -139,7 +139,6 @@ async function makeE2ETasks () {
   let remoteGraphQLOptions: Record<string, any> | undefined
   let remoteGraphQLInterceptBatched: RemoteGraphQLBatchInterceptor | undefined
   let scaffoldedProjects = new Set<string>()
-  // Spec-scoped opt-in (see __internal_optInToCloudAppMessages task below).
   let cachedCommercialRecommendations: string | undefined
 
   const cachedCwd = process.cwd()
@@ -385,12 +384,8 @@ async function makeE2ETasks () {
 
       return null
     },
-    // Targeted at cloud_message_banner.cy.ts: CI sets
-    // CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide to silence the end-of-run
-    // commercial-recommendations message. The same flag short-circuits the
-    // cloudAppMessages stitching executor — that spec is the one place we need
-    // to defeat it. Other specs keep the flag and short-circuit as before, so
-    // we don't introduce extra cloudAppMessages traffic into unrelated suites.
+    // CI sets CYPRESS_COMMERCIAL_RECOMMENDATIONS=0 org-wide; cloud_message_banner.cy.ts
+    // needs the cloudAppMessages channel live, other specs keep the short-circuit.
     __internal_optInToCloudAppMessages () {
       cachedCommercialRecommendations = process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS
       delete process.env.CYPRESS_COMMERCIAL_RECOMMENDATIONS


### PR DESCRIPTION
## Summary

Two related changes to back out unintended fallout from #33757:

1. **Narrow the env-var override.** The previous fix deleted `CYPRESS_COMMERCIAL_RECOMMENDATIONS` in `e2ePluginSetup.ts`, so every E2E spec went through the `cloudAppMessages` stitching executor instead of short-circuiting. That added one extra GraphQL operation per page render and shifted timing in adjacent specs already on the edge of flake. Move the override to a per-spec opt-in via two internal tasks (`__internal_optInToCloudAppMessages` / `__internal_restoreCommercialRecommendations`), called from `cloud_message_banner.cy.ts`'s `before`/`after`. Other specs return to pre-merge timing.

   `cy.task` (not `cy.withCtx`) because the spec is webpack-bundled and webpack rewrites `process.env` references — a rewritten access fails when the callback is serialized into a `withCtx` payload and re-eval'd in the AUT's plain Node.

2. **Deflake `specs_list_latest_runs.cy.ts` → "when not using a branch".** The context stubbed `currentBranch` to `undefined` *after* the outer describe's `beforeEach` had already called `startAppServer` and stubbed branch to `'fakeBranch'` with git hashes set. The binary booted with populated git state and the urql cache held runs derived from it — overriding the stub later raced against the cached data. Pull the scenario into its own top-level describe so the stub installs **before** `startAppServer`. Binary boots with no branch, no cached runs, no race.

The sibling `context.skip('when no runs are recorded')` has the same shape of race (intercept install vs initial cloud queries). Out of scope for this PR but worth a follow-up to try un-skipping after this lands.

## Test plan

- [ ] `develop` no longer shows the `when not using a branch` test as flaky after merge
- [ ] `cloud_message_banner.cy.ts` continues to pass (the channel is still defeatable for that spec via the opt-in task)
- [ ] No timing regressions in adjacent app/launchpad E2E suites (the previous unintended cloudAppMessages traffic is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Cypress-in-Cypress E2E test setup and spec organization, but could affect test environment variables and timing across the suite.
> 
> **Overview**
> Limits the previous global deletion of `CYPRESS_COMMERCIAL_RECOMMENDATIONS` during E2E plugin setup by introducing opt-in/restore tasks (`__internal_optInToCloudAppMessages` / `__internal_restoreCommercialRecommendations`) and using them only in `cloud_message_banner.cy.ts`.
> 
> Deflakes the "latest runs (no branch)" scenario by moving it into its own top-level `describe` that stubs `currentBranch` to `undefined` *before* `startAppServer`, avoiding cached run data from a previously-initialized git branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417a8c8859d4574cbfa1fcc8ea918eb748c5aa7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->