### PR TITLE
chore: sync yarn.lock for watchpack@2.5.1

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-05-15-2026
+06-09-2026

--- a/yarn.lock
+++ b/yarn.lock
@@ -32264,9 +32264,9 @@ warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
-watchpack@^2.3.1, watchpack@^2.4.1:
+watchpack@^2.3.1, watchpack@^2.4.1, watchpack@^2.5.1:
   version "2.5.1"
-  resolved "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz#dd38b601f669e0cbf567cb802e75cead82cde102"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.5.1.tgz#dd38b601f669e0cbf567cb802e75cead82cde102"
   integrity sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==
   dependencies:
     glob-to-regexp "^0.4.1"


### PR DESCRIPTION
## Summary

- Syncs the `watchpack@2.5.1` entry in `yarn.lock` so `yarn install` no longer rewrites the lockfile after a fresh clone
- Adds the missing `watchpack@^2.5.1` range specifier and updates the resolved registry URL from `registry.npmjs.org` to `registry.yarnpkg.com`
- Bumps `.circleci/cache-version.txt` to `06-09-2026` because the `yarn.lock` change invalidates the existing `node_modules` cache; `internal-pr-build` failed with "Should have found globbed node_modules to unpack"

Closes #34045

## Test plan

- [x] `git clone` + `yarn` produces no `yarn.lock` diff
- [x] Verified locally that `git diff` is clean after `yarn install`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and CI cache metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Aligns the root **`yarn.lock`** with the existing **`**/watchpack`: `^2.5.1`** resolution so a fresh **`yarn install`** no longer rewrites the lockfile.
> 
> The **`watchpack@2.5.1`** entry now includes the **`^2.5.1`** range in its key union and points **`resolved`** at **`registry.yarnpkg.com`** instead of **`registry.npmjs.org`**. **`.circleci/cache-version.txt`** is bumped to **`06-09-2026`** so CI dependency caches are rebuilt against the updated lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa57f2f3541e38514f089f37c5a86ef0eb6becd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->