### PR TITLE
chore: correct v8 snapshot artifact path so update PR is created

### DIFF
--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -156,10 +156,11 @@ jobs:
           set -e
           changed_files=()
           for platform in linux darwin win32; do
-            # upload-artifact@v4 preserves workspace-relative paths inside
-            # the artifact, so the file lands under the same tree it was
-            # uploaded from.
-            artifact_file="artifacts/v8-snapshot-cache-${platform}/tooling/v8-snapshot/cache/${platform}/snapshot-meta.json"
+            # upload-artifact@v4 uses the parent directory of a single-file
+            # `path:` as the artifact root, so only the bare filename is
+            # stored. With merge-multiple: false, download-artifact places it
+            # at artifacts/<artifact-name>/snapshot-meta.json.
+            artifact_file="artifacts/v8-snapshot-cache-${platform}/snapshot-meta.json"
             target_file="tooling/v8-snapshot/cache/${platform}/snapshot-meta.json"
             if [[ -f "${artifact_file}" ]]; then
               mkdir -p "$(dirname "${target_file}")"


### PR DESCRIPTION
- Closes <!-- no issue; mechanical CI workflow fix, explained below -->

### Additional details

The `update_v8_snapshot_cache` workflow was running green but never opening the "update v8 snapshot cache" PR, even when the per-platform jobs detected snapshot changes and uploaded artifacts (e.g. [run 26958478970](https://github.com/cypress-io/cypress/actions/runs/26958478970): all 3 platform artifacts uploaded, `consolidate-and-create-pr` succeeded in 12s, no PR created).

**Root cause:** the `Stage updated snapshots` step looks for each downloaded artifact at:

```
artifacts/v8-snapshot-cache-${platform}/tooling/v8-snapshot/cache/${platform}/snapshot-meta.json
```

based on the assumption (in the now-removed comment) that `upload-artifact@v4` preserves the full workspace-relative path. It does not. For a single-file `path:`, v4 uses the file's **parent directory** as the artifact root, so only the bare filename is stored. Confirmed by downloading the artifact from the run above:

```
$ gh run download 26958478970 -n v8-snapshot-cache-win32 && find .
./snapshot-meta.json
```

With `merge-multiple: false`, `download-artifact` places it at `artifacts/v8-snapshot-cache-${platform}/snapshot-meta.json`. The `[[ -f "${artifact_file}" ]]` test therefore failed for every platform, `changed_files` stayed empty, `has_changes` was always `false`, and the commit + `Create Pull Request` steps (both gated on `has_changes == 'true'`) were silently skipped.

**Fix:** point `artifact_file` at the path the file actually lands at. No change needed on the upload side.

### Steps to test

This only runs in CI (scheduled / on push to `release/**`, or via `workflow_dispatch`). To validate: trigger the workflow against a branch whose `snapshot-meta.json` differs per platform and confirm `consolidate-and-create-pr` now stages the files, reports `has_changes=true`, and opens the update PR.

### How has the user experience changed?

No change. Internal CI automation only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts internal GitHub Actions paths and comments; no product, auth, or runtime code changes.
> 
> **Overview**
> The **update v8 snapshot cache** workflow’s `consolidate-and-create-pr` job was copying downloaded artifacts from a path that assumed `upload-artifact@v4` kept the full repo-relative tree. For a single-file upload, v4 only stores the bare filename under the artifact name, so `Stage updated snapshots` never found `snapshot-meta.json`, always set `has_changes=false`, and skipped commit/PR steps even when platform jobs uploaded changes.
> 
> This PR updates `artifact_file` to `artifacts/v8-snapshot-cache-${platform}/snapshot-meta.json` and revises the inline comments to match actual upload/download layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2d5a4ba8558a6ae5d5942799f95bc15a750f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->