### PR TITLE
chore: fix changelog: move detached open bugfix from 15.17.1 to 15.17.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,10 +1,5 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 
-## 15.17.1
-
-**Bugfixes:**
-- Fixed an issue where `cypress open --detached` blocked the CLI process until the GUI was closed rather than returning once Cypress was ready to use.
-
 ## 15.17.0
 
 **Features:**
@@ -29,6 +24,7 @@
 - The internal `--dev`, `--inspect`, and `--inspect-brk` command line flags are no longer listed in the `cypress` CLI help output. These flags are only intended for developing Cypress itself and would error when used against an installed version, so they are no longer advertised to users. Fixes [#21320](https://github.com/cypress-io/cypress/issues/21320) and addresses [#23058](https://github.com/cypress-io/cypress/issues/23058).
 - Fixed an issue where `cy.wait('@alias')` could time out when the connection to the browser closed before an aliased intercepted request's response completed, including during navigation such as `cy.visit()`. Fixes [#19326](https://github.com/cypress-io/cypress/issues/19326).
 - Fixed an issue where a cross-origin navigation back to a previously-visited origin (for example, completing a login that redirects from an identity provider back to your application) could intermittently load the Cypress app interface instead of your application, causing flaky tests. Fixed in [#33991](https://github.com/cypress-io/cypress/pull/33991).
+- Fixed an issue where `cypress open --detached` blocked the CLI process until the GUI was closed rather than returning once Cypress was ready to use.
 
 **Misc:**
 


### PR DESCRIPTION
The detached open bugfix was accidentally added under a 15.17.1 entry, but
15.17.1 does not exist yet. Moved it into the 15.17.0 Bugfixes section and
removed the empty 15.17.1 section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no runtime or product behavior changes.
> 
> **Overview**
> Corrects **changelog** placement for the `cypress open --detached` bugfix: the entry is **removed** from a premature **`15.17.1`** section (that version is not released yet) and **added** under **`15.17.0`** **Bugfixes**, leaving a single accurate release section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d3f4a805dd7696bdaf0d262168e1a893aa46e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->