### PR TITLE
chore: document CircleCI full-workflow branch allowlist for agents

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -1,0 +1,52 @@
+# CircleCI Configuration
+
+Agent guidance for `.circleci/` — source configs under `src/` are packed into `packed/` at CI runtime. See [README.md](./README.md) for local CLI setup and the pre-commit `yarn pack-ci --verify` workflow.
+
+## Full CI branch allowlist
+
+Most PR branches run the **pull-request workflow** with path-based job filtering (`generate-pipeline-parameters.sh`). A small set of branch names instead run the **main workflows** (`linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `windows`).
+
+### When to add a branch name
+
+Add a branch when the change affects behavior that is only validated by main-branch CI — in particular:
+
+- **Windows jobs** — the `windows` workflow (`windows-v8-integration-tests`, `windows-create-build-artifacts`, etc.)
+- **V8 snapshot / packaging tooling** — `v8-integration-tests` on Linux, macOS, and Windows; snapshot cache updates in `tooling/v8-snapshot/cache/`
+- **Full binary tests** — kitchensink, staging, and npm-module verification jobs (see optional gates below)
+
+If only unit/integration tests scoped to changed packages are sufficient, do **not** add the branch — use a normal PR branch instead.
+
+### Where to add the branch name
+
+**Required:** append a **new** `- equal:` entry to the `or:` block in `&full-workflow-filters` in `.circleci/src/pipeline/workflows/@main.yml` (the `when:` at the top of `linux-x64`, reused by `windows` and other platform workflows). Do **not** rename or remove existing entries (`develop`, `update-v8-snapshot-cache-on-develop`, the `release/*` / `electron/*` patterns, or `force-persist-artifacts`):
+
+```yaml
+    or:
+      - equal: [ develop, << pipeline.git.branch >> ]
+      # ... leave existing entries unchanged ...
+      - equal: [ 'your-branch-name', << pipeline.git.branch >> ]  # add this line
+```
+
+Push your work to the branch name you add — do not repurpose an existing allowlisted branch (for example, do not change `update-v8-snapshot-cache-on-develop` to a different name).
+
+This gate turns on the main/multi-platform workflow graph — including `windows-v8-integration-tests` and `v8-integration-tests` on Linux/macOS. The existing `update-v8-snapshot-cache-on-develop` entry is reserved for automated v8 snapshot cache PRs.
+
+**Optional — only if you need more than main workflows + path-filtered jobs:**
+
+| Location | When you also need it |
+|----------|------------------------|
+| `pull-request.yml` exclusion list | Avoid the PR workflow running in parallel with the main workflows on the same branch |
+| `generate-pipeline-parameters.sh` branch override | Force every path-filtered job to run even when changed files would not normally select them (or trigger manually with `run-all-jobs=true`) |
+| `&mainBuildFilters` in `@main.yml` | Binary/kitchensink/staging jobs in `linux-x64` that have an extra branch filter beyond the workflow `when:` |
+
+For typical v8 snapshot cache work, changes under `tooling/*` already enable `run-v8-tests` via path filtering, so **`&full-workflow-filters` alone is usually enough**.
+
+After editing `.circleci/src/`, run `yarn pack-ci --verify` before committing.
+
+### What runs with only `&full-workflow-filters`
+
+- **`linux-x64`**: most develop CI (build, system tests, `v8-integration-tests`, packaging, etc.) — subject to path filtering unless overridden
+- **`windows`**: Windows build, binary artifacts, v8 integration tests, and selected integration/unit jobs
+- **`linux-arm64` / `darwin-*`**: platform builds, packaging, and v8 integration tests where supported
+
+`npm-release` still runs only on `develop`, not on allowlisted feature branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ yarn clean-deps && yarn
 
 ## CI/CD
 
-- **Primary CI**: CircleCI. Config lives in `.circleci/src/` (modular) and is compiled to `.circleci/packed/pipeline.yml`.
+- **Primary CI**: CircleCI. Config lives in `.circleci/src/` (modular) and is compiled to `.circleci/packed/pipeline.yml`. See [`.circleci/AGENTS.md`](.circleci/AGENTS.md) for when to add a branch to the full-CI allowlist (binary tests, Windows jobs, v8 snapshot validation).
 - **Supplementary**: GitHub Actions for security scanning (Snyk), SBOM generation, browser version auto-updates, and PR validation.
 - **Base branch**: `develop` — all PRs target `develop`; release branches follow `release/X.Y.Z`.
 - **Multi-platform matrix**: Linux x64, Linux ARM64, macOS x64, macOS ARM64, Windows — all run in parallel.


### PR DESCRIPTION
### Additional details

I'm very annoyed when the agent can't figure out what I mean by 'add the branch to circleci workflows so windows tests run'. Hoping this helps.

- Add .circleci/AGENTS.md documenting when to append a branch to &full-workflow-filters for main/Windows CI (v8 snapshot, binary tests, etc.)
- Link from root AGENTS.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no CI config or runtime behavior changes.
> 
> **Overview**
> Adds **`.circleci/AGENTS.md`**, agent-oriented docs for when and how to put a branch on the **full CI allowlist** (`&full-workflow-filters` in `@main.yml`) so **main / multi-platform** workflows (including **Windows** and **v8** jobs) run instead of relying only on path-filtered PR CI. It covers required vs optional config touchpoints, `yarn pack-ci --verify`, and what still does **not** run on feature branches (e.g. `npm-release`).
> 
> The root **`AGENTS.md`** CI/CD section now links to that file for binary, Windows, and v8 snapshot validation scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244b49d4a42e7710c66c39cb12a94791d23d6d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
