### PR TITLE
refactor(server): convert `network_failures` and `suppress_warnings` to TypeScript

### DIFF
--- a/packages/server/lib/file_server.ts
+++ b/packages/server/lib/file_server.ts
@@ -8,7 +8,7 @@ import send from 'send'
 import { httpUtils } from '@packages/network'
 import { allowDestroy } from './util/server_destroy'
 import { id as randomId } from './util/random'
-import networkFailures from './util/network_failures'
+import { get as getNetworkFailures } from './util/network_failures'
 import type { AddressInfo } from 'net'
 
 const debug = debugModule('cypress:server:file_server')
@@ -53,7 +53,7 @@ const onRequest = function (req: http.IncomingMessage, res: http.ServerResponse,
     res.setHeader('content-type', 'text/html')
     res.statusCode = err.status
 
-    return res.end(networkFailures.get(file, err.status))
+    return res.end(getNetworkFailures(file, err.status))
   }).pipe(res)
 }
 

--- a/packages/server/lib/util/network_failures.ts
+++ b/packages/server/lib/util/network_failures.ts
@@ -1,10 +1,10 @@
-const { stripIndents, html } = require('common-tags')
+import { stripIndents, html } from 'common-tags'
 
-const convertNewLinesToBr = (text) => {
+const convertNewLinesToBr = (text: string): string => {
   return text.split('\n').join('<br />')
 }
 
-const fileErr = (url, status) => {
+export const fileErr = (url: string, status: number): string => {
   return stripIndents`
     Cypress errored trying to serve this file from your system:
 
@@ -14,7 +14,7 @@ const fileErr = (url, status) => {
   `
 }
 
-const wrap = (contents) => {
+export const wrap = (contents: string): string => {
   return html`
     <!DOCTYPE html>
     <html>
@@ -25,16 +25,8 @@ const wrap = (contents) => {
   `
 }
 
-const get = (url, status) => {
+export const get = (url: string, status: number): string => {
   const contents = fileErr(url, status)
 
   return wrap(contents)
-}
-
-module.exports = {
-  fileErr,
-
-  wrap,
-
-  get,
 }

--- a/packages/server/lib/util/suppress_warnings.ts
+++ b/packages/server/lib/util/suppress_warnings.ts
@@ -1,11 +1,11 @@
-const _ = require('lodash')
-const Debug = require('debug')
+import _ from 'lodash'
+import Debug from 'debug'
 
 const debug = Debug('cypress:server:lib:util:suppress_warnings')
 
 let suppressed = false
 
-const suppress = () => {
+export const suppress = (): void => {
   if (suppressed) {
     return
   }
@@ -14,7 +14,12 @@ const suppress = () => {
 
   const originalEmitWarning = process.emitWarning
 
-  process.emitWarning = (warning, type, code, ...args) => {
+  process.emitWarning = ((
+    warning: string | Error,
+    type?: string,
+    code?: string,
+    ...args: unknown[]
+  ) => {
     /**
      * Don't emit the NODE_TLS_REJECT_UNAUTHORIZED warning while
      * we work on proper SSL verification.
@@ -40,10 +45,6 @@ const suppress = () => {
       return
     }
 
-    return originalEmitWarning.call(process, warning, type, code, ...args)
-  }
-}
-
-module.exports = {
-  suppress,
+    return (originalEmitWarning as (warning: string | Error, type?: string, code?: string, ...args: unknown[]) => void).call(process, warning, type, code, ...args)
+  }) as typeof process.emitWarning
 }

--- a/packages/server/start-cypress.js
+++ b/packages/server/start-cypress.js
@@ -7,6 +7,7 @@ const { override: overrideTty } = require('./lib/util/tty')
 const { GracefulExit } = require('./lib/util/graceful-exit')
 const { NetProfiler } = require('./lib/util/net_profiler')
 const { debugElapsedTime } = require('./lib/util/performance_benchmark')
+const { suppress } = require('./lib/util/suppress_warnings')
 
 const { calculateCypressInternalEnv, configureLongStackTraces } = require('./lib/environment')
 
@@ -112,6 +113,6 @@ process.noDeprecation = process.env.CYPRESS_INTERNAL_ENV === 'production'
 // always show stack traces for Electron deprecation warnings
 process.traceDeprecation = true
 
-require('./lib/util/suppress_warnings').suppress()
+suppress()
 
 module.exports = require('./lib/cypress').start(process.argv)

--- a/packages/server/test/unit/util/suppress_warnings_spec.ts
+++ b/packages/server/test/unit/util/suppress_warnings_spec.ts
@@ -5,10 +5,12 @@ import proxyquire from 'proxyquire'
 const TLS_WARNING = 'Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to \'0\' makes TLS connections and HTTPS requests insecure by disabling certificate verification.'
 
 describe('lib/util/suppress_warnings', function () {
-  it('passes through NODE_TLS_REJECT_UNAUTHORIZED warnings when not suppressed', () => {
+  it('passes through non-TLS warnings when suppressed', () => {
     const emitWarning = sinon.spy(process, 'emitWarning')
+    const { suppress } = proxyquire('../../../lib/util/suppress_warnings', {})
 
-    process.emitWarning(TLS_WARNING)
+    suppress()
+    process.emitWarning('some unrelated warning')
 
     expect(emitWarning).to.be.calledOnce
   })

--- a/packages/server/test/unit/util/suppress_warnings_spec.ts
+++ b/packages/server/test/unit/util/suppress_warnings_spec.ts
@@ -1,37 +1,27 @@
 import '../../spec_helper'
 import { expect } from 'chai'
-import execa from 'execa'
 import proxyquire from 'proxyquire'
 
-const ERROR_MESSAGE = 'Setting the NODE_TLS_REJECT_UNAUTHORIZED'
-
-const TLS_CONNECT = `require('tls').connect('5000').on('error', ()=>{});`
-const SUPPRESS_WARNING = `require('${__dirname}/../../../lib/util/suppress_warnings').suppress();`
+const TLS_WARNING = 'Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to \'0\' makes TLS connections and HTTPS requests insecure by disabling certificate verification.'
 
 describe('lib/util/suppress_warnings', function () {
-  it('tls.connect emits warning if NODE_TLS_REJECT_UNAUTHORIZED=0 and not suppressed', function () {
-    return execa(`node -e "${TLS_CONNECT}"`, {
-      shell: true,
-      env: {
-        'NODE_TLS_REJECT_UNAUTHORIZED': '0',
-      },
-    })
-    .then(({ stderr }) => {
-      expect(stderr).to.contain(ERROR_MESSAGE)
-    })
+  it('passes through NODE_TLS_REJECT_UNAUTHORIZED warnings when not suppressed', () => {
+    const emitWarning = sinon.spy(process, 'emitWarning')
+
+    process.emitWarning(TLS_WARNING)
+
+    expect(emitWarning).to.be.calledOnce
   })
 
-  it('tls.connect does not emit warning if NODE_TLS_REJECT_UNAUTHORIZED=0 and suppressed', function () {
-    // test 2 sequential tls.connects
-    return execa(`node -e "${SUPPRESS_WARNING} ${TLS_CONNECT} ${TLS_CONNECT}"`, {
-      shell: true,
-      env: {
-        'NODE_TLS_REJECT_UNAUTHORIZED': '0',
-      },
-    })
-    .then(({ stderr }) => {
-      expect(stderr).to.not.contain(ERROR_MESSAGE)
-    })
+  it('suppresses NODE_TLS_REJECT_UNAUTHORIZED warnings', () => {
+    const emitWarning = sinon.spy(process, 'emitWarning')
+    const { suppress } = proxyquire('../../../lib/util/suppress_warnings', {})
+
+    suppress()
+    process.emitWarning(TLS_WARNING)
+    process.emitWarning(TLS_WARNING)
+
+    expect(emitWarning).not.to.be.called
   })
 
   it('does not emit buffer deprecation warnings', () => {


### PR DESCRIPTION
## Summary
- Convert `network_failures.js` to TypeScript with named exports and update `file_server.ts` import
- Convert `suppress_warnings.js` to TypeScript with minimal typing on the `process.emitWarning` wrapper
- Simplify `suppress_warnings` unit tests to run in-process instead of spawning child node processes

## Test plan
- [x] `yarn workspace @packages/server test-unit suppress_warnings_spec.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a TypeScript refactor, but it touches widely-used `appData` path/cleanup utilities and warning suppression, so regressions could affect profile/cache locations or startup warning behavior across platforms.
> 
> **Overview**
> Converts `lib/util/app_data` from CommonJS `app_data.js` to TypeScript `app_data.ts` with named exports, and updates server call sites to import it as a module (including narrowing `appApi.appData` to an explicit surface in `makeDataContext`).
> 
> Converts `lib/util/network_failures` and `lib/util/suppress_warnings` to TypeScript with named exports, updates `file_server` and `start-cypress` to use them, and rewrites the `suppress_warnings` unit tests to run in-process instead of spawning node.
> 
> Includes small correctness/typing adjustments: use `span.setAttributes` in browser lifecycle spans, read WebKit version file as `utf8`, ensure Chrome remote debugging port is passed as a string, and fixes `cache.removeProjectPreferences` to update preferences asynchronously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a10d0c46503734c1d2d86480f0f676f62015d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->