### PR TITLE
chore: port non-v16-specific CircleCI changes from release/16.0.0

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -104,7 +104,7 @@ defaults: &defaults
   parameters: &defaultsParameters
     executor:
       type: executor
-      default: cy-doc
+      default: cy-docker
     only-cache-for-root-user:
       type: boolean
       default: false
@@ -122,8 +122,7 @@ defaults: &defaults
     LINES: 24
 
 executors:
-  # the Docker image with Cypress dependencies and Chrome browser
-  cy-doc:
+  cy-docker:
     docker:
       - image: *base-internal-trixie
     # by default, we use "medium" to balance performance + CI costs. bump or reduce on a per-job basis if needed.
@@ -200,7 +199,7 @@ commands:
             if [[ "<< pipeline.parameters.force-persist-artifacts >>" == "true" ]]; then
               echo 'export SHOULD_PERSIST_ARTIFACTS=true' >> "$BASH_ENV"
             else
-              echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* ]]; then
+              echo 'if ! [[ "$CIRCLE_BRANCH" != "develop" && "$CIRCLE_BRANCH" != "release/"* && "$CIRCLE_BRANCH" != "electron/"* ]]; then
                   export SHOULD_PERSIST_ARTIFACTS=true
               fi' >> "$BASH_ENV"
             fi
@@ -570,7 +569,7 @@ commands:
     parameters:
       executor:
         type: executor
-        default: cy-doc
+        default: cy-docker
     steps:
       - run: pwd
       ##- run:
@@ -613,7 +612,7 @@ commands:
       executor:
         description: The executor in use. Only used if Windows for workaround purposes
         type: executor
-        default: cy-doc
+        default: cy-docker
       install-chrome:
         description: whether or not to install google chrome
         type: boolean
@@ -1084,7 +1083,9 @@ commands:
             NEXT_VERSION=$(node ./cypress/scripts/get-next-version.js)
             cd -
 
-            git checkout $NEXT_VERSION || true
+            # Prefer a `release/<version>` branch (current convention) and
+            # fall back to a bare `<version>` branch for older versions.
+            git checkout "release/$NEXT_VERSION" || git checkout "$NEXT_VERSION" || true
       - when:
           condition: <<parameters.pull_request_id>>
           steps:
@@ -1250,7 +1251,7 @@ commands:
       executor:
         description: The executor in use. Only used if Windows for workaround purposes
         type: executor
-        default: cy-doc
+        default: cy-docker
     steps:
       - run:
           name: Install yarn if not already installed
@@ -1517,7 +1518,7 @@ commands:
     parameters:
       executor:
         type: executor
-        default: cy-doc
+        default: cy-docker
     steps:
       - run:
           name: Bump NPM version
@@ -2939,7 +2940,7 @@ jobs:
       executor:
         description: Executor name to use
         type: executor
-        default: cy-doc
+        default: cy-docker
       wd:
         description: Working directory, should be OUTSIDE cypress monorepo folder
         type: string
@@ -2979,7 +2980,7 @@ jobs:
       executor:
         description: Executor name to use
         type: executor
-        default: cy-doc
+        default: cy-docker
     <<: *defaults
     resource_class: small
     steps:

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -7,6 +7,9 @@ linux-x64:
       - matches:
           pattern: /^release\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
+      - matches:
+          pattern: /^electron\/\d+\.\d+\.\d+$/
+          value: << pipeline.git.branch >>
       - equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
   jobs:
     - node_modules_install:
@@ -309,9 +312,10 @@ linux-x64:
           - v8-integration-tests
 
     - npm-release:
-        # Expression-based filter: branch-based allowlist OR force-persist-artifacts pipeline parameter.
-        # 'update-v8-snapshot-cache-on-develop' is included so v8 snapshot cache updates are fully tested.
-        filters: &mainBuildFilters pipeline.git.branch == "develop" or pipeline.git.branch matches /^release\/\d+\.\d+\.\d+$/ or pipeline.git.branch == "update-v8-snapshot-cache-on-develop" or pipeline.parameters.force-persist-artifacts == true
+        filters:
+            branches:
+              only:
+                - develop
         context: [test-runner:npm-release, org-npm-credentials]
         requires:
           - ready-to-release
@@ -337,7 +341,9 @@ linux-x64:
     # and testing it on a real project
     - test-against-staging:
         context: test-runner:record-tests
-        filters: *mainBuildFilters
+        # Expression-based filter: branch-based allowlist OR force-persist-artifacts pipeline parameter.
+        # 'update-v8-snapshot-cache-on-develop' is included so v8 snapshot cache updates are fully tested.
+        filters: &mainBuildFilters pipeline.git.branch == "develop" or pipeline.git.branch matches /^release\/\d+\.\d+\.\d+$/ or pipeline.git.branch matches /^electron\/\d+\.\d+\.\d+$/ or pipeline.git.branch == "update-v8-snapshot-cache-on-develop" or pipeline.parameters.force-persist-artifacts == true
         requires:
           - build
     - test-kitchensink:

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -1,16 +1,20 @@
 # The workflow runs for:
 # External PR after approval (approved contributor PR that's not a main branch)
-# Internal PR for any branch that does is not develop or release/ related
+# Internal PR for any branch that is not develop, release/x.x.x, or electron/x.x.x related
 when:
   and:
     - not:
         matches:
-            pattern: /^release\//
+            pattern: /^release\/\d+\.\d+\.\d+$/
             value: << pipeline.git.branch >>
     - not:
         matches:
-            pattern: /^develop/
+            pattern: /^electron\/\d+\.\d+\.\d+$/
             value: << pipeline.git.branch >>
+    - not:
+        equal: [ 'develop', << pipeline.git.branch >> ]
+    - not:
+        equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - not:
         equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
 


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

Forward-ports CI improvements that originated on `release/16.0.0` but aren't version-specific. None of these touch product code or v16 breaking changes.

**`.circleci/src/pipeline/@pipeline.yml`**
- Rename the `cy-doc` executor to `cy-docker` (the original name was misleading — it never had anything to do with documentation).
- `setup_should_persist_artifacts` now treats `electron/*` branches like `release/*` (artifacts are persisted on those branches).
- `clone-repo-and-checkout-branch` (used by the kitchensink and RWA jobs) now prefers `release/<NEXT_VERSION>` and falls back to the bare `<NEXT_VERSION>` branch. The previous form only matched bare-version branches, so for the current `release/<version>` naming convention the checkout was silently failing and the jobs were running against `master`.

**`.circleci/src/pipeline/workflows/@main.yml`**
- Add `electron/x.x.x` to the linux-x64 workflow `when:` allowlist.
- Restructure the `npm-release` filter: it now uses `branches.only: [develop]` and the `&mainBuildFilters` anchor moves to `test-against-staging`. The expression-based anchor itself is preserved (so `force-persist-artifacts == true` still overrides) and now also matches `electron/x.x.x` branches.
- **Behavior change:** `npm-release` will no longer fire on `release/x.x.x` branches — only on `develop`. This matches what release/16.0.0 already does.

**`.circleci/src/pipeline/workflows/pull-request.yml`**
- Tighten the release-branch regex from `/^release\//` to `/^release\/\d+\.\d+\.\d+$/` so arbitrary `release/foo` branches aren't accidentally excluded.
- Switch the `develop` exclusion from a `/^develop/` regex (which also matched `develop-foo`) to an exact `equal` check.
- Add `electron/x.x.x` and `update-v8-snapshot-cache-on-develop` carve-outs to match the main workflow's allowlist.

V16-only changes (Node 24 base images, Electron 41 prebuild, `cache-version.txt`, `publish-binary-branch`, `npm-angular-zoneless` removal, `mschile/electron_41` temporary branches, etc.) are intentionally **not** included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CircleCI workflow filters and release triggering behavior (notably restricting `npm-release` to `develop`), which can affect what runs/publishes on release branches if misconfigured. No product/runtime code is touched.
> 
> **Overview**
> Updates CircleCI config to better align branch conventions and reduce accidental workflow runs.
> 
> Renames the default Docker executor from `cy-doc` to `cy-docker`, extends artifact persistence and main workflow allowlists to include `electron/x.y.z` branches, and fixes `clone-repo-and-checkout-branch` to prefer `release/<next_version>` (falling back to `<next_version>`) so downstream example-repo jobs test the intended branch.
> 
> Adjusts workflow filtering: tightens PR-workflow exclusions (exact `develop`, semver-only `release/x.y.z`, plus `electron/x.y.z` and `update-v8-snapshot-cache-on-develop` carve-outs), and changes `npm-release` to run only on `develop` while keeping the shared expression-based `&mainBuildFilters` for other staging/binary jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f3ba4010acd1bc525014ceacc9d68630d55240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Verification is via CircleCI itself:

1. Confirm the PR's pipeline still uses the `pull-request` workflow (the regex tightening shouldn't change behavior for a `mschile/*` branch — this PR's own branch is the test).
2. Confirm the packed config validates: `yarn workspace @cypress/scripts pack-ci --validate` (also runs in the pre-commit hook on this PR; it passed locally).
3. After merge, the next `develop` push should:
   - Still produce an `npm-release` (filter is `branches.only: [develop]`).
   - Run the `*mainBuildFilters` jobs (`test-against-staging`, `test-binary-against-*`, etc.) via the expression filter.

### How has the user experience changed?

No change — CI-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- mechanical CI port from release/16.0.0 -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?