### PR TITLE
fix: escape HTML in reporter assertion messages (#33416)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added [Bun](https://bun.sh) as a recognized package manager. The `cypress` npm package can now be installed and invoked with Bun (for example `bun run cypress open` or `bun run cypress run`). Addresses [#28962](https://github.com/cypress-io/cypress/issues/28962). Addressed in [#32580](https://github.com/cypress-io/cypress/pull/32580).
 - Improved CI environment detection and commit metadata capture for Cypress Cloud recorded runs within Argo CD and Argo Workflows. Addressed in [#33932](https://github.com/cypress-io/cypress/pull/33932).
 
+**Bugfixes:**
+
+- Fixed an issue where HTML markup passed as a Sinon spy argument (for example `expect(spy).to.have.been.calledOnceWith('<svg>...</svg>')`) was rendered as live DOM in the Cypress command log, truncating the assertion message and breaking the log layout. The assertion message is now HTML-escaped and the markup is shown as literal text. Fixes [#33416](https://github.com/cypress-io/cypress/issues/33416). Fixed in [#33941](https://github.com/cypress-io/cypress/pull/33941).
+
 ## 15.16.0
 
 **Features:**

--- a/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/formatted_message.cy.ts
@@ -99,6 +99,20 @@ describe('formattedMessage', () => {
 
       expect(result).to.equal('My Custom Message: expected <strong>abcdef</strong> to equal <strong>abcdef</strong>')
     })
+
+    it('escapes HTML in unwrapped trailing clause (sinon calledWith args)', () => {
+      const specialMessage = 'expected method to have been called once with <svg viewBox="0 0 10 10"></svg>'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected method to have been called once with &lt;svg viewBox=&quot;0 0 10 10&quot;&gt;&lt;/svg&gt;')
+    })
+
+    it('escapes HTML in unwrapped subject clause', () => {
+      const specialMessage = 'expected <img onerror=x> to be visible'
+      const result = formattedMessage(specialMessage, 'assert')
+
+      expect(result).to.equal('expected &lt;img onerror=x&gt; to be visible')
+    })
   })
 
   describe('when command that accepts url', () => {

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -73,7 +73,7 @@ export const formattedMessage = (message: string, name?: string) => {
     }
     // for assertions print the exact text so that characters like _ and *
     // are not escaped in the assertion display when comparing values
-    const result = assertionArray.flatMap((s, index) => [s, expectedActualArray()[index]])
+    const result = assertionArray.flatMap((s, index) => [_.escape(s), expectedActualArray()[index]])
 
     return result.join('')
   }


### PR DESCRIPTION
- Closes #33416

### Additional details

The reporter's `formattedMessage()` in [`packages/reporter/src/commands/command.tsx`](https://github.com/cypress-io/cypress/blob/develop/packages/reporter/src/commands/command.tsx) splits assert-command messages into two interleaved streams:

1. **Structural matches** from `assertionRegex` (e.g. `expected `, ` to have been called once`, ` with <svg ...></svg>`)
2. **Value parts** between matches (typically wrapped in `**…**`)

Value parts are HTML-escaped via `mdOnlyHTML.renderInline()`, but the structural matches were being concatenated **verbatim** into the string that's then handed to `dangerouslySetInnerHTML`. For sinon-chai messages like `expected method to have been called once with <svg>…</svg>`, the SVG argument is appended to the trailing ` with …` clause and never wrapped in `**`, so it slipped through unescaped and the browser rendered live markup in the command log.

The fix is a one-line change: apply `_.escape(s)` to the structural matches before joining, mirroring the escaping the value parts already get. Lodash is already imported. Existing assertion keywords (` to `, ` with `, etc.) contain no HTML entities so the escape is a no-op for them — all prior `formatted_message` tests keep their existing expected output.

No driver change is needed: `chai.ts`'s `escapeMarkdown` only protects against markdown image syntax; HTML escaping is the reporter's responsibility.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow reporter display fix with unit tests; standard assertion wording is unchanged by escaping.
> 
> **Overview**
> **Assertion messages in the command log** now HTML-escape structural text segments (e.g. `expected …`, ` with …`) before rendering, not only the `**…**` value parts. That stops markup in Sinon-style failures such as `calledOnceWith('<svg>…')` from being interpreted as live DOM and breaking the log layout.
> 
> The change is a one-line use of `_.escape()` in `formattedMessage()` in the reporter, plus two unit tests and a **15.17.0** changelog bugfix entry for [#33416](https://github.com/cypress-io/cypress/issues/33416).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb990d15e487e71ed58d4738dce5ce2ce272daf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Using the repro from the [linked repo](https://github.com/matafokka/cypress-html-escaping-bug-repro):

```js
describe('Strings passed in arguments', () => {
  it('should be escaped', () => {
    const obj = { method: () => undefined }

    cy.spy(obj, 'method')
    const markup = \`<svg viewBox="0 0 10 10" width="10" height="10"></svg>\`

    obj.method(markup)
    expect(obj.method).to.have.been.calledOnceWith(markup)
  })
})
```

1. Run the spec in the Cypress runner.
2. Observe the failed-assertion line in the command log: it should display the SVG markup as **literal text** (`<svg viewBox="0 0 10 10" width="10" height="10"></svg>`), not as a rendered SVG element that breaks the log's layout.
3. Inspect the assertion's `.command-message-text` in DevTools — its `innerHTML` should contain `&lt;svg`, not `<svg`.

Automated coverage: `yarn workspace @packages/reporter cypress:run -- --spec "cypress/e2e/unit/formatted_message.cy.ts"` — two new regression tests in the existing `when assertion` block cover HTML in the trailing `with` clause and in the subject clause.

### How has the user experience changed?

Before: HTML passed as a sinon spy argument (e.g. via `calledWith`) was injected into the reporter as live DOM, breaking the command log layout — the issue's screenshot shows an actual rendered SVG element where the assertion text should be.
<img width="1280" height="633" alt="before" src="https://github.com/user-attachments/assets/361bfb64-41fa-4039-ba5d-62bc80fb969e" />

After: the same HTML is shown as escaped literal text in the assertion message, so the command log layout is preserved and the user can read what was passed.
<img width="1280" height="633" alt="after" src="https://github.com/user-attachments/assets/b98f5784-c63a-4f3e-8a60-564f53621c55" />

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? — #33416 (`type: bug`, on the App triage board)
- [x] Have tests been added/updated? — two regression tests added to [`formatted_message.cy.ts`](packages/reporter/cypress/e2e/unit/formatted_message.cy.ts)
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?