### PR TITLE
misc: remove the global install warning from cypress install

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 **Misc:**
 
-- Running `cypress install` when Cypress is installed globally no longer prints a warning recommending that Cypress be installed as a per-project devDependency. A global install is a valid, supported configuration (for example, in the `cypress/included` Docker image), so the warning was a false positive in that case. Addresses [#34134](https://github.com/cypress-io/cypress/issues/34134).
+- Running `cypress install` when Cypress is installed globally no longer prints a warning recommending that Cypress be installed as a per-project devDependency. Addresses [#34134](https://github.com/cypress-io/cypress/issues/34134).
 - Running Cypress with process profiler debug logs enabled (for example `DEBUG=cypress*process_profiler`) no longer intermittently prints an `Expected DataContext to already have been set via setCtx` error to the logs. Addresses [#30670](https://github.com/cypress-io/cypress/issues/30670).
 - Cypress now shows a clear error explaining that `browsers` must be an array and that a specific browser should be selected with `--browser` when a `CYPRESS_BROWSERS` environment variable is set to a plain string (for example `CYPRESS_BROWSERS=chrome`) instead of showing an opaque `TypeError: a.map is not a function` error. Addresses [#33198](https://github.com/cypress-io/cypress/issues/33198).
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 **Misc:**
 
+- Running `cypress install` when Cypress is installed globally no longer prints a warning recommending that Cypress be installed as a per-project devDependency. A global install is a valid, supported configuration (for example, in the `cypress/included` Docker image), so the warning was a false positive in that case. Addresses [#34134](https://github.com/cypress-io/cypress/issues/34134).
 - Running Cypress with process profiler debug logs enabled (for example `DEBUG=cypress*process_profiler`) no longer intermittently prints an `Expected DataContext to already have been set via setCtx` error to the logs. Addresses [#30670](https://github.com/cypress-io/cypress/issues/30670).
 - Cypress now shows a clear error explaining that `browsers` must be an array and that a specific browser should be selected with `--browser` when a `CYPRESS_BROWSERS` environment variable is set to a plain string (for example `CYPRESS_BROWSERS=chrome`) instead of showing an opaque `TypeError: a.map is not a function` error. Addresses [#33198](https://github.com/cypress-io/cypress/issues/33198).
 

--- a/cli/lib/tasks/install.ts
+++ b/cli/lib/tasks/install.ts
@@ -56,24 +56,6 @@ const alreadyInstalledMsg = (): void => {
 }
 
 const displayCompletionMsg = (): void => {
-  // check here to see if we are globally installed
-  if (util.isInstalledGlobally()) {
-    // if we are display a warning
-    logger.log()
-    logger.warn(stripIndent`
-      ${logSymbols.warning} Warning: It looks like you\'ve installed Cypress globally.
-
-        The recommended way to install Cypress is as a devDependency per project.
-
-        You should probably run these commands:
-
-        - ${chalk.cyan('npm uninstall -g cypress')}
-        - ${chalk.cyan('npm install --save-dev cypress')}
-    `)
-
-    return
-  }
-
   logger.log()
   logger.log(
     'You can now open Cypress by running one of the following, depending on your package manager:',

--- a/cli/test/lib/tasks/install.spec.ts
+++ b/cli/test/lib/tasks/install.spec.ts
@@ -567,7 +567,7 @@ describe('/lib/tasks/install', function () {
       })
 
       describe('as a global install', function () {
-        it('does not log a global install warning and downloads', async function () {
+        it('a global install warning and downloads', async function () {
           const output = createStdoutCapture()
 
           vi.mocked(util.isInstalledGlobally).mockReturnValue(true)

--- a/cli/test/lib/tasks/install.spec.ts
+++ b/cli/test/lib/tasks/install.spec.ts
@@ -567,7 +567,7 @@ describe('/lib/tasks/install', function () {
       })
 
       describe('as a global install', function () {
-        it('a global install warning and downloads', async function () {
+        it('downloads', async function () {
           const output = createStdoutCapture()
 
           vi.mocked(util.isInstalledGlobally).mockReturnValue(true)
@@ -586,9 +586,6 @@ describe('/lib/tasks/install', function () {
 
           const plain = stripAnsi(output())
 
-          expect(plain).not.toContain(INSTALL_OUTPUT.globalInstallWarning)
-          expect(plain).not.toContain(INSTALL_OUTPUT.devDependencyPerProject)
-          expect(plain).not.toContain(INSTALL_OUTPUT.npmUninstallGlobalCypress)
           expect(plain).toContain(INSTALL_OUTPUT.finishedInstallation)
         })
       })

--- a/cli/test/lib/tasks/install.spec.ts
+++ b/cli/test/lib/tasks/install.spec.ts
@@ -567,7 +567,7 @@ describe('/lib/tasks/install', function () {
       })
 
       describe('as a global install', function () {
-        it('logs global warning and download', async function () {
+        it('does not log a global install warning and downloads', async function () {
           const output = createStdoutCapture()
 
           vi.mocked(util.isInstalledGlobally).mockReturnValue(true)
@@ -586,9 +586,9 @@ describe('/lib/tasks/install', function () {
 
           const plain = stripAnsi(output())
 
-          expect(plain).toContain(INSTALL_OUTPUT.globalInstallWarning)
-          expect(plain).toContain(INSTALL_OUTPUT.devDependencyPerProject)
-          expect(plain).toContain(INSTALL_OUTPUT.npmUninstallGlobalCypress)
+          expect(plain).not.toContain(INSTALL_OUTPUT.globalInstallWarning)
+          expect(plain).not.toContain(INSTALL_OUTPUT.devDependencyPerProject)
+          expect(plain).not.toContain(INSTALL_OUTPUT.npmUninstallGlobalCypress)
           expect(plain).toContain(INSTALL_OUTPUT.finishedInstallation)
         })
       })


### PR DESCRIPTION
- Closes #34134

### Additional details

Running `cypress install` when Cypress is installed globally printed a warning recommending that Cypress be installed as a per-project devDependency:

```
⚠ Warning: It looks like you've installed Cypress globally.

  The recommended way to install Cypress is as a devDependency per project.
  ...
```

This was a false positive when Cypress is *intentionally* installed globally — for example, the `cypress/included` Docker image installs Cypress with `npm install -g` because its `ENTRYPOINT` is `cypress run`, which requires the `cypress` binary to be on the `PATH` and has no host project to be a devDependency of.

The warning was also surfaced inconsistently: npm suppresses `postinstall` stdout, so it was effectively hidden for an accidental `npm install -g cypress`, but printed for the legitimate standalone `cypress install` flow (which is the path that the official images use, and which npm v11/v12's lifecycle-script restrictions push more users toward via `--ignore-scripts` + `cypress install`).

This PR removes the warning entirely from `displayCompletionMsg` in `cli/lib/tasks/install.ts`. The `util.isInstalledGlobally` helper is retained, as it is still used by `cli/lib/exec/open.ts`.

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Install Cypress globally with scripts ignored: `npm install -g cypress --ignore-scripts`
2. Run `cypress install`
3. Confirm the installation completes and **no** "It looks like you've installed Cypress globally" warning is printed.

Unit coverage lives in `cli/test/lib/tasks/install.spec.ts` under the `as a global install` block.

### How has the user experience changed?

**Before:** `cypress install` under a global install printed a warning advising the user to uninstall the global package and reinstall as a devDependency.

**After:** No warning is printed; the install completes with the normal completion output.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34134 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)