### PR TITLE
test(data-context): fix flaky GitDataSource lock race

### DIFF
--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -24,10 +24,10 @@ describe('GitDataSource', () => {
 
     if (process.env.CI) {
       // need to set a user on CI
-      await Promise.all([
-        git.addConfig('user.name', 'Test User', true, 'global'),
-        git.addConfig('user.email', 'test-user@example.com', true, 'global'),
-      ])
+      // run sequentially: concurrent writes to ~/.gitconfig race on the
+      // .gitconfig.lock file and intermittently fail with "could not lock"
+      await git.addConfig('user.name', 'Test User', true, 'global')
+      await git.addConfig('user.email', 'test-user@example.com', true, 'global')
     }
 
     await git.init()


### PR DESCRIPTION
- Closes n/a

### Additional details

The `beforeEach` hook in `packages/data-context/test/unit/sources/GitDataSource.spec.ts` set `user.name` and `user.email` on the global `~/.gitconfig` in parallel via `Promise.all`:

```ts
await Promise.all([
  git.addConfig('user.name', 'Test User', true, 'global'),
  git.addConfig('user.email', 'test-user@example.com', true, 'global'),
])
```

Both writes acquire `~/.gitconfig.lock`, so when the two `git config` invocations race, the loser fails with:

```
error: could not lock config file /home/circleci/.gitconfig: File exists
```

This intermittently fails the `unit-tests` job on CircleCI — for example, [job 3671516](https://app.circleci.com/pipelines/github/cypress-io/cypress/82174/workflows/2f9138a1-211e-4729-b6e7-bf1f44d44354/jobs/3671516) on `develop`, with the next run on the same branch passing untouched.

There is no benefit to parallelizing two writes to the same file. This PR serializes them with sequential `await`s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI setup change with no runtime, security, or data-handling impact.
> 
> **Overview**
> In **`GitDataSource.spec.ts`**, CI-only setup for global `user.name` and `user.email` no longer runs both `git addConfig` calls in parallel. The hook now **awaits each config write in order** and documents that concurrent updates to `~/.gitconfig` can race on `.gitconfig.lock` and fail intermittently on CircleCI.
> 
> No production or `GitDataSource` behavior changes—only test harness stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aaba0af88f550fb7f8bd6fcad40c254ab10d6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Existing `GitDataSource` unit tests should continue to pass; the change is limited to test setup.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-only flake fix -->
- [na] Have tests been added/updated? <!-- Test setup hardened; no new behavior to cover -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?