### PR TITLE
perf(server): release pending automation requests after response

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 **Performance:**
 
 - The Command Log no longer becomes progressively unresponsive when moving the mouse in and out of a test's command list during long tests. Hovering over the command area previously triggered a style recalculation across the entire list of commands, causing a delay that grew with the number of commands logged. Fixes [#33179](https://github.com/cypress-io/cypress/issues/33179).
+- Fixed a memory leak where runs with `screenshotOnRunFailure` enabled slowed down progressively, as each failure screenshot was retained in memory for the rest of the run. Fixes [#33516](https://github.com/cypress-io/cypress/issues/33516).
 
 **Features:**
 

--- a/packages/server/lib/automation/automation.ts
+++ b/packages/server/lib/automation/automation.ts
@@ -225,7 +225,7 @@ export class Automation {
     const request = this.requests[id]
 
     if (request) {
-      delete request[id]
+      delete this.requests[id]
 
       return request(resp)
     }

--- a/packages/server/test/unit/automation_spec.ts
+++ b/packages/server/test/unit/automation_spec.ts
@@ -31,4 +31,29 @@ describe('lib/automation', () => {
       expect(this.automation.getMiddleware().onPush).to.eq(onPush)
     })
   })
+
+  describe('.response', () => {
+    it('deletes the pending request from the requests map after responding', function () {
+      let capturedId
+
+      const fn = (_message, _data, id) => {
+        capturedId = id
+      }
+
+      const promise = this.automation.requestAutomationResponse('take:screenshot', {}, fn)
+
+      // the pending request is tracked while awaiting the browser's response
+      expect(this.automation.getRequests()).to.have.property(capturedId)
+
+      this.automation.response(capturedId, { response: 'foo' })
+
+      // once responded to, the request (and anything it retains, e.g. a large
+      // screenshot data URL) must be released to avoid a memory leak
+      expect(this.automation.getRequests()).to.not.have.property(capturedId)
+
+      return promise.then((resp) => {
+        expect(resp).to.eq('foo')
+      })
+    })
+  })
 })


### PR DESCRIPTION
The Automation#response handler deleted the request id off the handler
function object (delete request[id]) instead of off the requests map
(delete this.requests[id]). As a result, every automation request was
retained for the lifetime of the run.

For take:screenshot requests, the retained handler closure keeps the
resolved promise alive, which in turn holds the full base64 screenshot
data URL. With screenshotOnRunFailure enabled, each failure (and retry)
leaks a viewport-sized image into the Node process heap, causing the
run to progressively slow down as GC pressure builds.

Fixes #33516

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line bugfix in request cleanup with a focused unit test; behavior change only releases memory after responses complete.
> 
> **Overview**
> Fixes a **memory leak** in the server automation layer where completed browser automation callbacks were never removed from the internal pending-requests map.
> 
> `Automation#response` now deletes entries with `delete this.requests[id]` instead of incorrectly using `delete request[id]` on the handler function. Pending handlers (notably for `take:screenshot`) were retained for the entire run, which could keep large failure screenshot payloads in the Node heap when `screenshotOnRunFailure` is enabled and progressively slow runs.
> 
> A unit test asserts the request id is cleared from `getRequests()` after `response`, and the 15.17.0 changelog documents the performance fix ([#33516](https://github.com/cypress-io/cypress/issues/33516)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e6e02c5c7f5b9bed0ae8cb6b8a00fd3bb67b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->