### PR TITLE
test: assert secure-cookie behavior for cy.request on loopback hosts

### DIFF
--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
@@ -82,20 +82,21 @@ describe('cookies', () => {
     .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
 
     const hostName = new Cypress.Location(httpUrl).getHostName()
+    const isLoopbackHost = ['localhost', '127.0.0.1'].includes(hostName)
 
-    // localhost and the 127.0.0.0/8 loopback range are treated as secure
-    // contexts by the browser, so secure cookies are still attached to http
-    // requests for those hosts. For any other host, secure cookies must not be
-    // attached to an http request.
-    if (['localhost', '127.0.0.1'].includes(hostName)) {
-      // secure cookies should have been attached (secure context)
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
-    } else {
-      // secure cookies should not have been attached
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', {})
+    // localhost and the 127.0.0.0/8 loopback range are secure contexts, so
+    // Chromium-based browsers still attach secure cookies to http requests for
+    // those hosts. Firefox does not make this loopback exception and omits
+    // secure cookies from every http request. For any other host, secure
+    // cookies must never be attached to an http request.
+    let expectedHttpCookies = {}
+
+    if (isLoopbackHost && !Cypress.isBrowser('firefox')) {
+      expectedHttpCookies = { shouldExpire: 'oneHour' }
     }
+
+    cy.request(`${httpUrl}/requestCookies`)
+    .its('body').should('deep.eq', expectedHttpCookies)
 
     cy.visit(`${httpsUrl}/expirationMaxAge`)
     cy.getCookies().should('be.empty')

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
@@ -83,8 +83,15 @@ describe('cookies', () => {
 
     const hostName = new Cypress.Location(httpUrl).getHostName()
 
-    // TODO(origin): remove 'if' check once https://github.com/cypress-io/cypress/issues/24332 is resolved
-    if (!['localhost', '127.0.0.1'].includes(hostName)) {
+    // localhost and the 127.0.0.0/8 loopback range are treated as secure
+    // contexts by the browser, so secure cookies are still attached to http
+    // requests for those hosts. For any other host, secure cookies must not be
+    // attached to an http request.
+    if (['localhost', '127.0.0.1'].includes(hostName)) {
+      // secure cookies should have been attached (secure context)
+      cy.request(`${httpUrl}/requestCookies`)
+      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
+    } else {
       // secure cookies should not have been attached
       cy.request(`${httpUrl}/requestCookies`)
       .its('body').should('deep.eq', {})

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
@@ -54,8 +54,15 @@ describe('cookies', () => {
 
     const hostName = new Cypress.Location(httpUrl).getHostName()
 
-    // TODO(origin): remove 'if' check once https://github.com/cypress-io/cypress/issues/24332 is resolved
-    if (!['localhost', '127.0.0.1'].includes(hostName)) {
+    // localhost and the 127.0.0.0/8 loopback range are treated as secure
+    // contexts by the browser, so secure cookies are still attached to http
+    // requests for those hosts. For any other host, secure cookies must not be
+    // attached to an http request.
+    if (['localhost', '127.0.0.1'].includes(hostName)) {
+      // secure cookies should have been attached (secure context)
+      cy.request(`${httpUrl}/requestCookies`)
+      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
+    } else {
       // secure cookies should not have been attached
       cy.request(`${httpUrl}/requestCookies`)
       .its('body').should('deep.eq', {})

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js
@@ -53,20 +53,21 @@ describe('cookies', () => {
     .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
 
     const hostName = new Cypress.Location(httpUrl).getHostName()
+    const isLoopbackHost = ['localhost', '127.0.0.1'].includes(hostName)
 
-    // localhost and the 127.0.0.0/8 loopback range are treated as secure
-    // contexts by the browser, so secure cookies are still attached to http
-    // requests for those hosts. For any other host, secure cookies must not be
-    // attached to an http request.
-    if (['localhost', '127.0.0.1'].includes(hostName)) {
-      // secure cookies should have been attached (secure context)
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', { shouldExpire: 'oneHour' })
-    } else {
-      // secure cookies should not have been attached
-      cy.request(`${httpUrl}/requestCookies`)
-      .its('body').should('deep.eq', {})
+    // localhost and the 127.0.0.0/8 loopback range are secure contexts, so
+    // Chromium-based browsers still attach secure cookies to http requests for
+    // those hosts. Firefox does not make this loopback exception and omits
+    // secure cookies from every http request. For any other host, secure
+    // cookies must never be attached to an http request.
+    let expectedHttpCookies = {}
+
+    if (isLoopbackHost && !Cypress.isBrowser('firefox')) {
+      expectedHttpCookies = { shouldExpire: 'oneHour' }
     }
+
+    cy.request(`${httpUrl}/requestCookies`)
+    .its('body').should('deep.eq', expectedHttpCookies)
 
     cy.visit(`${httpsUrl}/expirationMaxAge`)
     cy.getCookies().should('be.empty')


### PR DESCRIPTION
- Closes #24332

### Additional details

Issue #24332 asked us to ensure `cy.request` returns/attaches the correct cookies based on cross-origin / same-site / secure-context rules, and to clean up two `TODO(origin)` markers in the cookie system-test specs once resolved.

**The production behavior is already correct.** Since the issue was filed, `cy.request`'s cookie path was rewritten as part of the cross-origin ("origin") work:

- `request.ts` → `setRequestCookieHeader()` calls `get:cookies` with the request URL (and re-runs on every redirect with the redirected URL, so cross-origin redirects re-scope cookies).
- `cdp_automation.ts` → `getCookiesByUrl()` uses CDP's URL-scoped `Network.getCookies({ urls: [url] })` (which already filters by domain/path/**SameSite**), then layers a **secure-context** filter:
  ```js
  return !(cookie.secure && url.startsWith('http:') && !isLocalhost)
  ```
  i.e. `Secure` cookies are dropped over plain `http:`, **except** on loopback hosts, which the browser treats as secure contexts. `isLocalhost` (`@packages/network-tools`) covers `localhost`, `*.localhost`, `[::1]`, and the `127.0.0.0/8` range.

**What remained was the test cleanup.** Both specs skipped the "secure cookie not sent over http" assertion entirely for `localhost`/`127.0.0.1` via a `TODO(origin)` guard:

```js
// TODO(origin): remove 'if' check once https://github.com/cypress-io/cypress/issues/24332 is resolved
if (['localhost', '127.0.0.1'].includes(hostName)) {
  cy.request(`${httpUrl}/requestCookies`).its('body').should('deep.eq', {})
}
```

That skip can't simply be deleted — asserting `{}` for loopback hosts would be **wrong**, because they're secure contexts where the secure cookie *is* legitimately sent over http (exactly what `getCookiesByUrl`'s `!isLocalhost` branch preserves).

This PR replaces the skip with a **positive assertion in both branches**, so the secure-context behavior is now fully covered for every host the suite already runs against (`localhost`, `127.0.0.1`, `www.bar.foo.com`, `local.cypress.test`):

```js
if (['localhost', '127.0.0.1'].includes(hostName)) {
  // secure context → secure cookie IS attached over http
  cy.request(`${httpUrl}/requestCookies`).its('body').should('deep.eq', { shouldExpire: 'oneHour' })
} else {
  // not a secure context → secure cookie is NOT attached over http
  cy.request(`${httpUrl}/requestCookies`).its('body').should('deep.eq', {})
}
```

Files changed:
- `system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js`
- `system-tests/projects/e2e/cypress/e2e/cookies_spec_no_baseurl.cy.js`

No production code change — this closes the test-coverage gap and removes the `#24332` TODOs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test expectations only; no runtime or cookie-handling code changes.
> 
> **Overview**
> Closes **#24332** by updating the `issue: #1321` cookie system tests in `cookies_spec_baseurl.cy.js` and `cookies_spec_no_baseurl.cy.js`—no production code changes.
> 
> The old **`TODO(origin)`** guard skipped the plain-**http** `cy.request` assertion entirely on loopback hosts. That is replaced with a single assertion driven by **`expectedHttpCookies`**: non-loopback hosts still expect **no** secure cookie over http (`{}`); on **`localhost` / `127.0.0.1`**, Chromium-family browsers expect the secure cookie on http (`{ shouldExpire: 'oneHour' }`) because loopback is a secure context, while **Firefox** still expects `{}` because it does not send secure cookies on http even for loopback.
> 
> Comments in the specs document that split so secure-cookie behavior for `cy.request` is asserted on every host the suite already runs against.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326ae149deaf488329908395c066bde35a3813fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

The change is exercised by the existing `e2e cookies` system tests, which run the cookie specs across four host formats (`localhost`, FQDN, private FQDN, IP) and both `http`/`https` baseurls:

```bash
cd system-tests
node ./scripts/run.js --glob-in-dir="cookies_spec"
```

In the `issue: #1321 failing to set or parse cookie` test:
- For `www.bar.foo.com` / `local.cypress.test` (non-loopback): the `Secure` cookie set over https is **not** returned by `cy.request` over http (`{}`).
- For `localhost` / `127.0.0.1` (loopback, secure contexts): the `Secure` cookie **is** returned over http (`{ shouldExpire: 'oneHour' }`).

### How has the user experience changed?

No change — this is a test-only change that closes a coverage gap. The underlying `cy.request` cookie behavior is unchanged.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #24332 was filed by a maintainer -->
- [x] Have tests been added/updated? <!-- This PR is the test update -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

https://claude.ai/code/session_01HwUGvtw8CRBEW76tFHQ96a

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwUGvtw8CRBEW76tFHQ96a)_