### PR TITLE
feat(proxy): support nonce injection for style-src and add directive …

### DIFF
--- a/packages/proxy/lib/http/util/csp-header.ts
+++ b/packages/proxy/lib/http/util/csp-header.ts
@@ -4,7 +4,7 @@ const cspRegExp = /[; ]*([^\n\r; ]+) ?([^\n\r;]+)*/g
 
 export const cspHeaderNames = ['content-security-policy', 'content-security-policy-report-only'] as const
 
-export const nonceDirectives = ['script-src-elem', 'script-src', 'default-src']
+export const nonceDirectives = ['script-src-elem', 'script-src', 'default-src', 'style-src']
 
 export const problematicCspDirectives = [
   ...nonceDirectives,

--- a/packages/proxy/test/unit/http/util/csp-header.spec.ts
+++ b/packages/proxy/test/unit/http/util/csp-header.spec.ts
@@ -130,6 +130,15 @@ describe('http/util/csp-header', () => {
   })
 
   describe('generateCspDirectives', () => {
+    it('should generate a CSP directive string including style-src', () => {
+      const policyMap = new Map<string, string[]>()
+
+      policyMap.set('style-src', ['self', 'https://fonts.googleapis.com'])
+
+      expect(generateCspDirectives(policyMap))
+        .toEqual('style-src self https://fonts.googleapis.com')
+    })
+
     it(`should generate a CSP directive string from a policy map`, () => {
       const policyMap = new Map<string, string[]>()
 


### PR DESCRIPTION
…generation test

Add `style-src` to the `nonceDirectives` list so the proxy correctly recognizes and processes nonce-capable style directives. This aligns style CSP handling with existing script-src behavior.

Also adds a unit test to `generateCspDirectives` verifying that a policy map containing `style-src` is serialized into a valid CSP directive string.

This is a partial fix for #30580

This [CSP](https://docs.cypress.io/app/references/content-security-policy) documentation will also need an update.

<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
