### PR TITLE
fix(server): cap Firefox BiDi networkRemoveIntercept with a 2s timeout

### DIFF
--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -289,17 +289,29 @@ export class BidiAutomation {
       this.autContextId = undefined
       this.setTopLevelContextId(undefined)
       if (this.interceptId) {
+        const interceptToRemove = this.interceptId
+
+        // Clear state up-front so the field stays consistent regardless of how the BiDi call resolves.
+        this.interceptId = undefined
+
         // since we either have:
         //   1. a new upper level browser context created above with shouldKeepTabOpen set to true.
         //   2. all the previous contexts are destroyed.
-        // we should clean up our top level interceptor to prevent a memory leak as we no longer need it
-        await this.webDriverClient.networkRemoveIntercept({
-          intercept: this.interceptId,
-        })
+        // we should clean up our top level interceptor to prevent a memory leak as we no longer need it.
+        //
+        // On Firefox 144 BiDi, network.removeIntercept can race with the browsingContext.close
+        // that just destroyed the context owning this intercept and never ack — which kills the
+        // automation socket and aborts the run. Cap the wait so a wedged server can't take us down.
+        try {
+          await Promise.race([
+            this.webDriverClient.networkRemoveIntercept({ intercept: interceptToRemove }),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('networkRemoveIntercept timed out (best-effort cleanup)')), 2000)),
+          ])
 
-        debug(`destroyed network intercept ${this.interceptId}`)
-
-        this.interceptId = undefined
+          debug(`destroyed network intercept ${interceptToRemove}`)
+        } catch (err) {
+          debug(`networkRemoveIntercept best-effort cleanup failed for ${interceptToRemove}: %s`, (err as Error).message)
+        }
       }
     }
 

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -1,7 +1,11 @@
 import EventEmitter from 'node:events'
 import type { Client as WebDriverClient } from 'webdriver'
-import { expect } from 'chai'
+import chai, { expect } from 'chai'
 import sinon from 'sinon'
+import sinonChai from '@cypress/sinon-chai'
+import chaiAsPromised from 'chai-as-promised'
+
+chai.use(sinonChai).use(chaiAsPromised)
 import { toInteger } from 'lodash'
 import { BidiAutomation } from '../../../lib/browsers/bidi_automation'
 import type { NetworkBeforeRequestSentParametersModified } from '../../../lib/browsers/bidi_automation'
@@ -195,6 +199,56 @@ describe('lib/browsers/bidi_automation', () => {
             expect(bidiAutomationInstance.topLevelContextId).to.be.undefined
             // @ts-expect-error
             expect(bidiAutomationInstance.interceptId).to.be.undefined
+            // @ts-expect-error
+            expect(bidiAutomationInstance.autContextId).to.equal(undefined)
+          })
+
+          // Regression: Firefox 144 BiDi can leave network.removeIntercept hanging when it races
+          // with the browsingContext.close of the owning context. The handler must not block the
+          // automation socket indefinitely on a wedged BiDi server.
+          it('does not block automation when networkRemoveIntercept hangs', async function () {
+            this.timeout(5000)
+
+            // never-resolving promise simulates a wedged Firefox BiDi server
+            mockWebdriverClient.networkRemoveIntercept = sinon.stub().returns(new Promise(() => {}))
+
+            const bidiAutomationInstance = BidiAutomation.create(mockWebdriverClient, mockAutomationClient)
+
+            bidiAutomationInstance.setTopLevelContextId('123')
+
+            mockWebdriverClient.emit('browsingContext.contextCreated', {
+              parent: '123',
+              context: '456',
+              url: 'www.foobar.com',
+              userContext: '',
+              children: [],
+            })
+
+            await flushPromises()
+            await waitForAsyncOperation(mockWebdriverClient.networkAddIntercept as sinon.SinonStub)
+
+            // @ts-expect-error
+            expect(bidiAutomationInstance.interceptId).to.equal('mockInterceptId')
+
+            mockWebdriverClient.emit('browsingContext.contextDestroyed', {
+              parent: null,
+              context: '123',
+              url: 'www.foobar.com',
+              userContext: '',
+              children: ['456'],
+            })
+
+            // wait past the 2s best-effort timeout so the swallowed rejection has fired
+            await new Promise((resolve) => setTimeout(resolve, 2500))
+
+            expect(mockWebdriverClient.networkRemoveIntercept).to.have.been.calledWith({
+              intercept: 'mockInterceptId',
+            })
+
+            // @ts-expect-error — even though the BiDi call never resolved, internal state is clean
+            expect(bidiAutomationInstance.interceptId).to.be.undefined
+            // @ts-expect-error
+            expect(bidiAutomationInstance.topLevelContextId).to.be.undefined
             // @ts-expect-error
             expect(bidiAutomationInstance.autContextId).to.equal(undefined)
           })


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

On Firefox 144 with BiDi, `network.removeIntercept` can race with the `browsingContext.close` that just destroyed the context owning the intercept. The BiDi server then never acknowledges the call, the WebDriver client surfaces a socket failure, and the automation socket dies — aborting the Cypress run.

This change makes the intercept teardown best-effort:

- Snapshot `interceptId` and clear it on the instance up-front, so internal state stays consistent regardless of how the BiDi call resolves.
- Race `networkRemoveIntercept` against a 2s timeout so a wedged BiDi server can't block the destroy path.
- Swallow + `debug`-log any failure since the upper-level browsing context is being torn down anyway and the intercept dies with it.

This is a pure resilience fix — the happy path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cleanup behavior in BiDi automation teardown and adds a timeout/race that could mask real interceptor-removal failures, but it’s limited to best-effort cleanup when a top-level context is already destroyed.
> 
> **Overview**
> Makes BiDi interceptor teardown **best-effort** when the top-level browsing context is destroyed to avoid Firefox 144 hangs. The destroy handler now snapshots and clears `interceptId` immediately, then races `networkRemoveIntercept` against a 2s timeout and swallows/logs any failure instead of blocking.
> 
> Adds a unit regression test that simulates a never-resolving `networkRemoveIntercept` and asserts the destroy path still clears internal context/intercept state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d248caa262d2c5de13eb3c7f728820d951cd40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run the new unit test:
   ```
   yarn workspace @packages/server test-unit -- test/unit/browsers/bidi_automation_spec.ts --grep "does not block automation when networkRemoveIntercept hangs"
   ```
2. The test stubs `networkRemoveIntercept` with a never-resolving promise, emits `browsingContext.contextDestroyed`, and asserts that internal state (`interceptId`, `topLevelContextId`, `autContextId`) is cleared and the call was issued — without the destroy path hanging.

### How has the user experience changed?

No visible change on the happy path. On Firefox 144 BiDi, runs that previously aborted due to a hung `network.removeIntercept` will now continue cleanly; the failure is logged via `debug` instead of killing the automation socket.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?