### PR TITLE
dependency: pin watchpack to ^2.5.1 to silence Windows EINVAL scan warnings

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -46,6 +46,7 @@
 **Dependency Updates:**
 
 - Upgraded `tsx` from `4.20.6` to `4.22.4`. Its bundled `esbuild` Go binary no longer reports [CVE-2025-68121](https://www.cve.org/CVERecord?id=CVE-2025-68121) in security scans, and loading TypeScript config files no longer emits the Node.js `[DEP0205] module.register() is deprecated` warning. Fixes [#33954](https://github.com/cypress-io/cypress/issues/33954) and [#33744](https://github.com/cypress-io/cypress/issues/33744).
+- Upgraded `watchpack` (a transitive dependency of `webpack`) from `2.4.2` to `2.5.1`. On Windows, running a spec in `cypress open` from an elevated (Administrator) shell no longer logs `Watchpack Error (initial scan): EINVAL` warnings for system files at the root of the drive such as `pagefile.sys`, `swapfile.sys`, and `DumpStack.log.tmp`. Fixes [#33586](https://github.com/cypress-io/cypress/issues/33586).
 
 ## 15.16.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -46,7 +46,7 @@
 **Dependency Updates:**
 
 - Upgraded `tsx` from `4.20.6` to `4.22.4`. Its bundled `esbuild` Go binary no longer reports [CVE-2025-68121](https://www.cve.org/CVERecord?id=CVE-2025-68121) in security scans, and loading TypeScript config files no longer emits the Node.js `[DEP0205] module.register() is deprecated` warning. Fixes [#33954](https://github.com/cypress-io/cypress/issues/33954) and [#33744](https://github.com/cypress-io/cypress/issues/33744).
-- Upgraded `watchpack` (a transitive dependency of `webpack`) from `2.4.2` to `2.5.1`. On Windows, running a spec in `cypress open` from an elevated (Administrator) shell no longer logs `Watchpack Error (initial scan): EINVAL` warnings for system files at the root of the drive such as `pagefile.sys`, `swapfile.sys`, and `DumpStack.log.tmp`. Fixes [#33586](https://github.com/cypress-io/cypress/issues/33586).
+- Upgraded `watchpack` (a transitive dependency of `webpack`) from `2.4.2` to `2.5.1`. On Windows, running a spec in `cypress open` from an elevated (Administrator) shell no longer logs `Watchpack Error (initial scan): EINVAL` warnings for root-of-drive system files such as `pagefile.sys`. Fixes [#33586](https://github.com/cypress-io/cypress/issues/33586).
 
 ## 15.16.0
 

--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "**/serve-handler/minimatch": "3.1.3",
     "**/ua-parser-js": "0.7.33",
     "**/uuid": "11.1.1",
+    "**/watchpack": "^2.5.1",
     "@definitelytyped/typescript-versions": "0.1.9",
     "@types/react": "18.3.12",
     "browserify-sign": "4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32265,9 +32265,9 @@ warning@^4.0.3:
     loose-envify "^1.0.0"
 
 watchpack@^2.3.1, watchpack@^2.4.1:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz#2feeaed67412e7c33184e5a79ca738fbd38564da"
-  integrity sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==
+  version "2.5.1"
+  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz#dd38b601f669e0cbf567cb802e75cead82cde102"
+  integrity sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"


### PR DESCRIPTION
On elevated Windows shells, watchpack's initial directory scan would log
'Watchpack Error (initial scan): EINVAL ... lstat C:\pagefile.sys' (and
similar for swapfile.sys, DumpStack.log.tmp, System Volume Information)
when webpack watched the C:\ root while resolving missing node_modules
directories during spec preprocessing in open mode.

watchpack 2.5.0+ swallows EINVAL on Windows during the initial scan
instead of logging it. The transitive dependency was previously resolving
to 2.4.2, which lacks this handling. Pin via resolutions to ^2.5.1.

Fixes #33586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency resolution and lockfile-only change; low blast radius beyond webpack file watching on Windows.
> 
> **Overview**
> Pins the transitive **webpack** dependency `watchpack` from **2.4.2** to **^2.5.1** via Yarn `resolutions` and refreshes the lockfile.
> 
> **watchpack 2.5.0+** no longer logs `Watchpack Error (initial scan): EINVAL` when webpack’s initial directory scan hits Windows root-of-drive files (e.g. `pagefile.sys`) during `cypress open` spec preprocessing—especially from an elevated Administrator shell. The **15.17.0** changelog records the upgrade and links **#33586**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6274186cb5aedf41360d81332c62553facb12f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->