### PR TITLE
fix: disable Chrome 141 Local Network Access checks that break cross-origin login flows

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where tests in Chrome and Electron could fail when the application made cross-origin requests to local or private network addresses (for example, a login or OAuth flow that redirects between local development hosts). Chrome 141 began enforcing Local Network Access checks that gate such requests behind a permission prompt the automated browser cannot answer. Cypress now opts out of these checks so these requests succeed as they did in Chrome 140. Fixes [#32708](https://github.com/cypress-io/cypress/issues/32708).
 - Fixed an issue where Cypress could load the config file through the wrong module system (for example, treating an ESM config as CommonJS), so ESM-only APIs such as `import.meta.resolve` were unavailable in config and plugin code. Cypress now picks ESM or CJS before loading, using Node.js rules from the config file extension and the nearest `package.json` `"type"`, then loads only via `import()` or `require()` and fails outright on error instead of retrying the other format:
   - `.mjs` and `.mts` always load as ESM
   - `.cjs` and `.cts` always load as CJS

--- a/packages/server/lib/util/chromium_flags.ts
+++ b/packages/server/lib/util/chromium_flags.ts
@@ -26,6 +26,18 @@ const disabledFeatures = [
   // https://github.com/cypress-io/cypress/issues/29199
   'PrivacySandboxSettings4',
 
+  // Disable Chrome's Local Network Access (LNA) checks, which began rolling out
+  // in Chrome 141. LNA gates requests from a page to local/private/loopback
+  // addresses behind a `local-network-access` permission prompt. In an automated
+  // browser the prompt cannot be answered, so cross-origin requests to local dev
+  // servers (e.g. login/redirect/OAuth flows) are blocked, breaking tests that
+  // worked in Chrome 140. Cypress fully controls the browser under test, so it's
+  // safe to opt out of these checks entirely.
+  // https://github.com/cypress-io/cypress/issues/32708
+  // https://developer.chrome.com/blog/local-network-access
+  'LocalNetworkAccessChecks',
+  'LocalNetworkAccessChecksWebRTC',
+
   // Disable manual option and popup prompt of Chrome translation
   // https://github.com/cypress-io/cypress/issues/28225
   'Translate',


### PR DESCRIPTION
Chrome 141 began enforcing Local Network Access (LNA) checks, which gate
requests from a page to local/private/loopback addresses behind a
permission prompt. In an automated browser the prompt cannot be answered,
so cross-origin requests to local dev servers (e.g. login/redirect/OAuth
flows) are silently blocked, causing tests that passed in Chrome 140 to
fail in 141.

Add LocalNetworkAccessChecks and LocalNetworkAccessChecksWebRTC to the
default disabled Chrome features so both Chrome and Electron opt out of
these checks, restoring pre-141 behavior.

Fixes #32708

### Sources

- LocalNetworkAccessChecks — lines 245–246:
https://github.com/chromium/chromium/blob/141.0.7390.66/services/network/public/cpp/features.cc#L245-L246
- LocalNetworkAccessChecksWebRTC — lines 261–262:
https://github.com/chromium/chromium/blob/141.0.7390.66/services/network/public/cpp/features.cc#L261-L262

The relevant definitions in that file:

```
// line 245
BASE_FEATURE(kLocalNetworkAccessChecks,
             "LocalNetworkAccessChecks",
             base::FEATURE_DISABLED_BY_DEFAULT);
...
// line 261
BASE_FEATURE(kLocalNetworkAccessChecksWebRTC,
             "LocalNetworkAccessChecksWebRTC",
             base::FEATURE_DISABLED_BY_DEFAULT);
```

Notable detail: in 141 the feature is FEATURE_DISABLED_BY_DEFAULT in code, it’s only turned on via a server-side Finch trial during the staged rollout (full default enforcement is 142).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted browser launch flag change aligned with existing disabled-feature patterns; affects Chrome/Electron networking behavior only in the controlled test browser.
> 
> **Overview**
> Fixes Chrome and Electron test failures caused by **Chrome 141’s Local Network Access (LNA)** checks, which block cross-origin requests to local/private hosts behind a permission prompt automation cannot satisfy (e.g. OAuth/login redirects between dev hosts).
> 
> Cypress now disables **`LocalNetworkAccessChecks`** and **`LocalNetworkAccessChecksWebRTC`** via the existing default `disable-features` list in `chromium_flags.ts`, so Chrome and Electron match pre-141 behavior. The **15.17.0 changelog** documents the fix (#32708).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8543e4f6a3b69ae52b403e348f3373dacc7c4ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->