### PR TITLE
fix: improve grep warning message when all specs are filtered

### DIFF
--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -149,11 +149,13 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
     if (greppedSpecs.length) {
       config.specPattern = greppedSpecs
     } else if (grep || grepTags) {
-      // hmm, we filtered out all specs, probably something is wrong
-      console.warn('grep and/or grepTags has eliminated all specs')
-      grep ? console.warn('grep: %s', grep) : null
-      grepTags ? console.warn('grepTags: %s', grepTags) : null
-      console.warn('Will leave all specs to run to filter at run-time')
+      // none of the specs contained a test matching the filter, so there is
+      // nothing to pre-filter — fall back to loading every spec and let the
+      // run-time filter narrow down the individual tests
+      console.warn('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
+      grep ? console.warn('@cypress/grep: grep filter: %s', grep) : null
+      grepTags ? console.warn('@cypress/grep: grepTags filter: %s', grepTags) : null
+      console.warn('@cypress/grep: All specs will be run and the filter applied to individual tests at run-time instead.')
     }
   }
 

--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -148,7 +148,7 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
 
     if (greppedSpecs.length) {
       config.specPattern = greppedSpecs
-    } else {
+    } else if (grep || grepTags) {
       // hmm, we filtered out all specs, probably something is wrong
       console.warn('grep and/or grepTags has eliminated all specs')
       grep ? console.warn('grep: %s', grep) : null

--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -149,13 +149,14 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
     if (greppedSpecs.length) {
       config.specPattern = greppedSpecs
     } else if (grep || grepTags) {
-      // none of the specs contained a test matching the filter, so there is
-      // nothing to pre-filter — fall back to loading every spec and let the
-      // run-time filter narrow down the individual tests
-      console.warn('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
-      grep ? console.warn('@cypress/grep: grep filter: %s', grep) : null
-      grepTags ? console.warn('@cypress/grep: grepTags filter: %s', grepTags) : null
-      console.warn('@cypress/grep: All specs will be run and the filter applied to individual tests at run-time instead.')
+      // Static pre-filtering found no spec whose tests match the filter. This
+      // is not necessarily a problem — titles/tags built at run-time can't be
+      // detected by static analysis — so fall back to running every spec and
+      // let the run-time filter select the individual tests.
+      console.log('@cypress/grep: could not pre-filter specs because none appeared to contain tests matching the filter:')
+      grep ? console.log('@cypress/grep:   grep: %s', grep) : null
+      grepTags ? console.log('@cypress/grep:   grepTags: %s', grepTags) : null
+      console.log('@cypress/grep: running all specs and applying the filter to individual tests at run-time instead.')
     }
   }
 

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -505,7 +505,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).not.toContain('grep and/or grepTags has eliminated all specs')
+        expect(calls).not.toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
         consoleSpy.mockRestore()
       })
 
@@ -516,7 +516,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('grep and/or grepTags has eliminated all specs')
+        expect(calls).toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
         consoleSpy.mockRestore()
       })
 
@@ -527,7 +527,7 @@ describe('utils', () => {
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('grep and/or grepTags has eliminated all specs')
+        expect(calls).toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
         consoleSpy.mockRestore()
       })
     })

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -490,6 +490,48 @@ describe('utils', () => {
       })
     })
 
+    describe('"eliminated all specs" warning', () => {
+      // use a spec pattern that matches no files so the outcome is deterministic
+      const mockConfig = {
+        specPattern: ['**/__does_not_exist__/*.cy.ts'],
+        excludeSpecPattern: [],
+        expose: {},
+      }
+
+      it('does not warn when grepFilterSpecs is set but no grep/grepTags is in use', () => {
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepFilterSpecs: true } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).not.toContain('grep and/or grepTags has eliminated all specs')
+        consoleSpy.mockRestore()
+      })
+
+      it('warns when grep is set but eliminates all specs', () => {
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepFilterSpecs: true, grep: 'noMatch' } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).toContain('grep and/or grepTags has eliminated all specs')
+        consoleSpy.mockRestore()
+      })
+
+      it('warns when grepTags is set but eliminates all specs', () => {
+        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        plugin({ ...mockConfig, expose: { grepFilterSpecs: true, grepTags: '@noMatch' } })
+
+        const calls = consoleSpy.mock.calls.map((args) => args[0])
+
+        expect(calls).toContain('grep and/or grepTags has eliminated all specs')
+        consoleSpy.mockRestore()
+      })
+    })
+
     describe('grepFilterSpecs handling', () => {
       const mockConfig = {
         specPattern: ['**/*.cy.ts'],

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -490,7 +490,8 @@ describe('utils', () => {
       })
     })
 
-    describe('"eliminated all specs" warning', () => {
+    describe('could-not-pre-filter notice', () => {
+      const noMatchMessage = '@cypress/grep: could not pre-filter specs because none appeared to contain tests matching the filter:'
       // use a spec pattern that matches no files so the outcome is deterministic
       const mockConfig = {
         specPattern: ['**/__does_not_exist__/*.cy.ts'],
@@ -498,37 +499,49 @@ describe('utils', () => {
         expose: {},
       }
 
-      it('does not warn when grepFilterSpecs is set but no grep/grepTags is in use', () => {
-        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      it('says nothing when grepFilterSpecs is set but no grep/grepTags is in use', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         plugin({ ...mockConfig, expose: { grepFilterSpecs: true } })
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).not.toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
+        expect(calls).not.toContain(noMatchMessage)
         consoleSpy.mockRestore()
       })
 
-      it('warns when grep is set but eliminates all specs', () => {
-        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      it('logs the notice when grep is set but matches no specs', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         plugin({ ...mockConfig, expose: { grepFilterSpecs: true, grep: 'noMatch' } })
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
+        expect(calls).toContain(noMatchMessage)
         consoleSpy.mockRestore()
       })
 
-      it('warns when grepTags is set but eliminates all specs', () => {
-        const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      it('logs the notice when grepTags is set but matches no specs', () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         plugin({ ...mockConfig, expose: { grepFilterSpecs: true, grepTags: '@noMatch' } })
 
         const calls = consoleSpy.mock.calls.map((args) => args[0])
 
-        expect(calls).toContain('@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.')
+        expect(calls).toContain(noMatchMessage)
         consoleSpy.mockRestore()
+      })
+
+      it('does not emit the notice as a warning', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+        plugin({ ...mockConfig, expose: { grepFilterSpecs: true, grep: 'noMatch' } })
+
+        const warnCalls = warnSpy.mock.calls.map((args) => args[0])
+
+        expect(warnCalls).not.toContain(noMatchMessage)
+        vi.restoreAllMocks()
       })
     })
 


### PR DESCRIPTION
### Description

This PR improves the warning message displayed when the `@cypress/grep` plugin filters out all specs during the pre-filtering phase.

**Changes:**

1. **Conditional warning logic**: The warning is now only shown when `grep` or `grepTags` is actually set. 
2. **Improved messaging**: Updated the warning messages to be more descriptive and consistent:
3. **Test coverage**: Added three new test cases to verify the behavior

### Behavior change

#### Before

```
grep and/or grepTags has eliminated all specs
grep: <value>
grepTags: <value>
Will leave all specs to run to filter at run-time
```

#### After

```
@cypress/grep: No specs contained tests matching the provided filter, so no specs could be pre-filtered.
@cypress/grep: grep filter: <value>
@cypress/grep: grepTags filter: <value>
@cypress/grep: All specs will be run and the filter applied to individual tests at run-time instead.
```

### Steps to test

1. Run the unit tests: `npm test -- unit.spec.ts`
2. Verify the three new test cases in the `"eliminated all specs" warning` describe block pass
3. Verify existing `grepFilterSpecs handling` tests continue to pass

### PR Tasks

- [x] Have tests been added/updated? (Yes, 3 new test cases added)
- [na] Is there an associated issue with maintainer approval? (Straightforward improvement to warning messages)
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? (Warning message improvement, minimal user-facing impact)
- [na] Have API changes been updated in the type definitions? (No API changes)

https://claude.ai/code/session_0193Dj5G31SNN3PoBWQf5ikX


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and user-facing copy only; spec selection fallback behavior is unchanged aside from skipping the message when no grep/grepTags is set.
> 
> **Overview**
> When **`grepFilterSpecs`** is on but static analysis finds **no specs** whose tests match **`grep`** / **`grepTags`**, the plugin now treats that as an expected case (e.g. run-time titles/tags) instead of a blanket warning.
> 
> **Messaging changes:** the notice runs only if a title or tag filter is actually set; output moves from **`console.warn`** to prefixed **`console.log`** lines that explain pre-filtering failed and that **all specs will run** with filtering applied per test at run-time.
> 
> **Tests:** a **`could-not-pre-filter notice`** block asserts silence without filters, logs for **`grep`** / **`grepTags`** with no matching specs, and that the text is not emitted as a warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290a61f2b700bea67b3c45717144e2e738751ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->