### PR TITLE
chore(server): remove Chrome specific handling for non-supported versions

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -29,7 +29,6 @@ const debug = debugModule('cypress:server:browsers:chrome')
 const LOAD_EXTENSION = '--load-extension='
 const CHROME_VERSIONS_WITH_BUGGY_ROOT_LAYER_SCROLLING = '66 67'.split(' ')
 const CHROME_VERSION_INTRODUCING_PROXY_BYPASS_ON_LOOPBACK = 72
-const CHROME_VERSION_WITH_FPS_INCREASE = 89
 const CHROME_VERSION_INTRODUCING_HEADLESS_NEW = 112
 
 const CHROME_PREFERENCE_PATHS = {
@@ -245,12 +244,10 @@ const _disableRestorePagesPrompt = function (userDir) {
   })
 }
 
-async function _recordVideo (cdpAutomation: CdpAutomation, videoOptions: RunModeVideoApi, browserMajorVersion: number) {
-  const screencastOptions = browserMajorVersion >= CHROME_VERSION_WITH_FPS_INCREASE ? screencastOpts() : screencastOpts(1)
-
+async function _recordVideo (cdpAutomation: CdpAutomation, videoOptions: RunModeVideoApi) {
   const { writeVideoFrame } = await videoOptions.useFfmpegVideoController()
 
-  await cdpAutomation.startVideoRecording(writeVideoFrame, screencastOptions)
+  await cdpAutomation.startVideoRecording(writeVideoFrame, screencastOpts())
 }
 
 // a utility function that navigates to the given URL
@@ -586,7 +583,7 @@ export = {
 
     await Promise.all([
       pageCriClient.send('ServiceWorker.enable'),
-      options.videoApi && this._recordVideo(cdpAutomation, options.videoApi, Number(options.browser.majorVersion)),
+      options.videoApi && this._recordVideo(cdpAutomation, options.videoApi),
       this._handleDownloads(pageCriClient, options.downloadsFolder, automation),
       utils.initializeCDP(pageCriClient, automation),
     ])

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -27,7 +27,6 @@ import { DEFAULT_CHROME_FLAGS } from '../util/chromium_flags'
 const debug = debugModule('cypress:server:browsers:chrome')
 
 const LOAD_EXTENSION = '--load-extension='
-const CHROME_VERSION_INTRODUCING_HEADLESS_NEW = 112
 
 const CHROME_PREFERENCE_PATHS = {
   default: path.join('Default', 'Preferences'),
@@ -384,18 +383,14 @@ export = {
       args.push('--allow-running-insecure-content')
     }
 
-    const { majorVersion, isHeadless } = browser
+    const { isHeadless } = browser
 
     // https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
     // https://github.com/cypress-io/cypress/issues/1872
     args.push('--proxy-bypass-list=<-loopback>')
 
     if (isHeadless) {
-      if (Number(majorVersion) >= CHROME_VERSION_INTRODUCING_HEADLESS_NEW) {
-        args.push('--headless=new')
-      } else {
-        args.push('--headless')
-      }
+      args.push('--headless=new')
 
       // set default headless size to 1280x720
       // https://github.com/cypress-io/cypress/issues/6210

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -27,8 +27,6 @@ import { DEFAULT_CHROME_FLAGS } from '../util/chromium_flags'
 const debug = debugModule('cypress:server:browsers:chrome')
 
 const LOAD_EXTENSION = '--load-extension='
-const CHROME_VERSIONS_WITH_BUGGY_ROOT_LAYER_SCROLLING = '66 67'.split(' ')
-const CHROME_VERSION_INTRODUCING_PROXY_BYPASS_ON_LOOPBACK = 72
 const CHROME_VERSION_INTRODUCING_HEADLESS_NEW = 112
 
 const CHROME_PREFERENCE_PATHS = {
@@ -386,21 +384,11 @@ export = {
       args.push('--allow-running-insecure-content')
     }
 
-    // prevent AUT shaking in 66 & 67, but flag breaks chrome in 68+
-    // https://github.com/cypress-io/cypress/issues/2037
-    // https://github.com/cypress-io/cypress/issues/2215
-    // https://github.com/cypress-io/cypress/issues/2223
     const { majorVersion, isHeadless } = browser
-
-    if (CHROME_VERSIONS_WITH_BUGGY_ROOT_LAYER_SCROLLING.includes(majorVersion)) {
-      args.push('--disable-blink-features=RootLayerScrolling')
-    }
 
     // https://chromium.googlesource.com/chromium/src/+/da790f920bbc169a6805a4fb83b4c2ab09532d91
     // https://github.com/cypress-io/cypress/issues/1872
-    if (Number(majorVersion) >= CHROME_VERSION_INTRODUCING_PROXY_BYPASS_ON_LOOPBACK) {
-      args.push('--proxy-bypass-list=<-loopback>')
-    }
+    args.push('--proxy-bypass-list=<-loopback>')
 
     if (isHeadless) {
       if (Number(majorVersion) >= CHROME_VERSION_INTRODUCING_HEADLESS_NEW) {

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -478,8 +478,7 @@ export = {
   _setProxy (webContents, proxyServer) {
     return webContents.session.setProxy({
       proxyRules: proxyServer,
-      // this should really only be necessary when
-      // running Chromium versions >= 72
+      // bypass the proxy for loopback addresses
       // https://github.com/cypress-io/cypress/issues/1872
       proxyBypassRules: '<-loopback>',
     })

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -157,21 +157,6 @@ describe('lib/browsers/chrome', () => {
       })
     })
 
-    it('sets headless in the old style for versions lower than 112', function () {
-      chrome._writeExtension.restore()
-
-      return chrome.open({ isHeadless: true, majorVersion: 111 }, 'http://', openOpts, this.automation)
-      .then(() => {
-        const args = launch.launch.firstCall.args[3]
-
-        expect(args).to.include.members([
-          '--headless',
-          '--window-size=1280,720',
-          '--force-device-scale-factor=1',
-        ])
-      })
-    })
-
     it('does not load extension in headless mode', function () {
       chrome._writeExtension.restore()
 

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -624,7 +624,7 @@ describe('lib/browsers/chrome', () => {
       }
 
       sinon.stub(chrome, '_getBrowserCriClient').returns(browserCriClient)
-      sinon.stub(chrome, '_recordVideo').withArgs(sinon.match.object, options.writeVideoFrame, 354).resolves()
+      sinon.stub(chrome, '_recordVideo').withArgs(sinon.match.object, options.writeVideoFrame).resolves()
       sinon.stub(chrome, '_navigateUsingCRI').withArgs(pageCriClient, options.url, 354).resolves()
       sinon.stub(chrome, '_handleDownloads').withArgs(pageCriClient, options.downloadFolder, automation).resolves()
 

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -935,48 +935,15 @@ describe('lib/browsers/chrome', () => {
       expect(args).not.to.include('--user-agent=foo')
     })
 
-    it('disables RootLayerScrolling in versions 66 or 67', () => {
-      const arg = '--disable-blink-features=RootLayerScrolling'
-
-      const disabledRootLayerScrolling = function (version, bool) {
-        const args = chrome._getArgs({
-          majorVersion: version,
-        }, {})
-
-        if (bool) {
-          return expect(args).to.include(arg)
-        }
-
-        expect(args).not.to.include(arg)
-      }
-
-      disabledRootLayerScrolling('65', false)
-      disabledRootLayerScrolling('66', true)
-      disabledRootLayerScrolling('67', true)
-
-      disabledRootLayerScrolling('68', false)
-    })
-
     // https://github.com/cypress-io/cypress/issues/1872
-    it('adds <-loopback> proxy bypass rule in version 72+', () => {
+    it('adds <-loopback> proxy bypass rule', () => {
       const arg = '--proxy-bypass-list=<-loopback>'
 
-      const chromeVersionHasLoopback = function (version, bool) {
-        const args = chrome._getArgs({
-          majorVersion: version,
-        }, {})
+      const args = chrome._getArgs({
+        majorVersion: '89',
+      }, {})
 
-        if (bool) {
-          return expect(args).to.include(arg)
-        }
-
-        expect(args).not.to.include(arg)
-      }
-
-      chromeVersionHasLoopback('71', false)
-      chromeVersionHasLoopback('72', true)
-
-      return chromeVersionHasLoopback('73', true)
+      expect(args).to.include(arg)
     })
   })
 


### PR DESCRIPTION
### Additional details

Cypress no longer supports Chrome/Chromium versions beyond the last 3 versions (stable being 150), so several version checks in the browser launch and video-recording code were dead. This PR removes that legacy handling (latest browser version removed was released in 2023).

All changes are confined to `@packages/server`

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

This is dead-code removal with no behavior change for **supported browsers**. Covered by existing unit tests:

```bash
yarn workspace @packages/server test-unit -- browsers/chrome_spec
```

All chrome unit tests pass and `yarn workspace @packages/server lint` reports no errors.

### How has the user experience changed?

No change. All removed branches only applied to Chrome/Chromium versions below the supported floor. For supported browsers the resulting launch arguments and video-recording options are identical.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical dead-code removal for unsupported browser versions. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?