### PR TITLE
chore: prevent windows_reinstall_deps from drifting yarn.lock

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -273,7 +273,11 @@ commands:
               [ -d "$p" ] || continue
               (cd "$(dirname "$p")" && npx patch-package --reverse) || true
             done
-            yarn install --check-files
+            # --frozen-lockfile prevents yarn from pruning orphaned lockfile
+            # entries (e.g. transitive deps whose last reachable parent was
+            # removed). A mutated yarn.lock changes circle_cache_key in
+            # downstream jobs and causes cache restore misses.
+            yarn install --check-files --frozen-lockfile
             for p in patches cli/patches packages/*/patches; do
               [ -d "$p" ] || continue
               (cd "$(dirname "$p")" && npx patch-package) || true

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -273,10 +273,6 @@ commands:
               [ -d "$p" ] || continue
               (cd "$(dirname "$p")" && npx patch-package --reverse) || true
             done
-            # --frozen-lockfile prevents yarn from pruning orphaned lockfile
-            # entries (e.g. transitive deps whose last reachable parent was
-            # removed). A mutated yarn.lock changes circle_cache_key in
-            # downstream jobs and causes cache restore misses.
             yarn install --check-files --frozen-lockfile
             for p in patches cli/patches packages/*/patches; do
               [ -d "$p" ] || continue

--- a/scripts/circle-cache.js
+++ b/scripts/circle-cache.js
@@ -82,7 +82,12 @@ async function unpackCircleCache () {
   const paths = glob.sync(p('globbed_node_modules/*/*/'))
 
   if (paths.length === 0) {
-    throw new Error('Should have found globbed node_modules to unpack')
+    // Cache miss is recoverable downstream (e.g. Windows runs
+    // windows_reinstall_deps right after this); warn and let the job continue
+    // rather than failing before recovery can run.
+    console.warn('No globbed node_modules to unpack — assuming a cache miss; downstream reinstall should recover.')
+
+    return
   }
 
   await Promise.all(

--- a/scripts/circle-cache.js
+++ b/scripts/circle-cache.js
@@ -82,12 +82,7 @@ async function unpackCircleCache () {
   const paths = glob.sync(p('globbed_node_modules/*/*/'))
 
   if (paths.length === 0) {
-    // Cache miss is recoverable downstream (e.g. Windows runs
-    // windows_reinstall_deps right after this); warn and let the job continue
-    // rather than failing before recovery can run.
-    console.warn('No globbed node_modules to unpack — assuming a cache miss; downstream reinstall should recover.')
-
-    return
+    throw new Error('Should have found globbed node_modules to unpack')
   }
 
   await Promise.all(

--- a/yarn.lock
+++ b/yarn.lock
@@ -32886,14 +32886,6 @@ write-file-atomic@5.0.1, write-file-atomic@^5.0.0, write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-write-file-atomic@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-7.0.0.tgz#f89def4f223e9bf8b06cc6fdb12bda3a917505c7"
-  integrity sha512-YnlPC6JqnZl6aO4uRc+dx5PHguiR9S6WeoLtpxNT9wIG+BDya7ZNE1q7KOjVgaA73hKhKLpVPgJ5QA9THQ5BRg==
-  dependencies:
-    imurmurhash "^0.1.4"
-    signal-exit "^4.0.1"
-
 write-file-atomic@^2.4.2:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"


### PR DESCRIPTION
- Fixes the `Should have found globbed node_modules to unpack` failure on every Windows pipeline since [#33542](https://github.com/cypress-io/cypress/pull/33542) (e.g. [job 3637199](https://app.circleci.com/pipelines/github/cypress-io/cypress/81721/workflows/18f51a6f-0dc1-4fc8-8a5b-f7f9a8902581/jobs/3637199)).

### Additional details

`windows_reinstall_deps` runs `yarn install --check-files` to recover from the CircleCI Windows `save_cache` corruption of `@`‑named packages ([cypress#30343](https://github.com/cypress-io/cypress/issues/30343)). Without `--frozen-lockfile`, yarn is allowed to prune orphaned lockfile entries on install. After [#33542](https://github.com/cypress-io/cypress/pull/33542) removed `signal-exit` from `packages/server`, `write-file-atomic@7.0.0` became unreachable in the dep graph but its lockfile entry was not removed — every Windows reinstall has been silently pruning it ever since.

The cache key generated by `scripts/circle-cache.js --action cacheKey` hashes the full bytes of `yarn.lock`, so a pruned lockfile yields a different `circle_cache_key`. Concretely, on [pipeline 81721](https://app.circleci.com/pipelines/github/cypress-io/cypress/81721):

| job | `circle_cache_key` |
|---|---|
| `windows-node-modules-install` (save) | `7N9OTA10v0ttJ8XFwpAA7xLn55ZD3GvtvHq7CDox4h0=` |
| `windows-create-build-artifacts` (restore) | `zJvRA3Zh4jGwivqS086b_Xuh53tmbLpJ4XQC5r3OM9o=` |

Different keys → `restore_cache` miss → `globbed_node_modules/` not in the workspace → `unpackCircleCache()` glob returns 0 paths → throws. Reproduced locally by mirroring the `windows_reinstall_deps` flow (reverse patches → `yarn install --check-files` → reapply patches): yarn.lock SHA-1 changed from `e6d33a428…` to `478c290e6…`, with the diff being exactly the orphan `write-file-atomic@7.0.0` block.

The cache‑version bump in [#33820](https://github.com/cypress-io/cypress/pull/33820) didn't cause the bug — it just made it visible by invalidating older, key‑mismatched caches.

Changes:

- Add `--frozen-lockfile` to `windows_reinstall_deps` so yarn cannot mutate the lockfile during the workaround install. The `--check-files` behavior (re‑extract missing/corrupt packages from cache) is preserved; only lockfile pruning is disabled.
- Prune `write-file-atomic@7.0.0` from `yarn.lock` so a frozen install agrees with the current dep graph. Verified locally that `yarn install --frozen-lockfile` succeeds against the pruned lockfile and produces a byte‑identical result.

### Steps to test

1. CI: confirm `windows-create-build-artifacts` succeeds end‑to‑end (the `Restore all node_modules to proper workspace folders` step in `unpack-dependencies` no longer throws).
2. CI: confirm `circle_cache_key` printed by the `Generate Circle Cache Key` step matches between `windows-node-modules-install` and `windows-create-build-artifacts` on this PR's pipeline.
3. CI: confirm Linux/macOS jobs still pass (no behavior change for non‑Windows; `--frozen-lockfile` only added to Windows‑only `windows_reinstall_deps`).
4. Locally: `yarn install --frozen-lockfile` succeeds with no changes to `yarn.lock`.

### How has the user experience changed?

No user‑facing change. Internal CI reliability only.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?