### PR TITLE
test: fix flaky assertions.cy.js `have.length` retry test

### DIFF
--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -1458,11 +1458,7 @@ describe('src/cy/commands/assertions', () => {
       })
 
       // https://github.com/cypress-io/cypress/issues/205
-      describe('does not pass not.visible for non-dom', function () {
-        beforeEach(function () {
-          return Cypress.config('defaultCommandTimeout', 50)
-        })
-
+      describe('does not pass not.visible for non-dom', { defaultCommandTimeout: 50 }, function () {
         it('undefined', function (done) {
           let spy
 


### PR DESCRIPTION
- Closes n/a — flake remediation; CI link in details below

### Additional details

The driver spec `commands/assertions.cy.js` has a flaky test, `chai overrides > #have.length > rejects any element not in the document`, surfaced on CI (e.g. [job 3686865](https://app.circleci.com/pipelines/github/cypress-io/cypress/82395/workflows/16e59b50-d2ea-4cef-b00c-1a033b723534/jobs/3686865/tests#failed-test-0)) with:

```
AssertionError: Timed out retrying after 50ms: Too many elements found. Found '3', expected '2'.
```

**Root cause.** An earlier inner describe in the same spec set `defaultCommandTimeout` via `Cypress.config()` inside a `beforeEach`:

```js
describe('does not pass not.visible for non-dom', function () {
  beforeEach(function () {
    return Cypress.config('defaultCommandTimeout', 50)
  })
  ...
})
```

Cypress intentionally does **not** restore `Cypress.config()` mutations between tests — see the comment in `packages/driver/src/cy/testConfigOverrides.ts`:

> we restore config back to what it was before the test ran **UNLESS the user mutated config with `Cypress.config`**, in which case we apply those changes to the global config
> TODO: (NEXT_BREAKING) always restore configuration

So once that describe ran, every subsequent test in the spec inherited a 50ms `defaultCommandTimeout`. Most subsequent tests are `done()`-driven and complete in one tick, so they don't notice. But `rejects any element not in the document` only removes the extra button on the **2nd** `command:retry` event:

```js
cy.on('command:retry', _.after(2, () => {
  cy.$$('button:last').remove()
}))
cy.wrap(buttons).should('have.length', length - 1)
```

Two retries inside 50ms is a race — exactly the flake observed.

**Fix.** Switch the inner describe to mocha-style test config overrides, which Cypress scopes to that block and restores automatically:

```js
describe('does not pass not.visible for non-dom', { defaultCommandTimeout: 50 }, function () {
  ...
})
```

This removes the global config side effect entirely, so the 50ms timeout no longer leaks into `#have.length` (or anything that gets added below it in the future).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in driver e2e specs; no product or runtime behavior changes.
> 
> **Overview**
> Fixes a flaky driver spec in `assertions.cy.js` by scoping a **50ms** `defaultCommandTimeout` to the **does not pass not.visible for non-dom** block instead of setting it in a `beforeEach` via `Cypress.config()`.
> 
> That global mutation was persisting for later tests in the same file, so **`#have.length` > rejects any element not in the document** could time out before its DOM update on the second retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78135ec1d8289f6eb783ebc9ff01c86a1b1ba8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Run `yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/assertions.cy.js` and confirm the full spec passes.
- The remediated test is `src/cy/commands/assertions > chai overrides > #have.length > rejects any element not in the document`.

### How has the user experience changed?

No change — internal test-only fix.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical/test-only flake fix -->
- [x] Have tests been added/updated? <!-- The failing test itself is the test being fixed -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?