### PR TITLE
perf: Fix Command Log performance regression on hover

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.17.0
 
+**Performance:**
+
+- The Command Log no longer becomes progressively unresponsive when moving the mouse in and out of a test's command list during long tests. Hovering over the command area previously triggered a style recalculation across the entire list of commands, causing a delay that grew with the number of commands logged. Fixes [#33179](https://github.com/cypress-io/cypress/issues/33179).
+
 **Features:**
 
 - When signing up to Cypress Cloud from the Cypress desktop app, if a project is auto-provisioned during signup, Cypress now automatically writes the `projectId` to the `cypress.config` file. If the file cannot be written, a modal is shown with the project ID as a copyable snippet and a link to open the config file directly in your IDE. Addressed in [#33976](https://github.com/cypress-io/cypress/pull/33976).

--- a/packages/reporter/src/runnables/runnables.scss
+++ b/packages/reporter/src/runnables/runnables.scss
@@ -193,17 +193,6 @@ $dotted-line-left-padding: 19px;
       }
     }
 
-    .attempt-item:hover {
-      > .runnable-wrapper .runnable-controls i.fa-redo {
-        visibility: visible !important;
-      }
-
-      .hooks-container,
-      .runnable-err-wrapper {
-        border-color: $gray-500;
-      }
-    }
-
     .runnable-state,
     .attempt-state {
       display: inline-block;


### PR DESCRIPTION
- Closes #33179

### Additional details

This PR removes a hover state rule from the attempt-item that was causing performance degradation in the Command Log during long tests.

**Why this change was necessary:**

The `.attempt-item:hover` selector was triggering style recalculations across the entire command list whenever the mouse moved in and out of a test's command area. This caused progressive unresponsiveness that grew worse as more commands were logged, making the UI sluggish during extended test runs.

The removed styles were purely visual enhancements that came at a significant performance cost due to how the CSS selector was structured.

### Steps to test

1. Run a long-running test with 3,000+ logged commands https://github.com/mmcev106/cypress-test-tiny
2. Move the mouse in and out of the command list area repeatedly
3. Verify the Command Log remains responsive without lag or stuttering
4. Confirm the UI is still usable and interactive during extended test execution

### How has the user experience changed?

#### Before


https://github.com/user-attachments/assets/1a94ecba-fd61-4bdd-af77-89842394d74a



#### After


https://github.com/user-attachments/assets/7300a008-c88e-47bb-adfd-131bc7ef68eb



### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? (Issue #33179)
- [na] Have tests been added/updated? (Pure CSS performance fix, no test changes needed)
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? (Internal performance improvement)
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? (No API changes)

https://claude.ai/code/session_01RucmzQiaXEfiAtemGhrTZQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporter-only CSS and changelog; no test runner or API behavior changes beyond minor loss of hover styling on attempt rows.
> 
> **Overview**
> Fixes **Command Log** sluggishness during long tests by removing the `.attempt-item:hover` rule in `runnables.scss`. That hover styling forced expensive style recalculations across the full command list whenever the pointer entered or left a test’s command area, so lag grew with the number of logged commands.
> 
> **User-visible tradeoff:** hover no longer reveals the redo icon on attempt rows or shifts border colors on hooks/error wrappers—purely cosmetic effects removed in favor of responsiveness. The **15.17.0** changelog documents the performance fix ([#33179](https://github.com/cypress-io/cypress/issues/33179)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a907205f0407494a3472e71856e014b0c12a567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->