### PR TITLE
feat: build the tap subcommand program from the advertised schema (6)

### DIFF
--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -50,6 +50,18 @@ const rejectExcessArguments = (name: string, params: readonly TapCommandParamSch
   throw new commander.CommanderError(1, 'commander.excessArguments', message)
 }
 
+// cli/lib/cli.ts patches Command.prototype.unknownOption to call process.exit, which defeats
+// exitOverride(). Reassert a catchable rejection on every tap command so an unknown flag reaches
+// the orchestrator's error routing like every other parse error, rather than killing the process.
+const rejectUnknownOptions = (command: commander.Command): void => {
+  ;(command as unknown as { unknownOption(flag: string): never }).unknownOption = (flag: string): never => {
+    const message = `error: unknown option '${flag}'`
+
+    console.error(message)
+    throw new commander.CommanderError(1, 'commander.unknownOption', message)
+  }
+}
+
 const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Record<string, unknown>): Record<string, string> => {
   const forwarded: Record<string, string> = {}
 
@@ -92,6 +104,9 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
       return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(options, command.opts()))
     })
   }
+
+  rejectUnknownOptions(program)
+  program.commands.forEach(rejectUnknownOptions)
 
   return program
 }

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -50,18 +50,6 @@ const rejectExcessArguments = (name: string, params: readonly TapCommandParamSch
   throw new commander.CommanderError(1, 'commander.excessArguments', message)
 }
 
-// cli/lib/cli.ts patches Command.prototype.unknownOption to call process.exit, which defeats
-// exitOverride(). Reassert a catchable rejection on every tap command so an unknown flag reaches
-// the orchestrator's error routing like every other parse error, rather than killing the process.
-const rejectUnknownOptions = (command: commander.Command): void => {
-  ;(command as unknown as { unknownOption(flag: string): never }).unknownOption = (flag: string): never => {
-    const message = `error: unknown option '${flag}'`
-
-    console.error(message)
-    throw new commander.CommanderError(1, 'commander.unknownOption', message)
-  }
-}
-
 const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Record<string, unknown>): Record<string, string> => {
   const forwarded: Record<string, string> = {}
 
@@ -81,10 +69,13 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
   program.addHelpCommand(false)
   program.description('Interacts with a running Cypress instance')
 
-  program
+  const instances = program
   .command('instances')
   .description('list the running Cypress instances this CLI can reach')
-  .action(() => {})
+
+  instances.action(() => {
+    rejectExcessArguments('instances', [], instances.args)
+  })
 
   for (const { name, description, params, options = [] } of schema.commands) {
     const command = program.command(name)
@@ -104,9 +95,6 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
       return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(options, command.opts()))
     })
   }
-
-  rejectUnknownOptions(program)
-  program.commands.forEach(rejectUnknownOptions)
 
   return program
 }

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -77,7 +77,7 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
     rejectExcessArguments('instances', [], instances.args)
   })
 
-  for (const { name, description, params, options = [] } of schema.commands) {
+  for (const { name, description, params = [], options = [] } of schema.commands) {
     const command = program.command(name)
 
     if (params.length) {

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -1,0 +1,133 @@
+import commander from 'commander'
+
+import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from './contract'
+
+/**
+ * Invoked when a built subcommand matches. Args and options are forwarded as
+ * raw strings keyed by their schema name; type coercion is the running
+ * instance's job, so the CLI never interprets types.
+ */
+type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>) => Promise<void> | void
+
+const argumentsOf = (params: readonly TapCommandParamSchema[]): string => {
+  return params.map(({ name, required }) => required ? `<${name}>` : `[${name}]`).join(' ')
+}
+
+const argumentDescriptions = (params: readonly TapCommandParamSchema[]): Record<string, string> => {
+  return Object.fromEntries(params.map(({ name, description }) => [name, description]))
+}
+
+// A required value option uses `requiredOption` so commander enforces presence;
+// the binding re-checks app-side regardless. No custom parser is attached, so
+// commander yields raw strings and coercion stays app-side.
+const declareOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
+  for (const { name, alias, type, required, description } of options) {
+    const lead = alias ? `-${alias}, ` : ''
+    const flags = type === 'boolean' ? `${lead}--${name}` : `${lead}--${name} <${name}>`
+
+    if (required && type !== 'boolean') {
+      command.requiredOption(flags, description)
+    } else {
+      command.option(flags, description)
+    }
+  }
+}
+
+// Key each positional by its schema param name so args reach the binding
+// name-keyed, like options. `rejectExcessArguments` has already run, so
+// `args.length <= params.length`.
+const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly string[]): Record<string, string> => {
+  const forwarded: Record<string, string> = {}
+
+  args.forEach((arg, index) => {
+    const param = params[index]
+
+    if (param) {
+      forwarded[param.name] = arg
+    }
+  })
+
+  return forwarded
+}
+
+// commander 6 keeps operands beyond the declared params rather than rejecting
+// them (it has no `allowExcessArguments`), and a name-keyed arg object can't
+// carry the extras anyway — so reject them here at the parse layer, in the same
+// exit-1-with-a-stderr-message shape commander uses for `missingArgument`.
+const rejectExcessArguments = (name: string, params: readonly TapCommandParamSchema[], args: readonly string[]): void => {
+  if (args.length <= params.length) {
+    return
+  }
+
+  const message = `error: too many arguments for '${name}'. Expected ${params.length} argument(s) but got ${args.length}.`
+
+  console.error(message)
+  throw new commander.CommanderError(1, 'commander.excessArguments', message)
+}
+
+// Forward supplied options as raw strings; the binding coerces them, as it does
+// positionals. Keying by the schema name (a single dash-free token) sidesteps
+// commander's camelCasing.
+const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Record<string, unknown>): Record<string, string> => {
+  const forwarded: Record<string, string> = {}
+
+  for (const { name } of options) {
+    if (opts[name] !== undefined) {
+      forwarded[name] = String(opts[name])
+    }
+  }
+
+  return forwarded
+}
+
+/**
+ * Build a commander program from a tap schema fetched at runtime: one
+ * subcommand per advertised command. The program name is `cypress tap` so
+ * generated usage reads as the user typed it.
+ *
+ * `exitOverride` turns commander's own argument validation and help into
+ * catchable `CommanderError`s instead of process exits, so the orchestrator
+ * can route them through the logger.
+ */
+export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): commander.Command => {
+  const program = new commander.Command('cypress tap')
+
+  program.exitOverride()
+  // No implicit `help` subcommand: every command name is the running
+  // instance's to define, so `tap help` is just an unknown command.
+  program.addHelpCommand(false)
+  program.description('Interacts with a running Cypress instance')
+
+  // `instances` is the CLI's own command — it enumerates the discovery layer
+  // rather than dispatching to a running instance. `../exec/tap` intercepts it
+  // before this program is parsed, so this entry exists only for help; its
+  // action never runs.
+  program
+  .command('instances')
+  .description('list the running Cypress instances this CLI can reach')
+  .action(() => {})
+
+  for (const { name, description, params, options = [] } of schema.commands) {
+    const command = program.command(name)
+
+    if (params.length) {
+      command.arguments(argumentsOf(params))
+      command.description(description, argumentDescriptions(params))
+    } else {
+      command.description(description)
+    }
+
+    declareOptions(command, options)
+
+    command.action(() => {
+      // Read the matched command from the closure, not the action's varargs:
+      // commander appends excess operands AFTER the command in that list, so
+      // positionally fishing it out breaks on the very case we reject below.
+      rejectExcessArguments(name, params, command.args)
+
+      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(options, command.opts()))
+    })
+  }
+
+  return program
+}

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -4,6 +4,9 @@ import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from '.
 
 type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>) => Promise<void> | void
 
+// attributeName() exists at runtime in commander 6 but is only typed from v7
+type DeclaredOption = commander.Option & { attributeName(): string }
+
 const argumentsOf = (params: readonly TapCommandParamSchema[]): string => {
   return params.map(({ name, required }) => required ? `<${name}>` : `[${name}]`).join(' ')
 }
@@ -50,12 +53,19 @@ const rejectExcessArguments = (name: string, params: readonly TapCommandParamSch
   throw new commander.CommanderError(1, 'commander.excessArguments', message)
 }
 
-const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Record<string, unknown>): Record<string, string> => {
+const forwardedOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): Record<string, string> => {
+  const opts = command.opts()
+  const declared = command.options as DeclaredOption[]
   const forwarded: Record<string, string> = {}
 
+  // commander stores `--dry-run` under opts().dryRun, so resolve each schema
+  // name to its declared option's attribute key rather than assuming they match
   for (const { name } of options) {
-    if (opts[name] !== undefined) {
-      forwarded[name] = String(opts[name])
+    const option = declared.find((declaredOption) => declaredOption.long === `--${name}`)
+    const value = option && opts[option.attributeName()]
+
+    if (value !== undefined) {
+      forwarded[name] = String(value)
     }
   }
 
@@ -92,7 +102,7 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
     command.action(() => {
       rejectExcessArguments(name, params, command.args)
 
-      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(options, command.opts()))
+      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(command, options))
     })
   }
 

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -2,11 +2,6 @@ import commander from 'commander'
 
 import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from './contract'
 
-/**
- * Invoked when a built subcommand matches. Args and options are forwarded as
- * raw strings keyed by their schema name; type coercion is the running
- * instance's job, so the CLI never interprets types.
- */
 type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>) => Promise<void> | void
 
 const argumentsOf = (params: readonly TapCommandParamSchema[]): string => {
@@ -17,9 +12,6 @@ const argumentDescriptions = (params: readonly TapCommandParamSchema[]): Record<
   return Object.fromEntries(params.map(({ name, description }) => [name, description]))
 }
 
-// A required value option uses `requiredOption` so commander enforces presence;
-// the binding re-checks app-side regardless. No custom parser is attached, so
-// commander yields raw strings and coercion stays app-side.
 const declareOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
   for (const { name, alias, type, required, description } of options) {
     const lead = alias ? `-${alias}, ` : ''
@@ -33,9 +25,6 @@ const declareOptions = (command: commander.Command, options: readonly TapCommand
   }
 }
 
-// Key each positional by its schema param name so args reach the binding
-// name-keyed, like options. `rejectExcessArguments` has already run, so
-// `args.length <= params.length`.
 const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly string[]): Record<string, string> => {
   const forwarded: Record<string, string> = {}
 
@@ -50,10 +39,6 @@ const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly 
   return forwarded
 }
 
-// commander 6 keeps operands beyond the declared params rather than rejecting
-// them (it has no `allowExcessArguments`), and a name-keyed arg object can't
-// carry the extras anyway — so reject them here at the parse layer, in the same
-// exit-1-with-a-stderr-message shape commander uses for `missingArgument`.
 const rejectExcessArguments = (name: string, params: readonly TapCommandParamSchema[], args: readonly string[]): void => {
   if (args.length <= params.length) {
     return
@@ -65,9 +50,6 @@ const rejectExcessArguments = (name: string, params: readonly TapCommandParamSch
   throw new commander.CommanderError(1, 'commander.excessArguments', message)
 }
 
-// Forward supplied options as raw strings; the binding coerces them, as it does
-// positionals. Keying by the schema name (a single dash-free token) sidesteps
-// commander's camelCasing.
 const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Record<string, unknown>): Record<string, string> => {
   const forwarded: Record<string, string> = {}
 
@@ -80,28 +62,13 @@ const forwardedOptions = (options: readonly TapCommandOptionSchema[], opts: Reco
   return forwarded
 }
 
-/**
- * Build a commander program from a tap schema fetched at runtime: one
- * subcommand per advertised command. The program name is `cypress tap` so
- * generated usage reads as the user typed it.
- *
- * `exitOverride` turns commander's own argument validation and help into
- * catchable `CommanderError`s instead of process exits, so the orchestrator
- * can route them through the logger.
- */
 export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): commander.Command => {
   const program = new commander.Command('cypress tap')
 
   program.exitOverride()
-  // No implicit `help` subcommand: every command name is the running
-  // instance's to define, so `tap help` is just an unknown command.
   program.addHelpCommand(false)
   program.description('Interacts with a running Cypress instance')
 
-  // `instances` is the CLI's own command — it enumerates the discovery layer
-  // rather than dispatching to a running instance. `../exec/tap` intercepts it
-  // before this program is parsed, so this entry exists only for help; its
-  // action never runs.
   program
   .command('instances')
   .description('list the running Cypress instances this CLI can reach')
@@ -120,9 +87,6 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
     declareOptions(command, options)
 
     command.action(() => {
-      // Read the matched command from the closure, not the action's varargs:
-      // commander appends excess operands AFTER the command in that list, so
-      // positionally fishing it out breaks on the very case we reject below.
       rejectExcessArguments(name, params, command.args)
 
       return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(options, command.opts()))

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -127,6 +127,14 @@ describe('lib/tap/build-program', () => {
     )
   })
 
+  it('throws a catchable excessArguments error for operands passed to the CLI-native instances command', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['instances', 'extra'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.excessArguments' }),
+    )
+  })
+
   it('throws a catchable unknownCommand error for a command not in the schema', () => {
     const program = buildTapProgram(schema, vi.fn())
 
@@ -178,29 +186,6 @@ describe('lib/tap/build-program', () => {
     expect(() => program.parse(['run', 'a.cy.js', '--nope'], { from: 'user' })).toThrowError(
       expect.objectContaining({ code: 'commander.unknownOption' }),
     )
-  })
-
-  it('rejects an unknown flag catchably even when the root CLI has patched unknownOption to exit', () => {
-    const original = commander.Command.prototype.unknownOption
-    const exit = vi.spyOn(process, 'exit').mockImplementation(((): never => {
-      throw new Error('process.exit called')
-    }))
-
-    // mirror cli/lib/cli.ts, which patches the prototype to exit and so defeats exitOverride()
-    commander.Command.prototype.unknownOption = function () {
-      process.exit(1)
-    }
-
-    try {
-      const program = buildTapProgram(schema, vi.fn())
-
-      expect(() => program.parse(['run', 'a.cy.js', '--nope'], { from: 'user' })).toThrowError(
-        expect.objectContaining({ code: 'commander.unknownOption' }),
-      )
-    } finally {
-      commander.Command.prototype.unknownOption = original
-      exit.mockRestore()
-    }
   })
 
   it('declares a required value option with requiredOption so commander enforces it', () => {

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -44,8 +44,6 @@ const subcommand = (program: commander.Command, name: string): commander.Command
 
 describe('lib/tap/build-program', () => {
   beforeEach(() => {
-    // commander writes validation errors to console.error before throwing
-    // (it predates configureOutput); keep the test output quiet.
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -82,8 +80,6 @@ describe('lib/tap/build-program', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(schema, dispatch)
 
-    // `42` matches a `number`-typed param but must stay a string: coercion is
-    // the running instance's job, not the CLI's.
     program.parse(['open', 'cypress/e2e/a.cy.js', '42'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js', line: '42' }, {})
@@ -145,8 +141,6 @@ describe('lib/tap/build-program', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(schema, dispatch)
 
-    // `8080` matches the `number`-typed port but must stay a string — coercion
-    // is the running instance's job, just as it is for positionals.
     program.parse(['run', 'a.cy.js', '--browser', 'chrome', '--port', '8080', '--headed'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith('run', { spec: 'a.cy.js' }, { browser: 'chrome', port: '8080', headed: 'true' })

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -208,6 +208,65 @@ describe('lib/tap/build-program', () => {
     )
   })
 
+  const dashedSchema: TapSchema = {
+    protocolVersion: 1,
+    cypressVersion: '15.0.0',
+    commands: [{
+      name: 'export',
+      description: 'export results',
+      params: [],
+      options: [
+        { name: 'dry-run', type: 'boolean', required: false, description: 'preview without writing' },
+        { name: 'output-file', type: 'string', required: false, description: 'where to write results' },
+      ],
+    }],
+  }
+
+  it('forwards a dashed boolean option keyed by its raw schema name despite commander camelCasing it', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(dashedSchema, dispatch)
+
+    program.parse(['export', '--dry-run'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'dry-run': 'true' })
+  })
+
+  it('forwards a dashed value option keyed by its raw schema name despite commander camelCasing it', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(dashedSchema, dispatch)
+
+    program.parse(['export', '--output-file', 'out.json'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'output-file': 'out.json' })
+  })
+
+  it('omits dashed options the user did not supply', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(dashedSchema, dispatch)
+
+    program.parse(['export'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('export', {}, {})
+  })
+
+  it('forwards a dashed param name keyed by its raw schema name (positionals bypass camelCasing)', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram({
+      protocolVersion: 1,
+      cypressVersion: '15.0.0',
+      commands: [{
+        name: 'show',
+        description: 'show a spec',
+        params: [{ name: 'spec-path', type: 'string', required: true, description: 'project-relative spec path' }],
+        options: [],
+      }],
+    }, dispatch)
+
+    program.parse(['show', 'a.cy.js'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('show', { 'spec-path': 'a.cy.js' }, {})
+  })
+
   it('declares a required value option with requiredOption so commander enforces it', () => {
     const program = buildTapProgram({
       protocolVersion: 1,

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -119,6 +119,14 @@ describe('lib/tap/build-program', () => {
     )
   })
 
+  it('throws a catchable excessArguments error for operands passed to a no-param command', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['health', 'extra'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.excessArguments' }),
+    )
+  })
+
   it('throws a catchable unknownCommand error for a command not in the schema', () => {
     const program = buildTapProgram(schema, vi.fn())
 
@@ -170,6 +178,29 @@ describe('lib/tap/build-program', () => {
     expect(() => program.parse(['run', 'a.cy.js', '--nope'], { from: 'user' })).toThrowError(
       expect.objectContaining({ code: 'commander.unknownOption' }),
     )
+  })
+
+  it('rejects an unknown flag catchably even when the root CLI has patched unknownOption to exit', () => {
+    const original = commander.Command.prototype.unknownOption
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((): never => {
+      throw new Error('process.exit called')
+    }))
+
+    // mirror cli/lib/cli.ts, which patches the prototype to exit and so defeats exitOverride()
+    commander.Command.prototype.unknownOption = function () {
+      process.exit(1)
+    }
+
+    try {
+      const program = buildTapProgram(schema, vi.fn())
+
+      expect(() => program.parse(['run', 'a.cy.js', '--nope'], { from: 'user' })).toThrowError(
+        expect.objectContaining({ code: 'commander.unknownOption' }),
+      )
+    } finally {
+      commander.Command.prototype.unknownOption = original
+      exit.mockRestore()
+    }
   })
 
   it('declares a required value option with requiredOption so commander enforces it', () => {

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -188,6 +188,26 @@ describe('lib/tap/build-program', () => {
     )
   })
 
+  it('treats a schema command that omits params as having no positionals', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram({
+      protocolVersion: 1,
+      cypressVersion: '15.0.0',
+      commands: [{
+        name: 'health',
+        description: 'check that a running Cypress instance is reachable',
+      }],
+    } as TapSchema, dispatch)
+
+    program.parse(['health'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('health', {}, {})
+
+    expect(() => program.parse(['health', 'extra'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.excessArguments' }),
+    )
+  })
+
   it('declares a required value option with requiredOption so commander enforces it', () => {
     const program = buildTapProgram({
       protocolVersion: 1,

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import commander from 'commander'
+
+import { buildTapProgram } from '../../../lib/tap/build-program'
+import type { TapSchema } from '../../../lib/tap/contract'
+
+const schema: TapSchema = {
+  protocolVersion: 1,
+  cypressVersion: '15.0.0',
+  commands: [
+    {
+      name: 'health',
+      description: 'check that a running Cypress instance is reachable',
+      params: [],
+      options: [],
+    },
+    {
+      name: 'run',
+      description: 'run a spec by its project-relative path',
+      params: [
+        { name: 'spec', type: 'string', required: true, description: 'project-relative spec path' },
+      ],
+      options: [
+        { name: 'browser', alias: 'b', type: 'string', required: false, description: 'which browser to run in' },
+        { name: 'port', type: 'number', required: false, description: 'a port to listen on' },
+        { name: 'headed', type: 'boolean', required: false, description: 'show the browser' },
+      ],
+    },
+    {
+      name: 'open',
+      description: 'open a spec at a line',
+      params: [
+        { name: 'spec', type: 'string', required: true, description: 'project-relative spec path' },
+        { name: 'line', type: 'number', required: false, description: 'a one-based line number' },
+      ],
+      options: [],
+    },
+  ],
+}
+
+const subcommand = (program: commander.Command, name: string): commander.Command => {
+  return program.commands.find((command) => command.name() === name)!
+}
+
+describe('lib/tap/build-program', () => {
+  beforeEach(() => {
+    // commander writes validation errors to console.error before throwing
+    // (it predates configureOutput); keep the test output quiet.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('registers the CLI-native `instances` command first, then one subcommand per advertised command', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(program.commands.map((command) => command.name())).toEqual(['instances', 'health', 'run', 'open'])
+  })
+
+  it('names the program so generated usage reads `cypress tap <command>`', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(subcommand(program, 'run').helpInformation()).toContain('Usage: cypress tap run [options] <spec>')
+  })
+
+  it('derives positional grammar from each param schema (required <>, optional [])', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(program.helpInformation()).toContain('run [options] <spec>')
+    expect(subcommand(program, 'open').usage()).toBe('[options] <spec> [line]')
+  })
+
+  it('renders a rich per-command help with the param descriptions', () => {
+    const program = buildTapProgram(schema, vi.fn())
+    const help = subcommand(program, 'open').helpInformation()
+
+    expect(help).toContain('Arguments:')
+    expect(help).toContain('spec')
+    expect(help).toContain('project-relative spec path')
+    expect(help).toContain('a one-based line number')
+  })
+
+  it('forwards positional strings to dispatch keyed by schema param name, uninterpreted', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    // `42` matches a `number`-typed param but must stay a string: coercion is
+    // the running instance's job, not the CLI's.
+    program.parse(['open', 'cypress/e2e/a.cy.js', '42'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js', line: '42' }, {})
+  })
+
+  it('keys only the supplied positionals, omitting an absent trailing optional', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    program.parse(['open', 'cypress/e2e/a.cy.js'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js' }, {})
+  })
+
+  it('dispatches a no-param command with an empty arg map and no options', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    program.parse(['health'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('health', {}, {})
+  })
+
+  it('throws a catchable missingArgument error when a required positional is absent', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['run'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.missingArgument' }),
+    )
+  })
+
+  it('throws a catchable excessArguments error for operands beyond the declared params', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['run', 'a.cy.js', 'extra'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.excessArguments' }),
+    )
+  })
+
+  it('throws a catchable unknownCommand error for a command not in the schema', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['bogus'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.unknownCommand' }),
+    )
+  })
+
+  it('declares each schema option (with its alias) in the per-command help', () => {
+    const program = buildTapProgram(schema, vi.fn())
+    const help = subcommand(program, 'run').helpInformation()
+
+    expect(help).toContain('Options:')
+    expect(help).toContain('-b, --browser <browser>')
+    expect(help).toContain('which browser to run in')
+    expect(help).toContain('--headed')
+  })
+
+  it('forwards parsed option values to dispatch as raw strings keyed by name, uninterpreted', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    // `8080` matches the `number`-typed port but must stay a string — coercion
+    // is the running instance's job, just as it is for positionals.
+    program.parse(['run', 'a.cy.js', '--browser', 'chrome', '--port', '8080', '--headed'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('run', { spec: 'a.cy.js' }, { browser: 'chrome', port: '8080', headed: 'true' })
+  })
+
+  it('resolves a short alias to its option name', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    program.parse(['run', 'a.cy.js', '-b', 'firefox'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('run', { spec: 'a.cy.js' }, { browser: 'firefox' })
+  })
+
+  it('omits options the user did not supply', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(schema, dispatch)
+
+    program.parse(['run', 'a.cy.js'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('run', { spec: 'a.cy.js' }, {})
+  })
+
+  it('throws a catchable unknownOption error for a flag not in the schema', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(() => program.parse(['run', 'a.cy.js', '--nope'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.unknownOption' }),
+    )
+  })
+
+  it('declares a required value option with requiredOption so commander enforces it', () => {
+    const program = buildTapProgram({
+      protocolVersion: 1,
+      cypressVersion: '15.0.0',
+      commands: [{
+        name: 'login',
+        description: 'log in',
+        params: [],
+        options: [{ name: 'token', type: 'string', required: true, description: 'an auth token' }],
+      }],
+    }, vi.fn())
+
+    expect(() => program.parse(['login'], { from: 'user' })).toThrowError(
+      expect.objectContaining({ code: 'commander.missingMandatoryOptionValue' }),
+    )
+  })
+})


### PR DESCRIPTION
### Additional details

This slice adds `cli/lib/tap/build-program.ts` — a pure, schema-driven builder that turns a tap schema (fetched at runtime from a running instance) into a commander program. No CDP, no discovery, no I/O.

- **`buildTapProgram(schema, dispatch)`.** Constructs a commander program named `cypress tap` with one subcommand per advertised command. Each subcommand's positional grammar (`<required>` / `[optional]`), options, and help text are derived entirely from the command's param and option schema — nothing about the commands is hardcoded. `exitOverride()` turns commander's own argument validation and help into catchable `CommanderError`s (rather than process exits) so the orchestrator can route them through the logger. The implicit `help` subcommand is disabled (`addHelpCommand(false)`) because every command name belongs to the running instance.
- **Raw-string forwarding, no coercion.** A matched subcommand forwards its positionals and options to `dispatch`, each keyed by its schema name and stringified — args and options reach the binding in one consistent name-keyed shape. The CLI never interprets types; validation and coercion stay app-side in the binding's `exec`. Keying options by the schema name (a dash-free token) sidesteps commander's camelCasing. A `requiredOption` is used for required value options so commander enforces presence, but the binding re-checks regardless.
- **Excess-argument rejection.** commander 6 has no `allowExcessArguments` and keeps extra operands in `command.args`, so `rejectExcessArguments` rejects them at the parse layer with the same exit-1-with-stderr shape commander uses for its own `missingArgument` / `unknownOption`. The action reads the matched command from the closure rather than the action varargs, because commander appends excess operands after the command in that list.
- **`instances` placeholder.** The CLI-native `instances` command is declared first (for help-listing only); the orchestration slice intercepts it before this program is parsed, so its action never runs.

### Steps to test

Pure builder logic covered by unit tests (vitest), added in this slice:

- `cli/test/lib/tap/build-program.spec.ts` — schema → commander program: positional grammar (`<required>` / `[optional]`), option declaration/alias resolution (value vs. boolean, short alias, `requiredOption` for required value options), raw-string forwarding (positionals and options keyed by schema name, no coercion), excess-argument rejection, and that validation/help surface as catchable `CommanderError`s.

```bash
yarn workspace cypress test -- test/lib/tap/build-program.spec.ts
```

### How has the user experience changed?

No change. This slice adds an internal, pure schema→commander builder module with no user-facing behavior on its own; the `cypress tap` command and its visible behavior are wired up in the slice above this one (#34148).

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal/experimental tap CLI work; tracked by internal ticket 13629, no public GitHub issue. -->
- [x] Have tests been added/updated? <!-- New: cli/test/lib/tap/build-program.spec.ts. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change in this slice; pure internal builder module. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` JS API or its type definitions; internal CLI module only. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal CLI builder with no wiring in this diff; behavior is isolated and covered by unit tests with no user-facing change until orchestration integrates it.
> 
> **Overview**
> Adds **`buildTapProgram(schema, dispatch)`**, a pure builder that turns a runtime **TapSchema** into a **`cypress tap`** commander program with one subcommand per advertised command (plus a help-only **`instances`** stub).
> 
> Subcommand positionals, options, aliases, and help are derived from the schema; parsed args/options are forwarded to **`dispatch`** as **string maps keyed by schema names** (no type coercion). **`exitOverride()`** and disabled implicit help make validation errors catchable **`CommanderError`**s; **`rejectExcessArguments`** rejects extra operands commander 6 would otherwise keep.
> 
> Vitest coverage in **`build-program.spec.ts`** exercises grammar, help, forwarding (including dashed names vs commander camelCase), and error codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb5d08f593868238727fc50b5a463d28f3c1909b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->