### PR TITLE
test: retry fixture cleanup on transient filesystem races

### DIFF
--- a/system-tests/lib/fixtures.ts
+++ b/system-tests/lib/fixtures.ts
@@ -20,7 +20,10 @@ const projectFixtureDirs = fs.readdirSync(projectFixtures, { withFileTypes: true
 
 const safeRemove = (path) => {
   try {
-    fs.removeSync(path)
+    // Use native fs.rmSync with retries to absorb transient filesystem races
+    // (ENOTEMPTY/EBUSY/EPERM) caused by child processes still writing to a
+    // subdirectory at cleanup time.
+    fs.rmSync(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
   } catch (_err) {
     const err = _err as NodeJS.ErrnoException
 


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `safeRemove` helper in `system-tests/lib/fixtures.ts` was calling `fs.removeSync` with no retry behavior. The cleanup path is invoked from the cypress-in-cypress `__internal__before` hook ([packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts:192](https://github.com/cypress-io/cypress/blob/develop/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts#L192)) at the start of every spec to wipe `/tmp/cy-projects`. When a previous spec leaves a child process (e.g. a Next.js dev server still flushing its webpack cache to `.next/cache`) racing against the recursive `rmdir`, the call throws `ENOTEMPTY` and Mocha aborts the `before all` hook with no retry — `test retries` do not cover hook failures.

Observed example: [CircleCI job 3683022](https://app.circleci.com/pipelines/github/cypress-io/cypress/82333/workflows/527ec5cf-b5ec-4d3c-9490-7543bbd03fb7/jobs/3683022) failed with `ENOTEMPTY: directory not empty, rmdir '/tmp/cy-projects/next-14/.next/cache'`. The same `run-webpack-dev-server-integration-tests` job has failed ~8 times in the last 30 days of `develop` runs with this class of race.

Switching to native `fs.rmSync` with `{ recursive: true, force: true, maxRetries: 5, retryDelay: 100 }` lets Node's own retry loop absorb transient `ENOTEMPTY`/`EBUSY`/`EPERM`/`EMFILE`/`ENFILE` errors. The existing Windows `EBUSY` fall-through remains as a final safety net.

`fs.rmSync` here resolves to native Node `rmSync` (re-exported verbatim by fs-extra 9.1.0 via `Object.keys(fs).forEach(...)` in `lib/fs/index.js`); fs-extra does not intercept the call or its retry options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to test fixture cleanup; no product runtime or user-facing behavior.
> 
> **Overview**
> Makes **system test fixture teardown** more resilient when wiping the temp project dir (e.g. `/tmp/cy-projects`) before each spec.
> 
> `safeRemove` in `system-tests/lib/fixtures.ts` now uses Node’s **`fs.rmSync`** with **`recursive`**, **`force`**, and built-in **retries** (`maxRetries: 5`, `retryDelay: 100ms`) instead of a single **`fs.removeSync`**. That absorbs transient **`ENOTEMPTY` / `EBUSY` / `EPERM`** races when a prior spec’s child process (e.g. a Next.js dev server still writing under `.next/cache`) overlaps cleanup—failures that could abort Mocha **`before all`** hooks and aren’t covered by test retries.
> 
> The existing **Windows `EBUSY` skip** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e64929e5c3afc8452691bdca0e08b32e7060da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This is a CI-only resiliency change. To exercise the cleanup path locally:

1. `yarn workspace @tooling/system-tests build`
2. Re-run any cypress-in-cypress spec that scaffolds Next.js, e.g. `npm/webpack-dev-server/cypress/e2e/next.cy.ts`, and confirm scaffolding still succeeds.

### How has the user experience changed?

No change — internal CI-only fix.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?