### PR TITLE
test: preserve allowCypressEnv in subscription test config rewrites

### DIFF
--- a/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
@@ -23,6 +23,7 @@ describe('errorWarningChange subscription', () => {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: '20',
@@ -36,6 +37,7 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: 20,
@@ -53,6 +55,7 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: ,
@@ -67,6 +70,7 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: 20,

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -164,6 +164,7 @@ describe('specChange subscription', () => {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -312,6 +313,7 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -436,6 +438,7 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -461,6 +464,7 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
+  allowCypressEnv: false,
   projectId: 'abc123',
   experimentalInteractiveRunEvents: true,
   component: {


### PR DESCRIPTION
### Additional details

`specChange-subscription.cy.ts` and `errorWarningChange-subscription.cy.ts` both overwrite the `cypress-in-cypress` fixture's `cypress.config.js` wholesale. The original fixture has `allowCypressEnv: false`, but every wholesale rewrite in these two specs has been omitting it — so the value flips back to its default `true`.

`allowCypressEnv` is flagged `requireRestartOnChange: 'server'` in `packages/config/src/options.ts`, so that change forces a server restart on every config reload these tests trigger. The restart calls `OpenProject.create`, which tries to re-bind port `4455` before the previous server has released it, and the resulting `Port 4455 is already in use` error leaves the data-context in a broken state. The driver-side symptom is the spec list never updating ("Found `17`, expected `3`"), an urql `[Network] undefined` toast in the AUT, or the loading spinner sticking around.

This was the actual cause of the long-running Mac/Linux flakes that prior PRs (#33729, #33823) tried to paper over with timeout bumps. The graceful-teardown work in #33542 widened the port-release window and made the race fire consistently rather than rarely.

The other tests that rewrite `cypress.config.js` (`cypress-in-cypress.cy.ts`, `specs_list_switcher.cy.ts`, `specs.cy.ts`, `cypress-in-cypress-component.cy.ts`, `configChange-subscription.cy.ts`) all use a `readFile → string-replace → writeFile` pattern that preserves the fixture's keys, so they aren't affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only change to embedded config strings; no runtime or user-facing code paths.
> 
> **Overview**
> Subscription e2e specs that **fully rewrite** `cypress.config.js` now include **`allowCypressEnv: false`** in every embedded config string, matching the `cypress-in-cypress` fixture.
> 
> Previously those rewrites dropped the flag, so it reverted to the default **`true`**. Because **`allowCypressEnv`** is **`requireRestartOnChange: 'server'`**, each reload triggered an extra server restart and port races (Mac/Linux flakes in spec-list and error-warning subscription tests). Other subscription tests that patch config via read/replace were already unaffected.
> 
> **Scope:** `errorWarningChange-subscription.cy.ts` (four rewrites) and `specChange-subscription.cy.ts` (four rewrites). No product behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af35b59fa1e7249d7fbbe2c1d96748bc4914ca17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run `yarn workspace @packages/app cypress:run:e2e -- --spec cypress/e2e/subscriptions/specChange-subscription.cy.ts --browser chrome` several times on Mac/Linux — it should pass on every run.
2. Same for `errorWarningChange-subscription.cy.ts`.
3. The follow-up: the 15s timeouts added in #33729 and #33823 can be reverted back to the original values in a follow-up cleanup — the assertions now resolve in well under a second.

### How has the user experience changed?

No change. Tests-only fix.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?