### PR TITLE
chore: remove no-op CYPRESS_DOWNLOAD_USE_CA environment variable

### DIFF
--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -429,21 +429,7 @@ const cliModule = {
       args = process.argv
     }
 
-    const { CYPRESS_INTERNAL_ENV, CYPRESS_DOWNLOAD_USE_CA } = process.env
-
-    if (process.env.CYPRESS_DOWNLOAD_USE_CA) {
-      let msg = `
-        ${logSymbols.warning} Warning: It looks like you're setting CYPRESS_DOWNLOAD_USE_CA=${CYPRESS_DOWNLOAD_USE_CA}
-
-        The environment variable "CYPRESS_DOWNLOAD_USE_CA" is no longer required to be set.
-        
-        You can safely unset this environment variable.
-      `
-
-      logger.log()
-      logger.warn(stripIndent(msg))
-      logger.log()
-    }
+    const { CYPRESS_INTERNAL_ENV } = process.env
 
     if (!util.isValidCypressInternalEnvValue(CYPRESS_INTERNAL_ENV)) {
       debug('invalid CYPRESS_INTERNAL_ENV value', CYPRESS_INTERNAL_ENV)


### PR DESCRIPTION
- Closes <!-- no associated issue; mechanical cleanup of a long-deprecated, no-op env var -->

### Additional details

Removes the `CYPRESS_DOWNLOAD_USE_CA` environment variable, which has been deprecated and a no-op since Cypress 11. The CLI no longer reads it or emits a deprecation warning when it is set.

This is a cleanup of dead code with **no user-facing impact** — the variable already did nothing — so it is typed `chore` and carries no changelog entry. To supply a custom certificate authority for the binary download, use the `cafile`/`ca` npm config options or `NODE_EXTRA_CA_CERTS` (unchanged behavior).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical removal of unused env-var handling with no functional behavior change.
> 
> **Overview**
> Removes dead CLI startup logic for **`CYPRESS_DOWNLOAD_USE_CA`**, a no-op env var since Cypress 11. **`cli.init`** no longer reads the variable or prints a deprecation warning when it is set.
> 
> **No change** to how custom CAs are used for binary downloads (`cafile`/`ca` npm config and `NODE_EXTRA_CA_CERTS` are unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917c0df17623ebb19386546e666b2fb9f9fb5f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. `export CYPRESS_DOWNLOAD_USE_CA=true`
2. Run any `cypress` CLI command (e.g. `npx cypress install` or `npx cypress verify`).
3. **Before:** a deprecation warning was printed. **After:** no warning is printed and the variable is ignored.

> Note: this was not run locally — `release/16.0.0` requires Node ≥ 24.15.0 and the change is verified by inspection (grep confirms no remaining references in source or tests). Relying on CI for lint/unit verification.

### How has the user experience changed?

No functional change. The deprecation warning previously shown when `CYPRESS_DOWNLOAD_USE_CA` was set is no longer printed; the variable was already a no-op. There is no change to how custom CAs are supplied for binary downloads.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical removal of a long-deprecated, no-op env var. -->
- [na] Have tests been added/updated? <!-- No tests referenced the removed code path; the variable was already a no-op. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change; docs that still mention the var can be cleaned up separately. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No public API/type changes. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)