### PR TITLE
test: deflake 'adds a scroll listener in open mode' reporter test

### DIFF
--- a/packages/reporter/cypress/e2e/runnables.cy.ts
+++ b/packages/reporter/cypress/e2e/runnables.cy.ts
@@ -217,6 +217,7 @@ describe('runnables', () => {
     })
 
     it('adds a scroll listener in open mode', () => {
+      appState.autoScrollingEnabled = false
       appState.startRunning()
       cy.get('.container')
       .trigger('scroll')


### PR DESCRIPTION
- Closes <!-- n/a -->

### Additional details

The `adds a scroll listener in open mode` test in `packages/reporter/cypress/e2e/runnables.cy.ts` is flaky because `appState.startRunning()` triggers `useScrollIntoView` reactions in each rendered test component. These call `scroller.scrollIntoView()` via `requestAnimationFrame`, which decrements `_userScrollCount`. When the RAF fires before Cypress processes the synthetic `.trigger('scroll')` commands, the count goes negative and 3 triggers aren't enough to reach the detection threshold of 3 — so the scroll callback never fires and the assertion fails.

Setting `appState.autoScrollingEnabled = false` before `startRunning()` prevents `useScrollIntoView` from triggering programmatic scrolls. The scroll detection callback in `runnables.tsx` only checks `appState.isRunning`, not `autoScrollingEnabled`, so it still fires correctly.

### Steps to test

1. Run the reporter component tests: `yarn workspace @packages/reporter cypress:run:ct -- --spec "cypress/e2e/runnables.cy.ts"`
2. The `adds a scroll listener in open mode` test should pass consistently.

### How has the user experience changed?

No user-facing changes — test-only fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to a Cypress reporter E2E test and only adjust app state setup to avoid timing-related flakiness, with no production logic changes.
> 
> **Overview**
> Stabilizes the `adds a scroll listener in open mode` reporter Cypress test by explicitly setting `appState.autoScrollingEnabled = false` before `appState.startRunning()`, preventing programmatic scroll effects from interfering with the user-scroll detection assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a1df1c7ad7b0951b403fe34e757c1a9301092d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->