### PR TITLE
chore(ci): run pure-Node jobs on slim node image

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -133,7 +133,7 @@ executors:
     environment:
       PLATFORM: linux
 
-  # Slim Node image for pure-Node jobs (check-ts, lint-types, health-check) that
+  # Slim Node image for pure-Node jobs (check-ts, lint-types, health-check)
   node-slim:
     docker:
       - image: cimg/node:22.19.0

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -133,6 +133,17 @@ executors:
     environment:
       PLATFORM: linux
 
+  # Slim Node image for pure-Node jobs (check-ts, lint-types, health-check) that
+  # need neither browsers nor the Electron build toolchain. Pulls/decompresses
+  # much faster than base-internal. Stays glibc-based (Ubuntu) and pins the same
+  # Node version, so the cached node_modules remain ABI-compatible.
+  cy-node-slim:
+    docker:
+      - image: cimg/node:22.19.0
+    resource_class: medium
+    environment:
+      PLATFORM: linux
+
   kitchensink-executor:
     docker:
       - image: *base-internal-trixie
@@ -1727,6 +1738,8 @@ jobs:
 
   check-ts:
     <<: *defaults
+    # Pure-Node type check — no browsers/Electron libs needed, so use the slim image.
+    executor: cy-node-slim
     steps:
       - restore_cached_workspace
       - install-required-node
@@ -1736,6 +1749,8 @@ jobs:
 
   health-check:
     <<: *defaults
+    # Pure-Node Knip analysis — no browsers/Electron libs needed, so use the slim image.
+    executor: cy-node-slim
     steps:
       - restore_cached_workspace
       - install-required-node
@@ -2045,6 +2060,8 @@ jobs:
 
   lint-types:
     <<: *defaults
+    # Pure-Node dtslint run — no browsers/Electron libs needed, so use the slim image.
+    executor: cy-node-slim
     parallelism: 1
     steps:
       - restore_cached_workspace

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -134,10 +134,7 @@ executors:
       PLATFORM: linux
 
   # Slim Node image for pure-Node jobs (check-ts, lint-types, health-check) that
-  # need neither browsers nor the Electron build toolchain. Pulls/decompresses
-  # much faster than base-internal. Stays glibc-based (Ubuntu) and pins the same
-  # Node version, so the cached node_modules remain ABI-compatible.
-  cy-node-slim:
+  node-slim:
     docker:
       - image: cimg/node:22.19.0
     resource_class: medium
@@ -1738,8 +1735,7 @@ jobs:
 
   check-ts:
     <<: *defaults
-    # Pure-Node type check — no browsers/Electron libs needed, so use the slim image.
-    executor: cy-node-slim
+    executor: node-slim
     steps:
       - restore_cached_workspace
       - install-required-node
@@ -1749,8 +1745,7 @@ jobs:
 
   health-check:
     <<: *defaults
-    # Pure-Node Knip analysis — no browsers/Electron libs needed, so use the slim image.
-    executor: cy-node-slim
+    executor: node-slim
     steps:
       - restore_cached_workspace
       - install-required-node
@@ -2060,8 +2055,7 @@ jobs:
 
   lint-types:
     <<: *defaults
-    # Pure-Node dtslint run — no browsers/Electron libs needed, so use the slim image.
-    executor: cy-node-slim
+    executor: node-slim
     parallelism: 1
     steps:
       - restore_cached_workspace


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `check-ts`, `lint-types`, and `health-check` jobs need neither browsers nor the Electron build toolchain, yet they pulled the full `cypress/base-internal:22.19.0-trixie` build image on every run. This adds a `node-slim` executor (`cimg/node:22.19.0`) and points those three jobs at it, cutting image pull/decompress time on this slice of the matrix.

- The slim image stays glibc-based (Ubuntu) and pins the same Node `22.19.0`, so the cached `node_modules` (including the native `better-sqlite3` prebuild) remain ABI-compatible. None of these three jobs load native modules anyway — they run `tsc`, `dtslint`, and Knip respectively.
- `lint` is intentionally **not** migrated: its `node cli/bin/cypress info --dev` step boots the dev server path, which loads the native `better-sqlite3` addon, so it stays on `cy-docker`.
- Only `.circleci/src/` is edited; `.circleci/packed/` is gitignored and rebuilt on-the-fly in CI.

#### Before

<img width="311" height="54" alt="Screenshot 2026-06-23 at 9 56 42 AM" src="https://github.com/user-attachments/assets/7c982086-b4fd-4af4-9c68-4a13a3daffe3" />
<img width="311" height="53" alt="Screenshot 2026-06-23 at 9 56 33 AM" src="https://github.com/user-attachments/assets/1b7a590d-564e-47d2-955a-17391ec9646b" />
<img width="307" height="55" alt="Screenshot 2026-06-23 at 9 56 26 AM" src="https://github.com/user-attachments/assets/3ae1196f-5886-4042-bfb1-891929a24357" />


#### After (not much difference really)

<img width="310" height="62" alt="Screenshot 2026-06-23 at 9 54 39 AM" src="https://github.com/user-attachments/assets/2f5b281c-ca28-4a8d-9f42-a7a1f4ba0359" />
<img width="317" height="52" alt="Screenshot 2026-06-23 at 9 54 26 AM" src="https://github.com/user-attachments/assets/8e3802d2-cc31-448c-8b69-c322d5047c02" />
<img width="316" height="57" alt="Screenshot 2026-06-23 at 9 54 48 AM" src="https://github.com/user-attachments/assets/ac8154f2-f201-4a65-b1a8-50c3edf64ed3" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Touches only CircleCI executor wiring for three Node-only jobs; no product code, auth, or release behavior changes.
> 
> **Overview**
> **CI-only change:** adds a `node-slim` CircleCI executor (`cimg/node:22.19.0`) and switches **`check-ts`**, **`health-check`**, and **`lint-types`** off the full `cypress/base-internal` image so those jobs avoid pulling the heavy browser/Electron toolchain image.
> 
> **`lint`** is unchanged on `cy-docker` because its `cypress info --dev` step still needs the full environment (including native addons). Job commands and workspace restore steps are the same; only the Docker image for those three jobs changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f14d62649f646d3992220b56f41823a48f07ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

CI itself is the test surface. On this PR, confirm that the `check-ts`, `lint-types`, and `health-check` jobs run on the `node-slim` executor (`cimg/node:22.19.0`) and pass, and that `lint` still runs on `cy-docker`.

### How has the user experience changed?

No change — internal CI-only change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical CI-infrastructure change; no behavioral/user-facing change. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1Xc1CDWt7qx5mqQUH76Aw)_