### PR TITLE
fix(cli): extract the Cypress binary with yauzl instead of extract-zip

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1292,6 +1292,14 @@ commands:
             fi
           working_directory: /tmp/<<parameters.repo>>
       - run:
+          # Explicitly install the binary in case the tarball's postinstall did
+          # not run (observed on npm 11.13.0, which is bundled with Node 24.16+).
+          name: Ensure Cypress binary is installed
+          working_directory: /tmp/<<parameters.repo>>
+          command: |
+            source ./ci-ensure-node.sh
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npx cypress install
+      - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
           command: |

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1293,11 +1293,13 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
       - run:
           # Explicitly install the binary in case the tarball's postinstall did not run.
+          # npm_config_loglevel=silent forces Listr's silent renderer so the install
+          # runs without a spinner that can stall in CI.
           name: Ensure Cypress binary is installed
           working_directory: /tmp/<<parameters.repo>>
           command: |
             source ./ci-ensure-node.sh
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npx cypress install
+            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm_config_loglevel=silent ./node_modules/.bin/cypress install
       - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1293,7 +1293,7 @@ commands:
           working_directory: /tmp/<<parameters.repo>>
       - run:
           # Explicitly install the binary in case the tarball's postinstall did
-          # not run (observed on npm 11.13.0, which is bundled with Node 24.16+).
+          # not run.
           name: Ensure Cypress binary is installed
           working_directory: /tmp/<<parameters.repo>>
           command: |

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1292,15 +1292,6 @@ commands:
             fi
           working_directory: /tmp/<<parameters.repo>>
       - run:
-          # Explicitly install the binary in case the tarball's postinstall did not run.
-          # npm_config_loglevel=silent forces Listr's silent renderer so the install
-          # runs without a spinner that can stall in CI.
-          name: Ensure Cypress binary is installed
-          working_directory: /tmp/<<parameters.repo>>
-          command: |
-            source ./ci-ensure-node.sh
-            CYPRESS_INSTALL_BINARY=~/cypress/cypress.zip npm_config_loglevel=silent ./node_modules/.bin/cypress install
-      - run:
           name: Print Cypress version
           working_directory: /tmp/<<parameters.repo>>
           command: |

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1292,8 +1292,7 @@ commands:
             fi
           working_directory: /tmp/<<parameters.repo>>
       - run:
-          # Explicitly install the binary in case the tarball's postinstall did
-          # not run.
+          # Explicitly install the binary in case the tarball's postinstall did not run.
           name: Ensure Cypress binary is installed
           working_directory: /tmp/<<parameters.repo>>
           command: |

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, leaving the test runner unable to launch with a "Cypress binary is missing" error. The Node-based unzip fallback no longer goes through `extract-zip` / `fd-slicer`, whose stream-based deflate pipeline stalls on the new Node release; it now uses a small `yauzl`-based extractor that preserves Unix file modes and refuses path-traversal entries. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
+- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, causing the test runner to fail to launch with a "Cypress binary is missing" error. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, causing the test runner to fail to launch with a "Cypress binary is missing" error. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
+- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, causing the test runner to fail to launch with a "Cypress binary is missing" error. Addresses [#33891](https://github.com/cypress-io/cypress/issues/33891). Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -17,7 +17,6 @@
 
 **Dependency Updates:**
 
-- Upgraded `yauzl` from `^2.10.0` to `^3.3.1` and removed `extract-zip` from the `cypress` package's `cli` dependencies. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Upgraded `esbuild` to `^0.28.0` to address [CVE-2025-68121](https://www.cve.org/CVERecord?id=CVE-2025-68121) in the bundled `esbuild` Go binary (incorrect TLS certificate validation during session resumption), as reported in container and image security scans. Fixes [#33599](https://github.com/cypress-io/cypress/issues/33599). Addressed in [#33816](https://github.com/cypress-io/cypress/pull/33816).
 
 ## 15.15.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, leaving the test runner unable to launch with a "Cypress binary is missing" error. The Node-based unzip fallback no longer goes through `extract-zip` / `fd-slicer`, whose stream-based deflate pipeline stalls on the new Node release; it now uses a small `yauzl`-based extractor that preserves Unix file modes and refuses path-traversal entries. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).
@@ -16,6 +17,7 @@
 
 **Dependency Updates:**
 
+- Upgraded `yauzl` from `^2.10.0` to `^3.3.1` and removed `extract-zip` from the `cypress` package's `cli` dependencies. Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Upgraded `esbuild` to `^0.28.0` to address [CVE-2025-68121](https://www.cve.org/CVERecord?id=CVE-2025-68121) in the bundled `esbuild` Go binary (incorrect TLS certificate validation during session resumption), as reported in container and image security scans. Fixes [#33599](https://github.com/cypress-io/cypress/issues/33599). Addressed in [#33816](https://github.com/cypress-io/cypress/pull/33816).
 
 ## 15.15.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue on Node 24.16.0+ where installing Cypress could silently extract only the first file from the binary archive, causing the test runner to fail to launch with a "Cypress binary is missing" error. Addresses [#33891](https://github.com/cypress-io/cypress/issues/33891). Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
+- Fixed an issue on Node 24.16.0+ and Node 26.1.0+ where installing Cypress could silently extract only the first file from the binary archive, causing the test runner to fail to launch with a "Cypress binary is missing" error. Addresses [#33891](https://github.com/cypress-io/cypress/issues/33891). Addressed in [#33887](https://github.com/cypress-io/cypress/pull/33887).
 - Fixed an issue where Cypress would abort the process and show a crash dialog when it received a SIGINT. Fixes [#29228](https://github.com/cypress-io/cypress/issues/29228). Fixed in [#33542](https://github.com/cypress-io/cypress/pull/33542/).
 - Fixed an issue where the [`clientCertificates`](https://docs.cypress.io/guides/references/client-certificates) config option failed to load ECDSA (EC) PEM or PKCS#12 client certificates. Fixes [#33767](https://github.com/cypress-io/cypress/issues/33767). Fixed in [#33799](https://github.com/cypress-io/cypress/pull/33799).
 - Fixed an issue where clicking "back to projects" or switching projects while a project's initial config load was still in flight could fail. Fixed in [#33810](https://github.com/cypress-io/cypress/pull/33810).

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -2,10 +2,9 @@ import _ from 'lodash'
 import path from 'path'
 import yauzl from 'yauzl'
 import fs from 'fs'
+import fsp from 'fs/promises'
 import { promisify } from 'util'
 import stream from 'stream'
-
-const fsp = fs.promises
 
 const pipelineAsync = promisify(stream.pipeline)
 
@@ -44,6 +43,7 @@ const extractWithYauzl = async (
       }
 
       const finish = _.once((err?: Error) => {
+        zipFile.removeAllListeners?.()
         zipFile.close?.()
         if (err) {
           return reject(err)

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -96,7 +96,7 @@ const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Prom
       throw new Error(`Refusing to extract symlink with target larger than ${MAX_SYMLINK_TARGET_BYTES} bytes: ${entry.fileName}`)
     }
 
-    const linkTarget = await readEntryAsString(zipFile, entry)
+    const linkTarget = await readEntryAsString(zipFile, entry, MAX_SYMLINK_TARGET_BYTES)
     const resolvedTarget = path.resolve(path.dirname(fileDest), linkTarget)
 
     if (
@@ -129,18 +129,43 @@ const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Prom
   await pipelineAsync(readStream, writeStream)
 }
 
-const readEntryAsString = (zipFile: any, entry: any): Promise<string> => {
+const readEntryAsString = (zipFile: any, entry: any, maxBytes: number): Promise<string> => {
   return new Promise((resolve, reject) => {
-    zipFile.openReadStream(entry, (err: any, rs: NodeJS.ReadableStream) => {
+    zipFile.openReadStream(entry, (err: any, rs: NodeJS.ReadableStream & { destroy?: (err?: Error) => void }) => {
       if (err) {
         return reject(err)
       }
 
       const chunks: Buffer[] = []
+      let received = 0
+      let bailed = false
 
-      rs.on('data', (chunk: Buffer) => chunks.push(chunk))
-      rs.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
-      rs.on('error', reject)
+      const bail = (err: Error) => {
+        if (bailed) return
+
+        bailed = true
+        rs.destroy?.(err)
+        reject(err)
+      }
+
+      rs.on('data', (chunk: Buffer) => {
+        received += chunk.length
+        if (received > maxBytes) {
+          bail(new Error(`Refusing to read entry body larger than ${maxBytes} bytes: ${entry.fileName}`))
+
+          return
+        }
+
+        chunks.push(chunk)
+      })
+
+      rs.on('end', () => {
+        if (bailed) return
+
+        resolve(Buffer.concat(chunks).toString('utf8'))
+      })
+
+      rs.on('error', bail)
     })
   })
 }

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -25,7 +25,7 @@ const MAX_SYMLINK_TARGET_BYTES = 4096
  * per archive entry processed. Refuses entries whose resolved path would
  * escape the destination directory.
  */
-export const extractWithYauzl = async (
+const extractWithYauzl = async (
   zipFilePath: string,
   destDir: string,
   onEntry: () => void,

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -1,0 +1,143 @@
+import _ from 'lodash'
+import path from 'path'
+import yauzl from 'yauzl'
+import fs from 'fs-extra'
+import { promisify } from 'util'
+import stream from 'stream'
+
+const pipelineAsync = promisify(stream.pipeline)
+
+// Unix file mode masks for entries stored in zip's externalFileAttributes
+// (the high 16 bits when the file was zipped on a Unix host).
+const S_IFMT = 0o170000
+const S_IFLNK = 0o120000
+
+// PATH_MAX on Linux/macOS is 4096; symlink targets larger than this are not
+// legal filesystem paths and almost certainly indicate a malformed or
+// malicious archive. The cap also prevents reading an arbitrarily large
+// "symlink" entry into memory.
+const MAX_SYMLINK_TARGET_BYTES = 4096
+
+/**
+ * Extracts the contents of a zip archive into the given destination directory.
+ * Recreates directories, regular files, and symlinks while preserving Unix
+ * file modes encoded in each entry's external attributes. Calls `onEntry` once
+ * per archive entry processed. Refuses entries whose resolved path would
+ * escape the destination directory.
+ */
+export const extractWithYauzl = async (
+  zipFilePath: string,
+  destDir: string,
+  onEntry: () => void,
+): Promise<void> => {
+  const resolvedDest = path.resolve(destDir)
+
+  await new Promise<void>((resolve, reject) => {
+    yauzl.open(zipFilePath, { lazyEntries: true }, (err: any, zipFile: any) => {
+      if (err) {
+        return reject(err)
+      }
+
+      const finish = _.once((err?: Error) => {
+        zipFile.close?.()
+        if (err) {
+          return reject(err)
+        }
+
+        return resolve()
+      })
+
+      zipFile.on('error', finish)
+      zipFile.on('end', () => finish())
+      zipFile.on('entry', (entry: any) => {
+        handleEntry(zipFile, entry, resolvedDest)
+        .then(() => {
+          onEntry()
+          zipFile.readEntry()
+        })
+        .catch(finish)
+      })
+
+      zipFile.readEntry()
+    })
+  })
+}
+
+const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Promise<void> => {
+  const fileDest = path.resolve(resolvedDest, entry.fileName)
+
+  // refuse anything that would write outside the install dir
+  if (
+    fileDest !== resolvedDest &&
+    !fileDest.startsWith(resolvedDest + path.sep)
+  ) {
+    throw new Error(`Refusing to extract entry outside of destination: ${entry.fileName}`)
+  }
+
+  const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff
+  const isDir = /\/$/.test(entry.fileName)
+  const isSymlink = (unixMode & S_IFMT) === S_IFLNK
+
+  if (isDir) {
+    await fs.ensureDir(fileDest)
+
+    return
+  }
+
+  await fs.ensureDir(path.dirname(fileDest))
+
+  if (isSymlink) {
+    if (entry.uncompressedSize > MAX_SYMLINK_TARGET_BYTES) {
+      throw new Error(`Refusing to extract symlink with target larger than ${MAX_SYMLINK_TARGET_BYTES} bytes: ${entry.fileName}`)
+    }
+
+    const linkTarget = await readEntryAsString(zipFile, entry)
+    const resolvedTarget = path.resolve(path.dirname(fileDest), linkTarget)
+
+    if (
+      resolvedTarget !== resolvedDest &&
+      !resolvedTarget.startsWith(resolvedDest + path.sep)
+    ) {
+      throw new Error(`Refusing to extract symlink pointing outside of destination: ${entry.fileName} -> ${linkTarget}`)
+    }
+
+    await fs.remove(fileDest).catch(() => undefined)
+    await fs.symlink(linkTarget, fileDest)
+
+    return
+  }
+
+  const readStream: NodeJS.ReadableStream = await new Promise((res, rej) => {
+    zipFile.openReadStream(entry, (err: any, rs: NodeJS.ReadableStream) => {
+      if (err) {
+        return rej(err)
+      }
+
+      return res(rs)
+    })
+  })
+
+  // Preserve the Unix mode bits when present; otherwise fall back to a sane default.
+  const fileMode = (unixMode & 0o7777) || 0o644
+  const writeStream = fs.createWriteStream(fileDest, { mode: fileMode })
+
+  await pipelineAsync(readStream, writeStream)
+}
+
+const readEntryAsString = (zipFile: any, entry: any): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    zipFile.openReadStream(entry, (err: any, rs: NodeJS.ReadableStream) => {
+      if (err) {
+        return reject(err)
+      }
+
+      const chunks: Buffer[] = []
+
+      rs.on('data', (chunk: Buffer) => chunks.push(chunk))
+      rs.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+      rs.on('error', reject)
+    })
+  })
+}
+
+export default extractWithYauzl

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -43,7 +43,13 @@ const extractWithYauzl = async (
         return reject(err)
       }
 
+      // `settled` guards against an in-flight `handleEntry` calling
+      // `zipFile.readEntry()` on a now-closed handle when extraction has
+      // already failed (e.g. yauzl emitted 'error' while we were writing
+      // an entry to disk).
+      let settled = false
       const finish = _.once((err?: Error) => {
+        settled = true
         zipFile.removeAllListeners?.()
         zipFile.close?.()
         if (err) {
@@ -65,6 +71,8 @@ const extractWithYauzl = async (
       zipFile.on('entry', (entry: any) => {
         handleEntry(zipFile, entry, resolvedDest)
         .then(() => {
+          if (settled) return
+
           onEntry()
           zipFile.readEntry()
         })

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -33,7 +33,10 @@ export const extractWithYauzl = async (
   const resolvedDest = path.resolve(destDir)
 
   await new Promise<void>((resolve, reject) => {
-    yauzl.open(zipFilePath, { lazyEntries: true }, (err: any, zipFile: any) => {
+    // autoClose: false — `finish` below owns closing the zipfile, so we don't
+    // want yauzl's internal end-listener closing it first and tripping a
+    // double-close (EBADF) when we do.
+    yauzl.open(zipFilePath, { lazyEntries: true, autoClose: false }, (err: any, zipFile: any) => {
       if (err) {
         return reject(err)
       }

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -1,9 +1,11 @@
 import _ from 'lodash'
 import path from 'path'
 import yauzl from 'yauzl'
-import fs from 'fs-extra'
+import fs from 'fs'
 import { promisify } from 'util'
 import stream from 'stream'
+
+const fsp = fs.promises
 
 const pipelineAsync = promisify(stream.pipeline)
 
@@ -82,12 +84,12 @@ const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Prom
   const isSymlink = (unixMode & S_IFMT) === S_IFLNK
 
   if (isDir) {
-    await fs.ensureDir(fileDest)
+    await fsp.mkdir(fileDest, { recursive: true })
 
     return
   }
 
-  await fs.ensureDir(path.dirname(fileDest))
+  await fsp.mkdir(path.dirname(fileDest), { recursive: true })
 
   if (isSymlink) {
     if (entry.uncompressedSize > MAX_SYMLINK_TARGET_BYTES) {
@@ -104,8 +106,8 @@ const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Prom
       throw new Error(`Refusing to extract symlink pointing outside of destination: ${entry.fileName} -> ${linkTarget}`)
     }
 
-    await fs.remove(fileDest).catch(() => undefined)
-    await fs.symlink(linkTarget, fileDest)
+    await fsp.rm(fileDest, { recursive: true, force: true })
+    await fsp.symlink(linkTarget, fileDest)
 
     return
   }

--- a/cli/lib/tasks/extract-with-yauzl.ts
+++ b/cli/lib/tasks/extract-with-yauzl.ts
@@ -11,6 +11,7 @@ const pipelineAsync = promisify(stream.pipeline)
 // Unix file mode masks for entries stored in zip's externalFileAttributes
 // (the high 16 bits when the file was zipped on a Unix host).
 const S_IFMT = 0o170000
+const S_IFDIR = 0o040000
 const S_IFLNK = 0o120000
 
 // PATH_MAX on Linux/macOS is 4096; symlink targets larger than this are not
@@ -52,7 +53,14 @@ const extractWithYauzl = async (
         return resolve()
       })
 
-      zipFile.on('error', finish)
+      // Normalize any thrown / emitted value into a real Error so that a
+      // falsy rejection (e.g. `Promise.reject(undefined)`) doesn't get
+      // misread by `finish` as a successful completion.
+      const fail = (err: unknown) => {
+        finish(err instanceof Error ? err : new Error(typeof err === 'string' && err ? err : 'zip extraction failed'))
+      }
+
+      zipFile.on('error', fail)
       zipFile.on('end', () => finish())
       zipFile.on('entry', (entry: any) => {
         handleEntry(zipFile, entry, resolvedDest)
@@ -60,7 +68,7 @@ const extractWithYauzl = async (
           onEntry()
           zipFile.readEntry()
         })
-        .catch(finish)
+        .catch(fail)
       })
 
       zipFile.readEntry()
@@ -80,7 +88,10 @@ const handleEntry = async (zipFile: any, entry: any, resolvedDest: string): Prom
   }
 
   const unixMode = (entry.externalFileAttributes >>> 16) & 0xffff
-  const isDir = /\/$/.test(entry.fileName)
+  // Some archivers mark directories by Unix mode bits instead of (or in
+  // addition to) a trailing slash; honor both so we don't extract a
+  // directory entry as a zero-byte file.
+  const isDir = /\/$/.test(entry.fileName) || (unixMode & S_IFMT) === S_IFDIR
   const isSymlink = (unixMode & S_IFMT) === S_IFLNK
 
   if (isDir) {

--- a/cli/lib/tasks/unzip.ts
+++ b/cli/lib/tasks/unzip.ts
@@ -3,7 +3,7 @@ import cp from 'child_process'
 import os from 'os'
 import yauzl from 'yauzl'
 import Debug from 'debug'
-import extract from 'extract-zip'
+import extractWithYauzl from './extract-with-yauzl'
 import readline from 'readline'
 import fs from 'fs-extra'
 import { throwFormErrorText, errors } from '../errors'
@@ -13,11 +13,17 @@ import assert from 'assert'
 const debug = Debug('cypress:cli:unzip')
 
 const unzipTools = {
-  extract,
+  extractWithYauzl,
+}
+
+interface UnzipOpts {
+  zipFilePath: string
+  installDir: string
+  progress: { onProgress: (percent: number, secsRemaining: string) => unknown }
 }
 
 // expose this function for simple testing
-const unzip = async ({ zipFilePath, installDir, progress }: any): Promise<void> => {
+const unzip = async ({ zipFilePath, installDir, progress }: UnzipOpts): Promise<void> => {
   debug('unzipping from %s', zipFilePath)
   debug('into', installDir)
 
@@ -31,7 +37,10 @@ const unzip = async ({ zipFilePath, installDir, progress }: any): Promise<void> 
   await fs.ensureDir(installDir)
 
   await new Promise<void>((resolve, reject) => {
-    return yauzl.open(zipFilePath, (err: any, zipFile: any) => {
+    // Open with lazyEntries so yauzl doesn't auto-emit entries (which would
+    // require the fd to stay open for the duration of the OS-tool extraction).
+    // We only need the entryCount here for the progress calculation.
+    return yauzl.open(zipFilePath, { lazyEntries: true }, (err: any, zipFile: any) => {
       yauzlDoneTime = Date.now()
 
       if (err) {
@@ -43,6 +52,9 @@ const unzip = async ({ zipFilePath, installDir, progress }: any): Promise<void> 
       const total = zipFile.entryCount
 
       debug('zipFile entries count', total)
+
+      // Close the count-only handle — the Node fallback re-opens the zip for extraction.
+      zipFile.close()
 
       const started = new Date()
 
@@ -69,15 +81,8 @@ const unzip = async ({ zipFilePath, installDir, progress }: any): Promise<void> 
       const unzipWithNode = async (): Promise<any> => {
         debug('unzipping with node.js (slow)')
 
-        const opts = {
-          dir: installDir,
-          onEntry: tick,
-        }
-
-        debug('calling Node extract tool %s %o', zipFilePath, opts)
-
         try {
-          await unzipTools.extract(zipFilePath, opts)
+          await unzipTools.extractWithYauzl(zipFilePath, installDir, tick)
           debug('node unzip finished')
 
           return resolve()

--- a/cli/package.json
+++ b/cli/package.json
@@ -44,7 +44,6 @@
     "eventemitter2": "6.4.7",
     "execa": "4.1.0",
     "executable": "^4.1.1",
-    "extract-zip": "2.0.1",
     "fs-extra": "^9.1.0",
     "hasha": "5.2.2",
     "is-installed-globally": "~0.4.0",
@@ -63,7 +62,7 @@
     "tslib": "1.14.1",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",
-    "yauzl": "^2.10.0"
+    "yauzl": "^3.3.1"
   },
   "devDependencies": {
     "@cypress/angular": "0.0.0-development",

--- a/cli/test/lib/tasks/__snapshots__/unzip.spec.ts.snap
+++ b/cli/test/lib/tasks/__snapshots__/unzip.spec.ts.snap
@@ -27,7 +27,7 @@ https://github.com/cypress-io/cypress/issues
 
 ----------
 
-Error: end of central directory record signature not found
+Error: End of central directory record signature not found. Either not a zip file, or file is truncated.
 
 ----------
 

--- a/cli/test/lib/tasks/extract-with-yauzl.spec.ts
+++ b/cli/test/lib/tasks/extract-with-yauzl.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import zlib from 'zlib'
+
+import extractWithYauzl from '../../../lib/tasks/extract-with-yauzl'
+
+// ---------------------------------------------------------------------------
+// Test helpers: build small zip archives in memory, byte-by-byte, so we can
+// exercise the extractor's behavior around modes, symlinks, path traversal,
+// and oversized / lying entries without checking in binary fixtures.
+// ---------------------------------------------------------------------------
+
+interface ZipEntryInput {
+  name: string
+  /** raw bytes for the entry body. For symlinks, this is the link target. */
+  body?: Buffer
+  /** if true, the entry is stored uncompressed (method 0); otherwise deflate (method 8). */
+  store?: boolean
+  /** Unix mode bits to encode in externalFileAttributes (high 16 bits). */
+  unixMode?: number
+  /** override the uncompressedSize field in the central + local headers (for "lying" zips). */
+  fakeUncompressedSize?: number
+}
+
+const buildZip = (entries: ZipEntryInput[]): Buffer => {
+  const localBlocks: Buffer[] = []
+  const cdrBlocks: Buffer[] = []
+  let offset = 0
+
+  for (const e of entries) {
+    const isDir = e.name.endsWith('/')
+    const fnBuf = Buffer.from(e.name)
+    const body = e.body || Buffer.alloc(0)
+    const method = isDir || e.store ? 0 : 8
+    const stored = method === 8 ? zlib.deflateRawSync(body) : body
+    const crc = zlib.crc32(body)
+    const declaredUncompressed = e.fakeUncompressedSize !== undefined ? e.fakeUncompressedSize : body.length
+    const externalAttr = ((e.unixMode || 0) << 16) >>> 0
+
+    const lfh = Buffer.alloc(30)
+
+    lfh.writeUInt32LE(0x04034b50, 0)
+    lfh.writeUInt16LE(20, 4)
+    lfh.writeUInt16LE(method, 8)
+    lfh.writeUInt32LE(crc, 14)
+    lfh.writeUInt32LE(stored.length, 18)
+    lfh.writeUInt32LE(declaredUncompressed, 22)
+    lfh.writeUInt16LE(fnBuf.length, 26)
+
+    localBlocks.push(lfh, fnBuf, stored)
+
+    const cdr = Buffer.alloc(46)
+
+    cdr.writeUInt32LE(0x02014b50, 0)
+    cdr.writeUInt16LE(20, 4)
+    cdr.writeUInt16LE(20, 6)
+    cdr.writeUInt16LE(method, 10)
+    cdr.writeUInt32LE(crc, 16)
+    cdr.writeUInt32LE(stored.length, 20)
+    cdr.writeUInt32LE(declaredUncompressed, 24)
+    cdr.writeUInt16LE(fnBuf.length, 28)
+    cdr.writeUInt32LE(externalAttr, 38)
+    cdr.writeUInt32LE(offset, 42)
+
+    cdrBlocks.push(cdr, fnBuf)
+
+    offset += lfh.length + fnBuf.length + stored.length
+  }
+
+  const cdrConcat = Buffer.concat(cdrBlocks)
+  const eocd = Buffer.alloc(22)
+
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(entries.length, 8)
+  eocd.writeUInt16LE(entries.length, 10)
+  eocd.writeUInt32LE(cdrConcat.length, 12)
+  eocd.writeUInt32LE(offset, 16)
+
+  return Buffer.concat([...localBlocks, cdrConcat, eocd])
+}
+
+const writeZip = (entries: ZipEntryInput[]): string => {
+  const zipPath = path.join(os.tmpdir(), `cy-extract-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.zip`)
+
+  fs.writeFileSync(zipPath, buildZip(entries))
+
+  return zipPath
+}
+
+describe('lib/tasks/extract-with-yauzl', () => {
+  let destDir: string
+  let onEntry: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    destDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'cy-extract-test-'))
+    onEntry = vi.fn()
+  })
+
+  afterEach(async () => {
+    await fsp.rm(destDir, { recursive: true, force: true })
+  })
+
+  it('extracts a single deflated file with default permissions', async () => {
+    const zip = writeZip([{ name: 'hello.txt', body: Buffer.from('hi there') }])
+
+    await extractWithYauzl(zip, destDir, onEntry)
+
+    const out = await fsp.readFile(path.join(destDir, 'hello.txt'), 'utf8')
+
+    expect(out).to.equal('hi there')
+    expect(onEntry).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates directory entries', async () => {
+    const zip = writeZip([
+      { name: 'sub/', unixMode: 0o755 },
+      { name: 'sub/inner.txt', body: Buffer.from('inside') },
+    ])
+
+    await extractWithYauzl(zip, destDir, onEntry)
+
+    expect((await fsp.stat(path.join(destDir, 'sub'))).isDirectory()).to.equal(true)
+    expect(await fsp.readFile(path.join(destDir, 'sub/inner.txt'), 'utf8')).to.equal('inside')
+    expect(onEntry).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves Unix file modes on extracted files', async () => {
+    const zip = writeZip([{ name: 'bin', body: Buffer.from('payload'), unixMode: 0o755 }])
+
+    await extractWithYauzl(zip, destDir, onEntry)
+
+    const stat = await fsp.stat(path.join(destDir, 'bin'))
+
+    // mask off file-type bits, keep only permission bits
+    expect(stat.mode & 0o777).to.equal(0o755)
+  })
+
+  it('creates symlinks for entries with the Unix symlink mode', async () => {
+    const zip = writeZip([
+      { name: 'target.txt', body: Buffer.from('real') },
+      { name: 'link', body: Buffer.from('target.txt'), unixMode: 0o120777, store: true },
+    ])
+
+    await extractWithYauzl(zip, destDir, onEntry)
+
+    const stat = await fsp.lstat(path.join(destDir, 'link'))
+
+    expect(stat.isSymbolicLink()).to.equal(true)
+    expect(await fsp.readlink(path.join(destDir, 'link'))).to.equal('target.txt')
+    expect(await fsp.readFile(path.join(destDir, 'link'), 'utf8')).to.equal('real')
+  })
+
+  it('refuses an entry whose path escapes the destination', async () => {
+    const zip = writeZip([{ name: '../escape.txt', body: Buffer.from('nope') }])
+
+    // yauzl 3.x rejects the entry name itself ("invalid relative path"); our own
+    // path-traversal guard would also catch this. Either rejection is acceptable.
+    await expect(extractWithYauzl(zip, destDir, onEntry)).rejects.toThrow()
+
+    expect(fs.existsSync(path.join(destDir, '..', 'escape.txt'))).to.equal(false)
+  })
+
+  it('refuses a symlink whose target resolves outside the destination', async () => {
+    const zip = writeZip([
+      { name: 'link', body: Buffer.from('../../etc/passwd'), unixMode: 0o120777, store: true },
+    ])
+
+    await expect(extractWithYauzl(zip, destDir, onEntry)).rejects.toThrow(/symlink pointing outside of destination/)
+
+    expect(fs.existsSync(path.join(destDir, 'link'))).to.equal(false)
+  })
+
+  it('refuses a symlink whose declared size exceeds the cap', async () => {
+    const big = Buffer.alloc(8 * 1024, 'a')
+    const zip = writeZip([{ name: 'link', body: big, unixMode: 0o120777, store: true }])
+
+    await expect(extractWithYauzl(zip, destDir, onEntry)).rejects.toThrow(/symlink with target larger than/)
+  })
+
+  it('refuses a symlink whose actual streamed body exceeds the cap (lying uncompressedSize)', async () => {
+    // declare 4 bytes in the headers, but actually stream 8 KB. yauzl 3.x
+    // catches the size mismatch during read; if a future yauzl ever surfaces
+    // the body anyway, our own per-chunk cap in readEntryAsString catches it.
+    const big = Buffer.alloc(8 * 1024, 'a')
+    const zip = writeZip([
+      { name: 'link', body: big, unixMode: 0o120777, store: true, fakeUncompressedSize: 4 },
+    ])
+
+    await expect(extractWithYauzl(zip, destDir, onEntry)).rejects.toThrow()
+  })
+
+  it('rejects an invalid zip file', async () => {
+    const bogus = path.join(os.tmpdir(), `cy-extract-test-bogus-${Date.now()}.zip`)
+
+    fs.writeFileSync(bogus, 'not a zip file')
+
+    await expect(extractWithYauzl(bogus, destDir, onEntry)).rejects.toThrow()
+
+    await fsp.unlink(bogus)
+  })
+})

--- a/cli/test/lib/tasks/extract-with-yauzl.spec.ts
+++ b/cli/test/lib/tasks/extract-with-yauzl.spec.ts
@@ -127,6 +127,16 @@ describe('lib/tasks/extract-with-yauzl', () => {
     expect(onEntry).toHaveBeenCalledTimes(2)
   })
 
+  it('treats entries with the Unix directory mode as directories even without a trailing slash', async () => {
+    // S_IFDIR (0o040000) in the high 16 bits of externalFileAttributes,
+    // and no trailing slash on the entry name.
+    const zip = writeZip([{ name: 'sub', unixMode: 0o040755, store: true }])
+
+    await extractWithYauzl(zip, destDir, onEntry)
+
+    expect((await fsp.stat(path.join(destDir, 'sub'))).isDirectory()).to.equal(true)
+  })
+
   it('preserves Unix file modes on extracted files', async () => {
     const zip = writeZip([{ name: 'bin', body: Buffer.from('payload'), unixMode: 0o755 }])
 
@@ -200,5 +210,18 @@ describe('lib/tasks/extract-with-yauzl', () => {
     await expect(extractWithYauzl(bogus, destDir, onEntry)).rejects.toThrow()
 
     await fsp.unlink(bogus)
+  })
+
+  it('rejects (not resolves) when a per-entry write fails — even with a falsy rejection', async () => {
+    // simulate a write failure by making the destination a file that already
+    // has a child path that should be a directory — fsp.mkdir on the parent
+    // will reject, and we want to make sure that rejection surfaces.
+    const blocker = path.join(destDir, 'blocked')
+
+    await fsp.writeFile(blocker, 'i am a file, not a directory')
+
+    const zip = writeZip([{ name: 'blocked/inside.txt', body: Buffer.from('hi') }])
+
+    await expect(extractWithYauzl(zip, destDir, onEntry)).rejects.toThrow()
   })
 })

--- a/cli/test/lib/tasks/unzip.spec.ts
+++ b/cli/test/lib/tasks/unzip.spec.ts
@@ -2,7 +2,6 @@ import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import events from 'events'
 import os from 'os'
 import path from 'path'
-import extract from 'extract-zip'
 import cp from 'child_process'
 import createDebug from 'debug'
 import readline from 'readline'
@@ -13,13 +12,14 @@ import { Console } from 'console'
 import logger from '../../../lib/logger'
 import util from '../../../lib/util'
 import unzip from '../../../lib/tasks/unzip'
+import extractWithYauzl from '../../../lib/tasks/extract-with-yauzl'
 
 const debug = createDebug('test')
 
 const version = '1.2.3'
 const installDir = path.join(os.tmpdir(), 'Cypress', version)
 
-vi.mock('extract-zip')
+vi.mock('../../../lib/tasks/extract-with-yauzl')
 vi.mock('child_process')
 vi.mock('readline')
 vi.mock('fs-extra')
@@ -64,7 +64,7 @@ vi.mock('../../../lib/util', async (importActual) => {
 describe('lib/tasks/unzip', function () {
   const createStdoutCapture = () => {
     const logs: string[] = []
-    // eslint-disable-next-line no-console
+
     const originalOut = process.stdout.write
 
     vi.spyOn(process.stdout, 'write').mockImplementation((strOrBugger: string | Uint8Array<ArrayBufferLike>) => {
@@ -87,10 +87,9 @@ describe('lib/tasks/unzip', function () {
       release: 'OsVersion',
     } as Systeminformation.OsData)
 
-    // @ts-expect-error - default import
-    const actualExtract = (await vi.importActual<typeof import('extract-zip')>('extract-zip')).default
+    const actualExtract = (await vi.importActual<typeof import('../../../lib/tasks/extract-with-yauzl')>('../../../lib/tasks/extract-with-yauzl')).default
 
-    vi.mocked(extract).mockImplementation(actualExtract)
+    vi.mocked(extractWithYauzl).mockImplementation(actualExtract)
 
     // @ts-expect-error - default import
     const actualChildProcess = (await vi.importActual<typeof import('child_process')>('child_process')).default
@@ -176,12 +175,7 @@ describe('lib/tasks/unzip', function () {
     it('can try unzip first then fall back to node unzip', async function () {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      vi.mocked(extract).mockImplementation((filePath: any, opts: any) => {
-        debug('unzip extract called with %s', filePath)
-        expect(filePath, 'zipfile is the same').toEqual(zipFilePath)
-
-        return Promise.resolve(undefined)
-      })
+      vi.mocked(extractWithYauzl).mockResolvedValue(undefined)
 
       const unzipChildProcess = new events.EventEmitter()
 
@@ -213,16 +207,13 @@ describe('lib/tasks/unzip', function () {
 
       debug('checking if unzip was called')
       expect(cp.spawn).toHaveBeenCalledExactlyOnceWith('unzip', ['-o', zipFilePath, '-d', installDir])
-      expect(extract).toHaveBeenCalledExactlyOnceWith(zipFilePath, expect.objectContaining({
-        dir: installDir,
-        onEntry: expect.any(Function),
-      }))
+      expect(extractWithYauzl).toHaveBeenCalledExactlyOnceWith(zipFilePath, installDir, expect.any(Function))
     })
 
     it('can try unzip first then fall back to node unzip and fails with an empty error', async function () {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      vi.mocked(extract).mockRejectedValue(undefined)
+      vi.mocked(extractWithYauzl).mockRejectedValue(undefined)
 
       const unzipChildProcess = new events.EventEmitter()
 
@@ -264,12 +255,7 @@ describe('lib/tasks/unzip', function () {
     it('calls node unzip just once', async function () {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      vi.mocked(extract).mockImplementation((filePath: any, opts: any) => {
-        debug('unzip extract called with %s', filePath)
-        expect(filePath, 'zipfile is the same').toEqual(zipFilePath)
-
-        return Promise.resolve(undefined)
-      })
+      vi.mocked(extractWithYauzl).mockResolvedValue(undefined)
 
       const unzipChildProcess = new events.EventEmitter()
 
@@ -307,10 +293,7 @@ describe('lib/tasks/unzip', function () {
 
       debug('checking if unzip was called')
       expect(cp.spawn).toHaveBeenCalledExactlyOnceWith('unzip', ['-o', zipFilePath, '-d', installDir])
-      expect(extract).toHaveBeenCalledExactlyOnceWith(zipFilePath, expect.objectContaining({
-        dir: installDir,
-        onEntry: expect.any(Function),
-      }))
+      expect(extractWithYauzl).toHaveBeenCalledExactlyOnceWith(zipFilePath, installDir, expect.any(Function))
     })
   })
 
@@ -322,12 +305,7 @@ describe('lib/tasks/unzip', function () {
     it('calls node unzip just once', async function () {
       const zipFilePath = path.join('test', 'fixture', 'example.zip')
 
-      vi.mocked(extract).mockImplementation((filePath: any, opts: any) => {
-        debug('unzip extract called with %s', filePath)
-        expect(filePath, 'zipfile is the same').toEqual(zipFilePath)
-
-        return Promise.resolve(undefined)
-      })
+      vi.mocked(extractWithYauzl).mockResolvedValue(undefined)
 
       const unzipChildProcess = new events.EventEmitter()
 
@@ -364,10 +342,7 @@ describe('lib/tasks/unzip', function () {
 
       debug('checking if unzip was called')
       expect(cp.spawn).toHaveBeenCalledExactlyOnceWith('ditto', ['-xkV', zipFilePath, installDir])
-      expect(extract).toHaveBeenCalledExactlyOnceWith(zipFilePath, expect.objectContaining({
-        dir: installDir,
-        onEntry: expect.any(Function),
-      }))
+      expect(extractWithYauzl).toHaveBeenCalledExactlyOnceWith(zipFilePath, installDir, expect.any(Function))
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -33318,6 +33318,14 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
+yauzl@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.3.1.tgz#b0de68ae3a862715e130849679a4236f54dba45f"
+  integrity sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    pend "~1.2.0"
+
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33891

### Additional details

The `test-binary-against-kitchensink*` CircleCI jobs (electron, chrome, firefox) started failing on develop on 2026-05-21 with:

```
The cypress npm package is installed, but the Cypress binary is missing.
We expected the binary to be installed here: /root/.cache/Cypress/beta-15.16.0-develop-<sha>/Cypress/Cypress
```

The trigger was a Node patch release picked up by `nvm install 24`:

| Run | Node | npm | Cypress binary after install |
|---|---|---|---|
| Last passing | v24.15.0 | 11.12.1 | `15.16.0` ✅ |
| First failing | v24.16.0 | 11.13.0 | `not installed` ❌ |

#### Root cause

Cypress's `postinstall` runs as expected on Node 24.16.0, but the **zip-extraction pipeline inside `extract-zip` silently truncates after the first compressed entry**. Bisected with minimal reproductions, the failure is in this pipeline:

```text
yauzl@2.x  ReadStream   →   zlib.createInflateRaw()   →   fs.createWriteStream
```

`yauzl@2.x`'s read stream uses `fd-slicer`, which hasn't been updated in 8 years. Something about how its `Readable` interacts with a `zlib` Transform changed in Node 24.16.0: `_read` is invoked, bytes accumulate in the source's internal buffer, but **zero bytes are forwarded into `InflateRaw`** — and no `data`, `end`, `close`, or `error` event fires on any stream. The process exits cleanly with code 0 because nothing keeps the event loop alive, and the post-install reports success despite having extracted only the first file in the archive.

The CircleCI failures came from the trixie base image not having the system `unzip` tool installed, so the Linux job fell back to the Node-based extractor (`extract-zip` → `yauzl@2.x` → `fd-slicer`). macOS (`ditto`) and most user environments with a working system `unzip` were unaffected.

`yauzl@3.x` dropped `fd-slicer` in favor of reading via `fs.read` directly and is unaffected by the regression.

#### The fix

- Bump `yauzl` to `^3.3.1` and drop `extract-zip`.
- Replace the Node fallback in `cli/lib/tasks/unzip.ts` with a small extractor (`cli/lib/tasks/extract-with-yauzl.ts`) built on yauzl + `fs.createWriteStream`. The new extractor:
  - preserves Unix file modes (so the binary keeps its `+x` bit),
  - recreates directories and symlinks,
  - refuses entries whose resolved path escapes the destination,
  - refuses symlinks whose target resolves outside the destination,
  - caps the in-memory read of a symlink body to `PATH_MAX` (4096 bytes).
- The OS-tool primary paths (`unzip` on Linux, `ditto` on macOS) are unchanged.

#### Follow-up

Windows currently uses the Node-based extractor as its primary path because `tar.exe` wasn't available when the original code was written. Windows 10 1803+ has shipped `tar.exe` for years, so a follow-up task can migrate Windows to match the Linux/macOS pattern of "OS tool primary, Node fallback." That is beyond the scope of this regression fix.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the Cypress binary extraction path used during `cypress install` (including Windows’ primary unzip implementation), so any regressions could break installs across platforms; it also touches archive-handling logic where mistakes can have security implications.
> 
> **Overview**
> Fixes a Node 24.16+/26.1+ regression where Cypress installation could silently extract only the first file by **removing `extract-zip`** and switching the CLI’s Node-based unzip to a new `yauzl`-driven extractor.
> 
> Adds `extract-with-yauzl` to safely recreate directories, files, and symlinks while preserving Unix modes, and includes guards against path traversal and out-of-destination symlinks plus a capped in-memory symlink-target read. Updates unzip progress handling to only open the zip for entry counting, bumps `yauzl` to `^3.3.1`, updates/extends unit tests (including new extractor tests), and documents the fix in the CLI changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5287ab46b6969612d09830259f3f788cc77641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

- Confirm the `test-binary-against-kitchensink`, `test-binary-against-kitchensink-chrome`, and `test-binary-against-kitchensink-firefox` jobs pass on this PR.
- Confirm `test-binary-against-recipes*`, `test-binary-against-cypress-realworld-app`, and the macOS/Windows binary jobs still pass.
- Confirm the new `cli` unit tests in `cli/test/lib/tasks/unzip.spec.ts` pass (`yarn workspace cypress test-unit -- unzip.spec.ts`).

### How has the user experience changed?

No user-visible change. The binary that lands on disk is identical; only the extraction path that produced it has changed.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
