### PR TITLE
chore: merge duplicate Bugfixes header in 15.17.0 changelog

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -11,9 +11,6 @@
 
 - Fixed an issue where invalid `CYPRESS_env` or `CYPRESS_expose` environment variables (for example, a plain string instead of a JSON object) were silently ignored with no warning. Cypress now emits a warning explaining that a JSON object is required and points to the `--env` or `--expose` CLI flags for setting individual values. Fixes [#29682](https://github.com/cypress-io/cypress/issues/29682) and [#19508](https://github.com/cypress-io/cypress/issues/19508). Fixed in [#33945](https://github.com/cypress-io/cypress/pull/33945).
 - Fixed an issue where HTML markup passed as a Sinon spy argument (for example `expect(spy).to.have.been.calledOnceWith('<svg>...</svg>')`) was rendered as live DOM in the Cypress command log, truncating the assertion message and breaking the log layout. The assertion message is now HTML-escaped and the markup is shown as literal text. Fixes [#33416](https://github.com/cypress-io/cypress/issues/33416). Fixed in [#33941](https://github.com/cypress-io/cypress/pull/33941).
-
-**Bugfixes:**
-
 - Fixed an issue where a recorded Chrome or Electron run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
 
 ## 15.16.0


### PR DESCRIPTION
- Closes n/a

### Additional details

The CI job for [#33943](https://github.com/cypress-io/cypress/pull/33943) failed the changelog validator because that PR added its entry under a second `**Bugfixes:**` header inside the 15.17.0 section instead of joining the existing Bugfixes block. See [this failed job](https://app.circleci.com/pipelines/github/cypress-io/cypress/82206/workflows/40232f2a-cfb4-4776-8e4e-49eada4295fe/jobs/3674037).

This PR removes the duplicate header so 15.17.0 has a single Bugfixes block listing all three fixes (#33945, #33941, #33943). No content changes — only the stray header is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog formatting with no product or runtime impact.
> 
> **Overview**
> Removes a duplicate **`**Bugfixes:**`** heading in the **15.17.0** section of `cli/CHANGELOG.md` so all three fix entries (#33945, #33941, #33943) sit under one Bugfixes block. No release-note text changes—only structure—so the changelog validator passes after a prior PR added a second header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f54cf0c51835177ba4797f558775ddbc1f9283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Inspect `cli/CHANGELOG.md` and confirm the 15.17.0 section has exactly one `**Bugfixes:**` header containing the #33945, #33941, and #33943 entries.
- The changelog validator job should now pass.

### How has the user experience changed?

No change — changelog formatting only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?