### PR TITLE
test: verify cy.reload() preserves localStorage and sessionStorage

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -46,6 +46,12 @@ describe('src/cy/commands/navigation', () => {
     })
 
     // https://github.com/cypress-io/cypress/issues/7598
+    // cy.reload() is just window.location.reload(), and per the WHATWG HTML
+    // Storage standard both localStorage and sessionStorage persist across a
+    // reload (localStorage lives for the origin; sessionStorage lives for the
+    // top-level traversable's session), so a reload must not clear them.
+    // https://html.spec.whatwg.org/multipage/webstorage.html#the-localstorage-attribute
+    // https://html.spec.whatwg.org/multipage/webstorage.html#the-sessionstorage-attribute
     it('preserves localStorage and sessionStorage across the reload', () => {
       cy.window().then((win) => {
         win.localStorage.setItem('reload-local', 'persisted')

--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -45,6 +45,21 @@ describe('src/cy/commands/navigation', () => {
       })
     })
 
+    // https://github.com/cypress-io/cypress/issues/7598
+    it('preserves localStorage and sessionStorage across the reload', () => {
+      cy.window().then((win) => {
+        win.localStorage.setItem('reload-local', 'persisted')
+        win.sessionStorage.setItem('reload-session', 'persisted')
+      })
+
+      cy.reload()
+
+      cy.window().then((win) => {
+        expect(win.localStorage.getItem('reload-local'), 'localStorage').to.eq('persisted')
+        expect(win.sessionStorage.getItem('reload-session'), 'sessionStorage').to.eq('persisted')
+      })
+    })
+
     it('removes window:load listeners', () => {
       const listeners = cy.listeners('window:load')
 


### PR DESCRIPTION
Adds a regression test to the #reload suite asserting that storage written
before cy.reload() survives the reload, since cy.reload() is simply
window.location.reload() and must not clear browser storage.

Closes #7598

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modifications.
> 
> **Overview**
> Adds a regression test in the `#reload` suite in `navigation.cy.js` that writes to **localStorage** and **sessionStorage**, calls **`cy.reload()`**, and asserts both values are still present afterward.
> 
> The test documents expected behavior per the WHATWG Web Storage spec (reload must not clear storage) and references issue **#7598**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bb9d753ffb1ada7e692050dbe64699e724f695. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->