### PR TITLE
chore: prevent telemetry shutdown errors from failing Cypress exit

### DIFF
--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -309,14 +309,9 @@ linux-x64:
           - v8-integration-tests
 
     - npm-release:
-        filters: &mainBuildFilters
-            branches:
-              only:
-                - develop
-                - /^release\/\d+\.\d+\.\d+$/
-                # use the following branch as well to ensure that v8 snapshot cache updates are fully tested
-                - 'update-v8-snapshot-cache-on-develop'
-                - 'feat/cy-prompt'
+        # Expression-based filter: branch-based allowlist OR force-persist-artifacts pipeline parameter.
+        # 'update-v8-snapshot-cache-on-develop' is included so v8 snapshot cache updates are fully tested.
+        filters: &mainBuildFilters pipeline.git.branch == "develop" or pipeline.git.branch matches /^release\/\d+\.\d+\.\d+$/ or pipeline.git.branch == "update-v8-snapshot-cache-on-develop" or pipeline.parameters.force-persist-artifacts == true
         context: [test-runner:npm-release, org-npm-credentials]
         requires:
           - ready-to-release

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).
 - Fixed an intermittent `ENOENT: no such file or directory, open <path>/bundle.tar-<rand>` error during `cy.prompt` and Studio bundle initialization. Fixed in [#33748](https://github.com/cypress-io/cypress/pull/33748).
-- Fixed an issue where Cypress could exit with code 1 and report "Cypress failed to start" during shutdown when internal telemetry had no record key to authenticate with (for example, when running with `--record false`). The telemetry exporter now silently drops spans it cannot send and no longer surfaces flush errors during graceful teardown. Fixed in [#33837](https://github.com/cypress-io/cypress/pull/33837).
 
 ## 15.15.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).
 - Fixed an intermittent `ENOENT: no such file or directory, open <path>/bundle.tar-<rand>` error during `cy.prompt` and Studio bundle initialization. Fixed in [#33748](https://github.com/cypress-io/cypress/pull/33748).
+- Fixed an issue where Cypress could exit with code 1 and report "Cypress failed to start" during shutdown when internal telemetry had no record key to authenticate with (for example, when running with `--record false`). The telemetry exporter now silently drops spans it cannot send and no longer surfaces flush errors during graceful teardown. Fixed in [#33837](https://github.com/cypress-io/cypress/pull/33837).
 
 ## 15.15.0
 

--- a/packages/server/start-cypress.js
+++ b/packages/server/start-cypress.js
@@ -64,8 +64,12 @@ if (isRunningElectron) {
       span?.end()
     } catch (error) {
       debug('Error during cleanup of telemetry span on exit: %o', error)
-    } finally {
+    }
+
+    try {
       await telemetry.shutdown()
+    } catch (error) {
+      debug('Error during telemetry shutdown on exit: %o', error)
     }
   }, 'finalize telemetry')
 

--- a/packages/telemetry/src/span-exporters/cloud-span-exporter.ts
+++ b/packages/telemetry/src/span-exporters/cloud-span-exporter.ts
@@ -140,6 +140,8 @@ export class OTLPTraceExporter extends OTLPTraceExporterHttp {
 
     if (this.requirementsToExport === 'unmet') {
       onError(new Error('Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.'))
+
+      return
     }
 
     let serviceRequest: string


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

After [#33542](https://github.com/cypress-io/cypress/pull/33542) (graceful teardown), the `test-binary-against-cypress-realworld-app` CI job started failing on every run with:

```
Error: Spans cannot be sent, exporter has unmet requirements, either project id or record key are undefined.
...
Additional errors occurred during teardown. Exiting with code 1.
```

Two bugs combine to cause this:

1. **`cloud-span-exporter.ts`** — When `requirementsToExport === 'unmet'`, `send()` calls `onError(...)` but doesn't return, so the failed span also falls through into `delayedItemsToExport`. Added the missing `return`.
2. **`start-cypress.js`** — In the `finalize telemetry` GracefulExit step, `telemetry.shutdown()` was in the `finally` block without its own try/catch. A flush rejection during shutdown bubbled up to GracefulExit, which converted it to exit code 1. Wrapped `telemetry.shutdown()` in its own try/catch so telemetry shutdown errors are logged and swallowed.

Before #33542, the abrupt exit path silently swallowed these errors, which is why the latent bugs only surfaced once graceful teardown started properly awaiting teardown steps.

Also updates `mainBuildFilters` in the CircleCI workflow:
- Converted from a `branches: only` block to an expression-based filter so it can reference the `force-persist-artifacts` pipeline parameter (CircleCI's traditional `filters:` doesn't support pipeline parameters; job-level `when:` isn't supported either).
- Added `pipeline.parameters.force-persist-artifacts == true` so gated jobs (npm-release, binary tests against staging/recipes/kitchensink/realworld-app) fire on force-persist-artifacts runs.
- Dropped the stale `feat/cy-prompt` branch entry.

Validated the new filter expression with `circleci config validate` (regex literal `/.../` works, `pipeline.parameters.<name>` references resolve, YAML anchor `&mainBuildFilters` propagates through all 9 alias references).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect process shutdown/telemetry flushing behavior and CircleCI job gating, which can impact CI pass/fail and when release/artifact jobs run.
> 
> **Overview**
> Prevents telemetry failures during shutdown from forcing a non-zero Cypress exit by wrapping `telemetry.shutdown()` in its own `try/catch` and ensuring the cloud span exporter `send()` returns immediately when export requirements are unmet.
> 
> Updates CircleCI `mainBuildFilters` from a branch allowlist to an expression so gated jobs can also run when `pipeline.parameters.force-persist-artifacts` is true, and removes the stale `feat/cy-prompt` branch entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d7e16e6069f2f7e94a88814a248eff780969e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Trigger CI on this branch — `test-binary-against-cypress-realworld-app` should now exit cleanly even with `--record false`.
2. Trigger a pipeline with `force-persist-artifacts=true` on a non-develop/non-release branch — the `mainBuildFilters`-gated jobs (e.g. `npm-release`, `test-binary-against-*`) should now run.
3. Normal pushes to `develop` / `release/*` branches continue to behave as before.

### How has the user experience changed?

No user-facing behavior change. Internal CI/telemetry reliability fix.

### PR Tasks

- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?