### PR TITLE
test: deflake reporter 'adds a scroll listener in open mode' (dispatch synchronously)

### DIFF
--- a/packages/reporter/cypress/e2e/runnables.cy.ts
+++ b/packages/reporter/cypress/e2e/runnables.cy.ts
@@ -219,10 +219,15 @@ describe('runnables', () => {
     it('adds a scroll listener in open mode', () => {
       appState.autoScrollingEnabled = false
       appState.startRunning()
-      cy.get('.container')
-      .trigger('scroll')
-      .trigger('scroll')
-      .trigger('scroll').then(() => {
+      cy.get('.container').then(($el) => {
+        // dispatch synchronously so the user-scroll threshold timer can't
+        // reset the counter between events under CI load
+        $el[0].dispatchEvent(new Event('scroll'))
+        $el[0].dispatchEvent(new Event('scroll'))
+        $el[0].dispatchEvent(new Event('scroll'))
+      })
+
+      cy.then(() => {
         expect(spy).to.have.been.calledWith(false)
       })
     })


### PR DESCRIPTION
- Closes n/a (CI flake follow-up to [#33809](https://github.com/cypress-io/cypress/pull/33809))

### Additional details

The `runnables > runnable-header (unified) > adds a scroll listener in open mode` test in [`packages/reporter/cypress/e2e/runnables.cy.ts`](packages/reporter/cypress/e2e/runnables.cy.ts) still flakes on `develop` after the earlier deflake — see [pipeline 82395 → reporter-integration-tests job 3686891](https://app.circleci.com/pipelines/github/cypress-io/cypress/82395/workflows/16e59b50-d2ea-4cef-b00c-1a033b723534/jobs/3686891).

The reporter's `Scroller` counts user scrolls and only invokes its `onUserScroll` callback once it sees three `scroll` events within a sliding threshold window (raised to 500ms for this test). The previous deflake added `appState.autoScrollingEnabled = false` to the test body, but the contaminating sequence happens earlier — during `start()` (in `beforeEach`):

1. `runner.emit('runnables:ready', ...)` runs `runnablesStore._finishedInitialRendering()`. At that point `isRunning === false` and `autoScrollingEnabled === true` (default — the subsequent `reporter:start: {}` calls `temporarilySetAutoScrolling(undefined)`, which is a no-op), so the store calls `scroller.scrollToEnd()`.
2. That programmatic scroll fires a real `scroll` event the listener treats as a user scroll (`_userScrollCount` goes 0 → 1, 500ms reset timer armed).
3. The test body then runs `cy.get('.container').trigger('scroll').trigger('scroll').trigger('scroll')` — three separate Cypress commands. Under CI load the gap between triggers can exceed 500ms, so the armed timer fires between them, resetting the counter, and the callback (`temporarilySetAutoScrolling(false)`) never runs.

The failure message matches: spy only records `temporarilySetAutoScrolling(undefined)` (from `reporter:start`), never `(false)`.

Fix: dispatch the three `scroll` events synchronously in a single `.then()`. The threshold timer can't fire between synchronous DOM event dispatches, so the counter reliably reaches three regardless of CI load or any prior contaminating scroll.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in a Cypress e2e spec; no application code paths are modified.
> 
> **Overview**
> Deflakes the reporter integration test **`adds a scroll listener in open mode`** in `runnables.cy.ts` by changing how scroll events are simulated.
> 
> Instead of three separate `cy.trigger('scroll')` commands on `.container`, the test now fires three `scroll` events **synchronously** via `dispatchEvent` inside a single `.then()`, then asserts `temporarilySetAutoScrolling(false)` in a following `cy.then()`. That keeps all three events inside the scroller’s user-scroll counting window so CI timing gaps cannot reset the counter before the callback runs.
> 
> No production reporter or scroller behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 173a86e75c0a77af197d2690bccc9731d266096b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- `yarn workspace @packages/reporter cypress:run:ct -- --spec packages/reporter/cypress/e2e/runnables.cy.ts` and confirm the `adds a scroll listener in open mode` test passes.

### How has the user experience changed?

No change — test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?