### PR TITLE
chore: add missing PR link to cypress open --detached changelog entry (#33972)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -31,7 +31,7 @@
 - The internal `--dev`, `--inspect`, and `--inspect-brk` command line flags are no longer listed in the `cypress` CLI help output. These flags are only intended for developing Cypress itself and would error when used against an installed version, so they are no longer advertised to users. Fixes [#21320](https://github.com/cypress-io/cypress/issues/21320) and addresses [#23058](https://github.com/cypress-io/cypress/issues/23058).
 - Fixed an issue where `cy.wait('@alias')` could time out when the connection to the browser closed before an aliased intercepted request's response completed, including during navigation such as `cy.visit()`. Fixes [#19326](https://github.com/cypress-io/cypress/issues/19326).
 - Fixed an issue where a cross-origin navigation back to a previously-visited origin (for example, completing a login that redirects from an identity provider back to your application) could intermittently load the Cypress app interface instead of your application, causing flaky tests. Fixed in [#33991](https://github.com/cypress-io/cypress/pull/33991).
-- Fixed an issue where `cypress open --detached` blocked the CLI process until the GUI was closed rather than returning once Cypress was ready to use.
+- Fixed an issue where `cypress open --detached` blocked the CLI process until the GUI was closed rather than returning once Cypress was ready to use. Fixed in [#33972](https://github.com/cypress-io/cypress/pull/33972).
 
 **Misc:**
 


### PR DESCRIPTION
- Closes n/a (purely mechanical changelog fix)

### Additional details

The `verify-release-readiness` job was failing on `develop`'s `validate-binary-changelog.js` step. The validator requires every PR merged since the last release to have its PR link in `cli/CHANGELOG.md`. The bugfix entry for [#33972](https://github.com/cypress-io/cypress/pull/33972) ("cypress open --detach mode") was added without its link, so validation threw:

```
The changelog entry does not include the pull request link. Please update your entry
for 'fix: cypress open --detach mode (#33972)' to include:
Fixed in [#33972](https://github.com/cypress-io/cypress/pull/33972).
```

This appends `Fixed in [#33972](https://github.com/cypress-io/cypress/pull/33972).` to that entry, matching the format used by every other entry in the section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `cli/CHANGELOG.md` with no runtime or test impact.
> 
> **Overview**
> **Changelog-only fix** for the `15.17.0` **Bugfixes** entry about `cypress open --detached`: the diff appends **`Fixed in [#33972](https://github.com/cypress-io/cypress/pull/33972).`** so the line matches other entries in the section.
> 
> That satisfies **`validate-binary-changelog.js`**, which requires every merged PR since the last release to reference its PR link in `cli/CHANGELOG.md`—the entry text was already there without the link, which was failing **`verify-release-readiness`** on `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df9fea8c7b85f09ebe4df2b18c3d69038676250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

CI: the `verify-release-readiness` job should now pass the `validate-binary-changelog.js` step.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical changelog fix to unblock release-readiness validation. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
