### PR TITLE
fix: cap lerna concurrency in binary build to available CPU count

### DIFF
--- a/scripts/binary/build.ts
+++ b/scripts/binary/build.ts
@@ -103,12 +103,14 @@ export async function buildCypressApp (options: BuildCypressAppOpts) {
       version,
     }, { spaces: 2 })
 
-    await execa('yarn', ['lerna', 'run', 'build', '--concurrency', '4'], {
+    const buildConcurrency = String(Math.min(4, os.availableParallelism()))
+
+    await execa('yarn', ['lerna', 'run', 'build', '--concurrency', buildConcurrency], {
       stdio: 'inherit',
       cwd: CY_ROOT_DIR,
     })
 
-    await execa('yarn', ['lerna', 'run', 'build-prod', '--concurrency', '4'], {
+    await execa('yarn', ['lerna', 'run', 'build-prod', '--concurrency', buildConcurrency], {
       stdio: 'inherit',
       cwd: CY_ROOT_DIR,
     })


### PR DESCRIPTION
- Closes n/a

### Additional details

[CircleCI job #38072](https://app.circleci.com/pipelines/gh/cypress-io/cypress-publish-binary/19598/workflows/59683948-cbe3-4089-916e-eb469f13c409/jobs/38072) failed with a V8 fatal crash (`unreachable code` in `HeapAllocator`) during `lerna run build-prod` on an ARM64 Linux CI runner. The `@packages/errors:build-prod` task hit the crash, cascading to skip 12 downstream packages.

This is the same class of V8 bytecode-cache deserializer segfault fixed for the root `yarn build` in #33730 via `scripts/lerna-build.js`. That fix caps lerna concurrency at `Math.min(4, os.availableParallelism())` so on arm.medium runners (2 CPU), only 2 concurrent tsc processes run instead of 4.

The **binary build path** in `scripts/binary/build.ts` was missed and still used hardcoded `--concurrency 4`. This PR applies the same dynamic cap to both `lerna run build` and `lerna run build-prod` calls in `buildCypressApp()`.

### Steps to test

1. Verify the change in `scripts/binary/build.ts` — both lerna calls should use `buildConcurrency` instead of `'4'`
2. Confirm the formula matches `scripts/lerna-build.js`: `Math.min(4, os.availableParallelism())`
3. Binary build on an ARM64 runner should no longer segfault

### How has the user experience changed?

No user-facing change. Binary builds on low-CPU ARM64 CI runners will no longer intermittently crash due to V8 memory pressure from excessive concurrency.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script change that only reduces parallelism on low-core machines; main impact is potentially slower builds, but should reduce CI instability/crashes.
> 
> **Overview**
> Updates the binary build pipeline to compute a `buildConcurrency` value as `Math.min(4, os.availableParallelism())` and use it for both `lerna run build` and `lerna run build-prod`, replacing the previous hardcoded `--concurrency 4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf6bbab3fb5323430f7e4678e96ffd6e07e2c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->