### PR TITLE
chore(cli): remove dead childProcessKilled error

### DIFF
--- a/cli/lib/errors.ts
+++ b/cli/lib/errors.ts
@@ -241,20 +241,6 @@ const invalidConfigFile = {
   solution: 'Either pass a relative path to a valid Cypress config file or remove this option.',
 }
 
-/**
- * This error happens when CLI detects that the child Test Runner process
- * was killed with a signal, like SIGBUS
- * @see https://github.com/cypress-io/cypress/issues/5808
- * @param {'close'|'event'} eventName Child close event name
- * @param {string} signal Signal that closed the child process, like "SIGBUS"
-*/
-const childProcessKilled = (eventName: string, signal: NodeJS.Signals | null): any => {
-  return {
-    description: `The Test Runner unexpectedly exited via a ${chalk.cyan(eventName)} event with signal ${chalk.cyan(signal)}`,
-    solution: solutionUnknown,
-  }
-}
-
 const CYPRESS_RUN_BINARY = {
   notValid: (value: string): any => {
     const properFormat = `**/${state.getPlatformExecutable()}`
@@ -274,7 +260,7 @@ const CYPRESS_RUN_BINARY = {
  * @example
   ```js
   // inside a Promise with "resolve" and "reject"
-  const errorObject = childProcessKilled('exit', 'SIGKILL')
+  const errorObject = errors.versionMismatch
   return getError(errorObject).then(reject)
   ```
  */
@@ -436,7 +422,6 @@ export const errors = {
   invalidCacheDirectory,
   CYPRESS_RUN_BINARY,
   smokeTestFailure,
-  childProcessKilled,
   incompatibleHeadlessFlags,
   invalidRunProjectPath,
   invalidTestingType,

--- a/cli/test/lib/__snapshots__/errors.spec.ts.snap
+++ b/cli/test/lib/__snapshots__/errors.spec.ts.snap
@@ -53,31 +53,15 @@ Cypress Version: 1.2.3"
 
 exports[`errors > getError > forms full message and creates Error object 1`] = `
 {
-  "description": "The Test Runner unexpectedly exited via a exit event with signal SIGKILL",
-  "solution": "Please search Cypress documentation for possible solutions:
-
-  https://on.cypress.io
-
-Check if there is a GitHub issue describing this crash:
-
-  https://github.com/cypress-io/cypress/issues
-
-Consider opening a new issue.",
+  "description": "Installed version does not match package version.",
+  "solution": "Install Cypress and verify app again",
 }
 `;
 
 exports[`errors > getError > forms full message and creates Error object 2`] = `
-"The Test Runner unexpectedly exited via a exit event with signal SIGKILL
+"Installed version does not match package version.
 
-Please search Cypress documentation for possible solutions:
-
-https://on.cypress.io
-
-Check if there is a GitHub issue describing this crash:
-
-https://github.com/cypress-io/cypress/issues
-
-Consider opening a new issue.
+Install Cypress and verify app again
 
 ----------
 
@@ -89,7 +73,6 @@ exports[`errors > individual > has the following errors 1`] = `
 [
   "CYPRESS_RUN_BINARY",
   "binaryNotExecutable",
-  "childProcessKilled",
   "failedDownload",
   "failedUnzip",
   "failedUnzipWindowsMaxPathLength",

--- a/cli/test/lib/errors.spec.ts
+++ b/cli/test/lib/errors.spec.ts
@@ -63,7 +63,7 @@ describe('errors', function () {
 
   describe('getError', () => {
     it('forms full message and creates Error object', async () => {
-      const errObject = errors.childProcessKilled('exit', 'SIGKILL')
+      const errObject = errors.versionMismatch
 
       expect(errObject).toMatchSnapshot()
 


### PR DESCRIPTION
The childProcessKilled error helper was no longer wired into the spawn
path (cli/lib/exec/spawn.ts now resolves with an exit code instead of
surfacing this error), leaving it as exported-but-unused dead code.

Remove the helper and its export, and repoint the getError unit test at
a live error object (versionMismatch) so coverage of getError/
formErrorText is preserved.

Refs https://github.com/cypress-io/cypress/issues/7045

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and test-only snapshot updates with no runtime behavior change.
> 
> **Overview**
> Removes the unused **`childProcessKilled`** CLI error helper and its export from `cli/lib/errors.ts`, since the test-runner spawn path no longer surfaces that error (it now returns an exit code instead).
> 
> Updates **`errors.spec.ts`** and snapshots so the **`getError`** test uses **`versionMismatch`** instead, keeping the same coverage of message formatting without the dead export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84ee00965239220bc495f056fce3323b38fa80b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->