### PR TITLE
chore: document why --turbo-profiling-input is filtered from mksnapshot args

### DIFF
--- a/tooling/electron-mksnapshot/src/process-args-from-file.ts
+++ b/tooling/electron-mksnapshot/src/process-args-from-file.ts
@@ -25,7 +25,16 @@ export function processArgsFromFile (
       return !arg.match(newlineRegEx) && arg !== ''
     })
 
-    // TODO: Figure out why we need to filter this out: https://github.com/cypress-io/cypress/issues/24092
+    // The `mksnapshot_args` file shipped inside Electron's mksnapshot zip records the exact
+    // args Electron used to build its own V8 snapshot, so we re-run mksnapshot with matching
+    // settings. Some Electron builds enable V8 builtins PGO (profile-guided optimization),
+    // which adds `--turbo-profiling-input <file>` pointing at a basic-block profiling log that
+    // existed in Electron's build environment but is NOT included in the redistributed zip.
+    // Re-running mksnapshot with that arg makes it try to open the missing profile file and
+    // abort. We strip the flag and its value so snapshot generation succeeds. Upstream Electron
+    // removed this arg from the Linux mksnapshot_args (electron/electron#36531), so on newer
+    // versions the flag is typically absent and this is a no-op.
+    // See https://github.com/cypress-io/cypress/issues/24092
     const turboProfilingInputIndex = mksnapshotArgsFromFile.indexOf('--turbo-profiling-input')
 
     if (turboProfilingInputIndex > -1) {


### PR DESCRIPTION
Replaces the stale TODO referencing #24092 with an explanation of the root
cause: Electron's recorded mksnapshot_args reference a V8 builtins PGO
profiling-input file that is not shipped in the redistributed mksnapshot zip,
so re-running mksnapshot with that arg fails on the missing file.

Closes #24092

https://claude.ai/code/session_01Ha78aKvTpw7duXD7MY7Qyk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change; snapshot arg filtering behavior is unchanged.
> 
> **Overview**
> This PR is **documentation-only**: it replaces the old TODO next to the `--turbo-profiling-input` stripping logic in `process-args-from-file.ts` with a full comment explaining **why** that flag is removed.
> 
> The new text clarifies that Electron’s bundled `mksnapshot_args` can include `--turbo-profiling-input` from V8 builtins PGO, but the profiling file is not in the redistributed zip, so leaving the arg in place makes `mksnapshot` fail. It also notes that newer Electron builds often omit the flag, so stripping is usually a no-op, and it keeps the link to cypress-io/cypress#24092.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159a66f7b6095634f19b8a49f5189115f48c839f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->