### PR TITLE
misc(errors): suggest checking RemoteDebuggingAllowed policy on CDP connect failure

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Fixed an issue where `cypress run` could crash with `TypeError: The "path" argument must be of type string. Received undefined` when the project path was not resolved (for example, due to an unset CI environment variable) or when `--browser` was passed without a value. Cypress now falls back to the current working directory in the first case and emits a clear "browser not found" error in the second. Fixes [#15418](https://github.com/cypress-io/cypress/issues/15418). Fixed in [#33958](https://github.com/cypress-io/cypress/pull/33958).
 - Fixed an issue where the version of `WebKit` was incorrectly displayed as version 0 when `playwright` version `1.60.0` was installed. Fixes [#33953](https://github.com/cypress-io/cypress/issues/33953).
 
+**Misc:**
+
+- When Cypress cannot connect to a Chromium-based browser such as Chrome or Edge over the Chrome DevTools Protocol, the resulting error now suggests checking whether remote debugging has been disabled by an enterprise or group policy. Because Cypress relies on remote debugging to control the browser, the `RemoteDebuggingAllowed` policy being disabled prevents Cypress from connecting, and the error now points to `chrome://policy` or `edge://policy` to investigate. Addresses [#32526](https://github.com/cypress-io/cypress/issues/32526).
+
 **Dependency Updates:**
 
 - Upgraded `tsx` from `4.20.6` to `4.22.4`. Its bundled `esbuild` Go binary no longer reports [CVE-2025-68121](https://www.cve.org/CVERecord?id=CVE-2025-68121) in security scans, and loading TypeScript config files no longer emits the Node.js `[DEP0205] module.register() is deprecated` warning. Fixes [#33954](https://github.com/cypress-io/cypress/issues/33954) and [#33744](https://github.com/cypress-io/cypress/issues/33744).

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1140,14 +1140,29 @@ export const AllCypressErrors = {
     // we include a stack trace here because it may contain useful information
     // to debug since this is an "uncontrolled" error even though it doesn't
     // come from a user
+
+    // The RemoteDebuggingAllowed enterprise/group policy only applies to
+    // standalone Chromium-based browsers (Chrome, Edge), not Electron, so only
+    // surface that hint for those browsers.
+    if (browserName.toLowerCase() !== 'electron') {
+      return errTemplate`\
+          Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 50 seconds.
+
+          This usually indicates there was a problem opening the ${fmt.off(_.capitalize(browserName))} browser.
+
+          The CDP port requested was ${fmt.highlight(port)}.
+
+          This can also happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the ${fmt.highlightSecondary('RemoteDebuggingAllowed')} policy has been set to disabled in your environment. You can review the applied policies by visiting ${fmt.url('chrome://policy')} (or ${fmt.url('edge://policy')} for Edge) in the affected browser.
+
+          ${fmt.stackTrace(err)}`
+    }
+
     return errTemplate`\
         Cypress failed to make a connection to the Chrome DevTools Protocol after retrying for 50 seconds.
 
         This usually indicates there was a problem opening the ${fmt.off(_.capitalize(browserName))} browser.
 
         The CDP port requested was ${fmt.highlight(port)}.
-
-        If you are using a Chromium-based browser (such as Chrome or Edge), this can happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the ${fmt.highlightSecondary('RemoteDebuggingAllowed')} policy has been set to disabled in your environment. You can review the applied policies by visiting ${fmt.url('chrome://policy')} (or ${fmt.url('edge://policy')} for Edge) in the affected browser.
 
         ${fmt.stackTrace(err)}`
   },

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1147,6 +1147,8 @@ export const AllCypressErrors = {
 
         The CDP port requested was ${fmt.highlight(port)}.
 
+        If you are using a Chromium-based browser (such as Chrome or Edge), this can happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the ${fmt.highlightSecondary('RemoteDebuggingAllowed')} policy has been set to disabled in your environment. You can review the applied policies by visiting ${fmt.url('chrome://policy')} (or ${fmt.url('edge://policy')} for Edge) in the affected browser.
+
         ${fmt.stackTrace(err)}`
   },
   FIREFOX_COULD_NOT_CONNECT: (arg1: Error) => {

--- a/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT - electron.ansi
+++ b/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT - electron.ansi
@@ -1,0 +1,9 @@
+[31mCypress failed to make a connection to the Chrome DevTools Protocol after retrying for 50 seconds.[39m
+[31m[39m
+[31mThis usually indicates there was a problem opening the Electron browser.[39m
+[31m[39m
+[31mThe CDP port requested was [33m2345[39m[31m.[39m
+[35m[39m
+[35mError: fail whale[39m
+[35m    at makeErr (cypress/packages/errors/test/visualSnapshotErrors.spec.ts)[39m
+[35m    at CDP_COULD_NOT_CONNECT (cypress/packages/errors/test/visualSnapshotErrors.spec.ts)[39m

--- a/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT.ansi
+++ b/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT.ansi
@@ -3,6 +3,8 @@
 [31mThis usually indicates there was a problem opening the Chrome browser.[39m
 [31m[39m
 [31mThe CDP port requested was [33m2345[39m[31m.[39m
+[31m[39m
+[31mIf you are using a Chromium-based browser (such as Chrome or Edge), this can happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the [95mRemoteDebuggingAllowed[39m[31m policy has been set to disabled in your environment. You can review the applied policies by visiting [94mchrome://policy[39m[31m (or [94medge://policy[39m[31m for Edge) in the affected browser.[39m
 [35m[39m
 [35mError: fail whale[39m
 [35m    at makeErr (cypress/packages/errors/test/visualSnapshotErrors.spec.ts)[39m

--- a/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT.ansi
+++ b/packages/errors/test/__snapshots__/CDP_COULD_NOT_CONNECT.ansi
@@ -4,7 +4,7 @@
 [31m[39m
 [31mThe CDP port requested was [33m2345[39m[31m.[39m
 [31m[39m
-[31mIf you are using a Chromium-based browser (such as Chrome or Edge), this can happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the [95mRemoteDebuggingAllowed[39m[31m policy has been set to disabled in your environment. You can review the applied policies by visiting [94mchrome://policy[39m[31m (or [94medge://policy[39m[31m for Edge) in the affected browser.[39m
+[31mThis can also happen when remote debugging is disabled by an enterprise or group policy. Cypress relies on remote debugging to control the browser, so it is worth checking whether the [95mRemoteDebuggingAllowed[39m[31m policy has been set to disabled in your environment. You can review the applied policies by visiting [94mchrome://policy[39m[31m (or [94medge://policy[39m[31m for Edge) in the affected browser.[39m
 [35m[39m
 [35mError: fail whale[39m
 [35m    at makeErr (cypress/packages/errors/test/visualSnapshotErrors.spec.ts)[39m

--- a/packages/errors/test/visualSnapshotErrors.spec.ts
+++ b/packages/errors/test/visualSnapshotErrors.spec.ts
@@ -889,6 +889,7 @@ describe('visual error templates', () => {
     CDP_COULD_NOT_CONNECT: () => {
       return {
         default: ['chrome', 2345, makeErr()],
+        electron: ['electron', 2345, makeErr()],
       }
     },
     FIREFOX_COULD_NOT_CONNECT: () => {


### PR DESCRIPTION
When Cypress fails to connect to the Chrome DevTools Protocol, the failure
is often caused by an enterprise/group policy disabling remote debugging
(RemoteDebuggingAllowed) for Chromium-based browsers like Chrome and Edge.

Add a non-definitive suggestion to the CDP_COULD_NOT_CONNECT error pointing
users to investigate this policy via chrome://policy / edge://policy.

Closes #32526

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error text and changelog only; no runtime connection or auth logic changes.
> 
> **Overview**
> When Cypress cannot connect over CDP to **Chrome** or **Edge**, the **`CDP_COULD_NOT_CONNECT`** message now adds a short, non-definitive hint that **enterprise/group policy** may have disabled remote debugging—specifically the **`RemoteDebuggingAllowed`** policy—and points users to **`chrome://policy`** or **`edge://policy`**. **Electron** keeps the original shorter message (that policy does not apply there).
> 
> The **15.17.0** changelog documents this under **Misc**, and error snapshot tests cover both the Chrome and Electron variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac54cf708d46295252d0c743f808e92bacdafb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->