### PR TITLE
docs: fix launcher README browser-detection commands

### DIFF
--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -4,18 +4,18 @@ This package finds and launches browsers for each operating system.
 
 ## Developing
 
-The TypeScript source files are in [`lib`](/lib) folder.
+The TypeScript source files are in the [`lib`](/lib) folder.
 
-To see browsers detected on your machine, just run:
+To see the browsers detected on your machine, run the following from the `packages/launcher` directory. The `@packages/ts` require hook transpiles the TypeScript on the fly:
 
 ```bash
-node index.js
+node -r @packages/ts/register -e "require('./lib/detect').detect().then(console.log, console.error)"
 ```
 
-You can supply a list of binaries to test if they're browsers or not. Try running:
+You can also check whether a specific binary is recognized as a browser by passing its path:
 
 ```bash
-node index.js /bin/bash /usr/bin/chromium-browser
+node -r @packages/ts/register -e "require('./lib/detect').detectByPath(process.argv[1]).then(console.log, console.error)" /usr/bin/chromium-browser
 ```
 
 ## Testing


### PR DESCRIPTION
- Closes #29697

### Additional details

The "Developing" section of `packages/launcher/README.md` told contributors to run `node index.js` to detect browsers on their machine. That file was removed in #15646 (Apr 2021) when the launcher package was converted to TypeScript — `index.js` was replaced by `index.ts`, which only re-exports functions and is not runnable. As a result the documented commands have failed with `MODULE_NOT_FOUND` for ~5 years.

This PR replaces the two stale commands with working equivalents that use the `@packages/ts` require hook to transpile and run the TypeScript on the fly:
- `detect()` — list all browsers detected on the machine
- `detectByPath()` — check whether a specific binary path is recognized as a browser

This is a documentation-only change; no source or behavior is affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Developing** section in `packages/launcher/README.md` so local browser-detection instructions work again after the old `index.js` entrypoint was removed.
> 
> The README no longer suggests `node index.js` (and path arguments). It now documents two `node -r @packages/ts/register` one-liners that call **`detect()`** to list browsers on the machine and **`detectByPath()`** to check whether a given binary path is recognized. Copy also clarifies running from `packages/launcher` and that `@packages/ts` transpiles TypeScript on the fly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa97ba63d842c1e961c4ec2f1a182b092cddfd9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

From the `packages/launcher` directory:

```bash
# Lists detected browsers
node -r @packages/ts/register -e "require('./lib/detect').detect().then(console.log, console.error)"

# Reports whether the given path is a recognized browser
node -r @packages/ts/register -e "require('./lib/detect').detectByPath(process.argv[1]).then(console.log, console.error)" /usr/bin/chromium-browser
```

Both were verified locally — `detect()` returned the installed Chrome builds, and `detectByPath('/bin/bash')` correctly reported "Unable to find browser."

### How has the user experience changed?

No change — documentation only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical documentation correction; see description. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?