### PR TITLE
fix(server): propagate browser renderer crash to sibling CRI clients

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added [Bun](https://bun.sh) as a recognized package manager. The `cypress` npm package can now be installed and invoked with Bun (for example `bun run cypress open` or `bun run cypress run`). Addresses [#28962](https://github.com/cypress-io/cypress/issues/28962). Addressed in [#32580](https://github.com/cypress-io/cypress/pull/32580).
 - Improved CI environment detection and commit metadata capture for Cypress Cloud recorded runs within Argo CD and Argo Workflows. Addressed in [#33932](https://github.com/cypress-io/cypress/pull/33932).
 
+**Bugfixes:**
+
+- Fixed an issue where a recorded Chrome run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
+
 ## 15.16.0
 
 **Features:**

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue where a recorded Chrome run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
+- Fixed an issue where a recorded Chrome or Electron run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
 
 ## 15.16.0
 

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -540,6 +540,16 @@ export = {
         return
       }
 
+      // Synchronously mark sibling CRI clients (which share the same targetId)
+      // as crashed. Each sibling has its own websocket and its own listener for
+      // Target.targetCrashed, but those listeners fire when Chrome happens to
+      // deliver the event on that connection — which can be after spec
+      // cleanup runs. Without this propagation, the protocol's `afterSpec`
+      // hook can call `cdpClient.send` on a crashed page and hang forever.
+      browserCriClient.currentlyAttachedProtocolTarget?.markCrashed()
+      browserCriClient.currentlyAttachedCyPromptTarget?.markCrashed()
+      browserCriClient.currentlyAttachedStudioTarget?.markCrashed()
+
       const err = errors.get('RENDERER_CRASHED', browser.displayName)
 
       await memory.endProfiling()

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -229,6 +229,20 @@ export class CriClient implements ICriClient {
     return this._crashed
   }
 
+  /**
+   * Synchronously mark this CRI client as crashed. Used to propagate a crash
+   * notification from a sibling client (e.g. the page client to the protocol,
+   * cy-prompt, and studio clones) before any of them can race against the
+   * separate `Target.targetCrashed` event delivery on their own connections.
+   *
+   * Without this, the sibling client may not yet have observed the crash event
+   * on its own websocket and a subsequent `send()` will hang forever because
+   * the renderer is dead and will never respond.
+   */
+  public markCrashed = () => {
+    this._crashed = true
+  }
+
   public connect = async () => {
     debug('connecting %o', { connected: this._connected, target: this.targetId })
 

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -180,6 +180,17 @@ export = {
       // causing screenshots/videos to be off by 1px
       resizable: !options.browser.isHeadless,
       async onCrashed () {
+        // Synchronously mark sibling CRI clients (which share the same targetId)
+        // as crashed. Each sibling has its own websocket and its own listener for
+        // Target.targetCrashed, but those listeners fire when Chromium happens
+        // to deliver the event on that connection — which can be after spec
+        // cleanup runs. Without this propagation, the protocol's `afterSpec`
+        // hook can call `cdpClient.send` on a crashed page and hang forever.
+        // See the chrome.ts handler for the analogous case.
+        browserCriClient?.currentlyAttachedProtocolTarget?.markCrashed()
+        browserCriClient?.currentlyAttachedCyPromptTarget?.markCrashed()
+        browserCriClient?.currentlyAttachedStudioTarget?.markCrashed()
+
         const err = errors.get('RENDERER_CRASHED', 'Electron')
 
         await memory.endProfiling()


### PR DESCRIPTION
- Closes n/a

### Additional details

This fixes an intermittent CI flake in `e2e record / capture-protocol / enabled / when the tab crashes in chrome / posts accurate test results` (and any user-facing scenario where a Chrome or Electron renderer crashes during a recorded run). The test would time out at mocha's 120s spec limit instead of failing the impacted spec and continuing.

**Root cause** — a race between two CRI WebSocket connections that share the same crashed target:

1. When the renderer crashes, the **page** CRI client's `Target.targetCrashed` listener (Chrome) — or Electron's IPC `onCrashed` hook — fires first and triggers spec recovery: `chrome.ts` / `electron.ts` → `onError` → `exitEarly`.
2. Recovery synchronously enters `waitForTestsToFinishRunning` cleanup → `protocolManager.afterSpec()` → the capture protocol's `cdpClient.send('Page.removeScriptToEvaluateOnNewDocument', …)`.
3. The capture protocol uses a **separate** CRI client (a clone of the page client, `browserCriClient.currentlyAttachedProtocolTarget`) on its own WebSocket. The `_crashed` flag on that clone is only set when *its* listener fires for `Target.targetCrashed`.
4. If Chromium delivers the crash event to the page connection a few ms before the protocol connection, the `send()` in step 2 runs while `_crashed` is still `false` on the protocol clone. The CDP request is queued for a dead renderer that never responds, and the run hangs until the mocha timeout fires.

**Fix** — propagate the crash synchronously to all sibling CRI clients (capture-protocol, cy-prompt, studio) in the renderer-crash handlers before triggering recovery. Their subsequent `send()` calls then reject immediately via the existing `_crashed` guard in `cri-client.ts`.

Three changes:
- `cri-client.ts` — new `markCrashed()` public method so a sibling can force the flag without waiting for its own websocket to receive the event.
- `chrome.ts` — call `markCrashed()` on the protocol/cy-prompt/studio targets in the existing `Target.targetCrashed` handler.
- `electron.ts` — same propagation in the Electron `onCrashed` handler (same protocol-clone architecture, same race shape).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser crash recovery and CDP client state for Chrome/Electron recorded runs; scope is narrow (synchronous sibling marking before existing onError path) but affects timing-critical shutdown paths.
> 
> **Overview**
> Fixes a **race on renderer crash** when Cypress keeps **multiple CRI WebSocket clients** on the same tab (page, capture-protocol, cy-prompt, studio). The page client’s crash handler could start spec recovery and run **`afterSpec` CDP** on the protocol clone **before** that clone’s own `Target.targetCrashed` fired, so `send()` could block until the **spec timeout** instead of failing fast.
> 
> Adds **`markCrashed()`** on `CriClient` and calls it on the protocol/cy-prompt/studio siblings from the **Chrome** `Target.targetCrashed` handler and **Electron** `onCrashed`, so those clients reject CDP immediately via the existing `_crashed` guard. Documents the fix in **`cli/CHANGELOG.md`** (15.17.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59390c396d2e16abba5a6c006d09e2f398fd6c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Locally reproduced the flake at ~4–12% rate without the fix; 0/100 with the fix.

```bash
for i in $(seq 1 50); do
  NODE_ENV=test CYPRESS_INTERNAL_ENV=test BROWSER=chrome \
    node --max-http-header-size=1048576 --tls-cipher-list=DEFAULT@SECLEVEL=0 \
    system-tests/node_modules/.bin/_mocha \
    system-tests/test/record_spec.js \
    --grep "when the tab crashes in chrome" \
    --timeout 180000 --recursive -r @packages/ts/register \
    --extension=js,ts --exit
done
```

Each iteration should pass in ~13s. Without the fix, ~1 in 10–25 hangs to a 120s mocha timeout with the stdout stopping after "We have failed the current spec but will continue running the next spec." and no `Running: record_pass.cy.js (2 of 2)` ever appearing.

The Electron change mirrors the chrome.ts handler and isn't covered by a dedicated system test today; it's verified by code symmetry with the chrome.ts path and a type-check pass.

### How has the user experience changed?

For users running recorded runs with the capture protocol: previously, if a Chrome or Electron renderer crashed during a spec, the run could hang silently for the duration of the mocha spec timeout (or, in CI, until the job hit its overall budget) instead of failing the impacted spec and continuing to the next one. With this change, the spec fails immediately and the run continues as designed.

No change to public APIs, config, or observable output on the happy path.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated? <!-- The existing `e2e record / capture-protocol / when the tab crashes in chrome / posts accurate test results` system test exercises this path and was previously flaky for this exact reason. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?
