### PR TITLE
chore: add code comment conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,31 @@ yarn clean-deps && yarn
 - **Blank line before `return`** — Enforced via `padding-line-between-statements`.
 - **Sync FS calls** — Flagged with a warning (except `existsSync`); prefer async variants.
 
+### Code Comments
+
+- **Prefer none** — Always prefer no code comment if the code is self-explanatory.
+- **Explain the why** — When a comment is necessary, use it to explain the *why* and anything relevant that is not directly expressed by the code itself.
+- **Don't repeat yourself** — Do not restate the same comment multiple times in a file as the code flows through each step.
+- **Present state only** — Keep comments relevant to the current state of the code. Do not describe what changed or how the code used to be different.
+
+Bad examples:
+
+```js
+// never wipe the entire jar - the old hack called clearCookies() with no filter
+// we no longer need to clear the state here, CDP added automatically clearing
+// Firefox previously relied on os-level focus, now we use WebDrive BiDi to focus
+```
+
+Good examples:
+
+```js
+// Close any extra pages so they don't leak into other tests
+// Firefox doesn't support this in native BiDi, so we pull remote.location from current frame
+// `cookie`'s serializer rejects an IPv6 literal Domain (e.g. `[::1]`), crashing
+// the proxy. Browsers scope cookies for IP hosts to that host anyway, so omit
+// Domain and let the cookie default to host-only.
+```
+
 ## Pull Requests
 
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) is the source of truth for PR conventions, including the semantic-release title prefix that determines the next version. The other essentials:


### PR DESCRIPTION
### Additional details

Adds a **Code Comments** subsection to the repo's base `AGENTS.md` (under **Code Conventions**), codifying how code comments should be written:

- Prefer no comment when the code is self-explanatory.
- When a comment is necessary, explain the *why* and anything not directly expressed by the code.
- Don't repeat the same comment as the code flows through each step of a file.
- Keep comments relevant to the present state — don't describe what changed or how the code used to be different.

Includes concrete bad/good examples. `AGENTS.md` is the correct base read: `CLAUDE.md` imports it via `@AGENTS.md`, so this guidance loads every session. This is a docs-only change to agent guidance — no code or behavior is affected.

### Steps to test

N/A — documentation-only change.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical/docs-only change to agent guidance. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent guidance; no application code, tests, or user-facing product behavior.
> 
> **Overview**
> Adds a **Code Comments** subsection under **Code Conventions** in `AGENTS.md`, documenting how contributors and agents should write inline comments: skip comments when code is clear, explain *why* when needed, avoid repeating the same note through a file, and describe present behavior only (not diffs or history).
> 
> The section includes **bad** vs **good** JavaScript comment examples. Because `CLAUDE.md` imports `@AGENTS.md`, this guidance applies to agent-assisted sessions without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d62f9de5db90ae7d4e9f99b15344bd251b9c704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->