### PR TITLE
chore(ci): bump npm-puppeteer-cypress-tests resource_class to default

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2594,7 +2594,6 @@ jobs:
 
   npm-puppeteer-cypress-tests:
     <<: *defaults
-    resource_class: small
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-npm-puppeteer-tests >>


### PR DESCRIPTION
- Closes [n/a]

### Additional details

The `npm-puppeteer-cypress-tests` CircleCI job has been flaking at ~5% (11 of 231 runs over the last 7 days) with a consistent fingerprint:

- Dies mid-extraction during the **Restore system tests node_modules cache** step
- Last log line is always `Extracting using zstd`
- Job ends with `status=failed`, `canceled=False`, `why=github` — but no `exit_code`, no `fail_reason`, no test results
- The step itself shows `canceled`, suggesting the agent process was killed out-of-band (consistent with an OOM during extraction)

The cache is **1.9 GiB compressed**, and this is the only consumer of `restore_cached_system_tests_deps` running on `resource_class: small` (2 GB RAM). Every other consumer — `run-system-tests`, `run-webpack-dev-server-integration-tests` (`medium+`), `v8-integration-tests`, etc. — uses the executor default (`medium`, 4 GB) or higher. zstd extraction peak memory occasionally tips a 2 GB box over the limit.

This PR drops the `resource_class: small` override so the job inherits the executor default `medium`, matching its siblings. If the flake disappears, we have our answer; if it persists, the next step is a CircleCI support ticket with the failure UUIDs.

Recent failure samples for reference (all same fingerprint):
- [3656860](https://app.circleci.com/pipelines/github/cypress-io/cypress/81979/workflows/24dbe899-0203-40bd-a9f7-32f4b24b9e42/jobs/3656860)
- 3655135, 3654739, 3654357, 3653294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that increases CircleCI resources for a single job; low functional risk but may slightly impact CI cost/queue time.
> 
> **Overview**
> Removes the `resource_class: small` override from the `npm-puppeteer-cypress-tests` CircleCI job so it inherits the executor default (currently `medium`). This is intended to reduce flakes during dependency cache restore by running the job with more available memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aeabe91e25d278a7aa324522bb8a655dc550d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Watch the CI run on this PR — the `npm-puppeteer-cypress-tests` job should pass and the cache restore should complete cleanly. Longer-term: monitor the failure rate over the next ~200 runs on develop.

### How has the user experience changed?

No change. CI infrastructure only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?