### PR TITLE
chore(ci): install Chrome on Windows via Google MSI instead of Chocolatey

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -824,20 +824,19 @@ commands:
           # TODO: How can we have preinstalled browsers on CircleCI?
           name: 'Install Chrome on Windows'
           command: |
-            # install with `--ignore-checksums` to avoid checksum error
-            # https://www.gep13.co.uk/blog/chocolatey-error-hashes-do-not-match
-            # Retry to tolerate 504s from the Chocolatey community feed. `choco install`
-            # exits 0 on "installed 0/0 packages", so gate the retry on whether chrome.exe
-            # actually exists, not on choco's exit code.
+            # Download Google's standalone enterprise MSI directly from dl.google.com.
             if [[ $PLATFORM == 'windows' && '<<parameters.browser>>' == 'chrome' ]]; then
               chrome_installed() {
                 [[ -f "/c/Program Files/Google/Chrome/Application/chrome.exe" || -f "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe" ]]
               }
+              msi_url="https://dl.google.com/chrome/install/GoogleChromeStandaloneEnterprise64.msi"
+              msi_path="$(mktemp -d)/googlechrome.msi"
               max_attempts=3
               n=0
               until [ $n -ge $max_attempts ]; do
-                choco install googlechrome -y --ignore-checksums --no-progress || true
-                if chrome_installed; then
+                if curl -fsSL --connect-timeout 30 --max-time 240 --retry 2 --retry-connrefused -o "$msi_path" "$msi_url" \
+                    && MSYS_NO_PATHCONV=1 msiexec.exe /i "$(cygpath -w "$msi_path")" /qn /norestart \
+                    && chrome_installed; then
                   break
                 fi
                 n=$((n+1))
@@ -849,7 +848,7 @@ commands:
                 fi
               done
               if ! chrome_installed; then
-                echo "ERROR: Chrome not installed after choco install"
+                echo "ERROR: Chrome not installed after MSI install"
                 exit 1
               fi
             fi


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `Install Chrome on Windows` CI step has been failing intermittently on `develop` against the Chocolatey community feed, in two distinct modes:

1. **Silent stalls** — `choco install googlechrome --no-progress` hangs against `community.chocolatey.org` long enough to trip CircleCI's default 10m no-output watchdog before the existing retry loop can fire. [Example](https://app.circleci.com/pipelines/github/cypress-io/cypress/82302/workflows/0c073ff4-60e3-4405-9fce-c2cdb09db3b1/jobs/3680633/parallel-runs/6).
2. **Fast-failing 5xx** — the community feed returns 503/504 across all 3 retry attempts within ~30s during sustained outages, with no chance for the existing 15s backoff to ride them out.

This change drops the Chocolatey dependency entirely and downloads Google's standalone enterprise MSI directly from `dl.google.com`:

- `curl -fsSL --connect-timeout 30 --max-time 240 --retry 2 --retry-connrefused` pulls `GoogleChromeStandaloneEnterprise64.msi`. Per-attempt connection/duration limits keep any single attempt well under the no-output window.
- `msiexec /qn /norestart` installs silently. `MSYS_NO_PATHCONV=1` + `cygpath -w` are needed to pass a Windows-style MSI path through git-bash to `msiexec`.
- Installs to `C:\Program Files\Google\Chrome\Application\chrome.exe` — the same path the chocolatey package used and the path `@packages/launcher` already detects, so no other CI or product code needs to change.
- The 3-attempt outer retry loop and `chrome_installed` file-existence gate are preserved as defense-in-depth.

Same moving-target version semantics as before — the MSI URL serves "latest stable", same as the previous `choco install googlechrome` invocation (which passed no `--version`). True version pinning on Windows would be a separate change.

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Run the full CI workflow on Windows (any job that calls `windows-install-chrome`, e.g. driver/app/launchpad UI tests on the Windows executor).
- Confirm the `Install Chrome on Windows` step succeeds and emits the new MSI download/install path.
- Confirm downstream `--browser chrome` test invocations still launch Chrome via the launcher.

### How has the user experience changed?

No change — internal CI infrastructure only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI infra fix in response to observed Chocolatey-feed flakes on develop; no associated issue. -->
- [na] Have tests been added/updated? <!-- CI plumbing; behavior is exercised by every existing Windows job. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
