### PR TITLE
chore: scope graphql-ws origin enforcement to launchpad server

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue introduced in [#33811](https://github.com/cypress-io/cypress/pull/33811) where the GraphQL WebSocket subscription transport on the test-runner server (`/__socket-graphql`) was rejected with a 403 when the application under test ran on a different origin from the Cypress server, causing Studio and other subscription-driven UI to hang. The origin/port check is now scoped to the launchpad GraphQL server, which is the only place it is meaningful. Fixed in [#33874](https://github.com/cypress-io/cypress/pull/33874).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 **Bugfixes:**
 
-- Fixed an issue introduced in [#33811](https://github.com/cypress-io/cypress/pull/33811) where the GraphQL WebSocket subscription transport on the test-runner server (`/__socket-graphql`) was rejected with a 403 when the application under test ran on a different origin from the Cypress server, causing Studio and other subscription-driven UI to hang. The origin/port check is now scoped to the launchpad GraphQL server, which is the only place it is meaningful. Fixed in [#33874](https://github.com/cypress-io/cypress/pull/33874).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).

--- a/packages/data-context/graphql/makeGraphQLServer.ts
+++ b/packages/data-context/graphql/makeGraphQLServer.ts
@@ -198,11 +198,7 @@ export interface GraphqlWsHandle {
   dispose: () => Promise<void>
 }
 
-export interface GraphqlWsOptions {
-  enforceOrigin?: boolean
-}
-
-export const graphqlWS = (httpServer: Server, targetRoute: string, options: GraphqlWsOptions = {}): GraphqlWsHandle => {
+export const graphqlWS = (httpServer: Server, targetRoute: string, options: { enforceOrigin?: boolean } = {}): GraphqlWsHandle => {
   const { enforceOrigin = true } = options
   const graphqlWs = new WebSocketServer({ noServer: true })
 

--- a/packages/data-context/graphql/makeGraphQLServer.ts
+++ b/packages/data-context/graphql/makeGraphQLServer.ts
@@ -127,7 +127,7 @@ export async function makeGraphQLServer () {
 
   gqlSocketServer = socketSrv.of('/data-context')
 
-  const gqlWs = graphqlWS(srv, '/__launchpad/graphql-ws', { enforceOrigin: true })
+  const gqlWs = graphqlWS(srv, '/__launchpad/graphql-ws')
 
   gqlGraphqlWsDispose = gqlWs.dispose
   ctx.actions.servers.setGqlGraphqlWsDispose(gqlWs.dispose)
@@ -190,7 +190,7 @@ export async function handleGraphQLSocketRequest (uid: string, payload: string, 
  *
  * @param httpServer The http server we are utilizing for the websocket
  * @param targetRoute Route to target in the server upgrade event
- * @param options.enforceOrigin When true, reject upgrades whose Origin port does not match the server's listen port. Only safe when the WS server is directly addressed by the browser (i.e. the launchpad GraphQL server).
+ * @param options.enforceOrigin Defaults to true: reject upgrades whose Origin port does not match the server's listen port. Set to false only when the server receives proxied upgrades whose Origin reflects an upstream host (i.e. the test-runner server) and another allowlist gates inbound connections.
  * @returns WebSocket server and graphql-ws dispose — call `dispose()` before destroying the HTTP server.
  */
 export interface GraphqlWsHandle {
@@ -203,11 +203,12 @@ export interface GraphqlWsOptions {
 }
 
 export const graphqlWS = (httpServer: Server, targetRoute: string, options: GraphqlWsOptions = {}): GraphqlWsHandle => {
+  const { enforceOrigin = true } = options
   const graphqlWs = new WebSocketServer({ noServer: true })
 
   httpServer.on('upgrade', (req: Request, socket: Socket, head) => {
     if (req.url?.startsWith(targetRoute)) {
-      if (options.enforceOrigin && !isOriginAllowed(req.headers.origin, req.socket.localPort)) {
+      if (enforceOrigin && !isOriginAllowed(req.headers.origin, req.socket.localPort)) {
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
         socket.destroy()
 

--- a/packages/data-context/graphql/makeGraphQLServer.ts
+++ b/packages/data-context/graphql/makeGraphQLServer.ts
@@ -127,7 +127,7 @@ export async function makeGraphQLServer () {
 
   gqlSocketServer = socketSrv.of('/data-context')
 
-  const gqlWs = graphqlWS(srv, '/__launchpad/graphql-ws')
+  const gqlWs = graphqlWS(srv, '/__launchpad/graphql-ws', { enforceOrigin: true })
 
   gqlGraphqlWsDispose = gqlWs.dispose
   ctx.actions.servers.setGqlGraphqlWsDispose(gqlWs.dispose)
@@ -190,6 +190,7 @@ export async function handleGraphQLSocketRequest (uid: string, payload: string, 
  *
  * @param httpServer The http server we are utilizing for the websocket
  * @param targetRoute Route to target in the server upgrade event
+ * @param options.enforceOrigin When true, reject upgrades whose Origin port does not match the server's listen port. Only safe when the WS server is directly addressed by the browser (i.e. the launchpad GraphQL server).
  * @returns WebSocket server and graphql-ws dispose — call `dispose()` before destroying the HTTP server.
  */
 export interface GraphqlWsHandle {
@@ -197,12 +198,16 @@ export interface GraphqlWsHandle {
   dispose: () => Promise<void>
 }
 
-export const graphqlWS = (httpServer: Server, targetRoute: string): GraphqlWsHandle => {
+export interface GraphqlWsOptions {
+  enforceOrigin?: boolean
+}
+
+export const graphqlWS = (httpServer: Server, targetRoute: string, options: GraphqlWsOptions = {}): GraphqlWsHandle => {
   const graphqlWs = new WebSocketServer({ noServer: true })
 
   httpServer.on('upgrade', (req: Request, socket: Socket, head) => {
     if (req.url?.startsWith(targetRoute)) {
-      if (!isOriginAllowed(req.headers.origin, req.socket.localPort)) {
+      if (options.enforceOrigin && !isOriginAllowed(req.headers.origin, req.socket.localPort)) {
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
         socket.destroy()
 

--- a/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
+++ b/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals'
-import { createServer, Server } from 'http'
-import { AddressInfo } from 'net'
+import { createServer } from 'http'
+import type { Server } from 'http'
+import type { AddressInfo } from 'net'
 import fetch from 'cross-fetch'
 import WebSocket from 'ws'
 

--- a/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
+++ b/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals'
 import { createServer } from 'http'
-import type { Server } from 'http'
+import type { ClientRequest, IncomingMessage, Server } from 'http'
 import type { AddressInfo } from 'net'
 import fetch from 'cross-fetch'
 import WebSocket from 'ws'
@@ -300,13 +300,14 @@ describe('graphqlWS helper', () => {
         ws.close()
       })
 
-      ws.once('unexpected-response', (_req, res) => {
+      ws.once('unexpected-response', (_req: ClientRequest, res: IncomingMessage) => {
         statusCode = res.statusCode
         ws.terminate()
         finish()
       })
 
       ws.once('close', () => finish())
+      // Swallow socket-level errors (e.g. ECONNRESET on the server's 403 close); 'unexpected-response' and 'close' are what we read.
       ws.once('error', () => {})
     })
   }

--- a/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
+++ b/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
@@ -310,11 +310,29 @@ describe('graphqlWS helper', () => {
     })
   }
 
-  describe('without enforceOrigin (default — used by the test-runner server)', () => {
-    it('accepts upgrade when Origin port does not match the server listen port', async () => {
+  describe('with default options (enforceOrigin: true)', () => {
+    it('rejects upgrade when Origin port does not match the server listen port', async () => {
       const { port } = await startServerWithGraphqlWS({})
 
       const result = await openWs(port, 'http://localhost:3000')
+
+      expect(result.opened).toBe(false)
+      expect(result.statusCode).toBe(403)
+    })
+
+    it('rejects upgrade with a non-localhost Origin', async () => {
+      const { port } = await startServerWithGraphqlWS({})
+
+      const result = await openWs(port, EVIL_ORIGIN)
+
+      expect(result.opened).toBe(false)
+      expect(result.statusCode).toBe(403)
+    })
+
+    it('accepts upgrade with the server\'s own origin', async () => {
+      const { port } = await startServerWithGraphqlWS({})
+
+      const result = await openWs(port, `http://localhost:${port}`)
 
       expect(result.opened).toBe(true)
     })
@@ -326,30 +344,29 @@ describe('graphqlWS helper', () => {
 
       expect(result.opened).toBe(true)
     })
+  })
+
+  describe('with enforceOrigin: false (used by the test-runner server)', () => {
+    it('accepts upgrade when Origin port does not match the server listen port', async () => {
+      const { port } = await startServerWithGraphqlWS({ enforceOrigin: false })
+
+      const result = await openWs(port, 'http://localhost:3000')
+
+      expect(result.opened).toBe(true)
+    })
 
     it('accepts upgrade with a non-localhost Origin', async () => {
-      const { port } = await startServerWithGraphqlWS({})
+      const { port } = await startServerWithGraphqlWS({ enforceOrigin: false })
 
       const result = await openWs(port, EVIL_ORIGIN)
 
       expect(result.opened).toBe(true)
     })
-  })
 
-  describe('with enforceOrigin: true (used by the launchpad GraphQL server)', () => {
-    it('rejects upgrade when Origin port does not match the server listen port', async () => {
-      const { port } = await startServerWithGraphqlWS({ enforceOrigin: true })
+    it('accepts upgrade with no Origin header', async () => {
+      const { port } = await startServerWithGraphqlWS({ enforceOrigin: false })
 
-      const result = await openWs(port, 'http://localhost:3000')
-
-      expect(result.opened).toBe(false)
-      expect(result.statusCode).toBe(403)
-    })
-
-    it('accepts upgrade with the server\'s own origin', async () => {
-      const { port } = await startServerWithGraphqlWS({ enforceOrigin: true })
-
-      const result = await openWs(port, `http://localhost:${port}`)
+      const result = await openWs(port, undefined)
 
       expect(result.opened).toBe(true)
     })

--- a/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
+++ b/packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts
@@ -1,10 +1,12 @@
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals'
+import { createServer, Server } from 'http'
+import { AddressInfo } from 'net'
 import fetch from 'cross-fetch'
 import WebSocket from 'ws'
 
 import { setCtx } from '../../../src'
 import type { DataContext } from '../../../src'
-import { makeGraphQLServer } from '../../../graphql/makeGraphQLServer'
+import { graphqlWS, makeGraphQLServer } from '../../../graphql/makeGraphQLServer'
 import { createTestDataContext } from '../helper'
 
 const EVIL_ORIGIN = 'https://evil.example.com'
@@ -243,6 +245,113 @@ describe('makeGraphQLServer (integration)', () => {
       const result = await attemptSocketIoUpgrade(PRODUCTION_CLOUD_ORIGIN)
 
       expect(result.opened).toBe(false)
+    })
+  })
+})
+
+describe('graphqlWS helper', () => {
+  const servers: Array<{ server: Server, dispose: () => Promise<void> }> = []
+
+  afterEach(async () => {
+    while (servers.length > 0) {
+      const { server, dispose } = servers.pop()!
+
+      await dispose()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  })
+
+  async function startServerWithGraphqlWS (options: { enforceOrigin?: boolean }) {
+    const server = createServer()
+    const handle = graphqlWS(server, '/__socket-graphql', options)
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const port = (server.address() as AddressInfo).port
+
+    servers.push({ server, dispose: handle.dispose })
+
+    return { port }
+  }
+
+  function openWs (port: number, origin: string | undefined): Promise<{ opened: boolean, statusCode?: number }> {
+    return new Promise((resolve) => {
+      const headers: Record<string, string> = {}
+
+      if (origin !== undefined) {
+        headers.Origin = origin
+      }
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/__socket-graphql`, 'graphql-transport-ws', { headers })
+      let opened = false
+      let statusCode: number | undefined
+      let done = false
+
+      const finish = () => {
+        if (done) return
+
+        done = true
+        resolve({ opened, statusCode })
+      }
+
+      ws.once('open', () => {
+        opened = true
+        ws.close()
+      })
+
+      ws.once('unexpected-response', (_req, res) => {
+        statusCode = res.statusCode
+        ws.terminate()
+        finish()
+      })
+
+      ws.once('close', () => finish())
+      ws.once('error', () => {})
+    })
+  }
+
+  describe('without enforceOrigin (default — used by the test-runner server)', () => {
+    it('accepts upgrade when Origin port does not match the server listen port', async () => {
+      const { port } = await startServerWithGraphqlWS({})
+
+      const result = await openWs(port, 'http://localhost:3000')
+
+      expect(result.opened).toBe(true)
+    })
+
+    it('accepts upgrade with no Origin header', async () => {
+      const { port } = await startServerWithGraphqlWS({})
+
+      const result = await openWs(port, undefined)
+
+      expect(result.opened).toBe(true)
+    })
+
+    it('accepts upgrade with a non-localhost Origin', async () => {
+      const { port } = await startServerWithGraphqlWS({})
+
+      const result = await openWs(port, EVIL_ORIGIN)
+
+      expect(result.opened).toBe(true)
+    })
+  })
+
+  describe('with enforceOrigin: true (used by the launchpad GraphQL server)', () => {
+    it('rejects upgrade when Origin port does not match the server listen port', async () => {
+      const { port } = await startServerWithGraphqlWS({ enforceOrigin: true })
+
+      const result = await openWs(port, 'http://localhost:3000')
+
+      expect(result.opened).toBe(false)
+      expect(result.statusCode).toBe(403)
+    })
+
+    it('accepts upgrade with the server\'s own origin', async () => {
+      const { port } = await startServerWithGraphqlWS({ enforceOrigin: true })
+
+      const result = await openWs(port, `http://localhost:${port}`)
+
+      expect(result.opened).toBe(true)
     })
   })
 })

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -259,7 +259,8 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
     this.server.on('connect', this.onConnect.bind(this))
     this.server.on('upgrade', (req, socket, head) => this.onUpgrade(req, socket, head, socketIoRoute))
 
-    this._graphqlWS = graphqlWS(this.server, `${socketIoRoute}-graphql`)
+    // enforceOrigin is disabled here because upgrades arrive via the cypress proxy with Origin reflecting the AUT host — never the runner port. Inbound connections are gated by socketAllowed.isRequestAllowed in proxyWebsockets.
+    this._graphqlWS = graphqlWS(this.server, `${socketIoRoute}-graphql`, { enforceOrigin: false })
 
     // Start the file server first so its port is known before we begin
     // listening for proxied requests on the main server. The primary

--- a/packages/server/test/integration/websockets_spec.js
+++ b/packages/server/test/integration/websockets_spec.js
@@ -328,7 +328,7 @@ describe('Web Sockets', () => {
     })
   })
 
-  context('graphql-ws handling on __socket-graphql', () => {
+  describe('graphql-ws handling on __socket-graphql', () => {
     beforeEach(function () {
       const automation = new Automation({
         cyNamespace: this.cfg.namespace,
@@ -339,7 +339,7 @@ describe('Web Sockets', () => {
       return this.server.startWebsockets(automation, this.cfg, {})
     })
 
-    const openGraphqlWs = function (origin) {
+    const openGraphqlWs = (origin) => {
       const agent = new httpsProxyAgent(`http://localhost:${cyPort}`)
       const headers = {}
 
@@ -379,22 +379,22 @@ describe('Web Sockets', () => {
       })
     }
 
-    it('accepts upgrade when Origin port differs from cypress server port', function () {
-      return openGraphqlWs(`http://localhost:${otherPort}`).then((result) => {
-        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
-      })
+    it('accepts upgrade when Origin port differs from cypress server port', async () => {
+      const result = await openGraphqlWs(`http://localhost:${otherPort}`)
+
+      expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
     })
 
-    it('accepts upgrade when Origin hostname is not localhost', function () {
-      return openGraphqlWs('http://foobar.com:4455').then((result) => {
-        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
-      })
+    it('accepts upgrade when Origin hostname is not localhost', async () => {
+      const result = await openGraphqlWs('http://foobar.com:4455')
+
+      expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
     })
 
-    it('accepts upgrade with no Origin header', function () {
-      return openGraphqlWs(undefined).then((result) => {
-        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
-      })
+    it('accepts upgrade with no Origin header', async () => {
+      const result = await openGraphqlWs(undefined)
+
+      expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
     })
   })
 })

--- a/packages/server/test/integration/websockets_spec.js
+++ b/packages/server/test/integration/websockets_spec.js
@@ -327,4 +327,74 @@ describe('Web Sockets', () => {
       })
     })
   })
+
+  context('graphql-ws handling on __socket-graphql', () => {
+    beforeEach(function () {
+      const automation = new Automation({
+        cyNamespace: this.cfg.namespace,
+        cookieNamespace: this.cfg.socketIoCookie,
+        screenshotsFolder: this.cfg.screenshotsFolder,
+      })
+
+      return this.server.startWebsockets(automation, this.cfg, {})
+    })
+
+    const openGraphqlWs = function (origin) {
+      const agent = new httpsProxyAgent(`http://localhost:${cyPort}`)
+      const headers = {}
+
+      if (origin !== undefined) {
+        headers.Origin = origin
+      }
+
+      return new Promise((resolve) => {
+        const client = new ws(`ws://localhost:${cyPort}/__socket-graphql`, 'graphql-transport-ws', {
+          agent,
+          headers,
+        })
+        let opened = false
+        let statusCode
+        let done = false
+
+        const finish = () => {
+          if (done) return
+
+          done = true
+          resolve({ opened, statusCode })
+        }
+
+        client.once('open', () => {
+          opened = true
+          client.close()
+        })
+
+        client.once('unexpected-response', (_req, res) => {
+          statusCode = res.statusCode
+          client.terminate()
+          finish()
+        })
+
+        client.once('close', () => finish())
+        client.once('error', () => {})
+      })
+    }
+
+    it('accepts upgrade when Origin port differs from cypress server port', function () {
+      return openGraphqlWs(`http://localhost:${otherPort}`).then((result) => {
+        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
+      })
+    })
+
+    it('accepts upgrade when Origin hostname is not localhost', function () {
+      return openGraphqlWs('http://foobar.com:4455').then((result) => {
+        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
+      })
+    })
+
+    it('accepts upgrade with no Origin header', function () {
+      return openGraphqlWs(undefined).then((result) => {
+        expect(result.opened, `expected upgrade to succeed; got statusCode=${result.statusCode}`).to.be.true
+      })
+    })
+  })
 })


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The CORS lockdown landed in #33811 (unreleased) added a same-port origin check to the shared `graphqlWS` upgrade handler (`packages/data-context/graphql/makeGraphQLServer.ts`). That helper is used in two places:

1. **Launchpad GraphQL server** (`makeGraphQLServer()`) — the browser loads the launchpad UI at the gql server's own port, so `Origin` port and `req.socket.localPort` match. The check works as intended.
2. **Test-runner server** (`packages/server/lib/server-base.ts:262`) — the browser's top URL is the AUT origin, and the cypress server listens on a different port. The upgrade arrives via the cypress proxy, so `Origin: http://<aut-host>:<aut-port>` and `req.socket.localPort = <cypress-server-port>` can never match. Every `__socket-graphql` upgrade gets a 403.

Symptom (caught locally during dev, since #33811 has not shipped): opening `cypress open` against any project whose AUT runs on a different port (the common case) produces a stream of `WebSocket connection to 'ws://<aut-host>:<aut-port>/__socket-graphql' failed: 403` errors and an empty `[Network] undefined` urql `CombinedError`. Studio and any other subscription-driven UI hangs because the subscription transport never connects. HTTP queries/mutations still work, which is why many existing tests didn't notice.

This change adds an `enforceOrigin` option on `graphqlWS` that defaults to `true` (secure by default). The launchpad call site keeps the default; the runner-side call in `server-base.ts` opts out explicitly with a brief comment pointing at the compensating `socketAllowed.isRequestAllowed` allowlist in `proxyWebsockets`. Any future caller of `graphqlWS` will get origin enforcement automatically and has to make a deliberate decision to disable it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebSocket upgrade/origin enforcement logic and relaxes checks for the test-runner server, which is security-sensitive even though the opt-out is explicit and still gated by existing allowlisting.
> 
> **Overview**
> Fixes a regression where `__socket-graphql` GraphQL-over-WebSocket upgrades were being rejected (403) when proxied through the Cypress server (Origin reflects the AUT, not the runner port).
> 
> `graphqlWS` now accepts an `enforceOrigin` option (default **true**) to keep strict same-port Origin checks for the launchpad GraphQL server while explicitly disabling them in `ServerBase` for the runner/proxy use case.
> 
> Adds unit coverage for both enforcement modes and new integration tests asserting `__socket-graphql` upgrades succeed through the proxy with cross-port, non-localhost, and missing `Origin` headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1e9cf9f2f7aee67b25289c9fdf37473a4faee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

1. `yarn cypress:open`, choose an E2E project whose AUT runs on a different port than the cypress server (e.g. TodoMVC on `localhost:3000`).
2. Launch the project, run a spec, open the browser devtools.
3. Verify: no `WebSocket connection to 'ws://<host>:<port>/__socket-graphql' failed: ... 403` errors, no `[Network] undefined` urql errors.
4. Open Studio from a passing test — the panel should load and reactive UI should be responsive.

Automated coverage added:

- `packages/data-context/test/unit/graphql/makeGraphQLServer.spec.ts` — 7 unit tests on the `graphqlWS` helper covering both the default (`enforceOrigin: true`, used by the launchpad GraphQL server — rejects cross-port and non-localhost origins, accepts self-origin and missing Origin) and the explicit opt-out (`enforceOrigin: false`, used by the test-runner server — accepts everything).
- `packages/server/test/integration/websockets_spec.js` — 3 integration tests inside the existing `Web Sockets` suite that boot a real `ServerBase`, open a WS to `__socket-graphql` through `httpsProxyAgent`, and assert the upgrade succeeds with a cross-port Origin, a non-localhost Origin, and no Origin header. Validated locally by temporarily reverting the fix and observing both cross-origin tests fail with 403.

### How has the user experience changed?

No change — #33811 has not been released, so no user has observed the regression this corrects.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [\`cypress-documentation\`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [\`type definitions\`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?