### PR TITLE
chore: clear cached node_modules on scaffold retry to deflake Angular CT tests

### DIFF
--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -113,7 +113,7 @@ async function makeE2ETasks () {
   const { toObject } = require('@packages/server/lib/util/args')
   const { makeDataContext } = require('./prod-dependencies')
   const Fixtures = require('@tooling/system-tests') as FixturesShape
-  const { scaffoldCommonNodeModules, scaffoldProjectNodeModules } = require('@tooling/system-tests/lib/dep-installer')
+  const { scaffoldCommonNodeModules, scaffoldProjectNodeModules, clearCachedNodeModules } = require('@tooling/system-tests/lib/dep-installer')
 
   const cli = require('../../../../cli/lib/cli').default
   const cliUtil = require('../../../../cli/lib/util').default
@@ -165,6 +165,10 @@ async function makeE2ETasks () {
       if (isRetry) {
         throw e
       }
+
+      // Clear the cached node_modules to avoid reusing a corrupted cache
+      // (e.g. from a previously interrupted install)
+      await clearCachedNodeModules(projectName)
 
       // If we have an error, it's likely that we don't have a lockfile, or it's out of date.
       // Let's run a quick "yarn" in the directory, kill the node_modules, and try again

--- a/system-tests/lib/dep-installer/index.ts
+++ b/system-tests/lib/dep-installer/index.ts
@@ -149,11 +149,6 @@ async function makeWorkspacePackagesAbsolute (pathToPkgJson: string, projectDir:
   return updatedDeps
 }
 
-/**
- * Given a `system-tests` project name, detect and install the `node_modules`
- * specified in the project's `package.json`. No-op if no `package.json` is found.
- * Will use `yarn` or `npm` based on the lockfile present.
- */
 export async function clearCachedNodeModules (project: string): Promise<void> {
   const cacheDir = path.join('/tmp', 'cy-system-tests-node-modules', project)
 
@@ -165,6 +160,11 @@ export async function clearCachedNodeModules (project: string): Promise<void> {
   }
 }
 
+/**
+ * Given a `system-tests` project name, detect and install the `node_modules`
+ * specified in the project's `package.json`. No-op if no `package.json` is found.
+ * Will use `yarn` or `npm` based on the lockfile present.
+ */
 export async function scaffoldProjectNodeModules ({
   project,
   updateLockFile = !!process.env.UPDATE_LOCK_FILE,

--- a/system-tests/lib/dep-installer/index.ts
+++ b/system-tests/lib/dep-installer/index.ts
@@ -154,6 +154,17 @@ async function makeWorkspacePackagesAbsolute (pathToPkgJson: string, projectDir:
  * specified in the project's `package.json`. No-op if no `package.json` is found.
  * Will use `yarn` or `npm` based on the lockfile present.
  */
+export async function clearCachedNodeModules (project: string): Promise<void> {
+  const cacheDir = path.join('/tmp', 'cy-system-tests-node-modules', project)
+
+  try {
+    await fs.remove(cacheDir)
+    log(`Cleared cached node_modules for ${project}`)
+  } catch {
+    // ignore if cache dir doesn't exist
+  }
+}
+
 export async function scaffoldProjectNodeModules ({
   project,
   updateLockFile = !!process.env.UPDATE_LOCK_FILE,


### PR DESCRIPTION
- Closes n/a

### Additional details

**Problem**: The "Angular 18 error conditions" test in `ct-framework-errors.cy.ts` flakes on Windows CI with:

```
Could not resolve "@angular-devkit/build-angular/src/utils/webpack-browser-config.js".
Do you have "@angular-devkit/build-angular" and "@angular-devkit/core" installed?
```

**Root cause**: The e2e scaffold flow caches installed `node_modules` at `/tmp/cy-system-tests-node-modules/<project>/node_modules` and symlinks (junctions on Windows) to this cache on subsequent scaffolds. If a prior install was interrupted, the cache contains incomplete packages. The existing retry logic in `__internal_scaffoldProject` clears the temp project's `node_modules` but never invalidates the **cache**, so the retry re-symlinks to the same broken cache.

Three `node_modules` locations exist during scaffolding:

| Location | Previously cleared | Purpose |
|---|---|---|
| `system-tests/projects/<project>/node_modules` | `clearFixtureNodeModules` | Source fixture leftovers |
| `/tmp/cy-<tmpdir>/<project>/node_modules` | `removeProject` | Temp copy where tests run |
| `/tmp/cy-system-tests-node-modules/<project>/node_modules` | **Never** | Persistent cache (symlink target) |

**Fix**: Add `clearCachedNodeModules()` to the dep-installer and call it before the scaffold retry, ensuring a fresh install instead of re-linking to a corrupted cache.

### Steps to test

1. This is a test infrastructure change — validation requires observing the flaky test on Windows CI
2. The fix ensures that when `scaffoldProjectNodeModules` fails, the cached `node_modules` are cleared before retrying
3. Check that the `clearCachedNodeModules` function correctly removes the cache directory at `/tmp/cy-system-tests-node-modules/<project>/`

### How has the user experience changed?

No user-facing changes. This is an internal test infrastructure fix.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-infrastructure change that only affects system-test scaffolding behavior; main risk is inadvertently removing the wrong cache directory or increasing install time on retries.
> 
> **Overview**
> Improves system-test scaffolding retry behavior by **clearing the persistent `node_modules` cache** when `scaffoldProjectNodeModules` fails, preventing retries from reusing a potentially corrupted cached install.
> 
> Adds `clearCachedNodeModules(project)` to the dep-installer (removing `/tmp/cy-system-tests-node-modules/<project>/`) and calls it from `__internal_scaffoldProject` in `e2ePluginSetup.ts` before re-running `yarn` and retrying the scaffold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 405402831e8daf65ea9a4238a3159c2e78e15902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->