### PR TITLE
test: stabilize flaky ajax-list component tests in @cypress/vue

### DIFF
--- a/npm/vue/cypress/component/xhr/ajax-list.cy.js
+++ b/npm/vue/cypress/component/xhr/ajax-list.cy.js
@@ -4,7 +4,12 @@
 import AjaxList from './AjaxList.vue'
 import { mount } from '@cypress/vue'
 
-/* eslint-env mocha */
+const users = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+  { id: 3, name: 'Charlie' },
+]
+
 describe('AjaxList', () => {
   context('using cy.intercept()', () => {
     // because this component loads data right away
@@ -13,44 +18,46 @@ describe('AjaxList', () => {
     // then will mount the component
 
     it('loads list of posts', () => {
+      cy.intercept('GET', '/users?_limit=3', { body: users }).as('users')
       mount(AjaxList)
+      cy.wait('@users')
       cy.get('li').should('have.length', 3)
     })
 
-    it('can inspect real data in XHR', () => {
-      cy.intercept('/users?_limit=3').as('users')
+    it('can inspect intercepted XHR', () => {
+      cy.intercept('GET', '/users?_limit=3', { body: users }).as('users')
       mount(AjaxList)
 
       cy.wait('@users').its('response.body').should('have.length', 3)
     })
 
     it('can display mock XHR response', () => {
-      const users = [{ id: 1, name: 'foo' }]
+      const singleUser = [{ id: 1, name: 'foo' }]
 
-      cy.intercept('GET', '/users?_limit=3', { body: users }).as('users')
+      cy.intercept('GET', '/users?_limit=3', { body: singleUser }).as('users')
       mount(AjaxList)
 
       cy.get('li').should('have.length', 1).first().contains('foo')
     })
 
     it('can inspect mocked XHR', () => {
-      const users = [{ id: 1, name: 'foo' }]
+      const singleUser = [{ id: 1, name: 'foo' }]
 
-      cy.intercept('GET', '/users?_limit=3', users).as('users')
+      cy.intercept('GET', '/users?_limit=3', singleUser).as('users')
       mount(AjaxList)
 
-      cy.wait('@users').its('response.body').should('deep.equal', users)
+      cy.wait('@users').its('response.body').should('deep.equal', singleUser)
     })
 
     it('can delay and wait on XHR', () => {
-      const users = [{ id: 1, name: 'foo' }]
+      const singleUser = [{ id: 1, name: 'foo' }]
 
       cy.intercept({
         method: 'GET',
         url: '/users?_limit=3',
       }, {
         delay: 1000,
-        body: users,
+        body: singleUser,
       }).as('users')
 
       mount(AjaxList)


### PR DESCRIPTION
- Closes <!-- n/a — flaky test fix -->

### Additional details

The `"loads list of posts"` test in `npm/vue/cypress/component/xhr/ajax-list.cy.js` was flaky in CI ([example failure](https://app.circleci.com/pipelines/github/cypress-io/cypress/81577/workflows/4a8c7f3d-ca22-4b5f-b4ef-d000a8aa06f2/jobs/3626412)). It mounted the `AjaxList` component without a `cy.intercept()` and relied on Cypress's 4-second assertion retry to outlast a real HTTP round-trip to `jsonplaceholder.cypress.io`. When the external API was slow under CI load, the retry window expired.

This PR mocks all XHR responses in the file via `cy.intercept()`, eliminating the external service dependency entirely. Each test still exercises a distinct intercept pattern (basic mock, response inspection, delayed response, etc.).

Changes:
- All tests now use `cy.intercept()` with mock response bodies instead of hitting `jsonplaceholder.cypress.io`
- Shared a 3-user fixture across tests that need a full list
- Renamed `"can inspect real data in XHR"` → `"can inspect intercepted XHR"` since there's no real data anymore
- Removed unnecessary `/* eslint-env mocha */` directive

### Steps to test

1. Run the spec: `yarn workspace @cypress/vue cy:run -- --spec cypress/component/xhr/ajax-list.cy.js`
2. All 5 tests should pass without any network calls to `jsonplaceholder.cypress.io`

### How has the user experience changed?

No user-facing changes. Internal test stability improvement only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Cypress component tests and only replace live network calls with deterministic `cy.intercept()` mocks.
> 
> **Overview**
> Stabilizes the `AjaxList` Cypress component spec by **mocking all `/users?_limit=3` requests** via `cy.intercept()` instead of relying on the external `jsonplaceholder.cypress.io` API.
> 
> Adds a shared 3-user fixture, waits on the intercepted alias where needed, and renames the inspection test to reflect that it now validates intercepted (not real) responses; also removes an unnecessary Mocha eslint directive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a428c77d5b1141f22f07d6d9ba1bc0fbcbbe07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->