### PR TITLE
chore: remove emitters when there is an error saving project slug after login/signup

### DIFF
--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -132,9 +132,6 @@ export class AuthActions {
             coreData.autoProvisionedProjectId = null
           })
 
-          this.ctx.emitter.toApp()
-          this.ctx.emitter.toLaunchpad()
-
           await this.ctx.lifecycleManager.refreshLifecycle()
         }
       } catch {

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -141,9 +141,6 @@ export class AuthActions {
         this.ctx.update((coreData) => {
           coreData.autoProvisionedProjectId = projectSlug
         })
-
-        this.ctx.emitter.toApp()
-        this.ctx.emitter.toLaunchpad()
       }
     }
 

--- a/packages/data-context/test/unit/actions/AuthActions.spec.ts
+++ b/packages/data-context/test/unit/actions/AuthActions.spec.ts
@@ -247,17 +247,12 @@ describe('AuthActions', () => {
       expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('sets autoProvisionedProjectId and notifies app and launchpad when setProjectIdInConfigFile fails', async () => {
+    it('sets autoProvisionedProjectId when setProjectIdInConfigFile fails', async () => {
       jest.spyOn(ctx.actions.project, 'setProjectIdInConfigFile').mockRejectedValue(new Error('write error'))
-      const toAppSpy = jest.spyOn(ctx.emitter, 'toApp')
-      const toLaunchpadSpy = jest.spyOn(ctx.emitter, 'toLaunchpad')
-
       // @ts-expect-error - incorrect number of arguments
       await actions.login()
 
       expect(ctx.coreData.autoProvisionedProjectId).toBe('my-project')
-      expect(toAppSpy).toHaveBeenCalledTimes(1)
-      expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -299,16 +294,11 @@ describe('AuthActions', () => {
       expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('sets autoProvisionedProjectId and notifies app and launchpad when setProjectIdInConfigFile fails during signup', async () => {
+    it('sets autoProvisionedProjectId when setProjectIdInConfigFile fails during signup', async () => {
       jest.spyOn(ctx.actions.project, 'setProjectIdInConfigFile').mockRejectedValue(new Error('write error'))
-      const toAppSpy = jest.spyOn(ctx.emitter, 'toApp')
-      const toLaunchpadSpy = jest.spyOn(ctx.emitter, 'toLaunchpad')
-
       await actions.signup('Binary: App', 'Studio', 'Signup')
 
       expect(ctx.coreData.autoProvisionedProjectId).toBe('my-project')
-      expect(toAppSpy).toHaveBeenCalledTimes(1)
-      expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/packages/data-context/test/unit/actions/AuthActions.spec.ts
+++ b/packages/data-context/test/unit/actions/AuthActions.spec.ts
@@ -233,18 +233,16 @@ describe('AuthActions', () => {
       expect(ctx.coreData.autoProvisionedProjectId).toBeNull()
     })
 
-    it('clears a stale autoProvisionedProjectId and notifies app and launchpad when setProjectIdInConfigFile succeeds', async () => {
+    it('clears a stale autoProvisionedProjectId and refreshes lifecycle when setProjectIdInConfigFile succeeds', async () => {
       ctx.coreData.autoProvisionedProjectId = 'my-project'
       jest.spyOn(ctx.actions.project, 'setProjectIdInConfigFile').mockResolvedValue(undefined)
-      const toAppSpy = jest.spyOn(ctx.emitter, 'toApp')
-      const toLaunchpadSpy = jest.spyOn(ctx.emitter, 'toLaunchpad')
+      const refreshLifecycleSpy = jest.spyOn(ctx.lifecycleManager, 'refreshLifecycle').mockResolvedValue(undefined)
 
       // @ts-expect-error - incorrect number of arguments
       await actions.login()
 
       expect(ctx.coreData.autoProvisionedProjectId).toBeNull()
-      expect(toAppSpy).toHaveBeenCalledTimes(1)
-      expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
+      expect(refreshLifecycleSpy).toHaveBeenCalledTimes(1)
     })
 
     it('sets autoProvisionedProjectId when setProjectIdInConfigFile fails', async () => {
@@ -281,17 +279,15 @@ describe('AuthActions', () => {
       expect(ctx.coreData.autoProvisionedProjectId).toBeNull()
     })
 
-    it('clears a stale autoProvisionedProjectId and notifies app and launchpad when setProjectIdInConfigFile succeeds during signup', async () => {
+    it('clears a stale autoProvisionedProjectId and refreshes lifecycle when setProjectIdInConfigFile succeeds during signup', async () => {
       ctx.coreData.autoProvisionedProjectId = 'my-project'
       jest.spyOn(ctx.actions.project, 'setProjectIdInConfigFile').mockResolvedValue(undefined)
-      const toAppSpy = jest.spyOn(ctx.emitter, 'toApp')
-      const toLaunchpadSpy = jest.spyOn(ctx.emitter, 'toLaunchpad')
+      const refreshLifecycleSpy = jest.spyOn(ctx.lifecycleManager, 'refreshLifecycle').mockResolvedValue(undefined)
 
       await actions.signup('Binary: App', 'Studio', 'Signup')
 
       expect(ctx.coreData.autoProvisionedProjectId).toBeNull()
-      expect(toAppSpy).toHaveBeenCalledTimes(1)
-      expect(toLaunchpadSpy).toHaveBeenCalledTimes(1)
+      expect(refreshLifecycleSpy).toHaveBeenCalledTimes(1)
     })
 
     it('sets autoProvisionedProjectId when setProjectIdInConfigFile fails during signup', async () => {


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->
When the project slug failed from getting saved in `cypress.config`, the app and launchpad emitters were racing with Auth’s unmount reset and was making the "copy your project slug" modal disappear. If the project slug fails to save, there is no need for the emitters because the login/signup mutation doesn’t resolve until after the server sets `autoProvisionedProjectId`, so the client already gets fresh data when that mutation completes


Current behavior:


https://github.com/user-attachments/assets/4fc82233-2884-48ba-a51c-f173c4d60826





Now:


https://github.com/user-attachments/assets/b14aff09-a734-49a6-9f3a-8bc8639c97f9






### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to post-auth project linking notifications; logout still emits toApp and success still refreshes lifecycle.
> 
> **Overview**
> After login/signup when a **project slug** is persisted via `setProjectIdInConfigFile`, **`AuthActions` no longer calls `emitter.toApp()` or `emitter.toLaunchpad()`** in either the success or failure branch. On success, lifecycle refresh via `refreshLifecycle()` is unchanged; on failure, the code still sets `autoProvisionedProjectId` but **does not broadcast a full app/launchpad refresh**.
> 
> Unit tests in `AuthActions.spec.ts` were updated to assert **`refreshLifecycle`** on the happy path and to drop expectations that emitters fire when config write fails (and on the success path where emitters were removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84ad48862c0cf0d47856f56b7c312f8e3b59798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
