### PR TITLE
chore: remove stale `allowCypressEnv` references for Cypress 16

### DIFF
--- a/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts
@@ -23,7 +23,6 @@ describe('errorWarningChange subscription', () => {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: '20',
@@ -37,7 +36,6 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: 20,
@@ -55,7 +53,6 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: ,
@@ -70,7 +67,6 @@ module.exports = {
           await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-  allowCypressEnv: false,
   projectId: 'abc123',
   component: {
     viewportHeight: 20,

--- a/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
+++ b/packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts
@@ -164,7 +164,6 @@ describe('specChange subscription', () => {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -313,7 +312,6 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -438,7 +436,6 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-allowCypressEnv: false,
 projectId: 'abc123',
 experimentalInteractiveRunEvents: true,
 component: {
@@ -464,7 +461,6 @@ e2e: {
         await ctx.actions.file.writeFileInProject('cypress.config.js',
 `   
 module.exports = {
-  allowCypressEnv: false,
   projectId: 'abc123',
   experimentalInteractiveRunEvents: true,
   component: {

--- a/system-tests/projects/plugin-config-is-interactive/cypress.config.js
+++ b/system-tests/projects/plugin-config-is-interactive/cypress.config.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = {
-  allowCypressEnv: false,
   fixturesFolder: false,
   e2e: {
     supportFile: false,

--- a/system-tests/test/cookies_spec.ts
+++ b/system-tests/test/cookies_spec.ts
@@ -405,7 +405,6 @@ describe('cookie jar stays in sync after same-origin requests', () => {
     browser: '!webkit', // TODO(webkit): fix+unskip (needs multidomain support)
     config: {
       baseUrl: `http://localhost:${httpPort}`,
-      allowCypressEnv: false,
     },
     spec: 'stale_cookie.cy.js',
   })

--- a/system-tests/test/firefox_video_spec.ts
+++ b/system-tests/test/firefox_video_spec.ts
@@ -57,12 +57,13 @@ describe('e2e firefox video', () => {
     spec: 'video_compression.cy.js,simple_passing.cy.js',
     snapshot: false,
     config: {
-      allowCypressEnv: true,
       video: true,
       videoCompression: false,
       env: {
-        NUM_TESTS,
         MS_PER_TEST,
+      },
+      expose: {
+        NUM_TESTS,
       },
     },
     async onRun (exec) {


### PR DESCRIPTION
## Summary

- Removes leftover `allowCypressEnv` usage from tests and fixtures after the option was deleted in Cypress 16.0.0 (#33963).
- Migrates `firefox_video_spec` to the `expose`/`env` config split already used by `video_compression_spec`, since `video_compression.cy.js` reads `NUM_TESTS` via `Cypress.expose()` and `MS_PER_TEST` via `cy.env()`.

## Why this is needed

`allowCypressEnv` was removed in Cypress 16. Any project config that still includes the key — even `allowCypressEnv: false` — triggers the `ALLOW_CYPRESS_ENV_REMOVED` warning at startup. These references were not user-facing API, but they added noisy warnings to CI/dev runs and left tests carrying a Cypress 15-era workaround that no longer applies.

## How the stale references got here

| Location | Introduced by | Notes |
|---|---|---|
| `packages/app/cypress/e2e/subscriptions/*` | [#33910](https://github.com/cypress-io/cypress/pull/33910) (merged from `develop`) | Added `allowCypressEnv: false` to config rewrites to prevent a server restart flake on Cypress 15 when the value flipped back to default `true`. Harmless on 15; obsolete once the option was removed in 16. |
| `system-tests/test/firefox_video_spec.ts` | [#33960](https://github.com/cypress-io/cypress/pull/33960) (merged from `develop`) | New Firefox video system test copied the pre-migration `allowCypressEnv: true` + root `env` pattern. `video_compression_spec.ts` on `release/16.0.0` had already moved to `expose`/`env`. |
| `system-tests/projects/plugin-config-is-interactive/cypress.config.js` | [#34007](https://github.com/cypress-io/cypress/pull/34007) (merged from `develop`) | New fixture copied `allowCypressEnv: false` from older plugin-config projects that predated the 16 removal. |
| `system-tests/test/cookies_spec.ts` (stale_cookie test) | Forgotten in [#33963](https://github.com/cypress-io/cypress/pull/33963) | The env-removal PR cleaned most `cookies_spec` overrides but missed this one remaining `allowCypressEnv: false`. |

Intentionally **not** changed: `packages/config` / `packages/errors` still list `allowCypressEnv` under `breakingOptions` so Cypress can warn users who still have the key in their own configs.

## Test plan

- [ ] `node system-tests/scripts/run.js --glob-in-dir="firefox_video"`
- [ ] `node system-tests/scripts/run.js --glob-in-dir="cookies_spec" -- --grep "stale_cookie"`
- [ ] `node system-tests/scripts/run.js --glob-in-dir="plugin_config"`
- [ ] `yarn workspace @packages/app cypress:run:e2e -- --spec packages/app/cypress/e2e/subscriptions/specChange-subscription.cy.ts`
- [ ] `yarn workspace @packages/app cypress:run:e2e -- --spec packages/app/cypress/e2e/subscriptions/errorWarningChange-subscription.cy.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only config cleanup with no production or user-facing API changes.
> 
> **Overview**
> Removes leftover **`allowCypressEnv`** from Cypress 16 test configs and fixtures so runs no longer hit the removed-option warning.
> 
> App subscription e2e tests (`errorWarningChange`, `specChange`) stop injecting `allowCypressEnv: false` into rewritten `cypress.config.js` snippets. The **`plugin-config-is-interactive`** fixture and **`cookies_spec`** stale-cookie override drop the same key.
> 
> **`firefox_video_spec`** is updated to match the Cypress 16 **`expose` / `env`** split: `NUM_TESTS` moves under `config.expose` (for `Cypress.expose()`), `MS_PER_TEST` stays under `env`, and `allowCypressEnv: true` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070d14489f5ebb45c3c321385c639d56da935e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->