### PR TITLE
test(data-context): pass real config path in ProjectConfigIpc EPIPE spec

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -148,6 +148,7 @@ while IFS= read -r file; do
     packages/server/*)
       server_tests=true
       system_tests=true
+      unit_tests=true
       ;;
     packages/proxy/*)
       server_tests=true
@@ -196,6 +197,7 @@ while IFS= read -r file; do
       launchpad_tests=true
       server_tests=true
       system_tests=true
+      unit_tests=true
       ;;
     packages/runner/*)
       driver_tests=true

--- a/npm/vite-dev-server/cypress.config.ts
+++ b/npm/vite-dev-server/cypress.config.ts
@@ -1,6 +1,8 @@
+import { createRequire } from 'module'
 import { defineConfig } from 'cypress'
-import { e2ePluginSetup } from '@packages/frontend-shared/cypress/e2e/e2ePluginSetup'
-import { setupCyInCyVariables } from '@packages/frontend-shared/cypress/tasks/cy-in-cy-variables'
+
+// @ts-expect-error — cypress.config is test-only; not included in the build tsconfig (import.meta requires ESM module settings, not node16)
+const require = createRequire(import.meta.url)
 
 export default defineConfig({
   projectId: 'ypt4pf',
@@ -17,12 +19,15 @@ export default defineConfig({
       process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
       process.env.CYPRESS_INTERNAL_VITE_OPEN_MODE_TESTING = 'true'
 
+      const { setupCyInCyVariables } = require('@packages/frontend-shared/cypress/tasks/cy-in-cy-variables') as typeof import('@packages/frontend-shared/cypress/tasks/cy-in-cy-variables')
       const { setCyInCyVariables, getCyInCyVariables } = setupCyInCyVariables()
 
       on('task', {
         setCyInCyVariables,
         getCyInCyVariables,
       })
+
+      const { e2ePluginSetup } = require('@packages/frontend-shared/cypress/e2e/e2ePluginSetup') as typeof import('@packages/frontend-shared/cypress/e2e/e2ePluginSetup')
 
       return await e2ePluginSetup(on, config)
     },

--- a/packages/data-context/test/unit/data/ProjectConfigIpc-real-child-process.spec.ts
+++ b/packages/data-context/test/unit/data/ProjectConfigIpc-real-child-process.spec.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals'
+import { describe, expect, it, beforeAll, beforeEach, afterEach, jest } from '@jest/globals'
 import path from 'path'
+import { scaffoldCommonNodeModules } from '@tooling/system-tests/lib/dep-installer'
 import { scaffoldMigrationProject as scaffoldProject } from '../helper'
 import { ProjectConfigIpc } from '../../../src/data/ProjectConfigIpc'
 
@@ -28,6 +29,10 @@ jest.mock('debug', () => {
 describe('ProjectConfigIpc', () => {
   describe('real-child-process', () => {
     let projectConfigIpc
+
+    beforeAll(async () => {
+      await scaffoldCommonNodeModules()
+    })
 
     beforeEach(async () => {
       const projectPath = await scaffoldProject('e2e')

--- a/packages/data-context/test/unit/data/ProjectConfigIpc-real-child-process.spec.ts
+++ b/packages/data-context/test/unit/data/ProjectConfigIpc-real-child-process.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals'
+import path from 'path'
 import { scaffoldMigrationProject as scaffoldProject } from '../helper'
 import { ProjectConfigIpc } from '../../../src/data/ProjectConfigIpc'
 
@@ -35,8 +36,8 @@ describe('ProjectConfigIpc', () => {
         undefined,
         undefined,
         projectPath,
-        '',
-        false,
+        path.join(projectPath, 'cypress.config.js'),
+        'cypress.config.js',
         (error) => {},
         () => {},
         () => {},

--- a/system-tests/project-fixtures/react/cypress-vite-async-function-config.config.ts
+++ b/system-tests/project-fixtures/react/cypress-vite-async-function-config.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig } from 'cypress'
 import reactPlugin from '@vitejs/plugin-react'
+import { fileURLToPath } from 'url'
 import * as path from 'path'
 import * as fs from 'fs'
 
-module.exports = defineConfig({
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
   component: {
     devServer: {
       framework: 'react',

--- a/yarn.lock
+++ b/yarn.lock
@@ -33329,7 +33329,7 @@ zimmerframe@^1.1.2:
   resolved "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz#5b75f1fa83b07ae2a428d51e50f58e2ae6855e5e"
   integrity sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==
 
-zod@^3.22.5:
+zod@^3.22.5, zod@^3.23.8:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
## Summary

### `ProjectConfigIpc` real-child-process spec (follow-up to #34003)

`ProjectConfigIpc-real-child-process.spec.ts` still constructed `ProjectConfigIpc` with an empty `configFilePath`. After #34003 removed the CJS→ESM config loading fallback, config loading uses strict Node module semantics and `require('')` fails immediately, so the EPIPE child-process test never reached its assertions. The spec now passes `path.join(projectPath, 'cypress.config.js')` so the IPC helper loads a real config file from the scaffolded project.

Loading that config also `require('cypress')`, which only resolves when `scaffoldCommonNodeModules()` has symlinked `cypress` into `{cyTmpDir}/node_modules` (as system tests do elsewhere). The spec now calls that in `beforeAll` so the real child process can load the e2e fixture config before exercising EPIPE handling.

### CI: run `unit-tests` for `data-context` and `server` changes

`@packages/data-context` Jest specs (including real child-process tests that exercise `@packages/server`) only run in the CircleCI `unit-tests` job, but path filtering did not set `run-unit-tests` when those packages changed. `generate-pipeline-parameters.sh` now enables `unit_tests` for `packages/data-context/*` and `packages/server/*` so those specs run on relevant PRs.

### `@cypress/vite-dev-server` cypress-in-cypress config

`@cypress/vite-dev-server` is an ESM package (`"type": "module"`), so its `cypress.config.ts` is evaluated as ESM. The frontend-shared Cypress-in-Cypress helpers (`e2ePluginSetup`, `setupCyInCyVariables`) must run in a CJS context (`hookRequire`, v8 snapshot preloads). Top-level ESM `import` of those modules breaks that loading model. The config now uses `createRequire(import.meta.url)` and `require()` inside `setupNodeEvents`, matching `@cypress/webpack-dev-server`. A `@ts-expect-error` on the `createRequire` line documents that this file is test-only and outside the package build tsconfig.

### Vite async-function config fixture (system-tests)

`cypress-vite-async-function-config.config.ts` used `module.exports` while `vite8.0.0-react` is `"type": "module"`. Under the same strict config loading rules, that mix fails. The fixture now uses `export default` and derives `__dirname` from `import.meta.url` so the async `viteConfig` hook can still write `wrote-to-file` for the vite-dev-server cypress-in-cypress test.

### Lockfile

`yarn.lock`: dedupe `zod` semver range keys from a local `yarn install` (unrelated to the functional fixes; keeps the lockfile consistent).

## Test plan

- [x] `yarn workspace @packages/data-context test -- packages/data-context/test/unit/data/ProjectConfigIpc-real-child-process.spec.ts`
- [ ] `@cypress/vite-dev-server` cypress-in-cypress E2E (`yarn cypress:run` from `npm/vite-dev-server` with parent env vars), if needed on this PR
- [ ] System test: vite async-function config (`cypress-vite-async-function-config.config.ts` via vite-dev-server E2E), if not covered by CI on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixtures, Cypress-in-Cypress config loading, and CI path filters only; no production runtime behavior changes.
> 
> **Overview**
> Fixes **test and CI gaps** after stricter ESM/CJS config loading (#34003): specs and fixtures now use real config paths and module formats, and CircleCI runs **unit tests** when `packages/data-context` or `packages/server` change.
> 
> The **`ProjectConfigIpc` real-child-process** Jest spec now points at the scaffolded `cypress.config.js`, runs **`scaffoldCommonNodeModules()`** so `require('cypress')` resolves in the child, and can exercise EPIPE handling instead of failing on an empty config path.
> 
> **`@cypress/vite-dev-server`** `cypress.config.ts` loads Cypress-in-Cypress helpers via **`createRequire` + `require()`** inside `setupNodeEvents` (not top-level ESM imports), preserving the CJS hook/snapshot behavior the ESM package needs for those tests.
> 
> The **vite async-function** system-test fixture switches from **`module.exports`** to **`export default`** and derives **`__dirname`** from **`import.meta.url`** so it matches the ESM project layout.
> 
> **`generate-pipeline-parameters.sh`** sets **`unit_tests=true`** for changes under **`packages/data-context/*`** and **`packages/server/*`**. **`yarn.lock`** only dedupes a **`zod`** range key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e985ec4881bb1c36f4fea523e6e8bda6c89919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->