### PR TITLE
fix: correct version detection for WebKit 1.60.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed an issue where invalid `CYPRESS_env` or `CYPRESS_expose` environment variables (for example, a plain string instead of a JSON object) were silently ignored with no warning. Cypress now emits a warning explaining that a JSON object is required and points to the `--env` or `--expose` CLI flags for setting individual values. Fixes [#29682](https://github.com/cypress-io/cypress/issues/29682) and [#19508](https://github.com/cypress-io/cypress/issues/19508). Fixed in [#33945](https://github.com/cypress-io/cypress/pull/33945).
 - Fixed an issue where HTML markup passed as a Sinon spy argument (for example `expect(spy).to.have.been.calledOnceWith('<svg>...</svg>')`) was rendered as live DOM in the Cypress command log, truncating the assertion message and breaking the log layout. The assertion message is now HTML-escaped and the markup is shown as literal text. Fixes [#33416](https://github.com/cypress-io/cypress/issues/33416). Fixed in [#33941](https://github.com/cypress-io/cypress/pull/33941).
 - Fixed an issue where a recorded Chrome or Electron run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
+- Fixed an issue where the version of `WebKit` was incorrectly displayed as version 0 when `playwright` version `1.60.0` was installed. Fixes [#33953](https://github.com/cypress-io/cypress/issues/33953).
 
 **Dependency Updates:**
 

--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -209,20 +209,21 @@ function extendLaunchOptionsFromPlugins (launchOptions, pluginConfigResult, opti
   return launchOptions
 }
 
-const wkBrowserVersionRe = /BROWSER_VERSION\s*=\s*(['"])(?<version>[\d.]+)\1/gm
-
 const getWebKitBrowserVersion = async () => {
   try {
-    // this seems to be the only way to accurately capture the WebKit version - it's not exported, and invoking the webkit binary with `--version` does not give the correct result
-    // after launching the browser, this is available at browser.version(), but we don't have a browser instance til later
     const pwCorePath = path.dirname(require.resolve('playwright-core', { paths: [process.cwd()] }))
-    const wkBrowserPath = path.join(pwCorePath, 'lib', 'server', 'webkit', 'wkBrowser.js')
-    const wkBrowserContents = await fs.readFile(wkBrowserPath, 'utf8')
-    const result = wkBrowserVersionRe.exec(wkBrowserContents)
+    const browsersJsonPath = path.join(pwCorePath, 'browsers.json')
+    const browsersJsonContents = await fs.readFile(browsersJsonPath, 'utf8')
+    const browsersJson = JSON.parse(browsersJsonContents)
+    const webkitEntry = browsersJson.browsers.find((b) => b.name === 'webkit')
 
-    if (!result || !result.groups!.version) return '0'
+    if (!webkitEntry || !webkitEntry.browserVersion) {
+      debug('Could not find webkit browserVersion in playwright-core browsers.json %o', { webkitEntry })
 
-    return result.groups!.version
+      return '0'
+    }
+
+    return webkitEntry.browserVersion
   } catch (err) {
     debug('Error detecting WebKit browser version %o', err)
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/33953

### Additional details

Cypress displays WebKit version `0` with `playwright@1.60.0` (includes WebKit `26.4`)

The current version detection was based on examining the file `wkBrowser.js` which no longer ships with [playwright-core@1.60.0](https://www.npmjs.com/package/playwright-core?activeTab=code).

Detection is changed to parse instead `browserVersion` in `playwright-core/browsers.json`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small detection-path change for experimental WebKit display only; same fallback to '0' on errors.
> 
> **Overview**
> Fixes **WebKit** showing version **0** in the Cypress UI when **Playwright 1.60.0** is installed, because the old detector read a constant from `wkBrowser.js`, which that release no longer ships.
> 
> **`getWebKitBrowserVersion`** in `packages/server/lib/browsers/utils.ts` now loads `playwright-core/browsers.json`, finds the `webkit` entry, and returns `browserVersion` (still falling back to `'0'` with debug logging on failure). The regex over `lib/server/webkit/wkBrowser.js` is removed.
> 
> The **15.17.0** changelog documents the fix for [#33953](https://github.com/cypress-io/cypress/issues/33953).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d0fd72ebe776c6b021533b97a93a069b53f56e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test

```shell
git clone --branch 33953-webkit-single-spec https://github.com/MikeMcC399/cypress-test-tiny
cd cypress-test-tiny
npm ci
npx playwright install-deps webkit
cd ..
git clone https://github.com/cypress-io/cypress
cd cypress
n auto # or manually install Node.js 22.19.0
npm install yarn@latest -g
git clean -xfd # if repeating
yarn
yarn start --project ../cypress-test-tiny
```

### How has the user experience changed?

BEFORE

<img width="1196" height="442" alt="Image" src="https://github.com/user-attachments/assets/a9e85722-bd01-4d79-bc02-be4c1c1e3828" />

AFTER

<img width="1197" height="442" alt="image" src="https://github.com/user-attachments/assets/289a20e2-2cdb-4072-a443-52889036c5f2" />

### PR Tasks

- [ ] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
