### PR TITLE
feat: add the specs tap command listing runnable specs (9)

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-06-11-2026
+07-13-2026

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -26,12 +26,12 @@ describe('tap binding', () => {
 
       expect('result' in outcome).to.eq(true)
 
-      const specs = (outcome as { result: Array<{ relative: string, specType: string }> }).result
+      const specs = (outcome as { result: Array<{ relativePath: string, specType: string }> }).result
 
-      expect(specs).to.deep.include({ relative: 'cypress/e2e/dom-content.spec.js', specType: 'integration' })
+      expect(specs).to.deep.include({ relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' })
 
       for (const spec of specs) {
-        expect(Object.keys(spec), `entry ${spec.relative}`).to.deep.eq(['relative', 'specType'])
+        expect(Object.keys(spec), `entry ${spec.relativePath}`).to.deep.eq(['relativePath', 'specType'])
       }
     })
   })

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -16,11 +16,23 @@ describe('tap binding', () => {
       const schema = await binding.getSchema()
 
       expect(schema.schemaVersion).to.eq(1)
-      expect(schema.commands).to.be.an('array')
+      expect(schema.commands.map((command) => command.name)).to.include.members(['specs'])
 
       const unknown = await binding.exec('not-a-command')
 
       expect((unknown as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')
+
+      const outcome = await binding.exec('specs')
+
+      expect('result' in outcome).to.eq(true)
+
+      const specs = (outcome as { result: Array<{ relative: string, specType: string }> }).result
+
+      expect(specs).to.deep.include({ relative: 'cypress/e2e/dom-content.spec.js', specType: 'integration' })
+
+      for (const spec of specs) {
+        expect(Object.keys(spec), `entry ${spec.relative}`).to.deep.eq(['relative', 'specType'])
+      }
     })
   })
 })

--- a/packages/app/src/tap/commands/index.ts
+++ b/packages/app/src/tap/commands/index.ts
@@ -1,6 +1,8 @@
 import type { TapCommandDefinition } from './definition'
+import { specsCommand } from './specs'
 
 // The command registry — the single source of truth for the tap binding.
-// Adding a subcommand is one sibling module plus its entry here. Ships empty;
-// the first real command lands with the `specs` module.
-export const tapCommands: Record<string, TapCommandDefinition> = {}
+// Adding a subcommand is one sibling module plus its entry here.
+export const tapCommands = {
+  specs: specsCommand,
+} satisfies Record<string, TapCommandDefinition>

--- a/packages/app/src/tap/commands/run-mode-specs.ts
+++ b/packages/app/src/tap/commands/run-mode-specs.ts
@@ -6,13 +6,6 @@ export interface SpecListEntry {
   specType: 'integration' | 'component'
 }
 
-/**
- * The server embeds `ctx.project.specs` in the runner HTML at serve time
- * (HtmlDataSource.replaceBody): a snapshot from the last page load — spec
- * files added or removed since then won't show until the runner reloads.
- * The global is declared as SpecFile[], but the embedded entries carry the
- * full found-spec shape.
- */
 export const readRunModeSpecs = (): FoundSpec[] => {
   return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
 }

--- a/packages/app/src/tap/commands/run-mode-specs.ts
+++ b/packages/app/src/tap/commands/run-mode-specs.ts
@@ -1,10 +1,7 @@
 import type { FoundSpec } from '@packages/types'
 
-export interface SpecListEntry {
-  /** Project-relative spec path — the form `cypress run --spec` accepts. */
-  relative: string
-  specType: 'integration' | 'component'
-}
+/** `relative` is the project-relative spec path — the form `cypress run --spec` accepts. */
+export type SpecListEntry = Pick<FoundSpec, 'relative' | 'specType'>
 
 export const readRunModeSpecs = (): FoundSpec[] => {
   return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]

--- a/packages/app/src/tap/commands/run-mode-specs.ts
+++ b/packages/app/src/tap/commands/run-mode-specs.ts
@@ -1,0 +1,22 @@
+import type { FoundSpec } from '@packages/types'
+
+export interface SpecListEntry {
+  /** Project-relative spec path — the form `cypress run --spec` accepts. */
+  relative: string
+  specType: 'integration' | 'component'
+}
+
+/**
+ * The server embeds `ctx.project.specs` in the runner HTML at serve time
+ * (HtmlDataSource.replaceBody): a snapshot from the last page load — spec
+ * files added or removed since then won't show until the runner reloads.
+ * The global is declared as SpecFile[], but the embedded entries carry the
+ * full found-spec shape.
+ */
+export const readRunModeSpecs = (): FoundSpec[] => {
+  return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
+}
+
+export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
+  return { relative, specType }
+}

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -1,12 +1,16 @@
 import type { FoundSpec } from '@packages/types'
 
-/** `relative` is the project-relative spec path — the form `cypress run --spec` accepts. */
-export type SpecListEntry = Pick<FoundSpec, 'relative' | 'specType'>
+export interface SpecListEntry {
+  /** Project-relative spec path — the form `cypress run --spec` accepts. */
+  relativePath: string
+  /** Whether the spec is an end-to-end (integration) or component spec. */
+  specType: FoundSpec['specType']
+}
 
 export const getRunnableSpecs = (): FoundSpec[] => {
   return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
 }
 
 export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
-  return { relative, specType }
+  return { relativePath: relative, specType }
 }

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -3,7 +3,7 @@ import type { FoundSpec } from '@packages/types'
 /** `relative` is the project-relative spec path — the form `cypress run --spec` accepts. */
 export type SpecListEntry = Pick<FoundSpec, 'relative' | 'specType'>
 
-export const readRunModeSpecs = (): FoundSpec[] => {
+export const getRunnableSpecs = (): FoundSpec[] => {
   return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
 }
 

--- a/packages/app/src/tap/commands/specs.cy.ts
+++ b/packages/app/src/tap/commands/specs.cy.ts
@@ -39,8 +39,8 @@ describe('tap/commands/specs', () => {
 
     expect(await manager.exec('specs')).to.deep.eq({
       result: [
-        { relative: 'cypress/e2e/login.cy.ts', specType: 'integration' },
-        { relative: 'src/Button.cy.tsx', specType: 'component' },
+        { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
+        { relativePath: 'src/Button.cy.tsx', specType: 'component' },
       ],
     })
   })

--- a/packages/app/src/tap/commands/specs.cy.ts
+++ b/packages/app/src/tap/commands/specs.cy.ts
@@ -1,0 +1,53 @@
+import type { FoundSpec } from '@packages/types'
+
+import { TapManager } from '../tap-manager'
+
+const CYPRESS_VERSION = '15.0.0'
+
+describe('tap/commands/specs', () => {
+  const RUN_MODE_SPECS: FoundSpec[] = [
+    {
+      name: 'login.cy.ts',
+      relative: 'cypress/e2e/login.cy.ts',
+      absolute: '/project/cypress/e2e/login.cy.ts',
+      baseName: 'login.cy.ts',
+      fileName: 'login',
+      fileExtension: '.ts',
+      specFileExtension: '.cy.ts',
+      specType: 'integration',
+    },
+    {
+      name: 'Button.cy.tsx',
+      relative: 'src/Button.cy.tsx',
+      absolute: '/project/src/Button.cy.tsx',
+      baseName: 'Button.cy.tsx',
+      fileName: 'Button',
+      fileExtension: '.tsx',
+      specFileExtension: '.cy.tsx',
+      specType: 'component',
+    },
+  ]
+
+  afterEach(() => {
+    delete (window as any).__RUN_MODE_SPECS__
+  })
+
+  it('lists the server-embedded specs, keeping only the lean entry fields', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('specs')).to.deep.eq({
+      result: [
+        { relative: 'cypress/e2e/login.cy.ts', specType: 'integration' },
+        { relative: 'src/Button.cy.tsx', specType: 'component' },
+      ],
+    })
+  })
+
+  it('resolves an empty list when the specs global is not present', async () => {
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('specs')).to.deep.eq({ result: [] })
+  })
+})

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -3,7 +3,7 @@ import { readRunModeSpecs, toSpecListEntry } from './run-mode-specs'
 import type { SpecListEntry } from './run-mode-specs'
 
 export const specsCommand = defineCommand({
-  description: 'List all runnable spec for the selected Cypress instance.',
+  description: 'List all runnable specs for the selected Cypress instance.',
   params: [],
   handler: async (): Promise<SpecListEntry[]> => {
     return readRunModeSpecs().map(toSpecListEntry)

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -3,7 +3,7 @@ import { readRunModeSpecs, toSpecListEntry } from './run-mode-specs'
 import type { SpecListEntry } from './run-mode-specs'
 
 export const specsCommand = defineCommand({
-  description: 'list the specs the running Cypress instance can run',
+  description: 'List all runnable spec for the selected Cypress instance.',
   params: [],
   handler: async (): Promise<SpecListEntry[]> => {
     return readRunModeSpecs().map(toSpecListEntry)

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -1,0 +1,11 @@
+import { defineCommand } from './definition'
+import { readRunModeSpecs, toSpecListEntry } from './run-mode-specs'
+import type { SpecListEntry } from './run-mode-specs'
+
+export const specsCommand = defineCommand({
+  description: 'list the specs the running Cypress instance can run',
+  params: [],
+  handler: async (): Promise<SpecListEntry[]> => {
+    return readRunModeSpecs().map(toSpecListEntry)
+  },
+})

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -1,11 +1,11 @@
 import { defineCommand } from './definition'
-import { readRunModeSpecs, toSpecListEntry } from './run-mode-specs'
-import type { SpecListEntry } from './run-mode-specs'
+import { getRunnableSpecs, toSpecListEntry } from './specs-list'
+import type { SpecListEntry } from './specs-list'
 
 export const specsCommand = defineCommand({
   description: 'List all runnable specs for the selected Cypress instance.',
   params: [],
   handler: async (): Promise<SpecListEntry[]> => {
-    return readRunModeSpecs().map(toSpecListEntry)
+    return getRunnableSpecs().map(toSpecListEntry)
   },
 })


### PR DESCRIPTION
### Additional details

This PR adds the first real data command to the `cypress tap` registry: **`specs`**, which lists the spec files the running Cypress instance can run. It sits directly above the registry scaffold (#34190) and gives the CLI a way to enumerate runnable specs before driving a run (in the stacked PRs above).

- **`specs` command** (`packages/app/src/runner/tap/commands/specs.ts`). A parameterless `defineCommand` whose handler returns the run-mode specs as lean `{ relativePath, specType }` entries — `relativePath` is the project-relative path that `cypress run --spec` accepts. Registered in the registry via one entry in `commands/index.ts`.
- **Runnable spec source** (`commands/specs-list.ts`). `getRunnableSpecs()` reads `window.__RUN_MODE_SPECS__`, the spec snapshot the server embeds in the runner HTML at serve time (`HtmlDataSource.replaceBody`). Because it is a point-in-time snapshot from the last page load, specs added/removed since then won't appear until the runner reloads — documented at the read site. `toSpecListEntry` projects the full found-spec shape down to the two fields the contract exposes.

### Steps to test

App-side binding logic covered by a component spec (`cypress:run:ct`) and exercised end-to-end by the binding e2e:

- `packages/app/src/runner/tap/commands/specs.cy.ts` — new spec: drives `exec('specs')` through `TapManager`, asserting it projects the server-embedded specs down to `{ relativePath, specType }` (integration + component), and resolves an empty list when the global is absent.
- `packages/app/cypress/e2e/tap-binding.cy.ts` — updated: `getSchema()` now advertises both `health` and `specs`, and `exec('specs')` returns entries whose keys are exactly `['relativePath', 'specType']`.

Manual end-to-end is exercised by the top wiring layer (#34148): start a Cypress instance, open a browser, and run `cypress tap specs` to list the runnable specs through the binding.

### How has the user experience changed?

No change to existing flows. This adds a new subcommand to the experimental `cypress tap` CLI (`cypress tap specs`); there is no change to the public `cypress` JS API or any GUI surface.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal/experimental tap CLI work; tracked by internal ticket, no public GitHub issue. -->
- [x] Have tests been added/updated? <!-- New: commands/specs.cy.ts. Updated: cypress/e2e/tap-binding.cy.ts. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Experimental internal feature; not yet publicly documented. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` JS API or its type definitions; this is internal tap binding code. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental tap CLI surface with read-only access to an existing window global; no auth, public API, or runner execution changes.
> 
> **Overview**
> Adds the first data command to the experimental **`cypress tap`** binding: **`specs`**, so the CLI can enumerate runnable spec files for the active instance.
> 
> The handler reads the server-embedded **`window.__RUN_MODE_SPECS__`** snapshot and returns lean **`{ relativePath, specType }`** entries (paths suitable for **`cypress run --spec`**). The command is registered in **`tapCommands`** via **`specs.ts`** and **`specs-list.ts`**.
> 
> Coverage includes a **`TapManager`** component spec and an updated tap-binding e2e that asserts **`getSchema()`** advertises **`specs`** and **`exec('specs')`** returns only those two keys per entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d948edd88a73b6e90c6bd5fd018a6cd6880b05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



