### PR TITLE
feat: add the run tap command triggering a spec via the runner URL (10)

### DIFF
--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -61,7 +61,6 @@ describe('tap binding', () => {
       })
     })
 
-    // The href change navigates from the specs page to the runner and runs the spec.
     cy.location('hash')
     .should('contain', '/specs/runner?file=cypress/e2e/dom-content.spec.js')
     .and('match', /tapRun=\d+/)
@@ -69,8 +68,7 @@ describe('tap binding', () => {
     cy.waitForSpecToFinish({ passCount: 1 })
     cy.contains('Dom Content').should('be.visible')
 
-    // Rerunning the same spec advances the tapRun nonce, so the query change
-    // kicks off a fresh run even though the active spec is unchanged.
+    // Rerunning advances the nonce, so the query changes even though the spec is unchanged.
     cy.location('hash').then((hashBefore) => {
       cy.window().then(async (win) => {
         const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })
@@ -90,7 +88,7 @@ describe('tap binding', () => {
         expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/does-not-exist.cy.js')
       })
 
-      // A domain failure resolves as an { error } value and never navigates.
+      // A domain failure never navigates.
       cy.location('hash').should('eq', hashBefore)
     })
   })

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -16,7 +16,7 @@ describe('tap binding', () => {
       const schema = await binding.getSchema()
 
       expect(schema.schemaVersion).to.eq(1)
-      expect(schema.commands.map((command) => command.name)).to.include.members(['specs'])
+      expect(schema.commands.map((command) => command.name)).to.include.members(['specs', 'run'])
 
       const unknown = await binding.exec('not-a-command')
 
@@ -33,6 +33,65 @@ describe('tap binding', () => {
       for (const spec of specs) {
         expect(Object.keys(spec), `entry ${spec.relativePath}`).to.deep.eq(['relativePath', 'specType'])
       }
+    })
+  })
+
+  it('runs and reruns a spec via the run command', () => {
+    cy.scaffoldProject('cypress-in-cypress')
+    cy.openProject('cypress-in-cypress')
+    cy.startAppServer('e2e')
+    cy.visitApp()
+    cy.specsPageIsVisible()
+
+    const getBinding = (win: Cypress.AUTWindow) => {
+      const binding = win.__CYPRESS_TAP_BINDING__
+
+      if (!binding) {
+        throw new Error('"window.__CYPRESS_TAP_BINDING__" is expected to be available')
+      }
+
+      return binding
+    }
+
+    cy.window().then(async (win) => {
+      const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })
+
+      expect(outcome).to.deep.eq({
+        result: { relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' },
+      })
+    })
+
+    // The href change navigates from the specs page to the runner and runs the spec.
+    cy.location('hash')
+    .should('contain', '/specs/runner?file=cypress/e2e/dom-content.spec.js')
+    .and('match', /tapRun=\d+/)
+
+    cy.waitForSpecToFinish({ passCount: 1 })
+    cy.contains('Dom Content').should('be.visible')
+
+    // Rerunning the same spec advances the tapRun nonce, so the query change
+    // kicks off a fresh run even though the active spec is unchanged.
+    cy.location('hash').then((hashBefore) => {
+      cy.window().then(async (win) => {
+        const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })
+
+        expect('result' in outcome).to.eq(true)
+      })
+
+      cy.location('hash').should('not.eq', hashBefore)
+      cy.waitForSpecToFinish({ passCount: 1 })
+    })
+
+    cy.location('hash').then((hashBefore) => {
+      cy.window().then(async (win) => {
+        const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/does-not-exist.cy.js' })
+
+        expect((outcome as { error: { code: string } }).error.code).to.eq('SPEC_NOT_FOUND')
+        expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/does-not-exist.cy.js')
+      })
+
+      // A domain failure resolves as an { error } value and never navigates.
+      cy.location('hash').should('eq', hashBefore)
     })
   })
 })

--- a/packages/app/src/tap/commands/index.ts
+++ b/packages/app/src/tap/commands/index.ts
@@ -1,8 +1,10 @@
 import type { TapCommandDefinition } from './definition'
+import { runCommand } from './run'
 import { specsCommand } from './specs'
 
 // The command registry — the single source of truth for the tap binding.
 // Adding a subcommand is one sibling module plus its entry here.
 export const tapCommands = {
   specs: specsCommand,
+  run: runCommand,
 } satisfies Record<string, TapCommandDefinition>

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -30,56 +30,56 @@ describe('tap/commands/run', () => {
   it('fails dispatch without navigating when the required spec arg is missing', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run')
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_ARGUMENTS')
     expect((outcome as { error: { message: string } }).error.message).to.contain('Usage: cypress tap run <spec>')
-    expect(assign).not.to.have.been.called
+    expect(setHash).not.to.have.been.called
   })
 
   it('fails with INVALID_SPEC without navigating when the param is an empty string', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: '' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_SPEC')
-    expect(assign).not.to.have.been.called
+    expect(setHash).not.to.have.been.called
   })
 
   it('fails with SPEC_NOT_FOUND without navigating when no spec matches', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/nope.cy.ts' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SPEC_NOT_FOUND')
     expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/nope.cy.ts')
-    expect(assign).not.to.have.been.called
+    expect(setHash).not.to.have.been.called
   })
 
   it('fails with SPEC_NOT_FOUND when the specs global is not present', async () => {
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SPEC_NOT_FOUND')
     expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/login.cy.ts')
-    expect(assign).not.to.have.been.called
+    expect(setHash).not.to.have.been.called
   })
 
   it('navigates to the runner URL and resolves with the lean entry of the started spec', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
@@ -88,14 +88,14 @@ describe('tap/commands/run', () => {
       result: { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
     })
 
-    expect(assign).to.have.been.calledOnce
-    expect(assign.firstCall.args[0]).to.match(/^\/specs\/runner\?file=cypress\/e2e\/login\.cy\.ts&tapRun=\d+$/)
+    expect(setHash).to.have.been.calledOnce
+    expect(setHash.firstCall.args[0]).to.match(/^\/specs\/runner\?file=cypress\/e2e\/login\.cy\.ts&tapRun=\d+$/)
   })
 
   it('advances the tapRun nonce so rerunning the same spec changes the query', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const readNonce = (href: string) => Number(href.match(/tapRun=(\d+)$/)?.[1])
@@ -103,8 +103,8 @@ describe('tap/commands/run', () => {
     await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
     await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
-    const first = readNonce(assign.firstCall.args[0])
-    const second = readNonce(assign.secondCall.args[0])
+    const first = readNonce(setHash.firstCall.args[0])
+    const second = readNonce(setHash.secondCall.args[0])
 
     expect(first).to.be.a('number').and.not.be.NaN
     expect(second).to.be.greaterThan(first)
@@ -113,7 +113,7 @@ describe('tap/commands/run', () => {
   it('matches windows-style entries against posix input and emits the posix form in the URL', async () => {
     window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress\\e2e\\login.cy.ts' }]
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
@@ -122,18 +122,18 @@ describe('tap/commands/run', () => {
       result: { relativePath: 'cypress\\e2e\\login.cy.ts', specType: 'integration' },
     })
 
-    expect(assign.firstCall.args[0]).to.contain('file=cypress/e2e/login.cy.ts')
+    expect(setHash.firstCall.args[0]).to.contain('file=cypress/e2e/login.cy.ts')
   })
 
   it('escapes URL-significant characters in the spec path', async () => {
     window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress/e2e/a&b?c+d%e.cy.ts' }]
 
-    const assign = stubNavigation()
+    const setHash = stubNavigation()
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/a&b?c+d%e.cy.ts' })
 
     expect('result' in outcome).to.eq(true)
-    expect(assign.firstCall.args[0]).to.contain('file=cypress/e2e/a%26b%3Fc%2Bd%25e.cy.ts')
+    expect(setHash.firstCall.args[0]).to.contain('file=cypress/e2e/a%26b%3Fc%2Bd%25e.cy.ts')
   })
 })

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -1,0 +1,139 @@
+import type { FoundSpec } from '@packages/types'
+
+import { TapManager } from '../tap-manager'
+import { tapNavigation } from './run'
+
+const CYPRESS_VERSION = '15.0.0'
+
+describe('tap/commands/run', () => {
+  const RUN_MODE_SPECS: FoundSpec[] = [
+    {
+      name: 'login.cy.ts',
+      relative: 'cypress/e2e/login.cy.ts',
+      absolute: '/project/cypress/e2e/login.cy.ts',
+      baseName: 'login.cy.ts',
+      fileName: 'login',
+      fileExtension: '.ts',
+      specFileExtension: '.cy.ts',
+      specType: 'integration',
+    },
+  ]
+
+  // Really setting the hash here would navigate the spec frame and stop
+  // the test mid-command, so every test stubs the navigation seam.
+  const stubNavigation = () => cy.stub(tapNavigation, 'setHash')
+
+  afterEach(() => {
+    delete (window as any).__RUN_MODE_SPECS__
+  })
+
+  it('fails dispatch without navigating when the required spec arg is missing', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run')
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_ARGUMENTS')
+    expect((outcome as { error: { message: string } }).error.message).to.contain('Usage: cypress tap run <spec>')
+    expect(assign).not.to.have.been.called
+  })
+
+  it('fails with INVALID_SPEC without navigating when the param is an empty string', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: '' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_SPEC')
+    expect(assign).not.to.have.been.called
+  })
+
+  it('fails with SPEC_NOT_FOUND without navigating when no spec matches', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/nope.cy.ts' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('SPEC_NOT_FOUND')
+    expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/nope.cy.ts')
+    expect(assign).not.to.have.been.called
+  })
+
+  it('fails with SPEC_NOT_FOUND when the specs global is not present', async () => {
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('SPEC_NOT_FOUND')
+    expect((outcome as { error: { message: string } }).error.message).to.contain('cypress/e2e/login.cy.ts')
+    expect(assign).not.to.have.been.called
+  })
+
+  it('navigates to the runner URL and resolves with the lean entry of the started spec', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    expect(outcome).to.deep.eq({
+      result: { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
+    })
+
+    expect(assign).to.have.been.calledOnce
+    expect(assign.firstCall.args[0]).to.match(/^\/specs\/runner\?file=cypress\/e2e\/login\.cy\.ts&tapRun=\d+$/)
+  })
+
+  it('advances the tapRun nonce so rerunning the same spec changes the query', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const readNonce = (href: string) => Number(href.match(/tapRun=(\d+)$/)?.[1])
+
+    await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+    await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    const first = readNonce(assign.firstCall.args[0])
+    const second = readNonce(assign.secondCall.args[0])
+
+    expect(first).to.be.a('number').and.not.be.NaN
+    expect(second).to.be.greaterThan(first)
+  })
+
+  it('matches windows-style entries against posix input and emits the posix form in the URL', async () => {
+    window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress\\e2e\\login.cy.ts' }]
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    expect(outcome).to.deep.eq({
+      result: { relativePath: 'cypress\\e2e\\login.cy.ts', specType: 'integration' },
+    })
+
+    expect(assign.firstCall.args[0]).to.contain('file=cypress/e2e/login.cy.ts')
+  })
+
+  it('escapes URL-significant characters in the spec path', async () => {
+    window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress/e2e/a&b?c+d%e.cy.ts' }]
+
+    const assign = stubNavigation()
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/a&b?c+d%e.cy.ts' })
+
+    expect('result' in outcome).to.eq(true)
+    expect(assign.firstCall.args[0]).to.contain('file=cypress/e2e/a%26b%3Fc%2Bd%25e.cy.ts')
+  })
+})

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -19,9 +19,15 @@ describe('tap/commands/run', () => {
     },
   ]
 
-  // Really setting the hash here would navigate the spec frame and stop
-  // the test mid-command, so every test stubs the navigation seam.
-  const stubNavigation = () => cy.stub(tapNavigation, 'setHash')
+  // Stub the navigation seam — a real hash change would navigate away and stop
+  // the test mid-command. Writes feed the stubbed read, like the real hash.
+  const stubNavigation = (initialHash = '') => {
+    const getHash = cy.stub(tapNavigation, 'getHash').returns(initialHash)
+
+    return cy.stub(tapNavigation, 'setHash').callsFake((hash: string) => {
+      getHash.returns(`#${hash}`)
+    })
+  }
 
   afterEach(() => {
     delete (window as any).__RUN_MODE_SPECS__
@@ -108,6 +114,17 @@ describe('tap/commands/run', () => {
 
     expect(first).to.be.a('number').and.not.be.NaN
     expect(second).to.be.greaterThan(first)
+  })
+
+  it('advances past a tapRun already in the hash, as after a page reload', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const setHash = stubNavigation('#/specs/runner?file=cypress/e2e/login.cy.ts&tapRun=7')
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    expect(setHash.firstCall.args[0]).to.eq('/specs/runner?file=cypress/e2e/login.cy.ts&tapRun=8')
   })
 
   it('matches windows-style entries against posix input and emits the posix form in the URL', async () => {

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -3,9 +3,6 @@ import { defineCommand, TapCommandError } from './definition'
 import { getRunnableSpecs, toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from './specs-list'
 
-// Seam so component tests can stub navigation — really navigating would stop
-// the test mid-command. The `hash` setter (not `href`) keeps it a synchronous
-// same-document navigation, so `exec` still resolves over CDP.
 export const tapNavigation = {
   getHash () {
     return window.location.hash
@@ -15,13 +12,11 @@ export const tapNavigation = {
   },
 }
 
-// watchSpecs only reruns a spec when route.query changes, so bump past whatever
-// tapRun the hash already holds — module state would reset to zero on a page
-// reload while the old value survives in the URL.
 const nextTapRunNonce = () => {
-  const current = /[?&]tapRun=(\d+)/.exec(tapNavigation.getHash())
+  const query = tapNavigation.getHash().split('?')[1] ?? ''
+  const current = Number(new URLSearchParams(query).get('tapRun'))
 
-  return (current ? Number(current[1]) : 0) + 1
+  return (Number.isInteger(current) ? current : 0) + 1
 }
 
 export const runCommand = defineCommand({
@@ -41,9 +36,9 @@ export const runCommand = defineCommand({
       throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
     }
 
-    // Encode the path but keep its slashes literal, since watchSpecs reads
+    // Encode each segment but keep the slashes literal, since watchSpecs reads
     // route.query.file back through getPathForPlatform.
-    const file = encodeURIComponent(posixify(match.relative)).replace(/%2F/g, '/')
+    const file = posixify(match.relative).split('/').map(encodeURIComponent).join('/')
 
     tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
 

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -1,0 +1,56 @@
+import { posixify } from '../../paths'
+import { defineCommand, TapCommandError } from './definition'
+import { getRunnableSpecs, toSpecListEntry } from './specs-list'
+import type { SpecListEntry } from './specs-list'
+
+// Distinguishes each `run` invocation in the runner URL so rerunning the
+// already-active spec still produces a query change (see the handler).
+let tapRunNonce = 0
+
+/**
+ * Seam over the one side effect `run` performs. Component tests stub this —
+ * really navigating there moves the spec frame and stops the test
+ * mid-command. The hash setter (rather than `location.href = '#…'`) is what
+ * guarantees a synchronous same-document fragment navigation, including when
+ * the runner page is itself an AUT (the cypress-in-cypress harness).
+ */
+export const tapNavigation = {
+  setHash (hash: string) {
+    window.location.hash = hash
+  },
+}
+
+export const runCommand = defineCommand({
+  description: 'run (or rerun) a spec by its project-relative path',
+  params: [
+    { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
+  ],
+  // Triggering is fire-and-forget: returning the started spec means navigation
+  // was issued, not that the spec finished or passed. The two failure cases
+  // throw — surfaced on stderr, never stdout, and the runner never navigates:
+  // INVALID_SPEC for an empty path, SPEC_NOT_FOUND when none matches.
+  handler: async ({ spec }): Promise<SpecListEntry> => {
+    if (spec.length === 0) {
+      throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
+    }
+
+    const wanted = posixify(spec)
+    const match = getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
+
+    if (!match) {
+      throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
+    }
+
+    // The tapRun nonce makes route.query differ from the previous query, so
+    // the unifiedRunner watchSpecs effect always kicks off a fresh run —
+    // even when this spec is already active (rerun). Hash navigation never
+    // reloads the page, so this promise still resolves over CDP. The path
+    // travels in posix form because watchSpecs converts route.query.file
+    // back via getPathForPlatform.
+    const file = encodeURIComponent(posixify(match.relative)).replace(/%2F/g, '/')
+
+    tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${++tapRunNonce}`)
+
+    return toSpecListEntry(match)
+  },
+})

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -3,21 +3,25 @@ import { defineCommand, TapCommandError } from './definition'
 import { getRunnableSpecs, toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from './specs-list'
 
-// Bumped per invocation so rerunning the active spec still changes route.query,
-// which is what makes unifiedRunner's watchSpecs kick off a fresh run.
-let tapRunNonce = 0
-
-/**
- * Seam over the command's one side effect so component tests can stub it —
- * really navigating moves the spec frame and stops the test mid-command. Uses
- * the `hash` setter (not `location.href`) for a synchronous same-document
- * navigation that never reloads, so the `exec` promise still resolves over CDP
- * even when the runner page is itself an AUT (cypress-in-cypress).
- */
+// Seam so component tests can stub navigation — really navigating would stop
+// the test mid-command. The `hash` setter (not `href`) keeps it a synchronous
+// same-document navigation, so `exec` still resolves over CDP.
 export const tapNavigation = {
+  getHash () {
+    return window.location.hash
+  },
   setHash (hash: string) {
     window.location.hash = hash
   },
+}
+
+// watchSpecs only reruns a spec when route.query changes, so bump past whatever
+// tapRun the hash already holds — module state would reset to zero on a page
+// reload while the old value survives in the URL.
+const nextTapRunNonce = () => {
+  const current = /[?&]tapRun=(\d+)/.exec(tapNavigation.getHash())
+
+  return (current ? Number(current[1]) : 0) + 1
 }
 
 export const runCommand = defineCommand({
@@ -43,7 +47,7 @@ export const runCommand = defineCommand({
     // route.query.file back through getPathForPlatform.
     const file = encodeURIComponent(posixify(match.relative)).replace(/%2F/g, '/')
 
-    tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${++tapRunNonce}`)
+    tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
 
     return toSpecListEntry(match)
   },

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -29,8 +29,6 @@ export const runCommand = defineCommand({
   params: [
     { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
   ],
-  // Fire-and-forget: a successful return means the run was triggered, not that
-  // the spec finished or passed.
   handler: async ({ spec }): Promise<SpecListEntry> => {
     if (spec.length === 0) {
       throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -3,16 +3,16 @@ import { defineCommand, TapCommandError } from './definition'
 import { getRunnableSpecs, toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from './specs-list'
 
-// Distinguishes each `run` invocation in the runner URL so rerunning the
-// already-active spec still produces a query change (see the handler).
+// Bumped per invocation so rerunning the active spec still changes route.query,
+// which is what makes unifiedRunner's watchSpecs kick off a fresh run.
 let tapRunNonce = 0
 
 /**
- * Seam over the one side effect `run` performs. Component tests stub this —
- * really navigating there moves the spec frame and stops the test
- * mid-command. The hash setter (rather than `location.href = '#…'`) is what
- * guarantees a synchronous same-document fragment navigation, including when
- * the runner page is itself an AUT (the cypress-in-cypress harness).
+ * Seam over the command's one side effect so component tests can stub it —
+ * really navigating moves the spec frame and stops the test mid-command. Uses
+ * the `hash` setter (not `location.href`) for a synchronous same-document
+ * navigation that never reloads, so the `exec` promise still resolves over CDP
+ * even when the runner page is itself an AUT (cypress-in-cypress).
  */
 export const tapNavigation = {
   setHash (hash: string) {
@@ -25,10 +25,8 @@ export const runCommand = defineCommand({
   params: [
     { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
   ],
-  // Triggering is fire-and-forget: returning the started spec means navigation
-  // was issued, not that the spec finished or passed. The two failure cases
-  // throw — surfaced on stderr, never stdout, and the runner never navigates:
-  // INVALID_SPEC for an empty path, SPEC_NOT_FOUND when none matches.
+  // Fire-and-forget: a successful return means the run was triggered, not that
+  // the spec finished or passed.
   handler: async ({ spec }): Promise<SpecListEntry> => {
     if (spec.length === 0) {
       throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
@@ -41,12 +39,8 @@ export const runCommand = defineCommand({
       throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
     }
 
-    // The tapRun nonce makes route.query differ from the previous query, so
-    // the unifiedRunner watchSpecs effect always kicks off a fresh run —
-    // even when this spec is already active (rerun). Hash navigation never
-    // reloads the page, so this promise still resolves over CDP. The path
-    // travels in posix form because watchSpecs converts route.query.file
-    // back via getPathForPlatform.
+    // Encode the path but keep its slashes literal, since watchSpecs reads
+    // route.query.file back through getPathForPlatform.
     const file = encodeURIComponent(posixify(match.relative)).replace(/%2F/g, '/')
 
     tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${++tapRunNonce}`)

--- a/packages/app/src/tap/tap-manager.cy.ts
+++ b/packages/app/src/tap/tap-manager.cy.ts
@@ -56,6 +56,21 @@ describe('tap/tap-manager', () => {
       }
     })
 
+    it('includes run with its required spec param', async () => {
+      const manager = new TapManager(CYPRESS_VERSION)
+      const schema = await manager.getSchema()
+      const run = schema.commands.find((command) => command.name === 'run')
+
+      expect(run).to.deep.eq({
+        name: 'run',
+        description: tapCommands.run.description,
+        params: [
+          { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
+        ],
+        options: [],
+      })
+    })
+
     it('round-trips through JSON (the CDP returnByValue boundary)', async () => {
       const manager = new TapManager(CYPRESS_VERSION)
       const schema = await manager.getSchema()


### PR DESCRIPTION
### Additional details

This PR adds the **`run`** command to the `cypress tap` registry — the action that triggers (or reruns) a spec from the CLI. It stacks on top of `specs` (#34192): `specs` enumerates the runnable paths, `run` takes one of those paths and starts it.

- **`run` command** (`packages/app/src/runner/tap/commands/run.ts`). A `defineCommand` with a required `spec` param (a project-relative path, as listed by `specs`). It resolves the path against the run-mode specs (posix-normalized on both sides via `posixify`, so platform path separators don't matter) and, on a match, navigates the runner to `/specs/runner?file=…&tapRun=<nonce>`. Two domain failures throw `TapCommandError` and never navigate: `INVALID_SPEC` (empty path) and `SPEC_NOT_FOUND` (no spec matches) — surfaced on stderr with a non-zero exit, never on stdout.
- **Fire-and-forget semantics.** Triggering returns the *started* spec entry (`{ relativePath, specType }`) — it means navigation was issued, not that the spec finished or passed. Observing the run to completion is a separate concern handled higher in the stack.
- **Rerun via nonce** (`tapRunNonce`). Each invocation bumps a monotonic nonce in the URL query, so `route.query` always differs from the previous one and the `unifiedRunner` `watchSpecs` effect kicks off a fresh run — even when the requested spec is already the active one.
- **Navigation seam** (`tapNavigation.setHash`). The single side effect is isolated behind a stubbable seam so component tests can assert the intended navigation without actually moving the spec frame (which would stop the test mid-command). It uses the `location.hash` setter rather than assigning `location.href`, guaranteeing a synchronous same-document fragment navigation — including when the runner page is itself an AUT (cypress-in-cypress), and ensuring the `exec` promise still resolves over CDP because the page never reloads.

### Steps to test

App-side logic covered by a component spec (`cypress:run:ct`) and exercised end-to-end by the binding e2e:

- `packages/app/src/runner/tap/commands/run.cy.ts` — new spec: drives `exec('run', …)` through `TapManager` with the navigation seam stubbed, covering the happy path, the rerun nonce, and the `INVALID_SPEC` / `SPEC_NOT_FOUND` domain failures (no navigation on failure).
- `packages/app/cypress/e2e/tap-binding.cy.ts` — updated: real run + rerun against the `cypress-in-cypress` project, asserting the runner URL changes, the spec finishes, and a non-existent spec resolves as `{ ok: false, code: 'SPEC_NOT_FOUND' }` without navigating.
- `packages/app/src/runner/tap/tap-manager.cy.ts` — updated: `getSchema()` advertises `run` with its required `spec` param.

Manual end-to-end is exercised by the top wiring layer (#34148): start a Cypress instance, open a browser, list specs with `cypress tap specs`, then `cypress tap run --spec <path>`.

### How has the user experience changed?

No change to existing flows. This adds a new subcommand to the experimental `cypress tap` CLI (`cypress tap run`); there is no change to the public `cypress` JS API or any GUI surface.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal/experimental tap CLI work; tracked by internal ticket, no public GitHub issue. -->
- [x] Have tests been added/updated? <!-- New: commands/run.cy.ts. Updated: cypress/e2e/tap-binding.cy.ts, tap-manager.cy.ts. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Experimental internal feature; not yet publicly documented. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` JS API or its type definitions; this is internal tap binding code. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental tap CLI only; behavior is hash navigation and spec lookup with no public API or auth changes, and failures are guarded to avoid navigation.
> 
> **Overview**
> Adds **`run`** to the `cypress tap` command registry so automation can start or rerun a spec by project-relative path (same paths as `specs`).
> 
> On success, the handler resolves the spec against run-mode specs (posix-normalized matching), sets `location.hash` to `/specs/runner?file=…&tapRun=<nonce>` via a stubbable **`tapNavigation`** seam, and returns `{ relativePath, specType }` without waiting for the run to finish. Each invocation bumps **`tapRun`** so rerunning the same spec still changes the query and retriggers the runner. **`INVALID_SPEC`** / **`SPEC_NOT_FOUND`** (and missing args) throw **`TapCommandError`** and do not navigate.
> 
> Coverage: new **`run.cy.ts`** (navigation stub, nonce, path/URL edge cases), **`tap-binding.cy.ts`** e2e for real run/rerun and `SPEC_NOT_FOUND`, and **`tap-manager.cy.ts`** schema assertion for `run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee945bcec5e6605ada0884c9e485c79b014dc86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


