### PR TITLE
refactor: rename 'fast' visibility references to 'modern'

### DIFF
--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -5,7 +5,7 @@ describe('src/cypress/dom/visibility', {
   slowTestThreshold: 500,
 }, () => {
   function assertVisibilityForEl (el: HTMLElement) {
-    const breakingChangeExpectedProp = Cypress.config('visibilityStrategy') === 'modern' ? 'cy-fast-expect' : 'cy-legacy-expect'
+    const breakingChangeExpectedProp = Cypress.config('visibilityStrategy') === 'modern' ? 'cy-modern-expect' : 'cy-legacy-expect'
     const expected = el.getAttribute('cy-expect') ?? el.getAttribute(breakingChangeExpectedProp)
 
     if (!expected) {
@@ -54,11 +54,11 @@ describe('src/cypress/dom/visibility', {
     }
   }
 
-  const modes = ['fast', 'legacy']
+  const modes = ['modern', 'legacy']
 
   for (const mode of modes) {
     describe(`${mode}`, {
-      visibilityStrategy: mode === 'fast' ? 'modern' : 'legacy',
+      visibilityStrategy: mode,
     }, () => {
       beforeEach(() => {
         cy.visit('/fixtures/generic.html')
@@ -364,14 +364,14 @@ describe('src/cypress/dom/visibility', {
         })
 
         describe('edge cases', () => {
-          const isFast = mode === 'fast'
+          const isModern = mode === 'modern'
 
           beforeEach(() => {
             cy.visit('/fixtures/empty.html')
           })
 
           it('`display: contents` element is hidden in both modes', () => {
-            // Per spec the element has no layout box; legacy's dim check and fast's
+            // Per spec the element has no layout box; legacy's dim check and modern's
             // checkVisibility() both report it hidden.
             cy.$$('body').append('<div id="contents-el" style="display: contents;">contents</div>')
             cy.get('#contents-el').should('be.hidden')
@@ -383,9 +383,9 @@ describe('src/cypress/dom/visibility', {
           })
 
           it('`content-visibility: hidden`', () => {
-            // Fast catches this via checkVisibility(); legacy doesn't model content-visibility.
+            // Modern catches this via checkVisibility(); legacy doesn't model content-visibility.
             cy.$$('body').append('<div id="cv-hidden" style="content-visibility: hidden;">cv hidden</div>')
-            cy.get('#cv-hidden').should(isFast ? 'be.hidden' : 'be.visible')
+            cy.get('#cv-hidden').should(isModern ? 'be.hidden' : 'be.visible')
           })
 
           it('element inside a <template> fragment is hidden in both modes', () => {
@@ -401,9 +401,9 @@ describe('src/cypress/dom/visibility', {
 
           it('single-axis zero (`width: 0; height: 100px`) with overflowing text', () => {
             // Legacy preserves visibility because text overflows the zero-width box.
-            // Fast hides it via the dim guard regardless of overflowing content.
+            // Modern hides it via the dim guard regardless of overflowing content.
             cy.$$('body').append('<div id="single-axis-zero" style="width: 0; height: 100px;">overflowing text</div>')
-            cy.get('#single-axis-zero').should(isFast ? 'be.hidden' : 'be.visible')
+            cy.get('#single-axis-zero').should(isModern ? 'be.hidden' : 'be.visible')
           })
 
           it('`inert` element is visible (affects interactivity, not layout)', () => {

--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -54,7 +54,7 @@ describe('src/cypress/dom/visibility', {
     }
   }
 
-  const modes = ['modern', 'legacy']
+  const modes: ('modern' | 'legacy')[] = ['modern', 'legacy']
 
   for (const mode of modes) {
     describe(`${mode}`, {

--- a/packages/driver/cypress/e2e/dom/visibility_shadow_dom.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility_shadow_dom.cy.ts
@@ -5,7 +5,7 @@ const { $ } = Cypress
 describe('src/cypress/dom/visibility - shadow dom', () => {
   let add: (el: string, shadowEl: string, rootIdentifier: string) => JQuery<HTMLElement>
 
-  const modes = ['modern', 'legacy']
+  const modes: ('modern' | 'legacy')[] = ['modern', 'legacy']
 
   for (const mode of modes) {
     describe(`${mode}`, {

--- a/packages/driver/cypress/e2e/dom/visibility_shadow_dom.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility_shadow_dom.cy.ts
@@ -5,13 +5,13 @@ const { $ } = Cypress
 describe('src/cypress/dom/visibility - shadow dom', () => {
   let add: (el: string, shadowEl: string, rootIdentifier: string) => JQuery<HTMLElement>
 
-  const modes = ['fast', 'legacy']
+  const modes = ['modern', 'legacy']
 
   for (const mode of modes) {
     describe(`${mode}`, {
-      visibilityStrategy: mode === 'fast' ? 'modern' : 'legacy',
+      visibilityStrategy: mode,
     }, () => {
-      const isFast = mode === 'fast'
+      const isModern = mode === 'modern'
 
       beforeEach(() => {
         cy.visit('/fixtures/empty.html').then((win) => {
@@ -26,7 +26,7 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
             }
           })
 
-          // Fast-friendly hosts: apply `display: block` via shadow CSS so that inline
+          // Modern-friendly hosts: apply `display: block` via shadow CSS so that inline
           // `style="display: none"` on the host still wins (inline > :host specificity).
           const installDefaultDisplay = (root: ShadowRoot, doc: Document) => {
             const style = doc.createElement('style')
@@ -152,8 +152,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
       // --- Slot scenarios -----------------------------------------------------------------------
       //
       // Legacy walks DOM parents, so it sees the shadow host but not the slot the light child
-      // renders into. Fast uses checkVisibility(), which walks the flat tree and therefore sees
-      // the slot. Tests below branch on `isFast` whenever the slot itself (rather than the host)
+      // renders into. Modern uses checkVisibility(), which walks the flat tree and therefore sees
+      // the slot. Tests below branch on `isModern` whenever the slot itself (rather than the host)
       // is what's hiding the content.
 
       describe('default slot', () => {
@@ -177,7 +177,7 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
 
         it('reports a slotted child as hidden by `display: none` on the slot', () => {
           // Slotted children that don't render have a zero-area bounding rect, so both
-          // algorithms report hidden (fast via checkVisibility, legacy via its dim check).
+          // algorithms report hidden (modern via checkVisibility, legacy via its dim check).
           const $host = $(`<shadow-host><span class="slotted">light</span></shadow-host>`).appendTo(cy.$$('body'))
 
           $(`<slot style="display: none;"></slot>`).appendTo(($host[0] as HTMLElement & { shadowRoot: ShadowRoot }).shadowRoot)
@@ -299,8 +299,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#shadow-root-no-width',
           )
 
-          cy.wrap($shadowRootNoWidth).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($shadowRootNoWidth).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($shadowRootNoWidth).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($shadowRootNoWidth).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom has overflow: hidden and no width', () => {
@@ -314,8 +314,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#outside-parent-no-width',
           )
 
-          cy.wrap($outsideParentNoWidth).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($outsideParentNoWidth).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($outsideParentNoWidth).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($outsideParentNoWidth).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent is shadow root and has overflow: hidden and no height', () => {
@@ -327,8 +327,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#shadow-root-no-height',
           )
 
-          cy.wrap($shadowRootNoHeight).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($shadowRootNoHeight).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($shadowRootNoHeight).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($shadowRootNoHeight).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom has overflow: hidden and no height', () => {
@@ -342,8 +342,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#outside-parent-no-height',
           )
 
-          cy.wrap($outsideParentNoHeight).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($outsideParentNoHeight).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($outsideParentNoHeight).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($outsideParentNoHeight).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
       })
 
@@ -448,8 +448,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#covered-up-by-outside-pos-fixed',
           )
 
-          cy.wrap($coveredUpByOutsidePosFixed).find('#inside-underneath', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($coveredUpByOutsidePosFixed).find('#inside-underneath', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($coveredUpByOutsidePosFixed).find('#inside-underneath', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($coveredUpByOutsidePosFixed).find('#inside-underneath', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is hidden if outside of shadow dom with position: fixed and covered by element inside of shadow dom (legacy only)', () => {
@@ -462,8 +462,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#covered-up-by-shadow-pos-fixed',
           )
 
-          cy.wrap($coveredUpByShadowPosFixed).find('#outside-underneath', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($coveredUpByShadowPosFixed).find('#outside-underneath', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($coveredUpByShadowPosFixed).find('#outside-underneath', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($coveredUpByShadowPosFixed).find('#outside-underneath', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is visible if position: fixed and parent outside shadow dom has pointer-events: none', () => {
@@ -489,8 +489,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#parent-pointer-events-none-covered',
           )
 
-          cy.wrap($parentPointerEventsNoneCovered).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($parentPointerEventsNoneCovered).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($parentPointerEventsNoneCovered).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($parentPointerEventsNoneCovered).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is visible if pointer-events: none and parent outside shadow dom has position: fixed', () => {
@@ -507,7 +507,7 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         })
       })
 
-      // All tests in this block exercise legacy's ancestor-overflow walking. Fast considers them
+      // All tests in this block exercise legacy's ancestor-overflow walking. Modern considers them
       // visible because checkVisibility() doesn't walk ancestor overflow.
       describe('css overflow', () => {
         it('parent outside of shadow dom overflow hidden and out of bounds to left', () => {
@@ -519,8 +519,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-bounds-to-left',
           )
 
-          cy.wrap($elOutOfParentBoundsToLeft).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentBoundsToLeft).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentBoundsToLeft).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentBoundsToLeft).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom overflow hidden and out of bounds to right', () => {
@@ -532,8 +532,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-bounds-to-right',
           )
 
-          cy.wrap($elOutOfParentBoundsToRight).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentBoundsToRight).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentBoundsToRight).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentBoundsToRight).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom overflow hidden and out of bounds above', () => {
@@ -545,8 +545,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-bounds-above',
           )
 
-          cy.wrap($elOutOfParentBoundsAbove).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentBoundsAbove).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentBoundsAbove).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentBoundsAbove).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom overflow hidden and out of bounds below', () => {
@@ -558,8 +558,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-bounds-below',
           )
 
-          cy.wrap($elOutOfParentBoundsBelow).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentBoundsBelow).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentBoundsBelow).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentBoundsBelow).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom overflow hidden-y and out of bounds', () => {
@@ -571,8 +571,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-with-overflow-y-hidden-bounds',
           )
 
-          cy.wrap($elOutOfParentWithOverflowYHiddenBounds).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentWithOverflowYHiddenBounds).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentWithOverflowYHiddenBounds).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentWithOverflowYHiddenBounds).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom overflow hidden-x and out of bounds', () => {
@@ -584,8 +584,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-parent-with-overflow-x-hidden-bounds',
           )
 
-          cy.wrap($elOutOfParentWithOverflowXHiddenBounds).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfParentWithOverflowXHiddenBounds).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfParentWithOverflowXHiddenBounds).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfParentWithOverflowXHiddenBounds).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is visible when parent overflow hidden but el in a closer parent outside of shadow dom with position absolute', () => {
@@ -614,8 +614,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-ancestor-overflow-auto-bounds-outside',
           )
 
-          cy.wrap($elOutOfAncestorOverflowAutoBoundsOutside).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfAncestorOverflowAutoBoundsOutside).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfAncestorOverflowAutoBoundsOutside).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfAncestorOverflowAutoBoundsOutside).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent is wide and ancestor inside shadow dom is overflow auto', () => {
@@ -629,8 +629,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-ancestor-overflow-auto-bounds-inside',
           )
 
-          cy.wrap($elOutOfAncestorOverflowAutoBoundsInside).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfAncestorOverflowAutoBoundsInside).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfAncestorOverflowAutoBoundsInside).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfAncestorOverflowAutoBoundsInside).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent outside of shadow dom has overflow scroll and out of bounds', () => {
@@ -642,8 +642,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-scrolling-parent-bounds',
           )
 
-          cy.wrap($elOutOfScrollingParentBounds).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfScrollingParentBounds).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfScrollingParentBounds).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfScrollingParentBounds).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('parent absolutely positioned and overflow hidden and out of bounds', () => {
@@ -659,8 +659,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-out-of-pos-abs-parent-bounds',
           )
 
-          cy.wrap($elOutOfPosAbsParentBounds).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elOutOfPosAbsParentBounds).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elOutOfPosAbsParentBounds).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elOutOfPosAbsParentBounds).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is visible when parent absolutely positioned and overflow hidden and not out of bounds', () => {
@@ -736,8 +736,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#el-is-relative-and-out-of-bounds-of-ancestor-overflow',
           )
 
-          cy.wrap($elIsRelativeAndOutOfBoundsOfAncestorOverflow).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($elIsRelativeAndOutOfBoundsOfAncestorOverflow).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($elIsRelativeAndOutOfBoundsOfAncestorOverflow).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($elIsRelativeAndOutOfBoundsOfAncestorOverflow).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('is visible when relatively positioned outside of ancestor outside shadow dom that does not hide overflow', () => {
@@ -870,8 +870,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#ancestor-inside-transform-makes-el-out-of-bounds-of-ancestor',
           )
 
-          cy.wrap($ancestorInsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($ancestorInsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($ancestorInsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($ancestorInsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
 
         it('out of ancestor bounds due to ancestor outside shadow dom transform', () => {
@@ -887,8 +887,8 @@ describe('src/cypress/dom/visibility - shadow dom', () => {
         '#ancestor-outside-transform-makes-el-out-of-bounds-of-ancestor',
           )
 
-          cy.wrap($ancestorOutsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isFast ? 'be.visible' : 'be.hidden')
-          cy.wrap($ancestorOutsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isFast ? 'not.be.hidden' : 'not.be.visible')
+          cy.wrap($ancestorOutsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isModern ? 'be.visible' : 'be.hidden')
+          cy.wrap($ancestorOutsideTransformMakesElOutOfBoundsOfAncestor).find('span', { includeShadowDom: true }).should(isModern ? 'not.be.hidden' : 'not.be.visible')
         })
       })
     })

--- a/packages/driver/cypress/e2e/e2e/visibility.cy.js
+++ b/packages/driver/cypress/e2e/e2e/visibility.cy.js
@@ -1,11 +1,11 @@
 describe('visibility', () => {
-  const modes = ['fast', 'legacy']
+  const modes = ['modern', 'legacy']
 
   for (const mode of modes) {
     describe(`${mode}`, {
-      visibilityStrategy: mode === 'fast' ? 'modern' : 'legacy',
+      visibilityStrategy: mode,
     }, () => {
-      const isFast = mode === 'fast'
+      const isModern = mode === 'modern'
 
       // https://github.com/cypress-io/cypress/issues/631
       describe('with overflow and transform - slider', () => {
@@ -13,25 +13,25 @@ describe('visibility', () => {
           cy.visit('/fixtures/issue-631.html')
 
           // Legacy walks ancestor overflow:hidden and reports slides 2/3 as hidden;
-          // fast does not, so it considers all slides visible based on their own dims.
+          // modern does not, so it considers all slides visible based on their own dims.
           cy.get('[name="test1"]').should('be.visible')
-          cy.get('[name="test2"]').should(isFast ? 'be.visible' : 'be.hidden')
-          cy.get('[name="test3"]').should(isFast ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test2"]').should(isModern ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test3"]').should(isModern ? 'be.visible' : 'be.hidden')
         })
 
         it('second slide', () => {
           cy.get('#button-2').click()
 
-          cy.get('[name="test1"]').should(isFast ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test1"]').should(isModern ? 'be.visible' : 'be.hidden')
           cy.get('[name="test2"]').should('be.visible')
-          cy.get('[name="test3"]').should(isFast ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test3"]').should(isModern ? 'be.visible' : 'be.hidden')
         })
 
         it('third slide', () => {
           cy.get('#button-3').click()
 
-          cy.get('[name="test1"]').should(isFast ? 'be.visible' : 'be.hidden')
-          cy.get('[name="test2"]').should(isFast ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test1"]').should(isModern ? 'be.visible' : 'be.hidden')
+          cy.get('[name="test2"]').should(isModern ? 'be.visible' : 'be.hidden')
           cy.get('[name="test3"]').should('be.visible')
         })
       })
@@ -45,13 +45,13 @@ describe('visibility', () => {
 
         // TODO: move with tests added in this PR when it merges: https://github.com/cypress-io/cypress/pull/8166
         // #shadow-element-10 uses `backface-visibility: hidden` + `rotateY(180deg)`. Legacy's
-        // transform analysis treats the back-facing element as hidden; fast does not.
+        // transform analysis treats the back-facing element as hidden; modern does not.
         it('non-visible ancestor causes element to not be visible', () => {
           cy.visit('/fixtures/shadow-dom.html')
           cy
           .get('#shadow-element-10')
           .find('.shadow-div', { includeShadowDom: true })
-          .should(isFast ? 'be.visible' : 'not.be.visible')
+          .should(isModern ? 'be.visible' : 'not.be.visible')
         })
       })
 

--- a/packages/driver/cypress/fixtures/visibility/overflow.html
+++ b/packages/driver/cypress/fixtures/visibility/overflow.html
@@ -14,28 +14,28 @@
     <!-- Zero width ancestor, parent, self -->
     <div class="testCase" cy-expect="hidden" cy-label="Zero width ancestor, parent, self" style="width: 0; height: 100px; overflow: hidden; background: lightcoral;">
       <div class="testCase" cy-expect="hidden" cy-label="Zero width parent" style="width: 0; height: 100px; overflow: hidden; background: lightcoral;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Zero width self">Zero width ancestor, parent, self</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Zero width self">Zero width ancestor, parent, self</span>
       </div>
     </div>
 
     <!-- Zero height ancestor, parent, self -->
     <div class="testCase" cy-expect="hidden" cy-label="Zero height ancestor, parent, self" style="width: 100px; height: 0; overflow: hidden; background: lightcoral;">
       <div class="testCase" cy-expect="hidden" cy-label="Zero height parent" style="width: 100px; height: 0; overflow: hidden; background: lightcoral;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Zero height self">Zero height ancestor, parent, self</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Zero height self">Zero height ancestor, parent, self</span>
       </div>
     </div>
 
     <!-- Zero width ancestor, positive parent, self -->
     <div class="testCase" cy-expect="hidden" cy-label="Zero width ancestor with positive parent" style="width: 0; height: 100px; overflow: hidden; background: lightcoral;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Positive parent under zero width ancestor" style="width: 100px; height: 100px; overflow: hidden; background: lightcoral;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Self under zero width ancestor">Zero width ancestor, positive parent</span>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Positive parent under zero width ancestor" style="width: 100px; height: 100px; overflow: hidden; background: lightcoral;">
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Self under zero width ancestor">Zero width ancestor, positive parent</span>
       </div>
     </div>
 
     <!-- Zero height ancestor, positive parent, self -->
     <div class="testCase" cy-expect="hidden" cy-label="Zero height ancestor with positive parent" style="width: 100px; height: 0; overflow: hidden; background: lightcoral;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Positive parent under zero height ancestor" style="width: 100px; height: 100px; overflow: hidden; background: lightcoral;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Self under zero height ancestor">Zero height ancestor, positive parent</span>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Positive parent under zero height ancestor" style="width: 100px; height: 100px; overflow: hidden; background: lightcoral;">
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Self under zero height ancestor">Zero height ancestor, positive parent</span>
       </div>
     </div>
   </div>
@@ -44,12 +44,12 @@
     <h3>Text Content with Zero Dimensions</h3>
     
     <!-- Self with text content, zero width -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Self with text content and zero width" style="width: 0; height: 100px; background: lightgreen;">
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Self with text content and zero width" style="width: 0; height: 100px; background: lightgreen;">
       lorem ipsum dolor sit amet
     </div>
 
     <!-- Self with text content, zero height -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Self with text content and zero height" style="width: 50px; height: 0px; background: lightgreen;">
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Self with text content and zero height" style="width: 50px; height: 0px; background: lightgreen;">
       lorem ipsum dolor sit amet
     </div>
 
@@ -59,14 +59,14 @@
     </div>
 
     <!-- Ancestor with text content, zero width -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Ancestor with text content and zero width" style="width: 0; height: 100px; background: lightgreen;">
-      <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Parent under zero width ancestor with text">
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Ancestor with text content and zero width" style="width: 0; height: 100px; background: lightgreen;">
+      <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Parent under zero width ancestor with text">
         <span class="testCase" cy-expect="visible" cy-label="Self under zero width ancestor with text">ancestor width: 0</span>
       </div>
     </div>
 
     <!-- Ancestor with text content, zero height -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Ancestor with text content and zero height" style="width: 100px; height: 0px; background: lightgreen;">
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Ancestor with text content and zero height" style="width: 100px; height: 0px; background: lightgreen;">
       <div class="testCase" cy-expect="visible" cy-label="Parent under zero height ancestor with text">
         <span class="testCase" cy-expect="visible" cy-label="Self under zero height ancestor with text">ancestor height: 0</span>
       </div>
@@ -86,7 +86,7 @@
     <!-- Positive ancestor, zero parent, self -->
     <div class="testCase" cy-expect="visible" cy-label="Positive ancestor with zero width parent" style="width: 100px; height: 100px; background: lightgreen;">
       <div class="testCase" cy-expect="hidden" cy-label="Zero width parent under positive ancestor" style="width: 0; height: 100px; overflow: hidden; background: lightcoral;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Self under zero width parent">positive ancestor, zero parent</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Self under zero width parent">positive ancestor, zero parent</span>
       </div>
     </div>
   </div>
@@ -95,8 +95,8 @@
     <h3>Overflow Auto with Zero Dimensions</h3>
     
     <!-- Zero dimensions with overflow auto -->
-    <div class="testCase" cy-fast-expect="hidden" cy-legacy-expect="visible" cy-label="Zero dimensions with overflow auto" style="width: 0; height: 0px; overflow: auto; background: lightgreen;">
-      <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Self under zero dimensions with overflow auto">parent no size, overflow: auto</span>
+    <div class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible" cy-label="Zero dimensions with overflow auto" style="width: 0; height: 0px; overflow: auto; background: lightgreen;">
+      <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Self under zero dimensions with overflow auto">parent no size, overflow: auto</span>
     </div>
   </div>
 
@@ -104,13 +104,13 @@
     <h3>Mixed Dimension Scenarios</h3>
     
     <!-- Zero width, positive height -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero width with text content" style="width: 0; height: 100px; background: lightgreen;">Zero width</div>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero width with text content" style="width: 0; height: 100px; background: lightgreen;">Zero width</div>
 
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero width with text content (blue)" style="width: 0; height: 100px; background: lightgreen;">Has text content</div>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero width with text content (blue)" style="width: 0; height: 100px; background: lightgreen;">Has text content</div>
     <div class="testCase" cy-expect="hidden" cy-label="Zero width with whitespace only" style="width: 0; height: 50px; background: lightcoral;">      </div>
 
     <div class="testCase" cy-expect="hidden" cy-label="Zero height without text content" style="width: 100px; height: 0; background: lightcoral;"></div>
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero height with text content" style="width: 100px; height: 0; background: lightgreen;">Has text content</div>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero height with text content" style="width: 100px; height: 0; background: lightgreen;">Has text content</div>
     <div class="testCase" cy-expect="hidden" cy-label="Zero height with whitespace only" style="width: 50px; height: 0; background: lightcoral;">        </div>
 
     <div style="width: 10; height: 10; background: lightyellow">
@@ -120,26 +120,26 @@
   <div class="test-section" cy-section="overflow-hidden">
     <h3>Overflow Hidden scenarios</h3>
     <div class="testCase" cy-expect="visible" cy-label="Overflow hidden with positive dimensions" style="width: 100px; height: 100px; overflow: hidden; background: lightgreen; position:relative;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds left" style="width:100px; height:100px; background: lightcoral; position:absolute; left: 100px"></div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds right" style="width:100px; height:100px; background: lightcoral; position:absolute; right: 100px"></div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds top" style="width:100px; height:100px; background: lightcoral; position:absolute; top: 100px"></div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds bottom" style="width:100px; height:100px; background: lightcoral; position:absolute; bottom: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds left" style="width:100px; height:100px; background: lightcoral; position:absolute; left: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds right" style="width:100px; height:100px; background: lightcoral; position:absolute; right: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds top" style="width:100px; height:100px; background: lightcoral; position:absolute; top: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds bottom" style="width:100px; height:100px; background: lightcoral; position:absolute; bottom: 100px"></div>
       <div class="testCase" cy-expect="visible" cy-label="Element in bounds" style="width:50px; height:50px; background: lightgreen; position:absolute; left: 50px; top: 50px;"></div>
     </div>
   </div>
   <div class="test-section" cy-section="overflow-y-hidden">
     <h3>Overflow Y Hidden scenarios</h3>
     <div class="testCase" cy-expect="visible" cy-label="Overflow y hidden with positive dimensions" style="width: 100px; height: 100px; overflow-y: hidden; background: lightgreen; position:relative;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds top" style="width:100px; height:100px; background: lightcoral; position:absolute; top: 100px"></div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds bottom" style="width:100px; height:100px; background: lightcoral; position:absolute; bottom: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds top" style="width:100px; height:100px; background: lightcoral; position:absolute; top: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds bottom" style="width:100px; height:100px; background: lightcoral; position:absolute; bottom: 100px"></div>
       <div class="testCase" cy-expect="visible" cy-label="Element in bounds" style="width:50px; height:50px; background: lightgreen; position:absolute; left: 50px; top: 50px;"></div>
     </div>
   </div>
   <div class="test-section" cy-section="overflow-x-hidden">
     <h3>Overflow X Hidden scenarios</h3>
     <div class="testCase" cy-expect="visible" cy-label="Overflow x hidden with positive dimensions" style="width: 100px; height: 100px; overflow-x: hidden; background: lightgreen; position:relative;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds left" style="width:100px; height:100px; background: lightcoral; position:absolute; left: 100px"></div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds right" style="width:100px; height:100px; background: lightcoral; position:absolute; right: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds left" style="width:100px; height:100px; background: lightcoral; position:absolute; left: 100px"></div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds right" style="width:100px; height:100px; background: lightcoral; position:absolute; right: 100px"></div>
       <div class="testCase" cy-expect="visible" cy-label="Element in bounds" style="width:50px; height:50px; background: lightgreen; position:absolute; left: 50px; top: 50px;"></div>
     </div>
   </div>
@@ -150,13 +150,13 @@
     <!-- Overflow auto with wide parent -->
     <div class="testCase" cy-expect="visible" cy-label="Overflow auto container with wide parent" style="width: 100px; height: 100px; overflow: auto; background: lightgreen;">
       <div class="testCase" cy-expect="visible" cy-label="Wide parent container" style="width: 1000px; height: 100px; position: relative;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of bounds with ancestor overflow auto" style="position: absolute; left: 300px; top: 0px;">out of bounds, parent wide, ancestor overflow: auto</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of bounds with ancestor overflow auto" style="position: absolute; left: 300px; top: 0px;">out of bounds, parent wide, ancestor overflow: auto</span>
       </div>
     </div>
 
     <!-- Overflow auto with zero dimensions -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero dimensions with overflow auto" style="width: 0; height: 0px; overflow: auto; background: lightgreen;">
-      <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child under zero dimensions with overflow auto">parent no size, overflow: auto</span>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero dimensions with overflow auto" style="width: 0; height: 0px; overflow: auto; background: lightgreen;">
+      <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child under zero dimensions with overflow auto">parent no size, overflow: auto</span>
     </div>
   </div>
 
@@ -167,7 +167,7 @@
     <div class="testCase" cy-expect="visible" cy-label="Overflow scroll container" style="width: 100px; height: 100px; overflow: scroll; position: relative; background: lightgreen;">
       <div class="testCase" cy-expect="hidden" cy-label="Parent container in scroll scenario">
         <div class="testCase" cy-expect="hidden" cy-label="Child container in scroll scenario">
-          <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Element out of scrolling bounds" style="position: absolute; left: 300px; top: 0px;">out of scrolling bounds, position: absolute</span>
+          <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Element out of scrolling bounds" style="position: absolute; left: 300px; top: 0px;">out of scrolling bounds, position: absolute</span>
         </div>
       </div>
     </div>
@@ -179,7 +179,7 @@
     <!-- Overflow hidden with relative positioning -->
     <div class="testCase" cy-expect="visible" cy-label="Overflow hidden container" style="overflow: hidden; background: lightgreen;">
       <div class="testCase" cy-expect="visible" cy-label="Parent container">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Relatively positioned element out of bounds" style="position: relative; left: 0; top: -200px;">out of bounds, position: relative</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Relatively positioned element out of bounds" style="position: relative; left: 0; top: -200px;">out of bounds, position: relative</span>
       </div>
     </div>
 
@@ -198,7 +198,7 @@
     <div class="testCase" cy-expect="visible" cy-label="Flex container with overflow hidden" style="display: flex; overflow: hidden; background: lightgreen;">
       <div class="testCase" cy-expect="visible" cy-label="Flex item 1" id="red" style="flex: 0 0 80%; background-color: lightgreen;">red</div>
       <div class="testCase" cy-expect="visible" cy-label="Flex item 2" id="green" style="flex: 0 0 80%; background-color: lightgreen;">green</div>
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Flex item 3 out of bounds" id="blue" style="background-color: lightcoral;">blue</div>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Flex item 3 out of bounds" id="blue" style="background-color: lightcoral;">blue</div>
     </div>
   </div>
 
@@ -226,8 +226,8 @@
           <div class="testCase" cy-expect="visible" cy-label="Absolute positioned item 1" style="height: 96px; position: absolute; left: 0; top: 0;">
             <a class="testCase" cy-expect="visible" cy-label="Link 1" href="">test test-1</a>
           </div>
-          <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Absolute positioned item 2" style="height: 36px; position: absolute; left: 0; top: 96px; background-color: lightcoral;">
-            <a class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Link 2" href="">test test-2</a>
+          <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Absolute positioned item 2" style="height: 36px; position: absolute; left: 0; top: 96px; background-color: lightcoral;">
+            <a class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Link 2" href="">test test-2</a>
           </div>
         </div>
       </div>

--- a/packages/driver/cypress/fixtures/visibility/positioning.html
+++ b/packages/driver/cypress/fixtures/visibility/positioning.html
@@ -9,7 +9,7 @@
     <h1>Positioning Visibility Tests</h1>
     <div class="test-section" cy-section="positioning-with-zero-dimensions">
       <h3>Positioning with Zero Dimensions</h3>
-      <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero dimensions parent with absolute positioned child" style="width: 0; height: 0; background: lightyellow">
+      <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero dimensions parent with absolute positioned child" style="width: 0; height: 0; background: lightyellow">
         <span class="testCase" cy-expect="visible" cy-label="Absolute positioned child under zero dimensions parent" style="position: absolute; top: 10px; left: 10px; background: white; padding: 5px;">Child with absolute positioning</span>
       </div>
     </div>
@@ -20,8 +20,8 @@
     <!-- Zero dimensions parent with absolute positioned child -->
 
     <!-- Zero dimensions ancestor with fixed positioned child -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Zero dimensions ancestor with fixed positioned child" style="width: 0; height: 0; position: relative; background: green">
-      <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Parent under zero dimensions ancestor">
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Zero dimensions ancestor with fixed positioned child" style="width: 0; height: 0; position: relative; background: green">
+      <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Parent under zero dimensions ancestor">
         <span class="testCase" cy-expect="visible" cy-label="Fixed positioned child under zero dimensions ancestor" style="position: fixed; top: 10px; left: 10px; background: white; padding: 5px;">Child with position: fixed</span>
       </div>
     </div>
@@ -40,7 +40,7 @@
   <div class="test-section" cy-section="position-fixed-element-covered-by-another">
 
     <!-- Position fixed element covered by another element -->
-    <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Fixed positioned element covered by another" style="position: fixed; bottom: 0; left: 0; background: lightcoral; width: 100px; height: 100px;">underneath</div>
+    <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Fixed positioned element covered by another" style="position: fixed; bottom: 0; left: 0; background: lightcoral; width: 100px; height: 100px;">underneath</div>
     <div class="testCase" cy-expect="visible" cy-label="Element covering fixed positioned element" style="position: fixed; bottom: 0; left: 0; background: lightskyblue; width: 100px; height: 100px;">on top</div>
   </div>
 
@@ -70,7 +70,7 @@
 
       <!-- Parent with pointer-events: none covered by another element -->
       <div class="testCase" cy-expect="visible" cy-label="Fixed child under pointer-events none parent covered by another" style="pointer-events: none; background: lightsteelblue;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Fixed child covered by another element" style="position: fixed; top: 40px;">parent pointer-events: none</span>
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Fixed child covered by another element" style="position: fixed; top: 40px;">parent pointer-events: none</span>
       </div>
       <div class="testCase" cy-expect="visible" cy-label="Element covering fixed child with pointer-events none parent" style="position: fixed; top: 40px; background: red;">covering the element with pointer-events: none</div>
 
@@ -80,7 +80,7 @@
     
     <!-- Position absolute child under normal parent -->
     <div class="testCase" cy-expect="hidden" cy-label="Normal parent with absolute positioned child" style="width: 0; height: 100px; overflow: hidden; background: lightblue;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Parent container for absolute child" style="height: 500px; width: 500px;">
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Parent container for absolute child" style="height: 500px; width: 500px;">
         <span class="testCase" cy-expect="visible" cy-label="Absolute positioned child" style="position: absolute;">position: absolute</span>
       </div>
     </div>
@@ -94,8 +94,8 @@
 
     <!-- Parent with position absolute but child not positioned -->
     <div class="testCase" cy-expect="hidden" cy-label="Parent with absolute positioning but child not positioned" style="width: 0; height: 100px; overflow: hidden; position: absolute; background: lightcoral;">
-      <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child container under absolute parent" style="height: 500px; width: 500px;">
-        <span class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Non-positioned child under absolute parent">parent position: absolute</span>
+      <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child container under absolute parent" style="height: 500px; width: 500px;">
+        <span class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Non-positioned child under absolute parent">parent position: absolute</span>
       </div>
     </div>
   </div>

--- a/packages/driver/cypress/fixtures/visibility/transforms.html
+++ b/packages/driver/cypress/fixtures/visibility/transforms.html
@@ -21,7 +21,7 @@
     <!-- Individual scale axes -->
     <div class="testCase" cy-expect="hidden" cy-label="ScaleX to zero" style="transform: scaleX(0)">ScaleX(0)</div>
     <div class="testCase" cy-expect="hidden" cy-label="ScaleY to zero" style="transform: scaleY(0)">ScaleY(0)</div>
-    <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="ScaleZ to zero" style="transform: scaleZ(0)">ScaleZ(0)</div>
+    <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="ScaleZ to zero" style="transform: scaleZ(0)">ScaleZ(0)</div>
     
     <!-- Multiple transforms with scale to zero -->
     <div class="testCase" cy-expect="hidden" cy-label="Multiple transforms with scale to zero" style="transform: translate(15px, 30px) skew(20deg) rotate(40deg) scale(0, 0)">Multiple transforms with scale(0,0)</div>
@@ -96,8 +96,8 @@
     <div class="testCase" cy-expect="visible" cy-label="Transform with rotation only" style="transform: rotate(20deg)">Rotated with text</div>
     
     <!-- Transform with zero dimensions but text content -->
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Transform with zero height but text content" style="transform: translate(0, 0); height: 0;">Text content</div>
-    <div class="testCase" cy-legacy-expect="visible" cy-fast-expect="hidden" cy-label="Transform with zero width but text content" style="transform: rotateX(30deg); width: 0;">Text content</div>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Transform with zero height but text content" style="transform: translate(0, 0); height: 0;">Text content</div>
+    <div class="testCase" cy-legacy-expect="visible" cy-modern-expect="hidden" cy-label="Transform with zero width but text content" style="transform: rotateX(30deg); width: 0;">Text content</div>
     
     <!-- Transform with zero dimensions and overflow -->
     <div class="testCase" cy-expect="hidden" cy-label="ScaleX(0) with height and overflow hidden" style="transform: scaleX(0); height: 10px; overflow: hidden">
@@ -106,31 +106,31 @@
     
     <!-- Transform with zero dimensions and overflow (different axes) -->
     <div class="testCase" cy-expect="hidden" cy-label="Height 0 + transform + overflow hidden" style="height: 0px; transform: translate(1, 2); overflow: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with height 0 + transform + overflow hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with height 0 + transform + overflow hidden">Test</p>
     </div>
     <div class="testCase" cy-expect="hidden" cy-label="Height 0 + transform + overflow-x hidden" style="height: 0px; transform: translate(1, 2); overflow-x: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with height 0 + transform + overflow-x hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with height 0 + transform + overflow-x hidden">Test</p>
     </div>
     <div class="testCase" cy-expect="hidden" cy-label="Height 0 + transform + overflow-y hidden" style="height: 0px; transform: translate(1, 2); overflow-y: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with height 0 + transform + overflow-y hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with height 0 + transform + overflow-y hidden">Test</p>
     </div>
     <div class="testCase" cy-expect="hidden" cy-label="Width 0 + transform + overflow hidden" style="width: 0px; transform: translate(1, 2); overflow: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with width 0 + transform + overflow hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with width 0 + transform + overflow hidden">Test</p>
     </div>
     <div class="testCase" cy-expect="hidden" cy-label="Width 0 + transform + overflow-x hidden" style="width: 0px; transform: translate(1, 2); overflow-x: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with width 0 + transform + overflow-x hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with width 0 + transform + overflow-x hidden">Test</p>
     </div>
     <div class="testCase" cy-expect="hidden" cy-label="Width 0 + transform + overflow-y hidden" style="width: 0px; transform: translate(1, 2); overflow-y: hidden">
-      <p class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Child with width 0 + transform + overflow-y hidden">Test</p>
+      <p class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Child with width 0 + transform + overflow-y hidden">Test</p>
     </div>
   </div>
 
   <div class="test-section" cy-section="backface-visibility">
     <h3>Backface Visibility</h3>
-    <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="RotateX 180deg with hidden backface" style="transform: rotateX(180deg); backface-visibility: hidden">Backface hidden on X axis</div>
-    <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="RotateY 180deg with hidden backface" style="transform: rotateY(180deg); backface-visibility: hidden">Backface hidden on Y axis</div>
+    <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="RotateX 180deg with hidden backface" style="transform: rotateX(180deg); backface-visibility: hidden">Backface hidden on X axis</div>
+    <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="RotateY 180deg with hidden backface" style="transform: rotateY(180deg); backface-visibility: hidden">Backface hidden on Y axis</div>
     <div class="testCase" cy-expect="visible" cy-label="RotateZ 180deg with hidden backface" style="transform: rotateZ(180deg); backface-visibility: hidden">Backface hidden on Z axis</div>
-    <div class="testCase" cy-legacy-expect="hidden" cy-fast-expect="visible" cy-label="Rotate3d 180deg with hidden backface" style="transform: rotate3d(1, 1, 1, 180deg); backface-visibility: hidden">Backface hidden on 3 axes</div>
+    <div class="testCase" cy-legacy-expect="hidden" cy-modern-expect="visible" cy-label="Rotate3d 180deg with hidden backface" style="transform: rotate3d(1, 1, 1, 180deg); backface-visibility: hidden">Backface hidden on 3 axes</div>
     <div class="testCase" cy-expect="visible" cy-label="RotateX 180deg with visible backface" style="transform: rotateX(180deg); backface-visibility: visible">Backface visible</div>
     <div class="testCase" cy-expect="visible" cy-label="RotateY 45deg with hidden backface and no preserve-3d" style="transform: rotateY(45deg); backface-visibility: hidden;">
       <div class="testCase" cy-expect="visible" cy-label="Nested rotateY 45deg with hidden backface but no preserve-3d" style="transform: rotateY(45deg); backface-visibility: hidden">Backface hidden on Y axis</div>

--- a/packages/driver/src/dom/visibility.ts
+++ b/packages/driver/src/dom/visibility.ts
@@ -5,7 +5,7 @@ import $elements from './elements'
 import $coordinates from './coordinates'
 import * as $transform from './transform'
 const { isElement, isBody, isHTML, isOption, isOptgroup, getParent, getFirstParentWithTagName, isAncestor, isChild, getAllParents, isDescendent, isUndefinedOrHTMLBodyDoc, elOrAncestorIsFixedOrSticky, isDetached, isFocusable, stringify: stringifyElement } = $elements
-import { fastIsHidden } from './visibility/fastIsHidden'
+import { modernIsHidden } from './visibility/modernIsHidden'
 const fixedOrAbsoluteRe = /(fixed|absolute)/
 
 const OVERFLOW_PROPS = ['hidden', 'clip', 'scroll', 'auto']
@@ -26,7 +26,7 @@ const isHidden = (el, methodName = 'isHidden()', options = { checkOpacity: true 
   if (Cypress.config('visibilityStrategy') === 'modern') {
     ensureEl(el, methodName)
 
-    return fastIsHidden(el, options)
+    return modernIsHidden(el, options)
   }
 
   if (isStrictlyHidden(el, methodName, options, isHidden)) {

--- a/packages/driver/src/dom/visibility/modernIsHidden.ts
+++ b/packages/driver/src/dom/visibility/modernIsHidden.ts
@@ -2,12 +2,12 @@ import $elements from '../elements'
 import { unwrap, wrap, isJquery } from '../jquery'
 import Debug from 'debug'
 
-const debug = Debug('cypress:driver:dom:visibility:fastIsHidden')
+const debug = Debug('cypress:driver:dom:visibility:modernIsHidden')
 
 const { isOption, isOptgroup, isBody, isHTML } = $elements
 
-export function fastIsHidden (subject: JQuery<HTMLElement> | HTMLElement, options: { checkOpacity: boolean } = { checkOpacity: true }): boolean {
-  debug('fastIsHidden', subject)
+export function modernIsHidden (subject: JQuery<HTMLElement> | HTMLElement, options: { checkOpacity: boolean } = { checkOpacity: true }): boolean {
+  debug('modernIsHidden', subject)
 
   if (isBody(subject) || isHTML(subject)) {
     return false
@@ -17,10 +17,10 @@ export function fastIsHidden (subject: JQuery<HTMLElement> | HTMLElement, option
     const subjects = unwrap(subject) as HTMLElement | HTMLElement[]
 
     if (Array.isArray(subjects)) {
-      return subjects.some((subject: HTMLElement) => fastIsHidden(subject, options))
+      return subjects.some((subject: HTMLElement) => modernIsHidden(subject, options))
     }
 
-    return fastIsHidden(subjects, options)
+    return modernIsHidden(subjects, options)
   }
 
   if (isOption(subject) || isOptgroup(subject)) {
@@ -31,7 +31,7 @@ export function fastIsHidden (subject: JQuery<HTMLElement> | HTMLElement, option
     const select = subject.closest('select')
 
     if (select) {
-      return fastIsHidden(wrap(select), options)
+      return modernIsHidden(wrap(select), options)
     }
   }
 


### PR DESCRIPTION
- Closes <!-- no issue -->

### Additional details

The `visibilityStrategy` config option already uses `'modern'` and `'legacy'` as its accepted values, but the internal source code, test parameterization, fixture HTML attributes, and comments still used the old `'fast'` terminology carried over from when this was `experimentalFastVisibility`.

This PR aligns all internal naming to match the public-facing API:

- **Renamed file**: `fastIsHidden.ts` → `modernIsHidden.ts`
- **Renamed function**: `fastIsHidden()` → `modernIsHidden()` (and updated the import in `visibility.ts`)
- **Updated debug namespace**: `cypress:driver:dom:visibility:fastIsHidden` → `...modernIsHidden`
- **Test parameterization** (3 files): mode `'fast'` → `'modern'`, variable `isFast` → `isModern`, simplified the `visibilityStrategy` ternary to just `mode` since the values now match directly
- **HTML fixture attributes** (3 files): `cy-fast-expect` → `cy-modern-expect`
- **Comments**: Updated all references from "Fast"/"fast" to "Modern"/"modern" where referring to the visibility algorithm

No behavioral changes — this is purely a naming consistency cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only refactor, but it touches the core `isHidden` path and a large set of fixtures/tests, so any missed reference could cause runtime/test failures.
> 
> **Overview**
> Aligns internal visibility terminology with the public `visibilityStrategy` API by renaming the “fast” implementation to **modern**.
> 
> Updates the driver to call `modernIsHidden` (and updates its debug namespace), and retargets visibility E2E tests/fixtures to use `modern` mode and `cy-modern-expect` attributes instead of the old `fast` naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd711b14964918ddf9d4f5286b41e3b51414100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run the driver visibility tests:
   - `yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/dom/visibility.cy.ts"`
   - `yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/dom/visibility_shadow_dom.cy.ts"`
   - `yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/e2e/visibility.cy.js"`
2. Verify all tests pass with both `modern` and `legacy` modes

### How has the user experience changed?

No user-facing changes. Internal naming only.

### PR Tasks

- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?