### PR TITLE
chore: update need help link for auto provision project slug error modal

### DIFF
--- a/packages/frontend-shared/src/gql-components/modals/AutoProvisionProjectIdModal.cy.tsx
+++ b/packages/frontend-shared/src/gql-components/modals/AutoProvisionProjectIdModal.cy.tsx
@@ -1,0 +1,39 @@
+// tslint:disable-next-line: no-implicit-dependencies - unsure how to handle these
+import { defaultMessages } from '@cy/i18n'
+import AutoProvisionProjectIdModal from './AutoProvisionProjectIdModal.vue'
+
+describe('<AutoProvisionProjectIdModal />', () => {
+  const projectId = 'my-project-slug'
+  const configFilePath = '/path/to/cypress.config.ts'
+
+  function mountModal (onClose?: () => void) {
+    cy.mount(() => (
+      <div class="h-screen">
+        <AutoProvisionProjectIdModal
+          projectId={projectId}
+          configFilePath={configFilePath}
+          onClose={onClose}
+        />
+      </div>
+    ))
+  }
+
+  it('renders project ID and links to project ID docs', () => {
+    mountModal()
+
+    cy.contains(defaultMessages.runs.connect.modal.autoProvision.title).should('be.visible')
+    cy.contains(defaultMessages.runs.connect.modal.autoProvision.body).should('be.visible')
+    cy.contains(`projectId: '${projectId}',`).should('be.visible')
+    cy.get('[data-cy="external"]')
+    .should('have.attr', 'href', 'https://on.cypress.io/what-is-a-project-id')
+  })
+
+  it('emits close when the footer close button is clicked', () => {
+    const onClose = cy.stub().as('closeStub')
+
+    mountModal(onClose)
+
+    cy.contains('button', defaultMessages.runs.connect.modal.autoProvision.close).click()
+    cy.get('@closeStub').should('have.been.calledOnce')
+  })
+})

--- a/packages/frontend-shared/src/gql-components/modals/AutoProvisionProjectIdModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/AutoProvisionProjectIdModal.vue
@@ -2,6 +2,7 @@
   <StandardModal
     model-value
     :title="t('runs.connect.modal.autoProvision.title')"
+    help-link="https://on.cypress.io/what-is-a-project-id"
     @update:model-value="emit('close')"
   >
     <div class="w-[640px]">


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI help-link change and new component tests only; no auth, data, or runtime logic changes.
> 
> **Overview**
> The auto-provision project ID modal now surfaces **Need help** via `StandardModal`’s `help-link`, pointing users to `https://on.cypress.io/what-is-a-project-id` instead of leaving that header help unset or mislinked.
> 
> Component coverage was added in `AutoProvisionProjectIdModal.cy.tsx` to check copy, the project ID snippet, that external link, and that the footer close button emits `close`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002c310ad79ffe2405f860131ea4c6256b8a681a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
