### PR TITLE
fix(cli): redact sensitive values in info output

### DIFF
--- a/cli/lib/exec/info.ts
+++ b/cli/lib/exec/info.ts
@@ -22,12 +22,41 @@ methods.findProxyEnvironmentVariables = (): any => {
   return _.pick(process.env, ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'])
 }
 
+const proxyUrlCredentialsRe = /^([a-z][a-z\d+.-]*:\/\/)([^@/?#]*@)/i
+const sensitiveVariableNameRe = /KEY|TOKEN|SECRET|PASSWORD|AUTH|CREDENTIAL/i
+
+const redactUrlCredentials = (value: any): any => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  try {
+    const url = new URL(value)
+
+    if (!url.username && !url.password) {
+      return value
+    }
+
+    return value.replace(proxyUrlCredentialsRe, '$1<redacted>@')
+  } catch {
+    return value
+  }
+}
+
+const formatProxyVariables = (): any => {
+  const vars = methods.findProxyEnvironmentVariables()
+
+  return _.mapValues(vars, redactUrlCredentials)
+}
+
 const maskSensitiveVariables = (obj: any): any => {
   const masked = { ...obj }
 
-  if (masked.CYPRESS_RECORD_KEY) {
-    masked.CYPRESS_RECORD_KEY = '<redacted>'
-  }
+  Object.keys(masked).forEach((key: string) => {
+    if (sensitiveVariableNameRe.test(key)) {
+      masked[key] = '<redacted>'
+    }
+  })
 
   return masked
 }
@@ -52,7 +81,7 @@ methods.start = async (options: any = {}): Promise<void> => {
   })
 
   console.log()
-  const proxyVars = methods.findProxyEnvironmentVariables()
+  const proxyVars = formatProxyVariables()
 
   if (_.isEmpty(proxyVars)) {
     console.log('Proxy Settings: none detected')

--- a/cli/test/lib/exec/__snapshots__/info.spec.ts.snap
+++ b/cli/test/lib/exec/__snapshots__/info.spec.ts.snap
@@ -76,6 +76,27 @@ System Memory: [32m1.2 GB[39m free [32m400 MB[39m
 "
 `;
 
+exports[`exec info > redacts proxy credentials > cypress redacts proxy credentials 1`] = `
+"
+Proxy Settings:
+HTTP_PROXY: [32mhttp://<redacted>@proxy.example.com:8080[39m
+HTTPS_PROXY: [32mhttps://<redacted>@secure-proxy.example.com[39m
+NO_PROXY: [32mlocalhost,127.0.0.1[39m
+
+Learn More: [34m[4mhttps://on.cypress.io/proxy-configuration[24m[39m
+
+Environment Variables: none detected
+
+Application Data: [36m/user/app/data/path[39m
+Browser Profiles: [36m/user/app/data/path/to/browsers[39m
+Binary Caches: [36m/user/path/to/binary/cache[39m
+
+Cypress Version: [32m0.0.0-development[39m [32m(stable)[39m
+System Platform: [32mlinux[39m ([32mFoo - OsVersion[39m)
+System Memory: [32m1.2 GB[39m free [32m400 MB[39m
+"
+`;
+
 exports[`exec info > redacts sensitive cypress variables > cypress redacts sensitive vars 1`] = `
 "
 Proxy Settings: none detected
@@ -84,6 +105,8 @@ CYPRESS_ENV_VAR1: [32mmy Cypress variable[39m
 CYPRESS_ENV_VAR2: [32mmy other Cypress variable[39m
 CYPRESS_PROJECT_ID: [32mabc123[39m
 CYPRESS_RECORD_KEY: [32m<redacted>[39m
+CYPRESS_AUTH_TOKEN: [32m<redacted>[39m
+CYPRESS_PASSWORD: [32m<redacted>[39m
 
 Application Data: [36m/user/app/data/path[39m
 Browser Profiles: [36m/user/app/data/path/to/browsers[39m

--- a/cli/test/lib/exec/info.spec.ts
+++ b/cli/test/lib/exec/info.spec.ts
@@ -154,11 +154,25 @@ describe('exec info', () => {
     expect(output()).toMatchSnapshot('cypress info with proxy and vars')
   })
 
+  it('redacts proxy credentials', async () => {
+    vi.stubEnv('HTTP_PROXY', 'http://username:password@proxy.example.com:8080')
+    vi.stubEnv('HTTPS_PROXY', 'https://token@secure-proxy.example.com')
+    vi.stubEnv('NO_PROXY', 'localhost,127.0.0.1')
+
+    const output = createStdoutCapture()
+
+    await info.start()
+
+    expect(output()).toMatchSnapshot('cypress redacts proxy credentials')
+  })
+
   it('redacts sensitive cypress variables', async () => {
     vi.stubEnv('CYPRESS_ENV_VAR1', 'my Cypress variable')
     vi.stubEnv('CYPRESS_ENV_VAR2', 'my other Cypress variable')
     vi.stubEnv('CYPRESS_PROJECT_ID', 'abc123') // not sensitive
     vi.stubEnv('CYPRESS_RECORD_KEY', 'really really secret stuff') // should not be printed
+    vi.stubEnv('CYPRESS_AUTH_TOKEN', 'another secret value')
+    vi.stubEnv('CYPRESS_PASSWORD', 'password value')
 
     const output = createStdoutCapture()
 


### PR DESCRIPTION
## Summary

- Redact credentials embedded in proxy URLs before `cypress info` prints proxy env vars.
- Mask `CYPRESS_*` env vars whose names look sensitive, while keeping ordinary Cypress env vars visible for debugging.
- Add CLI info snapshots for proxy credential redaction and broader env var masking.

## Testing

- `ASDF_NODEJS_VERSION=24.13.1 ../node_modules/.bin/vitest run test/lib/exec/info.spec.ts`
- `ASDF_NODEJS_VERSION=24.13.1 ../node_modules/.bin/eslint lib/exec/info.ts test/lib/exec/info.spec.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only hardening in the CLI info command; no runtime test or auth behavior changes, with minor risk of over-redacting env vars whose names match the sensitivity regex.
> 
> **Overview**
> **`cypress info`** no longer prints raw secrets from proxy env vars or broadly named sensitive **`CYPRESS_*`** variables.
> 
> Proxy settings (**`HTTP_PROXY`**, **`HTTPS_PROXY`**) now go through **`formatProxyVariables`**, which strips embedded userinfo from URLs (shown as **`http://<redacted>@host...`**) while leaving values like **`NO_PROXY`** unchanged. Cypress env masking replaces the single **`CYPRESS_RECORD_KEY`** check with a name pattern (**`KEY`**, **`TOKEN`**, **`SECRET`**, **`PASSWORD`**, **`AUTH`**, **`CREDENTIAL`**) so vars such as **`CYPRESS_AUTH_TOKEN`** and **`CYPRESS_PASSWORD`** are redacted; non-matching names (e.g. **`CYPRESS_PROJECT_ID`**) still print for debugging.
> 
> Tests and snapshots cover proxy credential redaction and the expanded env masking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14be3c7a6106bb3d03f8f02ffad93dc1f52fdb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->