### PR TITLE
test: deflake 'opens docs link in the default browser' launchpad test

### DIFF
--- a/packages/launchpad/cypress/e2e/project-setup.cy.ts
+++ b/packages/launchpad/cypress/e2e/project-setup.cy.ts
@@ -638,18 +638,28 @@ describe('Launchpad: Setup Project', () => {
       cy.contains('button', 'Pick a bundler').click()
       cy.findByText('Webpack').click()
       cy.findByRole('button', { name: 'Next step' }).should('not.be.disabled').click()
-      cy.intercept('POST', 'mutation-InstallDependencies_scaffoldFiles', (req) => {
-        req.continue((res) => {
-          for (const file of res.body.data.scaffoldTestingType.scaffoldedFiles) {
-            if (file.file.absolute.includes('cypress.config')) {
-              file.status = 'changes'
-            }
-          }
+      cy.withCtx(async (ctx) => {
+        Object.defineProperty(ctx.coreData, 'scaffoldedFiles', {
+          get () {
+            if (!this._scaffoldedFiles) return this._scaffoldedFiles
+
+            return this._scaffoldedFiles.map((scaffold) => {
+              if (scaffold.file.absolute.includes('cypress.config')) {
+                return { ...scaffold, status: 'changes' }
+              }
+
+              return scaffold
+            })
+          },
+          set (scaffoldedFiles) {
+            this._scaffoldedFiles = scaffoldedFiles
+          },
         })
       })
 
-      cy.findByRole('button', { name: 'Skip' }).click()
       cy.intercept('POST', 'mutation-ExternalLink_OpenExternal', { 'data': { 'openExternal': true } }).as('OpenExternal')
+
+      cy.findByRole('button', { name: 'Skip' }).click()
       cy.findByText('Learn more', { timeout: 10000 }).click()
       cy.wait('@OpenExternal')
       .its('request.body.variables.url')


### PR DESCRIPTION
- Closes <!-- n/a — flaky test fix -->

### Additional details

The previous deflake attempt (#33818) replaced `Object.defineProperty` on `ctx.coreData.scaffoldedFiles` with a `cy.intercept` on `mutation-InstallDependencies_scaffoldFiles`. The intercept approach only modified the mutation response once — subsequent `MainLaunchpadQuery` re-fetches read `scaffoldedFiles` from the server with the original file statuses, causing the `FileRow` to re-render without `status === 'changes'` and dropping the "Learn more" button before the click could complete.

This restores the `Object.defineProperty` approach with a null guard that was missing from the original implementation. The getter intercepts every server-side read so all GraphQL resolutions consistently return `status: 'changes'` for the cypress.config entry. The null guard (`if (!this._scaffoldedFiles) return this._scaffoldedFiles`) prevents a `TypeError` when concurrent GraphQL resolutions hit the getter before `_scaffoldedFiles` is populated by the scaffold mutation — which was the bug that motivated #33818.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts Cypress test stubbing to avoid race/flakiness; no production code paths are modified.
> 
> **Overview**
> Stabilizes the Launchpad `openLink` e2e test by replacing a one-off GraphQL `cy.intercept` mutation response tweak with a persistent `Object.defineProperty` override of `ctx.coreData.scaffoldedFiles`, ensuring `cypress.config` is consistently reported with `status: 'changes'`.
> 
> Adds a null guard in the getter to avoid errors when `_scaffoldedFiles` is not yet populated, so the "Learn more" button remains available long enough for the external-link assertion to complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32353d317bc00323a7c1a53de51f7fbf51134d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run the launchpad e2e test: `yarn workspace @packages/launchpad cypress:run:e2e -- --spec cypress/e2e/project-setup.cy.ts`
2. Verify the "opens docs link in the default browser" test passes consistently

### How has the user experience changed?

No user-facing changes — test-only fix.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?