### PR TITLE
chore(ci): run static analysis after node_modules install only

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -57,21 +57,21 @@ jobs:
           only: /^pull\/[0-9]+/
   - check-ts:
       requires:
-        - internal-pr-build
-        - external-pr-build
+        - node_modules_install
+        - contributor-node-modules-install
   - health-check:
       requires:
-        - internal-pr-build
-        - external-pr-build
+        - node_modules_install
+        - contributor-node-modules-install
   - lint:
       name: linux-lint
       requires:
-        - internal-pr-build
-        - external-pr-build
+        - node_modules_install
+        - contributor-node-modules-install
   - lint-types:
       requires:
-        - internal-pr-build
-        - external-pr-build
+        - node_modules_install
+        - contributor-node-modules-install
   # The following jobs are only run for contributor PRs once they are approved.
   # Each job checks its pipeline parameter at startup and halts early if the
   # changed files don't require it to run.


### PR DESCRIPTION
## Summary
- Start `check-ts`, `health-check`, `linux-lint`, and `lint-types` after `node_modules_install` instead of waiting on build
- Static analysis runs in parallel with `internal-pr-build` / `external-pr-build` on PR pipelines

## Test plan
- [ ] Confirm `linux-lint` / `check-ts` start before `internal-pr-build` finishes
- [ ] Confirm `all-jobs-passed` still passes

Made with [Cursor](https://cursor.com)