### PR TITLE
internal: pass projectSlug to cloudAppMessages query

### DIFF
--- a/packages/data-context/graphql/schema.ts
+++ b/packages/data-context/graphql/schema.ts
@@ -30,6 +30,9 @@ export const graphqlSchema = makeSchema({
     schema: remoteSchemaWrapped,
     skipFields: {
       Mutation: ['test'],
+      // Override so we can inject projectSlug from local context — needed for
+      // per-project feature-flag scoping. Local declaration in gql-Query.ts.
+      Query: ['cloudAppMessages'],
     },
   },
   plugins: [

--- a/packages/data-context/graphql/schemaTypes/objectTypes/gql-Query.ts
+++ b/packages/data-context/graphql/schemaTypes/objectTypes/gql-Query.ts
@@ -129,6 +129,21 @@ export const Query = objectType({
       description: 'Unique node machine identifier for this instance - may be nil if unable to resolve',
       resolve: async (source, args, ctx) => await ctx.coreData.machineId,
     })
+
+    t.list.nonNull.field('cloudAppMessages', {
+      type: 'CloudAppMessage',
+      description: 'Cloud-driven in-app banner content. Local override of the merged cloud field so we can inject the current project slug for per-project feature-flag scoping.',
+      resolve: async (root, args, ctx, info) => {
+        const projectId = await ctx.project.projectId()
+
+        return ctx.cloud.delegateCloudField({
+          field: 'cloudAppMessages',
+          args: { projectSlug: projectId },
+          ctx,
+          info,
+        })
+      },
+    })
   },
   sourceType: {
     module: path.join(__dirname, '../../'),

--- a/packages/data-context/graphql/schemaTypes/objectTypes/gql-Query.ts
+++ b/packages/data-context/graphql/schemaTypes/objectTypes/gql-Query.ts
@@ -136,9 +136,12 @@ export const Query = objectType({
       resolve: async (root, args, ctx, info) => {
         const projectId = await ctx.project.projectId()
 
+        // Omit projectSlug entirely in global mode — passing null is not the
+        // same as omitting in GraphQL, and the remote field's doc contract
+        // says "When omitted, only globally-targeted messages are returned."
         return ctx.cloud.delegateCloudField({
           field: 'cloudAppMessages',
-          args: { projectSlug: projectId },
+          args: projectId ? { projectSlug: projectId } : {},
           ctx,
           info,
         })

--- a/packages/data-context/schemas/cloud.graphql
+++ b/packages/data-context/schemas/cloud.graphql
@@ -38,15 +38,6 @@ type CloudAppMessageAnalytics {
 }
 
 """
-Optional UTM params for CTA destination URLs. CTA-level overrides message-level. utm_source/medium/campaign are auto-injected by the binary.
-"""
-type CloudAppMessageUtm {
-  content: String
-  id: String
-  term: String
-}
-
-"""
 Call-to-action button rendered alongside an in-app cloud message banner
 """
 type CloudAppMessageCta {
@@ -73,6 +64,15 @@ type CloudAppMessageDismissal {
 enum CloudAppMessageDismissalScope {
   project
   user
+}
+
+"""
+Optional UTM params for CTA destination URLs. CTA-level overrides message-level. utm_source/medium/campaign are auto-injected by the binary.
+"""
+type CloudAppMessageUtm {
+  content: String
+  id: String
+  term: String
 }
 
 enum CloudAppMessageVisualStyle {

--- a/packages/data-context/schemas/schema.graphql
+++ b/packages/data-context/schemas/schema.graphql
@@ -1865,14 +1865,9 @@ type Query {
   cachedUser: CachedUser
 
   """
-  Cloud-driven in-app messages eligible to be rendered as banners in the binary. Pre-filtered server-side by channel feature flag, version range, and cohort allow-lists. Public — accessible without authentication so logged-out users can still receive awareness messages. The binary may further filter on local state (run mode, env-var opt-out) before rendering.
+  Cloud-driven in-app banner content. Local override of the merged cloud field so we can inject the current project slug for per-project feature-flag scoping.
   """
-  cloudAppMessages(
-    """
-    Optional project slug used to scope cohort and channel-flag lookups. When omitted, only globally-targeted messages are returned.
-    """
-    projectSlug: String
-  ): [CloudAppMessage!]
+  cloudAppMessages: [CloudAppMessage!]
 
   """
   Polling query to determine when to refetch spec data. A null value here means no data available in the cloud.


### PR DESCRIPTION
## Summary

The `cloudAppMessages` fragment in the binary called the cypress-services field with no args. Per the schema doc on that field — *"When omitted, only globally-targeted messages are returned"* — cypress-services falls back to the **global** feature-flag check instead of the project-specific one. So enabling the `app-messaging-channel` flag for a single project had no effect; the banner never appeared.

Fix mirrors the pattern `CurrentProject.cloudProject` uses for `cloudProjectBySlug`:

- Skip `cloudAppMessages` from the schema merge (`schema.ts` → `skipFields: { Query: ['cloudAppMessages'] }`)
- Declare it locally on `Query` in `gql-Query.ts` with a resolver that pulls `ctx.project.projectId()` and delegates to the remote field with `{ projectSlug: projectId }` injected
- Clients (the binary's Vue queries) continue calling `cloudAppMessages` with no args; the projectSlug is added server-side inside the binary, then forwarded to cypress-services

Other server-side filter inputs were already correctly plumbed:

- **`cypressVersion`** — sent via `x-cypress-version` HTTP header from `CloudDataSource.additionalHeaders()`
- **Cohort fields** (`userId`, `orgUuid`) — derived server-side from the authenticated session + projectSlug

Only `projectSlug` was the gap.

## Auto-regenerated artifacts

Running `yarn workspace @packages/data-context build` after the source change shook out two SDL updates that are included in this PR:

- `schemas/schema.graphql` — `cloudAppMessages` now appears with no args (the local declaration's signature) instead of the merged `projectSlug: String` signature
- `schemas/cloud.graphql` — `CloudAppMessageUtm` moved alphabetically (a pure reorder; no shape change)

## Test plan

- [ ] Enable `app-messaging-channel` for a single project in cypress-services
- [ ] Launch the cypress binary against that project, log in, open the specs page
- [ ] V1 banner ("Faster Authoring. Smarter Assertions.") renders
- [ ] Enable the flag globally instead, confirm it still works for users without an active project (e.g. global mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL query stitching and the `cloudAppMessages` schema signature; incorrect delegation or argument handling could affect banner delivery and any callers that previously passed `projectSlug`.
> 
> **Overview**
> Ensures `cloudAppMessages` is scoped per-project by overriding the merged cloud `Query.cloudAppMessages` field and resolving it locally with a delegated call that injects `projectSlug` from the current project context (omitting the arg entirely in global mode).
> 
> Regenerates SDL artifacts to reflect the new local field signature (now no `projectSlug` arg in `schemas/schema.graphql`) and includes a no-op reorder in `schemas/cloud.graphql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fbc817709228cd63051aa744439d9ff0d36f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->