### PR TITLE
fix(proxy): keep server-side cookie jar in sync for same-origin responses

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed an issue where a recorded Chrome or Electron run could hang for the duration of the spec timeout when the renderer crashed mid-spec, instead of failing the affected spec and continuing. Fixed in [#33943](https://github.com/cypress-io/cypress/pull/33943).
 - Fixed an issue where `cypress run` could crash with `TypeError: The "path" argument must be of type string. Received undefined` when the project path was not resolved (for example, due to an unset CI environment variable) or when `--browser` was passed without a value. Cypress now falls back to the current working directory in the first case and emits a clear "browser not found" error in the second. Fixes [#15418](https://github.com/cypress-io/cypress/issues/15418). Fixed in [#33958](https://github.com/cypress-io/cypress/pull/33958).
 - Fixed an issue where the version of `WebKit` was incorrectly displayed as version 0 when `playwright` version `1.60.0` was installed. Fixes [#33953](https://github.com/cypress-io/cypress/issues/33953).
+- Fixed an issue where, after a same-origin `fetch` or XHR request updated a cookie, a subsequent page navigation or reload could send the previous (stale) cookie value to the server instead of the updated one. Fixes [#25841](https://github.com/cypress-io/cypress/issues/25841).
 
 **Dependency Updates:**
 

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -754,16 +754,6 @@ const MaybeCopyCookiesFromIncomingRes: ResponseMiddleware = async function () {
     }
   }
 
-  if (!doesTopNeedSimulating) {
-    ([] as string[]).concat(cookies).forEach((cookie) => {
-      appendCookie(cookie)
-    })
-
-    span?.end()
-
-    return this.next()
-  }
-
   const cookiesHelper = new CookiesHelper({
     cookieJar: this.getCookieJar(),
     currentAUTUrl: this.getAUTUrl(),
@@ -779,11 +769,29 @@ const MaybeCopyCookiesFromIncomingRes: ResponseMiddleware = async function () {
 
   await cookiesHelper.capturePreviousCookies()
 
+  // Record the response's cookies in our server-side cookie jar (subject to the
+  // same rules the browser would apply via `CookiesHelper.setCookie`) and append
+  // them to the response so the browser sets them too. We update the jar even
+  // when top does not need to be simulated: otherwise a same-origin XHR/fetch
+  // that sets a cookie would update the browser but not the jar, leaving the jar
+  // stale. A later top-level navigation reads from the jar and would overwrite
+  // the request's fresh cookie with the stale value.
+  // See https://github.com/cypress-io/cypress/issues/25841
   ;([] as string[]).concat(cookies).forEach((cookie) => {
     cookiesHelper.setCookie(cookie)
 
     appendCookie(cookie)
   })
+
+  // When top does not need to be simulated, the AUT is the primary super domain
+  // origin and the browser sets the response's cookies itself, so there's no
+  // need to sync cookies into the browser via automation. The server-side cookie
+  // jar has already been kept in sync above.
+  if (!doesTopNeedSimulating) {
+    span?.end()
+
+    return this.next()
+  }
 
   setSimulatedCookies(this)
 

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -703,13 +703,13 @@ const MaybeCopyCookiesFromIncomingRes: ResponseMiddleware = async function () {
 
   const cookies: string | string[] | undefined = this.incomingRes.headers['set-cookie']
 
-  const areCookiesPresent = !cookies || !cookies.length
+  const areCookiesAbsent = !cookies || !cookies.length
 
   span?.setAttributes({
-    areCookiesPresent,
+    areCookiesAbsent,
   })
 
-  if (areCookiesPresent) {
+  if (areCookiesAbsent) {
     setSimulatedCookies(this)
 
     span?.end()

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -1156,7 +1156,7 @@ describe('http/response-middleware', function () {
       expect(appendStub).not.toHaveBeenCalled()
     })
 
-    it('still records cookies in the jar to keep it in sync, but does not sync via automation, when top does NOT need simulating', async function () {
+    it('records cookie in jar but skips browser automation sync when top does not need simulating', async function () {
       const appendStub = vi.fn()
 
       const cookieJar = {
@@ -1204,7 +1204,7 @@ describe('http/response-middleware', function () {
     // keeps a stale value and overwrites the browser's fresh cookie on the next
     // top-level navigation (e.g. a reload following the request).
     ;['fetch', 'xhr'].forEach((resourceType) => {
-      it(`records same-origin ${resourceType} cookies in the jar even when top does NOT need simulating, so the jar does not go stale`, async function () {
+      it(`records same-origin ${resourceType} response cookie in jar without browser automation sync`, async function () {
         const appendStub = vi.fn()
 
         const cookieJar = {

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -1156,11 +1156,12 @@ describe('http/response-middleware', function () {
       expect(appendStub).not.toHaveBeenCalled()
     })
 
-    it('is a noop in the cookie jar when top does NOT need simulating', async function () {
+    it('still records cookies in the jar to keep it in sync, but does not sync via automation, when top does NOT need simulating', async function () {
       const appendStub = vi.fn()
 
       const cookieJar = {
         getAllCookies: () => [{ key: 'cookie', value: 'value' }],
+        getCookies: () => [],
         setCookie: vi.fn(),
       }
 
@@ -1182,8 +1183,73 @@ describe('http/response-middleware', function () {
 
       await testMiddleware([MaybeCopyCookiesFromIncomingRes], ctx)
 
-      expect(cookieJar.setCookie).not.toHaveBeenCalled()
+      // the cookie is still recorded in the server-side cookie jar so it does not
+      // go stale and overwrite fresh browser cookies on a later top-level
+      // navigation. See https://github.com/cypress-io/cypress/issues/25841
+      expect(cookieJar.setCookie).toHaveBeenCalledWith(expect.objectContaining({
+        key: 'cookie',
+        value: 'value',
+      }), 'http://www.foobar.com/login', 'strict')
+
+      // the browser sets the cookie itself since the AUT is the primary origin,
+      // so we do not need to sync the cookie into the browser via automation
+      expect(ctx.serverBus.emit).not.toHaveBeenCalled()
       expect(appendStub).toHaveBeenCalledExactlyOnceWith('Set-Cookie', 'cookie=value')
+    })
+
+    // https://github.com/cypress-io/cypress/issues/25841
+    // A same-origin fetch/XHR response that sets a cookie does not need top to be
+    // simulated (the AUT is the primary origin and is not the AUT frame), but the
+    // cookie must still be recorded in the server-side jar. Otherwise the jar
+    // keeps a stale value and overwrites the browser's fresh cookie on the next
+    // top-level navigation (e.g. a reload following the request).
+    ;['fetch', 'xhr'].forEach((resourceType) => {
+      it(`records same-origin ${resourceType} cookies in the jar even when top does NOT need simulating, so the jar does not go stale`, async function () {
+        const appendStub = vi.fn()
+
+        const cookieJar = {
+          getAllCookies: () => [],
+          getCookies: () => [],
+          setCookie: vi.fn(),
+        }
+
+        const ctx = prepareContext({
+          cookieJar,
+          res: {
+            append: appendStub,
+          },
+          req: {
+            // a same-origin, non-AUT-frame request: top does not need simulating
+            resourceType,
+            credentialsLevel: resourceType === 'fetch' ? 'same-origin' : true,
+            proxiedUrl: 'http://www.foobar.com/messages',
+            isAUTFrame: false,
+          },
+          incomingRes: {
+            headers: {
+              'set-cookie': '_venuu_flash=fresh-value',
+            },
+          },
+        })
+
+        ctx.getAUTUrl = () => 'http://www.foobar.com/index.html'
+        // the AUT is the primary super domain origin, so top does NOT need simulating
+        ctx.remoteStates.isPrimarySuperDomainOrigin = () => true
+
+        await testMiddleware([MaybeCopyCookiesFromIncomingRes], ctx)
+
+        // the fresh cookie is recorded in the jar so a subsequent navigation does
+        // not reuse a stale value
+        expect(cookieJar.setCookie).toHaveBeenCalledWith(expect.objectContaining({
+          key: '_venuu_flash',
+          value: 'fresh-value',
+        }), 'http://www.foobar.com/messages', 'strict')
+
+        // the browser sets the cookie natively for a same-origin request, so no
+        // automation sync is needed
+        expect(ctx.serverBus.emit).not.toHaveBeenCalled()
+        expect(appendStub).toHaveBeenCalledExactlyOnceWith('Set-Cookie', '_venuu_flash=fresh-value')
+      })
     })
 
     const getCookieJarStub = () => {

--- a/system-tests/projects/e2e/cypress/e2e/stale_cookie.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/stale_cookie.cy.js
@@ -1,0 +1,24 @@
+// https://github.com/cypress-io/cypress/issues/25841
+// A same-origin fetch/XHR that updates a cookie via Set-Cookie must keep the
+// server-side cookie jar in sync. Otherwise the next top-level navigation reads
+// a stale value from the jar and overwrites the browser's fresh cookie, causing
+// the server to receive (and render) the stale cookie value.
+describe('reused stale cookie', () => {
+  it('sends the fresh cookie set by a same-origin fetch on the next navigation', () => {
+    // the initial navigation seeds the server-side cookie jar with `flash=stale`
+    cy.visit('/stale_cookie')
+    cy.get('#flash').should('have.text', 'flash: stale')
+
+    // a same-origin fetch updates the cookie to a fresh value via Set-Cookie.
+    // this updates the browser, and the server-side cookie jar must update too.
+    cy.window().then((win) => {
+      return win.fetch('/stale_cookie/update', { method: 'POST' })
+    })
+
+    // reloading triggers a navigation that reads cookies from the jar. before
+    // the fix the stale jar value overwrote the browser's fresh cookie, so the
+    // server received `flash=stale`. it should now receive `flash=fresh`.
+    cy.reload()
+    cy.get('#flash').should('have.text', 'flash: fresh')
+  })
+})

--- a/system-tests/projects/e2e/cypress/e2e/stale_cookie.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/stale_cookie.cy.js
@@ -3,22 +3,35 @@
 // server-side cookie jar in sync. Otherwise the next top-level navigation reads
 // a stale value from the jar and overwrites the browser's fresh cookie, causing
 // the server to receive (and render) the stale cookie value.
-describe('reused stale cookie', () => {
-  it('sends the fresh cookie set by a same-origin fetch on the next navigation', () => {
-    // the initial navigation seeds the server-side cookie jar with `flash=stale`
-    cy.visit('/stale_cookie')
-    cy.get('#flash').should('have.text', 'flash: stale')
+describe('cookie jar stays in sync after same-origin requests', () => {
+  const updateCookie = {
+    fetch: (win) => win.fetch('/stale_cookie/update', { method: 'POST' }),
+    xhr: (win) => {
+      return new Promise((resolve) => {
+        const xhr = new win.XMLHttpRequest()
 
-    // a same-origin fetch updates the cookie to a fresh value via Set-Cookie.
-    // this updates the browser, and the server-side cookie jar must update too.
-    cy.window().then((win) => {
-      return win.fetch('/stale_cookie/update', { method: 'POST' })
+        xhr.open('POST', '/stale_cookie/update')
+        xhr.onload = resolve
+        xhr.send()
+      })
+    },
+  }
+
+  Object.keys(updateCookie).forEach((requestType) => {
+    it(`sends the fresh cookie set by a same-origin ${requestType} on the next navigation`, () => {
+      // the initial navigation seeds the server-side cookie jar with `flash=stale`
+      cy.visit('/stale_cookie')
+      cy.get('#flash').should('have.text', 'flash: stale')
+
+      // a same-origin request updates the cookie to a fresh value via Set-Cookie.
+      // this updates the browser, and the server-side cookie jar must update too.
+      cy.window().then((win) => updateCookie[requestType](win))
+
+      // reloading triggers a navigation that reads cookies from the jar. before
+      // the fix the stale jar value overwrote the browser's fresh cookie, so the
+      // server received `flash=stale`. it should now receive `flash=fresh`.
+      cy.reload()
+      cy.get('#flash').should('have.text', 'flash: fresh')
     })
-
-    // reloading triggers a navigation that reads cookies from the jar. before
-    // the fix the stale jar value overwrote the browser's fresh cookie, so the
-    // server received `flash=stale`. it should now receive `flash=fresh`.
-    cy.reload()
-    cy.get('#flash').should('have.text', 'flash: fresh')
   })
 })

--- a/system-tests/test/cookies_spec.ts
+++ b/system-tests/test/cookies_spec.ts
@@ -365,7 +365,7 @@ describe('cross-origin cookies, set:cookies', () => {
   })
 })
 
-describe('reused stale cookie', () => {
+describe('cookie jar stays in sync after same-origin requests', () => {
   const onServer = (app) => {
     app.use(parser())
 
@@ -405,7 +405,7 @@ describe('reused stale cookie', () => {
   })
 
   // https://github.com/cypress-io/cypress/issues/25841
-  it('does not reuse a stale cookie after a same-origin fetch updates it', {
+  it('keeps the cookie jar in sync after a same-origin fetch or XHR updates a cookie', {
     browser: '!webkit', // TODO(webkit): fix+unskip (needs multidomain support)
     config: {
       baseUrl: `http://localhost:${httpPort}`,

--- a/system-tests/test/cookies_spec.ts
+++ b/system-tests/test/cookies_spec.ts
@@ -364,3 +364,53 @@ describe('cross-origin cookies, set:cookies', () => {
     spec: 'multi_cookies.cy.js',
   })
 })
+
+describe('reused stale cookie', () => {
+  const onServer = (app) => {
+    app.use(parser())
+
+    // Renders the current value of the `flash` cookie. On the first visit (no
+    // cookie yet) it seeds `flash=stale`, so the server-side cookie jar is
+    // primed with a value via the navigation request.
+    app.get('/stale_cookie', (req, res) => {
+      const flash = req.cookies.flash
+
+      if (!flash) {
+        res.cookie('flash', 'stale')
+      }
+
+      return res
+      .type('html')
+      .send(`<html><body><div id="flash">flash: ${flash || 'stale'}</div></body></html>`)
+    })
+
+    // A same-origin XHR/fetch endpoint that updates the `flash` cookie to a
+    // fresh value via Set-Cookie, mirroring an AJAX request that mutates a
+    // cookie before the page is reloaded.
+    app.post('/stale_cookie/update', (req, res) => {
+      res.cookie('flash', 'fresh')
+
+      return res.json({ ok: true })
+    })
+  }
+
+  systemTests.setup({
+    servers: [{
+      onServer,
+      port: httpPort,
+    }],
+    settings: {
+      e2e: {},
+    },
+  })
+
+  // https://github.com/cypress-io/cypress/issues/25841
+  it('does not reuse a stale cookie after a same-origin fetch updates it', {
+    browser: '!webkit', // TODO(webkit): fix+unskip (needs multidomain support)
+    config: {
+      baseUrl: `http://localhost:${httpPort}`,
+      allowCypressEnv: false,
+    },
+    spec: 'stale_cookie.cy.js',
+  })
+})


### PR DESCRIPTION
Cookies set by a same-origin XHR/fetch response updated the browser but
not the server-side tough-cookie jar, because MaybeCopyCookiesFromIncomingRes
only wrote to the jar when top needed simulating. A subsequent top-level
navigation (e.g. a reload) reads from the jar and overwrites the request's
fresh browser cookie with the stale jar value, causing Cypress to reuse a
stale cookie.

Always record response cookies in the jar (subject to the existing
CookiesHelper.setCookie rules), and only skip the browser automation sync
when top does not need simulating, since the browser sets same-origin
cookies natively.

Fixes #25841

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core proxy cookie middleware used on every response with Set-Cookie; behavior is narrowed (jar always updated, automation sync unchanged when top need not be simulated) but incorrect jar logic could affect auth/session flows across navigations.
> 
> **Overview**
> Fixes stale cookies after same-origin **fetch** or **XHR** responses that set `Set-Cookie`: the proxy now always records those cookies in the server-side jar via `MaybeCopyCookiesFromIncomingRes`, even when top-level simulation is not needed.
> 
> Previously, jar updates were skipped in that case, so a later navigation or **reload** could pull an old value from the jar and overwrite the browser’s updated cookie on the outgoing request. Browser automation cookie sync is still skipped when the AUT is the primary super-domain origin (the browser applies same-origin cookies itself); only the early-return path was reordered so `CookiesHelper.setCookie` runs first.
> 
> Adds unit coverage for fetch/XHR, a **stale_cookie** system e2e spec, and a **15.17.0** changelog entry for [#25841](https://github.com/cypress-io/cypress/issues/25841).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889860d14b2959192674bf8d113896152e9a1a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->