### PR TITLE
feat(driver): add `Cypress.expose()` test config overrides

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Added [Bun](https://bun.sh) as a recognized package manager. The `cypress` npm package can now be installed and invoked with Bun (for example `bun run cypress open` or `bun run cypress run`). Addresses [#28962](https://github.com/cypress-io/cypress/issues/28962). Addressed in [#32580](https://github.com/cypress-io/cypress/pull/32580).
 - Improved CI environment detection and commit metadata capture for Cypress Cloud recorded runs within Argo CD and Argo Workflows. Addressed in [#33932](https://github.com/cypress-io/cypress/pull/33932).
+- [`Cypress.expose()`](https://on.cypress.io/expose) values can now be overridden per suite or test via test config overrides (for example, `describe()`, `context()`, `it()`, or `test()`) using `{ expose: { key: value } }`. Suite- and test-level overrides are merged, with test-level keys taking precedence; override keys are applied at test start and restored after each test without affecting unrelated values set in hooks. Addresses [#33356](https://github.com/cypress-io/cypress/issues/33356). Addressed in [#33925](https://github.com/cypress-io/cypress/pull/33925).
 
 ## 15.16.0
 

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3442,6 +3442,7 @@ declare namespace Cypress {
   >, Partial<Pick<ResolvedConfigOptions, 'baseUrl' | 'testIsolation'>> {
     browser?: IsBrowserMatcher | IsBrowserMatcher[]
     keystrokeDelay?: number
+    expose?: Record<string, any>
   }
 
   interface TestConfigOverrides extends Partial<
@@ -3449,6 +3450,7 @@ declare namespace Cypress {
   >, Partial<Pick<ResolvedConfigOptions, 'baseUrl'>> {
     browser?: IsBrowserMatcher | IsBrowserMatcher[]
     keystrokeDelay?: number
+    expose?: Record<string, any>
   }
 
   /**

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -904,6 +904,7 @@ namespace CypressTestConfigOverridesTests {
     animationDistanceThreshold: 10,
     defaultCommandTimeout: 6000,
     env: {},
+    expose: {},
     execTimeout: 6000,
     includeShadowDom: true,
     requestTimeout: 6000,

--- a/packages/driver/cypress/e2e/e2e/origin/config_env_expose.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/config_env_expose.cy.ts
@@ -10,6 +10,18 @@
       error: 'cy-origin-error',
     }
 
+    const getTestConfigOverride = (key: string, value: any) => {
+      if (fnName === 'config') {
+        return { [key]: value }
+      }
+
+      if (fnName === 'env') {
+        return { env: { [key]: value } }
+      }
+
+      return { expose: { [key]: value } }
+    }
+
     afterEach(() => {
       // @ts-ignore
       window.top.__cySkipValidateConfig = true
@@ -90,12 +102,7 @@
         })
       })
 
-      it(`does NOT sync Cypress.${fnName}() changes made in the secondary after the command queue is finished and the callback window is closed`, {
-        [USED_KEYS.baz]: undefined,
-        env: {
-          [USED_KEYS.baz]: undefined,
-        },
-      }, () => {
+      it(`does NOT sync Cypress.${fnName}() changes made in the secondary after the command queue is finished and the callback window is closed`, getTestConfigOverride(USED_KEYS.baz, undefined), () => {
         return new Promise<void>((resolve) => {
           cy.origin('http://www.foobar.com:3500', { args: { fnName, USED_KEYS } }, ({ fnName, USED_KEYS }) => {
             setTimeout(() => {
@@ -113,39 +120,23 @@
         })
       })
 
-      // Cypress.expose() is not configurable through testConfigOverrides
-      if (fnName !== 'expose') {
-        it('overwrites different values in secondary if one exists in the primary', {
-          [USED_KEYS.baz]: 'quux',
-          env: {
-            [USED_KEYS.baz]: 'quux',
-          },
-        }, () => {
-          cy.origin('http://www.foobar.com:3500', { args: { fnName, USED_KEYS } }, ({ fnName, USED_KEYS }) => {
+      it('overwrites different values in secondary if one exists in the primary', getTestConfigOverride(USED_KEYS.baz, 'quux'), () => {
+        cy.origin('http://www.foobar.com:3500', { args: { fnName, USED_KEYS } }, ({ fnName, USED_KEYS }) => {
           // in previous test, 'baz' was set to 'qux' after the callback window was closed.
           // this should be overwritten by 'quux' that exists in the primary
-            const quux = Cypress[fnName](USED_KEYS.baz)
+          const quux = Cypress[fnName](USED_KEYS.baz)
 
-            expect(quux).to.equal('quux')
-          })
+          expect(quux).to.equal('quux')
         })
-      }
+      })
 
-      // Cypress.expose() is not configurable through testConfigOverrides
-      if (fnName !== 'expose') {
-        it(`overwrites different values in secondary, even if the Cypress.${fnName}() value does not exist in the primary`, {
-          [USED_KEYS.baz]: undefined,
-          env: {
-            [USED_KEYS.baz]: undefined,
-          },
-        }, () => {
-          cy.origin('http://www.foobar.com:3500', { args: { fnName, USED_KEYS } }, ({ fnName, USED_KEYS }) => {
-            const isNowUndefined = Cypress[fnName](USED_KEYS.baz)
+      it(`overwrites different values in secondary, even if the Cypress.${fnName}() value does not exist in the primary`, getTestConfigOverride(USED_KEYS.baz, undefined), () => {
+        cy.origin('http://www.foobar.com:3500', { args: { fnName, USED_KEYS } }, ({ fnName, USED_KEYS }) => {
+          const isNowUndefined = Cypress[fnName](USED_KEYS.baz)
 
-            expect(isNowUndefined).to.be.undefined
-          })
+          expect(isNowUndefined).to.be.undefined
         })
-      }
+      })
     })
 
     context('unserializable', () => {

--- a/packages/driver/src/cy/testConfigOverrides.ts
+++ b/packages/driver/src/cy/testConfigOverrides.ts
@@ -37,7 +37,38 @@ type TestConfig = {
 
 type ConfigOverrides = {
   env: Object | undefined
+  expose?: Record<string, any>
 };
+
+type ExposeKeyBackup =
+  | { existed: true, value: any }
+  | { existed: false }
+
+type ExposeFn = Cypress.Cypress['expose']
+
+/**
+ * Saves an existing expose key and returns the original value to be restored after the test runs.
+ */
+function backupExposeKey (key: string, expose: ExposeFn): ExposeKeyBackup {
+  const allExpose = expose()
+
+  if (Object.prototype.hasOwnProperty.call(allExpose, key)) {
+    return { existed: true, value: _.cloneDeep(expose(key)) }
+  }
+
+  return { existed: false }
+}
+
+/**
+ * Restores an expose key from a backup value after the test runs. If no value existed, the key will be deleted.
+ */
+function restoreExposeKey (key: string, backup: ExposeKeyBackup, expose: ExposeFn) {
+  if (backup.existed) {
+    expose(key, _.cloneDeep(backup.value))
+  } else {
+    delete expose()[key]
+  }
+}
 
 function setConfig (testConfig: ResolvedTestConfigOverride, config, localConfigOverrides: ConfigOverrides = { env: undefined }) {
   const { testConfigList = [] } = testConfig
@@ -48,12 +79,16 @@ function setConfig (testConfig: ResolvedTestConfigOverride, config, localConfigO
     if (_.isArray(testConfigOverride)) {
       setConfig(resolvedConfig as ResolvedTestConfigOverride, config, localConfigOverrides)
     } else if (Object.keys(testConfigOverride).length) {
-      delete testConfigOverride.browser
+      const testConfigOverrideCopy = { ...testConfigOverride }
+      const exposeOverride = testConfigOverrideCopy.expose
+
+      delete testConfigOverrideCopy.browser
+      delete testConfigOverrideCopy.expose
 
       try {
         testConfig.applied = overrideLevel
 
-        config(testConfigOverride)
+        config(testConfigOverrideCopy)
       } catch (e: any) {
         let err = $errUtils.errByPath('config.invalid_test_override', {
           errMsg: e.message,
@@ -63,14 +98,21 @@ function setConfig (testConfig: ResolvedTestConfigOverride, config, localConfigO
         err.stack = $errUtils.stackWithReplacedProps({ stack: invocationDetails.stack }, err)
         throw err
       }
-      localConfigOverrides = { ...localConfigOverrides, ...testConfigOverride }
+      localConfigOverrides = { ...localConfigOverrides, ...testConfigOverrideCopy }
+
+      if (exposeOverride) {
+        localConfigOverrides.expose = {
+          ...localConfigOverrides.expose,
+          ...exposeOverride,
+        }
+      }
     }
   })
 
   return localConfigOverrides
 }
 
-function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, env) {
+function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, env, expose: ExposeFn) {
   let globalConfig = _.clone(config())
 
   const localConfigOverrides = setConfig(testConfig, config)
@@ -93,6 +135,7 @@ function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, en
   let globalEnv
   let localTestEnv
   let localTestEnvBackup
+  let testExposeBackup: Map<string, ExposeKeyBackup> | undefined
 
   if (config('allowCypressEnv')) {
     globalEnv = _.clone(env())
@@ -104,6 +147,18 @@ function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, en
     localTestEnvBackup = _.clone(localTestEnv)
   }
 
+  // Expose overrides are applied at test start and restored after each test for only the overridden keys
+  // so hook-level values remain intact.
+  if (localConfigOverrides.expose) {
+    const exposeBackup = new Map<string, ExposeKeyBackup>()
+
+    testExposeBackup = exposeBackup
+    _.each(localConfigOverrides.expose, (val, key) => {
+      exposeBackup.set(key, backupExposeKey(key, expose))
+      expose(key, _.cloneDeep(val))
+    })
+  }
+
   // we restore config back to what it was before the test ran
   // UNLESS the user mutated config with Cypress.config, in which case
   // we apply those changes to the global config
@@ -111,6 +166,10 @@ function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, en
   //   do not allow global mutations inside test
   const restoreConfigFn = function () {
     _.each(localConfigOverrides, (val, key) => {
+      if (key === 'expose') {
+        return
+      }
+
       if (localConfigOverridesBackup[key] !== val) {
         globalConfig[key] = val
       }
@@ -127,6 +186,12 @@ function mutateConfiguration (testConfig: ResolvedTestConfigOverride, config, en
           globalEnv[key] = val
         }
       })
+    }
+
+    if (testExposeBackup) {
+      for (const [key, backup] of testExposeBackup) {
+        restoreExposeKey(key, backup, expose)
+      }
     }
 
     // reset test config overrides
@@ -167,7 +232,18 @@ export function getResolvedTestConfigOverride (test): ResolvedTestConfigOverride
   const testConfig = {
     testConfigList: testConfigList.filter(({ overrides }) => overrides !== undefined),
     // collect test overrides to send to the Cypress Cloud api when @packages/server is ran in record mode
-    unverifiedTestConfig: _.reduce(testConfigList, (acc, { overrides }) => _.extend(acc, overrides), {}),
+    unverifiedTestConfig: _.reduce(testConfigList, (acc: Record<string, any>, { overrides }) => {
+      const result = _.extend({}, acc, overrides)
+
+      if (overrides?.expose) {
+        result.expose = {
+          ...acc.expose,
+          ...overrides.expose,
+        }
+      }
+
+      return result
+    }, {} as Record<string, any>),
   }
 
   return testConfig
@@ -176,7 +252,7 @@ export function getResolvedTestConfigOverride (test): ResolvedTestConfigOverride
 export class TestConfigOverride {
   private restoreTestConfigFn: Cypress.Nullable<() => void> = null
 
-  restoreAndSetTestConfigOverrides (test, config, env) {
+  restoreAndSetTestConfigOverrides (test, config, env, expose: ExposeFn) {
     if (this.restoreTestConfigFn) {
       test._testConfig.applied = 'restoring'
       this.restoreTestConfigFn()
@@ -187,7 +263,9 @@ export class TestConfigOverride {
     }
 
     if (Object.keys(resolvedTestConfig.unverifiedTestConfig).length > 0) {
-      this.restoreTestConfigFn = mutateConfiguration(resolvedTestConfig, config, env)
+      this.restoreTestConfigFn = mutateConfiguration(resolvedTestConfig, config, env, expose)
+    } else {
+      this.restoreTestConfigFn = null
     }
 
     resolvedTestConfig.applied = 'complete'

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -669,7 +669,7 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
       this.resetTimer()
       this.resetStability()
       this.removeAllListeners()
-      this.testConfigOverride.restoreAndSetTestConfigOverrides(test, this.Cypress.config, this.Cypress.env)
+      this.testConfigOverride.restoreAndSetTestConfigOverrides(test, this.Cypress.config, this.Cypress.env, this.Cypress.expose)
     } catch (err) {
       this.fail(err)
     }

--- a/system-tests/projects/expose-test-config-overrides/cypress.config.ts
+++ b/system-tests/projects/expose-test-config-overrides/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  allowCypressEnv: false,
+  e2e: {
+    supportFile: false,
+  },
+})

--- a/system-tests/projects/expose-test-config-overrides/cypress/e2e/expose-override-merge.cy.ts
+++ b/system-tests/projects/expose-test-config-overrides/cypress/e2e/expose-override-merge.cy.ts
@@ -1,0 +1,13 @@
+describe('suite and test expose overrides merge with test-level keys taking precedence', { expose: { shared: 'suite', suiteOnly: 'suite' } }, () => {
+  it('merges suite-level and test-level expose overrides', { expose: { shared: 'test', testOnly: 'test' } }, () => {
+    expect(Cypress.expose('shared')).to.eq('test')
+    expect(Cypress.expose('suiteOnly')).to.eq('suite')
+    expect(Cypress.expose('testOnly')).to.eq('test')
+  })
+
+  it('does not leak test-level expose overrides to subsequent tests', () => {
+    expect(Cypress.expose('shared')).to.eq('suite')
+    expect(Cypress.expose('suiteOnly')).to.eq('suite')
+    expect(Cypress.expose('testOnly')).to.eq(undefined)
+  })
+})

--- a/system-tests/projects/expose-test-config-overrides/cypress/e2e/override-hook-lifecycle.cy.ts
+++ b/system-tests/projects/expose-test-config-overrides/cypress/e2e/override-hook-lifecycle.cy.ts
@@ -1,0 +1,27 @@
+describe('suite and test override values persist through the full hook lifecycle', { expose: { describe: 'describe expose' } }, () => {
+  before(() => {
+    expect(Cypress.expose('describe')).to.eq('describe expose')
+    Cypress.expose('describe', 'before')
+    expect(Cypress.expose('it')).to.eq('it')
+  })
+
+  beforeEach(() => {
+    expect(Cypress.expose('describe')).to.eq('before')
+    Cypress.expose('describe', 'beforeEach')
+    expect(Cypress.expose('it')).to.eq('it')
+  })
+
+  afterEach(() => {
+    expect(Cypress.expose('describe')).to.eq('beforeEach')
+    Cypress.expose('describe', 'afterEach')
+  })
+
+  after(() => {
+    expect(Cypress.expose('describe')).to.eq('afterEach')
+  })
+
+  it('test-level key merges with suite-level key and hook mutations carry forward', { expose: { it: 'it' } }, () => {
+    expect(Cypress.expose('describe')).to.eq('beforeEach')
+    expect(Cypress.expose('it')).to.eq('it')
+  })
+})

--- a/system-tests/projects/expose-test-config-overrides/cypress/e2e/override-mutation-restore.cy.ts
+++ b/system-tests/projects/expose-test-config-overrides/cypress/e2e/override-mutation-restore.cy.ts
@@ -1,0 +1,11 @@
+describe('in-test mutations to override values are restored before the next test', () => {
+  it('applies the test config override value', { expose: { foo: 'from-override' } }, () => {
+    expect(Cypress.expose('foo')).to.eq('from-override')
+    Cypress.expose('foo', 'mutated-in-test')
+    expect(Cypress.expose('foo')).to.eq('mutated-in-test')
+  })
+
+  it('restores the key to its pre-override value when the next test has no override', () => {
+    expect(Cypress.expose('foo')).to.eq(undefined)
+  })
+})

--- a/system-tests/projects/expose-test-config-overrides/cypress/e2e/stale-restore-prevention.cy.ts
+++ b/system-tests/projects/expose-test-config-overrides/cypress/e2e/stale-restore-prevention.cy.ts
@@ -1,0 +1,16 @@
+describe('restore function is nulled out after a no-override test, preventing stale replays', () => {
+  it('test-level override applies the specified key for the test body', { expose: { x: 'A' } }, () => {
+    expect(Cypress.expose('x')).to.eq('A')
+  })
+
+  it('no-override test sees the prior key restored to its pre-override value', () => {
+    expect(Cypress.expose('x')).to.eq(undefined)
+    Cypress.expose('x', 'set-in-between')
+  })
+
+  it('runtime expose set in a no-override test is not cleared when the next test has overrides', { expose: { y: 'C' } }, () => {
+    // a stale restore from the first test would have deleted x before this test started
+    expect(Cypress.expose('x')).to.eq('set-in-between')
+    expect(Cypress.expose('y')).to.eq('C')
+  })
+})

--- a/system-tests/projects/expose-test-config-overrides/package.json
+++ b/system-tests/projects/expose-test-config-overrides/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "expose-test-config-overrides",
+  "version": "0.0.0-development",
+  "description": "Cypress.expose() test config overrides",
+  "type": "module"
+}

--- a/system-tests/projects/expose-test-config-overrides/tsconfig.json
+++ b/system-tests/projects/expose-test-config-overrides/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+  }
+}

--- a/system-tests/test/expose-test-config-overrides_spec.ts
+++ b/system-tests/test/expose-test-config-overrides_spec.ts
@@ -1,0 +1,11 @@
+import systemTests from '../lib/system-tests'
+
+describe('Cypress.expose() test config overrides', () => {
+  systemTests.setup()
+
+  systemTests.it('runs Cypress.expose() test config override specs', {
+    project: 'expose-test-config-overrides',
+    expectedExitCode: 0,
+    browser: 'electron',
+  })
+})


### PR DESCRIPTION
## Summary

- Adds support for overriding `Cypress.expose()` values via suite- and test-level config overrides using `{ expose: { key: value } }`.
- Suite- and test-level overrides are merged, with test-level keys taking precedence; override keys are applied at test start and restored after each test without affecting unrelated values set in hooks.
- Includes TypeScript types, dtslint coverage, a `expose_test_config_overrides` system test project, and a 15.17.0 changelog entry.

Addresses #33356.

## Steps to test

1. Build Cypress in dev mode (`yarn dev` or use the built binary).
2. From `system-tests/`, run:

```bash
yarn test expose_test_config_overrides
```

3. Confirm the `expose_test_config_overrides` system test passes.
4. Optionally run the fixture project directly:

```bash
yarn cypress:run -- --project system-tests/projects/expose_test_config_overrides
```

5. Verify suite-level expose values from `describe()`/`context()` merge with test-level expose values from `it()`/`test()`, and that hook-set values persist across tests.

## How has the user experience changed?

Users can now override public, non-sensitive plugin configuration per suite or test via existing test config override syntax, using `Cypress.expose()` instead of routing values through `Cypress.config()` or `Cypress.env()`.

No UI changes.

## Test plan

- [x] Driver type-check passes
- [x] dtslint updated for `expose` in test config overrides
- [ ] `yarn test expose_test_config_overrides` passes in CI
- [x] Driver origin e2e tests pass in CI

## PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [x] Has a PR for user-facing changes been opened in [cypress-documentation](https://github.com/cypress-io/cypress-documentation/pull/6467)?
- [x] Have API changes been updated in the type definitions?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-test driver state for `Cypress.expose()` (apply/restore timing); behavior is localized and covered by new system tests, but incorrect restore logic could leak or wipe expose values across tests.
> 
> **Overview**
> Adds **`expose`** to suite- and test-level config overrides so `Cypress.expose()` values can be set via `{ expose: { key: value } }` on `describe`/`context`/`it`/`test`, matching how other per-test config works.
> 
> The driver **merges** suite- and test-level `expose` maps (test wins on conflicts), **applies** only those keys at test start, and **restores** prior values after each test so hook-time mutations and unrelated expose keys are left alone. Restore is skipped when a test has no overrides to avoid stale restores clearing values set in between tests.
> 
> Type definitions and dtslint cover `expose`; origin e2e coverage now treats expose like `config`/`env` for primary→secondary sync scenarios. A dedicated system-test project exercises merge, hook lifecycle, mutation restore, and stale-restore behavior, with a 15.17.0 changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e25ac23ac655eece25a8f7c7454bc3647e3966a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->