### PR TITLE
feat: detect Argo CD and Argo Workflows as CI providers

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.17.0
+
+**Features:**
+
+- Improved CI environment detection and commit metadata capture for Cypress Cloud recorded runs within Argo CD and Argo Workflows. Addressed in [#33932](https://github.com/cypress-io/cypress/pull/33932).
+
 ## 15.16.0
 
 **Features:**

--- a/packages/server/lib/util/ci_provider.ts
+++ b/packages/server/lib/util/ci_provider.ts
@@ -90,6 +90,19 @@ const isJenkins = () => {
     process.env.HUDSON_HOME
 }
 
+// Argo CD injects build env vars during manifest generation (Helm, Kustomize, CMPs).
+// Ref: https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/
+const isArgoCd = () => {
+  return Boolean(process.env.ARGOCD_APP_NAME && process.env.ARGOCD_APP_REVISION)
+}
+
+// Argo Workflows injects executor env vars on workflow pods.
+// Ref: https://github.com/argoproj/argo-workflows/blob/main/workflow/common/common.go
+const isArgoWorkflows = () => {
+  // Injected together on workflow executor pods; avoids matching unrelated ARGO_* operator env vars.
+  return Boolean(process.env.ARGO_WORKFLOW_NAME && process.env.ARGO_NODE_ID)
+}
+
 /**
  * We detect CI providers by detecting an environment variable
  * unique to the provider, or by calling a function that returns true
@@ -100,6 +113,8 @@ const isJenkins = () => {
  */
 const CI_PROVIDERS = {
   'appveyor': 'APPVEYOR',
+  argoCd: isArgoCd,
+  argoWorkflows: isArgoWorkflows,
   'azure': isAzureCi,
   // Amplify Console runs on CodeBuild and can expose CODEBUILD_* env vars.
   // Since provider detection picks the first match, the more specific provider
@@ -176,6 +191,30 @@ const _providerCiParams = () => {
       'APPVEYOR_BUILD_VERSION',
       'APPVEYOR_PULL_REQUEST_NUMBER',
       'APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH',
+    ]),
+    // https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/
+    argoCd: extract([
+      'ARGOCD_APP_NAME',
+      'ARGOCD_APP_NAMESPACE',
+      'ARGOCD_APP_PROJECT_NAME',
+      'ARGOCD_APP_REVISION',
+      'ARGOCD_APP_REVISION_SHORT',
+      'ARGOCD_APP_REVISION_SHORT_8',
+      'ARGOCD_APP_SOURCE_PATH',
+      'ARGOCD_APP_SOURCE_REPO_URL',
+      'ARGOCD_APP_SOURCE_TARGET_REVISION',
+      'KUBE_VERSION',
+      'KUBE_API_VERSIONS',
+    ]),
+    // https://github.com/argoproj/argo-workflows/blob/main/workflow/common/common.go
+    argoWorkflows: extract([
+      'ARGO_WORKFLOW_NAME',
+      'ARGO_WORKFLOW_UID',
+      'ARGO_NODE_ID',
+      'ARGO_POD_NAME',
+      'ARGO_POD_UID',
+      'ARGO_CONTAINER_NAME',
+      'ARGO_INSTANCE_ID',
     ]),
     // https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables
     azure: extract([
@@ -521,6 +560,13 @@ const _providerCommitParams = () => {
       // remoteOrigin: ???
       // defaultBranch: ???
     },
+    argoCd: {
+      sha: env.ARGOCD_APP_REVISION,
+      branch: env.ARGOCD_APP_SOURCE_TARGET_REVISION,
+      remoteOrigin: env.ARGOCD_APP_SOURCE_REPO_URL,
+      // message, authorName, authorEmail, defaultBranch: not provided by Argo CD build env
+    },
+    argoWorkflows: {},
     awsCodeBuild: {
       sha: env.CODEBUILD_RESOLVED_SOURCE_VERSION,
       // branch: ???,

--- a/packages/server/test/unit/util/ci_provider_spec.ts
+++ b/packages/server/test/unit/util/ci_provider_spec.ts
@@ -89,6 +89,8 @@ describe('lib/util/ci_provider', () => {
 
     expect(providers).to.deep.eq([
       'appveyor',
+      'argoCd',
+      'argoWorkflows',
       'awsAmplifyConsole',
       'awsCodeBuild',
       'azure',
@@ -167,6 +169,70 @@ describe('lib/util/ci_provider', () => {
     return expectsCommitParams({
       message: 'repoCommitMessage\nrepoCommitMessageExtended',
     })
+  })
+
+  it('argoCd', () => {
+    resetEnv = mockedEnv({
+      ARGOCD_APP_NAME: 'argoCdAppName',
+      ARGOCD_APP_NAMESPACE: 'argoCdAppNamespace',
+      ARGOCD_APP_PROJECT_NAME: 'argoCdAppProjectName',
+      ARGOCD_APP_REVISION: 'argoCdAppRevision',
+      ARGOCD_APP_REVISION_SHORT: 'argoCdAppRevisionShort',
+      ARGOCD_APP_REVISION_SHORT_8: 'argoCdRev8',
+      ARGOCD_APP_SOURCE_PATH: 'argoCdAppSourcePath',
+      ARGOCD_APP_SOURCE_REPO_URL: 'https://github.com/org/repo.git',
+      ARGOCD_APP_SOURCE_TARGET_REVISION: 'main',
+      KUBE_VERSION: '1.28.0',
+      KUBE_API_VERSIONS: 'apps/v1,batch/v1',
+    }, { clear: true })
+
+    expectsName('argoCd')
+    expectsCiParams({
+      argocdAppName: 'argoCdAppName',
+      argocdAppNamespace: 'argoCdAppNamespace',
+      argocdAppProjectName: 'argoCdAppProjectName',
+      argocdAppRevision: 'argoCdAppRevision',
+      argocdAppRevisionShort: 'argoCdAppRevisionShort',
+      argocdAppRevisionShort8: 'argoCdRev8',
+      argocdAppSourcePath: 'argoCdAppSourcePath',
+      argocdAppSourceRepoUrl: 'https://github.com/org/repo.git',
+      argocdAppSourceTargetRevision: 'main',
+      kubeVersion: '1.28.0',
+      kubeApiVersions: 'apps/v1,batch/v1',
+    })
+
+    expectsCommitParams({
+      sha: 'argoCdAppRevision',
+      branch: 'main',
+      remoteOrigin: 'https://github.com/org/repo.git',
+    })
+
+    return undefined
+  })
+
+  it('argoWorkflows', () => {
+    resetEnv = mockedEnv({
+      ARGO_WORKFLOW_NAME: 'argoWorkflowName',
+      ARGO_WORKFLOW_UID: 'argoWorkflowUid',
+      ARGO_NODE_ID: 'argoNodeId',
+      ARGO_POD_NAME: 'argoPodName',
+      ARGO_POD_UID: 'argoPodUid',
+      ARGO_CONTAINER_NAME: 'argoContainerName',
+      ARGO_INSTANCE_ID: 'argoInstanceId',
+    }, { clear: true })
+
+    expectsName('argoWorkflows')
+    expectsCiParams({
+      argoWorkflowName: 'argoWorkflowName',
+      argoWorkflowUid: 'argoWorkflowUid',
+      argoNodeId: 'argoNodeId',
+      argoPodName: 'argoPodName',
+      argoPodUid: 'argoPodUid',
+      argoContainerName: 'argoContainerName',
+      argoInstanceId: 'argoInstanceId',
+    })
+
+    return expectsCommitParams({})
   })
 
   it('awsCodeBuild', () => {


### PR DESCRIPTION
### Additional details

Adds Cypress CI provider detection for **Argo CD** and **Argo Workflows**, so runs in those environments send the correct `ci.provider` and `ci.params` to Cypress Cloud (including for `--parallel` / `--group` when Cloud can derive a `ciBuildId`).

- **`argoCd`** — Detects Argo CD’s [build environment](https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/) during Helm, Kustomize, Jsonnet, or config management plugin execution. Maps revision, target revision, and repo URL into commit metadata.
- **`argoWorkflows`** — Detects Argo Workflows executor pods via `ARGO_WORKFLOW_NAME` and `ARGO_NODE_ID`, and extracts workflow/pod identifiers for Cloud.

These are separate providers with distinct env var prefixes (`ARGOCD_*` vs `ARGO_WORKFLOW_*`) so they do not conflict.

### Argo CD vs Argo Workflows

| Provider | When Cypress sees it |
|----------|----------------------|
| `argoCd` | Cypress runs during Argo CD manifest generation (CMP, Helm, Kustomize, etc.) with build env vars set |
| `argoWorkflows` | Cypress runs inside an Argo Workflows step container |

### Cypress Cloud `ciBuildId`

Auto `ciBuildId` generation lives on Cypress Cloud, not in this repo. Cloud may need a follow-up to map `argocdAppRevision` / `argoWorkflowUid` (or similar) for `--parallel` / `--group` without an explicit `--ci-build-id`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CI provider detection and metadata mapping, consistent with existing providers; no auth or core runner changes.
> 
> **Overview**
> Adds **Argo CD** and **Argo Workflows** as first-class CI providers so Cypress Cloud recorded runs get the right `ci.provider`, `ci.params`, and commit hints when tests run in those environments.
> 
> **Argo CD** is detected when `ARGOCD_APP_NAME` and `ARGOCD_APP_REVISION` are set (manifest generation / CMP / Helm / Kustomize). It maps Argo CD build env vars into `ci.params` and fills commit metadata from revision, target revision, and source repo URL.
> 
> **Argo Workflows** is detected when `ARGO_WORKFLOW_NAME` and `ARGO_NODE_ID` are present on executor pods, with workflow/pod identifiers extracted for Cloud. Commit metadata is not supplied by that environment.
> 
> Both providers appear in the alphabetical `detectableCiBuildIdProviders` list used in user-facing errors for `--parallel` / `--group` without `--ci-build-id`. **Auto `ciBuildId` on Cloud may still need a follow-up** to map these providers’ IDs.
> 
> The **15.17.0** changelog documents improved CI detection for Argo CD and Argo Workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac3a3b8e67218d5ad2e5f78cf7f66e6a040c05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

- [ ] `yarn test test/unit/util/ci_provider_spec.ts`
- [ ] Confirm with the reporting user that their environment exposes `ARGOCD_APP_*` (Argo CD) or `ARGO_WORKFLOW_*` + `ARGO_NODE_ID` (Workflows) when Cypress runs
- [ ] If using Cloud parallel/group recording, verify `ciBuildId` auto-detection or pass `--ci-build-id` until Cloud mapping exists

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
