### PR TITLE
test: deflake 'opens docs link in the default browser' launchpad test

### DIFF
--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -638,20 +638,13 @@ describe('Launchpad: Setup Project', () => {
       cy.contains('button', 'Pick a bundler').click()
       cy.findByText('Webpack').click()
       cy.findByRole('button', { name: 'Next step' }).should('not.be.disabled').click()
-      cy.withCtx(async (ctx) => {
-        Object.defineProperty(ctx.coreData, 'scaffoldedFiles', {
-          get () {
-            return this._scaffoldedFiles.map((scaffold) => {
-              if (scaffold.file.absolute.includes('cypress.config')) {
-                return { ...scaffold, status: 'changes' }
-              }
-
-              return scaffold
-            })
-          },
-          set (scaffoldedFiles) {
-            this._scaffoldedFiles = scaffoldedFiles
-          },
+      cy.intercept('POST', 'mutation-InstallDependencies_scaffoldFiles', (req) => {
+        req.continue((res) => {
+          for (const file of res.body.data.scaffoldTestingType.scaffoldedFiles) {
+            if (file.file.absolute.includes('cypress.config')) {
+              file.status = 'changes'
+            }
+          }
         })
       })
 


### PR DESCRIPTION
- Closes <!-- flaky test issue -->

### Additional details

The `opens docs link in the default browser` test in `project-setup.cy.ts` was flaky due to a race condition in its `Object.defineProperty` mock on `coreData.scaffoldedFiles`.

The mock replaced the `scaffoldedFiles` data property with a getter/setter pair to force `status: 'changes'` on the cypress.config file. However, the getter called `this._scaffoldedFiles.map()` without a null guard. Between mock setup and the scaffold mutation setting the value via the setter, `_scaffoldedFiles` was `undefined`. If any concurrent GraphQL resolution of the `scaffoldedFiles` field (e.g., from the active `MainLaunchpadQuery` or a refetch triggered by the config-loading watch in `Main.vue`) hit the getter during this window, it threw a `TypeError`, which could disrupt the mutation response or urql cache update and prevent the scaffolded files view (and "Learn more" button) from rendering.

This replaces the server-side `Object.defineProperty` mock with a `cy.intercept` on the `mutation-InstallDependencies_scaffoldFiles` GraphQL mutation response, modifying the `status` field client-side. This eliminates the race window entirely since there's no server-side state manipulation or getter that can throw.

### Steps to test

1. Run `packages/launchpad/cypress/e2e/project-setup.cy.ts` — specifically the `opens docs link in the default browser` test
2. Verify all tests pass, including the previously flaky test

### How has the user experience changed?

No user-facing changes — test-only fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that swaps a brittle in-context property mock for a network intercept; risk is limited to potentially masking real scaffold status behavior in this one spec.
> 
> **Overview**
> Deflakes the `opens docs link in the default browser` launchpad Cypress test by removing a `cy.withCtx` `Object.defineProperty` override of `coreData.scaffoldedFiles`.
> 
> The test now uses `cy.intercept` to patch the `mutation-InstallDependencies_scaffoldFiles` GraphQL response, forcing `status: 'changes'` for the `cypress.config` scaffolded file before proceeding to click *Learn more* and assert the external-link mutation URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bed6912ba760618cb73ba88f0ec40fa5f6a0aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->