### PR TITLE
refactor: add support for default selected instances where possible (4)

### DIFF
--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -14,8 +14,6 @@ export { isPidAlive, verifyInstanceRecord } from './liveness'
 export { getInstancesDir, pruneDeadInstanceRecords, readInstanceRecords } from './store'
 
 export interface ListInstanceOptions {
-  /** Optional project-root filter; omitted lists instances across all projects. */
-  projectRoot?: string
   /** Optional pid filter; omitted lists every matching instance. */
   instance?: number
   probeTimeoutMs?: number
@@ -25,11 +23,10 @@ const matchesProject = (record: CypressInstance, projectRoot: string): boolean =
   return path.resolve(record.projectRoot) === path.resolve(projectRoot)
 }
 
-// An undefined facet does not constrain, so an absent `--project` (every
-// project) and an absent `--instance` (every pid) narrow records the same way.
-const matchesFilters = (record: CypressInstance, projectRoot: string | undefined, instance: number | undefined): boolean => {
-  return (projectRoot === undefined || matchesProject(record, projectRoot))
-    && (instance === undefined || record.pid === instance)
+// An undefined instance does not constrain, so an absent `--instance` lists
+// every pid.
+const matchesInstance = (record: CypressInstance, instance: number | undefined): boolean => {
+  return instance === undefined || record.pid === instance
 }
 
 // A dead pid is skipped without a probe (it proves the writer is gone); the
@@ -44,20 +41,20 @@ const probeMatches = async (matches: CypressInstance[], probeTimeoutMs?: number)
 
 /**
  * Enumerate every verified-live Cypress instance, optionally narrowed to a
- * project root and/or a specific pid. "No instances" is a valid, empty list,
- * never an error — this backs the `instances` command.
+ * specific pid. "No instances" is a valid, empty list, never an error — this
+ * backs the `instances` command.
  */
 export const listLiveInstances = async (options: ListInstanceOptions = {}): Promise<LiveInstanceState[]> => {
   const records = await readInstanceRecords()
 
-  const matches = records.filter((record) => matchesFilters(record, options.projectRoot, options.instance))
+  const matches = records.filter((record) => matchesInstance(record, options.instance))
 
   return probeMatches(matches, options.probeTimeoutMs)
 }
 
 /**
  * How {@link resolveInstance} settled on its target:
- * - `explicit`  — an explicit `--instance`/`--project` filter pinned the choice.
+ * - `explicit`  — an explicit `--instance` filter pinned the choice.
  * - `only`      — no filter, and exactly one instance was live.
  * - `cwd-match` — several were live; the one rooted at the cwd was chosen.
  * - `arbitrary` — several were live, none rooted at the cwd; lowest pid won.
@@ -73,8 +70,6 @@ export interface InstanceSelection {
 }
 
 export interface ResolveInstanceOptions {
-  /** Explicit project-root filter; when omitted, every project is a candidate. */
-  project?: string
   /** Explicit pid filter; when omitted, every matching instance is a candidate. */
   instance?: number
   /** Working directory, used only as a tiebreak when several instances are live. */
@@ -83,14 +78,10 @@ export interface ResolveInstanceOptions {
 }
 
 // Phrase the filter that came up empty so the discovery errors name what the
-// user actually asked for (a pid, a project, or nothing in particular).
-const describeFilter = (project: string | undefined, instance: number | undefined): string => {
+// user actually asked for (a pid, or nothing in particular).
+const describeFilter = (instance: number | undefined): string => {
   if (instance !== undefined) {
     return ` with pid ${instance}`
-  }
-
-  if (project !== undefined) {
-    return ` for ${project}`
   }
 
   return ''
@@ -105,7 +96,7 @@ const lowestPid = (instances: LiveInstanceState[]): LiveInstanceState => {
 // whatever is chosen.
 const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptions): { instance: LiveInstanceState, reason: InstanceSelectionReason } => {
   if (live.length === 1) {
-    const filtered = options.project !== undefined || options.instance !== undefined
+    const filtered = options.instance !== undefined
 
     return { instance: live[0], reason: filtered ? 'explicit' : 'only' }
   }
@@ -121,24 +112,24 @@ const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptio
 
 /**
  * Resolve the single Cypress instance a tap command should target, with its live
- * browser CDP state. With no `--instance`/`--project`, the cwd is only a
- * tiebreak: a lone running Cypress is used wherever it lives, and several are
- * disambiguated by the cwd then by lowest pid (see {@link InstanceSelectionReason}).
+ * browser CDP state. With no `--instance`, the cwd is only a tiebreak: a lone
+ * running Cypress is used wherever it lives, and several are disambiguated by
+ * the cwd then by lowest pid (see {@link InstanceSelectionReason}).
  *
  * @throws {CypressInstanceError} `NO_INSTANCE` when no record matches the filters
  * @throws {CypressInstanceError} `STALE_INSTANCE` when records match but none verify as alive
  * @throws {CypressInstanceError} `NO_BROWSER_ATTACHED` when the chosen instance is live but has no browser
  */
 export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
-  const { project, instance, probeTimeoutMs } = options
+  const { instance, probeTimeoutMs } = options
   const records = await readInstanceRecords()
 
-  const matches = records.filter((record) => matchesFilters(record, project, instance))
+  const matches = records.filter((record) => matchesInstance(record, instance))
 
   if (matches.length === 0) {
     throw new CypressInstanceError(
       'NO_INSTANCE',
-      `No Cypress instance found${describeFilter(project, instance)}. This command requires Cypress running in open mode. Start Cypress in open mode, open a browser, and try again.`,
+      `No Cypress instance found${describeFilter(instance)}. This command requires Cypress running in open mode. Start Cypress in open mode, open a browser, and try again.`,
     )
   }
 
@@ -147,7 +138,7 @@ export const resolveInstance = async (options: ResolveInstanceOptions): Promise<
   if (live.length === 0) {
     throw new CypressInstanceError(
       'STALE_INSTANCE',
-      `Cypress was previously running${describeFilter(project, instance)}, but is no longer responding. Cypress likely exited uncleanly; start Cypress in open mode, open a browser, and try again.`,
+      `Cypress was previously running${describeFilter(instance)}, but is no longer responding. Cypress likely exited uncleanly; start Cypress in open mode, open a browser, and try again.`,
     )
   }
 

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -52,27 +52,16 @@ export const listLiveInstances = async (options: ListInstanceOptions = {}): Prom
   return probeMatches(matches, options.probeTimeoutMs)
 }
 
-/**
- * How {@link resolveInstance} settled on its target:
- * - `explicit`  — an explicit `--instance` filter pinned the choice.
- * - `only`      — no filter, and exactly one instance was live.
- * - `cwd-match` — several were live; the one rooted at the cwd was chosen.
- * - `arbitrary` — several were live, none rooted at the cwd; lowest pid won.
- */
 export type InstanceSelectionReason = 'explicit' | 'only' | 'cwd-match' | 'arbitrary'
 
 export interface InstanceSelection {
-  /** The chosen instance, guaranteed to have a browser attached. */
   instance: ReadyInstanceState
   reason: InstanceSelectionReason
-  /** Count of verified-live instances that matched before disambiguation (>= 1). */
   candidateCount: number
 }
 
 export interface ResolveInstanceOptions {
-  /** Explicit pid filter; when omitted, every matching instance is a candidate. */
   instance?: number
-  /** Working directory, used only as a tiebreak when several instances are live. */
   cwd: string
   probeTimeoutMs?: number
 }
@@ -88,7 +77,6 @@ const describeFilter = (instance: number | undefined): string => {
 }
 
 const lowestPid = (instances: LiveInstanceState[]): LiveInstanceState => {
-  // Directory read order is not guaranteed, so sort for a deterministic pick.
   return [...instances].sort((a, b) => a.pid - b.pid)[0]
 }
 
@@ -110,16 +98,6 @@ const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptio
   return { instance: lowestPid(live), reason: 'arbitrary' }
 }
 
-/**
- * Resolve the single Cypress instance a tap command should target, with its live
- * browser CDP state. With no `--instance`, the cwd is only a tiebreak: a lone
- * running Cypress is used wherever it lives, and several are disambiguated by
- * the cwd then by lowest pid (see {@link InstanceSelectionReason}).
- *
- * @throws {CypressInstanceError} `NO_INSTANCE` when no record matches the filters
- * @throws {CypressInstanceError} `STALE_INSTANCE` when records match but none verify as alive
- * @throws {CypressInstanceError} `NO_BROWSER_ATTACHED` when the chosen instance is live but has no browser
- */
 export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
   const { instance, probeTimeoutMs } = options
   const records = await readInstanceRecords()

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import { CypressInstanceError } from './record'
-import type { LiveInstanceState, ReadyInstanceState } from './record'
+import type { LiveInstanceState, ReadyInstanceState, CypressInstance } from './record'
 import { isPidAlive, verifyInstanceRecord } from './liveness'
 import { readInstanceRecords } from './store'
 
@@ -13,55 +13,152 @@ export { isPidAlive, verifyInstanceRecord } from './liveness'
 
 export { getInstancesDir, pruneDeadInstanceRecords, readInstanceRecords } from './store'
 
-export interface FindInstanceOptions {
+export interface ListInstanceOptions {
+  /** Optional project-root filter; omitted lists instances across all projects. */
+  projectRoot?: string
+  /** Optional pid filter; omitted lists every matching instance. */
   instance?: number
   probeTimeoutMs?: number
 }
 
-export const findLiveInstance = async (projectRoot: string, options: FindInstanceOptions = {}): Promise<LiveInstanceState> => {
+const matchesProject = (record: CypressInstance, projectRoot: string): boolean => {
+  return path.resolve(record.projectRoot) === path.resolve(projectRoot)
+}
+
+// An undefined facet does not constrain, so an absent `--project` (every
+// project) and an absent `--instance` (every pid) narrow records the same way.
+const matchesFilters = (record: CypressInstance, projectRoot: string | undefined, instance: number | undefined): boolean => {
+  return (projectRoot === undefined || matchesProject(record, projectRoot))
+    && (instance === undefined || record.pid === instance)
+}
+
+// A dead pid is skipped without a probe (it proves the writer is gone); the
+// survivors carry the live browser CDP state from their probe response.
+const probeMatches = async (matches: CypressInstance[], probeTimeoutMs?: number): Promise<LiveInstanceState[]> => {
+  const probed = await Promise.all(matches.map(async (record) => {
+    return isPidAlive(record.pid) ? verifyInstanceRecord(record, probeTimeoutMs) : null
+  }))
+
+  return probed.filter((instance): instance is LiveInstanceState => instance !== null)
+}
+
+/**
+ * Enumerate every verified-live Cypress instance, optionally narrowed to a
+ * project root and/or a specific pid. "No instances" is a valid, empty list,
+ * never an error — this backs the `instances` command.
+ */
+export const listLiveInstances = async (options: ListInstanceOptions = {}): Promise<LiveInstanceState[]> => {
   const records = await readInstanceRecords()
-  const resolvedProjectRoot = path.resolve(projectRoot)
 
-  let matches = records.filter((record) => path.resolve(record.projectRoot) === resolvedProjectRoot)
+  const matches = records.filter((record) => matchesFilters(record, options.projectRoot, options.instance))
 
-  if (options.instance !== undefined) {
-    matches = matches.filter((record) => record.pid === options.instance)
+  return probeMatches(matches, options.probeTimeoutMs)
+}
+
+/**
+ * How {@link resolveInstance} settled on its target:
+ * - `explicit`  — an explicit `--instance`/`--project` filter pinned the choice.
+ * - `only`      — no filter, and exactly one instance was live.
+ * - `cwd-match` — several were live; the one rooted at the cwd was chosen.
+ * - `arbitrary` — several were live, none rooted at the cwd; lowest pid won.
+ */
+export type InstanceSelectionReason = 'explicit' | 'only' | 'cwd-match' | 'arbitrary'
+
+export interface InstanceSelection {
+  /** The chosen instance, guaranteed to have a browser attached. */
+  instance: ReadyInstanceState
+  reason: InstanceSelectionReason
+  /** Count of verified-live instances that matched before disambiguation (>= 1). */
+  candidateCount: number
+}
+
+export interface ResolveInstanceOptions {
+  /** Explicit project-root filter; when omitted, every project is a candidate. */
+  project?: string
+  /** Explicit pid filter; when omitted, every matching instance is a candidate. */
+  instance?: number
+  /** Working directory, used only as a tiebreak when several instances are live. */
+  cwd: string
+  probeTimeoutMs?: number
+}
+
+// Phrase the filter that came up empty so the discovery errors name what the
+// user actually asked for (a pid, a project, or nothing in particular).
+const describeFilter = (project: string | undefined, instance: number | undefined): string => {
+  if (instance !== undefined) {
+    return ` with pid ${instance}`
   }
+
+  if (project !== undefined) {
+    return ` for ${project}`
+  }
+
+  return ''
+}
+
+const lowestPid = (instances: LiveInstanceState[]): LiveInstanceState => {
+  // Directory read order is not guaranteed, so sort for a deterministic pick.
+  return [...instances].sort((a, b) => a.pid - b.pid)[0]
+}
+
+// Browser readiness is not a selection criterion — the caller requires it of
+// whatever is chosen.
+const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptions): { instance: LiveInstanceState, reason: InstanceSelectionReason } => {
+  if (live.length === 1) {
+    const filtered = options.project !== undefined || options.instance !== undefined
+
+    return { instance: live[0], reason: filtered ? 'explicit' : 'only' }
+  }
+
+  const cwdMatches = live.filter((record) => matchesProject(record, options.cwd))
+
+  if (cwdMatches.length > 0) {
+    return { instance: lowestPid(cwdMatches), reason: 'cwd-match' }
+  }
+
+  return { instance: lowestPid(live), reason: 'arbitrary' }
+}
+
+/**
+ * Resolve the single Cypress instance a tap command should target, with its live
+ * browser CDP state. With no `--instance`/`--project`, the cwd is only a
+ * tiebreak: a lone running Cypress is used wherever it lives, and several are
+ * disambiguated by the cwd then by lowest pid (see {@link InstanceSelectionReason}).
+ *
+ * @throws {CypressInstanceError} `NO_INSTANCE` when no record matches the filters
+ * @throws {CypressInstanceError} `STALE_INSTANCE` when records match but none verify as alive
+ * @throws {CypressInstanceError} `NO_BROWSER_ATTACHED` when the chosen instance is live but has no browser
+ */
+export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
+  const { project, instance, probeTimeoutMs } = options
+  const records = await readInstanceRecords()
+
+  const matches = records.filter((record) => matchesFilters(record, project, instance))
 
   if (matches.length === 0) {
     throw new CypressInstanceError(
       'NO_INSTANCE',
-      `No Cypress instance found for ${projectRoot}. This command requires Cypress running in open mode. Start Cypress in open mode, open a browser, and try again.`,
+      `No Cypress instance found${describeFilter(project, instance)}. This command requires Cypress running in open mode. Start Cypress in open mode, open a browser, and try again.`,
     )
   }
 
-  for (const record of matches) {
-    if (!isPidAlive(record.pid)) {
-      continue
-    }
+  const live = await probeMatches(matches, probeTimeoutMs)
 
-    const live = await verifyInstanceRecord(record, options.probeTimeoutMs)
-
-    if (live) {
-      return live
-    }
+  if (live.length === 0) {
+    throw new CypressInstanceError(
+      'STALE_INSTANCE',
+      `Cypress was previously running${describeFilter(project, instance)}, but is no longer responding. Cypress likely exited uncleanly; start Cypress in open mode, open a browser, and try again.`,
+    )
   }
 
-  throw new CypressInstanceError(
-    'STALE_INSTANCE',
-    `Cypress was previously running for ${projectRoot}, but is no longer responding. Please ensure Cypress has completely exited; start Cypress again in open mode, open a browser, and try again.`,
-  )
-}
+  const { instance: selected, reason } = selectInstance(live, options)
 
-export const findReadyInstance = async (projectRoot: string, options: FindInstanceOptions = {}): Promise<ReadyInstanceState> => {
-  const instance = await findLiveInstance(projectRoot, options)
-
-  if (!instance.cdpBrowserWsUrl) {
+  if (!selected.cdpBrowserWsUrl) {
     throw new CypressInstanceError(
       'NO_BROWSER_ATTACHED',
-      `Cypress is running for ${projectRoot}, but no test browser is open. Open a browser in Cypress and try again.`,
+      `Cypress is running (pid ${selected.pid}, ${selected.projectRoot}), but no test browser is open. Open a browser in Cypress and try again.`,
     )
   }
 
-  return instance as ReadyInstanceState
+  return { instance: selected as ReadyInstanceState, reason, candidateCount: live.length }
 }

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -39,11 +39,6 @@ const probeMatches = async (matches: CypressInstance[], probeTimeoutMs?: number)
   return probed.filter((instance): instance is LiveInstanceState => instance !== null)
 }
 
-/**
- * Enumerate every verified-live Cypress instance, optionally narrowed to a
- * specific pid. "No instances" is a valid, empty list, never an error — this
- * backs the `instances` command.
- */
 export const listLiveInstances = async (options: ListInstanceOptions = {}): Promise<LiveInstanceState[]> => {
   const records = await readInstanceRecords()
 
@@ -66,8 +61,6 @@ export interface ResolveInstanceOptions {
   probeTimeoutMs?: number
 }
 
-// Phrase the filter that came up empty so the discovery errors name what the
-// user actually asked for (a pid, or nothing in particular).
 const describeFilter = (instance: number | undefined): string => {
   if (instance !== undefined) {
     return ` with pid ${instance}`
@@ -80,8 +73,6 @@ const lowestPid = (instances: LiveInstanceState[]): LiveInstanceState => {
   return [...instances].sort((a, b) => a.pid - b.pid)[0]
 }
 
-// Browser readiness is not a selection criterion — the caller requires it of
-// whatever is chosen.
 const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptions): { instance: LiveInstanceState, reason: InstanceSelectionReason } => {
   if (live.length === 1) {
     const filtered = options.instance !== undefined

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -55,6 +55,13 @@ export interface InstanceSelection {
   candidateCount: number
 }
 
+// Like InstanceSelection, but the chosen instance may have no browser attached yet.
+export interface LiveInstanceSelection {
+  instance: LiveInstanceState
+  reason: InstanceSelectionReason
+  candidateCount: number
+}
+
 export interface ResolveInstanceOptions {
   instance?: number
   cwd: string
@@ -69,27 +76,29 @@ const describeFilter = (instance: number | undefined): string => {
   return ''
 }
 
-const lowestPid = (instances: LiveInstanceState[]): LiveInstanceState => {
+const lowestPid = <T extends LiveInstanceState>(instances: T[]): T => {
   return [...instances].sort((a, b) => a.pid - b.pid)[0]
 }
 
-const selectInstance = (live: LiveInstanceState[], options: ResolveInstanceOptions): { instance: LiveInstanceState, reason: InstanceSelectionReason } => {
-  if (live.length === 1) {
+const selectInstance = <T extends LiveInstanceState>(candidates: T[], options: ResolveInstanceOptions): { instance: T, reason: InstanceSelectionReason } => {
+  if (candidates.length === 1) {
     const filtered = options.instance !== undefined
 
-    return { instance: live[0], reason: filtered ? 'explicit' : 'only' }
+    return { instance: candidates[0], reason: filtered ? 'explicit' : 'only' }
   }
 
-  const cwdMatches = live.filter((record) => matchesProject(record, options.cwd))
+  const cwdMatches = candidates.filter((record) => matchesProject(record, options.cwd))
 
   if (cwdMatches.length > 0) {
     return { instance: lowestPid(cwdMatches), reason: 'cwd-match' }
   }
 
-  return { instance: lowestPid(live), reason: 'arbitrary' }
+  return { instance: lowestPid(candidates), reason: 'arbitrary' }
 }
 
-export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
+// Reads, filters by pid, and probes for liveness. Throws NO_INSTANCE when
+// nothing matches and STALE_INSTANCE when matches exist but none responds.
+const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanceState[]> => {
   const { instance, probeTimeoutMs } = options
   const records = await readInstanceRecords()
 
@@ -111,14 +120,40 @@ export const resolveInstance = async (options: ResolveInstanceOptions): Promise<
     )
   }
 
-  const { instance: selected, reason } = selectInstance(live, options)
+  return live
+}
 
-  if (!selected.cdpBrowserWsUrl) {
+// Resolves a live instance without requiring a browser; `status` reports
+// instances that have no browser attached yet.
+export const resolveLiveInstance = async (options: ResolveInstanceOptions): Promise<LiveInstanceSelection> => {
+  const live = await liveMatches(options)
+
+  const { instance, reason } = selectInstance(live, options)
+
+  return { instance, reason, candidateCount: live.length }
+}
+
+// Adds the browser-readiness requirement to resolveLiveInstance: the instance
+// it returns is guaranteed to have a browser attached. Gate on the browser
+// before selecting so a browserless instance never shadows a ready one that
+// could serve the command.
+export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
+  const live = await liveMatches(options)
+
+  const ready = live.filter((record): record is ReadyInstanceState => record.cdpBrowserWsUrl !== null)
+
+  if (ready.length === 0) {
+    const detail = live.length === 1
+      ? ` (pid ${live[0].pid}, ${live[0].projectRoot})`
+      : describeFilter(options.instance)
+
     throw new CypressInstanceError(
       'NO_BROWSER_ATTACHED',
-      `Cypress is running (pid ${selected.pid}, ${selected.projectRoot}), but no test browser is open. Open a browser in Cypress and try again.`,
+      `Cypress is running${detail}, but no test browser is open. Open a browser in Cypress and try again.`,
     )
   }
 
-  return { instance: selected as ReadyInstanceState, reason, candidateCount: live.length }
+  const { instance: selected, reason } = selectInstance(ready, options)
+
+  return { instance: selected, reason, candidateCount: ready.length }
 }

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -252,10 +252,10 @@ describe('lib/cypress-instances', () => {
     })
 
     it('throws NO_INSTANCE when no record matches the filters', async () => {
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, projectRoot: '/other/project' }) } })
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
       stubKill({ alive: [111] })
 
-      await expect(resolveInstance({ project: PROJECT, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+      await expect(resolveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
     })
 
     it('throws STALE_INSTANCE when a match exists but its process is dead', async () => {
@@ -286,7 +286,7 @@ describe('lib/cypress-instances', () => {
       await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
     })
 
-    it('skips a stale record and resolves the live one matching the same project', async () => {
+    it('skips a stale record and resolves the live one', async () => {
       const closedPort = await getClosedPort()
       const livePort = await startReadyInstance('live-instance')
 
@@ -299,7 +299,7 @@ describe('lib/cypress-instances', () => {
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ project: PROJECT, cwd: PROJECT })
+      const selection = await resolveInstance({ cwd: PROJECT })
 
       expect(selection.instance.pid).toBe(222)
       // Only the verified-live record counts as a candidate.
@@ -413,21 +413,6 @@ describe('lib/cypress-instances', () => {
       stubKill({ alive: [111, 333] })
 
       expect((await listLiveInstances()).map((instance) => instance.pid)).toEqual([111])
-    })
-
-    it('filters by project root', async () => {
-      const port = await startFakeInstance()
-
-      mockfs({
-        [INSTANCES_DIR]: {
-          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: port }),
-          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: port }),
-        },
-      })
-
-      stubKill({ alive: [111, 222] })
-
-      expect((await listLiveInstances({ projectRoot: '/projects/app' })).map((instance) => instance.pid)).toEqual([111])
     })
 
     it('filters by pid', async () => {

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -9,8 +9,8 @@ import {
   isPidAlive,
   verifyInstanceRecord,
   readInstanceRecords,
-  findLiveInstance,
-  findReadyInstance,
+  resolveInstance,
+  listLiveInstances,
   getInstancesDir,
   pruneDeadInstanceRecords,
   CypressInstanceError,
@@ -229,31 +229,40 @@ describe('lib/cypress-instances', () => {
     })
   })
 
-  describe('.findLiveInstance', () => {
-    it('returns the live instance state once its instance echoes the instanceId', async () => {
-      const port = await startFakeInstance()
+  describe('.resolveInstance', () => {
+    // resolveInstance requires an attached browser, so its happy-path fake instance
+    // must echo a CDP endpoint in the probe response.
+    const startReadyInstance = (instanceId: string) => {
+      return startFakeInstance({ instanceId, respondWith: { instanceId, cdpBrowserWsUrl: CDP_WS_URL } })
+    }
+
+    it('uses a lone live instance wherever it lives, ignoring the cwd (reason: only)', async () => {
+      const port = await startReadyInstance(INSTANCE_ID)
 
       mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const instance = await findLiveInstance(PROJECT)
+      const selection = await resolveInstance({ cwd: '/somewhere/unrelated' })
 
-      expect(instance.pid).toBe(111)
-      expect(instance.cdpBrowserWsUrl).toBeNull()
+      expect(selection.instance.pid).toBe(111)
+      expect(selection.reason).toBe('only')
+      expect(selection.candidateCount).toBe(1)
+      // The live CDP endpoint comes from the probe response, not the disk record.
+      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
     })
 
-    it('throws NO_INSTANCE when no record matches the project', async () => {
+    it('throws NO_INSTANCE when no record matches the filters', async () => {
       mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, projectRoot: '/other/project' }) } })
       stubKill({ alive: [111] })
 
-      await expect(findLiveInstance(PROJECT)).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+      await expect(resolveInstance({ project: PROJECT, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
     })
 
     it('throws STALE_INSTANCE when a match exists but its process is dead', async () => {
       mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
       stubKill({ alive: [] })
 
-      const err = await findLiveInstance(PROJECT).catch((e) => e)
+      const err = await resolveInstance({ cwd: PROJECT }).catch((e) => e)
 
       expect(err).toBeInstanceOf(CypressInstanceError)
       expect(err.code).toBe('STALE_INSTANCE')
@@ -265,12 +274,21 @@ describe('lib/cypress-instances', () => {
       mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await expect(findLiveInstance(PROJECT)).rejects.toMatchObject({ code: 'STALE_INSTANCE' })
+      await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'STALE_INSTANCE' })
     })
 
-    it('skips a stale record and returns the verified one for the same project', async () => {
+    it('throws NO_BROWSER_ATTACHED when the chosen instance is live but has no browser', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
+    })
+
+    it('skips a stale record and resolves the live one matching the same project', async () => {
       const closedPort = await getClosedPort()
-      const livePort = await startFakeInstance({ instanceId: 'live-instance' })
+      const livePort = await startReadyInstance('live-instance')
 
       mockfs({
         [INSTANCES_DIR]: {
@@ -281,10 +299,138 @@ describe('lib/cypress-instances', () => {
 
       stubKill({ alive: [111, 222] })
 
-      expect((await findLiveInstance(PROJECT)).pid).toBe(222)
+      const selection = await resolveInstance({ project: PROJECT, cwd: PROJECT })
+
+      expect(selection.instance.pid).toBe(222)
+      // Only the verified-live record counts as a candidate.
+      expect(selection.candidateCount).toBe(1)
     })
 
-    it('targets a specific instance by pid', async () => {
+    it('targets a specific instance by pid (reason: explicit)', async () => {
+      const port = await startReadyInstance(INSTANCE_ID)
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, serverPort: port }),
+          '222.json': makeRecord({ pid: 222, serverPort: port }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      const selection = await resolveInstance({ instance: 222, cwd: PROJECT })
+
+      expect(selection.instance.pid).toBe(222)
+      expect(selection.reason).toBe('explicit')
+      await expect(resolveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+    })
+
+    it('prefers the instance rooted at the cwd when several are live (reason: cwd-match)', async () => {
+      const appPort = await startReadyInstance('app-instance')
+      const otherPort = await startReadyInstance('other-instance')
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, instanceId: 'app-instance' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, instanceId: 'other-instance' }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      const selection = await resolveInstance({ cwd: '/projects/other' })
+
+      expect(selection.instance.pid).toBe(222)
+      expect(selection.reason).toBe('cwd-match')
+      expect(selection.candidateCount).toBe(2)
+    })
+
+    it('falls back to the lowest pid when several are live and none match the cwd (reason: arbitrary)', async () => {
+      const aPort = await startReadyInstance('a-instance')
+      const bPort = await startReadyInstance('b-instance')
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          // '1000.json' sorts before '999.json', so the read order is 1000 then
+          // 999 — picking 999 proves the choice is by lowest pid, not read order.
+          '1000.json': makeRecord({ pid: 1000, projectRoot: '/projects/a', serverPort: aPort, instanceId: 'a-instance' }),
+          '999.json': makeRecord({ pid: 999, projectRoot: '/projects/b', serverPort: bPort, instanceId: 'b-instance' }),
+        },
+      })
+
+      stubKill({ alive: [1000, 999] })
+
+      const selection = await resolveInstance({ cwd: '/unrelated/dir' })
+
+      expect(selection.instance.pid).toBe(999)
+      expect(selection.reason).toBe('arbitrary')
+      expect(selection.candidateCount).toBe(2)
+    })
+  })
+
+  describe('.listLiveInstances', () => {
+    it('returns every verified-live instance across all projects, with its CDP state', async () => {
+      const appPort = await startFakeInstance({ instanceId: 'app-instance', respondWith: { instanceId: 'app-instance', cdpBrowserWsUrl: CDP_WS_URL } })
+      const otherPort = await startFakeInstance({ instanceId: 'other-instance' })
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, instanceId: 'app-instance' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, instanceId: 'other-instance' }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      const instances = await listLiveInstances()
+
+      expect(instances.map((instance) => instance.pid).sort()).toEqual([111, 222])
+      expect(instances.find((instance) => instance.pid === 111)!.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      // No endpoint in the probe response — no browser attached.
+      expect(instances.find((instance) => instance.pid === 222)!.cdpBrowserWsUrl).toBeNull()
+    })
+
+    it('resolves an empty list when no record exists', async () => {
+      mockfs({ [CACHE_DIR]: {} })
+
+      expect(await listLiveInstances()).toEqual([])
+    })
+
+    it('skips dead-pid and unverified (recycled-pid) records', async () => {
+      const livePort = await startFakeInstance()
+      const closedPort = await getClosedPort()
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, serverPort: livePort }),
+          // pid is dead — skipped without a probe
+          '222.json': makeRecord({ pid: 222, serverPort: livePort }),
+          // pid looks alive but nothing answers — recycled pid, skipped
+          '333.json': makeRecord({ pid: 333, serverPort: closedPort }),
+        },
+      })
+
+      stubKill({ alive: [111, 333] })
+
+      expect((await listLiveInstances()).map((instance) => instance.pid)).toEqual([111])
+    })
+
+    it('filters by project root', async () => {
+      const port = await startFakeInstance()
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: port }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: port }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      expect((await listLiveInstances({ projectRoot: '/projects/app' })).map((instance) => instance.pid)).toEqual([111])
+    })
+
+    it('filters by pid', async () => {
       const port = await startFakeInstance()
 
       mockfs({
@@ -296,36 +442,7 @@ describe('lib/cypress-instances', () => {
 
       stubKill({ alive: [111, 222] })
 
-      expect((await findLiveInstance(PROJECT, { instance: 222 })).pid).toBe(222)
-      await expect(findLiveInstance(PROJECT, { instance: 999 })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
-    })
-  })
-
-  describe('.findReadyInstance', () => {
-    it('takes the live CDP endpoint from the probe response, not the disk record', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL } })
-
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
-      stubKill({ alive: [111] })
-
-      const instance = await findReadyInstance(PROJECT)
-
-      expect(instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
-    })
-
-    it('throws NO_BROWSER_ATTACHED when the instance is live but has no browser', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null } })
-
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
-      stubKill({ alive: [111] })
-
-      await expect(findReadyInstance(PROJECT)).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
-    })
-
-    it('propagates NO_INSTANCE from findLiveInstance', async () => {
-      mockfs({ [CACHE_DIR]: {} })
-
-      await expect(findReadyInstance(PROJECT)).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+      expect((await listLiveInstances({ instance: 222 })).map((instance) => instance.pid)).toEqual([222])
     })
   })
 

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -10,6 +10,7 @@ import {
   verifyInstanceRecord,
   readInstanceRecords,
   resolveInstance,
+  resolveLiveInstance,
   listLiveInstances,
   getInstancesDir,
   pruneDeadInstanceRecords,
@@ -286,6 +287,30 @@ describe('lib/cypress-instances', () => {
       await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
     })
 
+    it('resolves a browser-attached instance over a live one at the cwd that has none', async () => {
+      const readyPort = await startReadyInstance('ready-instance')
+      const browserlessPort = await startFakeInstance({ instanceId: 'browserless-instance', respondWith: { instanceId: 'browserless-instance', cdpBrowserWsUrl: null } })
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          // The cwd-rooted instance has no browser, so it cannot be the target
+          // even though it would otherwise win by cwd-match.
+          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: browserlessPort, instanceId: 'browserless-instance' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, instanceId: 'ready-instance' }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      const selection = await resolveInstance({ cwd: PROJECT })
+
+      expect(selection.instance.pid).toBe(222)
+      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      // Only the browser-attached instance is a candidate.
+      expect(selection.reason).toBe('only')
+      expect(selection.candidateCount).toBe(1)
+    })
+
     it('skips a stale record and resolves the live one', async () => {
       const closedPort = await getClosedPort()
       const livePort = await startReadyInstance('live-instance')
@@ -365,6 +390,47 @@ describe('lib/cypress-instances', () => {
       expect(selection.instance.pid).toBe(999)
       expect(selection.reason).toBe('arbitrary')
       expect(selection.candidateCount).toBe(2)
+    })
+  })
+
+  describe('.resolveLiveInstance', () => {
+    it('resolves a live instance that has no browser attached, instead of throwing', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      const selection = await resolveLiveInstance({ cwd: PROJECT })
+
+      expect(selection.instance.pid).toBe(111)
+      expect(selection.reason).toBe('only')
+      // The browser-optional resolver returns the live instance as-is — no browser.
+      expect(selection.instance.cdpBrowserWsUrl).toBeNull()
+    })
+
+    it('carries the live CDP endpoint when a browser is attached', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      const selection = await resolveLiveInstance({ cwd: PROJECT })
+
+      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+    })
+
+    it('throws NO_INSTANCE when no record matches the filters', async () => {
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, projectRoot: '/other/project' }) } })
+      stubKill({ alive: [111] })
+
+      await expect(resolveLiveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+    })
+
+    it('throws STALE_INSTANCE when a match exists but its process is dead', async () => {
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
+      stubKill({ alive: [] })
+
+      await expect(resolveLiveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'STALE_INSTANCE' })
     })
   })
 


### PR DESCRIPTION
### Additional details

- **Why.** The tap CLI needs two distinct discovery shapes: a list of all reachable instances (to back an `instances` command) and a single resolved target (to open a CDP session against). The old `findLiveRunner`/`findReadyRunner` pair only ever resolved one runner for one project root and treated "nothing found" as an error, which neither shape can use. This slice replaces that pair with the two functions the rest of the stack builds on.
- **`listLiveRunners`.** Enumerates every verified-live runner, optionally narrowed by project root and/or pid. Both filters are optional and narrow independently — an absent `--project` means every project, an absent `--instance` means every pid. "No runners" is a valid, empty list, never an error (this is what backs the future `instances` command). Each result carries the live browser CDP state taken from its probe response, not from the disk record.
- **`resolveRunner`.** Resolves the single runner a command targets, requiring a browser to be attached, and returns a `RunnerSelection` carrying the chosen runner, a `candidateCount`, and a `reason` recording how it was chosen: `explicit` (a `--project`/`--instance` filter pinned it), `only` (no filter, exactly one live), `cwd-match` (several live, the cwd-rooted one won), or `arbitrary` (several live, none at the cwd, lowest pid won). With no filters the cwd is only a tiebreak — a lone running Cypress is used wherever it lives. Throws the same `NO_DISCOVERY_FILE` / `STALE_DISCOVERY_FILE` / `NO_BROWSER_ATTACHED` errors as before, with messages now phrased around the filter the user actually supplied (a pid, a project, or nothing in particular).
- **Shared internals.** A single `matchesFilters` predicate backs both functions so project/pid narrowing is identical between them, and liveness probing is now extracted into a shared `probeMatches` helper that probes the pre-filtered records concurrently (a dead pid is skipped without a probe). Disambiguation by lowest pid sorts the live set first, since directory read order is not guaranteed.

### Steps to test

Internal discovery-layer refactor covered by unit tests (vitest):

```
yarn workspace @packages/cli test -- cli/test/lib/runner-discovery.spec.ts
```

`cli/test/lib/runner-discovery.spec.ts` was updated to exercise the new API: the `.resolveRunner` block covers each selection reason (`only`, `explicit`, `cwd-match`, `arbitrary`), the three discovery errors, candidate counting, and that the CDP endpoint is read from the probe response; the new `.listLiveRunners` block covers cross-project enumeration, the empty-list case, skipping dead/recycled pids, and the project/pid filters.

### How has the user experience changed?

No change. This slice has no user-facing surface on its own — it is an internal CLI discovery-layer refactor whose functions are only consumed by later slices in the stack.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal/experimental tap CLI work; tracked by internal ticket 13629, no public GitHub issue. -->
- [x] Have tests been added/updated? <!-- Updated: cli/test/lib/runner-discovery.spec.ts to cover listLiveRunners and resolveRunner. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change; internal refactor consumed only by later stack slices. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` JS API or its type definitions; this is an internal CLI module. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI instance discovery and multi-instance selection logic used before CDP attachment; behavior shifts when several Cypress processes run (cwd/pid tiebreaks, browser gating).
> 
> **Overview**
> Replaces **`findLiveInstance`** / **`findReadyInstance`** (single project-root lookup) with **`listLiveInstances`**, **`resolveLiveInstance`**, and **`resolveInstance`** so the tap CLI can both enumerate instances and pick one target with explicit disambiguation.
> 
> **`listLiveInstances`** returns every probe-verified live instance (optional pid filter), including CDP state from the probe—not the disk record—with an empty result instead of an error.
> 
> **`resolveLiveInstance`** and **`resolveInstance`** take **`cwd`** plus optional **`instance`** pid; they no longer require matching **`projectRoot`** up front. A lone live Cypress is used regardless of cwd; with multiple candidates, selection prefers the instance whose **`projectRoot`** matches **`cwd`**, else lowest pid. Both return **`InstanceSelection`** / **`LiveInstanceSelection`** with **`reason`** (`explicit` | `only` | `cwd-match` | `arbitrary`) and **`candidateCount`**. **`resolveInstance`** filters to browser-attached instances before selection so a browserless cwd match cannot hide a ready instance elsewhere.
> 
> Shared **`probeMatches`** probes survivors concurrently and skips dead pids without probing. Error messages for **`NO_INSTANCE`**, **`STALE_INSTANCE`**, and **`NO_BROWSER_ATTACHED`** are phrased around the pid filter when supplied.
> 
> Tests in **`cypress-instances.spec.ts`** were expanded for the new APIs and selection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f13c8ffef58f949c9a0a916df0b984d10019a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->