### PR TITLE
chore: don't redeclare inherited observable Session.name

### DIFF
--- a/packages/reporter/src/sessions/sessions-model.ts
+++ b/packages/reporter/src/sessions/sessions-model.ts
@@ -15,7 +15,10 @@ export interface SessionProps extends InstrumentProps {
 }
 
 export default class Session extends Instrument {
-  name: string
+  // `name` is inherited from Instrument (and made observable in its
+  // constructor). Do NOT redeclare it as a class field: under
+  // useDefineForClassFields a subclass field re-defines the inherited
+  // observable and throws "Cannot redefine property: name".
   status: string
   isGlobalSession: boolean = false
   tagType: string

--- a/packages/reporter/src/sessions/sessions-model.ts
+++ b/packages/reporter/src/sessions/sessions-model.ts
@@ -18,7 +18,8 @@ export default class Session extends Instrument {
   // `name` is inherited from Instrument (and made observable in its
   // constructor). Do NOT redeclare it as a class field: under
   // useDefineForClassFields a subclass field re-defines the inherited
-  // observable and throws "Cannot redefine property: name".
+  // observable and throws "Cannot redefine property: name" when
+  // reporter is embedded into test-replay as a submodule.
   status: string
   isGlobalSession: boolean = false
   tagType: string


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

`Session extends Instrument` (`Log`), which declares `name` and converts it to a MobX observable in its constructor. `Session` redeclared `name: string` purely to narrow the inherited optional type to required.

Under `useDefineForClassFields: true`, that redeclaration is emitted as a real class field whose `[[Define]]` initializer runs **after** `super()` and re-defines the property MobX already installed in the base constructor — throwing:

\`\`\`
TypeError: Cannot redefine property: name
    at <instance_members_initializer> (.../sessions-model.ts)
\`\`\`

whenever a `Session` model is constructed. The Cypress app's own build (babel) erases declaration-only fields, so it never surfaced there — but the [test-replay viewer](https://github.com/cypress-io/cypress-services) bundles the reporter with esbuild + `useDefineForClassFields: true`, which *emits* the field, so it crashes the reporter and cascades across replay rendering.

**Fix:** remove the redeclaration entirely and rely on the inherited `Instrument.name`. `Session.name` is only assigned (`this.name = id`), never read with a narrowed type, so the inherited type suffices.

Note: `declare name: string` was the first attempt (type-only, no emit), but the app's babel pipeline runs `@babel/plugin-transform-class-properties` before the TS transform and so cannot strip `declare` fields — it errors with *"TypeScript 'declare' fields must first be transformed by @babel/plugin-transform-typescript"*. Removing the field is the only form that compiles cleanly under **both** the app's babel build and test-replay's esbuild build.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small model-layer change with no intended Cypress app runtime impact; fixes a crash only in alternate bundler configs.
> 
> **Overview**
> Removes the subclass `name` field on reporter `Session` so it no longer redefines the MobX observable `name` already set up on base `Instrument`/`Log`.
> 
> With **`useDefineForClassFields: true`** (e.g. test-replay’s esbuild bundle), that redeclaration caused **`TypeError: Cannot redefine property: name`** when constructing a `Session`. The Cypress app’s Babel build already erased the field, so behavior there is unchanged; **`this.name = id`** still uses the inherited property.
> 
> Adds an inline comment warning against redeclaring inherited observables on subclasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7db9f6771901ff979b32620755c96c75e3a783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

No-op for the Cypress app at runtime (the field was already erased by the app's build). Existing reporter session specs cover rendering; the behavioral validation is downstream in test-replay, where constructing a `Session` model no longer throws.

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

No change — type-only refactor with no runtime emit in the Cypress app.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- type-only refactor unblocking the test-replay viewer -->
- [na] Have tests been added/updated? <!-- no runtime change in-app; existing reporter session specs cover rendering -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- no user-facing change -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- no public API change -->