### PR TITLE
chore(ci): drop vestigial COLUMNS=100 assertion blocking Windows CI

### DIFF
--- a/scripts/check-terminal.js
+++ b/scripts/check-terminal.js
@@ -7,7 +7,5 @@ if (isMainLinux) {
   assert.ok(process.env.TERM === 'xterm', `process.env.TERM=${process.env.TERM} and must be set to "xterm" for Docker to work`)
 }
 
-assert.ok(process.env.COLUMNS === '100', `process.env.COLUMNS=${process.env.COLUMNS} must be set to 100 for snapshots to pass`)
-
 console.log('stdout.isTTY?', process.stdout.isTTY)
 console.log('stderr.isTTY?', process.stderr.isTTY)


### PR DESCRIPTION
- Closes N/A — unblocks the Windows workflow on `develop`

### Additional details

The `yarn check-terminal` step in `windows-node-modules-install` has been failing on every Windows pipeline since approximately 2026-05-20 15:30 UTC, blocking the entire Windows workflow at the first job:

```
AssertionError [ERR_ASSERTION]: process.env.COLUMNS=80 must be set to 100 for snapshots to pass
    at scripts/check-terminal.js:10:8
```

**Cause:** A CircleCI `task-agent` rollout (`1.0.327751-b04d8598` → `1.0.327870-01d0b024`) between two pipelines for the same commit. The new task-agent stops propagating the `COLUMNS: 100` env var (set in `defaultsEnvironment` of `.circleci/src/pipeline/@pipeline.yml`) into `bash.exe` on the Windows runner — Git Bash's `checkwinsize` then resets `COLUMNS` to the conhost width (80).

| Job | task-agent | Result |
|---|---|---|
| 3647647 (15:07 UTC) | `1.0.327751` | ✅ |
| 3647817 → 3649731 (15:30+ UTC) | `1.0.327870` | ❌ × 5 |

Same image (`windows-server-2022-gui:2024.12.1`), same provider, same commit — only the agent changed.

**Why removing the assertion is safe:**

The 2018 comment on the assertion says \"must be set to 100 for snapshots to pass.\" That stopped being true long ago:

1. `packages/server/lib/util/terminal-size.ts` already forces `columns = 100` whenever `CI` is set, independent of any env var.
2. `system-tests/lib/system-tests.ts` explicitly sets `COLUMNS: 100` on every child Cypress process it spawns, ignoring the parent shell.
3. `cli-table3` is passed explicit `colWidths` derived from (1); it doesn't auto-detect.
4. Spawned Cypress stdout is a pipe, not a TTY — no terminal-width wrapping happens to the captured bytes.
5. No source file in the repo reads `process.env.COLUMNS` other than the assertion itself.

The parent shell's `COLUMNS` value has had no downstream effect on snapshot output for years; the assertion was checking a value nothing consumed. Removing it unblocks Windows CI without changing any test behavior.

The TERM=xterm check (Linux-only, for Docker) is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes a CI-only assertion on `process.env.COLUMNS` that was failing on Windows runners; no runtime or product behavior changes.
> 
> **Overview**
> Removes the `COLUMNS=100` assertion from `scripts/check-terminal.js`, so `yarn check-terminal` no longer fails when the shell reports a different terminal width (notably on Windows CI).
> 
> The Linux-only `TERM=xterm` check for Docker remains, and the script continues to log TTY status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f53e92d8a9d37ad838c1057cf4d5f39fe861a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
- Trigger or wait for the next pipeline on this branch; the `windows` workflow should progress past `windows-node-modules-install` for the first time since 15:30 UTC on 2026-05-20.

### How has the user experience changed?
No change — internal CI script only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?
