### PR TITLE
chore: stub event collector endpoints in cypress-in-cypress E2E tests

### DIFF
--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -368,11 +368,6 @@ async function makeE2ETasks () {
           }), { status: 200 })
         }
 
-        // Cypress-in-cypress safety net: never let test runs hit the real
-        // event collector endpoints. `EventCollectorActions.recordEvent`
-        // posts here, and `cloudEnv` defaults to 'production'
-        // (cloud.cypress.io). Tests that mount banners or otherwise trigger
-        // `recordEvent` would otherwise leak events to production every run.
         const urlStr = String(url)
 
         if (urlStr.endsWith('/machine-collect') || urlStr.endsWith('/anon-collect')) {

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -368,6 +368,17 @@ async function makeE2ETasks () {
           }), { status: 200 })
         }
 
+        // Cypress-in-cypress safety net: never let test runs hit the real
+        // event collector endpoints. `EventCollectorActions.recordEvent`
+        // posts here, and `cloudEnv` defaults to 'production'
+        // (cloud.cypress.io). Tests that mount banners or otherwise trigger
+        // `recordEvent` would otherwise leak events to production every run.
+        const urlStr = String(url)
+
+        if (urlStr.endsWith('/machine-collect') || urlStr.endsWith('/anon-collect')) {
+          return new Response('{}', { status: 200 })
+        }
+
         return fetchApi(url, init)
       })
 


### PR DESCRIPTION
## Summary

The cypress-in-cypress E2E test setup at `packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts:246-372` stubs `ctx.util.fetch` but only short-circuits three URL patterns (`/test-runner-graphql`, manifest, npm registry). Everything else falls through to the real fetch.

`EventCollectorActions.recordEvent` posts to `cloud.cypress.io/machine-collect` (or `/anon-collect`) — `cloudEnv` defaults to `'production'`. That endpoint never matched the stub, so any E2E test that triggered `recordEvent` was POSTing real machine-linked events to production cloud on every run.

Known leak paths today:
- `packages/app/cypress/e2e/cloud_message_banner.cy.ts` — opts in to `cloudAppMessages`, stubs `getCurrentProjectSavedState` without `banners._disabled`, and mounts a real `CloudMessageBanner`. The `watchEffect` in `TrackedBanner.vue:104-108` fires `TrackedBanner_RecordBannerSeen`, which resolves into `EventCollectorActions.recordEvent` → real fetch → production cloud.
- `packages/app/cypress/e2e/debug.cy.ts:47` — `sinon.spy(ctx.actions.eventCollector, 'recordEvent')` (spy, not stub), so the real function executes and the fetch goes out.

This change adds a single guard at the existing fetch stub: any `/machine-collect` or `/anon-collect` request returns `{}` with 200 instead of hitting the network. This matches the pattern already used for the other test-only URL short-circuits and protects all current and future E2E tests by default — no per-test plumbing required.

## Test plan

- [ ] Run `packages/app/cypress/e2e/cloud_message_banner.cy.ts` and confirm tests still pass (banner mounts, dismissal still works) — only the network call is suppressed.
- [ ] Run `packages/app/cypress/e2e/debug.cy.ts` and confirm the `recordEvent` spy assertions still pass (the spy still captures the call; only the downstream fetch is suppressed).
- [ ] Spot-check network logs for any other E2E spec that mounts banners or invokes `useRecordEvent` to confirm no `cloud.cypress.io/machine-collect` or `/anon-collect` traffic leaves the test machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that only affects Cypress-in-Cypress E2E runs by preventing outbound requests to cloud event collector endpoints.
> 
> **Overview**
> Prevents Cypress-in-Cypress E2E tests from sending real analytics/event data by extending the global `ctx.util.fetch` stub to short-circuit requests ending in `/machine-collect` and `/anon-collect` with a `200` `{}` response.
> 
> All other URLs continue to fall through to the original `fetch`, so behavior outside these collector endpoints remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03e948cd6888ac00117d5d46b9b76b005cd6e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->