### PR TITLE
test: Add test that we handle promise rejections with undefined gracefully

### DIFF
--- a/packages/driver/cypress/e2e/issues/27183.cy.js
+++ b/packages/driver/cypress/e2e/issues/27183.cy.js
@@ -1,0 +1,23 @@
+// https://github.com/cypress-io/cypress/issues/27183
+describe('issue 27183', () => {
+  // a promise rejected with `undefined` (e.g. `reject()`) used to surface the
+  // misleading internal error "Cannot read property 'message' of undefined".
+  // We should fail gracefully and still attribute it to the application code
+  // as an unhandled promise rejection.
+  it('fails gracefully when the app rejects a promise with undefined', (done) => {
+    cy.once('uncaught:exception', (err, runnable, promise) => {
+      expect(err.message).to.include('An unknown error has occurred: undefined')
+      expect(err.message).to.include('The following error originated from your application code, not from Cypress.')
+      expect(err.message).to.include('It was caused by an unhandled promise rejection.')
+      expect(err.message).not.to.include('Cannot read property')
+      expect(promise).to.be.a('promise')
+
+      done()
+
+      return false
+    })
+
+    cy.visit('/fixtures/errors.html')
+    cy.get('.trigger-undefined-rejection').click()
+  })
+})

--- a/packages/driver/cypress/fixtures/errors.html
+++ b/packages/driver/cypress/fixtures/errors.html
@@ -9,6 +9,7 @@
     <button class="trigger-sync-error">Trigger Sync Error</button>
     <button class="trigger-async-error">Trigger Async Error</button>
     <button class="trigger-unhandled-rejection">Trigger Unhandled Rejection</button>
+    <button class="trigger-undefined-rejection">Trigger Undefined Rejection</button>
     <button class="define-window-onerror">Define window.onerror</button>
   </div>
   <p class="error-one"></p>
@@ -24,11 +25,11 @@
     })
 
     window.addEventListener('unhandledrejection', (event) => {
-      document.querySelector('.error-one').innerText = event.reason.message
+      document.querySelector('.error-one').innerText = event.reason?.message
     })
 
     window.addEventListener('unhandledrejection', (event) => {
-      document.querySelector('.error-two').innerText = event.reason.message
+      document.querySelector('.error-two').innerText = event.reason?.message
     })
 
     function one(message) {
@@ -59,6 +60,12 @@
 
     document.querySelector(".trigger-unhandled-rejection").addEventListener('click', function () {
       (async () => one('promise rejection'))()
+    })
+
+    document.querySelector(".trigger-undefined-rejection").addEventListener('click', function () {
+      new Promise(function (resolve, reject) {
+        reject()
+      })
     })
 
     document.querySelector(".define-window-onerror").addEventListener('click', function () {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/27183

### Additional details

When an application rejects a promise with `undefined` (e.g., `reject()` without arguments), Cypress was surfacing a misleading internal error: "Cannot read property 'message' of undefined". This occurred because the error handling code attempted to access the `message` property on the rejection reason without null-checking it first.

This change adds a test case that validates the graceful handling of undefined promise rejections, ensuring that:
1. The error message clearly indicates an unknown error occurred
2. The error is properly attributed to application code, not Cypress internals
3. The error is identified as an unhandled promise rejection
4. No misleading "Cannot read property" errors surface

The test fixture has been updated to:
- Add a button that triggers an undefined promise rejection
- Use optional chaining (`?.`) when accessing the `message` property on rejection reasons in event listeners, preventing errors when the reason is undefined

### Steps to test

1. Run the new test: `cypress run --spec packages/driver/cypress/e2e/issues/27183.cy.js`
2. Verify the test passes and the error message is handled gracefully
3. Confirm that clicking the "Trigger Undefined Rejection" button in the fixture produces the expected error handling behavior

### How has the user experience changed?

None - this is just testing that this issue's behavior has been fixed since the issue was opened originally

### PR Tasks

- [x] Have tests been added/updated? (Added new test case in `27183.cy.js`)
- [na] Is there an associated issue with maintainer approval for PR submission? (Issue reference provided)
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the type definitions?

https://claude.ai/code/session_01QjQ5ZKGjmieDy7GBMghXvk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and fixture-only changes; no production driver logic modified in this diff.
> 
> **Overview**
> Adds regression coverage for **issue #27183**: when the app calls `reject()` with no value, Cypress should report an application **unhandled promise rejection** with a clear *unknown error* message—not an internal `Cannot read property 'message' of undefined`.
> 
> The new e2e spec drives `errors.html` via **Trigger Undefined Rejection** and asserts the `uncaught:exception` payload (including that the third argument is a **promise**). The fixture gains that button, a `reject()`-only promise on click, and **optional chaining** on `event.reason?.message` in `unhandledrejection` listeners so the page doesn’t throw while the rejection reason is `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59097ebbad57bf79846f58243f649749a3fb0280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->