### PR TITLE
fix: stabilize canceled net-stubbing waits

### DIFF
--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -3792,9 +3792,18 @@ describe('network stubbing', { retries: 15 }, function () {
       it('stops waiting when an xhr request is canceled', () => {
         cy.visit('http://localhost:3500/fixtures/generic.html')
 
-        cy.intercept('POST', /users/, {
-          body: { name: 'b' },
-          delay: 2000,
+        let resolveRequestReceived = () => {}
+        const requestReceived = new Cypress.Promise<void>((resolve) => {
+          resolveRequestReceived = resolve
+        })
+
+        cy.intercept('POST', /users/, (req) => {
+          resolveRequestReceived()
+
+          req.reply({
+            body: { name: 'b' },
+            delay: 2000,
+          })
         }).as('createUser')
 
         cy.window()
@@ -3805,18 +3814,29 @@ describe('network stubbing', { retries: 15 }, function () {
 
           xhr.send()
 
-          win.location.reload()
-
-          cy.wait('@createUser').its('state').should('eq', 'Errored')
+          return requestReceived.then(() => {
+            win.location.reload()
+          })
         })
+
+        cy.wait('@createUser').its('state').should('eq', 'Errored')
       })
 
       it('stops waiting when an fetch request is canceled', () => {
         cy.visit('http://localhost:3500/fixtures/generic.html')
 
-        cy.intercept('POST', /users/, {
-          body: { name: 'b' },
-          delay: 2000,
+        let resolveRequestReceived = () => {}
+        const requestReceived = new Cypress.Promise<void>((resolve) => {
+          resolveRequestReceived = resolve
+        })
+
+        cy.intercept('POST', /users/, (req) => {
+          resolveRequestReceived()
+
+          req.reply({
+            body: { name: 'b' },
+            delay: 2000,
+          })
         }).as('createUser')
 
         cy.window()
@@ -3824,21 +3844,16 @@ describe('network stubbing', { retries: 15 }, function () {
           const controller = new AbortController()
           const { signal } = controller
 
-          fetch('/users/', { signal, method: 'POST' }).catch((e) => {
-          // do nothing on an abort
+          fetch('/users/', { signal, method: 'POST' }).catch(() => {
+            // do nothing on an abort
           })
 
-          // if you abort too fast in firefox or safari, the fetch is never sent to the server for us to intercept
-          if (!Cypress.isBrowser({ family: 'chromium' })) {
-            setTimeout(() => {
-              controller.abort()
-            }, 100)
-          } else {
+          return requestReceived.then(() => {
             controller.abort()
-          }
-
-          cy.wait('@createUser').its('state').should('eq', 'Errored')
+          })
         })
+
+        cy.wait('@createUser').its('state').should('eq', 'Errored')
       })
 
       it('should resolve a handler based intercept when navigation cancels the request', () => {


### PR DESCRIPTION
## Summary
- Stabilize the "stops waiting when an xhr/fetch request is canceled" net-stubbing e2e tests by synchronizing on intercept receipt before triggering navigation abort or fetch abort
- Remove browser-specific abort timing workarounds (100ms delay for Firefox/Safari) in favor of waiting for the intercept handler to run
- Move `cy.wait('@createUser')` assertions outside `cy.window()` callbacks for clearer command ordering

## Context
These tests live under `describe('network stubbing', { retries: 15 })` and were flaky due to race conditions: reload/abort could happen before the intercept received the request, causing intermittent failures especially in non-Chromium browsers.

## Test plan
- [ ] CI passes for driver e2e tests
- [ ] Run `net_stubbing.cy.ts` canceled-wait tests repeatedly to confirm stability


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to driver e2e specs; production net-stubbing behavior is unchanged.
> 
> **Overview**
> Stabilizes two **net-stubbing** e2e cases under `abort and cancel` that assert `cy.wait()` ends with interception state **`Errored`** when XHR or fetch is canceled mid-flight.
> 
> **Intercept setup** moves from a static `cy.intercept` + `delay` object to a handler that calls `req.reply({ body, delay: 2000 })` and resolves a **`requestReceived`** `Cypress.Promise` when the route handler runs, so cancel/reload only happens after Cypress has seen the request.
> 
> **XHR test:** `win.location.reload()` runs inside `requestReceived.then(...)` instead of immediately after `xhr.send()`; **`cy.wait('@createUser')`** is asserted outside the `cy.window()` callback.
> 
> **Fetch test:** Drops Chromium vs Firefox/Safari timing (`setTimeout(100)` before `abort()`); **`controller.abort()`** runs after `requestReceived`, same pattern as XHR. **`cy.wait`** is likewise hoisted out of `cy.window()`.
> 
> No driver or net-stubbing runtime changes—test-only race fixes for flaky canceled-wait behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0f57950610ea747d2687dc707185fb37ca0ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->