### PR TITLE
test: stabilize flaky cloud settings e2e test timeout

### DIFF
--- a/packages/app/cypress/e2e/settings.cy.ts
+++ b/packages/app/cypress/e2e/settings.cy.ts
@@ -99,9 +99,7 @@ describe('App: Settings', () => {
       cy.findByTestId('spec-list-container').scrollTo('bottom')
       // Visit the test to trigger the ws.off() for the TR websockets
       cy.contains('test1.js').click()
-      cy.waitForSpecToFinish()
-      // Wait for the test to pass, so the test is completed
-      cy.get('.passed > .num').should('contain', 1)
+      cy.waitForSpecToFinish({ passCount: 1 })
       cy.get(SidebarSettingsLinkSelector).click()
       cy.contains('Cypress Cloud settings').click()
       // Assert the data is not there before it arrives


### PR DESCRIPTION
- Closes <!-- no issue -->

### Additional details

The `shows deferred remote cloud data after navigating from a run` test in `packages/app/cypress/e2e/settings.cy.ts` was flaky because it asserted `.passed > .num` contains `1` using the default 4-second Cypress timeout. Under CI load, the reporter stats may not populate within 4 seconds after the restart button appears — the element remains `<span class="num empty">` when the assertion fires.

The fix passes `{ passCount: 1 }` to `waitForSpecToFinish()` instead of manually asserting the passed count on the next line. This delegates to `shouldHaveTestResults()` which retries with a 40-second timeout — the established pattern used across the rest of the test suite.

The test also has `{ retries: 0 }`, making it extra sensitive to timing issues since it gets zero retries.

### Steps to test

1. The fix is a test-only change — verify the updated test passes in CI (app-e2e job).

### How has the user experience changed?

No user-facing changes. This is a test stability fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts synchronization/timeout behavior in a single Cypress e2e spec; no production code paths affected.
> 
> **Overview**
> Stabilizes the `shows deferred remote cloud data after navigating from a run` e2e by replacing the manual `.passed > .num` assertion with `cy.waitForSpecToFinish({ passCount: 1 })`, leveraging the existing longer-retry `shouldHaveTestResults` timeouts to reduce CI flake.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b394792e776792ddd947844b20632d45926d97ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->