### PR TITLE
test(server): re-measure proxy performance baseline on retry

### DIFF
--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -460,22 +460,6 @@ describe('Proxy Performance', function () {
         })
       })
 
-      // Re-measure baseline on retry. The ratio assertion is only meaningful when
-      // baseline and scenario are captured under similar machine load; on shared CI,
-      // load can drift between the `before` hook and a later test case, leaving the
-      // first-pass baseline unfairly low. Without this, retries compare against the
-      // same stale baseline and can fail 15× in a row.
-      beforeEach(function () {
-        if (this.currentTest.currentRetry() === 0) return
-
-        return runBrowserTest(urlUnderTest, testCases[0])
-        .then((runtime) => {
-          debug('re-measured baseline runtime is: ', runtime)
-
-          baseline = runtime
-        })
-      })
-
       // slice(1) since first test is used as baseline above
       testCases.slice(1).map((testCase) => {
         let multiplier = 3
@@ -489,9 +473,22 @@ describe('Proxy Performance', function () {
         it(`${testCase.name} loads 1000 images less than ${multiplier}x as slowly as Chrome`, function () {
           debug('Current test: ', testCase.name)
 
-          return runBrowserTest(urlUnderTest, testCase)
-          .then((results) => {
-            expect(results['Total']).to.be.lessThan(multiplier * baseline['Total'])
+          // On retry, re-measure baseline so the ratio stays paired in time with this
+          // scenario. The `before`-hook baseline can drift relative to current machine
+          // load on shared CI; without re-measuring, all 15 retries compare against the
+          // same stale baseline. Scoped locally so it doesn't leak to sibling tests.
+          const baselineForAttempt = this.currentTest.currentRetry() === 0
+            ? Promise.resolve(baseline)
+            : runBrowserTest(urlUnderTest, testCases[0]).then((runtime) => {
+              debug('re-measured baseline runtime is: ', runtime)
+
+              return runtime
+            })
+
+          return baselineForAttempt.then((currentBaseline) => {
+            return runBrowserTest(urlUnderTest, testCase).then((results) => {
+              expect(results['Total']).to.be.lessThan(multiplier * currentBaseline['Total'])
+            })
           })
         })
       })

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -444,7 +444,6 @@ describe('Proxy Performance', function () {
   })
 
   URLS_UNDER_TEST.map((urlUnderTest) => {
-    // TODO: fix flaky tests https://github.com/cypress-io/cypress/issues/23214
     describe(urlUnderTest, function () {
       this.retries(15)
 
@@ -456,6 +455,22 @@ describe('Proxy Performance', function () {
         return runBrowserTest(urlUnderTest, testCases[0])
         .then((runtime) => {
           debug('baseline runtime is: ', runtime)
+
+          baseline = runtime
+        })
+      })
+
+      // Re-measure baseline on retry. The ratio assertion is only meaningful when
+      // baseline and scenario are captured under similar machine load; on shared CI,
+      // load can drift between the `before` hook and a later test case, leaving the
+      // first-pass baseline unfairly low. Without this, retries compare against the
+      // same stale baseline and can fail 15× in a row.
+      beforeEach(function () {
+        if (this.currentTest.currentRetry() === 0) return
+
+        return runBrowserTest(urlUnderTest, testCases[0])
+        .then((runtime) => {
+          debug('re-measured baseline runtime is: ', runtime)
 
           baseline = runtime
         })

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -477,7 +477,9 @@ describe('Proxy Performance', function () {
           // scenario. The `before`-hook baseline can drift relative to current machine
           // load on shared CI; without re-measuring, all 15 retries compare against the
           // same stale baseline. Scoped locally so it doesn't leak to sibling tests.
-          const baselineForAttempt = this.currentTest.currentRetry() === 0
+          // Inside `it`, the running test is `this.test` (not `this.currentTest`,
+          // which is only defined in hooks).
+          const baselineForAttempt = this.test.currentRetry() === 0
             ? Promise.resolve(baseline)
             : runBrowserTest(urlUnderTest, testCases[0]).then((runtime) => {
               debug('re-measured baseline runtime is: ', runtime)


### PR DESCRIPTION
- Closes #23214

### Additional details

The proxy performance suite at `packages/server/test/performance/proxy_performance_spec.js` asserts each scenario loads 1000 images in less than `3x` (or `4.5x` for HTTPS upstream) the baseline runtime. Baseline is captured once in the `describe` block's `before` hook, then reused by every test case in the block.

On shared CI runners, machine load can drift meaningfully between the baseline measurement and a test case run minutes later. If the `before` hook lands during an idle moment, the captured baseline is unfairly low — every subsequent scenario is squeezed against a too-tight ceiling, and the existing `this.retries(15)` can't recover because **baseline isn't re-measured on retry**. All 15 retries compare against the same stale baseline and fail in sequence.

Recent failure: `expected 4132 to be below 3783` — baseline 1261 ms, scenario 4132 ms (3.28×, only ~9% over the 3× cutoff).

When a scenario retries, this change re-measures baseline alongside the retry and asserts against that locally-scoped value. The happy path is unchanged (single baseline in `before`); the re-measure is scoped inside the `it` body so a retrying scenario doesn't mutate the shared `baseline` that sibling tests use on their first run.

The suite was effectively a no-op for years (see #33803) until #33804 restored it in 2026-05; the original 2022-era flake (#23214) was the first regression to resurface, which this PR resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `proxy_performance_spec.js`; no runtime or product behavior is affected.
> 
> **Overview**
> Addresses flaky proxy performance comparisons on shared CI by **re-measuring the baseline Chrome scenario on each test retry**, so the `3×` / `4.5×` ratio is evaluated against a baseline taken at roughly the same time as the scenario run.
> 
> On the first attempt, behavior is unchanged: the suite still uses the baseline captured once in the `describe` **`before`** hook. When **`this.test.currentRetry()`** is greater than zero, the spec runs the baseline test case again and asserts against that fresh **`currentBaseline`**, without updating the shared **`baseline`** used by sibling tests on their first try.
> 
> The obsolete TODO referencing #23214 is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05116970b2619d123cb8bc136345467fcff264d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This is a CI-noise-driven test-only change; the most reliable validation is observing the suite over multiple CI runs rather than a single local pass. To exercise the new code path locally:

1. Temporarily lower the multiplier in the spec (e.g. `multiplier = 1.5`) to force retries.
2. Run `yarn workspace @packages/server test-performance`.
3. Confirm `debug=test:proxy-performance` output shows `re-measured baseline runtime is:` before each retry.
4. Revert the multiplier change.

### How has the user experience changed?

No change — this is a test-infrastructure-only change.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?
