### PR TITLE
chore: use GitHub API for verified commits in browser version update workflow

### DIFF
--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -31,11 +31,6 @@ jobs:
       - name: Setup CircleCI CLI
         run: |
           sudo snap install circleci
-      - name: Set committer info
-        ## attribute the commit to cypress-bot: https://github.community/t/logging-into-git-as-a-github-app/115916
-        run: |
-          git config --local user.email "${{ env.CYPRESS_BOT_APP_ID }}+cypress-bot[bot]@users.noreply.github.com"
-          git config --local user.name "cypress-bot[bot]"
       - name: Checkout base branch
         run: |
           git fetch origin
@@ -84,10 +79,6 @@ jobs:
               latestBetaVersion: '${{ steps.get-versions.outputs.latest_beta_version }}',
               latestChromeForTestingStableVersion: '${{ steps.get-versions.outputs.latest_chrome_for_testing_stable_version }}',
             })
-      ## Update available and a PR doesn't already exist
-      - name: Checkout new branch
-        if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        run: git checkout -b ${{ steps.check-branch.outputs.branch_name }} ${{ env.BASE_BRANCH }}
       ## Both
       - name: Update Browser Versions File
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
@@ -101,13 +92,25 @@ jobs:
               latestBetaVersion: '${{ steps.get-versions.outputs.latest_beta_version }}',
               latestChromeForTestingStableVersion: '${{ steps.get-versions.outputs.latest_chrome_for_testing_stable_version }}',
             })
-      - name: Commit the changes
+      - name: Commit and push via API
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        run: |
-          git commit -am "chore: ${{ steps.get-versions.outputs.description }}"
-      - name: Push branch to remote
-        if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        run: git push origin ${{ steps.check-branch.outputs.branch_name }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { join } = await import('node:path')
+            const { pathToFileURL } = await import('node:url')
+            const moduleUrl = pathToFileURL(join(process.cwd(), 'scripts/github-actions/commit-via-api.mjs')).href
+            const { commitViaApi } = await import(moduleUrl)
+
+            await commitViaApi({
+              context,
+              github,
+              baseBranch: '${{ env.BASE_BRANCH }}',
+              branchName: '${{ steps.check-branch.outputs.branch_name }}',
+              filePaths: ['.circleci/src/pipeline/@pipeline.yml'],
+              message: 'chore: ${{ steps.get-versions.outputs.description }}',
+            })
       ## Update available and a branch/PR already exists
       - name: Update PR Title
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}


### PR DESCRIPTION
- Closes n/a

### Additional details

The `update-browser-versions.yml` workflow creates commits using `git commit` + `git push` with a GitHub App token. GitHub doesn't cryptographically sign commits created this way, so they appear as **unverified** (e.g. the commit in #33795).

This PR switches to using the existing `commitViaApi` utility (`scripts/github-actions/commit-via-api.mjs`), which creates commits via GitHub's `createCommitOnBranch` GraphQL mutation. GitHub automatically signs commits made through its own API, so they'll appear as **Verified**. This is the same pattern the V8 snapshot cache workflow (`update_v8_snapshot_cache.yml`) already uses.

**Changes:**
- **Removed** the "Set committer info" step — no longer needed since the API commit is attributed to the GitHub App automatically
- **Removed** the "Checkout new branch" step — `commitViaApi` creates the branch on GitHub's side when it doesn't exist
- **Replaced** the "Commit the changes" + "Push branch to remote" steps with a single "Commit and push via API" step

### Steps to test

1. After merging, trigger the workflow via `workflow_dispatch`
2. If a browser version update is available, verify the resulting commit on the PR branch shows the green "Verified" badge

### How has the user experience changed?

Commits created by the browser version update workflow will now show as "Verified" on GitHub.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `update-browser-versions` GitHub Action to write commits/branches via the GitHub API instead of `git commit`/`git push`, which could affect the reliability of the automated update PR flow if the API commit step misbehaves or permissions differ.
> 
> **Overview**
> Switches the `update-browser-versions` workflow from creating commits with local git commands to using the shared `commitViaApi` GraphQL-based helper, so automated browser-version update commits are created (and signed) by GitHub.
> 
> Removes manual committer configuration and the explicit “checkout new branch” + `git push` flow, relying on `commitViaApi` to create the branch when missing and commit the updated `.circleci/src/pipeline/@pipeline.yml` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69315d905f207e9b47e417978608582fd992754e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->