### PR TITLE
chore: reporter support for test replay embedding

### DIFF
--- a/packages/reporter/cypress/e2e/commands.cy.ts
+++ b/packages/reporter/cypress/e2e/commands.cy.ts
@@ -1313,3 +1313,65 @@ describe('commands', { viewportHeight: 1000 }, () => {
     })
   })
 })
+
+describe('cy.prompt command buttons', { viewportHeight: 1000 }, () => {
+  let runner: EventEmitter
+  let runnables: RootRunnable
+
+  const addPromptCommand = () => {
+    addCommand(runner, {
+      id: 200,
+      name: 'prompt',
+      message: 'cy.prompt instructions',
+      state: 'passed',
+    })
+  }
+
+  beforeEach(() => {
+    cy.fixture('runnables_commands').then((_runnables) => {
+      runnables = _runnables
+    })
+
+    runner = new EventEmitter()
+
+    cy.visit('/').then((win) => {
+      win.render({
+        runner,
+        runnerStore: {
+          spec: {
+            name: 'foo',
+            absolute: '/foo/bar',
+            relative: 'foo/bar',
+          },
+        },
+      })
+    })
+
+    cy.get('.reporter.mounted').then(() => {
+      runner.emit('runnables:ready', runnables)
+      runner.emit('reporter:start', {})
+    })
+  })
+
+  it('shows the Feedback and Get Code buttons by default', () => {
+    addPromptCommand()
+
+    cy.get('.command-name-prompt').should('exist')
+    cy.get('.command-prompt-get-feedback').should('be.visible')
+    cy.get('.command-prompt-get-code').should('be.visible')
+  })
+
+  it('hides the buttons when cy.prompt actions are disabled (e.g. test replay)', () => {
+    // command.tsx reads the reporter's appState singleton, exposed as window.state
+    cy.window().then((win) => {
+      win.state.setCyPromptActionsEnabled(false)
+      addPromptCommand()
+    })
+
+    // command still renders; only the buttons are gated
+    cy.get('.command-name-prompt').should('exist')
+    cy.get('.command-prompt-get-code-feedback-container').should('not.exist')
+    cy.get('.command-prompt-get-feedback').should('not.exist')
+    cy.get('.command-prompt-get-code').should('not.exist')
+  })
+})

--- a/packages/reporter/cypress/e2e/unit/app_state.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/app_state.cy.ts
@@ -239,5 +239,29 @@ describe('app state', () => {
       instance.reset()
       expect(instance.studioActive).to.be.false
     })
+
+    it('preserves cyPromptActionsEnabled', () => {
+      const instance = new AppState()
+
+      // intentionally excluded from reset defaults
+      instance.setCyPromptActionsEnabled(false)
+      instance.reset()
+      expect(instance.cyPromptActionsEnabled).to.be.false
+    })
+  })
+
+  context('#setCyPromptActionsEnabled', () => {
+    it('defaults to true', () => {
+      const instance = new AppState()
+
+      expect(instance.cyPromptActionsEnabled).to.be.true
+    })
+
+    it('sets cyPromptActionsEnabled', () => {
+      const instance = new AppState()
+
+      instance.setCyPromptActionsEnabled(false)
+      expect(instance.cyPromptActionsEnabled).to.be.false
+    })
   })
 })

--- a/packages/reporter/src/attempts/attempts.tsx
+++ b/packages/reporter/src/attempts/attempts.tsx
@@ -111,4 +111,7 @@ const Attempts: React.FC<AttemptsProps> = observer(({ test, isSingleStudioTest, 
 
 Attempts.displayName = 'Attempts'
 
+/** @public - consumed by the external test-replay viewer */
+export { Attempt }
+
 export default Attempts

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -567,7 +567,7 @@ const Command: React.FC<CommandProps> = observer(({ model, aliasesWithDuplicates
                 <CommandDetails model={model} groupId={groupId} aliasesWithDuplicates={aliasesWithDuplicates} />
                 <CommandControls model={model} commandName={commandName} />
               </div>
-              {model.isCyPrompt && (
+              {model.isCyPrompt && appState.cyPromptActionsEnabled && (
                 <div
                   className='command-prompt-get-code-feedback-container'
                   onClick={(e) => e.stopPropagation()}

--- a/packages/reporter/src/lib/app-state.ts
+++ b/packages/reporter/src/lib/app-state.ts
@@ -34,6 +34,9 @@ class AppState {
   studioActive = defaults.studioActive
   studioSingleTestActive = defaults.studioSingleTestActive
   showFetchRequests = true
+  // Gates the cy.prompt Feedback / Get Code buttons; read-only hosts disable it.
+  // Omitted from `defaults` so it survives `reset()`.
+  cyPromptActionsEnabled = true
   isStopped = false
   hasBeenPaused = defaults.hasBeenPaused
   _resetAutoScrollingEnabledTo = true
@@ -52,6 +55,7 @@ class AppState {
       studioActive: observable,
       studioSingleTestActive: observable,
       showFetchRequests: observable,
+      cyPromptActionsEnabled: observable,
       hasBeenPaused: observable,
       codeEditorLineWrap: observable,
     })
@@ -150,6 +154,10 @@ class AppState {
 
   setShowFetchRequests (showFetchRequests: boolean) {
     this.showFetchRequests = showFetchRequests
+  }
+
+  setCyPromptActionsEnabled (cyPromptActionsEnabled: boolean) {
+    this.cyPromptActionsEnabled = cyPromptActionsEnabled
   }
 
   reset () {


### PR DESCRIPTION
### Additional details

The [test-replay](https://github.com/cypress-io/cypress-services) viewer bundles this reporter as a git submodule and renders it in a **read-only** context (replaying a past run; no live Cypress backend). Two small reporter changes are needed to support that embedding. **Default behavior in the Cypress app is unchanged.**

**1. Re-export the singular `Attempt` component** (`attempts/attempts.tsx`)

`Attempt` was dropped from the module's exports in #33212 ("Remove unused exports"). That's correct *within* the reporter, but the test-replay submodule barrel imports `{ Attempt }` directly to render one attempt at a time from a single `AttemptModel` (the default-exported `Attempts` takes a whole `TestModel` and isn't a substitute). Re-exporting it restores the downstream consumer.

**2. Gate the cy.prompt Feedback / Get Code buttons behind a new appState flag** (`lib/app-state.ts`, `commands/command.tsx`)

These buttons call a live backend (`Cypress.backendRequestHandler`) and emit `prompt:get-code`, neither of which exists in a read-only replay. Added `appState.cyPromptActionsEnabled` (default `true`); the buttons now render only when `model.isCyPrompt && appState.cyPromptActionsEnabled`. Read-only hosts set it to `false`.

`appState` was chosen over a per-command-model field because this is one host-wide mode (interactive host vs. read-only replay), which is exactly what `appState` already models (`studioActive`, `showFetchRequests`). It's intentionally **excluded from `appState`'s reset defaults** so it survives `reset()` for the lifetime of the host.

### Steps to test

1. In the Cypress app, run a spec using `cy.prompt`. The **Feedback** and **Get Code** buttons appear on the prompt command as before (default `cyPromptActionsEnabled === true`).
2. With `appState.cyPromptActionsEnabled` set to `false` (as read-only embedders do), the prompt command still renders but neither button is shown.

Covered by automated tests:
- `cypress/e2e/unit/app_state.cy.ts` — default `true`, `setCyPromptActionsEnabled`, and that `reset()` preserves it.
- `cypress/e2e/commands.cy.ts` — buttons shown by default; hidden (command still renders) when disabled.

### How has the user experience changed?

No change for Cypress app users — the gating flag defaults to the existing behavior and is only flipped by external read-only embedders (test replay).

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- internal enablement for the cypress-services test-replay viewer; no user-facing Cypress change -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- no user-facing change -->
- [na] Have API changes been updated in the type definitions? <!-- no public API change -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped reporter UI/export changes with default-on behavior unchanged for the Cypress app; embedders opt out explicitly.
> 
> **Overview**
> Enables the reporter to be embedded in **read-only** hosts (e.g. test-replay) without changing default Cypress app behavior.
> 
> **Re-exports** the singular `Attempt` component from `attempts.tsx` so external viewers can render one attempt from an `AttemptModel` (restores a consumer dropped in an earlier export cleanup).
> 
> **Adds** `appState.cyPromptActionsEnabled` (default `true`, **not** reset by `appState.reset()`) and **`setCyPromptActionsEnabled`**. `command.tsx` only shows **Feedback** / **Get Code** on `cy.prompt` when `model.isCyPrompt && appState.cyPromptActionsEnabled`; read-only embedders set the flag to `false` so backend-dependent actions stay hidden while the prompt row still renders.
> 
> **Tests:** unit coverage for the new flag and reset behavior; e2e coverage for buttons visible by default vs hidden when disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f761dc3c33d5061663e92ef4975f2495d8f8e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->