### PR TITLE
chore: bump cypress-example-kitchensink to 6.0.2 for release

### DIFF
--- a/guides/release-process.md
+++ b/guides/release-process.md
@@ -86,11 +86,11 @@ _Note: It is advisable to notify the team that the `develop` branch is locked do
 
 2. Ensure all changes to the links manifest to [`on.cypress.io`](https://github.com/cypress-io/cypress-services/tree/develop/packages/on) have been merged to `develop` and deployed.
 
-3. Create a Release PR -
+3. (optional) Create a Release PR -
    Bump, submit, get approvals on, and merge a new PR. This PR should:
-    - Bump the Cypress `version` in [`package.json`](package.json)
     - Bump the [`packages/example`](../packages/example) dependency if there is a new [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink/releases) version, and `yarn` to ensure the lockfile is up to date.
     - Follow the writing the [Cypress Changelog release steps](./writing-the-cypress-changelog.md#release) to update the [`cli/CHANGELOG.md`](../cli/CHANGELOG.md).
+    - NOTE: If edits to the [`cli/CHANGELOG.md`](../cli/CHANGELOG.md) are not needed, nor is a new version of [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink/releases), this step can be skipped and the last build off `develop` can be used below.
 
 4. Once the `develop` branch is passing in CI and you have confirmed the `cypress-bot` has commented on the commit with the pre-release versions for `darwin-x64`, `darwin-arm64`, `linux-x64`,`linux-arm64`, and `win32-x64`, publishing can proceed.
     Tips for getting a green build:

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
     "test-unit": "echo 'no unit tests'"
   },
   "devDependencies": {
-    "cypress-example-kitchensink": "6.0.0",
+    "cypress-example-kitchensink": "6.0.2",
     "gh-pages": "5.0.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14201,10 +14201,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-cypress-example-kitchensink@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-6.0.0.tgz#935fa68b41ec4e03316075bb1ace38f1087f91fd"
-  integrity sha512-01XN6mhvPIVNHw7ZHVkPYxUROxd1WrmwbVJ5PU+OKh+RKMhzsGHcAkOoGJ7enxFgKoNOSbZeyZEv5+SC8eBisg==
+cypress-example-kitchensink@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-6.0.2.tgz#1b87eb80a07776b82d07d15965bb4103f817506e"
+  integrity sha512-Khi6Olh6xxezUWt6ZZ9vP6nK4p+mZGGjIh2tnYGMTnl3TKxNW6OLcveDs2oD+kBSgMI7tL633Jh6Yvynl/mKYQ==
   dependencies:
     npm-run-all2 "8.0.4"
     serve "14.2.6"


### PR DESCRIPTION
## Summary

- Bump `cypress-example-kitchensink` from `6.0.0` to `6.0.2` in `@packages/example` and update `yarn.lock`.
- Clarify in the release process guide that the release PR step is optional when no changelog or kitchensink updates are required.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only changes with no runtime product logic.
> 
> **Overview**
> Updates **`@packages/example`** to use **`cypress-example-kitchensink` 6.0.2** (from 6.0.0) and refreshes **`yarn.lock`** accordingly.
> 
> The **release process** guide now marks step 3 (**Create a Release PR**) as **optional**, and notes that when neither **`cli/CHANGELOG.md`** nor a new kitchensink release is required, teams can skip that PR and ship from the latest **`develop`** build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0fc38e0c0051b18d6d9644c37df3ef1e1cd1f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->