### PR TITLE
chore: add Cursor Cloud Agent environment config

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -139,7 +139,7 @@ while IFS= read -r file; do
     .percy.yml|.releaserc.js|renovate.json|docker-compose.yml|lerna.json|\
     electron-builder.json|knip.json|nx.json|jsconfig.json|autobarrel.json|\
     mocha-reporter-config.json|apollo.config.js|\
-    .husky/*|.vscode/*|__snapshots__/*)
+    .husky/*|.vscode/*|.cursor/*|__snapshots__/*)
       ;;
     packages/driver/*)
       driver_tests=true

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,13 @@
+# Cloud dev environment for the Cypress monorepo (Cursor Cloud Agents).
+#
+# Base image ships Node 22.19.0 (matches .node-version) plus Chrome/Firefox/Edge
+# and every OS dependency Cypress needs to launch browsers and the Electron app.
+# NOTE: Chrome/Edge are amd64-only in this base image; run the cloud agent on amd64.
+FROM cypress/browsers:22.19.0
+
+# Pin the package manager to the repo's Yarn 1 (see "packageManager" in package.json).
+RUN npm install -g yarn@1.22.22
+
+# Headless X display so `yarn cypress:run` / the Electron GUI can render.
+# The Xvfb server itself is launched by the `start` command in environment.json.
+ENV DISPLAY=:1

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,13 +1,19 @@
 # Cloud dev environment for the Cypress monorepo (Cursor Cloud Agents).
 #
-# Base image ships Node 22.19.0 (matches .node-version) plus Chrome/Firefox/Edge
-# and every OS dependency Cypress needs to launch browsers and the Electron app.
-# NOTE: Chrome/Edge are amd64-only in this base image; run the cloud agent on amd64.
-FROM cypress/browsers:22.19.0
+# Mirrors the image the monorepo's own CI uses: the `cy-docker` executor in
+# .circleci/src/pipeline/@pipeline.yml -> cypress/base-internal:22.19.0-trixie.
+# This is the base for building/testing Cypress itself. (cypress/included and
+# cypress/browsers are for end users running Cypress in their own CI, not for
+# CI that runs *against* the Cypress source.)
+#
+# Node 22.19.0 matches .node-version. Browsers are NOT bundled in this image;
+# CI installs them at runtime via the circleci/browser-tools orb, so a run that
+# needs a real Chrome/Firefox should install it (or use the built-in Electron).
+FROM cypress/base-internal:22.19.0-trixie
 
 # Pin the package manager to the repo's Yarn 1 (see "packageManager" in package.json).
 RUN npm install -g yarn@1.22.22
 
-# Headless X display so `yarn cypress:run` / the Electron GUI can render.
+# Headless X display so the Electron GUI / browsers can render.
 # The Xvfb server itself is launched by the `start` command in environment.json.
 ENV DISPLAY=:1

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://cursor.com/schemas/environment.schema.json",
+  "name": "cypress-monorepo",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "yarn --frozen-lockfile || yarn",
+  "start": "Xvfb :1 -screen 0 1920x1080x24 -ac +extension RANDR > /tmp/xvfb.log 2>&1 &"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -405,6 +405,8 @@ system-tests/lib/validations
 .cursor/*
 !.cursor/BUGBOT.md
 !.cursor/skills
+!.cursor/environment.json
+!.cursor/Dockerfile
 
 settings.local.json
 


### PR DESCRIPTION
## Summary

Adds a committed Cursor Cloud Agent environment so background/cloud agent runs (e.g. the upcoming daily flaky-test triage automation) boot a dev environment that matches the monorepo's own CI, instead of relying on a personal/team snapshot.

- `.cursor/Dockerfile` — based on `cypress/base-internal:22.19.0-trixie`, the same image the `cy-docker` executor uses in `.circleci/src/pipeline/@pipeline.yml`. Node 22.19.0 matches `.node-version`; pins Yarn `1.22.22`; sets `DISPLAY=:1`.
- `.cursor/environment.json` — builds from `.cursor/Dockerfile`, runs `yarn --frozen-lockfile || yarn` as the install step (workspace build + V8 snapshot, which Cursor then caches as a snapshot), and starts `Xvfb` on `:1` for headless runs.
- `.gitignore` — un-ignores the two files (`.cursor/*` is otherwise ignored).

Repo-level `.cursor/environment.json` takes precedence over personal/team environment config, so this becomes the source of truth for cloud runs and is shared across the team.

## Notes

- `cypress/base-internal` is the image for building/testing Cypress itself — not `cypress/included` / `cypress/browsers`, which are for end users running Cypress in their own CI.
- Browsers are not bundled in `base-internal` (CI installs them at runtime via the `circleci/browser-tools` orb). A cloud run that needs a real Chrome/Firefox should install it as a step, or use the built-in Electron browser.
- Optional follow-up: after a successful provision, capture a snapshot from the Cloud Agents dashboard and swap `build` for `"snapshot": "<id>"` to skip the Docker build.

## Test plan

- [ ] Launch a cloud agent on this branch and confirm the environment builds, `yarn` install completes, and Xvfb is up.
- [ ] Run a Cypress spec (Electron, or after installing Chrome) to confirm the runner works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling and CI path-filtering only; no runtime product, auth, or data-path changes.
> 
> **Overview**
> Introduces a **shared Cursor Cloud Agent** dev environment so cloud/background runs boot like monorepo CI instead of personal snapshots.
> 
> **`.cursor/Dockerfile`** builds from `cypress/base-internal:22.19.0-trixie` (same base as Circle’s `cy-docker`), pins **Yarn 1.22.22**, and sets **`DISPLAY=:1`** for headless GUI. **`.cursor/environment.json`** wires Docker build, **`yarn --frozen-lockfile || yarn`** install, and **Xvfb** on `:1` at start.
> 
> **`.gitignore`** now tracks **`environment.json`** and **`Dockerfile`** under `.cursor/*`. **`generate-pipeline-parameters.sh`** treats **`.cursor/*`** like other repo-metadata paths so PRs that only touch Cursor config **don’t trigger** the full test matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4284a9996ac2b07008703e72d0d315ef15670c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->