### PR TITLE
fix(cli): hide internal --dev/--inspect flags from public help

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed an issue where a recorded Chrome or Electron run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
 - Fixed an issue where `cypress run` could crash with `TypeError: The "path" argument must be of type string. Received undefined` when the project path was not resolved (for example, due to an unset CI environment variable) or when `--browser` was passed without a value. Cypress now falls back to the current working directory in the first case and emits a clear "browser not found" error in the second. Fixes [#15418](https://github.com/cypress-io/cypress/issues/15418). Fixed in [#33958](https://github.com/cypress-io/cypress/pull/33958).
 - Fixed an issue where the version of `WebKit` was incorrectly displayed as version 0 when `playwright` version `1.60.0` was installed. Fixes [#33953](https://github.com/cypress-io/cypress/issues/33953).
+- The internal `--dev`, `--inspect`, and `--inspect-brk` command line flags are no longer listed in the `cypress` CLI help output. These flags are only intended for developing Cypress itself and would error when used against an installed version, so they are no longer advertised to users. Fixes [#21320](https://github.com/cypress-io/cypress/issues/21320) and addresses [#23058](https://github.com/cypress-io/cypress/issues/23058).
 
 **Dependency Updates:**
 

--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -124,6 +124,8 @@ const descriptions: any = {
   group: 'a named group for recorded runs in Cypress Cloud',
   headed: 'displays the browser instead of running headlessly',
   headless: 'hide the browser instead of running headed (default for cypress run)',
+  inspect: 'enable the Node.js inspector to debug the Cypress development process. only available when used with --dev',
+  inspectBrk: 'enable the Node.js inspector and break before the Cypress development process starts. only available when used with --dev',
   key: 'your secret Record Key. you can omit this if you set a CYPRESS_RECORD_KEY environment variable.',
   parallel: 'enables concurrent runs and automatic load balancing of specs across multiple machines or processes',
   passWithNoTests: 'pass when no tests are found',
@@ -273,7 +275,6 @@ const addCypressRunCommand = (program: any): any => {
   .option('-o, --reporter-options <reporter-options>', text('reporterOptions'))
   .option('-s, --spec <spec>', text('spec'))
   .option('-t, --tag <tag>', text('tag'))
-  .option('--dev', text('dev'), coerceFalse)
 }
 
 const addCypressOpenCommand = (program: any): any => {
@@ -292,14 +293,26 @@ const addCypressOpenCommand = (program: any): any => {
   .option('--global', text('global'))
   .option('-p, --port <port>', text('port'))
   .option('-P, --project <project-path>', text('project'))
-  .option('--dev', text('dev'), coerceFalse)
 }
 
-const maybeAddInspectFlags = (program: any): any => {
-  if (process.argv.includes('--dev')) {
+// `--dev`, `--inspect` and `--inspect-brk` are internal flags used when
+// developing Cypress itself. They are intentionally hidden from the public
+// `--help` output and only registered when `--dev` is actually passed, so that
+// released versions don't advertise flags that error for end users.
+// See https://github.com/cypress-io/cypress/issues/21320
+const maybeAddDevFlag = (program: any, args: string[]): any => {
+  if (args.includes('--dev')) {
+    return program.option('--dev', text('dev'), coerceFalse)
+  }
+
+  return program
+}
+
+const maybeAddInspectFlags = (program: any, args: string[]): any => {
+  if (args.includes('--dev')) {
     return program
-    .option('--inspect', 'Node option')
-    .option('--inspect-brk', 'Node option')
+    .option('--inspect', text('inspect'))
+    .option('--inspect-brk', text('inspectBrk'))
   }
 
   return program
@@ -349,7 +362,7 @@ const cliModule = {
       debug('creating program parser')
       const program = createProgram()
 
-      maybeAddInspectFlags(addCypressRunCommand(program))
+      maybeAddInspectFlags(maybeAddDevFlag(addCypressRunCommand(program), cliArgs), cliArgs)
       .action((...fnArgs: any[]) => {
         debug('parsed Cypress run %o', fnArgs)
         const options = parseVariableOpts(fnArgs, cliArgs)
@@ -390,7 +403,7 @@ const cliModule = {
       debug('creating program parser')
       const program = createProgram()
 
-      maybeAddInspectFlags(addCypressOpenCommand(program))
+      maybeAddInspectFlags(maybeAddDevFlag(addCypressOpenCommand(program), cliArgs), cliArgs)
       .action((...fnArgs: any[]) => {
         debug('parsed Cypress open %o', fnArgs)
         const options = parseVariableOpts(fnArgs, cliArgs)
@@ -479,7 +492,7 @@ const cliModule = {
     .command('version')
     .description(text('version')))
 
-    maybeAddInspectFlags(addCypressOpenCommand(program))
+    maybeAddInspectFlags(maybeAddDevFlag(addCypressOpenCommand(program), args), args)
     .action(async (opts: any) => {
       debug('opening Cypress')
 
@@ -492,7 +505,7 @@ const cliModule = {
       }
     })
 
-    maybeAddInspectFlags(addCypressRunCommand(program))
+    maybeAddInspectFlags(maybeAddDevFlag(addCypressRunCommand(program), args), args)
     .action(async (...fnArgs: any[]) => {
       debug('running Cypress with args %o', fnArgs)
       try {
@@ -519,13 +532,12 @@ const cliModule = {
       }
     })
 
-    program
+    maybeAddDevFlag(program
     .command('verify')
     .usage('[options]')
     .description(
       'Verifies that Cypress is installed correctly and executable',
-    )
-    .option('--dev', text('dev'), coerceFalse)
+    ), args)
     .action(async (opts: any) => {
       const defaultOpts = { force: true, welcomeMessage: false }
       const parsedOpts = util.parseOpts(opts)
@@ -582,11 +594,10 @@ const cliModule = {
       cache[command]()
     })
 
-    program
+    maybeAddDevFlag(program
     .command('info')
     .usage('[command]')
-    .description('Prints Cypress and system information')
-    .option('--dev', text('dev'), coerceFalse)
+    .description('Prints Cypress and system information'), args)
     .action(async (opts: any) => {
       try {
         const code = await infoModule.start(opts)

--- a/cli/test/lib/__snapshots__/cli.spec.ts.snap
+++ b/cli/test/lib/__snapshots__/cli.spec.ts.snap
@@ -22,10 +22,10 @@ exports[`cli > CYPRESS_INTERNAL_ENV > allows and warns when staging environment 
     run [options]      Runs Cypress tests from the CLI without the GUI
     install [options]  Installs the Cypress executable matching this package's
                        version
-    verify [options]   Verifies that Cypress is installed correctly and
+    verify             Verifies that Cypress is installed correctly and
                        executable
     cache [options]    Manages the Cypress binary cache
-    info [options]     Prints Cypress and system information
+    info               Prints Cypress and system information
   -------
   stderr:
   -------
@@ -232,10 +232,10 @@ exports[`cli > help command > shows help 1`] = `
     run [options]      Runs Cypress tests from the CLI without the GUI
     install [options]  Installs the Cypress executable matching this package's
                        version
-    verify [options]   Verifies that Cypress is installed correctly and
+    verify             Verifies that Cypress is installed correctly and
                        executable
     cache [options]    Manages the Cypress binary cache
-    info [options]     Prints Cypress and system information
+    info               Prints Cypress and system information
   -------
   stderr:
   -------
@@ -268,10 +268,10 @@ exports[`cli > help command > shows help for --help 1`] = `
     run [options]      Runs Cypress tests from the CLI without the GUI
     install [options]  Installs the Cypress executable matching this package's
                        version
-    verify [options]   Verifies that Cypress is installed correctly and
+    verify             Verifies that Cypress is installed correctly and
                        executable
     cache [options]    Manages the Cypress binary cache
-    info [options]     Prints Cypress and system information
+    info               Prints Cypress and system information
   -------
   stderr:
   -------
@@ -304,10 +304,10 @@ exports[`cli > help command > shows help for -h 1`] = `
     run [options]      Runs Cypress tests from the CLI without the GUI
     install [options]  Installs the Cypress executable matching this package's
                        version
-    verify [options]   Verifies that Cypress is installed correctly and
+    verify             Verifies that Cypress is installed correctly and
                        executable
     cache [options]    Manages the Cypress binary cache
-    info [options]     Prints Cypress and system information
+    info               Prints Cypress and system information
   -------
   stderr:
   -------
@@ -341,10 +341,10 @@ exports[`cli > unknown command > shows usage and exits 1`] = `
     run [options]      Runs Cypress tests from the CLI without the GUI
     install [options]  Installs the Cypress executable matching this package's
                        version
-    verify [options]   Verifies that Cypress is installed correctly and
+    verify             Verifies that Cypress is installed correctly and
                        executable
     cache [options]    Manages the Cypress binary cache
-    info [options]     Prints Cypress and system information
+    info               Prints Cypress and system information
   -------
   stderr:
   -------
@@ -397,8 +397,6 @@ exports[`cli > unknown option > shows help 1`] = `
     -p, --port <port>                runs Cypress on a specific port. overrides
                                      any value in cypress.config.{js,ts,mjs,cjs}.
     -P, --project <project-path>     path to the project
-    --dev                            runs cypress in development and bypasses
-                                     binary check
     -h, --help                       display help for command
   -------
   stderr:
@@ -553,7 +551,6 @@ exports[`cli > unknown option > shows help for run command 1`] = `
     -o, --reporter-options <reporter-options>                   options for the mocha reporter. defaults to "null"
     -s, --spec <spec>                                           runs specific spec file(s). defaults to "all"
     -t, --tag <tag>                                             named tag(s) for recorded runs in Cypress Cloud
-    --dev                                                       runs cypress in development and bypasses binary check
     -h, --help                                                  display help for command
   -------
   stderr:


### PR DESCRIPTION
The --dev, --inspect and --inspect-brk CLI flags are only used when
developing Cypress itself and error for end users on released binaries.
They were advertised in the public --help output, which was misleading.

Register these flags only when --dev is actually passed, mirroring the
existing pattern for --inspect, so released versions no longer list them
while contributors retain full functionality (and now see proper
descriptions). Also gate on the parsed args rather than process.argv so
the programmatic run/open parsers behave consistently.

Closes #21320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI help and option registration only; no change to default test execution paths for normal users.
> 
> **Overview**
> The CLI no longer advertises **`--dev`**, **`--inspect`**, and **`--inspect-brk`** in public help for `open`, `run`, `verify`, and `info`. Those options are registered only when **`--dev`** appears on the command line, matching the existing pattern for inspect flags and avoiding misleading docs on released binaries.
> 
> **`--dev`** was removed from the always-on `run`/`open` command definitions; **`maybeAddDevFlag`** applies it (and **`verify`/`info`** use the same gate) so help snapshots no longer show `[options]` or `--dev` on subcommands. Inspect flags now use proper help text instead of generic "Node option" labels. Programmatic **`parseRunCommand`** / **`parseOpenCommand`** pass parsed **`cliArgs`** instead of **`process.argv`** so conditional registration stays consistent.
> 
> CHANGELOG documents the user-facing fix for issues **#21320** and **#23058**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fb592f70c69f15a02a8d53b8efbe381348f7261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->