### PR TITLE
internal: apply modern visibility strategy consistently in checks and actionability

### DIFF
--- a/packages/app/src/navigation/KeyboardBindingsModal.cy.tsx
+++ b/packages/app/src/navigation/KeyboardBindingsModal.cy.tsx
@@ -137,7 +137,7 @@ describe('KeyboardBindingsModal', () => {
 
       cy.get('[data-cy="keyboard-modal"]').should('be.visible')
       // Click outside the modal (on the backdrop)
-      cy.get('body').click(0, 0)
+      cy.get('[role="dialog"]').click('topLeft')
       cy.get('@closeSpy').should('have.been.calledOnce')
     })
   })

--- a/packages/driver/cypress/e2e/dom/visibility.cy.ts
+++ b/packages/driver/cypress/e2e/dom/visibility.cy.ts
@@ -220,7 +220,25 @@ describe('src/cypress/dom/visibility', {
       })
 
       describe('visibility scenarios', () => {
+        // The legacy strategy always treats <html>/<body> as visible. The modern
+        // strategy does not special-case them: they obey checkVisibility and the
+        // 0-dimension rule like any other element.
         describe('html and body overrides', () => {
+          const rootExpectation = mode === 'legacy' ? 'visible' : 'hidden'
+
+          const assertRoot = (selector: 'html' | 'body', expected: 'visible' | 'hidden') => {
+            const opposite = expected === 'visible' ? 'hidden' : 'visible'
+
+            expect(cy.$$(selector).is(`:${expected}`), `${selector} should be :${expected}`).to.be.true
+            expect(cy.$$(selector).is(`:${opposite}`), `${selector} should not be :${opposite}`).to.be.false
+
+            expect(cy.$$(selector)).to.be[expected]
+            expect(cy.$$(selector)).to.not.be[opposite]
+
+            cy.wrap(cy.$$(selector)).should(`be.${expected}`)
+            cy.wrap(cy.$$(selector)).should(`not.be.${opposite}`)
+          }
+
           beforeEach(() => {
             cy.visit('/fixtures/empty.html')
           })
@@ -236,44 +254,26 @@ describe('src/cypress/dom/visibility', {
               })
             })
 
-            it('is always visible', () => {
-              expect(cy.$$('html').is(':hidden')).to.be.false
-              expect(cy.$$('html').is(':visible')).to.be.true
-
-              expect(cy.$$('html')).not.to.be.hidden
-              expect(cy.$$('html')).to.be.visible
-
-              cy.wrap(cy.$$('html')).should('not.be.hidden')
-              cy.wrap(cy.$$('html')).should('be.visible')
-              expect(cy.$$('body').is(':hidden')).to.be.false
-              expect(cy.$$('body').is(':visible')).to.be.true
-
-              expect(cy.$$('body')).not.to.be.hidden
-              expect(cy.$$('body')).to.be.visible
-
-              cy.wrap(cy.$$('body')).should('not.be.hidden')
-              cy.wrap(cy.$$('body')).should('be.visible')
+            it(`is ${rootExpectation}`, () => {
+              assertRoot('html', rootExpectation)
+              assertRoot('body', rootExpectation)
             })
           })
 
-          describe('when not display none', () => {
+          describe('when empty', () => {
+            it(`body is ${rootExpectation}`, () => {
+              assertRoot('body', rootExpectation)
+            })
+          })
+
+          describe('when it has rendered dimensions', () => {
+            beforeEach(() => {
+              cy.get('body').invoke('html', '<div style="width: 100px; height: 100px;">content</div>')
+            })
+
             it('is visible', () => {
-              expect(cy.$$('html').is(':hidden')).to.be.false
-              expect(cy.$$('html').is(':visible')).to.be.true
-
-              expect(cy.$$('html')).not.to.be.hidden
-              expect(cy.$$('html')).to.be.visible
-
-              cy.wrap(cy.$$('html')).should('not.be.hidden')
-              cy.wrap(cy.$$('html')).should('be.visible')
-              expect(cy.$$('body').is(':hidden')).to.be.false
-              expect(cy.$$('body').is(':visible')).to.be.true
-
-              expect(cy.$$('body')).not.to.be.hidden
-              expect(cy.$$('body')).to.be.visible
-
-              cy.wrap(cy.$$('body')).should('not.be.hidden')
-              cy.wrap(cy.$$('body')).should('be.visible')
+              assertRoot('html', 'visible')
+              assertRoot('body', 'visible')
             })
           })
         })

--- a/packages/driver/cypress/fixtures/visibility/form-elements.html
+++ b/packages/driver/cypress/fixtures/visibility/form-elements.html
@@ -11,8 +11,8 @@
   <div class="test-section" cy-section="select-and-option-elements" cy-has-conflicts="true">
     <h3>Select and Option Elements</h3>
     <select class="testCase" cy-expect="visible" id="visible-select">
-      <option class="testCase" cy-expect="visible" id="visible-option" cy-label="first option">Visible Option</option>
-      <option class="testCase" cy-expect="visible" id="visible-option-2">Another Visible Option</option>
+      <option class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible" id="visible-option" cy-label="first option">Visible Option</option>
+      <option class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible" id="visible-option-2">Another Visible Option</option>
     </select>
     
     <select class="testCase" cy-expect="hidden" id="hidden-select" style="display: none;">
@@ -23,9 +23,9 @@
   <div class="test-section" cy-section="optgroup-elements" cy-has-conflicts="true">
     <h3>Optgroup Elements</h3>
     <select class="testCase" cy-expect="visible" id="select-with-optgroup" cy-label="select with optgroup">
-      <optgroup class="testCase" cy-expect="visible" id="visible-optgroup" cy-label="Visible opt Group">
-        <option class="testCase" cy-expect="visible">Option 1</option>
-        <option class="testCase" cy-expect="visible">Option 2</option>
+      <optgroup class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible" id="visible-optgroup" cy-label="Visible opt Group">
+        <option class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible">Option 1</option>
+        <option class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible">Option 2</option>
       </optgroup>
     </select>
     
@@ -50,7 +50,7 @@
   <div class="test-section" cy-section="hidden-options-within-visible-select" cy-has-conflicts="true">
     <h3>Hidden Options Within Visible Select</h3>
     <select class="testCase" cy-expect="visible" id="select-with-hidden-option">
-      <option class="testCase" cy-expect="visible" id="visible-option-in-select">Visible Option</option>
+      <option class="testCase" cy-modern-expect="hidden" cy-legacy-expect="visible" id="visible-option-in-select">Visible Option</option>
       <option class="testCase" cy-expect="hidden" id="hidden-option-in-select" style="display: none;">Hidden Option</option>
     </select>
   </div>

--- a/packages/driver/src/cy/actionability.ts
+++ b/packages/driver/src/cy/actionability.ts
@@ -536,12 +536,17 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
         }
 
         if (options.ensure.visibility) {
-          // ensure element is visible but do not check if hidden by ancestors
-          // until nudging algorithm occurs
-          // https://whimsical.com/actionability-J38eY9K2Y3vA6uCMWtmLVA
-
-          // @ts-ignore
-          Cypress.ensure.isStrictlyVisible($el, name, _log)
+          // The modern strategy's visibility check is ancestor-aware, so it is a
+          // single check with no separate ancestor phase below. The legacy strategy
+          // checks the element in isolation here and defers the ancestor check until
+          // after the nudging algorithm. https://whimsical.com/actionability-J38eY9K2Y3vA6uCMWtmLVA
+          if (Cypress.config('visibilityStrategy') === 'modern') {
+            // @ts-ignore
+            Cypress.ensure.isVisible($el, name, _log)
+          } else {
+            // @ts-ignore
+            Cypress.ensure.isStrictlyVisible($el, name, _log)
+          }
         }
 
         if (options.ensure.notReadonly) {
@@ -577,7 +582,12 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
         // this calculation is relative from the viewport so we
         // only care about fromElViewport coords
         $elAtCoords = options.ensure.notCovered && ensureElIsNotCovered(cy, win, $el, coords.fromElViewport, options, _log, onScroll)
-        Cypress.ensure.isNotHiddenByAncestors($el, name, _log)
+
+        // the modern strategy already accounts for ancestors in its visibility
+        // check above, so only the legacy strategy needs this ancestor phase
+        if (Cypress.config('visibilityStrategy') !== 'modern') {
+          Cypress.ensure.isNotHiddenByAncestors($el, name, _log)
+        }
       }
 
       // pass our final object into onReady

--- a/packages/driver/src/cy/actionability.ts
+++ b/packages/driver/src/cy/actionability.ts
@@ -536,15 +536,14 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
         }
 
         if (options.ensure.visibility) {
-          // The modern strategy's visibility check is ancestor-aware, so it is a
-          // single check with no separate ancestor phase below. The legacy strategy
-          // checks the element in isolation here and defers the ancestor check until
-          // after the nudging algorithm. https://whimsical.com/actionability-J38eY9K2Y3vA6uCMWtmLVA
+          // The legacy strategy checks visibility in two stages: the element here, then
+          // — after the covering/nudging algorithm below — whether it's hidden by ancestors.
+          // The modern strategy does it in one checkVisibility-based call here, so it has
+          // no second stage. https://whimsical.com/actionability-J38eY9K2Y3vA6uCMWtmLVA
           if (Cypress.config('visibilityStrategy') === 'modern') {
-            // @ts-ignore
             Cypress.ensure.isVisible($el, name, _log)
           } else {
-            // @ts-ignore
+            // @ts-expect-error - isStrictlyVisible is not declared on the Cypress.ensure type
             Cypress.ensure.isStrictlyVisible($el, name, _log)
           }
         }
@@ -583,8 +582,9 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
         // only care about fromElViewport coords
         $elAtCoords = options.ensure.notCovered && ensureElIsNotCovered(cy, win, $el, coords.fromElViewport, options, _log, onScroll)
 
-        // the modern strategy already accounts for ancestors in its visibility
-        // check above, so only the legacy strategy needs this ancestor phase
+        // Only the legacy strategy runs this ancestor phase. The modern check above
+        // already covers ancestor display/visibility, and it intentionally omits the
+        // legacy overflow/out-of-bounds clipping check (matching modern `should('be.visible')`).
         if (Cypress.config('visibilityStrategy') !== 'modern') {
           Cypress.ensure.isNotHiddenByAncestors($el, name, _log)
         }

--- a/packages/driver/src/dom/jquery.ts
+++ b/packages/driver/src/dom/jquery.ts
@@ -2,7 +2,7 @@ import $ from 'jquery'
 import _ from 'lodash'
 
 // wrap the object in jquery
-export function wrap (obj) {
+function wrap (obj) {
   return $(obj)
 }
 

--- a/packages/driver/src/dom/visibility/modernIsHidden.ts
+++ b/packages/driver/src/dom/visibility/modernIsHidden.ts
@@ -1,17 +1,10 @@
-import $elements from '../elements'
-import { unwrap, wrap, isJquery } from '../jquery'
+import { unwrap, isJquery } from '../jquery'
 import Debug from 'debug'
 
 const debug = Debug('cypress:driver:dom:visibility:modernIsHidden')
 
-const { isOption, isOptgroup, isBody, isHTML } = $elements
-
 export function modernIsHidden (subject: JQuery<HTMLElement> | HTMLElement, options: { checkOpacity: boolean } = { checkOpacity: true }): boolean {
   debug('modernIsHidden', subject)
-
-  if (isBody(subject) || isHTML(subject)) {
-    return false
-  }
 
   if (isJquery(subject)) {
     const subjects = unwrap(subject) as HTMLElement | HTMLElement[]
@@ -21,18 +14,6 @@ export function modernIsHidden (subject: JQuery<HTMLElement> | HTMLElement, opti
     }
 
     return modernIsHidden(subjects, options)
-  }
-
-  if (isOption(subject) || isOptgroup(subject)) {
-    if (subject.hasAttribute('style') && subject.style.display === 'none') {
-      return true
-    }
-
-    const select = subject.closest('select')
-
-    if (select) {
-      return modernIsHidden(wrap(select), options)
-    }
   }
 
   if (!subject.checkVisibility({

--- a/packages/frontend-shared/src/components/StandardModal.cy.tsx
+++ b/packages/frontend-shared/src/components/StandardModal.cy.tsx
@@ -176,12 +176,12 @@ describe('<StandardModal />', { viewportWidth: 800, viewportHeight: 400 }, () =>
     })
 
     it('closes with click-outside', () => {
-      cy.get('body').click()
+      cy.get('[role="dialog"]').click('top')
       cy.get('@updateSpy').should('have.been.calledOnceWith', false)
     })
 
     it('does not close w/ click-outside when viewport is xs', { viewportWidth: 400 }, () => {
-      cy.get('body').click()
+      cy.get('[role="dialog"]').click('top')
       cy.get('@updateSpy').should('not.have.been.called')
     })
 


### PR DESCRIPTION
- Closes n/a

### Additional details

The modern visibility strategy (`visibilityStrategy: 'modern'`, introduced in #33794 and not yet released) was inconsistent in two ways. This PR makes it apply uniformly.

**1. `modernIsHidden` no longer special-cases roots or options.** It carried over two branches from the legacy algorithm:
- `<html>`/`<body>` were treated as always visible.
- `<option>`/`<optgroup>` visibility was inferred by recursing into the parent `<select>` (with an inline-only `display:none` check).

`Element.checkVisibility()` already models both correctly — including class-based `display:none` on an option (which the old inline-only check missed) and the listbox-vs-closed-dropdown distinction. Both branches are removed, so roots and options now obey `checkVisibility()` + dimensions like any other element.

**2. Actionability now follows the configured strategy.** `runAllChecks` called the legacy `isStrictlyVisible` / `isNotHiddenByAncestors` directly, so `cy.click()`, `cy.type()`, `cy.select()`, `cy.trigger()`, etc. gated on the legacy algorithm even when `'modern'` was configured. The visibility gate now branches on `visibilityStrategy`. Under `'modern'` it is a single ancestor-aware check (`checkVisibility()` accounts for ancestors), so the separate ancestor phase is skipped — while the geometric covering check (`ensureElIsNotCovered`) still runs for both strategies. Per design, modern actionability relies on `checkVisibility()` + covering and does not re-add the legacy overflow-clip gate, matching how modern `should('be.visible')` already behaves.

Behavior differences are confined to the modern strategy (unreleased); `visibilityStrategy: 'legacy'` is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core driver visibility and actionability for the default modern strategy (roots, options, and command gates), though legacy remains untouched and modern is not yet released.
> 
> **Overview**
> Aligns the unreleased **`visibilityStrategy: 'modern'`** path so DOM visibility, assertions, and actionability all use the same rules. **`modernIsHidden`** no longer force-treats `<html>`/`<body>` as visible or infers `<option>`/`<optgroup>` via the parent `<select>`; those elements now follow **`checkVisibility()`** plus the zero-dimension guard like everything else.
> 
> **Actionability** (`cy.click`, `cy.type`, etc.) now respects the configured strategy: modern runs a single **`Cypress.ensure.isVisible`** check (ancestor-aware via `checkVisibility`) and skips the legacy ancestor overflow phase; legacy still uses **`isStrictlyVisible`** then **`isNotHiddenByAncestors`**. Geometric covering checks still run for both.
> 
> Driver e2e and form fixture expectations are split per strategy (`cy-modern-expect` / `cy-legacy-expect`, parameterized `<html>`/`<body>` tests). App component tests click the dialog backdrop (`[role="dialog"]`) instead of `body` so “click outside” still hits a visible target under modern visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc3375c9a649e8c447d88d669dd9fe61424b30e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

With `visibilityStrategy: 'modern'`:
1. `<html>`/`<body>` with `display: none`, and an empty (0-height) `<body>`, are now reported hidden (legacy reports them visible).
2. `<option>`/`<optgroup>` in a closed `<select>` are reported hidden; options in a `multiple`/`size` listbox are visible; class-based `display:none` on an option is now caught.
3. Actionability honors the strategy — e.g. `cy.get('body').click()` on an empty body fails the modern visibility gate ("is not visible") rather than the legacy covering check ("being covered").

Covered by `cypress/e2e/dom/visibility.cy.ts` (both strategies) and the `cypress/e2e/commands/actions/*` suites.

### How has the user experience changed?

Only under the unreleased `visibilityStrategy: 'modern'`. Roots and closed-dropdown options that were previously force-visible now follow the browser's actual visibility, and actionability gates on the same modern rules as assertions instead of legacy ones. No change for `visibilityStrategy: 'legacy'`.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- internal refinement of the unreleased modern visibility strategy (#33794) -->
- [x] Have tests been added/updated? <!-- visibility.cy.ts + form-elements.html per-strategy expectations -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- modern strategy unreleased -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- no public API change -->
