### PR TITLE
chore: correct misleading WebKit browser debug log message

### DIFF
--- a/packages/server/lib/browsers/utils.ts
+++ b/packages/server/lib/browsers/utils.ts
@@ -289,7 +289,7 @@ async function getWebKitBrowser () {
 
     return browser
   } catch (err) {
-    debug('WebKit is enabled, but there was an error constructing the WebKit browser: %o', { err })
+    debug('There was an error constructing the WebKit browser: %o', { err })
 
     return
   }


### PR DESCRIPTION
The debug log in getWebKitBrowser() prefixed every failure with
'WebKit is enabled, but ...' even when experimentalWebKitSupport was
disabled and playwright-webkit was simply not installed. WebKit is
detected unconditionally (so a warning can be shown when the browser
is present but the experiment is off), so this prefix was inaccurate.

Addresses #30229

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011GWHj3vkTQSYrDwLakkHb5


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single debug string change with no runtime behavior impact.
> 
> **Overview**
> Updates the `getWebKitBrowser()` catch-path debug message so it no longer claims **“WebKit is enabled, but …”** when construction fails.
> 
> That prefix was wrong because WebKit is probed unconditionally during `getBrowsers()` (e.g. missing `playwright-webkit`), not only when `experimentalWebKitSupport` is on. The log now states generically that there was an error constructing the WebKit browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15de4f525f540d31cfd73d7c92de638e605abdea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->