### PR TITLE
feat: implement the tap CLI commands (specs, run, tests, commands)

### DIFF
--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -6,7 +6,7 @@ import { withTapSession, TapTransportError } from '../tap/tap-session'
 import type { TapSession } from '../tap/tap-session'
 import { buildTapProgram } from '../tap/build-program'
 import { renderFailure, renderInstancesHelp, renderResult, respondToHelp } from '../tap/output'
-import { TAP_BINDING_GLOBAL, TAP_EXEC_METHOD, TAP_PROTOCOL_VERSION, TAP_SCHEMA_METHOD } from '../tap/contract'
+import { TAP_EXEC_METHOD, TAP_PROTOCOL_VERSION, TAP_SCHEMA_METHOD } from '../tap/contract'
 import type { TapExecResult, TapSchema } from '../tap/contract'
 
 const debug = Debug('cypress:cli:tap')

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -15,7 +15,7 @@ type TapDispatch = (command: string, args: Record<string, string>, options: Reco
 
 // `run <spec>` for one required param, `foo <bar> [baz]` with an optional
 // second — commander's positional-argument grammar, derived from the schema.
-const argumentsOf = (params: readonly TapCommandParamSchema[]): string => {
+const argumentsFrom = (params: readonly TapCommandParamSchema[]): string => {
   return params.map(({ name, required }) => required ? `<${name}>` : `[${name}]`).join(' ')
 }
 
@@ -28,7 +28,7 @@ const argumentDescriptions = (params: readonly TapCommandParamSchema[]): Record<
 // alias. A required value option uses `requiredOption` so commander enforces
 // presence; the binding re-checks app-side regardless. No custom parser is
 // attached, so commander yields raw strings and coercion stays app-side.
-const declareOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
+const addCommandOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
   for (const { name, alias, type, required, description } of options) {
     const lead = alias ? `-${alias}, ` : ''
     const flags = type === 'boolean' ? `${lead}--${name}` : `${lead}--${name} <${name}>`
@@ -131,13 +131,13 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
     const command = program.command(name)
 
     if (params.length) {
-      command.arguments(argumentsOf(params))
+      command.arguments(argumentsFrom(params))
       command.description(description, argumentDescriptions(params))
     } else {
       command.description(description)
     }
 
-    declareOptions(command, options)
+    addCommandOptions(command, options)
 
     command.action(() => {
       // Read the matched command from the closure, not the action's varargs:

--- a/cli/lib/tap/contract.ts
+++ b/cli/lib/tap/contract.ts
@@ -15,9 +15,10 @@
  *
  * Every value MUST round-trip through JSON cleanly: the CLI invokes binding
  * methods over CDP `Runtime.callFunctionOn` with `returnByValue: true` +
- * `awaitPromise: true`, which serializes arguments and return values.
- * Failures are returned values, never thrown — a thrown error is treated as
- * a binding bug.
+ * `awaitPromise: true`, which serializes arguments and return values. Both
+ * dispatch and domain failures come back as `{ ok: false }` values (see
+ * `TapExecResult`); a binding method that actually throws is treated as a
+ * binding bug.
  */
 
 /** The runner-window global the binding is mounted on. */
@@ -74,11 +75,12 @@ export interface TapSchema {
 }
 
 /**
- * The wire envelope `exec` resolves with. `ok: false` covers dispatch-level
- * failures only (unknown command, positionals that do not satisfy the param
- * schema) — the CLI unwraps the envelope, so command results stay
- * envelope-free on stdout. Domain failures are values inside `ok: true`
- * results, shaped by each command.
+ * The wire envelope `exec` resolves with. On `ok: true` the CLI unwraps
+ * `result` to stdout, so command results stay envelope-free. `ok: false`
+ * covers both dispatch-level failures (unknown command, args that do not
+ * satisfy the schema) and domain failures a command raised (e.g. no run yet,
+ * no such spec); the CLI renders the message on stderr and exits non-zero for
+ * either, telling them apart only by `code`.
  */
 export type TapExecResult =
   | { ok: true, result: unknown }

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -18,7 +18,7 @@ describe('tap binding', () => {
       const schema = await binding.getSchema()
 
       expect(schema.protocolVersion).to.eq(1)
-      expect(schema.commands.map((command) => command.name)).to.include.members(['health', 'specs', 'run', 'tests'])
+      expect(schema.commands.map((command) => command.name)).to.include.members(['health', 'specs', 'run', 'tests', 'commands'])
 
       const unknown = await binding.exec('not-a-command')
 
@@ -29,6 +29,11 @@ describe('tap binding', () => {
       const testsBeforeRun = await binding.exec('tests')
 
       expect(testsBeforeRun).to.deep.include({ ok: false, code: 'NO_RUN' })
+
+      // The commands command reads the same runner, so it is NO_RUN too.
+      const commandsBeforeRun = await binding.exec('commands', {}, { test: 'r1' })
+
+      expect(commandsBeforeRun).to.deep.include({ ok: false, code: 'NO_RUN' })
 
       const outcome = await binding.exec('specs')
 
@@ -109,10 +114,31 @@ describe('tap binding', () => {
       expect(detail.timings).to.be.an('object')
       expect(detail.error).to.be.undefined
 
-      // An unknown test id details nothing — a domain failure.
+      // An unknown test id details nothing — same domain failure as commands.
       const missingDetail = await getBinding(win).exec('tests', { test: 'not-a-test' })
 
       expect(missingDetail).to.deep.include({ ok: false, code: 'TEST_NOT_FOUND' })
+
+      // The commands command reads that same test's command log from the runner.
+      const testId = tests[0].id as string
+
+      const commandsOutcome = await getBinding(win).exec('commands', {}, { test: testId })
+
+      expect(commandsOutcome.ok).to.eq(true)
+
+      const commands = (commandsOutcome as { ok: true, result: Array<Record<string, unknown>> }).result
+
+      expect(commands).to.have.length.greaterThan(0)
+
+      for (const command of commands) {
+        expect(Object.keys(command), `command ${command.id}`).to.include.members(['id', 'name'])
+        expect(Object.keys(command)).to.satisfy((keys: string[]) => keys.every((key) => ['id', 'name', 'message', 'state', 'type'].includes(key)))
+      }
+
+      // An unknown test id is a domain failure surfaced as ok: false.
+      const missing = await getBinding(win).exec('commands', {}, { test: 'not-a-test' })
+
+      expect(missing).to.deep.include({ ok: false, code: 'TEST_NOT_FOUND' })
     })
 
     // Rerunning the same spec advances the tapRun nonce, so the query change

--- a/packages/app/src/runner/tap/commands/commands.cy.ts
+++ b/packages/app/src/runner/tap/commands/commands.cy.ts
@@ -1,0 +1,106 @@
+import { TapManager } from '../tap-manager'
+import { tapRunnerSource } from './test-state'
+
+const CYPRESS_VERSION = '15.0.0'
+
+describe('tap/commands/commands', () => {
+  // getTestsState returns every test keyed by id, each carrying its full
+  // serialized command log. The fixture gives commands extra DISPLAY_PROPS
+  // (displayName, hookId, …) to prove the handler keeps only the lean fields.
+  const TESTS_STATE = {
+    r2: {
+      id: 'r2',
+      title: 'logs in',
+      state: 'passed',
+      commands: [
+        { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent', displayName: 'visit', hookId: 'h1' },
+        { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+      ],
+    },
+    // A test that has not run yet carries no command log.
+    r3: {
+      id: 'r3',
+      title: 'logs out',
+    },
+  }
+
+  // The spec window's own `window.Cypress` is the instance running this
+  // test, so every test stubs the runner seam instead of replacing it.
+  const stubRunner = (runner: unknown) => cy.stub(tapRunnerSource, 'getRunner').returns(runner)
+
+  it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
+    stubRunner(undefined)
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands', {}, { test: 'r2' })
+
+    expect(outcome).to.deep.eq({
+      ok: false,
+      code: 'NO_RUN',
+      message: 'no spec has been run yet — use the run command to run a spec first',
+    })
+  })
+
+  it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
+    const getTestsState = cy.stub().returns(TESTS_STATE)
+
+    stubRunner({ getTestsState })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands', {}, { test: 'nope' })
+
+    expect(getTestsState).to.have.been.calledOnceWith('__never__')
+    expect(outcome).to.deep.eq({
+      ok: false,
+      code: 'TEST_NOT_FOUND',
+      message: 'no test of this run matches the id "nope" — use the tests command to list this run’s tests',
+    })
+  })
+
+  it('returns just the command log via the __never__ sentinel, keeping only the lean entry fields', async () => {
+    const getTestsState = cy.stub().returns(TESTS_STATE)
+
+    stubRunner({ getTestsState })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands', {}, { test: 'r2' })
+
+    // '__never__' (not the test id) is the sentinel — getTestsState excludes
+    // the matching id and everything after it, so passing 'r2' would drop it.
+    expect(getTestsState).to.have.been.calledOnceWith('__never__')
+
+    expect(outcome).to.deep.eq({
+      ok: true,
+      result: [
+        { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
+        { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+      ],
+    })
+  })
+
+  it('returns an empty command list for a known test that has not run yet, and round-trips through JSON', async () => {
+    stubRunner({ getTestsState: () => TESTS_STATE })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands', {}, { test: 'r3' })
+
+    expect(outcome).to.deep.eq({ ok: true, result: [] })
+
+    expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+  })
+
+  it('fails dispatch without reading the runner when the required test option is missing', async () => {
+    const getRunner = stubRunner({ getTestsState: () => ({}) })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands')
+
+    expect(outcome).to.deep.include({ ok: false, code: 'INVALID_ARGUMENTS' })
+    expect(getRunner).not.to.have.been.called
+  })
+})

--- a/packages/app/src/runner/tap/commands/commands.ts
+++ b/packages/app/src/runner/tap/commands/commands.ts
@@ -1,0 +1,30 @@
+import { defineCommand, TapCommandError } from './definition'
+import { serializeTestCommands, tapRunnerSource } from './test-state'
+import type { CommandEntry } from './test-state'
+
+export const commandsCommand = defineCommand({
+  description: 'list the command-log entries of a test of the active run',
+  params: [],
+  options: [
+    { name: 'test', type: 'string', required: true, description: 'test id, as listed by the tests command' },
+  ],
+  // Returns just the test's command-log entries. A known test that has not run
+  // yet has no log, which is an empty array — not a failure. The two failure
+  // cases throw: NO_RUN when no spec has mounted a runner, TEST_NOT_FOUND when
+  // the run holds no test with that id — both surface on stderr, never stdout.
+  handler: async (_params, { test }): Promise<CommandEntry[]> => {
+    const runner = tapRunnerSource.getRunner()
+
+    if (!runner) {
+      throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+    }
+
+    const commands = serializeTestCommands(runner, test)
+
+    if (commands === undefined) {
+      throw new TapCommandError('TEST_NOT_FOUND', `no test of this run matches the id "${test}" — use the tests command to list this run’s tests`)
+    }
+
+    return commands
+  },
+})

--- a/packages/app/src/runner/tap/commands/index.ts
+++ b/packages/app/src/runner/tap/commands/index.ts
@@ -1,3 +1,4 @@
+import { commandsCommand } from './commands'
 import type { TapCommandDefinition } from './definition'
 import { healthCommand } from './health'
 import { runCommand } from './run'
@@ -15,4 +16,5 @@ export const tapCommands = {
   specs: specsCommand,
   run: runCommand,
   tests: testsCommand,
+  commands: commandsCommand,
 } satisfies Record<string, TapCommandDefinition>

--- a/packages/app/src/runner/tap/commands/test-state.ts
+++ b/packages/app/src/runner/tap/commands/test-state.ts
@@ -53,6 +53,24 @@ export interface TestDetailEntry {
 }
 
 /**
+ * One command-log entry of a test, trimmed to the fields a tap caller needs to
+ * follow what a test did — the reporter's command list. Optional fields are
+ * absent (never `null` — JSON drops `undefined` keys at the CDP boundary) when
+ * the serialized log did not carry them.
+ */
+export interface CommandEntry {
+  id: string
+  /** Command name, e.g. `visit`, `get`, `click`. */
+  name?: string
+  /** The command's argument summary, e.g. the URL, selector, or assertion text. */
+  message?: string
+  /** `passed` | `failed` | `pending` once the command has settled. */
+  state?: string
+  /** `parent` | `child` | `dual`. */
+  type?: string
+}
+
+/**
  * The slice of the driver's `Cypress.runner` the tap commands consume.
  * `getTestsState(testId)` serializes the run's tests up to (excluding) the
  * one whose id matches, so a never-matching sentinel yields every test.
@@ -150,4 +168,35 @@ export const serializeTestDetail = (runner: TapTestsRunner, testId: string): Tes
     ...(timings !== undefined ? { timings } : {}),
     ...(err !== undefined ? { error: serializeTestError(err) } : {}),
   }
+}
+
+/**
+ * Serialize the command log of one test into lean, JSON-clean entries.
+ * Returns `undefined` when no test of the run has that id (the command turns
+ * this into a `testNotFound` result); a known test that has not run yet has no
+ * command log, which serializes to an empty array, not a failure.
+ */
+export const serializeTestCommands = (runner: TapTestsRunner, testId: string): CommandEntry[] | undefined => {
+  // '__never__' serializes every test with its logs. We must NOT pass testId:
+  // getTestsState serializes tests UP TO (excluding) the matching id, so it
+  // would never include the test we are after.
+  const test = runner.getTestsState('__never__')[testId]
+
+  if (!test) {
+    return undefined
+  }
+
+  // `commands` is one of the serialized RUNNABLE_LOGS; it is absent until the
+  // test runs and is otherwise an array of serialized command logs.
+  const commands = (test.commands ?? []) as Array<Record<string, unknown>>
+
+  return commands.map(({ id, name, message, state, type }): CommandEntry => {
+    return {
+      id: id as string,
+      ...(name !== undefined ? { name: name as string } : {}),
+      ...(message !== undefined ? { message: message as string } : {}),
+      ...(state !== undefined ? { state: state as string } : {}),
+      ...(type !== undefined ? { type: type as string } : {}),
+    }
+  })
 }


### PR DESCRIPTION
- Closes: N/A (internal, experimental tap CLI work — no public GitHub issue)

### Additional details

The "tap CLI" feature mounts a `__CYPRESS_TAP_BINDING__` binding on the runner window and wires the `cypress tap` CLI to it over CDP (`getSchema` + `exec(command, args)`); the binding so far ships only a `health` command. This PR adds the actual commands an external caller drives a running Cypress instance with, and reshapes the binding internals so adding a command stays a one-entry job.

- **New subcommands** (all registered in the new `packages/app/src/runner/tap/commands/index.ts` registry):
  - `specs` — lists the specs the running instance can run, read from the server-embedded `window.__RUN_MODE_SPECS__` snapshot, trimmed to lean `{ relative, specType }` entries.
  - `run <spec>` — runs (or reruns) a spec by its project-relative path. Fire-and-forget: it navigates the runner via a hash change and resolves with the started spec's lean entry — resolution means navigation was issued, not that the spec passed.
  - `tests [test]` — lists the active run's tests and state (`{ id, title, duration?, state, retries? }`), or details one test by id (adds `fullTitle`, per-phase `timings`, and the latest attempt's trimmed `error`).
  - `commands` (with required `--test <id>`) — returns that test's command-log entries (`{ id, name?, message?, state?, type? }`).
- **Registry refactor**: the former single `commands.ts` is split into `commands/` — one module per command (`health.ts`, `specs.ts`, `run.ts`, `tests.ts`, `commands.ts`) plus `definition.ts` (the `defineCommand` helper and shared types) and `index.ts` (the registry). Per-command result shapes now live with their command and reach the CLI as opaque JSON; they are explicitly NOT part of the frozen contract.
- **Domain failures**: a new `TapCommandError` (in `commands/definition.ts`) lets a handler signal a failure it ran into but expected (`NO_RUN`, `TEST_NOT_FOUND`, `SPEC_NOT_FOUND`, `INVALID_SPEC`). `TapManager.exec` catches it and returns `{ ok: false, code, message }` — the same envelope dispatch failures use — so the CLI renders the message on stderr and exits non-zero either way; only `code` tells them apart. Any other throw still propagates as a binding bug. The contract docs and `TapExecResult` are updated accordingly: `code` is now an open `string`, with the reserved dispatch codes captured as `TapExecDispatchFailureCode` (`UNKNOWN_COMMAND` | `INVALID_ARGUMENTS`).
- **Runner state access** (`commands/test-state.ts`): the tests/commands handlers read the driver via a `tapRunnerSource` seam that resolves the instance from the event manager (`window.getEventManager().getCypress().runner`), not `window.Cypress` — under the cypress-in-cypress harness `window.Cypress` is the outer driver. Serialization passes a `'__never__'` sentinel to `getTestsState`, which serializes tests up to (excluding) the matching id, so a never-matching id yields every test. All entries are built with optional keys omitted rather than set to `undefined`, so the in-memory value already equals its JSON wire form.
- **`run` navigation** (`commands/run.ts`): navigation goes through a `tapNavigation.setHash` seam (a synchronous same-document fragment change, which survives even when the runner page is itself an AUT). A module-level `tapRunNonce` is appended as `&tapRun=<n>` so rerunning the already-active spec still changes `route.query` and re-triggers the unified runner's `watchSpecs` effect; the spec path is matched and emitted in posix form.
- **Driver/types change**: `RUNNABLE_LOGS`, `RUNNABLE_PROPS`, and a new `SerializedTest` type move from `packages/driver/src/cypress/runner.ts` into `@packages/types` (`src/driver.ts`) so the serialized-test shape has one shared key source. `getTestsState` and `serializeTest` are typed against it.
- CLI helper rename only in `cli/lib/tap/build-program.ts` (`argumentsOf` → `argumentsFrom`, `declareOptions` → `addCommandOptions`); no behavior change. `cli/lib/exec/tap.ts` drops an unused import. `cli/lib/tap/contract.ts` doc comment updated to match the app-side contract.

### Steps to test

Component specs (app-side handlers, fully stubbed):

```bash
yarn cypress:run:ct -- --spec "packages/app/src/runner/tap/commands/*.cy.ts,packages/app/src/runner/tap/exec-args.cy.ts,packages/app/src/runner/tap/tap-manager.cy.ts"
```

End-to-end against a real runner (cypress-in-cypress harness), which exercises the full binding round-trip — `specs`, `run`, rerun via the nonce, `tests` list + detail, and `commands`:

```bash
yarn cypress:run -- --spec "packages/app/cypress/e2e/tap-binding.cy.ts"
```

That e2e drives the binding directly from the spec window: `exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })` navigates to the runner and resolves with the spec entry; after the run finishes, `exec('tests')`, `exec('tests', { test })`, and `exec('commands', {}, { test })` read the runner state; a second `run` of the same spec advances `tapRun` to force a rerun; and a missing spec resolves `{ ok: false, code: 'SPEC_NOT_FOUND' }` without navigating.

### How has the user experience changed?

This is a developer/automation-facing CLI surface (no GUI change). What's now possible: an external caller holding the runner binding can drive a running Cypress instance beyond the `health` ping — list runnable specs, run/rerun a spec by path, and read back per-test state, per-test detail (full title, timings, error), and a test's command log. Failures the caller can expect (no run yet, unknown test, unknown/empty spec) surface as `{ ok: false, code, message }` so the CLI can render them on stderr and exit non-zero.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal, experimental tap CLI epic; follow-on to the tap CLI handshake stack, no public issue. -->
- [x] Have tests been added/updated? <!-- Component specs for each command (specs/run/tests/commands), exec-args, and tap-manager domain-error handling, plus the tap-binding e2e exercising the full round-trip. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Internal/experimental CLI, not documented yet. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` type definitions; all types are internal to @packages/app and @packages/types. -->

