### PR TITLE
docs: document changelog linking + monorepoPaths regeneration conventions

### DIFF
--- a/guides/writing-the-cypress-changelog.md
+++ b/guides/writing-the-cypress-changelog.md
@@ -49,6 +49,10 @@ The changelog should include anything that was merged into the `develop` branch 
     - For other issues: "Addresses [#12]([https://github.com/cypress-io/cypress/issues/12](https://github.com/cypress-io/cypress/issues/1234))."
     - When no issues, but PR: "Addressed in [#12]([https://github.com/cypress-io/cypress/issues/12](https://github.com/cypress-io/cypress/issues/1234))."
     - When multiple issues: "Fixes [#12]([https://github.com/cypress-io/cypress/issues/12](https://github.com/cypress-io/cypress/issues/1234)), [#13]([https://github.com/cypress-io/cypress/issues/13](https://github.com/cypress-io/cypress/issues/1234)) and [#14]([https://github.com/cypress-io/cypress/issues/14](https://github.com/cypress-io/cypress/issues/1234))."
+10. When a changelog item references a Cypress command, plugin event, or configuration option, link the first mention to its documentation for consistency with existing entries. Either link form is acceptable: the `https://on.cypress.io/<slug>` short link or an absolute `https://docs.cypress.io/<path>` URL.
+    - _Example (`on.cypress.io`):_ `` [`cy.visit()`](https://on.cypress.io/visit) ``, `` [`before:spec`](https://on.cypress.io/before-spec-api) ``.
+    - _Example (`docs.cypress.io`):_ `` [`before:spec`](https://docs.cypress.io/api/plugins/before-spec-api) ``, `` [`numTestsKeptInMemory`](https://docs.cypress.io/app/references/configuration#Global) ``.
+11. If a change is only observable under a specific run context (e.g. `cypress run` vs. `cypress open`, or behind an experimental flag), state which context is affected so users can tell whether the change applies to them.
 
 ## Formatting
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -89,3 +89,4 @@ yarn build
 - Many packages use `vitest` for unit tests; the front-end packages (`app`, `launchpad`, `frontend-shared`) use Cypress component tests and E2E tests (cypress-in-cypress pattern).
 - The `nohoist` workspace option is set in `driver` and `frontend-shared` to prevent specific dependencies from being hoisted to the monorepo root.
 - Packages that depend on generated GraphQL types (from `data-context`) must run `yarn build:graphql` before type-checking will pass.
+- **When adding or removing a package under `packages/`**, regenerate the path map with `yarn gulp makePathMap` (from the repo root). This rewrites the auto-generated [`scripts/gulp/monorepoPaths.ts`](../scripts/gulp/monorepoPaths.ts) — do not hand-edit that file. It is also regenerated as part of `yarn dev`, but run the task explicitly so the change is committed alongside the package addition.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -22,6 +22,7 @@ This workspace (`internal-scripts`) contains the monorepo's build tooling, relea
 **Gotchas / Notes**
 
 - The gulp tasks in `gulp/gulpfile.ts` are the canonical way to drive local development; most developers run `yarn dev` from the monorepo root rather than invoking scripts here directly.
+- `gulp/monorepoPaths.ts` is **auto-generated** by `gulp/utils/makePathMap.ts` (which enumerates `packages/*`); do not hand-edit it. After adding or removing a package under `packages/`, regenerate it with `yarn gulp makePathMap` so the path map stays in sync.
 - `binary/build.ts` calls into `../../packages/electron` and depends on `electron-builder`; it must be run with the full monorepo installed and the `@packages/electron` package present.
 - Scripts that interact with S3 or CloudFlare require the appropriate environment variables (`AWS_*`, `CF_*`) to be set; they are intended for CI use, not local runs.
 - `github-actions/semantic-pull-request/` has its own `package.json` and is deployed as a standalone GitHub Action — do not modify it without understanding the action's deployment model.


### PR DESCRIPTION
## Summary

Two contributor-docs fixes prompted by drift surfaced while reviewing #34057:

- **Changelog conventions** — [`guides/writing-the-cypress-changelog.md`](guides/writing-the-cypress-changelog.md) now instructs:
  - Link a command/plugin event/config option on its first mention. Either link form is fine — the `on.cypress.io/<slug>` short link or an absolute `docs.cypress.io/<path>` URL (both are already used throughout the changelog).
  - State the affected run context (e.g. `cypress run` vs. `cypress open`, or an experimental flag) when a change is only observable in one of them.
- **`monorepoPaths.ts` is generated** — `packages/AGENTS.md` and `scripts/AGENTS.md` now note that [`scripts/gulp/monorepoPaths.ts`](scripts/gulp/monorepoPaths.ts) is auto-generated by `makePathMap.ts` and should be regenerated with `yarn gulp makePathMap` **when a package is added/removed**, rather than hand-edited.

## Why

While reviewing #34057, two recurring inconsistencies showed up:
- That PR picked up a regenerated `monorepoPaths.ts` containing a new `network-interception` entry — i.e. the generated file had drifted and got regenerated downstream in an unrelated change. Ideally `yarn gulp makePathMap` is run (and the result committed) at the moment a package is added or removed, so the path map doesn't go stale and then resurface in an unrelated PR. This file has drifted this way before.
- Changelog entries vary in whether (and how) they link the APIs they mention. Documenting the accepted forms keeps future entries consistent.

Docs-only; no code or behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown contributor guides only; no product code, config, or release artifacts are modified.
> 
> **Overview**
> Contributor documentation only—no runtime or build behavior changes.
> 
> **Changelog guide** (`guides/writing-the-cypress-changelog.md`) adds two writing rules: link the first mention of commands, plugin events, or config options to docs (`on.cypress.io` or `docs.cypress.io`), and call out when a change only applies in a specific run context (`cypress run` vs `cypress open`, experimental flags, etc.).
> 
> **Monorepo agent docs** (`packages/AGENTS.md`, `scripts/AGENTS.md`) document that `scripts/gulp/monorepoPaths.ts` is generated by `makePathMap.ts`, must not be hand-edited, and should be refreshed with `yarn gulp makePathMap` when packages are added or removed so path-map drift does not show up in unrelated PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d17a933eb16a9d9cd6b2d21c78fbc92ef5c809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->