### PR TITLE
chore(ci): add ready-to-test gate for PR workflow requires

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -3210,3 +3210,13 @@ jobs:
       - run:
           name: All jobs passed
           command: echo "✅ All required jobs passed"
+
+  # Fan-in gate: build complete and contributor PR approved (when applicable).
+  ready-to-test:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small
+    steps:
+      - run:
+          name: Ready to test
+          command: echo "✅ Build finished and contributor PR approved"

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -55,6 +55,11 @@ jobs:
       filters:
         branches:
           only: /^pull\/[0-9]+/
+  - ready-to-test:
+      requires:
+        - internal-pr-build
+        - external-pr-build
+        - approve-contributor-pr
   - check-ts:
       requires:
         - internal-pr-build
@@ -78,35 +83,23 @@ jobs:
   - cli-visual-tests:
       context: test-runner:percy
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - unit-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - server-unit-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - server-integration-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - server-performance-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - system-tests-node-modules-install:
       context: test-runner:performance-tracking
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - system-tests-chrome:
       context: test-runner:performance-tracking
       requires:
@@ -131,50 +124,34 @@ jobs:
   - driver-integration-tests-chrome:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-chrome-inject-document-domain:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-chrome-beta:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-chrome-beta-inject-document-domain:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-firefox:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-electron:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-tests-webkit:
       context: test-runner:cypress-record-key
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - driver-integration-memory-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-frontend-shared-component-tests-chrome:
       context:
         [
@@ -184,9 +161,7 @@ jobs:
         ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-launchpad-integration-tests-chrome:
       context:
         [
@@ -196,9 +171,7 @@ jobs:
         ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-launchpad-component-tests-chrome:
       context:
         [
@@ -208,9 +181,7 @@ jobs:
         ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-app-integration-tests-chrome:
       context:
         [
@@ -220,9 +191,7 @@ jobs:
         ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-webpack-dev-server-integration-tests:
       context: [ test-runner:cypress-record-key, test-runner:percy ]
       requires:
@@ -240,95 +209,61 @@ jobs:
         ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - run-reporter-component-tests-chrome:
       context: [ test-runner:cypress-record-key, test-runner:percy ]
       percy: true
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - reporter-integration-tests:
       context: [ test-runner:cypress-record-key, test-runner:percy ]
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-webpack-dev-server:
       requires:
         - system-tests-node-modules-install
   - npm-vite-dev-server:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-vite-plugin-cypress-esm:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-webpack-preprocessor:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-webpack-batteries-included-preprocessor:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-vue:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-puppeteer-unit-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-puppeteer-cypress-tests:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-react:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-angular:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-angular-zoneless:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-mount-utils:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-grep:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-eslint-plugin-dev:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - npm-cypress-schematic:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - v8-integration-tests:
       requires:
         - system-tests-node-modules-install
@@ -356,9 +291,7 @@ jobs:
         - wait-for-binary-publish
   - test-kitchensink:
       requires:
-        - internal-pr-build
-        - external-pr-build
-        - approve-contributor-pr
+        - ready-to-test
   - test-npm-module-on-minimum-node-version:
       context: publish-binary
       requires:


### PR DESCRIPTION
- Closes N/A

### Additional details

Consolidates the PR workflow dual-path fan-in (`internal-pr-build`, `external-pr-build`, `approve-contributor-pr`) into a single `ready-to-test` gate job. ~37 test jobs now depend on one gate instead of repeating three `requires` lines.

Static analysis jobs (`check-ts`, `linux-lint`, `health-check`, `lint-types`) intentionally remain on direct build requires — they need build artifacts in the workspace (validated by closing #34171).

No behavioral change for internal vs external PR filtering.

### Steps to test

- [x] `ready-to-test` passes on internal PR pipeline (83224, job 3744708)
- [x] Test jobs fan in through `ready-to-test` and run after build
- [ ] `all-jobs-passed` passes on a clean CI run (previous run blocked by unrelated `system-tests-chrome` cookie assertion failure)

### How has the user experience changed?

No change

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? N/A — mechanical CI workflow refactor
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in cypress-documentation?
- [na] Have API changes been updated in the type definitions?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow graph refactor only; intended behavior matches the prior triple `requires` pattern, with static analysis jobs unchanged.
> 
> **Overview**
> Introduces a lightweight **`ready-to-test`** CircleCI job that fans in **`internal-pr-build`**, **`external-pr-build`**, and **`approve-contributor-pr`**, so contributor approval and the correct build path complete before heavy test work starts.
> 
> Roughly **37 PR test/npm jobs** now **`require: ready-to-test`** instead of repeating the same three **`requires`** entries. **Static analysis jobs** (`check-ts`, `health-check`, `linux-lint`, `lint-types`) still depend only on the build jobs so they can use build workspace artifacts.
> 
> The new job is defined in **`@pipeline.yml`** as a no-op echo step, matching the existing **`all-jobs-passed`** aggregator pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce0d99514f1e7034f225a00f7861f585c7056b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->