### PR TITLE
chore: bump esbuild to ^0.28.0

### DIFF
--- a/packages/packherd-require/src/transpile-ts.ts
+++ b/packages/packherd-require/src/transpile-ts.ts
@@ -11,7 +11,7 @@ type EnhancedModule = NodeModule & {
 }
 
 const DEFAULT_TRANSFORM_OPTS: TransformOptions = {
-  target: ['node20'],
+  target: ['node22'],
   loader: 'ts',
   format: 'cjs',
   sourcemap: 'inline',

--- a/tooling/packherd/src/create-bundle.ts
+++ b/tooling/packherd/src/create-bundle.ts
@@ -3,7 +3,7 @@ import type { CreateBundleOpts, CreateBundleResult } from './types'
 
 const DEFAULT_BUNDLE_OPTS: Partial<CreateBundleOpts> = {
   platform: 'node',
-  target: ['node20'],
+  target: ['node22'],
 }
 
 /**


### PR DESCRIPTION
## Summary

- Bump `esbuild` from `^0.25.2` to `^0.28.0` across `@packages/packherd-require`, `@tooling/packherd`, `@packages/server`, system-tests, and nested fixture projects (with lockfile updates).
- Align esbuild transpile/bundle `target` with Cypress-supported Node (`node22`) in packherd and packherd-require.

This updates the npm-shipped `@esbuild/*` Go binaries past versions affected by **CVE-2025-68121**, addressing scanner findings on `cypress/included` described in https://github.com/cypress-io/cypress/issues/33599.

## Test plan

- [x] `yarn workspace @packages/packherd-require test`
- [x] `yarn workspace @tooling/packherd test-integration` (if run locally)
- [ ] CI green on this PR
- [ ] Optional: `trivy image --ignore-unfixed --pkg-types library --scanners vuln --severity CRITICAL` on a built image containing this change to confirm the `@esbuild` finding is cleared


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that updates esbuild transpile/bundle targets; main risk is unexpected output/runtime differences if consumers still run on older Node versions.
> 
> **Overview**
> Updates `esbuild` default `target` from `node20` to `node22` for both TypeScript on-the-fly transpilation (`packages/packherd-require/src/transpile-ts.ts`) and bundling (`tooling/packherd/src/create-bundle.ts`), aligning generated output with Node 22.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbba4906e6d3677bf5055d80d9c2206e0d2cfb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->