### PR TITLE
chore: route all CI lerna builds through lerna-build.js for concurrency cap

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2493,7 +2493,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/webpack-preprocessor
+          command: node scripts/lerna-build.js --scope=@cypress/webpack-preprocessor
       - run:
           name: Run tests
           command: yarn workspace @cypress/webpack-preprocessor test
@@ -2544,7 +2544,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/vue
+          command: node scripts/lerna-build.js --scope=@cypress/vue
       - run:
           name: Run tests
           command: yarn test
@@ -2560,7 +2560,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/angular
+          command: node scripts/lerna-build.js --scope=@cypress/angular
 
   npm-angular-zoneless:
     <<: *defaults
@@ -2570,7 +2570,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope @cypress/angular-zoneless
+          command: node scripts/lerna-build.js --scope @cypress/angular-zoneless
 
   npm-puppeteer-unit-tests:
     <<: *defaults
@@ -2580,7 +2580,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/puppeteer
+          command: node scripts/lerna-build.js --scope=@cypress/puppeteer
       - run:
           name: Run tests
           command: yarn test
@@ -2611,7 +2611,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/react
+          command: node scripts/lerna-build.js --scope=@cypress/react
       - run:
           name: Run tests
           command: yarn test
@@ -2627,7 +2627,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/vite-plugin-cypress-esm
+          command: node scripts/lerna-build.js --scope=@cypress/vite-plugin-cypress-esm
       - run:
           name: Run tests
           command: yarn test
@@ -2643,7 +2643,7 @@ jobs:
       - restore_cached_workspace
       - run:
           name: Build
-          command: yarn lerna run build --scope=@cypress/mount-utils
+          command: node scripts/lerna-build.js --scope=@cypress/mount-utils
 
   npm-grep:
     <<: *defaults
@@ -2701,7 +2701,7 @@ jobs:
       - run:
           name: Build + Install
           command: |
-            yarn lerna run build --scope=@cypress/schematic
+            node scripts/lerna-build.js --scope=@cypress/schematic
       - run:
           name: Run unit tests
           command: |

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -10,8 +10,8 @@ const concurrency = Math.min(4, os.availableParallelism())
 
 const child = spawn(
   'lerna',
-  ['run', 'build', '--stream', `--concurrency=${concurrency}`],
-  { stdio: 'inherit', shell: true },
+  ['run', 'build', '--stream', `--concurrency=${concurrency}`, ...process.argv.slice(2)],
+  { stdio: 'inherit' },
 )
 
 child.on('exit', (code, signal) => {

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -5,17 +5,15 @@
 // segfaults inside V8's bytecode-cache deserializer (#33730).
 const { spawn } = require('child_process')
 const os = require('os')
+const minimist = require('minimist')
 
+const argv = minimist(process.argv.slice(2), { string: ['scope'] })
 const concurrency = Math.min(4, os.availableParallelism())
 
 const args = ['run', 'build', '--stream', `--concurrency=${concurrency}`]
 
-const scopeIdx = process.argv.indexOf('--scope')
-
-if (scopeIdx !== -1 && process.argv[scopeIdx + 1]) {
-  args.push('--scope', process.argv[scopeIdx + 1])
-} else if (process.argv.find((a) => a.startsWith('--scope='))) {
-  args.push(process.argv.find((a) => a.startsWith('--scope=')))
+if (argv.scope) {
+  args.push('--scope', argv.scope)
 }
 
 const child = spawn(

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -4,8 +4,11 @@
 // arm.medium (2 CPU) runs 4 simultaneous tsc startups and intermittently
 // segfaults inside V8's bytecode-cache deserializer (#33730).
 const { spawn } = require('child_process')
+const path = require('path')
 const os = require('os')
 const minimist = require('minimist')
+
+const lerna = path.resolve(__dirname, '..', 'node_modules', '.bin', 'lerna')
 
 const argv = minimist(process.argv.slice(2), { string: ['scope'] })
 const concurrency = Math.min(4, os.availableParallelism())
@@ -17,7 +20,7 @@ if (argv.scope) {
 }
 
 const child = spawn(
-  'lerna',
+  lerna,
   args,
   { stdio: 'inherit', shell: true },
 )

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -11,7 +11,7 @@ const concurrency = Math.min(4, os.availableParallelism())
 const child = spawn(
   'lerna',
   ['run', 'build', '--stream', `--concurrency=${concurrency}`, ...process.argv.slice(2)],
-  { stdio: 'inherit' },
+  { stdio: 'inherit', shell: true },
 )
 
 child.on('exit', (code, signal) => {

--- a/scripts/lerna-build.js
+++ b/scripts/lerna-build.js
@@ -8,9 +8,19 @@ const os = require('os')
 
 const concurrency = Math.min(4, os.availableParallelism())
 
+const args = ['run', 'build', '--stream', `--concurrency=${concurrency}`]
+
+const scopeIdx = process.argv.indexOf('--scope')
+
+if (scopeIdx !== -1 && process.argv[scopeIdx + 1]) {
+  args.push('--scope', process.argv[scopeIdx + 1])
+} else if (process.argv.find((a) => a.startsWith('--scope='))) {
+  args.push(process.argv.find((a) => a.startsWith('--scope=')))
+}
+
 const child = spawn(
   'lerna',
-  ['run', 'build', '--stream', `--concurrency=${concurrency}`, ...process.argv.slice(2)],
+  args,
   { stdio: 'inherit', shell: true },
 )
 


### PR DESCRIPTION
- Closes <!-- n/a — addresses the same V8 crash as #33797 but for scoped npm-* CI jobs -->

### Additional details

The `npm-cypress-schematic` CI job (and 8 other `npm-*` jobs) called `yarn lerna run build --scope=...` directly, bypassing the concurrency cap in `scripts/lerna-build.js`. On `medium` (2 vCPU) runners this launched 9+ concurrent `tsc` processes that crashed V8's bytecode-cache deserializer ([#33730](https://github.com/cypress-io/cypress/issues/33730)).

**What changed:**
- `scripts/lerna-build.js` now forwards `process.argv.slice(2)` so callers can pass `--scope` and other flags.
- All 9 CI `npm-*` jobs that ran bare `yarn lerna run build --scope=...` now use `node scripts/lerna-build.js --scope=...` instead

The binary build in `scripts/binary/build.ts` already has its own concurrency cap and is unaffected.

### Steps to test

1. Verify the CI `npm-cypress-schematic` job (and other `npm-*` build jobs) pass without V8 crashes
2. Confirm the main `yarn build` still works (it already used `lerna-build.js`)

### How has the user experience changed?

No user-facing changes. CI reliability improvement only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CircleCI jobs and the shared `lerna-build.js` wrapper; mis-parsing args or path resolution could break CI builds, but it does not affect runtime/product code.
> 
> **Overview**
> Updates several `npm-*` CircleCI jobs to run builds via `node scripts/lerna-build.js --scope=...` instead of calling `yarn lerna run build` directly, ensuring the concurrency cap is applied consistently.
> 
> Enhances `scripts/lerna-build.js` to parse CLI args (currently `--scope`) and invoke the repository-local `lerna` binary with the computed concurrency, rather than relying on a global `lerna` resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1d61238328943f852e7866c095832a1363feed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->