### PR TITLE
test: update unauthenticated cloud panel assertion

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-state-management.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-state-management.cy.ts
@@ -70,7 +70,7 @@ describe('Cypress Studio - State Management', () => {
 
     // since we aren't logged in, we need to close the connect to cloud panel
     cy.get('[data-cy="studio-error"]').within(() => {
-      cy.contains('Connect to Cypress Cloud').should('be.visible')
+      cy.contains('Login').should('be.visible')
       cy.get('[aria-label="Close"]').click()
     })
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
Updates tests for the logic changed here https://github.com/cypress-io/cypress-services/pull/13509

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a Cypress Studio E2E test assertion to match updated unauthenticated Cloud panel copy, with no production code impact.
> 
> **Overview**
> Updates the Cypress Studio state-management E2E test to expect the unauthenticated Cloud panel to show **"Login"** instead of **"Connect to Cypress Cloud"** before closing the panel, aligning the test with the new UI messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d35e5db248d70563ba5f6a7d0e2b335cdb1a077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
