### PR TITLE
misc(@cypress/grep): only print "will omit filtered tests" when a filter is active

### DIFF
--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -61,7 +61,7 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
 
   const omitFiltered = expose.grepOmitFiltered || expose['grep-omit-filtered']
 
-  if (omitFiltered) {
+  if (omitFiltered && (grep || grepTags || grepUntagged)) {
     console.log('@cypress/grep: will omit filtered tests')
   }
 

--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -62,7 +62,7 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
   const omitFiltered = expose.grepOmitFiltered || expose['grep-omit-filtered']
 
   if (omitFiltered && (grep || grepTags || grepUntagged)) {
-    console.log('@cypress/grep: will omit filtered tests')
+    console.log('@cypress/grep: non-matching tests will be omitted from results (not skipped)')
   }
 
   const { specPattern, excludeSpecPattern } = config

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'vitest'
+import { expect, describe, it, vi } from 'vitest'
 import {
   parseGrep,
   parseTitleGrep,
@@ -438,6 +438,58 @@ describe('utils', () => {
   })
 
   describe('plugin', () => {
+    describe('grepOmitFiltered message', () => {
+      const mockConfig = {
+        specPattern: ['**/*.cy.ts'],
+        excludeSpecPattern: [],
+        expose: {},
+      }
+
+      it('does not print "will omit filtered tests" when no filter is set', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepOmitFiltered: true } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).not.toContain('@cypress/grep: will omit filtered tests')
+        consoleSpy.mockRestore()
+      })
+
+      it('prints "will omit filtered tests" when grep filter is set', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepOmitFiltered: true, grep: 'myTest' } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        consoleSpy.mockRestore()
+      })
+
+      it('prints "will omit filtered tests" when grepTags filter is set', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepOmitFiltered: true, grepTags: '@smoke' } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        consoleSpy.mockRestore()
+      })
+
+      it('prints "will omit filtered tests" when grepUntagged is set', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepOmitFiltered: true, grepUntagged: true } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        consoleSpy.mockRestore()
+      })
+    })
+
     describe('grepFilterSpecs handling', () => {
       const mockConfig = {
         specPattern: ['**/*.cy.ts'],

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -452,7 +452,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).not.toContain('@cypress/grep: will omit filtered tests')
+        expect(calls).not.toContain('@cypress/grep: non-matching tests will be omitted from results (not skipped)')
         consoleSpy.mockRestore()
       })
 
@@ -463,7 +463,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        expect(calls).toContain('@cypress/grep: non-matching tests will be omitted from results (not skipped)')
         consoleSpy.mockRestore()
       })
 
@@ -474,7 +474,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        expect(calls).toContain('@cypress/grep: non-matching tests will be omitted from results (not skipped)')
         consoleSpy.mockRestore()
       })
 
@@ -485,7 +485,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('@cypress/grep: will omit filtered tests')
+        expect(calls).toContain('@cypress/grep: non-matching tests will be omitted from results (not skipped)')
         consoleSpy.mockRestore()
       })
     })


### PR DESCRIPTION
Closes #24449 — the message was printed whenever grepOmitFiltered was
set, even with no grep/grepTags/grepUntagged in use. Guard the log so it
only fires when there is actually something being filtered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plugin startup logging and tests only; runtime omit/skip behavior in register.ts is unchanged.
> 
> **Overview**
> The `@cypress/grep` plugin no longer logs that non-matching tests will be omitted when **`grepOmitFiltered`** is enabled but **no** title, tag, or untagged filter is active. The omit message is gated on **`grep`**, **`grepTags`**, or **`grepUntagged`** being set, and the log text now states that non-matching tests are **omitted from results (not skipped)**.
> 
> Unit tests spy on **`console.log`** to assert the message is absent vs present for each filter combination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30a8182f63ec4347469c6c7205f9d6e9ebd6287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->