### PR TITLE
chore: de-flake cy.origin waiting "throws when foo cannot resolve" driver test

### DIFF
--- a/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
@@ -303,20 +303,19 @@ context('cy.origin waiting', { browser: '!webkit' }, () => {
         })
       })
 
-      it('throws when foo cannot resolve', { requestTimeout: 100 }, (done) => {
+      it('throws when foo cannot resolve', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.include('`cy.wait()` timed out waiting `100ms` for the 1st request to the route: `foo`. No request ever occurred.')
+          expect(err.message).to.include('for the 1st request to the route: `foo`. No request ever occurred.')
 
           done()
         })
-
-        cy.once('command:retry', () => xhrGet('/bar'))
 
         cy.intercept('/foo', {}).as('foo')
         cy.intercept('/bar', {}).as('bar')
 
         cy.origin('http://www.foobar.com:3500', () => {
-          cy.wait(['@foo', '@bar'])
+          cy.then(() => window.xhrGet('/bar'))
+          .wait(['@foo', '@bar'], { requestTimeout: 100 })
         })
       })
 

--- a/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts
@@ -305,7 +305,7 @@ context('cy.origin waiting', { browser: '!webkit' }, () => {
 
       it('throws when foo cannot resolve', (done) => {
         cy.on('fail', (err) => {
-          expect(err.message).to.include('for the 1st request to the route: `foo`. No request ever occurred.')
+          expect(err.message).to.include('`cy.wait()` timed out waiting `100ms` for the 1st request to the route: `foo`. No request ever occurred.')
 
           done()
         })


### PR DESCRIPTION
- Closes N/A

### Additional details

**Why was this change necessary?**

The driver test `cy.origin waiting` → `errors` → `throws when foo cannot resolve` (`packages/driver/cypress/e2e/e2e/origin/commands/waiting.cy.ts`) is intermittently flaky in CI, failing with:

> `Timed out after 4000ms. The done() callback was never invoked!`

i.e. the expected `cy.wait()` timeout failure didn't propagate back and call `done()` within mocha's per-test timeout, so the run tripped the `done()` timeout instead.

**What was the test doing?**

The test waits on a two-alias array `cy.wait(['@foo', '@bar'])` inside `cy.origin` where `@foo` never receives a request, and asserts it times out on the first unresolved alias. The `@bar` request was fired from a **primary-origin** `command:retry` listener:

```js
cy.once('command:retry', () => xhrGet('/bar'))
...
cy.origin('http://www.foobar.com:3500', () => {
  cy.wait(['@foo', '@bar'])
})
```

The `cy.wait` retries inside the **secondary** origin (`www.foobar.com`), but the `command:retry` listener that drives the `/bar` request is registered in the **primary** origin. That cross-boundary coupling makes the timing of the `/bar` request — and the propagation of the resulting failure back to the primary `cy.on('fail')` handler — non-deterministic, which is the source of the intermittent `done()` timeout.

**What changed**

- Trigger the `/bar` request deterministically **inside** the origin via `cy.then(() => window.xhrGet('/bar'))`, matching the pattern already used by sibling tests in this file (e.g. lines 98, 269, 301).
- Move `requestTimeout: 100` from a test-level config override onto the `cy.wait` command directly, so the short timeout is applied to the command regardless of cross-origin config propagation.
- The assertion is unchanged — `requestTimeout` is still `100ms`, so the error message is identical.

**Coverage**

`@foo` is still never requested, so `cy.wait` still times out on the first alias and throws the same `No request ever occurred` error. The assertion is byte-for-byte identical to before.

> [!NOTE]
> One intentional behavioral nuance changes: previously `@bar`'s request landed *during* the wait's retry loop; now it is satisfied just before the wait begins. The asserted behavior (timeout on the unresolved `@foo`) is identical, but this no longer exercises the "request for a later array alias arrives mid-wait" timing specifically. Flagging for reviewer awareness. Opened as a **draft** pending CI confirmation that the cy.origin suite passes green across the browser matrix, since this is a flake fix that should be validated on CI rather than asserted from a single run.

### Steps to test

1. Run the driver origin waiting spec across browsers:
   ```bash
   yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/e2e/origin/commands/waiting.cy.ts
   ```
2. Confirm `cy.origin waiting > errors > throws when foo cannot resolve` passes consistently (ideally over repeated runs / the CI browser matrix), without the intermittent `done()` timeout.

### How has the user experience changed?

No change. This is a test-only change (CI stability); no product code is touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-only flake fix; no product behavior change. -->
- [x] Have tests been added/updated? <!-- The flaky test itself is updated. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSB732fFjhTxFXveuzb1VE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no product or runtime behavior impact; only adjusts how a flaky e2e spec sets up timing and timeouts.
> 
> **Overview**
> Stabilizes the **`cy.origin waiting` → `errors` → `throws when foo cannot resolve`** driver spec, which intermittently hit Mocha’s `done()` timeout instead of the expected `cy.wait()` failure.
> 
> The test still asserts that `cy.wait(['@foo', '@bar'])` times out on `@foo` when no `/foo` request occurs. **`/bar` is now triggered inside the secondary origin** via `cy.then(() => window.xhrGet('/bar'))`, aligned with sibling tests in the same file, instead of firing from a primary-origin `command:retry` listener. **`requestTimeout: 100`** moves from the test config onto **`cy.wait(..., { requestTimeout: 100 })`** so the short timeout applies reliably across origins. The expected error message is unchanged.
> 
> **Note:** `@bar` is satisfied before the wait starts rather than mid-retry; the asserted failure on `@foo` is the same, but the “later alias arrives during wait retries” timing is no longer exercised here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5feffd422c85b4550efda66a6a52fd860ec21d6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->