### PR TITLE
chore: pin snyk/actions/setup to a SHA and let Renovate maintain action pins

### DIFF
--- a/.github/workflows/auto_approve_low_risk.yml
+++ b/.github/workflows/auto_approve_low_risk.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Extract risk level and reviewed SHA from CURSOR_SUMMARY
         id: risk-check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -158,7 +158,7 @@ jobs:
       - name: Generate Cypress Bot App token
         if: steps.action.outputs.should_dismiss == 'true' || steps.action.outputs.should_approve == 'true'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -33,7 +33,7 @@ jobs:
     environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr-review' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}
@@ -41,7 +41,7 @@ jobs:
         working-directory: scripts/github-actions/semantic-pull-request/
       - name: Lint PR Title and Cypress Changelog Entry
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const verifyPullRequest = require('./scripts/github-actions/semantic-pull-request')

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -48,7 +48,7 @@ jobs:
         run: yarn build
       - name: Installing snyk-delta and dependencies
         run: npm i -g snyk-delta
-      - uses: snyk/actions/setup@master
+      - uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
       - name: Perform SCA Scan
         continue-on-error: false
         run: |

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -31,13 +31,13 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           # Cache only on pull_request (internal PRs) — pull_request_target writes scope to the base branch and could be poisoned by an approved fork PR.

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -39,7 +39,7 @@ jobs:
         run: yarn
       - name: Run build
         run: yarn build
-      - uses: snyk/actions/setup@master
+      - uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1
       - name: Perform Static Analysis Test
         continue-on-error: true
         run: |

--- a/.github/workflows/snyk_static_analysis_scan.yaml
+++ b/.github/workflows/snyk_static_analysis_scan.yaml
@@ -24,13 +24,13 @@ jobs:
     environment: ${{ github.event_name == 'pull_request_target' && 'fork-pr-review' || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           # Cache only on pull_request (internal PRs) — pull_request_target writes scope to the base branch and could be poisoned by an approved fork PR.

--- a/.github/workflows/stale_issues_and_pr_cleanup.yml
+++ b/.github/workflows/stale_issues_and_pr_cleanup.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'cypress-io/cypress'
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           days-before-stale: ${{ github.event.inputs.days-before-stale || env.DEFAULT_DAYS_BEFORE_STALE }}
           days-before-close: ${{ github.event.inputs.days-before-close || env.DEFAULT_DAYS_BEFORE_CLOSE }}

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -39,7 +39,7 @@ jobs:
             } ' -f org=${{ github.repository_owner }} -f repo=${{ github.event.repository.name }} -f user=${{ github.event.pull_request.user.login || github.event.issue.user.login }} > collaborators.json
 
           echo 'IS_COLLABORATOR='$(jq -r '.data.repository.collaborators.totalCount' collaborators.json) >> $GITHUB_ENV
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         # only add issues/prs from outside contributors to the project
         if: ${{ env.IS_COLLABORATOR == 0 || github.event.repository.name == 'cypress-support-internal' || github.event.pull_request.user.login == 'github-actions[bot]' || github.event.issue.user.login == 'github-actions[bot]' }}
         with:
@@ -49,17 +49,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: 'cypress-io/release-automations'
-          ref: 'master'
+          ref: 'fa3826c4388bf0964e8507ab74cba78ffe9e83a8' # master
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: 'cypress-io/release-automations'
           ref: 'master'
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: 'cypress-io/release-automations'
-          ref: 'master'
+          ref: 'fa3826c4388bf0964e8507ab74cba78ffe9e83a8' # master
           ssh-key: ${{ secrets.WORKFLOW_DEPLOY_KEY }} 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - name: Generate Cypress Bot App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -36,14 +36,14 @@ jobs:
           git fetch origin
           git checkout ${{ env.BASE_BRANCH }}
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .node-version
       - name: install dependencies
         run: CI=true yarn
       - name: Check for new Chrome versions
         id: get-versions
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { getVersions } = require('./scripts/github-actions/update-browser-versions.js')
@@ -68,7 +68,7 @@ jobs:
       - name: Check need for update on existing branch
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
         id: check-need-for-branch-update
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { checkNeedForBranchUpdate } = require('./scripts/github-actions/update-browser-versions.js')
@@ -82,7 +82,7 @@ jobs:
       ## Both
       - name: Update Browser Versions File
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { updateBrowserVersionsFile } = require('./scripts/github-actions/update-browser-versions.js')
@@ -94,7 +94,7 @@ jobs:
             })
       - name: Commit and push via API
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -114,7 +114,7 @@ jobs:
       ## Update available and a branch/PR already exists
       - name: Update PR Title
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -131,7 +131,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -77,19 +77,19 @@ jobs:
         run: sudo -H pip install setuptools
       - name: Generate Cypress Bot App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: read
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ env.BASE_BRANCH }}
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: 'yarn'
@@ -111,7 +111,7 @@ jobs:
         shell: bash
       - name: Upload snapshot artifact
         if: ${{ steps.check-for-v8-snapshot-cache-changes.outputs.has_changes == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: v8-snapshot-cache-${{ env.PLATFORM }}
           path: ${{ env.SNAPSHOT_FILE }}
@@ -126,14 +126,14 @@ jobs:
     steps:
       - name: Generate Cypress Bot App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.CYPRESS_BOT_APP_ID }}
           private-key: ${{ secrets.CYPRESS_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
           token: ${{ steps.app-token.outputs.token }}
@@ -145,7 +145,7 @@ jobs:
         # to continue so the stage step below can exit cleanly with
         # has_changes=false.
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: v8-snapshot-cache-*
           path: artifacts/
@@ -199,7 +199,7 @@ jobs:
         shell: bash
       - name: Commit snapshot update via API
         if: ${{ steps.stage.outputs.has_changes == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           SNAPSHOT_FILES: ${{ steps.stage.outputs.files }}
           BASE_BRANCH: ${{ env.BASE_BRANCH }}
@@ -226,7 +226,7 @@ jobs:
             })
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Download Fossa binary and install
 # This step utilizes a curl of the latest install pkg from Fossa.  Using a git action from 
 # Fossa doesn't produce the SBOM artifact needed. This manual approach is the only way to 
@@ -33,7 +33,7 @@ jobs:
           ls -lht|head
           cat SBOM.rpt      
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./SBOM.rpt

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":semanticPrefixFixDepsChoreOthers",
     "group:monorepos",
     "group:recommended",
+    "helpers:pinGitHubActionDigests",
     "replacements:all",
     "workarounds:all"
   ],
@@ -24,6 +25,14 @@
         "pin",
         "digest"
       ]
+    },
+    {
+      "description": "Cooldown before updating pinned GitHub Action SHAs so a moved/compromised tag isn't merged immediately",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "minimumReleaseAge": "7 days",
+      "internalChecksFilter": "strict"
     }
   ],
   "postUpdateOptions": [

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,21 @@
     "replacements:all",
     "workarounds:all"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the pinned cypress-io/release-automations checkout ref updated to the latest master commit",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "repository: 'cypress-io/release-automations'\\s+ref: '(?<currentDigest>[0-9a-f]+)' # (?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "cypress-io/release-automations",
+      "packageNameTemplate": "https://github.com/cypress-io/release-automations",
+      "datasourceTemplate": "git-refs"
+    }
+  ],
   "ignorePaths": [
     "**/node_modules/**",
     "**/system-tests/projects/**"
@@ -29,7 +44,8 @@
     {
       "description": "Cooldown before updating pinned GitHub Action SHAs so a moved/compromised tag isn't merged immediately",
       "matchManagers": [
-        "github-actions"
+        "github-actions",
+        "custom.regex"
       ],
       "minimumReleaseAge": "7 days",
       "internalChecksFilter": "strict"


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34070

### Additional details

[#34070](https://github.com/cypress-io/cypress/issues/34070) flagged that `snyk/actions/setup` — the only third-party GitHub Action in our public workflows — was referenced by the mutable `@master` branch in `.github/workflows/snyk_sca_scan.yaml` and `.github/workflows/snyk_static_analysis_scan.yaml`. A force-push or compromise of that upstream branch would run in CI with the job's token, so [GitHub's hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends pinning third-party actions to an immutable commit SHA.

This PR hardens **all** actions, not just the one flagged:

- **Pins `snyk/actions/setup` to a SHA on a released tag.** `snyk/actions` publishes versioned releases, so rather than pin the `master` branch HEAD we move to the `v1` release pinned to its commit (`snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1`). This is immutable *and* keeps us on a published release instead of an arbitrary branch.
- **Pins every first-party `actions/*` reference to its commit SHA** across all workflows, each with a readable `# vX` comment. The trailing version comment is what Renovate uses to keep tracking published releases — pinning to a SHA does not switch us to following arbitrary commits.
- **Adds the `helpers:pinGitHubActionDigests` Renovate preset** so any newly added action references are auto-pinned, and existing pins are kept current.
- **Adds a 7-day cooldown (`minimumReleaseAge`) for `github-actions` updates** with `internalChecksFilter: strict`, so if an upstream tag is moved or compromised, the digest bump is not auto-merged immediately (our existing config auto-merges `pin`/`digest` updates).

The only `uses:` left unpinned is the commented-out `github/codeql-action/upload-sarif@v1` (disabled — requires an Advanced Security license).

The Renovate config was validated locally with `renovate-config-validator` (`Config validated successfully`), and all workflow YAML files were verified to still parse.

### Steps to test

This is a CI/dependency-tooling change with no runtime effect. To verify:
1. Confirm the Snyk SCA and Static Analysis checks run and pass on this PR (proves the pinned `snyk/actions/setup@…` and `actions/*` refs resolve).
2. Spot-check that each pinned SHA matches the commit its `# vX` comment points to.
3. After merge, confirm Renovate keeps the pins current via `digest`-type PRs (subject to the new 7-day cooldown).

### How has the user experience changed?

No change — internal CI hardening only.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34070 -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pinning and Renovate policy; no product runtime or auth logic changes.
> 
> **Overview**
> Hardens CI by replacing mutable action refs (`@vN`, `@master`) with **immutable commit SHAs** and `# vX` comments across workflows, including moving **`snyk/actions/setup`** from `@master` to the **`v1` release SHA** in the Snyk SCA and SAST jobs.
> 
> Triage workflows that checkout **`cypress-io/release-automations`** now pin **`ref`** to a specific commit instead of **`master`**.
> 
> **`renovate.json`** adds **`helpers:pinGitHubActionDigests`**, a regex custom manager to bump the release-automations pin, and a **7-day `minimumReleaseAge`** (with strict internal checks) for **`github-actions`** and that custom manager so digest updates are not auto-merged immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06bdfdb65bb596aad4f337bc4e57a5c61b4bf404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->