### PR TITLE
chore: increase timeout on prepare-release-artifacts unit test

### DIFF
--- a/scripts/unit/prepare-release-artifacts-spec.js
+++ b/scripts/unit/prepare-release-artifacts-spec.js
@@ -2,7 +2,8 @@ const shelljs = require('shelljs')
 const snapshot = require('snap-shot-it')
 
 describe('prepare-release-artifacts', () => {
-  it('runs expected commands', () => {
+  it('runs expected commands', function () {
+    this.timeout(10_000)
     const stdout = shelljs.exec('yarn prepare-release-artifacts --dry-run --sha 57d0a85108fad6f77b39db88b8a7d8a3bfdb51a2 --version 1.2.3')
 
     snapshot(stdout)


### PR DESCRIPTION
- Closes n/a (flaky CI test cleanup)

### Additional details

The `prepare-release-artifacts > runs expected commands` unit test synchronously runs `yarn prepare-release-artifacts --dry-run …` via `shelljs.exec`, which in turn spawns a `node` child to run the script. With mocha's default 2 s timeout, this occasionally flakes on busy CI runners even though the dry-run completes successfully — example failure: https://app.circleci.com/pipelines/github/cypress-io/cypress/82122/workflows/bbe770b0-ed11-4743-8d33-4851d713e418/jobs/3668448.

Bumping the per-test timeout to 10 s gives the spawned `yarn` + `node` enough headroom without masking real regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI stability change with no production or runtime behavior impact.
> 
> **Overview**
> Raises the Mocha timeout for **`prepare-release-artifacts > runs expected commands`** from the default **2s** to **10s** so the test can finish when it shells out to `yarn prepare-release-artifacts --dry-run` under slow CI.
> 
> The example is switched from an arrow function to a **`function`** callback so **`this.timeout(10_000)`** is valid in Mocha.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ad7cb11034552b0098016b354d7564312021ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- `yarn test-scripts` (or run just this spec) — the `prepare-release-artifacts` test should pass consistently.

### How has the user experience changed?

No change — internal CI flake fix only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?