### PR TITLE
chore: reduce memory pressure in run-app-component-tests-chrome

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2339,10 +2339,11 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium+
+        default: large
       percy:
         type: boolean
         default: false
+    resource_class: << parameters.resource_class >>
     parallelism: 7
     steps:
       - run-new-ui-tests:

--- a/packages/frontend-shared/cypress/support/common.ts
+++ b/packages/frontend-shared/cypress/support/common.ts
@@ -27,10 +27,3 @@ declare global {
     }
   }
 }
-
-// tslint:disable-next-line: no-implicit-dependencies - unsure how to handle these tsconfig compiler paths
-import { initHighlighter } from '@cy/components/highlight'
-
-// Make sure highlighter is initialized before
-// we show any code to avoid jank at rendering
-await initHighlighter()


### PR DESCRIPTION
### Additional details

The `run-app-component-tests-chrome` CI job has been intermittently failing with "Chrome Renderer process just crashed" followed by a 10-minute no-output timeout. Heap-snapshot analysis of a full app CT run revealed two cumulative contributors to renderer memory pressure under `experimentalSingleTabRunMode`:

1. **Each spec page-load eagerly loaded Shiki + Onigasm.** The CT test-support file (`packages/frontend-shared/cypress/support/common.ts`) had a top-level `await initHighlighter()`. In single-tab run mode the renderer process is reused across spec navigations, and heap snapshots show prior page realms (V8 `NativeContext` objects) remain reachable for some time after navigation rather than being immediately collected. Each retained realm holds its own ~150 MB Onigasm WASM Memory backing store; locally we observed 2–3 realms retained simultaneously (~300–450 MB of WASM virtual memory). `ShikiHighlight.vue` already lazy-initializes the highlighter in its own `onBeforeMount` hook, so the eager init was redundant for the few specs that render code and pure waste for the many that don't.

   Locally, removing the eager init drops late-suite renderer heap from ~226 MB to ~84 MB and shifts the trajectory from "growing 112 MB across the run" to "shrinking 11 MB across the run".

2. **The job's `resource_class` parameter was declared but never bound**, so `cy-docker`'s default `medium` (2 vCPU / 4 GB) was always used despite the job declaring a `medium+` default. Bind the parameter on the job and bump the default to `large` (4 vCPU / 8 GB) — matches the pattern of sibling jobs like `run-app-integration-tests-chrome`. The AUT iframe alone holds 800–1000 MB during a run, so the previous 4 GB cap left almost no headroom for the parent Node process plus the OS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-infra and CI sizing only; no product runtime or auth/data paths change, and highlighting remains lazy where components need it.
> 
> **Overview**
> Addresses intermittent **Chrome renderer crashes** in `run-app-component-tests-chrome` by cutting renderer memory use and giving the job more CI memory.
> 
> **CI:** `run-app-component-tests-chrome` now sets `resource_class: << parameters.resource_class >>` (the parameter was unused before, so runs stayed on the executor default `medium`). The parameter default moves from `medium+` to **`large`** (4 vCPU / 8 GB), aligned with `run-app-integration-tests-chrome`.
> 
> **Component test support:** Removes the top-level `await initHighlighter()` from `packages/frontend-shared/cypress/support/common.ts`, so Shiki/Onigasm is not loaded on every spec navigation in single-tab CT. Highlighting still initializes where needed (`ShikiHighlight.vue` and specs that call `initHighlighter` themselves).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10bb6cca6eb70e91c518fdf550f32ba29e29c961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Pull this branch and run `yarn workspace @packages/app cypress:run:ct --browser chrome` locally; all 133 component specs should pass with no behavior change.
2. In CI, the `run-app-component-tests-chrome` job should pass on the `large` executor (4 vCPU / 8 GB). Job duration is comparable to before (~5 min).

### How has the user experience changed?

No change. The eager `initHighlighter()` only ran in CT test support; `ShikiHighlight` components already lazy-initialize. The CI executor change is invisible to users.

Before:
<img width="3210" height="875" alt="Screenshot 2026-06-01 at 12 15 06 PM" src="https://github.com/user-attachments/assets/52481285-de0c-4bf2-b35b-8e556c19e2c0" />

After:
<img width="3211" height="875" alt="Screenshot 2026-06-01 at 12 11 49 PM" src="https://github.com/user-attachments/assets/377e47e8-2db5-4b5e-a0bf-d27889f18706" />

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
