### PR TITLE
chore: add debug logs to silent timeout fallback paths

### DIFF
--- a/packages/data-context/src/data/ProjectConfigManager.ts
+++ b/packages/data-context/src/data/ProjectConfigManager.ts
@@ -26,6 +26,10 @@ const debug = debugLib(`cypress:lifecycle:ProjectConfigManager`)
 
 const UNDEFINED_SERIALIZED = '__cypress_undefined__'
 
+// how long to wait for a reply to an execute:plugins ipc message before
+// logging (when debug logging is enabled)
+const EXECUTE_PLUGINS_REPLY_LOG_TIMEOUT_MS = 10000
+
 export type OnFinalConfigLoadedOptions = {
   shouldRestartBrowser: boolean
 }
@@ -299,12 +303,28 @@ export class ProjectConfigManager {
       this.options.eventRegistrar.registerEvent(event, function (...args: any[]) {
         return new Promise((resolve, reject) => {
           const invocationId = _.uniqueId('inv')
+          const sentAt = Date.now()
+          let replyLogTimeout: NodeJS.Timeout | undefined
 
           debug('call event', event, 'for invocation id', invocationId)
 
+          // this reply has no timeout; when debug logging is enabled, log if
+          // it has not arrived after EXECUTE_PLUGINS_REPLY_LOG_TIMEOUT_MS
+          if (debug.enabled) {
+            replyLogTimeout = setTimeout(() => {
+              debug('no promise:fulfilled received for invocation id %s (event %s) within %dms of sending execute:plugins', invocationId, event, EXECUTE_PLUGINS_REPLY_LOG_TIMEOUT_MS)
+            }, EXECUTE_PLUGINS_REPLY_LOG_TIMEOUT_MS)
+
+            replyLogTimeout.unref?.()
+          }
+
           ipc.once(`promise:fulfilled:${invocationId}`, (err: any, value: any) => {
+            if (replyLogTimeout) {
+              clearTimeout(replyLogTimeout)
+            }
+
             if (err) {
-              debug('promise rejected for id %s %o', invocationId, ':', err.stack)
+              debug('promise rejected for id %s after %dms %o', invocationId, Date.now() - sentAt, ':', err.stack)
               reject(_.extend(new Error(err.message), err))
 
               return
@@ -314,7 +334,7 @@ export class ProjectConfigManager {
               value = undefined
             }
 
-            debug(`promise resolved for id '${invocationId}' with value`, value)
+            debug(`promise resolved for id '${invocationId}' after ${Date.now() - sentAt}ms with value`, value)
 
             return resolve(value)
           })

--- a/packages/driver/src/cross-origin/communicator.ts
+++ b/packages/driver/src/cross-origin/communicator.ts
@@ -6,6 +6,8 @@ import { $Location } from '../cypress/location'
 import { preprocessLogForSerialization, reifyLogFromSerialization, preprocessSnapshotForSerialization, reifySnapshotFromSerialization } from '../util/serialization/log'
 
 const debug = debugFn('cypress:driver:multi-origin')
+// for logs emitted on every promisified cross-origin message
+const debugVerbose = debugFn('cypress-verbose:driver:multi-origin')
 
 const CROSS_ORIGIN_PREFIX = 'cross:origin:'
 const LOG_EVENTS = [`${CROSS_ORIGIN_PREFIX}log:added`, `${CROSS_ORIGIN_PREFIX}log:changed`]
@@ -44,7 +46,7 @@ const sharedPromiseSetup = ({
 
   const handler = (result) => {
     clearTimeout(timeoutId)
-    debug('%s received a response from %s spec bridge %dms after setup (timeout %dms)', event, specBridgeName, Date.now() - sentAt, timeout)
+    debugVerbose('%s received a response from %s spec bridge %dms after setup (timeout %dms)', event, specBridgeName, Date.now() - sentAt, timeout)
     resolve(result)
   }
 

--- a/packages/driver/src/cross-origin/communicator.ts
+++ b/packages/driver/src/cross-origin/communicator.ts
@@ -40,9 +40,11 @@ const sharedPromiseSetup = ({
   let timeoutId
 
   const responseEvent = `${event}:${Date.now()}`
+  const sentAt = Date.now()
 
   const handler = (result) => {
     clearTimeout(timeoutId)
+    debug('%s received a response from %s spec bridge %dms after setup (timeout %dms)', event, specBridgeName, Date.now() - sentAt, timeout)
     resolve(result)
   }
 

--- a/packages/driver/src/cy/actionability.ts
+++ b/packages/driver/src/cy/actionability.ts
@@ -99,6 +99,7 @@ const ensureElIsNotAnimating = ($el, coords = [], threshold, name: string) => {
 
   // bail if we dont yet have two points
   if (lastTwo.length !== 2) {
+    debug('animation check for `%s` has %d coordinate sample(s); 2 are required', name, lastTwo.length)
     $errUtils.throwErrByPath('dom.animation_check_failed')
   }
 
@@ -107,8 +108,12 @@ const ensureElIsNotAnimating = ($el, coords = [], threshold, name: string) => {
   // verify that there is not a distance
   // greater than a default of '5' between
   // the points
-  if ($utils.getDistanceBetween(point1, point2) > threshold) {
+  const distance = $utils.getDistanceBetween(point1, point2)
+
+  if (distance > threshold) {
     const node = $dom.stringify($el)
+
+    debug('distance between coordinate samples %o and %o is %d with threshold %d for `%s` on %s', point1, point2, distance, threshold, name, node)
 
     $errUtils.throwErrByPath('dom.animating', {
       args: { cmd: name, node },
@@ -146,6 +151,8 @@ const ensureIsDescendent = ($el1, $el2, name: string, onFail) => {
     if ($el2) {
       const element1 = $dom.stringify($el1)
       const element2 = $dom.stringify($el2)
+
+      debug('element at the checked coordinates is %s, which is not a descendent of %s, the target of `%s`', element2, element1, name)
 
       $errUtils.throwErrByPath('dom.covered', {
         onFail,
@@ -607,6 +614,8 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
           if ($el.length === 0 || $dom.isDetached($el)) {
             const current = cy.state('current')
             const subjectChain = cy.subjectChain(current.get('chainerId'))
+
+            debug('re-queried subject for `%s` has length %d, isDetached %o', current.get('name'), $el.length, $dom.isDetached($el))
 
             $errUtils.throwErrByPath('subject.detached_during_actionability', {
               args: { name: current.get('name'), subjectChain },

--- a/packages/driver/src/cy/actionability.ts
+++ b/packages/driver/src/cy/actionability.ts
@@ -10,6 +10,8 @@ import $elements from '../dom/elements'
 import $errUtils from '../cypress/error_utils'
 import { callNativeMethod, getNativeProp } from '../dom/elements/nativeProps'
 const debug = debugFn('cypress:driver:actionability')
+// for logs emitted on every retry iteration of an actionability check
+const debugVerbose = debugFn('cypress-verbose:driver:actionability')
 
 const delay = 50
 
@@ -113,7 +115,7 @@ const ensureElIsNotAnimating = ($el, coords = [], threshold, name: string) => {
   if (distance > threshold) {
     const node = $dom.stringify($el)
 
-    debug('distance between coordinate samples %o and %o is %d with threshold %d for `%s` on %s', point1, point2, distance, threshold, name, node)
+    debugVerbose('distance between coordinate samples %o and %o is %d with threshold %d for `%s` on %s', point1, point2, distance, threshold, name, node)
 
     $errUtils.throwErrByPath('dom.animating', {
       args: { cmd: name, node },
@@ -152,7 +154,7 @@ const ensureIsDescendent = ($el1, $el2, name: string, onFail) => {
       const element1 = $dom.stringify($el1)
       const element2 = $dom.stringify($el2)
 
-      debug('element at the checked coordinates is %s, which is not a descendent of %s, the target of `%s`', element2, element1, name)
+      debugVerbose('element at the checked coordinates is %s, which is not a descendent of %s, the target of `%s`', element2, element1, name)
 
       $errUtils.throwErrByPath('dom.covered', {
         onFail,
@@ -615,7 +617,7 @@ const verify = function (cy, $el, config, options, callbacks: VerifyCallbacks) {
             const current = cy.state('current')
             const subjectChain = cy.subjectChain(current.get('chainerId'))
 
-            debug('re-queried subject for `%s` has length %d, isDetached %o', current.get('name'), $el.length, $dom.isDetached($el))
+            debugVerbose('re-queried subject for `%s` has length %d, isDetached %o', current.get('name'), $el.length, $dom.isDetached($el))
 
             $errUtils.throwErrByPath('subject.detached_during_actionability', {
               args: { name: current.get('name'), subjectChain },

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -372,6 +372,7 @@ const stabilityChanged = async (Cypress, state, config, stable) => {
       // If this request is still pending after the test run, resolve it, no commands were waiting on its result.
       cy.once('test:after:run', () => {
         if (promise.isPending()) {
+          debug('test:after:run fired while the page load promise was still pending; resolving it without window:load')
           options._log?.set('message', '').end()
           resolve()
         }

--- a/packages/driver/src/cy/commands/navigation.ts
+++ b/packages/driver/src/cy/commands/navigation.ts
@@ -600,6 +600,8 @@ export const go = (Cypress: Cypress.Cypress, cy: Cypress.Cypress, state: StateFu
         .then(() => {
           knownCommandCausedInstability = false
 
+          debug('go(%d): didUnload is %o 100ms after navigating history', num, didUnload)
+
           // if we've didUnload then we know we're
           // doing a full page refresh and we need
           // to wait until

--- a/packages/driver/src/cy/commands/sessions/utils.ts
+++ b/packages/driver/src/cy/commands/sessions/utils.ts
@@ -96,7 +96,7 @@ const setPostMessageLocalStorage = async (specWindow, originOptions) => {
     $iframeContainer.remove()
   })
   .catch((err) => {
-    debug('failed to set session storage data within %dms on origin(s) %o. Session data will be incomplete for those origins: %o', postMessageStorageTimeoutMs, _.xor(origins, successOrigins), err)
+    debug('did not receive set:storage:complete from origin(s) %o within %dms: %o', _.xor(origins, successOrigins), postMessageStorageTimeoutMs, err)
 
     Cypress.log({
       name: 'warning',
@@ -191,7 +191,7 @@ const getPostMessageLocalStorage = (specWindow, origins): Promise<any[]> => {
     $iframeContainer.remove()
   })
   .catch((err) => {
-    debug('failed to get session storage data within %dms on origin(s) %o. Session data will be incomplete for those origins: %o', postMessageStorageTimeoutMs, _.xor(origins, successOrigins), err)
+    debug('did not receive localStorage data from origin(s) %o within %dms: %o', _.xor(origins, successOrigins), postMessageStorageTimeoutMs, err)
 
     Cypress.log({
       name: 'warning',

--- a/packages/driver/src/cy/commands/sessions/utils.ts
+++ b/packages/driver/src/cy/commands/sessions/utils.ts
@@ -1,7 +1,14 @@
 import _ from 'lodash'
 import $ from 'jquery'
 import Bluebird from 'bluebird'
+import Debug from 'debug'
 import { $Location } from '../../../cypress/location'
+
+const debug = Debug('cypress:driver:sessions')
+
+// How long to wait for each cross-origin iframe to post its storage data back
+// before giving up and continuing with incomplete session data.
+const postMessageStorageTimeoutMs = 2000
 
 const getSessionDetailsByDomain = (sessState: Cypress.SessionData) => {
   return _.merge(
@@ -83,12 +90,14 @@ const setPostMessageLocalStorage = async (specWindow, originOptions) => {
     specWindow.addEventListener('message', onPostMessage)
   })
   // timeout just in case something goes wrong and the iframe never loads in
-  .timeout(2000)
+  .timeout(postMessageStorageTimeoutMs)
   .finally(() => {
     specWindow.removeEventListener('message', onPostMessage)
     $iframeContainer.remove()
   })
-  .catch(() => {
+  .catch((err) => {
+    debug('failed to set session storage data within %dms on origin(s) %o. Session data will be incomplete for those origins: %o', postMessageStorageTimeoutMs, _.xor(origins, successOrigins), err)
+
     Cypress.log({
       name: 'warning',
       message: `failed to access session localStorage data on origin(s): ${_.xor(origins, successOrigins).join(', ')}`,
@@ -176,12 +185,14 @@ const getPostMessageLocalStorage = (specWindow, origins): Promise<any[]> => {
     specWindow.addEventListener('message', onPostMessage)
   })
   // timeout just in case something goes wrong and the iframe never loads in
-  .timeout(2000)
+  .timeout(postMessageStorageTimeoutMs)
   .finally(() => {
     specWindow.removeEventListener('message', onPostMessage)
     $iframeContainer.remove()
   })
   .catch((err) => {
+    debug('failed to get session storage data within %dms on origin(s) %o. Session data will be incomplete for those origins: %o', postMessageStorageTimeoutMs, _.xor(origins, successOrigins), err)
+
     Cypress.log({
       name: 'warning',
       message: `failed to access session localStorage data on origin(s): ${_.xor(origins, successOrigins).join(', ')}`,

--- a/packages/driver/src/cy/location.ts
+++ b/packages/driver/src/cy/location.ts
@@ -1,12 +1,30 @@
+import Debug from 'debug'
 import { $Location, LocationObject } from '../cypress/location'
 import type { StateFunc } from '../cypress/state'
 import $utils from '../cypress/utils'
 
+const debug = Debug('cypress:driver:location')
+
+// this wait has no timeout; when debug logging is enabled, log if no message
+// has arrived on the channel after this long
+const locationResponseLogTimeoutMs = 2000
+
 const getRemoteLocationFromCrossOriginWindow = (autWindow: Window): Promise<LocationObject> => {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
+    let responseLogTimeout: ReturnType<typeof setTimeout> | undefined
+
+    if (debug.enabled) {
+      responseLogTimeout = setTimeout(() => {
+        debug('no message received on the channel within %dms of posting aut:cypress:location', locationResponseLogTimeoutMs)
+      }, locationResponseLogTimeoutMs)
+    }
 
     channel.port1.onmessage = ({ data }) => {
+      if (responseLogTimeout) {
+        clearTimeout(responseLogTimeout)
+      }
+
       channel.port1.close()
       resolve($Location.create(data))
     }

--- a/packages/driver/src/cy/retries.ts
+++ b/packages/driver/src/cy/retries.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import Promise from 'bluebird'
+import Debug from 'debug'
 
 import $errUtils, { CypressError } from '../cypress/error_utils'
 import type { ICypress } from '../cypress'
@@ -9,9 +10,12 @@ import type { Log } from '../cypress/log'
 
 const { errByPath, modifyErrMsg, throwErr, mergeErrProps } = $errUtils
 
+const debug = Debug('cypress:driver:retries')
+
 type retryOptions = {
   _interval?: number
   _log?: Log
+  _name?: string
   _retries?: number
   _runnable?: any
   _runnableTimeout?: number
@@ -115,7 +119,24 @@ export const create = (Cypress: ICypress, state: StateFunc, timeout: $Cy['timeou
       // bug in bluebird with not propagating cancellations
       // fast enough in a series of promises
       // https://github.com/petkaantonov/bluebird/issues/1424
-      return state('canceled') || runnableHasChanged()
+
+      // reaching this code at all after cancellation or after the runnable
+      // has changed means bluebird did not cancel this retry's promise chain
+      // in time, so log it to make any resulting cross-test contamination
+      // diagnosable
+      if (state('canceled')) {
+        debug('retry of command `%s` (retry #%d) ran after its test was canceled; bailing without retrying', options._name, options._retries)
+
+        return true
+      }
+
+      if (runnableHasChanged()) {
+        debug('retry of command `%s` (retry #%d) from runnable %o leaked into runnable %o because its promise was not canceled in time; bailing without retrying', options._name, options._retries, options._runnable?.title, state('runnable')?.title)
+
+        return true
+      }
+
+      return false
     }
 
     return Promise

--- a/packages/driver/src/cy/retries.ts
+++ b/packages/driver/src/cy/retries.ts
@@ -125,13 +125,13 @@ export const create = (Cypress: ICypress, state: StateFunc, timeout: $Cy['timeou
       // in time, so log it to make any resulting cross-test contamination
       // diagnosable
       if (state('canceled')) {
-        debug('retry of command `%s` (retry #%d) ran after its test was canceled; bailing without retrying', options._name, options._retries)
+        debug('retry #%d of `%s` ran while state(\'canceled\') was true; not retrying', options._retries, options._name)
 
         return true
       }
 
       if (runnableHasChanged()) {
-        debug('retry of command `%s` (retry #%d) from runnable %o leaked into runnable %o because its promise was not canceled in time; bailing without retrying', options._name, options._retries, options._runnable?.title, state('runnable')?.title)
+        debug('retry #%d of `%s` ran after the runnable changed from %o to %o; not retrying', options._retries, options._name, options._runnable?.title, state('runnable')?.title)
 
         return true
       }

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -16,7 +16,7 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
     const pending = whenStableQueue.splice(0)
 
     if (pending.length) {
-      debug('clearing %d stability waiter(s) that were never released before test reset', pending.length)
+      debug('rejecting %d stability waiter(s) still queued at reset', pending.length)
     }
 
     // reject each waiter so they don't run in the next test
@@ -61,7 +61,7 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
         // released anyway, so their commands may run while the page is
         // transitioning
         if (state('isStable') === false) {
-          debug('releasing %d stability waiter(s) although the page became unstable again before the release ran; their commands may run while the page is transitioning', waitersToRelease.length)
+          debug('releasing %d stability waiter(s) while state(\'isStable\') is false', waitersToRelease.length)
         }
 
         // release the waiters

--- a/packages/driver/src/cy/stability.ts
+++ b/packages/driver/src/cy/stability.ts
@@ -1,6 +1,9 @@
 import Promise from 'bluebird'
+import Debug from 'debug'
 import type { ICypress } from '../cypress'
 import type { StateFunc } from '../cypress/state'
+
+const debug = Debug('cypress:driver:stability')
 
 export const create = (Cypress: ICypress, state: StateFunc) => {
   const whenStableQueue: Array<{
@@ -11,6 +14,10 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
 
   const reset = () => {
     const pending = whenStableQueue.splice(0)
+
+    if (pending.length) {
+      debug('clearing %d stability waiter(s) that were never released before test reset', pending.length)
+    }
 
     // reject each waiter so they don't run in the next test
     for (const waiter of pending) {
@@ -47,6 +54,14 @@ export const create = (Cypress: ICypress, state: StateFunc) => {
         // if there are no waiters to release, return
         if (!waitersToRelease.length) {
           return
+        }
+
+        // detect the race where the page became unstable again between the
+        // stability change and this asynchronous release - the waiters are
+        // released anyway, so their commands may run while the page is
+        // transitioning
+        if (state('isStable') === false) {
+          debug('releasing %d stability waiter(s) although the page became unstable again before the release ran; their commands may run while the page is transitioning', waitersToRelease.length)
         }
 
         // release the waiters

--- a/packages/driver/src/cypress/command_queue.ts
+++ b/packages/driver/src/cypress/command_queue.ts
@@ -13,6 +13,7 @@ import type { $Cy } from './cy'
 import type { IStability } from '../cy/stability'
 
 const debugErrors = Debug('cypress:driver:errors')
+const debug = Debug('cypress:driver:command_queue')
 
 const __stackReplacementMarker = (fn, args) => {
   return fn(...args)
@@ -222,6 +223,10 @@ export class CommandQueue extends Queue<$Command> {
     // and forcibly move the index needle to the
     // end in case we have after / afterEach hooks
     // which need to run
+    if (this.index < this.length) {
+      debug('cleanup called with %d of %d command(s) not yet run: %o', this.length - this.index, this.length, this.names().slice(this.index))
+    }
+
     this.index = this.length
 
     // Mark the state as stable, so that any cypress commands can be re-queued during the after / afterEach hooks

--- a/packages/driver/src/cypress/ensure.ts
+++ b/packages/driver/src/cypress/ensure.ts
@@ -1,9 +1,12 @@
 import _ from 'lodash'
+import Debug from 'debug'
 import $dom from '../dom'
 import $utils from './utils'
 import $errUtils from './error_utils'
 import type { $Cy } from './cy'
 import { isRunnerAbleToCommunicateWithAut } from '../util/commandAUTCommunication'
+
+const debug = Debug('cypress:driver:ensure')
 
 // TODO: in 4.0 we should accept a new validation type called 'elements'
 // which accepts an array of elements (and they all have to be elements!!)
@@ -162,6 +165,8 @@ const isAttached = (subject, name: string, cy: $Cy, onFail?) => {
     const current = cy.state('current')
 
     const subjectChain = cy.subjectChain(current.get('chainerId'))
+
+    debug('subject %s is detached after `%s`', $dom.stringify(subject), name)
 
     $errUtils.throwErrByPath('subject.detached_after_command', {
       onFail,

--- a/packages/driver/src/cypress/ensure.ts
+++ b/packages/driver/src/cypress/ensure.ts
@@ -6,7 +6,8 @@ import $errUtils from './error_utils'
 import type { $Cy } from './cy'
 import { isRunnerAbleToCommunicateWithAut } from '../util/commandAUTCommunication'
 
-const debug = Debug('cypress:driver:ensure')
+// verbose since subject validation runs on every retry of a query
+const debugVerbose = Debug('cypress-verbose:driver:ensure')
 
 // TODO: in 4.0 we should accept a new validation type called 'elements'
 // which accepts an array of elements (and they all have to be elements!!)
@@ -166,7 +167,7 @@ const isAttached = (subject, name: string, cy: $Cy, onFail?) => {
 
     const subjectChain = cy.subjectChain(current.get('chainerId'))
 
-    debug('subject %s is detached after `%s`', $dom.stringify(subject), name)
+    debugVerbose('subject %s is detached after `%s`', $dom.stringify(subject), name)
 
     $errUtils.throwErrByPath('subject.detached_after_command', {
       onFail,

--- a/packages/driver/src/cypress/proxy-logging.ts
+++ b/packages/driver/src/cypress/proxy-logging.ts
@@ -244,6 +244,8 @@ export default class ProxyLogging {
     const proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === interception.browserRequestId)
 
     if (!proxyRequest) {
+      debug('no proxy request found for interception with browserRequestId %s for url %s; %d proxy request(s) in list', interception.browserRequestId, interception.request.url, this.proxyRequests.length)
+
       // request was never logged
       return undefined
     }
@@ -262,7 +264,7 @@ export default class ProxyLogging {
     const proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === responseReceived.requestId)
 
     if (!proxyRequest) {
-      return debug('unmatched responseReceived event %o', responseReceived)
+      return debug('no proxy request found for responseReceived with requestId %s; %d proxy request(s) in list %o', responseReceived.requestId, this.proxyRequests.length, responseReceived)
     }
 
     proxyRequest.responseReceived = responseReceived
@@ -281,7 +283,7 @@ export default class ProxyLogging {
     const proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === error.requestId)
 
     if (!proxyRequest) {
-      return debug('unmatched error event %o', error)
+      return debug('no proxy request found for error event with requestId %s; %d proxy request(s) in list %o', error.requestId, this.proxyRequests.length, error)
     }
 
     proxyRequest.error = $errUtils.makeErrFromObj(error.error)

--- a/packages/driver/src/cypress/proxy-logging.ts
+++ b/packages/driver/src/cypress/proxy-logging.ts
@@ -5,6 +5,8 @@ import $errUtils from './error_utils'
 import Debug from 'debug'
 
 const debug = Debug('cypress:driver:proxy-logging')
+// for logs emitted once per request on expected paths
+const debugVerbose = Debug('cypress-verbose:driver:proxy-logging')
 
 function formatInterception ({ route, interception }: ProxyRequest['interceptions'][number]) {
   const ret = {
@@ -244,7 +246,7 @@ export default class ProxyLogging {
     const proxyRequest = _.find(this.proxyRequests, ({ preRequest }) => preRequest.requestId === interception.browserRequestId)
 
     if (!proxyRequest) {
-      debug('no proxy request found for interception with browserRequestId %s for url %s; %d proxy request(s) in list', interception.browserRequestId, interception.request.url, this.proxyRequests.length)
+      debugVerbose('no proxy request found for interception with browserRequestId %s for url %s; %d proxy request(s) in list', interception.browserRequestId, interception.request.url, this.proxyRequests.length)
 
       // request was never logged
       return undefined

--- a/packages/net-stubbing/lib/server/middleware/request.ts
+++ b/packages/net-stubbing/lib/server/middleware/request.ts
@@ -41,6 +41,10 @@ export const SetMatchingRoutes: RequestMiddleware = async function () {
 
   this.req.matchingRoutes = this.networkInterceptionCore.matchRoutes(this.netStubbingState.routes, this.req)
 
+  if (!this.req.matchingRoutes?.length && this.netStubbingState.routes.length) {
+    this.debug('%s %s with resourceType %o matched 0 of %d registered route(s)', this.req.method, this.req.proxiedUrl, this.req.resourceType, this.netStubbingState.routes.length)
+  }
+
   span?.end()
   this.next()
 }

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -622,6 +622,20 @@ const MaybeCopyCookiesFromIncomingRes: ResponseMiddleware = async function () {
     return this.next()
   }
 
+  const cookiesEmittedAt = Date.now()
+  let cookiesReceivedLogTimeout: NodeJS.Timeout | undefined
+
+  // this wait has no timeout; when debug logging is enabled, log if the
+  // event has not arrived after CROSS_ORIGIN_COOKIES_RECEIVED_LOG_TIMEOUT_MS
+  // (the response remains held until the event arrives)
+  if (this.debug.enabled) {
+    cookiesReceivedLogTimeout = setTimeout(() => {
+      this.debug('cross:origin:cookies:received has not been received within %dms of emitting cross:origin:cookies for url %s', CROSS_ORIGIN_COOKIES_RECEIVED_LOG_TIMEOUT_MS, this.req.proxiedUrl)
+    }, CROSS_ORIGIN_COOKIES_RECEIVED_LOG_TIMEOUT_MS)
+
+    cookiesReceivedLogTimeout.unref?.()
+  }
+
   // we want to set the cookies via automation so they exist in the browser
   // itself. however, firefox will hang if we try to use the extension
   // to set cookies on a url that's in-flight, so we send the cookies down to
@@ -629,12 +643,22 @@ const MaybeCopyCookiesFromIncomingRes: ResponseMiddleware = async function () {
   // from the driver once the page has loaded but before we run any further
   // commands
   this.serverBus.once('cross:origin:cookies:received', () => {
+    if (cookiesReceivedLogTimeout) {
+      clearTimeout(cookiesReceivedLogTimeout)
+    }
+
+    this.debug('cross:origin:cookies:received %dms after emitting cross:origin:cookies for url %s', Date.now() - cookiesEmittedAt, this.req.proxiedUrl)
+
     span?.end()
     this.next()
   })
 
+  this.debug('emitting cross:origin:cookies with %d cookie(s) for url %s', addedCookies.length, this.req.proxiedUrl)
+
   this.serverBus.emit('cross:origin:cookies', addedCookies)
 }
+
+const CROSS_ORIGIN_COOKIES_RECEIVED_LOG_TIMEOUT_MS = 5000
 
 const REDIRECT_STATUS_CODES: any[] = [301, 302, 303, 307, 308]
 

--- a/packages/proxy/lib/http/util/buffers.ts
+++ b/packages/proxy/lib/http/util/buffers.ts
@@ -5,6 +5,8 @@ import type { Readable } from 'stream'
 import type { IncomingMessage } from 'http'
 
 const debug = debugModule('cypress:proxy:http:util:buffers')
+// for logs emitted on every request while a buffer is held
+const debugVerbose = debugModule('cypress-verbose:proxy:http:util:buffers')
 
 export type HttpBuffer = {
   details: object
@@ -68,7 +70,7 @@ export class HttpBuffers {
     }
 
     if (this.buffer) {
-      debug('requested url %o did not match buffered url %o; buffer not taken', stripPort(str), this.buffer.url)
+      debugVerbose('requested url %o did not match buffered url %o; buffer not taken', stripPort(str), this.buffer.url)
     }
   }
 }

--- a/packages/proxy/lib/http/util/buffers.ts
+++ b/packages/proxy/lib/http/util/buffers.ts
@@ -27,7 +27,11 @@ export class HttpBuffers {
   buffer: Optional<HttpBuffer> | undefined = undefined
 
   reset (): void {
-    debug('resetting buffers')
+    if (this.buffer) {
+      debug('resetting buffers; discarding buffer %o', _.pick(this.buffer, 'url'))
+    } else {
+      debug('resetting buffers')
+    }
 
     delete this.buffer
   }
@@ -61,6 +65,10 @@ export class HttpBuffers {
       debug('found request buffer %o', { buffer: _.pick(foundBuffer, 'url') })
 
       return foundBuffer
+    }
+
+    if (this.buffer) {
+      debug('requested url %o did not match buffered url %o; buffer not taken', stripPort(str), this.buffer.url)
     }
   }
 }

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -222,6 +222,8 @@ export class PreRequests {
         return
       }
 
+      debug('Pre-request for %s arrived after the request had already timed out waiting %sms for it. The request proceeded without correlation data. %o', key, this.requestTimeout, browserPreRequest)
+
       this.protocolManager?.responseStreamTimedOut({
         requestId: browserPreRequest.requestId,
         timings,
@@ -330,8 +332,8 @@ export class PreRequests {
       callback,
       proxyRequestReceivedTimestamp: performance.now() + performance.timeOrigin,
       timeout: setTimeout(() => {
-        ctxDebug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one.', key, this.requestTimeout)
-        debug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one.', key, this.requestTimeout)
+        ctxDebug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request will be missing correlation data (e.g. resourceType), which can prevent cy.intercept routes that rely on it from matching this request.', key, this.requestTimeout)
+        debug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request will be missing correlation data (e.g. resourceType), which can prevent cy.intercept routes that rely on it from matching this request.', key, this.requestTimeout)
         metrics.unmatchedRequests++
         pendingRequest.timedOut = true
         callback({
@@ -362,13 +364,18 @@ export class PreRequests {
   }
 
   reset () {
+    if (this.pendingRequests.length > 0) {
+      debug('Resetting pre-request state with %d pending request(s). They will proceed without pre-requests and will be missing correlation data (e.g. resourceType).', this.pendingRequests.length)
+    }
+
     this.pendingPreRequests = new QueueMap<PendingPreRequest>()
 
     // Clear out the pending requests timeout callbacks first then clear the queue
-    this.pendingRequests.forEach(({ callback, timeout, timedOut }) => {
+    this.pendingRequests.forEach(({ key, callback, timeout, timedOut }) => {
       // If the request has already timed out, just return
       if (timedOut) return
 
+      debugVerbose('Pending request %s proceeding without a pre-request due to reset', key)
       clearTimeout(timeout)
       metrics.unmatchedRequests++
       callback?.({

--- a/packages/proxy/lib/http/util/prerequests.ts
+++ b/packages/proxy/lib/http/util/prerequests.ts
@@ -222,7 +222,7 @@ export class PreRequests {
         return
       }
 
-      debug('Pre-request for %s arrived after the request had already timed out waiting %sms for it. The request proceeded without correlation data. %o', key, this.requestTimeout, browserPreRequest)
+      debug('Received pre-request for %s after the request had already timed out at %sms. The request proceeded without it. %o', key, this.requestTimeout, browserPreRequest)
 
       this.protocolManager?.responseStreamTimedOut({
         requestId: browserPreRequest.requestId,
@@ -332,8 +332,8 @@ export class PreRequests {
       callback,
       proxyRequestReceivedTimestamp: performance.now() + performance.timeOrigin,
       timeout: setTimeout(() => {
-        ctxDebug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request will be missing correlation data (e.g. resourceType), which can prevent cy.intercept routes that rely on it from matching this request.', key, this.requestTimeout)
-        debug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request will be missing correlation data (e.g. resourceType), which can prevent cy.intercept routes that rely on it from matching this request.', key, this.requestTimeout)
+        ctxDebug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request has no browser pre-request data (no resourceType).', key, this.requestTimeout)
+        debug('Never received pre-request or url without pre-request for request %s after waiting %sms. Continuing without one. The request has no browser pre-request data (no resourceType).', key, this.requestTimeout)
         metrics.unmatchedRequests++
         pendingRequest.timedOut = true
         callback({
@@ -365,7 +365,7 @@ export class PreRequests {
 
   reset () {
     if (this.pendingRequests.length > 0) {
-      debug('Resetting pre-request state with %d pending request(s). They will proceed without pre-requests and will be missing correlation data (e.g. resourceType).', this.pendingRequests.length)
+      debug('Resetting pre-request state with %d pending request(s); each is resolved without a pre-request.', this.pendingRequests.length)
     }
 
     this.pendingPreRequests = new QueueMap<PendingPreRequest>()
@@ -375,7 +375,7 @@ export class PreRequests {
       // If the request has already timed out, just return
       if (timedOut) return
 
-      debugVerbose('Pending request %s proceeding without a pre-request due to reset', key)
+      debugVerbose('Pending request %s resolved without a pre-request during reset', key)
       clearTimeout(timeout)
       metrics.unmatchedRequests++
       callback?.({

--- a/packages/proxy/lib/http/util/service-worker-manager.ts
+++ b/packages/proxy/lib/http/util/service-worker-manager.ts
@@ -256,7 +256,7 @@ export class ServiceWorkerManager {
         try {
           isControlled = await this.isURLControlledByServiceWorker(browserPreRequest)
         } catch (e) {
-          debug('timed out after %dms checking if pre-request is controlled by service worker. Treating the request as NOT controlled by the service worker, which may be incorrect on a slow or heavily loaded system: %o', isControlledByServiceWorkerTimeoutMs, { url: browserPreRequest.url, requestId: browserPreRequest.requestId })
+          debug('no service worker fetch event received within %dms; treating the request as not controlled by a service worker: %o', isControlledByServiceWorkerTimeoutMs, { url: browserPreRequest.url, requestId: browserPreRequest.requestId })
         }
 
         if (isControlled) {

--- a/packages/proxy/lib/http/util/service-worker-manager.ts
+++ b/packages/proxy/lib/http/util/service-worker-manager.ts
@@ -5,6 +5,11 @@ import type Protocol from 'devtools-protocol'
 
 const debug = Debug('cypress:proxy:service-worker-manager')
 
+// How long to wait for the service worker fetch event to determine whether the
+// service worker controls a request before falling back to treating the
+// request as uncontrolled.
+const isControlledByServiceWorkerTimeoutMs = 250
+
 type ServiceWorkerRegistration = {
   registrationId: string
   scopeURL: string
@@ -251,7 +256,7 @@ export class ServiceWorkerManager {
         try {
           isControlled = await this.isURLControlledByServiceWorker(browserPreRequest)
         } catch (e) {
-          debug('timed out checking if pre-request is controlled by service worker: %o', { url: browserPreRequest.url, requestId: browserPreRequest.requestId })
+          debug('timed out after %dms checking if pre-request is controlled by service worker. Treating the request as NOT controlled by the service worker, which may be incorrect on a slow or heavily loaded system: %o', isControlledByServiceWorkerTimeoutMs, { url: browserPreRequest.url, requestId: browserPreRequest.requestId })
         }
 
         if (isControlled) {
@@ -385,7 +390,7 @@ export class ServiceWorkerManager {
     // race the deferred promise with a timeout to prevent the pre-request from hanging indefinitely
     const racingPromises = Promise.race([
       deferred.promise,
-      new Promise<boolean>((_resolve, reject) => timer = setTimeout(reject, 250)),
+      new Promise<boolean>((_resolve, reject) => timer = setTimeout(reject, isControlledByServiceWorkerTimeoutMs)),
     ]).finally(() => clearTimeout(timer))
 
     return racingPromises

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -435,7 +435,10 @@ export class BrowserCriClient {
     if (targetId !== browserCriClient.currentlyAttachedTarget?.targetId) {
       if (browserCriClient.hasExtraTargetClient(targetId)) {
         debug('Close extra target client (id: %s)')
-        browserCriClient.getExtraTargetClient(targetId)!.client.close().catch(() => { })
+        browserCriClient.getExtraTargetClient(targetId)!.client.close().catch((err) => {
+          debug('error closing extra target client %s: %o', targetId, err)
+        })
+
         browserCriClient.removeExtraTargetClient(targetId)
       }
 
@@ -454,11 +457,17 @@ export class BrowserCriClient {
     //
     // otherwise it means the the browser itself was closed
 
+    const debugCloseError = (targetName: string) => {
+      return (err: Error) => {
+        debug('error closing %s target client after Target.targetDestroyed for %s: %o', targetName, targetId, err)
+      }
+    }
+
     // always close the connection to the page targets because it was destroyed
-    browserCriClient.currentlyAttachedTarget.close().catch(() => { })
-    browserCriClient.currentlyAttachedProtocolTarget?.close().catch(() => { })
-    browserCriClient.currentlyAttachedCyPromptTarget?.close().catch(() => { })
-    browserCriClient.currentlyAttachedStudioTarget?.close().catch(() => { })
+    browserCriClient.currentlyAttachedTarget.close().catch(debugCloseError('page'))
+    browserCriClient.currentlyAttachedProtocolTarget?.close().catch(debugCloseError('protocol'))
+    browserCriClient.currentlyAttachedCyPromptTarget?.close().catch(debugCloseError('cy-prompt'))
+    browserCriClient.currentlyAttachedStudioTarget?.close().catch(debugCloseError('studio'))
 
     const targetDestroyedAt = Date.now()
 
@@ -593,11 +602,17 @@ export class BrowserCriClient {
 
       debug('target closed', this.currentlyAttachedTarget.targetId)
 
+      const debugResetCloseError = (targetName: string) => {
+        return (err: Error) => {
+          debug('error closing %s target client while resetting browser targets: %o', targetName, err)
+        }
+      }
+
       await Promise.all([
-        this.currentlyAttachedTarget.close().catch(() => {}),
-        this.currentlyAttachedProtocolTarget?.close().catch(() => {}),
-        this.currentlyAttachedCyPromptTarget?.close().catch(() => {}),
-        this.currentlyAttachedStudioTarget?.close().catch(() => {}),
+        this.currentlyAttachedTarget.close().catch(debugResetCloseError('page')),
+        this.currentlyAttachedProtocolTarget?.close().catch(debugResetCloseError('protocol')),
+        this.currentlyAttachedCyPromptTarget?.close().catch(debugResetCloseError('cy-prompt')),
+        this.currentlyAttachedStudioTarget?.close().catch(debugResetCloseError('studio')),
       ])
 
       debug('target client closed', this.currentlyAttachedTarget.targetId)

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -13,11 +13,6 @@ import type { ServiceWorkerEventHandler } from '@packages/proxy/lib/http/util/se
 
 const debug = Debug('cypress:server:browsers:browser-cri-client')
 
-interface Version {
-  major: number
-  minor: number
-}
-
 type BrowserCriClientOptions = {
   browserClient: CriClient
   versionInfo: CRI.VersionResult
@@ -465,24 +460,36 @@ export class BrowserCriClient {
     browserCriClient.currentlyAttachedCyPromptTarget?.close().catch(() => { })
     browserCriClient.currentlyAttachedStudioTarget?.close().catch(() => { })
 
+    const targetDestroyedAt = Date.now()
+
     new Bluebird((resolve) => {
       // this event could fire either expectedly or unexpectedly
       // it's not a problem if we're expected to be closing the browser naturally
       // and not as a result of an unexpected page or browser closure
       if (browserCriClient.resettingBrowserTargets) {
+        debug('Target.targetDestroyed received for %s while resettingBrowserTargets is true', targetId)
+
         // do nothing, we're good
         return resolve(true)
       }
 
       if (typeof browserCriClient.gracefulShutdown !== 'undefined') {
+        debug('Target.targetDestroyed received for %s while gracefulShutdown is %o', targetId, browserCriClient.gracefulShutdown)
+
         return resolve(browserCriClient.gracefulShutdown)
       }
 
       // when process.on('exit') is called, we call onClose
-      browserCriClient.onClose = resolve
+      browserCriClient.onClose = (gracefulShutdown) => {
+        debug('onClose called with %o %dms after Target.targetDestroyed for %s', gracefulShutdown, Date.now() - targetDestroyedAt, targetId)
+
+        resolve(gracefulShutdown)
+      }
 
       // or when the browser's CDP ws connection is closed
       browserClient.ws?.once('close', () => {
+        debug('browser websocket closed %dms after Target.targetDestroyed for %s', Date.now() - targetDestroyedAt, targetId)
+
         resolve(false)
       })
     })
@@ -498,7 +505,7 @@ export class BrowserCriClient {
       errors.throwErr('BROWSER_PROCESS_CLOSED_UNEXPECTEDLY', browserName)
     })
     .catch(Bluebird.TimeoutError, () => {
-      debug('browser websocket did not close, page was closed %o', { targetId })
+      debug('neither a browser websocket close nor onClose was observed within 500ms of Target.targetDestroyed for %s', targetId)
       // the browser websocket didn't close meaning
       // only the page was closed, not the browser
       errors.throwErr('BROWSER_PAGE_CLOSED_UNEXPECTEDLY', browserName)

--- a/packages/server/lib/browsers/cdp-connection.ts
+++ b/packages/server/lib/browsers/cdp-connection.ts
@@ -176,11 +176,12 @@ export class CDPConnection {
     }
 
     let attempt = 0
+    const reconnectionStartedAt = Date.now()
 
     this._reconnection = asyncRetry(async () => {
       attempt++
 
-      this.debug('Reconnection attempt %d for Target %s', attempt, this._options.target)
+      this.debug('Reconnection attempt %d for Target %s, %dms after reconnection started', attempt, this._options.target, Date.now() - reconnectionStartedAt)
 
       if (this._terminated) {
         this.debug('Not reconnecting, connection to %s has been terminated', this._options.target)
@@ -204,7 +205,7 @@ export class CDPConnection {
       await this._reconnection
       this._emitter.emit('cdp-connection-reconnect')
     } catch (err) {
-      this.debug('error(s) on reconnecting: ', err)
+      this.debug('reconnection to target %s did not succeed after %d attempt(s) over %dms: ', this._options.target, attempt, Date.now() - reconnectionStartedAt, err)
       const significantError: Error = err.errors ? (err as AggregateError).errors[err.errors.length - 1] : err
 
       const retryHaltedDueToClosed = CDPTerminatedError.isCDPTerminatedError(err) ||

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -537,7 +537,7 @@ export = {
     pageCriClient.on('Target.targetCrashed', async (event) => {
       debug('target crashed!', event)
       if (event.targetId !== browserCriClient?.currentlyAttachedTarget?.targetId) {
-        debug('ignoring Target.targetCrashed for target %s because the currently attached target is %s. No sibling CRI clients will be marked as crashed for this event; if the comparison target is stale, sends to the crashed target may hang', event.targetId, browserCriClient?.currentlyAttachedTarget?.targetId)
+        debug('Target.targetCrashed received for target %s while the currently attached target is %s; event ignored, no sibling CRI clients marked as crashed', event.targetId, browserCriClient?.currentlyAttachedTarget?.targetId)
 
         return
       }

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -240,7 +240,9 @@ const _disableRestorePagesPrompt = function (userDir) {
 
     return
   })
-  .catch(() => { })
+  .catch((err) => {
+    debug('error reading or writing the preferences file %s: %o', prefsPath, err)
+  })
 }
 
 async function _recordVideo (cdpAutomation: CdpAutomation, videoOptions: RunModeVideoApi, browserMajorVersion: number) {

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -537,6 +537,8 @@ export = {
     pageCriClient.on('Target.targetCrashed', async (event) => {
       debug('target crashed!', event)
       if (event.targetId !== browserCriClient?.currentlyAttachedTarget?.targetId) {
+        debug('ignoring Target.targetCrashed for target %s because the currently attached target is %s. No sibling CRI clients will be marked as crashed for this event; if the comparison target is stale, sends to the crashed target may hang', event.targetId, browserCriClient?.currentlyAttachedTarget?.targetId)
+
         return
       }
 

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -432,7 +432,7 @@ export class CriClient implements ICriClient {
         debug('uncaught error in CriClient reconnect callback: ', e)
       }
     } catch (e) {
-      debug('error re-establishing state on reconnection: ', e)
+      debug('error re-establishing state on reconnection to target %s. CDP domain enablements and enqueued commands may not have been fully restored, so CDP events (e.g. network traffic used by cy.intercept) may no longer be received: ', this.targetId, e)
     }
   }
 

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -173,7 +173,7 @@ export class CriClient implements ICriClient {
         }
 
         if (this._crashed) {
-          debug('target %s was already marked as crashed via sibling propagation before its own Target.targetCrashed event was delivered on this connection', this.targetId)
+          debug('Target.targetCrashed received for target %s; _crashed was already true (set via markCrashed before this event was delivered on this connection)', this.targetId)
         } else {
           debug('crash detected for target %s', this.targetId)
         }
@@ -250,7 +250,7 @@ export class CriClient implements ICriClient {
    */
   public markCrashed = () => {
     if (!this._crashed) {
-      debug('marking target %s as crashed via sibling propagation; its own Target.targetCrashed event has not yet been delivered on this connection', this.targetId)
+      debug('markCrashed called for target %s; no Target.targetCrashed event had been received on this connection', this.targetId)
     }
 
     this._crashed = true
@@ -278,7 +278,7 @@ export class CriClient implements ICriClient {
     sessionId?: string,
   ): Promise<ProtocolMapping.Commands[TCmd]['returnType']> => {
     if (this._crashed) {
-      debug('refusing to send %s to target %s because it has crashed', command, this.targetId)
+      debug('not sending %s to target %s; _crashed is true', command, this.targetId)
 
       return Promise.reject(new Error(`${command} will not run as the target browser or tab CRI connection has crashed`))
     }
@@ -311,7 +311,7 @@ export class CriClient implements ICriClient {
 
       if (debug.enabled) {
         hangDetectionTimer = setTimeout(() => {
-          debug('command %s to target %s has not resolved after %dms. If the renderer crashed without this connection receiving Target.targetCrashed, this send will hang indefinitely', command, this.targetId, SEND_HANG_DETECTION_MS)
+          debug('command %s to target %s has not resolved after %dms (_crashed: %o)', command, this.targetId, SEND_HANG_DETECTION_MS, this._crashed)
         }, SEND_HANG_DETECTION_MS)
 
         hangDetectionTimer.unref?.()
@@ -465,7 +465,7 @@ export class CriClient implements ICriClient {
         debug('uncaught error in CriClient reconnect callback: ', e)
       }
     } catch (e) {
-      debug('error re-establishing state on reconnection to target %s. CDP domain enablements and enqueued commands may not have been fully restored, so CDP events (e.g. network traffic used by cy.intercept) may no longer be received: ', this.targetId, e)
+      debug('error re-establishing state on reconnection to target %s; %d enablement(s) registered, %d command(s) still enqueued: ', this.targetId, this.enableCommands.length, this._commandQueue.entries.length, e)
     }
   }
 
@@ -500,7 +500,7 @@ export class CriClient implements ICriClient {
             // otherwise invisible: events from this domain silently stop arriving
             // on this connection (e.g. a Network.enable failure means network
             // traffic used by cy.intercept is no longer observed)
-            debug('failed to re-enable %s on target %s after reconnect and no in-flight command exists to receive the error. Events from this domain will no longer be received on this connection: ', command, this.targetId, err)
+            debug('re-enabling %s on target %s after reconnect failed with a non-connection error and no in-flight command was in the queue to receive the rejection: ', command, this.targetId, err)
           }
 
           // non-connection errors are appropriate for rejecting the original command promise

--- a/packages/server/lib/browsers/cri-client.ts
+++ b/packages/server/lib/browsers/cri-client.ts
@@ -42,6 +42,10 @@ export const DEFAULT_NETWORK_ENABLE_OPTIONS = {
   maxPostDataSize: 0,
 }
 
+// How long a sent CDP command can go unresolved before we log it as
+// potentially hung (debug logging only - the command is not aborted)
+const SEND_HANG_DETECTION_MS = 10000
+
 export interface ICriClient {
   /**
    * The target id attached to by this client
@@ -168,7 +172,12 @@ export class CriClient implements ICriClient {
           return
         }
 
-        debug('crash detected')
+        if (this._crashed) {
+          debug('target %s was already marked as crashed via sibling propagation before its own Target.targetCrashed event was delivered on this connection', this.targetId)
+        } else {
+          debug('crash detected for target %s', this.targetId)
+        }
+
         this._crashed = true
       })
 
@@ -240,6 +249,10 @@ export class CriClient implements ICriClient {
    * the renderer is dead and will never respond.
    */
   public markCrashed = () => {
+    if (!this._crashed) {
+      debug('marking target %s as crashed via sibling propagation; its own Target.targetCrashed event has not yet been delivered on this connection', this.targetId)
+    }
+
     this._crashed = true
   }
 
@@ -265,6 +278,8 @@ export class CriClient implements ICriClient {
     sessionId?: string,
   ): Promise<ProtocolMapping.Commands[TCmd]['returnType']> => {
     if (this._crashed) {
+      debug('refusing to send %s to target %s because it has crashed', command, this.targetId)
+
       return Promise.reject(new Error(`${command} will not run as the target browser or tab CRI connection has crashed`))
     }
 
@@ -288,6 +303,20 @@ export class CriClient implements ICriClient {
     }
 
     if (this._connected && this.cdpConnection) {
+      // a send to a renderer that crashed without this connection observing
+      // Target.targetCrashed will never resolve. When debug logging is
+      // enabled, surface commands that go unresolved so that hang can be
+      // diagnosed (the command itself is not aborted)
+      let hangDetectionTimer: NodeJS.Timeout | undefined
+
+      if (debug.enabled) {
+        hangDetectionTimer = setTimeout(() => {
+          debug('command %s to target %s has not resolved after %dms. If the renderer crashed without this connection receiving Target.targetCrashed, this send will hang indefinitely', command, this.targetId, SEND_HANG_DETECTION_MS)
+        }, SEND_HANG_DETECTION_MS)
+
+        hangDetectionTimer.unref?.()
+      }
+
       try {
         return await this.cdpConnection.send(command, params, sessionId)
       } catch (err) {
@@ -312,6 +341,10 @@ export class CriClient implements ICriClient {
         }
 
         return p
+      } finally {
+        if (hangDetectionTimer) {
+          clearTimeout(hangDetectionTimer)
+        }
       }
     }
 
@@ -462,6 +495,14 @@ export class CriClient implements ICriClient {
 
           throw err
         } else {
+          if (!inFlightCommand) {
+            // with no in-flight command to receive the rejection, this failure is
+            // otherwise invisible: events from this domain silently stop arriving
+            // on this connection (e.g. a Network.enable failure means network
+            // traffic used by cy.intercept is no longer observed)
+            debug('failed to re-enable %s on target %s after reconnect and no in-flight command exists to receive the error. Events from this domain will no longer be received on this connection: ', command, this.targetId, err)
+          }
+
           // non-connection errors are appropriate for rejecting the original command promise
           inFlightCommand?.deferred.reject(err)
         }

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -409,7 +409,10 @@ export async function connectToNewSpec (browser: Browser, options: BrowserNewTab
   } catch (err) {
     // if navigation/BiDi setup fails, tear down the ffmpeg encoder we just started so it isn't
     // left orphaned (and so a retry doesn't start a second one alongside it).
-    await video?.controller.endVideoCapture(false).catch(() => {})
+    await video?.controller.endVideoCapture(false).catch((endVideoCaptureErr) => {
+      debug('error ending video capture during BiDi connect failure teardown: %o', endVideoCaptureErr)
+    })
+
     throw err
   }
 

--- a/packages/server/lib/browsers/webkit.ts
+++ b/packages/server/lib/browsers/webkit.ts
@@ -152,6 +152,8 @@ export async function open (browser: Browser, url: string, options: BrowserLaunc
      */
     private suppressUnhandledEconnreset () {
       unhandledExceptions.handle((err: NodeJS.ErrnoException) => {
+        debug('unhandled exception with code %o observed while WebKit is running: %o', err.code, err)
+
         return err.code === 'ECONNRESET'
       })
 

--- a/packages/server/lib/cloud/protocol.ts
+++ b/packages/server/lib/cloud/protocol.ts
@@ -189,7 +189,11 @@ export class ProtocolManager implements ProtocolManagerShape {
     this._errors = []
 
     try {
+      const beforeSpecStartedAt = performance.now() + performance.timeOrigin
+
       this._beforeSpec(spec)
+
+      debug('beforeSpec for %s completed in %dms', spec.name, (performance.now() + performance.timeOrigin) - beforeSpecStartedAt)
     } catch (error) {
       // Clear out protocol since we will not have a valid state when spec has failed
       this.cleanup()

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -501,7 +501,11 @@ async function waitForBrowserToConnect (options: { project: Project, socketId: s
 
   if (options.experimentalSingleTabRunMode && options.testingType === 'component' && !options.isFirstSpecInBrowser) {
     // reset browser state to match default behavior when opening/closing a new tab
+    const resetBrowserStateStartedAt = Date.now()
+
     await openProject.resetBrowserState()
+
+    debug('resetBrowserState completed in %dms', Date.now() - resetBrowserStateStartedAt)
 
     // Send the new telemetry context to the browser to set the parent/child relationship appropriately for tests
     if (telemetry.isEnabled()) {
@@ -728,7 +732,11 @@ async function waitForTestsToFinishRunning (options: { project: Project, screens
   if (!usingExperimentalSingleTabMode || isLastSpec) {
     debug('attempting to close the browser tab')
 
+    const resetTabsStartedAt = Date.now()
+
     await openProject.resetBrowserTabsForNextSpec(shouldKeepTabOpen)
+
+    debug('resetBrowserTabsForNextSpec completed in %dms', Date.now() - resetTabsStartedAt)
 
     debug('resetting server state')
 

--- a/packages/server/lib/plugins/util.ts
+++ b/packages/server/lib/plugins/util.ts
@@ -2,10 +2,13 @@ import _ from 'lodash'
 import EE from 'events'
 import Promise from 'bluebird'
 import path from 'path'
+import Debug from 'debug'
 import type Bluebird from 'bluebird'
 import type { CompilerErrorLocation, ProcessIpcWrapper, TransformError } from '@packages/types'
 import type { SerializedError } from '@packages/errors'
 import type { PluginInvokeIds } from './child/types'
+
+const debug = Debug('cypress:server:plugins:util')
 
 const UNDEFINED_SERIALIZED = '__cypress_undefined__'
 
@@ -74,6 +77,8 @@ export const wrapIpc = (aProcess: WrappedIpcProcess): ProcessIpcWrapper => {
   return {
     send (event, ...args) {
       if (aProcess.killed || !aProcess.connected) {
+        debug('not sending ipc event %s; process killed: %o, connected: %o', event, aProcess.killed, aProcess.connected)
+
         return
       }
 
@@ -94,10 +99,14 @@ export const wrapChildPromise = (
   ids: PluginInvokeIds,
   args: any[] = [],
 ): Bluebird<void> => {
+  const invokedAt = Date.now()
+
   return Promise.try(() => {
     return invoke(ids.eventId, args)
   })
   .then((value) => {
+    debug('invocation %s (event id %d) fulfilled after %dms', ids.invocationId, ids.eventId, Date.now() - invokedAt)
+
     // undefined is coerced into null when sent over ipc, but we need
     // to differentiate between them for 'task' event
     if (value === undefined) {
@@ -106,6 +115,8 @@ export const wrapChildPromise = (
 
     return ipc.send(`promise:fulfilled:${ids.invocationId}`, null, value)
   }).catch((err) => {
+    debug('invocation %s (event id %d) rejected after %dms: %o', ids.invocationId, ids.eventId, Date.now() - invokedAt, err)
+
     return ipc.send(`promise:fulfilled:${ids.invocationId}`, serializeError(err))
   })
 }

--- a/packages/server/lib/screenshots.ts
+++ b/packages/server/lib/screenshots.ts
@@ -136,6 +136,10 @@ const hasHelperPixels = function (image, pixelRatio) {
   )
 }
 
+// the maximum time captureAndCheck keeps capturing before resolving with the
+// most recent capture regardless of the condition fn
+const MAX_CAPTURE_AND_CHECK_DURATION_MS = 1500
+
 const captureAndCheck = function (data: Data, automate, conditionFn) {
   let attempt
   const start = new Date()
@@ -157,8 +161,14 @@ const captureAndCheck = function (data: Data, automate, conditionFn) {
     }).then((image) => {
       debug(`read buffer to image ${image.bitmap.width} x ${image.bitmap.height}`)
 
-      if ((totalDuration > 1500) || conditionFn(data, image)) {
-        debug('resolving with image %o', { tries, totalDuration })
+      if (totalDuration > MAX_CAPTURE_AND_CHECK_DURATION_MS) {
+        debug('totalDuration %dms exceeded %dms after %d tries; resolving with the last capture without evaluating the condition fn', totalDuration, MAX_CAPTURE_AND_CHECK_DURATION_MS, tries)
+
+        return { image, takenAt }
+      }
+
+      if (conditionFn(data, image)) {
+        debug('condition fn returned true; resolving with image %o', { tries, totalDuration })
 
         return { image, takenAt }
       }

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -7,7 +7,7 @@ import { handleGraphQLSocketRequest } from '@packages/data-context/graphql/makeG
 import type { ForInterceptRegistration } from '@packages/network-interception'
 import * as socketIo from '@packages/socket'
 import { CDPSocketServer } from '@packages/socket'
-import type { SocketBroadcaster } from '@packages/socket'
+import type { SocketBroadcaster, Socket } from '@packages/socket'
 import * as errors from './errors'
 import { get as fixtureGet } from './fixture'
 import { ensureProp } from './util/class-helpers'
@@ -21,8 +21,6 @@ import type { OTLPTraceExporterCloud } from '@packages/telemetry'
 import { telemetry } from '@packages/telemetry'
 import type { Automation } from './automation'
 import { openExternal } from './gui/links'
-
-import type { Socket } from '@packages/socket'
 
 import type { RunState, CachedTestState, ProtocolManagerShape, AutomationCommands } from '@packages/types'
 import { RUN_ALL_SPECS_KEY } from '@packages/types'
@@ -250,22 +248,30 @@ export class SocketBase implements SocketBroadcaster {
           automationClient.on('disconnect', () => {
             const { activeBrowser } = getCtx().coreData
 
+            debug('automation client disconnected %o', { ended: this.ended, connectedBrowser: connectedBrowser?.path, activeBrowser: activeBrowser?.path })
+
             // if we've stopped or if we've switched to another browser then don't do anything
             if (this.ended || (connectedBrowser?.path !== activeBrowser?.path)) {
               return
             }
+
+            const disconnectedAt = Date.now()
 
             // if we are in headless mode then log out an error and maybe exit with process.exit(1)?
             return Bluebird.delay(2000)
             .then(() => {
               // bail if we've swapped to a new automationClient
               if (automationClient !== socket) {
+                debug('a different automation client connected %dms after the disconnect', Date.now() - disconnectedAt)
+
                 return
               }
 
               // give ourselves about 2000ms to reconnect
               // and if we're connected its all good
               if (automationClient.connected) {
+                debug('automation client socket is connected %dms after the disconnect', Date.now() - disconnectedAt)
+
                 return
               }
 

--- a/packages/server/lib/video_capture.ts
+++ b/packages/server/lib/video_capture.ts
@@ -136,8 +136,14 @@ export function start (options: StartOptions) {
       })
       .then(() => endVideoCapture())
       .timeout(3000)
-      .catch(() => endVideoCapture(false))
+      .catch((err) => {
+        debug('wait for additional frames failed or timed out after 3000ms with %d frame(s) written; ending capture without waiting: %o', writtenFramesCount, err)
+
+        return endVideoCapture(false)
+      })
     }
+
+    debug('ending video capture with %d frame(s) written and %d frame(s) skipped', writtenFramesCount, skippedFramesCount)
 
     doneCapturing = true
 


### PR DESCRIPTION
Several timeout-based fallbacks degrade silently, making flake hard to
diagnose. Add/improve debug logs so each surfaces what happened and its
consequence:

- proxy pre-request correlation: state that an uncorrelated request is
  missing resourceType (affects cy.intercept matching), log pre-requests
  that arrive after the correlation timeout, and log pending requests
  discarded by reset()
- proxy service worker manager: name the 250ms control-check timeout
  constant and log the fallback (request treated as not SW-controlled)
- driver cy.session storage sync: name the 2000ms postMessage timeout,
  log the underlying error and affected origins when storage data is
  incomplete
- server CriClient: on reconnect state-restore failure, log that CDP
  enablements/commands may not be restored and events may stop arriving

https://claude.ai/code/session_01BJ5btBZHMq3wtqpyPMjF9Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated on debug namespaces or replace swallowed errors with logs; no altered timeouts or control flow in normal runs.
> 
> **Overview**
> Adds **debug-only observability** across driver, proxy, server, and lifecycle so timeout fallbacks and async races that used to fail silently are easier to diagnose when `DEBUG` / `cypress-verbose:*` is enabled.
> 
> **Named timeouts and clearer fallback messages** include proxy pre-request correlation (missing `resourceType`, late pre-requests, reset discards), service worker control checks (250ms), `cy.session` cross-origin storage postMessage (2000ms), screenshot `captureAndCheck` max duration, and cross-origin cookie handshake wait logging.
> 
> **Driver** gains timing/elapsed logs for plugin IPC (`execute:plugins`), retries that run after cancel or runnable change, stability waiter release races, command queue cleanup with skipped commands, navigation edge cases (`test:after:run` vs pending page load, `cy.go` `didUnload`), and verbose namespaces for actionability, ensure, and proxy request matching.
> 
> **Server/browser** improvements cover CDP hang detection on unresolved `send`, reconnect/enablement restore failures, `Target.targetDestroyed` / crash propagation, automation client disconnect timing, and replacing empty `.catch()` handlers with logged errors (Chrome prefs, Firefox video teardown, CRI client close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c85b65b1c31c65cf1b87354ff8421d5b0a19c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->