### PR TITLE
chore: send standard identity headers on cy-prompt/studio session requests

### DIFF
--- a/packages/server/lib/cloud/api/cy-prompt/post_cy_prompt_session.ts
+++ b/packages/server/lib/cloud/api/cy-prompt/post_cy_prompt_session.ts
@@ -1,9 +1,8 @@
 import { asyncRetry, linearDelay } from '../../../util/async_retry'
 import { isRetryableError } from '../../network/is_retryable_error'
-import os from 'os'
 import { ParseKinds, postFetch } from '../../network/fetch'
+import { getStandardHeaders } from '../get_standard_headers'
 
-const pkg = require('@packages/root')
 const routes = require('../../routes') as typeof import('../../routes')
 
 interface PostCyPromptSessionOptions {
@@ -13,14 +12,15 @@ interface PostCyPromptSessionOptions {
 const _delay = linearDelay(500)
 
 export const postCyPromptSession = async ({ projectId }: PostCyPromptSessionOptions) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(await getStandardHeaders()),
+  }
+
   return await (asyncRetry(() => {
     return postFetch<{ cyPromptUrl: string }>(routes.apiRoutes.cyPromptSession(), {
       parse: ParseKinds.JSON,
-      headers: {
-        'Content-Type': 'application/json',
-        'x-os-name': os.platform(),
-        'x-cypress-version': pkg.version,
-      },
+      headers,
       body: JSON.stringify({ projectSlug: projectId, cyPromptMountVersion: 2 }),
     })
   }, {

--- a/packages/server/lib/cloud/api/get_standard_headers.ts
+++ b/packages/server/lib/cloud/api/get_standard_headers.ts
@@ -1,0 +1,20 @@
+import os from 'os'
+import { machineId } from '../machine_id'
+
+const pkg = require('@packages/root')
+
+/**
+ * The standard identity headers sent on cloud requests so the backend can
+ * attribute traffic by Cypress version, OS, and machine. The recording-service
+ * records these on its Honeycomb request spans.
+ *
+ * `x-machine-id` resolves to an empty string when the machine id is
+ * unavailable, matching the behavior of other cloud requests.
+ */
+export const getStandardHeaders = async (): Promise<Record<string, string>> => {
+  return {
+    'x-os-name': os.platform(),
+    'x-cypress-version': pkg.version,
+    'x-machine-id': await machineId() ?? '',
+  }
+}

--- a/packages/server/lib/cloud/api/studio/post_studio_session.ts
+++ b/packages/server/lib/cloud/api/studio/post_studio_session.ts
@@ -1,9 +1,8 @@
 import { asyncRetry, linearDelay } from '../../../util/async_retry'
 import { isRetryableError } from '../../network/is_retryable_error'
-import os from 'os'
 import { ParseKinds, postFetch } from '../../network/fetch'
+import { getStandardHeaders } from '../get_standard_headers'
 
-const pkg = require('@packages/root')
 const routes = require('../../routes') as typeof import('../../routes')
 
 interface PostStudioSessionOptions {
@@ -13,14 +12,15 @@ interface PostStudioSessionOptions {
 const _delay = linearDelay(500)
 
 export const postStudioSession = async ({ projectId }: PostStudioSessionOptions) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(await getStandardHeaders()),
+  }
+
   return await (asyncRetry(() => {
     return postFetch<{ studioUrl: string, protocolUrl: string }>(routes.apiRoutes.studioSession(), {
       parse: ParseKinds.JSON,
-      headers: {
-        'Content-Type': 'application/json',
-        'x-os-name': os.platform(),
-        'x-cypress-version': pkg.version,
-      },
+      headers,
       body: JSON.stringify({ projectSlug: projectId, studioMountVersion: 1, protocolMountVersion: 2 }),
     })
   }, {

--- a/packages/server/test/unit/cloud/api/cy-prompt/post_cy_prompt_session_spec.ts
+++ b/packages/server/test/unit/cloud/api/cy-prompt/post_cy_prompt_session_spec.ts
@@ -1,9 +1,13 @@
 import { SystemError } from '../../../../../lib/cloud/network/system_error'
 import { proxyquire } from '../../../../spec_helper'
-import os from 'os'
-import pkg from '@packages/root'
 import { ParseKinds } from '../../../../../lib/cloud/network/fetch'
 import sinon from 'sinon'
+
+const standardHeaders = {
+  'x-os-name': 'test-os',
+  'x-cypress-version': 'test-version',
+  'x-machine-id': 'test-machine-id',
+}
 
 describe('postCyPromptSession', () => {
   let postCyPromptSession: typeof import('@packages/server/lib/cloud/api/cy-prompt/post_cy_prompt_session').postCyPromptSession
@@ -14,6 +18,9 @@ describe('postCyPromptSession', () => {
     postCyPromptSession = (proxyquire('@packages/server/lib/cloud/api/cy-prompt/post_cy_prompt_session', {
       '../../network/fetch': {
         postFetch: postFetchStub,
+      },
+      '../get_standard_headers': {
+        getStandardHeaders: sinon.stub().resolves(standardHeaders),
       },
     }) as typeof import('@packages/server/lib/cloud/api/cy-prompt/post_cy_prompt_session')).postCyPromptSession
   })
@@ -38,8 +45,7 @@ describe('postCyPromptSession', () => {
         parse: ParseKinds.JSON,
         headers: {
           'Content-Type': 'application/json',
-          'x-os-name': os.platform(),
-          'x-cypress-version': pkg.version,
+          ...standardHeaders,
         },
         body: JSON.stringify({ projectSlug: '12345', cyPromptMountVersion: 2 }),
       },

--- a/packages/server/test/unit/cloud/api/get_standard_headers_spec.ts
+++ b/packages/server/test/unit/cloud/api/get_standard_headers_spec.ts
@@ -1,0 +1,34 @@
+import { proxyquire } from '../../../spec_helper'
+import os from 'os'
+import pkg from '@packages/root'
+import sinon from 'sinon'
+
+describe('getStandardHeaders', () => {
+  const loadWithMachineId = (machineId: string | null) => {
+    return (proxyquire('@packages/server/lib/cloud/api/get_standard_headers', {
+      '../machine_id': {
+        machineId: sinon.stub().resolves(machineId),
+      },
+    }) as typeof import('@packages/server/lib/cloud/api/get_standard_headers')).getStandardHeaders
+  }
+
+  it('returns the standard identity headers', async () => {
+    const getStandardHeaders = loadWithMachineId('test-machine-id')
+
+    expect(await getStandardHeaders()).to.deep.equal({
+      'x-os-name': os.platform(),
+      'x-cypress-version': pkg.version,
+      'x-machine-id': 'test-machine-id',
+    })
+  })
+
+  it('falls back to an empty x-machine-id when the machine id is unavailable', async () => {
+    const getStandardHeaders = loadWithMachineId(null)
+
+    expect(await getStandardHeaders()).to.deep.equal({
+      'x-os-name': os.platform(),
+      'x-cypress-version': pkg.version,
+      'x-machine-id': '',
+    })
+  })
+})

--- a/packages/server/test/unit/cloud/api/studio/post_studio_session_spec.ts
+++ b/packages/server/test/unit/cloud/api/studio/post_studio_session_spec.ts
@@ -1,9 +1,13 @@
 import { SystemError } from '../../../../../lib/cloud/network/system_error'
 import { proxyquire } from '../../../../spec_helper'
-import os from 'os'
-import pkg from '@packages/root'
 import { ParseKinds } from '../../../../../lib/cloud/network/fetch'
 import sinon from 'sinon'
+
+const standardHeaders = {
+  'x-os-name': 'test-os',
+  'x-cypress-version': 'test-version',
+  'x-machine-id': 'test-machine-id',
+}
 
 describe('postStudioSession', () => {
   let postStudioSession: typeof import('@packages/server/lib/cloud/api/studio/post_studio_session').postStudioSession
@@ -14,6 +18,9 @@ describe('postStudioSession', () => {
     postStudioSession = (proxyquire('@packages/server/lib/cloud/api/studio/post_studio_session', {
       '../../network/fetch': {
         postFetch: postFetchStub,
+      },
+      '../get_standard_headers': {
+        getStandardHeaders: sinon.stub().resolves(standardHeaders),
       },
     }) as typeof import('@packages/server/lib/cloud/api/studio/post_studio_session')).postStudioSession
   })
@@ -40,8 +47,7 @@ describe('postStudioSession', () => {
         parse: ParseKinds.JSON,
         headers: {
           'Content-Type': 'application/json',
-          'x-os-name': os.platform(),
-          'x-cypress-version': pkg.version,
+          ...standardHeaders,
         },
         body: JSON.stringify({ projectSlug: '12345', studioMountVersion: 1, protocolMountVersion: 2 }),
       },


### PR DESCRIPTION
## Why

The cloud `recording-service` attributes traffic on its Honeycomb request spans using headers the client sends (`x-cypress-version`, `x-os-name`, `x-machine-id`, …). The `cy-prompt` and `studio` **session** requests (which resolve the app bundle URLs) only sent `Content-Type`, `x-os-name`, and `x-cypress-version` — so `x-machine-id` was missing on those spans and per-machine attribution wasn't possible.

We're investigating a volume spike on `/cy-prompt/session`; machine id lets the backend tell "same machines calling repeatedly" apart from "more machines."

## What

- Add `packages/server/lib/cloud/api/get_standard_headers.ts` — a small shared helper returning the standard cloud identity headers (`x-os-name`, `x-cypress-version`, `x-machine-id`). `x-machine-id` falls back to `''` when unavailable, matching `CloudDataSource`/`VersionsDataSource`.
- Use it in `post_cy_prompt_session.ts` and `post_studio_session.ts` (previously each constructed headers inline; logic is now shared). The studio session response also carries the protocol bundle URL, so this covers capture-protocol bundle resolution too.
- Headers are resolved once before the retry loop, so the machine id isn't re-read on each attempt.

## Notes

- There is no separate capture-protocol session request — the protocol bundle URL is returned from the studio session — so no protocol-specific change is needed.
- The companion cloud-side PR (cypress-services) reads `x-machine-id` automatically once it arrives (it's already in the recording-service header allowlist).

## Testing

- `packages/server` unit specs: `get_standard_headers_spec.ts` (new), `post_cy_prompt_session_spec.ts`, `post_studio_session_spec.ts` — 6 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only change for observability/attribution on session endpoints; no auth or request-body behavior changes.
> 
> **Overview**
> Introduces shared `getStandardHeaders()` so cy-prompt and studio **session** POSTs send the same cloud identity headers as other requests, including **`x-machine-id`** (empty string when unavailable).
> 
> `post_cy_prompt_session` and `post_studio_session` drop inline `os`/`pkg` header construction and merge `Content-Type` with the helper output. Headers are resolved **once** before the retry loop so machine id is not re-fetched on each attempt.
> 
> Unit tests cover the helper and stub `getStandardHeaders` in the session specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a256ea13c0eb73c1c2970b02a3b1b9c1bcced48d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->