### PR TITLE
chore(ci): remove duplicate test run in npm-webpack-dev-server job

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2553,9 +2553,6 @@ jobs:
       - run:
           name: Run tests
           command: yarn workspace @cypress/webpack-dev-server test
-      - run:
-          name: Run tests
-          command: yarn workspace @cypress/webpack-dev-server test
 
   npm-vite-dev-server:
     <<: *defaults


### PR DESCRIPTION
- Closes N/A

### Additional details

The `npm-webpack-dev-server` CI job ran the exact same test command twice back-to-back:

```yaml
- run:
    name: Run tests
    command: yarn workspace @cypress/webpack-dev-server test
- run:
    name: Run tests
    command: yarn workspace @cypress/webpack-dev-server test
```

This was a copy-paste duplication that doubled the job's runtime with no added coverage. This PR removes the redundant second invocation, roughly halving the job's wall-clock time.

The change is made in the source config (`.circleci/src/pipeline/@pipeline.yml`); the `packed/` output is generated at CI runtime and is not checked in, so no generated files needed updating.

### Steps to test

- Confirm the `npm-webpack-dev-server` job in CI runs `yarn workspace @cypress/webpack-dev-server test` exactly once and still passes.

### How has the user experience changed?

No change. This is a CI-only change with no user-facing or behavioral impact.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical CI cleanup: removes an accidental duplicate step. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the type definitions?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eoUAD9KJxyc5TdfFSyMSM

---
_Generated by [Claude Code](https://claude.ai/code/session_017eoUAD9KJxyc5TdfFSyMSM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only YAML cleanup with no product, test, or release behavior changes beyond shorter job runtime.
> 
> **Overview**
> Removes a **duplicate CircleCI step** in the `npm-webpack-dev-server` job so `yarn workspace @cypress/webpack-dev-server test` runs once instead of twice.
> 
> The change is only in `.circleci/src/pipeline/@pipeline.yml`; it should cut that job’s wall time with no change to which tests run. The separate `run-webpack-dev-server-integration-tests` job is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94393f3648d1fc18987fe35eaeee14b117ea5779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->