### PR TITLE
perf: speed up Cypress binary verification

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 **Performance:**
 
 - Fixed an issue where an application that repeatedly threw the same uncaught exception (for example, a benign `ResizeObserver loop ...` notification fired on every animation frame) could exhaust renderer memory and crash the browser. Consecutive identical uncaught exceptions within a test now collapse into a single, updating command-log entry, and a handled (suppressed) uncaught exception no longer captures a DOM snapshot. Addresses [#27415](https://github.com/cypress-io/cypress/issues/27415).
-- Verifying that the Cypress binary can run — which happens the first time a newly installed version is used, before `cypress open` or `cypress run`, and whenever `cypress verify` is invoked — now completes more quickly.
+- Verifying that the Cypress binary can run, which happens the first time a newly installed version is used (before `cypress open` or `cypress run`) and whenever `cypress verify` is invoked, now completes more quickly.
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 **Performance:**
 
 - Fixed an issue where an application that repeatedly threw the same uncaught exception (for example, a benign `ResizeObserver loop ...` notification fired on every animation frame) could exhaust renderer memory and crash the browser. Consecutive identical uncaught exceptions within a test now collapse into a single, updating command-log entry, and a handled (suppressed) uncaught exception no longer captures a DOM snapshot. Addresses [#27415](https://github.com/cypress-io/cypress/issues/27415).
+- Verifying that the Cypress binary can run — which happens the first time a newly installed version is used, before `cypress open` or `cypress run`, and whenever `cypress verify` is invoked — now completes more quickly.
 
 **Bugfixes:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 **Performance:**
 
 - Fixed an issue where an application that repeatedly threw the same uncaught exception (for example, a benign `ResizeObserver loop ...` notification fired on every animation frame) could exhaust renderer memory and crash the browser. Consecutive identical uncaught exceptions within a test now collapse into a single, updating command-log entry, and a handled (suppressed) uncaught exception no longer captures a DOM snapshot. Addresses [#27415](https://github.com/cypress-io/cypress/issues/27415).
-- Verifying that the Cypress binary can run, which happens the first time a newly installed version is used (before `cypress open` or `cypress run`) and whenever `cypress verify` is invoked, now completes more quickly.
+- Verifying that the Cypress binary can run, which happens the first time a newly installed version is used (before `cypress open` or `cypress run`) and whenever `cypress verify` is invoked, now completes more quickly. Addressed in [#34133](https://github.com/cypress-io/cypress/pull/34133).
 
 **Bugfixes:**
 

--- a/cli/lib/tasks/verify.ts
+++ b/cli/lib/tasks/verify.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk'
 import { Listr, PRESET_TIMESTAMP } from 'listr2'
 import Debug from 'debug'
 import { stripIndent } from 'common-tags'
-import Bluebird from 'bluebird'
 import logSymbols from 'log-symbols'
 import os from 'os'
 import { throwFormErrorText, errors } from '../errors'
@@ -213,10 +212,7 @@ async function verifyBinary (installedVersion: string, binaryDir: string, option
 
       await state.clearBinaryStateAsync(binaryDir)
 
-      await Promise.all([
-        runSmokeTest(binaryDir, options),
-        Bluebird.delay(1500), // good user experience
-      ])
+      await runSmokeTest(binaryDir, options)
 
       debug('write verified: true')
 


### PR DESCRIPTION
- Closes N/A (no associated issue; small, self-contained performance change)

### Additional details

The binary verification step (`cypress verify`, and the automatic check that runs the first time a newly installed version is used before `cypress open` / `cypress run`) ran the binary smoke test in parallel with a fixed minimum-duration timer. That timer existed only to keep the on-screen "Verifying Cypress can run" spinner visible long enough to read, and it was introduced back when the spinner itself was first added.

On modern hardware the smoke test often completes faster than that floor, so the timer added latency to a one-time verification with no functional benefit. In CI it could never help at all, since there is no spinner to watch (the renderer already switches to non-spinner, timestamped output in CI).

Verification now finishes as soon as the smoke test passes. Output, the "Verified Cypress!" message, and all success/failure behavior are unchanged.

**What is affected:** `cypress verify`, and the implicit verification before the first `cypress open` / `cypress run` after install. Verification is cached after it first succeeds, so this is a one-time-per-installed-binary cost.

### Steps to test

1. Build the CLI (`cd cli && yarn build-cli`).
2. With a freshly installed binary (or after clearing the cached verified state), run `cypress verify` (or the first `cypress open` / `cypress run`).
3. Confirm the "Verifying Cypress can run" step still runs and prints "Verified Cypress!" on success, and that an invalid/missing binary still fails verification as before.
4. Run the verify unit tests: `yarn workspace cypress test-unit -- test/lib/tasks/verify.spec.ts` (39 tests pass).

### How has the user experience changed?

The "Verifying Cypress can run" step completes more quickly. There is no change to what is printed or to the success/failure outcome of verification.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No associated issue; this is a small, self-contained performance change. -->
- [na] Have tests been added/updated? <!-- No behavior change; the existing verify unit tests (cli/test/lib/tasks/verify.spec.ts, 39 tests) cover this path and continue to pass. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No documentation change; covered by the CHANGELOG entry. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No public API change. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01MFdaexzUgDiTENDb84yKYo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path timing change in CLI verify with no change to smoke-test logic or pass/fail criteria; only removes artificial delay and an unused import in verify.ts.
> 
> **Overview**
> Binary verification (`cypress verify` and the one-time check before first `cypress open` / `cypress run`) **no longer waits on a fixed 1.5s minimum** alongside the smoke test.
> 
> In `verify.ts`, the verify task used to run `runSmokeTest` in parallel with `Bluebird.delay(1500)` so the "Verifying Cypress can run" spinner stayed visible; it now **awaits only the smoke test** and drops the `bluebird` import from that file. Success/failure behavior and messaging are unchanged. A **15.17.1 Performance** changelog entry documents the faster verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ee39bc387685d2906a6b10160499a78ed6beb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->