### PR TITLE
test(server): cover Reporter#end awaiting async reporter done() hook

### DIFF
--- a/packages/server/test/unit/reporter_spec.ts
+++ b/packages/server/test/unit/reporter_spec.ts
@@ -133,6 +133,57 @@ describe('lib/reporter', () => {
     })
   })
 
+  // https://github.com/cypress-io/cypress/issues/7139
+  // Reporters that need to perform asynchronous work on completion must use
+  // Mocha's `done(failures, callback)` hook (not the synchronous `end` event,
+  // which Cypress cannot await). `Reporter#end` must wait for that callback
+  // before resolving so the async work is not torn down by the run exiting.
+  context('#end', () => {
+    it('waits for the reporter\'s async done() callback before resolving', function () {
+      let doneFinished = false
+
+      this.reporter.reporter.done = (failures, cb) => {
+        setTimeout(() => {
+          doneFinished = true
+          cb()
+        }, 50)
+      }
+
+      const endResult = this.reporter.end()
+
+      // end() must return a promise (not resolve synchronously) when done() exists
+      expect(endResult).to.be.an.instanceOf(Promise)
+
+      return endResult.then((results) => {
+        // if end() resolved before the callback fired, the async work would be lost
+        expect(doneFinished, 'done() callback completed before end() resolved').to.be.true
+        expect(results).to.have.property('stats')
+      })
+    })
+
+    it('passes the runner\'s failure count to done()', function () {
+      this.reporter.runner.failures = 3
+
+      const done = sinon.stub().callsFake((failures, cb) => cb())
+
+      this.reporter.reporter.done = done
+
+      return this.reporter.end().then(() => {
+        expect(done).to.be.calledWith(3)
+      })
+    })
+
+    it('returns results synchronously when the reporter has no done() method', function () {
+      // the default spec reporter does not implement done()
+      expect(this.reporter.reporter.done).to.be.undefined
+
+      const results = this.reporter.end()
+
+      expect(results).not.to.be.an.instanceOf(Promise)
+      expect(results).to.have.property('stats')
+    })
+  })
+
   context('#emit', () => {
     beforeEach(function () {
       this.emit = sinon.spy(this.reporter.runner, 'emit')


### PR DESCRIPTION
Adds regression coverage for the behavior behind cypress-io/cypress#7139:
custom Mocha reporters that perform asynchronous work on completion must
use Mocha's done(failures, callback) hook, which Reporter#end awaits
before resolving. Verifies end() returns a promise that waits for the
done() callback, forwards the runner's failure count, and falls back to
synchronous results when no done() method is present.

https://claude.ai/code/session_017n6n9cvCDhMMwoLBGRmXQL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds a **`#end`** unit test block in `reporter_spec.ts` (linked to cypress-io/cypress#7139) so custom Mocha reporters that finish work via **`done(failures, callback)`** stay covered by tests.
> 
> The new cases assert **`Reporter#end`** returns a **promise** that resolves only after the reporter’s async **`done`** callback runs (so teardown doesn’t cut off reporter work), passes **`runner.failures`** into **`done`**, and still returns **synchronous** results when the reporter has no **`done`** method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac0b84cc1d3d75385388cfa960fffc58f60d968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->