### PR TITLE
chore: adjust CI workflow ordering for contributor PRs

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -15,9 +15,12 @@ when:
         equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
 
 jobs:
-  # Always run — these are cheap and catch broad issues regardless of what changed
+  # Internal PRs — install and build run immediately
   - node_modules_install:
       build-better-sqlite3: true
+      filters:
+        branches:
+          ignore: /^pull\/[0-9]+/
   - build:
       name: internal-pr-build
       context: test-runner:env-canary
@@ -26,10 +29,25 @@ jobs:
       filters:
         branches:
           ignore: /^pull\/[0-9]+/
+
+  # External (contributor) PRs — everything gates behind manual approval
+  - approve-contributor-pr:
+      type: approval
+      filters:
+        branches:
+          only: /^pull\/[0-9]+/
+  - node_modules_install:
+      name: contributor-node-modules-install
+      build-better-sqlite3: true
+      requires:
+        - approve-contributor-pr
+      filters:
+        branches:
+          only: /^pull\/[0-9]+/
   - build:
       name: external-pr-build
       requires:
-        - node_modules_install
+        - contributor-node-modules-install
       filters:
         branches:
           only: /^pull\/[0-9]+/
@@ -50,12 +68,6 @@ jobs:
       requires:
         - internal-pr-build
         - external-pr-build
-  - approve-contributor-pr:
-      type: approval
-      filters:
-        branches:
-          only: /^pull\/[0-9]+/
-
   # The following jobs are only run for contributor PRs once they are approved.
   # Each job checks its pipeline parameter at startup and halts early if the
   # changed files don't require it to run.

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -30,6 +30,7 @@ jobs:
   main:
     name: Semantic Pull Request
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
- Closes n/a

### Additional details

Adjusts the ordering of CI jobs for contributor PRs so that the approval step comes first in the workflow sequence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow ordering/filters and should only affect when jobs start for forked PRs, with minimal impact on product code.
> 
> **Overview**
> **Reorders CircleCI PR workflow** so internal PRs run `node_modules_install`/build immediately, while *forked contributor PRs* are gated behind an `approve-contributor-pr` step and a separate install job (`contributor-node-modules-install`) that the external build depends on.
> 
> **Adjusts GitHub semantic PR check** to set an `environment` only for forked PRs, enabling environment-based controls without changing the linting logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b278f3dc5ada44b3d9ef0c94fce4e96c443c3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Open a test PR from a fork and verify the approval gate appears before any jobs run
2. Verify internal (non-fork) PRs are unaffected

### How has the user experience changed?

No user-facing changes.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?