### PR TITLE
chore(ci): store HAR artifacts from server-performance-tests

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2083,6 +2083,9 @@ jobs:
           install-firefox: true
       - run:
           command: yarn workspace @packages/server test-performance
+      - store_artifacts:
+          path: /tmp/artifacts
+          when: always
       - sanitize-verify-and-store-mocha-results:
           expectedResultCount: 1
 


### PR DESCRIPTION
- Closes #N/A — supports diagnosing the flake reported at https://app.circleci.com/pipelines/github/cypress-io/cypress/81852/workflows/eaba34d0-d6f4-45a9-a063-926868f7ca82/jobs/3647598/tests

### Additional details

The `proxy_performance_spec` writes a HAR file for each test case to `$CIRCLE_ARTIFACTS` (`/tmp/artifacts`) via [packages/server/test/performance/proxy_performance_spec.js:303-316](https://github.com/cypress-io/cypress/blob/develop/packages/server/test/performance/proxy_performance_spec.js#L303-L316), but the `server-performance-tests` job has no `store_artifacts` step, so those HARs are discarded when the container shuts down. The CircleCI artifacts API confirmed an empty artifact list for the failing job above.

This PR adds:

```yaml
- store_artifacts:
    path: /tmp/artifacts
    when: always
```

between the test run and `sanitize-verify-and-store-mocha-results`. `when: always` is important — without it the upload would be skipped on the failing job, which is precisely when we need the HAR.

Why: two recent flakes in the `"With Cypress proxy, Intercepted loads 1000 images less than 3x as slowly as Chrome"` `before all` hook tripped `expect(timings.total.length).to.be.at.least(1000)` with `999` (HTTPS) and `933` (HTTP). Without the HAR we can't tell whether the missing entries are tail-truncation, in-flight-at-shutdown, failed requests, or proxy backpressure. Storing the HARs unblocks a root-cause fix instead of blindly tuning the assertion threshold or the post-hook idle timer.

Validated with `yarn pack-ci --all --validate` — both the base config and the packed `pipeline.yml` pass CircleCI validation. The pre-commit hook also re-packed and validated successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds artifact persistence; primary risk is minor CI storage/cost increase and ensuring uploads occur even on failures.
> 
> **Overview**
> Updates the CircleCI `server-performance-tests` job to **always upload artifacts** from `/tmp/artifacts` after running `yarn workspace @packages/server test-performance`.
> 
> This ensures diagnostics (e.g., generated HAR files) are preserved even when the job fails by using `store_artifacts` with `when: always`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7b3c08119f0f02d355be94ec66787c38851a84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Trigger any CI run that includes `server-performance-tests` (e.g. opening this PR).
2. Open the job in the CircleCI UI and confirm an **Artifacts** tab appears with `*.har` files (one per test case) under `/tmp/artifacts/`.
3. Confirm HARs are uploaded on both passing and failing runs (the `when: always` clause).

### How has the user experience changed?

No change — internal CI tooling only.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- purely mechanical CI change to enable diagnostics on an existing flake; no behavior change -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?