### PR TITLE
dependency: bump shell-quote to 1.8.4 to fix critical command injection

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -28588,9 +28588,9 @@ shell-env@4.0.1:
     strip-ansi "^7.0.1"
 
 shell-quote@^1.6.1, shell-quote@^1.7.3, shell-quote@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 shelljs@0.8.5:
   version "0.8.5"


### PR DESCRIPTION
- Closes n/a (Snyk vulnerability remediation)

### Additional details

Relocks `shell-quote` from 1.8.1 → 1.8.4 to resolve [SNYK-JS-SHELLQUOTE-16799355](https://security.snyk.io/vuln/SNYK-JS-SHELLQUOTE-16799355) (Arbitrary Command Injection, **critical**).

`shell-quote` is pulled in transitively via `launch-editor@2.9.1 > shell-quote@1.8.1`. All declared ranges in the lockfile (`^1.6.1`, `^1.7.3`, `^1.8.1`) already permit 1.8.4, so this is a relock-only fix — no `package.json` changes or `resolutions` entry needed.

Verified:
- shell-quote now resolves to 1.8.4 in `yarn.lock`
- 1.8.4 is not deprecated on npm
- Snyk re-scan at critical severity reports 0 vulnerabilities across all 58 projects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a lockfile-only patch bump of a transitive dependency. Main risk is minor behavioral changes in shell argument quoting/parsing in tooling that relies on `shell-quote`.
> 
> **Overview**
> This PR **relocks a single transitive dependency** by updating `shell-quote` from `1.8.1` to `1.8.4` in `yarn.lock`, pulling in the upstream fix for a *critical command injection* advisory.
> 
> No `package.json` ranges or application code change; only the resolved tarball/integrity for `shell-quote` is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcff1a9efa965d1ea75d2ab53467f4f4bfdbcda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

No behavior change. CI green is sufficient.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- mechanical dependency security bump -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?