### PR TITLE
test: stabilize remaining 'cypress.config.js file change' Windows CI flakes

### DIFF
--- a/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
@@ -5,7 +5,7 @@ describe('errorWarningChange subscription', () => {
   })
 
   function assertLoadingIntoErrorWorks (errorName: string) {
-    cy.contains('h2', errorName).should('be.visible')
+    cy.contains('h2', errorName, { timeout: 15000 }).should('be.visible')
     cy.contains('[role="alert"]', 'Loading').should('not.exist')
   }
 

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -181,7 +181,7 @@ e2e: {
 }`)
       })
 
-      cy.get('[data-cy="spec-item-link"]', { timeout: 7500 })
+      cy.get('[data-cy="spec-item-link"]', { timeout: 15000 })
       .should('have.length', 3)
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -329,7 +329,7 @@ e2e: {
 }`)
       })
 
-      cy.get('[data-cy="spec-file-item"]', { timeout: 7500 })
+      cy.get('[data-cy="spec-file-item"]', { timeout: 15000 })
       .should('have.length', 3)
       .should('contain', 'dom-container.spec.js')
       .should('contain', 'dom-content.spec.js')
@@ -453,7 +453,7 @@ e2e: {
 }`)
       })
 
-      cy.get('[data-cy="file-match-indicator"]', { timeout: 7500 })
+      cy.get('[data-cy="file-match-indicator"]', { timeout: 15000 })
       .should('contain', '3 matches')
 
       // Regression for https://github.com/cypress-io/cypress/issues/27103
@@ -487,7 +487,7 @@ module.exports = {
 }`)
       })
 
-      cy.get('[data-cy="create-spec-page-title"]', { timeout: 10000 })
+      cy.get('[data-cy="create-spec-page-title"]', { timeout: 15000 })
       .should('contain', defaultMessages.createSpec.page.customPatternNoSpecs.title)
     })
   })


### PR DESCRIPTION
- Closes [no linked issue]

### Additional details

Follow-up to #33729. That PR bumped the timeout on the *final* `cy.get('[data-cy=\"create-spec-page-title\"]')` in the `responds to a cypress.config.js file change` spec pattern modal test from 4s to 10s, on the theory that the file-write → watcher → config reload → setupNodeEvents → GraphQL subscription → UI re-render chain just takes longer than the default on Windows CI.

Recent CI has surfaced the same flake on additional assertions across two specs in `packages/app/cypress/e2e/subscriptions/` that all hit the same chain. Example failures:

- [specChange-subscription job 3636886](https://app.circleci.com/pipelines/github/cypress-io/cypress/81717/workflows/103a6a1d-014d-43cd-8ceb-95f094d20b7a/jobs/3636886/tests)
- [errorWarningChange-subscription job 3639076](https://app.circleci.com/pipelines/github/cypress-io/cypress/81747/workflows/b902f582-169c-456b-a35c-08a2169f8e32/jobs/3639076/parallel-runs/4)

#### `specChange-subscription.cy.ts`

There are three parallel `responds to a cypress.config.js file change` tests (one per describe block) — all exercise the same chain. Bumps every `cypress.config.js`-rewrite assertion in this file to a uniform 15s ceiling:

| Line | Describe block | Before | After |
| --- | --- | --- | --- |
| 184 | specs page | 7500 | 15000 |
| 332 | inline specs list | 7500 | 15000 |
| 456 | spec pattern modal — first rewrite (`file-match-indicator`) | 7500 | 15000 |
| 490 | spec pattern modal — second rewrite (`create-spec-page-title`) | 10000 | 15000 |

Pulling line 490 along too so all four assertions on the same Windows-CI-slow chain share one ceiling — avoids the drift that left 184/332/456 lagging behind 490 after #33729.

#### `errorWarningChange-subscription.cy.ts`

Same root cause. Both `when the config file is saved with errors` tests time out on `cy.contains('h2', errorName)` (4s default) inside the `assertLoadingIntoErrorWorks` helper, which runs immediately after a `writeFileInProject('cypress.config.js', ...)`. The chain here is file-write → watcher → config reload → validation → UI error render, which is the same Windows-slow path.

Bumps the `cy.contains` in the helper to 15s.

15s is above the 10s precedent from #33729; locally on a healthy machine the assertions still pass in well under a second, so the retry logic absorbs the extra headroom without slowing the green path.

### Steps to test

1. Run `packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts` and `packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts` locally and confirm the tests still pass.
2. Re-run the previously failing Windows CI jobs — the assertions should no longer time out.

### How has the user experience changed?

No user-facing change. Test stabilization only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Cypress e2e test timeouts to reduce Windows CI flakiness, with no production code or user-facing behavior changes.
> 
> **Overview**
> Stabilizes subscription-based e2e tests that depend on `cypress.config.js` file-watcher reloads by increasing assertion timeouts to `15000ms`.
> 
> This updates `specChange-subscription.cy.ts` time ceilings for spec list/file-match assertions after config rewrites, and updates `errorWarningChange-subscription.cy.ts` to wait longer for error headers to render after writing invalid config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f8a1e8a6775298c72d96b92f7e7fc6d23a49173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->