### PR TITLE
fix(ci): keep run-all-jobs default false and add path-filtering tests

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -92,7 +92,9 @@ fi
 # contributor's fork. This ensures fork PRs compare against the real develop branch.
 UPSTREAM_URL="https://github.com/${CIRCLE_PROJECT_USERNAME:-cypress-io}/${CIRCLE_PROJECT_REPONAME:-cypress}.git"
 MERGE_BASE=""
-if git fetch "$UPSTREAM_URL" develop 2>/dev/null; then
+if [[ "${PIPELINE_PARAMS_SKIP_FETCH:-}" == "true" ]]; then
+  echo "PIPELINE_PARAMS_SKIP_FETCH=true — using HEAD~1 for changed files" >&2
+elif git fetch "$UPSTREAM_URL" develop 2>/dev/null; then
   MERGE_BASE=$(git merge-base HEAD FETCH_HEAD 2>/dev/null || echo "")
 else
   echo "Could not fetch upstream develop" >&2

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -23,6 +23,11 @@ parameters:
   force-persist-artifacts:
     type: boolean
     default: false
+  # Manual override from CircleCI "Trigger Pipeline" — must default false so PR path
+  # filtering is not bypassed unless explicitly requested (see generate-pipeline-parameters.sh).
+  run-all-jobs:
+    type: boolean
+    default: false
   # Path-filtering parameters — set by generate-pipeline-parameters.sh on PRs.
   # Default true so develop/release branches run everything without explicit params.
   run-driver-tests:

--- a/scripts/circleci/pipeline-parameter-defaults.js
+++ b/scripts/circleci/pipeline-parameter-defaults.js
@@ -1,0 +1,65 @@
+const fs = require('fs')
+const path = require('path')
+const yaml = require('yaml')
+
+const REPO_ROOT = path.join(__dirname, '../..')
+
+const RUN_ALL_JOBS_CONFIGS = [
+  '.circleci/config.yml',
+  '.circleci/src/pipeline/@pipeline.yml',
+]
+
+/**
+ * Reads the default value of run-all-jobs from a CircleCI config file.
+ * @param {string} configPath absolute path to a YAML config
+ * @returns {boolean | null} default when declared, otherwise null
+ */
+function getRunAllJobsDefault (configPath) {
+  const content = fs.readFileSync(configPath, 'utf8')
+  const doc = yaml.parse(content)
+  const param = doc?.parameters?.['run-all-jobs']
+
+  if (!param) {
+    return null
+  }
+
+  return param.default
+}
+
+/**
+ * Ensures run-all-jobs defaults to false everywhere it is declared.
+ * A true default disables PR path filtering because CircleCI injects pipeline
+ * parameter defaults into the environment for generate-pipeline-parameters.sh.
+ */
+function assertRunAllJobsDefaultsFalse () {
+  const errors = []
+
+  for (const rel of RUN_ALL_JOBS_CONFIGS) {
+    const full = path.join(REPO_ROOT, rel)
+
+    if (!fs.existsSync(full)) {
+      continue
+    }
+
+    const def = getRunAllJobsDefault(full)
+
+    if (def === null) {
+      errors.push(`${rel}: must declare run-all-jobs with default: false`)
+      continue
+    }
+
+    if (def !== false) {
+      errors.push(`${rel}: run-all-jobs default must be false (got ${JSON.stringify(def)})`)
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(errors.join('\n'))
+  }
+}
+
+module.exports = {
+  RUN_ALL_JOBS_CONFIGS,
+  getRunAllJobsDefault,
+  assertRunAllJobsDefaultsFalse,
+}

--- a/scripts/unit/generate-pipeline-parameters-spec.js
+++ b/scripts/unit/generate-pipeline-parameters-spec.js
@@ -1,0 +1,148 @@
+const { expect } = require('chai')
+const { execSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const {
+  assertRunAllJobsDefaultsFalse,
+  getRunAllJobsDefault,
+} = require('../circleci/pipeline-parameter-defaults')
+
+const REPO_ROOT = path.join(__dirname, '../..')
+const SCRIPT = path.join(REPO_ROOT, '.circleci/scripts/generate-pipeline-parameters.sh')
+const SETUP_CONFIG = path.join(REPO_ROOT, '.circleci/config.yml')
+const PRIMARY_CONFIG = path.join(REPO_ROOT, '.circleci/src/pipeline/@pipeline.yml')
+
+function runGeneratePipelineParameters ({ cwd, env }) {
+  const mergedEnv = {
+    ...process.env,
+    PIPELINE_PARAMS_SKIP_FETCH: 'true',
+    ...env,
+  }
+
+  delete mergedEnv.RUN_ALL_JOBS
+
+  if (env && Object.prototype.hasOwnProperty.call(env, 'RUN_ALL_JOBS')) {
+    mergedEnv.RUN_ALL_JOBS = env.RUN_ALL_JOBS
+  }
+
+  const stdout = execSync(`bash "${SCRIPT}"`, {
+    cwd,
+    env: mergedEnv,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+
+  return JSON.parse(stdout.trim())
+}
+
+function createTempRepoWithChange (changedFile) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pipeline-params-'))
+
+  execSync('git init -b develop', { cwd: tmpDir })
+  execSync('git config user.email "test@example.com"', { cwd: tmpDir })
+  execSync('git config user.name "Test User"', { cwd: tmpDir })
+
+  fs.writeFileSync(path.join(tmpDir, 'README.md'), 'base\n')
+  execSync('git add . && git commit -m "base"', { cwd: tmpDir })
+
+  execSync('git checkout -b feature/narrow-change', { cwd: tmpDir })
+
+  const target = path.join(tmpDir, changedFile)
+
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, 'changed\n')
+  execSync('git add . && git commit -m "narrow change"', { cwd: tmpDir })
+
+  return tmpDir
+}
+
+describe('generate-pipeline-parameters.sh', function () {
+  this.timeout(10000)
+  describe('run-all-jobs config defaults', () => {
+    it('declares run-all-jobs with default false in setup and primary configs', () => {
+      expect(getRunAllJobsDefault(SETUP_CONFIG)).to.equal(false)
+      expect(getRunAllJobsDefault(PRIMARY_CONFIG)).to.equal(false)
+      assertRunAllJobsDefaultsFalse()
+    })
+  })
+
+  describe('path filtering on feature branches', () => {
+    let tmpDir
+
+    afterEach(() => {
+      if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+        tmpDir = undefined
+      }
+    })
+
+    it('enables only targeted jobs for a narrow packages/icons change', () => {
+      tmpDir = createTempRepoWithChange('packages/icons/foo.ts')
+      const params = runGeneratePipelineParameters({
+        cwd: tmpDir,
+        env: {
+          CIRCLE_BRANCH: 'feature/narrow-change',
+          CIRCLE_PROJECT_USERNAME: 'cypress-io',
+          CIRCLE_PROJECT_REPONAME: 'cypress',
+        },
+      })
+
+      expect(params['run-driver-tests']).to.equal(true)
+      expect(params['run-server-tests']).to.equal(true)
+      expect(params['run-system-tests']).to.equal(true)
+      expect(params['run-cli-tests']).to.equal(false)
+      expect(params['run-v8-tests']).to.equal(false)
+      expect(params['run-app-ui-tests']).to.equal(true)
+    })
+
+    it('skips path filtering when RUN_ALL_JOBS=true (manual Trigger Pipeline)', () => {
+      tmpDir = createTempRepoWithChange('packages/icons/foo.ts')
+      const params = runGeneratePipelineParameters({
+        cwd: tmpDir,
+        env: {
+          CIRCLE_BRANCH: 'feature/narrow-change',
+          CIRCLE_PROJECT_USERNAME: 'cypress-io',
+          CIRCLE_PROJECT_REPONAME: 'cypress',
+          RUN_ALL_JOBS: 'true',
+        },
+      })
+
+      const runFlags = Object.entries(params).filter(([key]) => key.startsWith('run-'))
+
+      for (const [, value] of runFlags) {
+        expect(value, 'all run-* parameters should be true when RUN_ALL_JOBS=true').to.equal(true)
+      }
+    })
+
+    it('does not treat unset RUN_ALL_JOBS as true (path filtering still applies)', () => {
+      tmpDir = createTempRepoWithChange('packages/icons/foo.ts')
+      const params = runGeneratePipelineParameters({
+        cwd: tmpDir,
+        env: {
+          CIRCLE_BRANCH: 'feature/narrow-change',
+          CIRCLE_PROJECT_USERNAME: 'cypress-io',
+          CIRCLE_PROJECT_REPONAME: 'cypress',
+        },
+      })
+
+      expect(params['run-cli-tests']).to.equal(false)
+    })
+
+    it('runs all jobs on develop without RUN_ALL_JOBS', () => {
+      tmpDir = createTempRepoWithChange('packages/icons/foo.ts')
+      const params = runGeneratePipelineParameters({
+        cwd: tmpDir,
+        env: {
+          CIRCLE_BRANCH: 'develop',
+          CIRCLE_PROJECT_USERNAME: 'cypress-io',
+          CIRCLE_PROJECT_REPONAME: 'cypress',
+        },
+      })
+
+      expect(params['run-cli-tests']).to.equal(true)
+      expect(params['run-v8-tests']).to.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [PR #33896 discussion r3313803557](https://github.com/cypress-io/cypress/pull/33896#discussion_r3313803557): `run-all-jobs` was briefly added to the primary pipeline config with `default: true`, which would bypass PR path filtering when CircleCI injects pipeline parameter defaults into `RUN_ALL_JOBS` for `generate-pipeline-parameters.sh`.

The parameter is still needed on the continued pipeline so it can be set from CircleCI’s “Trigger Pipeline” UI on PRs, but it must default to `false` so path filtering remains the default behavior.

## Root cause

`launch-primary-workflow` passes `RUN_ALL_JOBS: << pipeline.parameters.run-all-jobs >>` into `generate-pipeline-parameters.sh`. When `run-all-jobs` defaults to `true`, every PR build skips path filtering and runs all jobs.

## Changes

- Declare `run-all-jobs` in `.circleci/src/pipeline/@pipeline.yml` with `default: false` and a short comment
- Add `scripts/unit/generate-pipeline-parameters-spec.js` integration tests for path filtering vs `RUN_ALL_JOBS=true`
- Add `scripts/circleci/pipeline-parameter-defaults.js` to assert both setup and primary configs keep `default: false`
- Add `PIPELINE_PARAMS_SKIP_FETCH` test hook so unit tests avoid `git fetch` to GitHub

## How to test

```bash
yarn test-scripts --grep "generate-pipeline-parameters"
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da8f6737-dcff-4637-a232-4a8d5f1d30e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da8f6737-dcff-4637-a232-4a8d5f1d30e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

