### PR TITLE
fix: Warn and ignore invalid `CYPRESS_env` and `CYPRESS_expose` values

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where invalid `CYPRESS_env` or `CYPRESS_expose` environment variables (for example, a plain string instead of a JSON object) were silently ignored with no warning. Cypress now emits a warning explaining that a JSON object is required and points to the `--env` or `--expose` CLI flags for setting individual values. Fixes [#29682](https://github.com/cypress-io/cypress/issues/29682). Fixed in [#33945](https://github.com/cypress-io/cypress/pull/33945).
 - Fixed an issue where HTML markup passed as a Sinon spy argument (for example `expect(spy).to.have.been.calledOnceWith('<svg>...</svg>')`) was rendered as live DOM in the Cypress command log, truncating the assertion message and breaking the log layout. The assertion message is now HTML-escaped and the markup is shown as literal text. Fixes [#33416](https://github.com/cypress-io/cypress/issues/33416). Fixed in [#33941](https://github.com/cypress-io/cypress/pull/33941).
 
 ## 15.16.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue where invalid `CYPRESS_env` or `CYPRESS_expose` environment variables (for example, a plain string instead of a JSON object) were silently ignored with no warning. Cypress now emits a warning explaining that a JSON object is required and points to the `--env` or `--expose` CLI flags for setting individual values. Fixes [#29682](https://github.com/cypress-io/cypress/issues/29682). Fixed in [#33945](https://github.com/cypress-io/cypress/pull/33945).
+- Fixed an issue where invalid `CYPRESS_env` or `CYPRESS_expose` environment variables (for example, a plain string instead of a JSON object) were silently ignored with no warning. Cypress now emits a warning explaining that a JSON object is required and points to the `--env` or `--expose` CLI flags for setting individual values. Fixes [#29682](https://github.com/cypress-io/cypress/issues/29682) and [#19508](https://github.com/cypress-io/cypress/issues/19508). Fixed in [#33945](https://github.com/cypress-io/cypress/pull/33945).
 - Fixed an issue where HTML markup passed as a Sinon spy argument (for example `expect(spy).to.have.been.calledOnceWith('<svg>...</svg>')`) was rendered as live DOM in the Cypress command log, truncating the assertion message and breaking the log layout. The assertion message is now HTML-escaped and the markup is shown as literal text. Fixes [#33416](https://github.com/cypress-io/cypress/issues/33416). Fixed in [#33941](https://github.com/cypress-io/cypress/pull/33941).
 
 ## 15.16.0

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -33,6 +33,7 @@ src/
 
 ## Gotchas / Notes
 
+- `CYPRESS_env` and `CYPRESS_expose` must be valid JSON objects (e.g. `{"key":"value"}`). Plain strings are warned and ignored; use `--env key=value` for individual Cypress env vars instead.
 - Builds to both `cjs/` and `esm/` directories. The `browser` field in `package.json` points to the ESM build so bundlers targeting the browser get a tree-shakeable subset without Node.js-only imports.
 - The `ast-utils/` directory uses Babel's parser and `recast` to perform lossless source transforms on config files (preserving comments and formatting).
 - Tests use `vitest run` — no watch mode by default; use `test-debug` for breakpoint debugging with `--inspect-brk`.

--- a/packages/config/src/project/utils.ts
+++ b/packages/config/src/project/utils.ts
@@ -123,6 +123,15 @@ export function parseEnv (cfg: Record<string, any>, cliEnvs: Record<string, any>
     const cfgKey = matchesConfigKey(key)
 
     if (cfgKey) {
+      const validationFn = options.find((o) => o.name === cfgKey)?.validation
+
+      if (validationFn && validationFn(cfgKey, val) !== true) {
+        errors.warning('INVALID_CYPRESS_ENV_OVERRIDE', cfgKey, val)
+        memo.push(key)
+
+        return memo
+      }
+
       // only change the value if it hasn't been
       // set by the CLI. override default + config
       if (resolved[cfgKey] !== 'cli') {

--- a/packages/config/src/project/utils.ts
+++ b/packages/config/src/project/utils.ts
@@ -21,6 +21,7 @@ import {
 } from '../browser'
 import { hideKeys, setUrls, coerce } from '../utils'
 import { options } from '../options'
+import { isPlainObject } from '../validation'
 
 const debug = Debug('cypress:config:project:utils')
 
@@ -88,6 +89,10 @@ const CYPRESS_SPECIAL_ENV_VARS = [
   'RECORD_KEY',
 ]
 
+// CYPRESS_env and CYPRESS_expose must be JSON objects. Invalid strings are coerced
+// then spread via _.extend, producing indexed keys that pass isPlainObject validation.
+const PLAIN_OBJECT_CONFIG_KEYS_FROM_ENV = new Set(['env', 'expose'])
+
 const isCypressEnvLike = (key: string) => {
   return _.chain(key)
   .invoke('toUpperCase')
@@ -123,13 +128,15 @@ export function parseEnv (cfg: Record<string, any>, cliEnvs: Record<string, any>
     const cfgKey = matchesConfigKey(key)
 
     if (cfgKey) {
-      const validationFn = options.find((o) => o.name === cfgKey)?.validation
+      if (PLAIN_OBJECT_CONFIG_KEYS_FROM_ENV.has(cfgKey)) {
+        const validationResult = isPlainObject(cfgKey, val)
 
-      if (validationFn && validationFn(cfgKey, val) !== true) {
-        errors.warning('INVALID_CYPRESS_ENV_OVERRIDE', cfgKey, val)
-        memo.push(key)
+        if (validationResult !== true) {
+          errors.warning('INVALID_CYPRESS_ENV_OVERRIDE', cfgKey, val)
+          memo.push(key)
 
-        return memo
+          return memo
+        }
       }
 
       // only change the value if it hasn't been

--- a/packages/config/test/project/utils.spec.ts
+++ b/packages/config/test/project/utils.spec.ts
@@ -296,6 +296,15 @@ describe('config/src/project/utils', () => {
       expect(result).toEqual({ existing: 'value' })
     })
 
+    it('does not spread invalid CYPRESS_env into indexed env keys', () => {
+      vi.stubEnv('CYPRESS_env', 'bad')
+
+      const result = parseEnv({ env: { existing: 'value' } }, {})
+
+      expect(result).toEqual({ existing: 'value' })
+      expect(result).not.toHaveProperty('0')
+    })
+
     it('warns and ignores CYPRESS_env when set to a numeric string', () => {
       vi.stubEnv('CYPRESS_env', '42')
 
@@ -307,7 +316,25 @@ describe('config/src/project/utils', () => {
       expect(result).toEqual({})
     })
 
-    it('does not warn when CYPRESS_env is set to a valid JSON object', () => {
+    it('warns and ignores CYPRESS_env when set to a JSON array', () => {
+      vi.stubEnv('CYPRESS_env', '[]')
+
+      const result = parseEnv({ env: { existing: 'value' } }, {})
+
+      expect(errors.warning).toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', [])
+      expect(result).toEqual({ existing: 'value' })
+    })
+
+    it('warns and ignores CYPRESS_ENV regardless of casing', () => {
+      vi.stubEnv('CYPRESS_ENV', 'notAnObject')
+
+      const result = parseEnv({ env: { existing: 'value' } }, {})
+
+      expect(errors.warning).toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 'notAnObject')
+      expect(result).toEqual({ existing: 'value' })
+    })
+
+    it('applies CYPRESS_env when set to a valid JSON object', () => {
       vi.stubEnv('CYPRESS_env', '{"foo":"bar"}')
 
       const obj = { env: {} }
@@ -315,6 +342,18 @@ describe('config/src/project/utils', () => {
       parseEnv(obj, {})
 
       expect(errors.warning).not.toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', expect.anything())
+      expect(obj.env).toEqual({ foo: 'bar' })
+    })
+
+    it('warns and ignores CYPRESS_expose when set to a non-object string value', () => {
+      vi.stubEnv('CYPRESS_expose', 'notAnObject')
+
+      const obj = { expose: { existing: 'value' } }
+
+      parseEnv(obj, {})
+
+      expect(errors.warning).toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'expose', 'notAnObject')
+      expect(obj.expose).toEqual({ existing: 'value' })
     })
   })
 

--- a/packages/config/test/project/utils.spec.ts
+++ b/packages/config/test/project/utils.spec.ts
@@ -284,6 +284,38 @@ describe('config/src/project/utils', () => {
         baz: 'quux',
       })
     })
+
+    it('warns and ignores CYPRESS_env when set to a non-object string value', () => {
+      vi.stubEnv('CYPRESS_env', 'notAnObject')
+
+      const obj = { env: { existing: 'value' } }
+
+      const result = parseEnv(obj, {})
+
+      expect(errors.warning).toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 'notAnObject')
+      expect(result).toEqual({ existing: 'value' })
+    })
+
+    it('warns and ignores CYPRESS_env when set to a numeric string', () => {
+      vi.stubEnv('CYPRESS_env', '42')
+
+      const obj = { env: {} }
+
+      const result = parseEnv(obj, {})
+
+      expect(errors.warning).toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 42)
+      expect(result).toEqual({})
+    })
+
+    it('does not warn when CYPRESS_env is set to a valid JSON object', () => {
+      vi.stubEnv('CYPRESS_env', '{"foo":"bar"}')
+
+      const obj = { env: {} }
+
+      parseEnv(obj, {})
+
+      expect(errors.warning).not.toHaveBeenCalledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', expect.anything())
+    })
   })
 
   describe('.resolveConfigValues', () => {

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1127,6 +1127,22 @@ export const AllCypressErrors = {
 
         CYPRESS_INTERNAL_ENV is reserved for internal use and cannot be modified.`
   },
+  INVALID_CYPRESS_ENV_OVERRIDE: (cfgKey: string, val: any) => {
+    if (cfgKey === 'env') {
+      return errTemplate`\
+          The ${fmt.highlightSecondary(`CYPRESS_env`)} environment variable must be a valid JSON object, but received: ${fmt.highlight(String(val))}
+
+          To pass individual key-value pairs, use the ${fmt.highlightSecondary(`--env`)} CLI flag instead:
+          ${fmt.highlightSecondary(`cypress run --env key=value`)}
+
+          The ${fmt.highlightSecondary(`CYPRESS_env`)} override will be ignored.`
+    }
+
+    return errTemplate`\
+        The ${fmt.highlightSecondary(`CYPRESS_${cfgKey}`)} environment variable has an invalid value and will be ignored.
+
+        Received: ${fmt.highlight(String(val))}`
+  },
   CDP_COULD_NOT_CONNECT: (browserName: string, port: number, err: Error) => {
     // we include a stack trace here because it may contain useful information
     // to debug since this is an "uncontrolled" error even though it doesn't

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1128,20 +1128,13 @@ export const AllCypressErrors = {
         CYPRESS_INTERNAL_ENV is reserved for internal use and cannot be modified.`
   },
   INVALID_CYPRESS_ENV_OVERRIDE: (cfgKey: string, val: any) => {
-    if (cfgKey === 'env') {
-      return errTemplate`\
-          The ${fmt.highlightSecondary(`CYPRESS_env`)} environment variable must be a valid JSON object, but received: ${fmt.highlight(String(val))}
-
-          To pass individual key-value pairs, use the ${fmt.highlightSecondary(`--env`)} CLI flag instead:
-          ${fmt.highlightSecondary(`cypress run --env key=value`)}
-
-          The ${fmt.highlightSecondary(`CYPRESS_env`)} override will be ignored.`
-    }
-
     return errTemplate`\
-        The ${fmt.highlightSecondary(`CYPRESS_${cfgKey}`)} environment variable has an invalid value and will be ignored.
+        The ${fmt.highlightSecondary(`CYPRESS_${cfgKey}`)} environment variable must be a valid JSON object, but received: ${fmt.highlight(String(val))}
 
-        Received: ${fmt.highlight(String(val))}`
+        To pass individual key-value pairs, use the ${fmt.highlightSecondary(`--${cfgKey}`)} CLI flag instead:
+        ${fmt.highlightSecondary(`cypress run --${cfgKey} key=value`)}
+
+        The ${fmt.highlightSecondary(`CYPRESS_${cfgKey}`)} override will be ignored.`
   },
   CDP_COULD_NOT_CONNECT: (browserName: string, port: number, err: Error) => {
     // we include a stack trace here because it may contain useful information

--- a/packages/errors/test/__snapshots__/INVALID_CYPRESS_ENV_OVERRIDE.ansi
+++ b/packages/errors/test/__snapshots__/INVALID_CYPRESS_ENV_OVERRIDE.ansi
@@ -1,0 +1,6 @@
+[31mThe [95mCYPRESS_env[39m[31m environment variable must be a valid JSON object, but received: [33mnotAnObject[39m[31m[39m
+[31m[39m
+[31mTo pass individual key-value pairs, use the [95m--env[39m[31m CLI flag instead:[39m
+[31m[95mcypress run --env key=value[39m[31m[39m
+[31m[39m
+[31mThe [95mCYPRESS_env[39m[31m override will be ignored.[39m

--- a/packages/errors/test/visualSnapshotErrors.spec.ts
+++ b/packages/errors/test/visualSnapshotErrors.spec.ts
@@ -881,6 +881,11 @@ describe('visual error templates', () => {
         default: ['foo'],
       }
     },
+    INVALID_CYPRESS_ENV_OVERRIDE: () => {
+      return {
+        default: ['env', 'notAnObject'],
+      }
+    },
     CDP_COULD_NOT_CONNECT: () => {
       return {
         default: ['chrome', 2345, makeErr()],

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -882,13 +882,25 @@ describe('lib/cypress', () => {
       })
     })
 
-    it('logs error and exits when project has invalid config values from env vars', function () {
+    it('logs warning and continues when project has invalid config values from env vars', function () {
       process.env.CYPRESS_BASE_URL = 'localhost:9999'
 
       return cypress.start([`--run-project=${this.todosPath}`])
       .then(() => {
-        this.expectExitWithErr('CONFIG_VALIDATION_ERROR', 'localhost:9999')
-        this.expectExitWithErr('CONFIG_VALIDATION_ERROR', 'An invalid configuration value was set.')
+        delete process.env.CYPRESS_BASE_URL
+        expect(console.log).to.be.calledWithMatch('CYPRESS_baseUrl')
+        this.expectExitWith(0)
+      })
+    })
+
+    it('logs warning and continues when CYPRESS_env is set to a non-object value', function () {
+      process.env.CYPRESS_env = 'invalid-string'
+
+      return cypress.start([`--run-project=${this.todosPath}`])
+      .then(() => {
+        delete process.env.CYPRESS_env
+        expect(console.log).to.be.calledWithMatch('CYPRESS_env')
+        this.expectExitWith(0)
       })
     })
 

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -882,14 +882,14 @@ describe('lib/cypress', () => {
       })
     })
 
-    it('logs warning and continues when project has invalid config values from env vars', function () {
+    it('logs error and exits when project has invalid config values from env vars', function () {
       process.env.CYPRESS_BASE_URL = 'localhost:9999'
 
       return cypress.start([`--run-project=${this.todosPath}`])
       .then(() => {
         delete process.env.CYPRESS_BASE_URL
-        expect(console.log).to.be.calledWithMatch('CYPRESS_baseUrl')
-        this.expectExitWith(0)
+        this.expectExitWithErr('CONFIG_VALIDATION_ERROR', 'localhost:9999')
+        this.expectExitWithErr('CONFIG_VALIDATION_ERROR', 'An invalid configuration value was set.')
       })
     })
 
@@ -899,7 +899,10 @@ describe('lib/cypress', () => {
       return cypress.start([`--run-project=${this.todosPath}`])
       .then(() => {
         delete process.env.CYPRESS_env
+        expect(errors.warning).to.be.calledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 'invalid-string')
         expect(console.log).to.be.calledWithMatch('CYPRESS_env')
+        expect(console.log).to.be.calledWithMatch('must be a valid JSON object')
+        expect(console.log).to.be.calledWithMatch('--env')
         this.expectExitWith(0)
       })
     })

--- a/packages/server/test/integration/cypress_spec.js
+++ b/packages/server/test/integration/cypress_spec.js
@@ -29,6 +29,7 @@ const cwd = require(`../../lib/cwd`).getCwd
 const user = require(`../../lib/cloud/user`).default
 const cache = require(`../../lib/cache`).cache
 const errors = require(`../../lib/errors`)
+const errorsPkg = require('@packages/errors')
 const cypress = require(`../../lib/cypress`)
 const ProjectBase = require(`../../lib/project-base`).ProjectBase
 const { ServerBase } = require(`../../lib/server-base`)
@@ -199,10 +200,17 @@ describe('lib/cypress', () => {
     sinon.stub(detect, 'detect').resolves([...TYPICAL_BROWSERS])
     sinon.stub(process, 'exit')
     sinon.stub(ServerBase.prototype, 'reset')
-    sinon.stub(errors, 'warning')
-    .callThrough()
-    .withArgs('INVOKED_BINARY_OUTSIDE_NPM_MODULE')
-    .returns(null)
+    const originalWarning = errorsPkg.default.warning
+
+    sinon.stub(errorsPkg.default, 'warning').callsFake((type, ...args) => {
+      if (type === 'INVOKED_BINARY_OUTSIDE_NPM_MODULE') {
+        return null
+      }
+
+      return originalWarning(type, ...args)
+    })
+
+    sinon.stub(errors, 'warning').callsFake((type, ...args) => errorsPkg.default.warning(type, ...args))
 
     sinon.spy(errors, 'log')
     sinon.spy(errors, 'logException')
@@ -899,7 +907,7 @@ describe('lib/cypress', () => {
       return cypress.start([`--run-project=${this.todosPath}`])
       .then(() => {
         delete process.env.CYPRESS_env
-        expect(errors.warning).to.be.calledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 'invalid-string')
+        expect(errorsPkg.default.warning).to.be.calledWith('INVALID_CYPRESS_ENV_OVERRIDE', 'env', 'invalid-string')
         expect(console.log).to.be.calledWithMatch('CYPRESS_env')
         expect(console.log).to.be.calledWithMatch('must be a valid JSON object')
         expect(console.log).to.be.calledWithMatch('--env')


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/19508
- Closes https://github.com/cypress-io/cypress/issues/29682
- And https://github.com/cypress-io/cypress-documentation/issues/5847

### Additional details

Warn and ignore invalid `CYPRESS_env` and `CYPRESS_expose` values instead of silently discarding them (or corrupting env config). Other `CYPRESS_*` config overrides (e.g. `CYPRESS_BASE_URL`) keep existing fatal validation behavior.

Fixes the confusion reported in [#29682](https://github.com/cypress-io/cypress/issues/29682) where setting `CYPRESS_env=development` appeared to do nothing with no explanation.

## Problem

`CYPRESS_env` and `CYPRESS_expose` must be **JSON objects** — they override the entire `env` / `expose` config option, not individual Cypress env vars.

When set to a plain string (e.g. `export CYPRESS_env=development`):

1. The override was consumed but effectively ignored, with **no warning**.
2. In some cases, invalid strings could be mishandled internally (spread into indexed keys like `'0'`, `'1'`, …) while still passing `isPlainObject` validation.

Users expected `CYPRESS_env=development` to set `Cypress.env('env')`, but the correct approaches are:

- `cypress run --env env=development`
- `export CYPRESS_env='{"env":"development"}'`

## Solution

In `parseEnv`, validate `CYPRESS_env` and `CYPRESS_expose` with `isPlainObject` **before** applying the override. On failure:

- Emit a non-fatal `INVALID_CYPRESS_ENV_OVERRIDE` warning
- Ignore the invalid override
- Continue the run with existing config values

The warning explains that a JSON object is required and points users to `--env` / `--expose` for individual key-value pairs.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config parsing change is narrow (env/expose only), non-fatal warnings, and other CYPRESS_* validation is unchanged; well-covered by unit and integration tests.
> 
> **Overview**
> Invalid **`CYPRESS_env`** and **`CYPRESS_expose`** values (plain strings, numbers, JSON arrays, etc.) are no longer applied silently or mishandled into bogus env keys. During **`parseEnv`**, those overrides are validated with **`isPlainObject`** first; on failure Cypress emits a non-fatal **`INVALID_CYPRESS_ENV_OVERRIDE`** warning (JSON object required, use **`--env`** / **`--expose`** for single keys), drops the bad override, and keeps the run going with existing config.
> 
> Other **`CYPRESS_*`** config env overrides (e.g. invalid **`CYPRESS_BASE_URL`**) still fail with **`CONFIG_VALIDATION_ERROR`**. Changelog, **`packages/config/AGENTS.md`**, unit/integration tests, and an error snapshot cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54c759af8fb15d7b22d1c73a76df2225e840396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test

- [ ] `@packages/config` unit tests for `parseEnv` (invalid string, number, array, casing, valid JSON, `expose`, indexed-key regression)
- [ ] `@packages/errors` visual snapshot for `INVALID_CYPRESS_ENV_OVERRIDE`
- [ ] `@packages/server` integration test: invalid `CYPRESS_env` warns and exits `0`
- [ ] `@packages/server` integration test: invalid `CYPRESS_BASE_URL` still exits with `CONFIG_VALIDATION_ERROR` (exit `1`)


### How has the user experience changed?

| Scenario | Before | After |
|----------|--------|-------|
| `CYPRESS_env=notAnObject` (plain string) | Silent ignore / possible env corruption | Warning, override ignored, exit `0` |
| `CYPRESS_env='{"foo":"bar"}'` | Sets config `env` object | Unchanged |
| `CYPRESS_expose=notAnObject` | Silent ignore | Warning, override ignored, exit `0` |
| `CYPRESS_BASE_URL=localhost:9999` (invalid) | Fatal `CONFIG_VALIDATION_ERROR`, exit `1` | **Unchanged** |

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
