### PR TITLE
refactor(server): remove unused ConfiguratorNetworkPolicyAdapter.getRegistry

### DIFF
--- a/packages/server/lib/adapters/configurator-network-policy.ts
+++ b/packages/server/lib/adapters/configurator-network-policy.ts
@@ -20,11 +20,6 @@ export class ConfiguratorNetworkPolicyAdapter implements ForNetworkPolicyRegistr
     return this.registry.getPolicies()
   }
 
-  /** Exposed for policy registry access and unit tests. */
-  getRegistry (): NetworkPolicyRegistry {
-    return this.registry
-  }
-
   runPolicies (options: RunPoliciesOptions): Promise<RunPoliciesResult> {
     return this.registry.runPolicies(options)
   }

--- a/packages/server/test/unit/adapters/configurator-network-policy_spec.ts
+++ b/packages/server/test/unit/adapters/configurator-network-policy_spec.ts
@@ -13,6 +13,5 @@ describe('lib/adapters/configurator-network-policy', () => {
     adapter.add(policy)
 
     expect(adapter.getPolicies()).to.deep.equal([policy])
-    expect(adapter.getRegistry().getPolicies()).to.deep.equal([policy])
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes `ConfiguratorNetworkPolicyAdapter.getRegistry()` — it had no production callers and the unit test already asserted the same behavior via `getPolicies()`.

### Steps to test

```bash
yarn workspace @packages/server test-unit adapters/configurator-network-policy_spec.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6939e8fa-f6cb-4d6e-81bf-b0104e58fda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6939e8fa-f6cb-4d6e-81bf-b0104e58fda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

