### PR TITLE
chore: Pass remoteOrigin to the cloud on login/signup

### DIFF
--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -4,8 +4,8 @@ import { gql } from '@urql/core'
 
 export interface AuthApiShape {
   getUser(): Promise<Partial<AuthenticatedUserShape>>
-  logIn(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape>
-  signUp(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape>
+  logIn(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape | undefined>
+  signUp(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape | undefined>
   logOut(): Promise<void>
   resetAuthState(): void
 }
@@ -81,7 +81,7 @@ export class AuthActions {
 
     const ac = new AbortController()
 
-    const user = await new Promise<AuthenticatedUserShape | null>((resolve, reject) => {
+    const user = await new Promise<AuthenticatedUserShape | null | undefined>((resolve, reject) => {
       // A resolver is exposed to the instance so that we can
       // resolve this promise and the original mutation promise
       // if a reset occurs. We also abort the signal so any async

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -4,8 +4,8 @@ import { gql } from '@urql/core'
 
 export interface AuthApiShape {
   getUser(): Promise<Partial<AuthenticatedUserShape>>
-  logIn(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null): Promise<AuthenticatedUserShape>
-  signUp(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null): Promise<AuthenticatedUserShape>
+  logIn(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape>
+  signUp(onMessage: (message: AuthStateShape) => void, utmSource: string, utmMedium: string, utmContent: string | null, signal?: AbortSignal): Promise<AuthenticatedUserShape>
   logOut(): Promise<void>
   resetAuthState(): void
 }
@@ -57,14 +57,14 @@ export class AuthActions {
   }
 
   async login (utmSource: string, utmMedium: string, utmContent?: string | null) {
-    return this.#authenticate((onMessage, utmSource, utmMedium, utmContent) => {
-      return this.authApi.logIn(onMessage, utmSource, utmMedium, utmContent)
+    return this.#authenticate((onMessage, utmSource, utmMedium, utmContent, signal) => {
+      return this.authApi.logIn(onMessage, utmSource, utmMedium, utmContent, signal)
     }, utmSource, utmMedium, utmContent)
   }
 
   async signup (utmSource: string, utmMedium: string, utmContent?: string | null) {
-    return this.#authenticate((onMessage, utmSource, utmMedium, utmContent) => {
-      return this.authApi.signUp(onMessage, utmSource, utmMedium, utmContent)
+    return this.#authenticate((onMessage, utmSource, utmMedium, utmContent, signal) => {
+      return this.authApi.signUp(onMessage, utmSource, utmMedium, utmContent, signal)
     }, utmSource, utmMedium, utmContent)
   }
 
@@ -79,14 +79,20 @@ export class AuthActions {
       this.ctx.emitter.authChange()
     }
 
+    const ac = new AbortController()
+
     const user = await new Promise<AuthenticatedUserShape | null>((resolve, reject) => {
       // A resolver is exposed to the instance so that we can
       // resolve this promise and the original mutation promise
-      // if a reset occurs
-      this.#cancelActiveLogin = () => resolve(null)
+      // if a reset occurs. We also abort the signal so any async
+      // work gated on it (e.g. the git-origin lookup) is skipped.
+      this.#cancelActiveLogin = () => {
+        ac.abort()
+        resolve(null)
+      }
 
       // NOTE: auth should never reject, it uses `onMessage` to propagate state changes (including errors) to the frontend.
-      authenticate(onMessage, utmSource, utmMedium, utmContent || null).then(resolve, reject)
+      authenticate(onMessage, utmSource, utmMedium, utmContent || null, ac.signal).then(resolve, reject)
     })
 
     const isMainWindowFocused = this.ctx._apis.electronApi.isMainWindowFocused()

--- a/packages/data-context/test/unit/actions/AuthActions.spec.ts
+++ b/packages/data-context/test/unit/actions/AuthActions.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, jest, it } from '@jest/globals'
 import type { DataContext } from '../../../src'
 import { AuthActions } from '../../../src/actions/AuthActions'
+import type { AuthenticatedUserShape } from '../../../src/data'
 import { createTestDataContext } from '../helper'
 import { FoundBrowser } from '@packages/types'
 
@@ -130,6 +131,37 @@ describe('AuthActions', () => {
       expect(ctx._apis.electronApi.focusMainWindow).not.toHaveBeenCalled()
       expect(ctx._apis.browserApi.focusActiveBrowserWindow).not.toHaveBeenCalled()
     })
+
+    it('aborts the pending auth and does not set user when resetAuthState is called during login', async () => {
+      let capturedSignal: AbortSignal | undefined
+
+      jest.mocked(ctx._apis.authApi.logIn).mockImplementation(
+        (_onMessage, _utmSource, _utmMedium, _utmContent, signal) => {
+          capturedSignal = signal
+
+          // Simulate the async git-origin lookup being in flight — never resolves
+          return new Promise<AuthenticatedUserShape>(() => {})
+        },
+      )
+
+      const loginPromise = actions.login('Binary: App', 'In-App')
+
+      // The mock is called synchronously before the first await in #authenticate,
+      // so capturedSignal is already set here
+      expect(capturedSignal).toBeInstanceOf(AbortSignal)
+      expect(capturedSignal!.aborted).toBe(false)
+
+      // User cancels while the git-origin lookup is in flight
+      actions.resetAuthState()
+
+      // resetAuthState must have aborted the signal so the logIn implementation
+      // can gate auth.start on signal.aborted and bail out
+      expect(capturedSignal!.aborted).toBe(true)
+
+      // The outer promise resolves via #cancelActiveLogin; user must not be set
+      await loginPromise
+      expect(ctx.coreData.user).toBeNull()
+    })
   })
 
   describe('.signup', () => {
@@ -152,7 +184,7 @@ describe('AuthActions', () => {
     it('calls authApi.signUp with utm parameters', async () => {
       await actions.signup('Binary: App', 'Studio', 'Signup')
 
-      expect(ctx._apis.authApi.signUp).toHaveBeenCalledWith(expect.any(Function), 'Binary: App', 'Studio', 'Signup')
+      expect(ctx._apis.authApi.signUp).toHaveBeenCalledWith(expect.any(Function), 'Binary: App', 'Studio', 'Signup', expect.any(AbortSignal))
       expect(ctx._apis.authApi.logIn).not.toHaveBeenCalled()
     })
 

--- a/packages/server/lib/cloud/auth.ts
+++ b/packages/server/lib/cloud/auth.ts
@@ -36,7 +36,7 @@ const buildLoginRedirectUrl = (server) => {
   return `http://127.0.0.1:${port}/redirect-to-auth`
 }
 
-const buildFullAuthUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent, flow = 'login') => {
+const buildFullAuthUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent, flow = 'login', remoteOrigin) => {
   const { port } = server.address()
   const authFlow = AUTH_FLOWS[flow] || AUTH_FLOWS.login
 
@@ -56,6 +56,10 @@ const buildFullAuthUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent
       platform: os.platform(),
     }
 
+    if (remoteOrigin) {
+      authUrl.query.remoteOrigin = remoteOrigin
+    }
+
     if (utmMedium) {
       authUrl.query = {
         utm_source: utmSource,
@@ -70,12 +74,12 @@ const buildFullAuthUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent
   })
 }
 
-const buildFullLoginUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent) => {
-  return buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, 'login')
+const buildFullLoginUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent, remoteOrigin) => {
+  return buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, 'login', remoteOrigin)
 }
 
-const buildFullSignupUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent) => {
-  return buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, 'signup')
+const buildFullSignupUrl = (baseLoginUrl, server, utmSource, utmMedium, utmContent, remoteOrigin) => {
+  return buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, 'signup', remoteOrigin)
 }
 
 const getOriginFromUrl = (originalUrl) => {
@@ -87,7 +91,7 @@ const getOriginFromUrl = (originalUrl) => {
 /**
  * @returns the currently running auth server instance, launches one if there is not one
  */
-const launchServer = (baseLoginUrl, sendMessage, utmSource, utmMedium, utmContent, flow = 'login') => {
+const launchServer = (baseLoginUrl, sendMessage, utmSource, utmMedium, utmContent, flow = 'login', remoteOrigin) => {
   if (!server) {
     // launch an express server to listen for the auth callback from Cypress Cloud
     const origin = getOriginFromUrl(baseLoginUrl)
@@ -98,7 +102,7 @@ const launchServer = (baseLoginUrl, sendMessage, utmSource, utmMedium, utmConten
     app.get('/redirect-to-auth', (req, res) => {
       authRedirectReached = true
 
-      buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, flow)
+      buildFullAuthUrl(baseLoginUrl, server, utmSource, utmMedium, utmContent, flow, remoteOrigin)
       .then((fullAuthUrl) => {
         debug('Received GET to /redirect-to-auth, redirecting: %o', { fullAuthUrl })
 
@@ -211,7 +215,7 @@ const _internal = {
 /**
  * @returns a promise that is resolved with a user when auth is complete or rejected when it fails
  */
-const startAuth = (flow, onMessage, utmSource, utmMedium, utmContent) => {
+const startAuth = (flow, onMessage, utmSource, utmMedium, utmContent, remoteOrigin) => {
   function sendMessage (name, message) {
     onMessage({
       name,
@@ -224,7 +228,7 @@ const startAuth = (flow, onMessage, utmSource, utmMedium, utmContent) => {
 
   return authFlow.getBaseUrl()
   .then((baseAuthUrl) => {
-    return _internal.launchServer(baseAuthUrl, sendMessage, utmSource, utmMedium, utmContent, flow)
+    return _internal.launchServer(baseAuthUrl, sendMessage, utmSource, utmMedium, utmContent, flow, remoteOrigin)
   })
   .then(() => {
     return _internal.buildLoginRedirectUrl(server)
@@ -253,12 +257,12 @@ const startAuth = (flow, onMessage, utmSource, utmMedium, utmContent) => {
 /**
  * @returns a promise that is resolved with a user when auth is complete or rejected when it fails
  */
-const start = (onMessage, utmSource, utmMedium, utmContent) => {
-  return startAuth('login', onMessage, utmSource, utmMedium, utmContent)
+const start = (onMessage, utmSource, utmMedium, utmContent, remoteOrigin) => {
+  return startAuth('login', onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
 }
 
-const startSignup = (onMessage, utmSource, utmMedium, utmContent) => {
-  return startAuth('signup', onMessage, utmSource, utmMedium, utmContent)
+const startSignup = (onMessage, utmSource, utmMedium, utmContent, remoteOrigin) => {
+  return startAuth('signup', onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
 }
 
 export = {

--- a/packages/server/lib/makeDataContext.ts
+++ b/packages/server/lib/makeDataContext.ts
@@ -86,14 +86,14 @@ export function makeDataContext (options: MakeDataContextOptions): DataContext {
         return user.get()
       },
       logIn (onMessage, utmSource, utmMedium, utmContent, signal) {
-        return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+        return resolveAuthRemoteOrigin().catch(() => {}).then((remoteOrigin) => {
           if (signal?.aborted) return
 
           return auth.start(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
         })
       },
       signUp (onMessage, utmSource, utmMedium, utmContent, signal) {
-        return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+        return resolveAuthRemoteOrigin().catch(() => {}).then((remoteOrigin) => {
           if (signal?.aborted) return
 
           return auth.startSignup(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)

--- a/packages/server/lib/makeDataContext.ts
+++ b/packages/server/lib/makeDataContext.ts
@@ -43,7 +43,7 @@ export { getCtx, setCtx, clearCtx }
 
 async function resolveAuthRemoteOrigin (): Promise<string | undefined> {
   const ctx = getCtx()
-  const projectRoot = ctx?.coreData.currentProject
+  const projectRoot = ctx.coreData.currentProject
 
   if (!projectRoot) {
     return Promise.resolve(undefined)

--- a/packages/server/lib/makeDataContext.ts
+++ b/packages/server/lib/makeDataContext.ts
@@ -86,13 +86,17 @@ export function makeDataContext (options: MakeDataContextOptions): DataContext {
       getUser () {
         return user.get()
       },
-      logIn (onMessage, utmSource, utmMedium, utmContent) {
+      logIn (onMessage, utmSource, utmMedium, utmContent, signal) {
         return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+          if (signal?.aborted) return
+
           return auth.start(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
         })
       },
-      signUp (onMessage, utmSource, utmMedium, utmContent) {
+      signUp (onMessage, utmSource, utmMedium, utmContent, signal) {
         return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+          if (signal?.aborted) return
+
           return auth.startSignup(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
         })
       },

--- a/packages/server/lib/makeDataContext.ts
+++ b/packages/server/lib/makeDataContext.ts
@@ -18,6 +18,7 @@ import type {
 import browserUtils from './browsers/utils'
 import auth from './cloud/auth'
 import user from './cloud/user'
+import commitInfo from './util/commit-info'
 import * as cohorts from './cohorts'
 import { openProject } from './open_project'
 import { cache } from './cache'
@@ -39,6 +40,19 @@ interface MakeDataContextOptions {
 }
 
 export { getCtx, setCtx, clearCtx }
+
+async function resolveAuthRemoteOrigin (): Promise<string | undefined> {
+  const ctx = getCtx()
+  const projectRoot = ctx?.coreData.currentProject
+
+  if (!projectRoot) {
+    return Promise.resolve(undefined)
+  }
+
+  const commit = await commitInfo.commitInfo(projectRoot)
+
+  return commit?.remote ?? undefined
+}
 
 export function makeDataContext (options: MakeDataContextOptions): DataContext {
   const ctx = new DataContext({
@@ -73,10 +87,14 @@ export function makeDataContext (options: MakeDataContextOptions): DataContext {
         return user.get()
       },
       logIn (onMessage, utmSource, utmMedium, utmContent) {
-        return auth.start(onMessage, utmSource, utmMedium, utmContent)
+        return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+          return auth.start(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
+        })
       },
       signUp (onMessage, utmSource, utmMedium, utmContent) {
-        return auth.startSignup(onMessage, utmSource, utmMedium, utmContent)
+        return resolveAuthRemoteOrigin().then((remoteOrigin) => {
+          return auth.startSignup(onMessage, utmSource, utmMedium, utmContent, remoteOrigin)
+        })
       },
       logOut () {
         return user.logOut()

--- a/packages/server/lib/makeDataContext.ts
+++ b/packages/server/lib/makeDataContext.ts
@@ -46,12 +46,11 @@ async function resolveAuthRemoteOrigin (): Promise<string | undefined> {
   const projectRoot = ctx.coreData.currentProject
 
   if (!projectRoot) {
-    return Promise.resolve(undefined)
+    return
   }
 
-  const commit = await commitInfo.commitInfo(projectRoot)
-
-  return commit?.remote ?? undefined
+  return commitInfo.getRemoteOrigin(projectRoot)
+    .then((value) => value ?? undefined)
 }
 
 export function makeDataContext (options: MakeDataContextOptions): DataContext {

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -518,7 +518,6 @@ export class ProjectBase extends EE {
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_START)
             await browsers.connectProtocolToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, protocolManager: studio.protocolManager })
-
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_END)
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_STUDIO_TO_BROWSER_START)

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -509,20 +509,17 @@ export class ProjectBase extends EE {
               return { canAccessStudioAI, cloudStudioSessionId }
             }
 
-            const protocolManager = studio.protocolManager
-
-            protocolManager.setupProtocol()
-            protocolManager.beforeSpec({
+            this.protocolManager = studio.protocolManager
+            this.protocolManager.setupProtocol()
+            this.protocolManager.beforeSpec({
               ...this.spec,
               instanceId: randomUUID(),
             })
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_START)
-            await browsers.connectProtocolToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, protocolManager })
-            telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_END)
+            await browsers.connectProtocolToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, protocolManager: studio.protocolManager })
 
-            // Attach to the proxy only after connectToBrowser has initialized network capture.
-            this.protocolManager = protocolManager
+            telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_END)
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_STUDIO_TO_BROWSER_START)
             await browsers.connectStudioToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, studioManager: studio })

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -509,16 +509,20 @@ export class ProjectBase extends EE {
               return { canAccessStudioAI, cloudStudioSessionId }
             }
 
-            this.protocolManager = studio.protocolManager
-            this.protocolManager.setupProtocol()
-            this.protocolManager.beforeSpec({
+            const protocolManager = studio.protocolManager
+
+            protocolManager.setupProtocol()
+            protocolManager.beforeSpec({
               ...this.spec,
               instanceId: randomUUID(),
             })
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_START)
-            await browsers.connectProtocolToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, protocolManager: studio.protocolManager })
+            await browsers.connectProtocolToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, protocolManager })
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_PROTOCOL_TO_BROWSER_END)
+
+            // Attach to the proxy only after connectToBrowser has initialized network capture.
+            this.protocolManager = protocolManager
 
             telemetryManager.mark(INITIALIZATION_MARK_NAMES.CONNECT_STUDIO_TO_BROWSER_START)
             await browsers.connectStudioToBrowser({ browser: this.browser, foundBrowsers: this.options.browsers, studioManager: studio })

--- a/packages/server/lib/util/commit-info.ts
+++ b/packages/server/lib/util/commit-info.ts
@@ -156,5 +156,4 @@ export = {
   commitInfo,
   getGitCommands,
   getRemoteOrigin,
-  sanitizeRemoteOrigin,
 }

--- a/packages/server/lib/util/commit-info.ts
+++ b/packages/server/lib/util/commit-info.ts
@@ -18,6 +18,30 @@ interface GitCommand {
   transform?: (result: string) => string | number | null
 }
 
+// Strips HTTP basic auth credentials from a remote origin URL to prevent them
+// from leaking into query parameters, proxy logs, or other storage.
+// SSH remotes (e.g. git@github.com:org/repo.git) are returned unchanged.
+function sanitizeRemoteOrigin (remoteOrigin: string): string {
+  if (!/\/\//.test(remoteOrigin)) {
+    return remoteOrigin
+  }
+
+  try {
+    const parsed = new URL(remoteOrigin)
+
+    if (parsed.username || parsed.password) {
+      parsed.username = ''
+      parsed.password = ''
+
+      return parsed.toString()
+    }
+  } catch {
+    // not a valid URL, return as-is
+  }
+
+  return remoteOrigin
+}
+
 /**
  * Returns the git command configuration for all commit info properties.
  * Exported for use in tests.
@@ -57,6 +81,7 @@ function getGitCommands (): Record<keyof CommitInfo, GitCommand> {
     remote: {
       envVar: 'COMMIT_INFO_REMOTE',
       gitCmd: ['config', '--get', 'remote.origin.url'],
+      transform: sanitizeRemoteOrigin,
     },
   }
 }
@@ -94,6 +119,13 @@ function getGitValue (
     .catch(() => null)
 }
 
+function getRemoteOrigin (folder?: string): Promise<string | null> {
+  const cwd = folder ? path.resolve(folder) : process.cwd()
+  const { remote } = getGitCommands()
+
+  return getGitValue(cwd, remote.envVar, remote.gitCmd, remote.transform) as Promise<string | null>
+}
+
 /**
  * Collects Git commit info using git CLI commands.
  * Falls back to environment variables if git commands fail.
@@ -123,4 +155,6 @@ function commitInfo (folder?: string): Promise<CommitInfo> {
 export = {
   commitInfo,
   getGitCommands,
+  getRemoteOrigin,
+  sanitizeRemoteOrigin,
 }

--- a/packages/server/lib/util/commit-info.ts
+++ b/packages/server/lib/util/commit-info.ts
@@ -18,10 +18,16 @@ interface GitCommand {
   transform?: (result: string) => string | number | null
 }
 
-// Strips credentials from HTTP/HTTPS remote origin URLs to prevent them from
-// leaking into query parameters, proxy logs, or other storage. Only http/https
-// schemes are stripped — ssh:// usernames (e.g. git@) are protocol components,
-// not credentials, and must be preserved.
+// Strips credentials from remote origin URLs to prevent them from leaking into
+// proxy logs or other storage. For HTTP/HTTPS, any username or password is
+// removed. For other schemes (e.g. ssh://), only passwords are removed —
+// usernames like "git" are protocol components and must be preserved.
+//
+// Known gaps (intentional tradeoffs):
+//   - ssh://token@host (username-as-token, no password): indistinguishable from
+//     legitimate ssh://git@host without a scheme-specific allowlist.
+//   - Tokens embedded in query params (e.g. ?token=secret): clearing all query
+//     params would break remotes that use them for non-credential purposes.
 function sanitizeRemoteOrigin (remoteOrigin: string): string {
   if (!/\/\//.test(remoteOrigin)) {
     return remoteOrigin
@@ -31,8 +37,9 @@ function sanitizeRemoteOrigin (remoteOrigin: string): string {
     const parsed = new URL(remoteOrigin)
 
     const isHttpUrl = parsed.protocol === 'https:' || parsed.protocol === 'http:'
+    const hasCredentials = parsed.password || (isHttpUrl && parsed.username)
 
-    if (isHttpUrl && (parsed.username || parsed.password)) {
+    if (hasCredentials) {
       parsed.username = ''
       parsed.password = ''
 

--- a/packages/server/lib/util/commit-info.ts
+++ b/packages/server/lib/util/commit-info.ts
@@ -18,9 +18,10 @@ interface GitCommand {
   transform?: (result: string) => string | number | null
 }
 
-// Strips HTTP basic auth credentials from a remote origin URL to prevent them
-// from leaking into query parameters, proxy logs, or other storage.
-// SSH remotes (e.g. git@github.com:org/repo.git) are returned unchanged.
+// Strips credentials from HTTP/HTTPS remote origin URLs to prevent them from
+// leaking into query parameters, proxy logs, or other storage. Only http/https
+// schemes are stripped — ssh:// usernames (e.g. git@) are protocol components,
+// not credentials, and must be preserved.
 function sanitizeRemoteOrigin (remoteOrigin: string): string {
   if (!/\/\//.test(remoteOrigin)) {
     return remoteOrigin
@@ -29,7 +30,9 @@ function sanitizeRemoteOrigin (remoteOrigin: string): string {
   try {
     const parsed = new URL(remoteOrigin)
 
-    if (parsed.username || parsed.password) {
+    const isHttpUrl = parsed.protocol === 'https:' || parsed.protocol === 'http:'
+
+    if (isHttpUrl && (parsed.username || parsed.password)) {
       parsed.username = ''
       parsed.password = ''
 
@@ -156,4 +159,5 @@ export = {
   commitInfo,
   getGitCommands,
   getRemoteOrigin,
+  sanitizeRemoteOrigin,
 }

--- a/packages/server/test/unit/cloud/auth_spec.ts
+++ b/packages/server/test/unit/cloud/auth_spec.ts
@@ -99,6 +99,23 @@ describe('lib/cloud/auth', function () {
         )
       })
     })
+
+    it('includes remoteOrigin in the login URL when provided', function () {
+      return auth._internal.buildFullLoginUrl(
+        BASE_URL,
+        this.server,
+        'UTM Source',
+        'UTM Medium',
+        'UTM Content',
+        'https://github.com/cypress-io/cypress.git',
+      )
+      .then((url) => {
+        expect(url).to.include('remoteOrigin=')
+        expect(decodeURIComponent(url)).to.include(
+          'https://github.com/cypress-io/cypress.git',
+        )
+      })
+    })
   })
 
   describe('_internal.launchNativeAuth', function () {

--- a/packages/server/test/unit/cloud/auth_spec.ts
+++ b/packages/server/test/unit/cloud/auth_spec.ts
@@ -82,6 +82,23 @@ describe('lib/cloud/auth', function () {
         expect(url).to.eq(FULL_SIGNUP_URL_UTM)
       })
     })
+
+    it('includes remoteOrigin in the auth URL when provided', function () {
+      return auth._internal.buildFullSignupUrl(
+        BASE_URL,
+        this.server,
+        'UTM Source',
+        'UTM Medium',
+        'UTM Content',
+        'https://github.com/cypress-io/cypress.git',
+      )
+      .then((url) => {
+        expect(url).to.include('remoteOrigin=')
+        expect(decodeURIComponent(url)).to.include(
+          'https://github.com/cypress-io/cypress.git',
+        )
+      })
+    })
   })
 
   describe('_internal.launchNativeAuth', function () {

--- a/packages/server/test/unit/util/commit-info_spec.ts
+++ b/packages/server/test/unit/util/commit-info_spec.ts
@@ -262,6 +262,11 @@ describe('lib/util/commit-info', () => {
       .to.eq('ssh://git@github.com/org/repo.git')
     })
 
+    it('strips username and password from an ssh:// remote with embedded credentials', () => {
+      expect(sanitizeRemoteOrigin('ssh://user:password@host/repo.git'))
+      .to.eq('ssh://host/repo.git')
+    })
+
     it('leaves a git:// remote unchanged', () => {
       expect(sanitizeRemoteOrigin('git://github.com/org/repo.git'))
       .to.eq('git://github.com/org/repo.git')

--- a/packages/server/test/unit/util/commit-info_spec.ts
+++ b/packages/server/test/unit/util/commit-info_spec.ts
@@ -252,9 +252,14 @@ describe('lib/util/commit-info', () => {
       .to.eq('https://github.com/org/repo.git')
     })
 
-    it('leaves an SSH remote unchanged', () => {
+    it('leaves an SCP-style SSH remote unchanged', () => {
       expect(sanitizeRemoteOrigin('git@github.com:org/repo.git'))
       .to.eq('git@github.com:org/repo.git')
+    })
+
+    it('leaves an ssh:// remote unchanged, preserving the git username', () => {
+      expect(sanitizeRemoteOrigin('ssh://git@github.com/org/repo.git'))
+      .to.eq('ssh://git@github.com/org/repo.git')
     })
 
     it('leaves a git:// remote unchanged', () => {

--- a/packages/server/test/unit/util/commit-info_spec.ts
+++ b/packages/server/test/unit/util/commit-info_spec.ts
@@ -7,6 +7,8 @@ import mockedEnv from 'mocked-env'
 let execaStub: ReturnType<typeof sinon.stub>
 let commitInfo: typeof import('../../../lib/util/commit-info').commitInfo
 let getGitCommands: typeof import('../../../lib/util/commit-info').getGitCommands
+let getRemoteOrigin: typeof import('../../../lib/util/commit-info').getRemoteOrigin
+let sanitizeRemoteOrigin: typeof import('../../../lib/util/commit-info').sanitizeRemoteOrigin
 let resetEnv: (() => void) | null = null
 
 // Helper to get git command key string from property name
@@ -90,6 +92,8 @@ describe('lib/util/commit-info', () => {
 
     commitInfo = commitInfoModule.commitInfo
     getGitCommands = commitInfoModule.getGitCommands
+    getRemoteOrigin = commitInfoModule.getRemoteOrigin
+    sanitizeRemoteOrigin = commitInfoModule.sanitizeRemoteOrigin
   })
 
   afterEach(() => {
@@ -228,6 +232,69 @@ describe('lib/util/commit-info', () => {
 
       return commitInfo(customFolder).then(() => {
         expect(execaStub.called).to.be.true
+      })
+    })
+  })
+
+  context('sanitizeRemoteOrigin', () => {
+    it('strips username and password from an HTTPS remote', () => {
+      expect(sanitizeRemoteOrigin('https://user:secret@github.com/org/repo.git'))
+      .to.eq('https://github.com/org/repo.git')
+    })
+
+    it('strips only the password when username is absent', () => {
+      expect(sanitizeRemoteOrigin('https://:secret@github.com/org/repo.git'))
+      .to.eq('https://github.com/org/repo.git')
+    })
+
+    it('leaves an HTTPS remote without credentials unchanged', () => {
+      expect(sanitizeRemoteOrigin('https://github.com/org/repo.git'))
+      .to.eq('https://github.com/org/repo.git')
+    })
+
+    it('leaves an SSH remote unchanged', () => {
+      expect(sanitizeRemoteOrigin('git@github.com:org/repo.git'))
+      .to.eq('git@github.com:org/repo.git')
+    })
+
+    it('leaves a git:// remote unchanged', () => {
+      expect(sanitizeRemoteOrigin('git://github.com/org/repo.git'))
+      .to.eq('git://github.com/org/repo.git')
+    })
+
+    it('leaves an unparseable value unchanged', () => {
+      expect(sanitizeRemoteOrigin('not-a-url')).to.eq('not-a-url')
+    })
+
+    it('strips credentials from a remote returned by git via commitInfo', () => {
+      execaStub.callsFake(createGitResponses({
+        remote: { stdout: 'https://token:x-oauth-basic@github.com/org/repo.git' },
+      }))
+
+      return commitInfo().then((info) => {
+        expect(info.remote).to.eq('https://github.com/org/repo.git')
+      })
+    })
+
+    it('strips credentials from a remote returned by getRemoteOrigin', () => {
+      execaStub.callsFake(createGitResponses({
+        remote: { stdout: 'https://token:x-oauth-basic@github.com/org/repo.git' },
+      }))
+
+      return getRemoteOrigin().then((remote) => {
+        expect(remote).to.eq('https://github.com/org/repo.git')
+      })
+    })
+
+    it('strips credentials from COMMIT_INFO_REMOTE env var', () => {
+      resetEnv = mockedEnv({
+        COMMIT_INFO_REMOTE: 'https://user:pass@bitbucket.org/org/repo.git',
+      }, { clear: true })
+
+      execaStub.callsFake(() => Promise.reject(new Error('Git should not be called')))
+
+      return commitInfo().then((info) => {
+        expect(info.remote).to.eq('https://bitbucket.org/org/repo.git')
       })
     })
   })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details

When a user logs in or signs up through the Cypress desktop app, the project's git remote origin URL is now included as a `remoteOrigin` query parameter in the auth redirect URL sent to Cypress Cloud. This allows Cloud to automatically associate the authenticated session with the correct project, enabling auto-create-project flows (RAP-120).

**What changed:**
- `packages/server/lib/cloud/auth.ts` — `buildFullAuthUrl`, `buildFullLoginUrl`, `buildFullSignupUrl`, `launchServer`, `startAuth`, `start`, and `startSignup` all accept an optional `remoteOrigin` param and attach it to the auth URL query string when present.
- `packages/server/lib/makeDataContext.ts` — New `resolveAuthRemoteOrigin()` helper reads the current project's remote URL via `commitInfo` and passes it into `auth.start` / `auth.startSignup`.
- `packages/server/lib/project-base.ts` — Minor refactor to delay assigning `this.protocolManager` until after `connectProtocolToBrowser` completes, ensuring the proxy attaches only after network capture is initialized.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the login/signup pipeline and sends project git remote URLs to Cloud (mitigated by sanitization); abort/signal wiring must not leave auth half-started after cancel.
> 
> **Overview**
> Login and signup now attach the open project's **sanitized** `remote.origin` URL to Cypress Cloud auth redirects as a `remoteOrigin` query parameter, so Cloud can tie the session to a repo (e.g. auto-create project). When a project is open, the server resolves that URL via a new `getRemoteOrigin` git helper before starting auth; with no project, behavior is unchanged.
> 
> **Auth cancellation:** `AuthActions` creates an `AbortController` and passes its signal into `logIn` / `signUp`. Canceling auth (`resetAuthState`) aborts the signal so in-flight git lookup does not still call `auth.start`, and login/signup may resolve `undefined` instead of a user.
> 
> **Credential hygiene:** `sanitizeRemoteOrigin` strips HTTP(S) userinfo (and ssh passwords where applicable) from remotes used in commit info and auth, with tests for git, env, and `getRemoteOrigin` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28bd7a4061e063a86f33476b465238e3f8b8967a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Open the Cypress desktop app on a project that has a git remote set (`git remote get-url origin`).
2. Log out if currently logged in.
3. Click **Log In** and complete the browser-based login flow.
4. Verify the auth redirect URL in the browser includes `remoteOrigin=<encoded-url>` matching the project's remote.
5. Repeat with **Sign Up** flow.
6. Open the Cypress desktop app with no project selected (global mode) and confirm login/signup still works without `remoteOrigin` in the URL.

### How has the user experience changed?

No visible change to the user. The `remoteOrigin` parameter is added silently to the auth URL, enabling Cloud-side project auto-creation without any extra prompts.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission?
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?