### PR TITLE
feat: add the tests tap command reading the run's test state (11)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -837,6 +837,9 @@
     "packages/app/src/prompt/prompt-app-types.ts": [
       "types"
     ],
+    "packages/app/src/tap/commands/test-state.ts": [
+      "types"
+    ],
     "packages/app/src/tap/contract.ts": [
       "types"
     ],

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -96,7 +96,7 @@ describe('tap binding', () => {
       const detail = (detailOutcome as { result: Record<string, unknown> }).result
 
       expect(detail.id).to.eq(tests[0].id)
-      expect(detail.fullTitle).to.be.a('string').and.contain(tests[0].title)
+      expect(detail.fullTitle).to.eq('Dom Content > renders the test content')
       expect(detail.state).to.eq('passed')
       expect(detail.timings).to.be.an('object')
       expect(detail.error).to.be.undefined

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -16,11 +16,17 @@ describe('tap binding', () => {
       const schema = await binding.getSchema()
 
       expect(schema.schemaVersion).to.eq(1)
-      expect(schema.commands.map((command) => command.name)).to.include.members(['specs', 'run'])
+      expect(schema.commands.map((command) => command.name)).to.include.members(['specs', 'run', 'tests'])
 
       const unknown = await binding.exec('not-a-command')
 
       expect((unknown as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')
+
+      // No spec has run yet, so the runner window has no Cypress instance to
+      // read — a domain failure surfaced as { error }, not a stdout result.
+      const testsBeforeRun = await binding.exec('tests')
+
+      expect((testsBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
       const outcome = await binding.exec('specs')
 
@@ -67,6 +73,43 @@ describe('tap binding', () => {
 
     cy.waitForSpecToFinish({ passCount: 1 })
     cy.contains('Dom Content').should('be.visible')
+
+    // With a run finished, the tests command reads the runner's tests state.
+    cy.window().then(async (win) => {
+      const outcome = await getBinding(win).exec('tests')
+
+      expect('result' in outcome).to.eq(true)
+
+      const tests = (outcome as { result: Array<Record<string, unknown>> }).result
+
+      expect(tests).to.have.length.greaterThan(0)
+
+      for (const test of tests) {
+        expect(Object.keys(test), `entry ${test.id}`).to.deep.eq(['id', 'title', 'duration', 'state', 'retries'])
+        expect(test.state).to.eq('passed')
+        expect(test.duration).to.be.a('number')
+        expect(test.retries).to.eq(0)
+      }
+
+      // The tests command with an id details that one test: full title path,
+      // per-phase timings, and (here, a passing test) no error.
+      const detailOutcome = await getBinding(win).exec('tests', { test: tests[0].id as string })
+
+      expect('result' in detailOutcome).to.eq(true)
+
+      const detail = (detailOutcome as { result: Record<string, unknown> }).result
+
+      expect(detail.id).to.eq(tests[0].id)
+      expect(detail.fullTitle).to.be.a('string').and.contain(tests[0].title)
+      expect(detail.state).to.eq('passed')
+      expect(detail.timings).to.be.an('object')
+      expect(detail.error).to.be.undefined
+
+      // An unknown test id details nothing — a domain failure.
+      const missingDetail = await getBinding(win).exec('tests', { test: 'not-a-test' })
+
+      expect((missingDetail as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+    })
 
     // Rerunning advances the nonce, so the query changes even though the spec is unchanged.
     cy.location('hash').then((hashBefore) => {

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -22,8 +22,7 @@ describe('tap binding', () => {
 
       expect((unknown as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')
 
-      // No spec has run yet, so the runner window has no Cypress instance to
-      // read — a domain failure surfaced as { error }, not a stdout result.
+      // No spec has run yet, so there is no run to read — a domain failure.
       const testsBeforeRun = await binding.exec('tests')
 
       expect((testsBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
@@ -74,7 +73,6 @@ describe('tap binding', () => {
     cy.waitForSpecToFinish({ passCount: 1 })
     cy.contains('Dom Content').should('be.visible')
 
-    // With a run finished, the tests command reads the runner's tests state.
     cy.window().then(async (win) => {
       const outcome = await getBinding(win).exec('tests')
 
@@ -91,8 +89,6 @@ describe('tap binding', () => {
         expect(test.retries).to.eq(0)
       }
 
-      // The tests command with an id details that one test: full title path,
-      // per-phase timings, and (here, a passing test) no error.
       const detailOutcome = await getBinding(win).exec('tests', { test: tests[0].id as string })
 
       expect('result' in detailOutcome).to.eq(true)
@@ -105,7 +101,6 @@ describe('tap binding', () => {
       expect(detail.timings).to.be.an('object')
       expect(detail.error).to.be.undefined
 
-      // An unknown test id details nothing — a domain failure.
       const missingDetail = await getBinding(win).exec('tests', { test: 'not-a-test' })
 
       expect((missingDetail as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -89,6 +89,13 @@ export class EventManager {
     return Cypress
   }
 
+  // Whether the active spec's mocha run has finished. The tap `tests` command
+  // reads this to tell an unreached test (still pending, run in flight) from a
+  // genuinely skipped one (run complete).
+  get runComplete (): boolean {
+    return hasMochaRunEnded
+  }
+
   addGlobalListeners (state: MobxRunnerStore, options: AddGlobalListenerOptions) {
     // Moving away from the runner turns off all websocket listeners. addGlobalListeners adds them back
     // but connect is added when the websocket is created elsewhere so we need to add it back.

--- a/packages/app/src/runner/event-manager.ts
+++ b/packages/app/src/runner/event-manager.ts
@@ -89,9 +89,6 @@ export class EventManager {
     return Cypress
   }
 
-  // Whether the active spec's mocha run has finished. The tap `tests` command
-  // reads this to tell an unreached test (still pending, run in flight) from a
-  // genuinely skipped one (run complete).
   get runComplete (): boolean {
     return hasMochaRunEnded
   }

--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -8,7 +8,7 @@ async, JSON-only methods — `getSchema()` and `exec(command, args?, options?)`.
 ## Layout
 
 - `tap-manager.ts` — the binding surface; validates the wire payload and dispatches to a command.
-- `TapManagerDataSource.ts` — the single seam onto runner-window globals (`getEventManager` → `getCypress().runner` → `getAllTestsState` plus `runComplete`, `__RUN_MODE_SPECS__`, `location.hash`). Commands read globals only through it.
+- `tap-manager-data-source.ts` — the single seam onto runner-window globals (`getEventManager` → `getCypress().runner` → `getAllTestsState` plus `runComplete`, `__RUN_MODE_SPECS__`, `location.hash`). Commands read globals only through it; component tests stub its methods instead of the real globals.
 - `contract.ts` — the frozen cross-process contract. The shared half lives in `@packages/cypress-instances`; the CLI reads the same contract from that package's compiled build. Do not fork it here.
 - `exec-args.ts` — app-side coercion of raw wire strings into typed params/options.
 - `commands/index.ts` — the command registry, the single source of truth for available subcommands.

--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -8,7 +8,7 @@ async, JSON-only methods — `getSchema()` and `exec(command, args?, options?)`.
 ## Layout
 
 - `tap-manager.ts` — the binding surface; validates the wire payload and dispatches to a command.
-- `TapManagerDataSource.ts` — the single seam onto runner-window globals (`getEventManager` → `getCypress().runner` → `getTestsState` plus `runComplete`, `__RUN_MODE_SPECS__`, `location.hash`). Commands read globals only through it.
+- `TapManagerDataSource.ts` — the single seam onto runner-window globals (`getEventManager` → `getCypress().runner` → `getAllTestsState` plus `runComplete`, `__RUN_MODE_SPECS__`, `location.hash`). Commands read globals only through it.
 - `contract.ts` — the frozen cross-process contract. The shared half lives in `@packages/cypress-instances`; the CLI reads the same contract from that package's compiled build. Do not fork it here.
 - `exec-args.ts` — app-side coercion of raw wire strings into typed params/options.
 - `commands/index.ts` — the command registry, the single source of truth for available subcommands.
@@ -28,7 +28,7 @@ Rules:
   failure code — MUST be asserted in `tap-binding.cy.ts` against the real binding,
   with no stubbing or mocking of the runner seam.** This is the only layer that
   proves the coupling to Cypress internals (`getEventManager`, `getCypress().runner`,
-  `getTestsState` and its `'__never__'` sentinel, `eventManager.runComplete`, and the
+  `getAllTestsState`, `eventManager.runComplete`, and the
   runtime `SerializedTest` shape) still holds. Those internals are not ours; only an
   unmocked end-to-end run catches them drifting.
 - Adding or changing a subcommand is not done until its happy path **and** its

--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -8,12 +8,13 @@ async, JSON-only methods — `getSchema()` and `exec(command, args?, options?)`.
 ## Layout
 
 - `tap-manager.ts` — the binding surface; validates the wire payload and dispatches to a command.
+- `TapManagerDataSource.ts` — the single seam onto runner-window globals (`getEventManager` → `getCypress().runner` → `getTestsState` plus `runComplete`, `__RUN_MODE_SPECS__`, `location.hash`). Commands read globals only through it.
 - `contract.ts` — the frozen cross-process contract. The shared half lives in `@packages/cypress-instances`; the CLI reads the same contract from that package's compiled build. Do not fork it here.
 - `exec-args.ts` — app-side coercion of raw wire strings into typed params/options.
 - `commands/index.ts` — the command registry, the single source of truth for available subcommands.
 - `commands/definition.ts` — `defineCommand` authoring helper and `TapCommandError` (domain failures).
 - `commands/*.ts` — one module per subcommand (`specs`, `run`, `tests`).
-- `commands/test-state.ts` — the seam onto Cypress internals for the `tests` command (`getEventManager` → `getCypress().runner` → `getTestsState`, plus `runComplete`).
+- `commands/test-state.ts` — serialization of runner test state for the `tests` command.
 
 ## Contracts MUST be validated in the e2e tests, without mocking
 
@@ -36,7 +37,7 @@ Rules:
   not just presence — the contract is that nothing internal leaks onto the wire.
 
 The co-located `*.cy.ts` component tests (e.g. `commands/tests.cy.ts`) stub the seam
-(`tapRunnerSource.getRunner`) to exercise serialization branches and edge cases
+(`tapManagerDataSource.getRunner`) to exercise serialization branches and edge cases
 cheaply. They are a supplement, never a substitute: because they replace the seam,
 they cannot catch a Cypress-internals change. Never treat green component tests as
 proof a contract holds.

--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -1,0 +1,50 @@
+# tap — the `cypress tap` binding
+
+The runner-side implementation of the tap binding: the surface the CLI drives over
+CDP to inspect and control a live Cypress run. `TapManager` (`tap-manager.ts`) is
+mounted at `window.__CYPRESS_TAP_BINDING__` on the runner top window and exposes two
+async, JSON-only methods — `getSchema()` and `exec(command, args?, options?)`.
+
+## Layout
+
+- `tap-manager.ts` — the binding surface; validates the wire payload and dispatches to a command.
+- `contract.ts` — the frozen cross-process contract. The shared half lives in `@packages/cypress-instances`; the CLI reads the same contract from that package's compiled build. Do not fork it here.
+- `exec-args.ts` — app-side coercion of raw wire strings into typed params/options.
+- `commands/index.ts` — the command registry, the single source of truth for available subcommands.
+- `commands/definition.ts` — `defineCommand` authoring helper and `TapCommandError` (domain failures).
+- `commands/*.ts` — one module per subcommand (`specs`, `run`, `tests`).
+- `commands/test-state.ts` — the seam onto Cypress internals for the `tests` command (`getEventManager` → `getCypress().runner` → `getTestsState`, plus `runComplete`).
+
+## Contracts MUST be validated in the e2e tests, without mocking
+
+The e2e spec `packages/app/cypress/e2e/tap-binding.cy.ts` is the authoritative test
+of this package. It drives the **real** `window.__CYPRESS_TAP_BINDING__` against a
+**real** runner (scaffold → open → run a spec → `exec(...)`).
+
+Rules:
+
+- **Every command contract — its result shape, its exact field set, and every
+  failure code — MUST be asserted in `tap-binding.cy.ts` against the real binding,
+  with no stubbing or mocking of the runner seam.** This is the only layer that
+  proves the coupling to Cypress internals (`getEventManager`, `getCypress().runner`,
+  `getTestsState` and its `'__never__'` sentinel, `eventManager.runComplete`, and the
+  runtime `SerializedTest` shape) still holds. Those internals are not ours; only an
+  unmocked end-to-end run catches them drifting.
+- Adding or changing a subcommand is not done until its happy path **and** its
+  domain-failure codes are covered by real `exec(...)` calls in that spec.
+- Assert the **exact** key set of every result (e.g. `expect(Object.keys(entry)).to.deep.eq([...])`),
+  not just presence — the contract is that nothing internal leaks onto the wire.
+
+The co-located `*.cy.ts` component tests (e.g. `commands/tests.cy.ts`) stub the seam
+(`tapRunnerSource.getRunner`) to exercise serialization branches and edge cases
+cheaply. They are a supplement, never a substitute: because they replace the seam,
+they cannot catch a Cypress-internals change. Never treat green component tests as
+proof a contract holds.
+
+## Adding a subcommand
+
+1. Add a `commands/<name>.ts` module built with `defineCommand`.
+2. Register it in `commands/index.ts`.
+3. Add real `exec('<name>', ...)` coverage to `tap-binding.cy.ts` — happy path and
+   every failure code — with no mocking (see above).
+4. Component tests for branch coverage are optional and stub-based; the e2e coverage is not.

--- a/packages/app/src/tap/TapManagerDataSource.ts
+++ b/packages/app/src/tap/TapManagerDataSource.ts
@@ -1,9 +1,6 @@
-import type { FoundSpec, SerializedTest } from '@packages/types'
+import type { FoundSpec } from '@packages/types'
 
-export interface TapTestsRunner {
-  getTestsState (testId?: string): Record<string, SerializedTest>
-  isRunComplete (): boolean
-}
+import type { TapTestsRunner } from './types'
 
 // Every runner-window global a tap command reads (or writes) goes through this
 // one seam, so component tests stub a method here instead of the real globals.

--- a/packages/app/src/tap/TapManagerDataSource.ts
+++ b/packages/app/src/tap/TapManagerDataSource.ts
@@ -1,0 +1,41 @@
+import type { FoundSpec, SerializedTest } from '@packages/types'
+
+export interface TapTestsRunner {
+  getTestsState (testId?: string): Record<string, SerializedTest>
+  isRunComplete (): boolean
+}
+
+// Every runner-window global a tap command reads (or writes) goes through this
+// one seam, so component tests stub a method here instead of the real globals.
+export const tapManagerDataSource = {
+  getRunner (): TapTestsRunner | undefined {
+    try {
+      // Both a throw and undefined here mean there is no run to read yet.
+      const eventManager = window.getEventManager?.()
+      const runner = eventManager?.getCypress()?.runner
+
+      if (!eventManager || !runner) {
+        return undefined
+      }
+
+      return {
+        getTestsState: runner.getTestsState,
+        isRunComplete: () => eventManager.runComplete,
+      }
+    } catch {
+      return undefined
+    }
+  },
+
+  getRunnableSpecs (): FoundSpec[] {
+    return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
+  },
+
+  getHash () {
+    return window.location.hash
+  },
+
+  setHash (hash: string) {
+    window.location.hash = hash
+  },
+}

--- a/packages/app/src/tap/TapManagerDataSource.ts
+++ b/packages/app/src/tap/TapManagerDataSource.ts
@@ -16,7 +16,7 @@ export const tapManagerDataSource = {
       }
 
       return {
-        getTestsState: runner.getTestsState,
+        getAllTestsState: runner.getAllTestsState,
         isRunComplete: () => eventManager.runComplete,
       }
     } catch {

--- a/packages/app/src/tap/commands/index.ts
+++ b/packages/app/src/tap/commands/index.ts
@@ -1,10 +1,12 @@
 import type { TapCommandDefinition } from './definition'
 import { runCommand } from './run'
 import { specsCommand } from './specs'
+import { testsCommand } from './tests'
 
 // The command registry — the single source of truth for the tap binding.
 // Adding a subcommand is one sibling module plus its entry here.
 export const tapCommands = {
   specs: specsCommand,
   run: runCommand,
+  tests: testsCommand,
 } satisfies Record<string, TapCommandDefinition>

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -1,7 +1,7 @@
 import type { FoundSpec } from '@packages/types'
 
+import { tapManagerDataSource } from '../TapManagerDataSource'
 import { TapManager } from '../tap-manager'
-import { tapNavigation } from './run'
 
 const CYPRESS_VERSION = '15.0.0'
 
@@ -22,9 +22,9 @@ describe('tap/commands/run', () => {
   // Stub the navigation seam — a real hash change would navigate away and stop
   // the test mid-command. Writes feed the stubbed read, like the real hash.
   const stubNavigation = (initialHash = '') => {
-    const getHash = cy.stub(tapNavigation, 'getHash').returns(initialHash)
+    const getHash = cy.stub(tapManagerDataSource, 'getHash').returns(initialHash)
 
-    return cy.stub(tapNavigation, 'setHash').callsFake((hash: string) => {
+    return cy.stub(tapManagerDataSource, 'setHash').callsFake((hash: string) => {
       getHash.returns(`#${hash}`)
     })
   }

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -1,6 +1,6 @@
 import type { FoundSpec } from '@packages/types'
 
-import { tapManagerDataSource } from '../TapManagerDataSource'
+import { tapManagerDataSource } from '../tap-manager-data-source'
 import { TapManager } from '../tap-manager'
 
 const CYPRESS_VERSION = '15.0.0'

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -1,19 +1,11 @@
 import { posixify } from '../../paths'
+import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand, TapCommandError } from './definition'
-import { getRunnableSpecs, toSpecListEntry } from './specs-list'
+import { toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from './specs-list'
 
-export const tapNavigation = {
-  getHash () {
-    return window.location.hash
-  },
-  setHash (hash: string) {
-    window.location.hash = hash
-  },
-}
-
 const nextTapRunNonce = () => {
-  const query = tapNavigation.getHash().split('?')[1] ?? ''
+  const query = tapManagerDataSource.getHash().split('?')[1] ?? ''
   const current = Number(new URLSearchParams(query).get('tapRun'))
 
   return (Number.isInteger(current) ? current : 0) + 1
@@ -30,7 +22,7 @@ export const runCommand = defineCommand({
     }
 
     const wanted = posixify(spec)
-    const match = getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
+    const match = tapManagerDataSource.getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
 
     if (!match) {
       throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
@@ -40,7 +32,7 @@ export const runCommand = defineCommand({
     // route.query.file back through getPathForPlatform.
     const file = posixify(match.relative).split('/').map(encodeURIComponent).join('/')
 
-    tapNavigation.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
+    tapManagerDataSource.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
 
     return toSpecListEntry(match)
   },

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -2,7 +2,7 @@ import { posixify } from '../../paths'
 import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand, TapCommandError } from './definition'
 import { toSpecListEntry } from './specs-list'
-import type { SpecListEntry } from './specs-list'
+import type { SpecListEntry } from '../types'
 
 const nextTapRunNonce = () => {
   const query = tapManagerDataSource.getHash().split('?')[1] ?? ''

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -1,5 +1,5 @@
 import { posixify } from '../../paths'
-import { tapManagerDataSource } from '../TapManagerDataSource'
+import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
 import { toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from '../types'

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -7,10 +7,6 @@ export interface SpecListEntry {
   specType: FoundSpec['specType']
 }
 
-export const getRunnableSpecs = (): FoundSpec[] => {
-  return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
-}
-
 export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
   return { relativePath: relative, specType }
 }

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -1,11 +1,6 @@
 import type { FoundSpec } from '@packages/types'
 
-export interface SpecListEntry {
-  /** Project-relative spec path — the form `cypress run --spec` accepts. */
-  relativePath: string
-  /** Whether the spec is an end-to-end (integration) or component spec. */
-  specType: FoundSpec['specType']
-}
+import type { SpecListEntry } from '../types'
 
 export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
   return { relativePath: relative, specType }

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -1,7 +1,7 @@
 import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand } from './definition'
 import { toSpecListEntry } from './specs-list'
-import type { SpecListEntry } from './specs-list'
+import type { SpecListEntry } from '../types'
 
 export const specsCommand = defineCommand({
   description: 'List all runnable specs for the selected Cypress instance.',

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -1,4 +1,4 @@
-import { tapManagerDataSource } from '../TapManagerDataSource'
+import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand } from './definition'
 import { toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from '../types'

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -1,11 +1,12 @@
+import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand } from './definition'
-import { getRunnableSpecs, toSpecListEntry } from './specs-list'
+import { toSpecListEntry } from './specs-list'
 import type { SpecListEntry } from './specs-list'
 
 export const specsCommand = defineCommand({
   description: 'List all runnable specs for the selected Cypress instance.',
   params: [],
   handler: async (): Promise<SpecListEntry[]> => {
-    return getRunnableSpecs().map(toSpecListEntry)
+    return tapManagerDataSource.getRunnableSpecs().map(toSpecListEntry)
   },
 })

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,5 +1,7 @@
 import type { SerializedTest } from '@packages/types'
 
+import type { TapTestsRunner } from '../TapManagerDataSource'
+
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
 
 export interface TestStateEntry {
@@ -27,32 +29,6 @@ export interface TestDetailEntry {
   retries?: number
   timings?: Record<string, unknown>
   error?: TestError
-}
-
-export interface TapTestsRunner {
-  getTestsState (testId?: string): Record<string, SerializedTest>
-  isRunComplete (): boolean
-}
-
-export const tapRunnerSource = {
-  getRunner (): TapTestsRunner | undefined {
-    try {
-      // Both a throw and undefined here mean there is no run to read yet.
-      const eventManager = window.getEventManager?.()
-      const runner = eventManager?.getCypress()?.runner
-
-      if (!eventManager || !runner) {
-        return undefined
-      }
-
-      return {
-        getTestsState: runner.getTestsState,
-        isRunComplete: () => eventManager.runComplete,
-      }
-    } catch {
-      return undefined
-    }
-  },
 }
 
 // A state-less test was never reached: 'pending' while the run is still going,

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,8 +1,5 @@
 import type { SerializedTest } from '@packages/types'
 
-// Optional fields throughout are absent rather than null: JSON drops undefined
-// keys at the CDP boundary, so the in-memory shape already equals the wire form.
-
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
 
 export interface TestStateEntry {
@@ -32,20 +29,10 @@ export interface TestDetailEntry {
   error?: TestError
 }
 
-/**
- * `getTestsState(testId)` serializes the run's tests up to (excluding) the one
- * whose id matches, so a never-matching sentinel yields every test.
- */
 export interface TapTestsRunner {
   getTestsState (testId?: string): Record<string, SerializedTest>
 }
 
-/**
- * Seam over the driver runner the tap commands read (component tests stub it).
- * The instance comes from the event manager, not `window.Cypress`: when the
- * runner page is itself an AUT (cypress-in-cypress), `window.Cypress` is the
- * outer driver injected into it, while the event manager only holds this app's.
- */
 export const tapRunnerSource = {
   getRunner (): TapTestsRunner | undefined {
     try {
@@ -66,17 +53,12 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
       id,
       title,
       ...(duration !== undefined ? { duration } : {}),
-      // The driver marks `it.skip` tests 'pending' explicitly (mocha `pending`
-      // event), so a state-less test was never reached — 'skipped', matching
-      // the driver's own run summary.
       state: state ?? 'skipped',
       ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
     }
   })
 }
 
-// The driver's `wrapErr` copies these props verbatim from whatever the user
-// threw, so a non-Error throw can put non-strings here — narrow, don't cast.
 const serializeTestError = (err: Record<string, unknown>): TestError => {
   const { name, message, stack } = err
 
@@ -87,15 +69,7 @@ const serializeTestError = (err: Record<string, unknown>): TestError => {
   }
 }
 
-export const serializeTestDetail = (runner: TapTestsRunner, testId: string): TestDetailEntry | undefined => {
-  // Pass the sentinel, not testId: getTestsState excludes the matching id, so
-  // the wanted test would never be in the result (see TapTestsRunner).
-  const test = runner.getTestsState('__never__')[testId]
-
-  if (!test) {
-    return undefined
-  }
-
+export const serializeTestDetail = (test: SerializedTest): TestDetailEntry => {
   const { id, title, duration, state, currentRetry, timings, err } = test
   const titlePath = test._titlePath
 
@@ -106,9 +80,6 @@ export const serializeTestDetail = (runner: TapTestsRunner, testId: string): Tes
     ...(duration !== undefined ? { duration } : {}),
     state: state ?? 'skipped',
     ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
-    // The driver's serialization shallow-copies the runnable, so `timings` is a
-    // live reference into its test object — JSON-clone to return a snapshot
-    // (which is also exactly the wire form).
     ...(timings != null ? { timings: JSON.parse(JSON.stringify(timings)) } : {}),
     ...(err != null ? { error: serializeTestError(err) } : {}),
   }

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,81 +1,53 @@
 import type { SerializedTest } from '@packages/types'
 
-/**
- * One test of the active run, trimmed to the fields a tap caller needs to
- * follow run progress. `duration` and `retries` are absent (never `null` —
- * JSON drops `undefined` keys at the CDP boundary) until the test has run;
- * `state` defaults to `'pending'` until then.
- */
+// Optional fields throughout are absent rather than null: JSON drops undefined
+// keys at the CDP boundary, so the in-memory shape already equals the wire form.
+
 export interface TestStateEntry {
   id: string
   title: string
-  /** Milliseconds the latest attempt took. */
   duration?: number
   state: string
   /** Retries actually taken this run, not the configured maximum. */
   retries?: number
 }
 
-/**
- * The failure of a test's latest attempt, trimmed to its messaging fields.
- * Every field is optional and absent (never `null` — JSON drops `undefined`
- * keys at the CDP boundary) when the serialized error did not carry it.
- */
 export interface TestError {
-  /** The error's constructor name, e.g. `AssertionError`, `CypressError`. */
   name?: string
-  /** The human-readable failure message. */
   message?: string
-  /** The full stack trace, as the driver normalized it. */
   stack?: string
 }
 
-/**
- * One test of the active run with the detail a tap caller needs to diagnose
- * it — the lean `TestStateEntry` fields plus its full title path, per-phase
- * timings, and the latest attempt's error. As elsewhere, optional fields are
- * absent (never `null`) until the run produces them.
- */
 export interface TestDetailEntry {
   id: string
   title: string
-  /** The suite titles leading to this test plus its own, joined with ` > `. */
+  /** Suite titles leading to this test plus its own, joined with ` > `. */
   fullTitle: string
-  /** Milliseconds the latest attempt took. */
   duration?: number
   state: string
-  /** Retries actually taken this run, not the configured maximum. */
   retries?: number
-  /** The driver's per-phase timing breakdown (lifecycle, hooks, test body). */
   timings?: Record<string, unknown>
-  /** The latest attempt's failure; absent when the test has not failed. */
   error?: TestError
 }
 
 /**
- * The slice of the driver's `Cypress.runner` the tap commands consume.
- * `getTestsState(testId)` serializes the run's tests up to (excluding) the
- * one whose id matches, so a never-matching sentinel yields every test.
+ * `getTestsState(testId)` serializes the run's tests up to (excluding) the one
+ * whose id matches, so a never-matching sentinel yields every test.
  */
 export interface TapTestsRunner {
   getTestsState (testId?: string): Record<string, SerializedTest>
 }
 
 /**
- * Seam over the driver runner the tap commands read. Component tests stub
- * this — the real lookup reaches the Cypress instance running the test.
- *
- * The instance comes from the event manager rather than `window.Cypress`:
- * when the runner page is itself an AUT (the cypress-in-cypress harness),
- * `window.Cypress` is the OUTER driver injected into it, while the event
- * manager only ever holds this app's own instance.
+ * Seam over the driver runner the tap commands read (component tests stub it).
+ * The instance comes from the event manager, not `window.Cypress`: when the
+ * runner page is itself an AUT (cypress-in-cypress), `window.Cypress` is the
+ * outer driver injected into it, while the event manager only holds this app's.
  */
 export const tapRunnerSource = {
   getRunner (): TapTestsRunner | undefined {
     try {
-      // getEventManager throws until the unified runner page initializes it,
-      // and getCypress() is undefined until a spec is set up — both mean
-      // there is no run to read yet.
+      // Both a throw and undefined here mean there is no run to read yet.
       return window.getEventManager?.().getCypress()?.runner
     } catch {
       return undefined
@@ -83,14 +55,10 @@ export const tapRunnerSource = {
   },
 }
 
-/** Serialize every test of the run into lean, JSON-clean entries. */
 export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] => {
-  // '__never__' matches no test id, so getTestsState serializes every
-  // test of the run instead of stopping at the active one.
+  // '__never__' matches no id, so every test is serialized (see TapTestsRunner).
   const tests = Object.values(runner.getTestsState('__never__'))
 
-  // Optional fields are omitted rather than set to undefined so the
-  // in-memory result already equals its JSON wire form.
   return tests.map(({ id, title, duration, state, currentRetry }): TestStateEntry => {
     return {
       id,
@@ -102,10 +70,6 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
   })
 }
 
-/**
- * Trim a serialized error to its messaging fields, omitting any the driver did
- * not record so the result already equals its JSON wire form.
- */
 const serializeTestError = (err: Record<string, unknown>): TestError => {
   const { name, message, stack } = err
 
@@ -116,16 +80,9 @@ const serializeTestError = (err: Record<string, unknown>): TestError => {
   }
 }
 
-/**
- * Serialize the detail of one test of the run into a lean, JSON-clean entry.
- * Returns `undefined` when no test of the run has that id (the command turns
- * this into a `TEST_NOT_FOUND` failure); a known test that has not run yet
- * simply carries no duration, timings, or error.
- */
 export const serializeTestDetail = (runner: TapTestsRunner, testId: string): TestDetailEntry | undefined => {
-  // '__never__' serializes every test; we must NOT pass testId, as
-  // getTestsState serializes tests UP TO (excluding) the matching id and so
-  // would never include the test we are after.
+  // Pass the sentinel, not testId: getTestsState excludes the matching id, so
+  // the wanted test would never be in the result (see TapTestsRunner).
   const test = runner.getTestsState('__never__')[testId]
 
   if (!test) {
@@ -133,9 +90,6 @@ export const serializeTestDetail = (runner: TapTestsRunner, testId: string): Tes
   }
 
   const { id, title, duration, state, currentRetry } = test
-  // `_titlePath` is the runnable's titlePath() — suite titles plus the test's
-  // own; `timings` and `err` are absent until the test runs (and `err` only on
-  // failure). All three are typed `unknown` on the serialized shape.
   const titlePath = test._titlePath as string[] | undefined
   const timings = test.timings as Record<string, unknown> | undefined
   const err = test.err as Record<string, unknown> | undefined

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -77,6 +77,13 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
   })
 }
 
+// The driver serializes a runnable by copying own properties, so object values
+// like `timings` are live references into its runner state. The JSON round-trip
+// snapshots the value at read time and normalizes it to its wire form.
+const cloneReferenceObject = <T>(value: T): T => {
+  return JSON.parse(JSON.stringify(value))
+}
+
 const serializeTestError = (err: Record<string, unknown>): TestError => {
   const { name, message, stack } = err
 
@@ -98,7 +105,7 @@ export const serializeTestDetail = (test: SerializedTest, runComplete: boolean):
     ...(duration !== undefined ? { duration } : {}),
     state: state ?? unreachedState(runComplete),
     ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
-    ...(timings != null ? { timings: JSON.parse(JSON.stringify(timings)) } : {}),
+    ...(timings != null ? { timings: cloneReferenceObject(timings) } : {}),
     ...(err != null ? { error: serializeTestError(err) } : {}),
   }
 }

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,35 +1,6 @@
 import type { SerializedTest } from '@packages/types'
 
-import type { TapTestsRunner } from '../types'
-
-export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
-
-export interface TestStateEntry {
-  id: string
-  title: string
-  duration?: number
-  state: TestStateValue
-  /** Retries actually taken this run, not the configured maximum. */
-  retries?: number
-}
-
-export interface TestError {
-  name?: string
-  message?: string
-  stack?: string
-}
-
-export interface TestDetailEntry {
-  id: string
-  title: string
-  /** Suite titles leading to this test plus its own, joined with ` > `. */
-  fullTitle: string
-  duration?: number
-  state: TestStateValue
-  retries?: number
-  timings?: Record<string, unknown>
-  error?: TestError
-}
+import type { TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from '../types'
 
 // A state-less test was never reached: 'pending' while the run is still going,
 // 'skipped' once it is complete (matching the driver's end-of-run summary).

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -3,11 +3,13 @@ import type { SerializedTest } from '@packages/types'
 // Optional fields throughout are absent rather than null: JSON drops undefined
 // keys at the CDP boundary, so the in-memory shape already equals the wire form.
 
+export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
+
 export interface TestStateEntry {
   id: string
   title: string
   duration?: number
-  state: string
+  state: TestStateValue
   /** Retries actually taken this run, not the configured maximum. */
   retries?: number
 }
@@ -24,7 +26,7 @@ export interface TestDetailEntry {
   /** Suite titles leading to this test plus its own, joined with ` > `. */
   fullTitle: string
   duration?: number
-  state: string
+  state: TestStateValue
   retries?: number
   timings?: Record<string, unknown>
   error?: TestError
@@ -64,19 +66,24 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
       id,
       title,
       ...(duration !== undefined ? { duration } : {}),
-      ...(state !== undefined ? { state } : { state: 'pending' }),
+      // The driver marks `it.skip` tests 'pending' explicitly (mocha `pending`
+      // event), so a state-less test was never reached — 'skipped', matching
+      // the driver's own run summary.
+      state: state ?? 'skipped',
       ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
     }
   })
 }
 
+// The driver's `wrapErr` copies these props verbatim from whatever the user
+// threw, so a non-Error throw can put non-strings here — narrow, don't cast.
 const serializeTestError = (err: Record<string, unknown>): TestError => {
   const { name, message, stack } = err
 
   return {
-    ...(name !== undefined ? { name: name as string } : {}),
-    ...(message !== undefined ? { message: message as string } : {}),
-    ...(stack !== undefined ? { stack: stack as string } : {}),
+    ...(typeof name === 'string' ? { name } : {}),
+    ...(typeof message === 'string' ? { message } : {}),
+    ...(typeof stack === 'string' ? { stack } : {}),
   }
 }
 
@@ -89,19 +96,20 @@ export const serializeTestDetail = (runner: TapTestsRunner, testId: string): Tes
     return undefined
   }
 
-  const { id, title, duration, state, currentRetry } = test
-  const titlePath = test._titlePath as string[] | undefined
-  const timings = test.timings as Record<string, unknown> | undefined
-  const err = test.err as Record<string, unknown> | undefined
+  const { id, title, duration, state, currentRetry, timings, err } = test
+  const titlePath = test._titlePath
 
   return {
     id,
     title,
     fullTitle: Array.isArray(titlePath) ? titlePath.join(' > ') : title,
     ...(duration !== undefined ? { duration } : {}),
-    ...(state !== undefined ? { state } : { state: 'pending' }),
+    state: state ?? 'skipped',
     ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
-    ...(timings !== undefined ? { timings } : {}),
-    ...(err !== undefined ? { error: serializeTestError(err) } : {}),
+    // The driver's serialization shallow-copies the runnable, so `timings` is a
+    // live reference into its test object — JSON-clone to return a snapshot
+    // (which is also exactly the wire form).
+    ...(timings != null ? { timings: JSON.parse(JSON.stringify(timings)) } : {}),
+    ...(err != null ? { error: serializeTestError(err) } : {}),
   }
 }

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -2,15 +2,15 @@ import type { SerializedTest } from '@packages/types'
 
 import type { TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from '../types'
 
-// A state-less test was never reached: 'pending' while the run is still going,
-// 'skipped' once it is complete (matching the driver's end-of-run summary).
+// A test with no final status state set yet was never reached: 'pending' while
+// the run is still going, 'skipped' once it is complete (matching the driver's
+// end-of-run summary).
 const unreachedState = (runComplete: boolean): TestStateValue => {
   return runComplete ? 'skipped' : 'pending'
 }
 
 export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] => {
-  // '__never__' matches no id, so every test is serialized (see TapTestsRunner).
-  const tests = Object.values(runner.getTestsState('__never__'))
+  const tests = Object.values(runner.getAllTestsState())
   const runComplete = runner.isRunComplete()
 
   return tests.map(({ id, title, duration, state, currentRetry }): TestStateEntry => {
@@ -25,10 +25,10 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
 }
 
 // The driver serializes a runnable by copying own properties, so object values
-// like `timings` are live references into its runner state. The JSON round-trip
-// snapshots the value at read time and normalizes it to its wire form.
+// like `timings` are live references into its runner state — snapshot them at
+// read time. The JSON round-trip covers browsers without native structuredClone.
 const cloneReferenceObject = <T>(value: T): T => {
-  return JSON.parse(JSON.stringify(value))
+  return typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value))
 }
 
 const serializeTestError = (err: Record<string, unknown>): TestError => {

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,0 +1,153 @@
+import type { SerializedTest } from '@packages/types'
+
+/**
+ * One test of the active run, trimmed to the fields a tap caller needs to
+ * follow run progress. `duration` and `retries` are absent (never `null` —
+ * JSON drops `undefined` keys at the CDP boundary) until the test has run;
+ * `state` defaults to `'pending'` until then.
+ */
+export interface TestStateEntry {
+  id: string
+  title: string
+  /** Milliseconds the latest attempt took. */
+  duration?: number
+  state: string
+  /** Retries actually taken this run, not the configured maximum. */
+  retries?: number
+}
+
+/**
+ * The failure of a test's latest attempt, trimmed to its messaging fields.
+ * Every field is optional and absent (never `null` — JSON drops `undefined`
+ * keys at the CDP boundary) when the serialized error did not carry it.
+ */
+export interface TestError {
+  /** The error's constructor name, e.g. `AssertionError`, `CypressError`. */
+  name?: string
+  /** The human-readable failure message. */
+  message?: string
+  /** The full stack trace, as the driver normalized it. */
+  stack?: string
+}
+
+/**
+ * One test of the active run with the detail a tap caller needs to diagnose
+ * it — the lean `TestStateEntry` fields plus its full title path, per-phase
+ * timings, and the latest attempt's error. As elsewhere, optional fields are
+ * absent (never `null`) until the run produces them.
+ */
+export interface TestDetailEntry {
+  id: string
+  title: string
+  /** The suite titles leading to this test plus its own, joined with ` > `. */
+  fullTitle: string
+  /** Milliseconds the latest attempt took. */
+  duration?: number
+  state: string
+  /** Retries actually taken this run, not the configured maximum. */
+  retries?: number
+  /** The driver's per-phase timing breakdown (lifecycle, hooks, test body). */
+  timings?: Record<string, unknown>
+  /** The latest attempt's failure; absent when the test has not failed. */
+  error?: TestError
+}
+
+/**
+ * The slice of the driver's `Cypress.runner` the tap commands consume.
+ * `getTestsState(testId)` serializes the run's tests up to (excluding) the
+ * one whose id matches, so a never-matching sentinel yields every test.
+ */
+export interface TapTestsRunner {
+  getTestsState (testId?: string): Record<string, SerializedTest>
+}
+
+/**
+ * Seam over the driver runner the tap commands read. Component tests stub
+ * this — the real lookup reaches the Cypress instance running the test.
+ *
+ * The instance comes from the event manager rather than `window.Cypress`:
+ * when the runner page is itself an AUT (the cypress-in-cypress harness),
+ * `window.Cypress` is the OUTER driver injected into it, while the event
+ * manager only ever holds this app's own instance.
+ */
+export const tapRunnerSource = {
+  getRunner (): TapTestsRunner | undefined {
+    try {
+      // getEventManager throws until the unified runner page initializes it,
+      // and getCypress() is undefined until a spec is set up — both mean
+      // there is no run to read yet.
+      return window.getEventManager?.().getCypress()?.runner
+    } catch {
+      return undefined
+    }
+  },
+}
+
+/** Serialize every test of the run into lean, JSON-clean entries. */
+export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] => {
+  // '__never__' matches no test id, so getTestsState serializes every
+  // test of the run instead of stopping at the active one.
+  const tests = Object.values(runner.getTestsState('__never__'))
+
+  // Optional fields are omitted rather than set to undefined so the
+  // in-memory result already equals its JSON wire form.
+  return tests.map(({ id, title, duration, state, currentRetry }): TestStateEntry => {
+    return {
+      id,
+      title,
+      ...(duration !== undefined ? { duration } : {}),
+      ...(state !== undefined ? { state } : { state: 'pending' }),
+      ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
+    }
+  })
+}
+
+/**
+ * Trim a serialized error to its messaging fields, omitting any the driver did
+ * not record so the result already equals its JSON wire form.
+ */
+const serializeTestError = (err: Record<string, unknown>): TestError => {
+  const { name, message, stack } = err
+
+  return {
+    ...(name !== undefined ? { name: name as string } : {}),
+    ...(message !== undefined ? { message: message as string } : {}),
+    ...(stack !== undefined ? { stack: stack as string } : {}),
+  }
+}
+
+/**
+ * Serialize the detail of one test of the run into a lean, JSON-clean entry.
+ * Returns `undefined` when no test of the run has that id (the command turns
+ * this into a `TEST_NOT_FOUND` failure); a known test that has not run yet
+ * simply carries no duration, timings, or error.
+ */
+export const serializeTestDetail = (runner: TapTestsRunner, testId: string): TestDetailEntry | undefined => {
+  // '__never__' serializes every test; we must NOT pass testId, as
+  // getTestsState serializes tests UP TO (excluding) the matching id and so
+  // would never include the test we are after.
+  const test = runner.getTestsState('__never__')[testId]
+
+  if (!test) {
+    return undefined
+  }
+
+  const { id, title, duration, state, currentRetry } = test
+  // `_titlePath` is the runnable's titlePath() — suite titles plus the test's
+  // own; `timings` and `err` are absent until the test runs (and `err` only on
+  // failure). All three are typed `unknown` on the serialized shape.
+  const titlePath = test._titlePath as string[] | undefined
+  const timings = test.timings as Record<string, unknown> | undefined
+  const err = test.err as Record<string, unknown> | undefined
+
+  return {
+    id,
+    title,
+    fullTitle: Array.isArray(titlePath) ? titlePath.join(' > ') : title,
+    ...(duration !== undefined ? { duration } : {}),
+    ...(state !== undefined ? { state } : { state: 'pending' }),
+    ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
+    ...(timings !== undefined ? { timings } : {}),
+    ...(err !== undefined ? { error: serializeTestError(err) } : {}),
+  }
+}

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -46,7 +46,7 @@ export const tapRunnerSource = {
       }
 
       return {
-        getTestsState: runner.getTestsState.bind(runner),
+        getTestsState: runner.getTestsState,
         isRunComplete: () => eventManager.runComplete,
       }
     } catch {

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -1,6 +1,6 @@
 import type { SerializedTest } from '@packages/types'
 
-import type { TapTestsRunner } from '../TapManagerDataSource'
+import type { TapTestsRunner } from '../types'
 
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
 

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -31,29 +31,47 @@ export interface TestDetailEntry {
 
 export interface TapTestsRunner {
   getTestsState (testId?: string): Record<string, SerializedTest>
+  isRunComplete (): boolean
 }
 
 export const tapRunnerSource = {
   getRunner (): TapTestsRunner | undefined {
     try {
       // Both a throw and undefined here mean there is no run to read yet.
-      return window.getEventManager?.().getCypress()?.runner
+      const eventManager = window.getEventManager?.()
+      const runner = eventManager?.getCypress()?.runner
+
+      if (!eventManager || !runner) {
+        return undefined
+      }
+
+      return {
+        getTestsState: runner.getTestsState.bind(runner),
+        isRunComplete: () => eventManager.runComplete,
+      }
     } catch {
       return undefined
     }
   },
 }
 
+// A state-less test was never reached: 'pending' while the run is still going,
+// 'skipped' once it is complete (matching the driver's end-of-run summary).
+const unreachedState = (runComplete: boolean): TestStateValue => {
+  return runComplete ? 'skipped' : 'pending'
+}
+
 export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] => {
   // '__never__' matches no id, so every test is serialized (see TapTestsRunner).
   const tests = Object.values(runner.getTestsState('__never__'))
+  const runComplete = runner.isRunComplete()
 
   return tests.map(({ id, title, duration, state, currentRetry }): TestStateEntry => {
     return {
       id,
       title,
       ...(duration !== undefined ? { duration } : {}),
-      state: state ?? 'skipped',
+      state: state ?? unreachedState(runComplete),
       ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
     }
   })
@@ -69,7 +87,7 @@ const serializeTestError = (err: Record<string, unknown>): TestError => {
   }
 }
 
-export const serializeTestDetail = (test: SerializedTest): TestDetailEntry => {
+export const serializeTestDetail = (test: SerializedTest, runComplete: boolean): TestDetailEntry => {
   const { id, title, duration, state, currentRetry, timings, err } = test
   const titlePath = test._titlePath
 
@@ -78,7 +96,7 @@ export const serializeTestDetail = (test: SerializedTest): TestDetailEntry => {
     title,
     fullTitle: Array.isArray(titlePath) ? titlePath.join(' > ') : title,
     ...(duration !== undefined ? { duration } : {}),
-    state: state ?? 'skipped',
+    state: state ?? unreachedState(runComplete),
     ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
     ...(timings != null ? { timings: JSON.parse(JSON.stringify(timings)) } : {}),
     ...(err != null ? { error: serializeTestError(err) } : {}),

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -35,8 +35,13 @@ describe('tap/commands/tests', () => {
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
-  // the runner seam rather than replace it.
-  const stubRunner = (runner: unknown) => cy.stub(tapRunnerSource, 'getRunner').returns(runner)
+  // the runner seam rather than replace it. Fixtures stand for a completed run
+  // by default; a test overrides isRunComplete to exercise the mid-run path.
+  const stubRunner = (runner: unknown) => {
+    return cy.stub(tapRunnerSource, 'getRunner').returns(
+      runner && typeof runner === 'object' ? { isRunComplete: () => true, ...runner } : runner,
+    )
+  }
 
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
@@ -70,6 +75,24 @@ describe('tap/commands/tests', () => {
         { id: 'r3', title: 'logs out', retries: 0, state: 'skipped' },
         { id: 'r4', title: 'stays logged in', state: 'pending' },
       ],
+    })
+  })
+
+  it('reports a state-less test as pending while the run is still going, skipped once it completes', async () => {
+    const state = { r3: { id: 'r3', title: 'logs out' } }
+
+    stubRunner({ getTestsState: () => state, isRunComplete: () => false })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('tests')).to.deep.eq({
+      result: [{ id: 'r3', title: 'logs out', state: 'pending' }],
+    })
+
+    stubRunner({ getTestsState: () => state, isRunComplete: () => true })
+
+    expect(await new TapManager(CYPRESS_VERSION).exec('tests')).to.deep.eq({
+      result: [{ id: 'r3', title: 'logs out', state: 'skipped' }],
     })
   })
 

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -25,6 +25,13 @@ describe('tap/commands/tests', () => {
       currentRetry: 0,
       body: 'function () {}',
     },
+    // The driver sets 'pending' explicitly for `it.skip` — distinct from the
+    // state-less r3, which never ran and comes back 'skipped'.
+    r4: {
+      id: 'r4',
+      title: 'stays logged in',
+      state: 'pending',
+    },
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
@@ -60,12 +67,13 @@ describe('tap/commands/tests', () => {
     expect(outcome).to.deep.eq({
       result: [
         { id: 'r2', title: 'logs in', duration: 120, state: 'passed', retries: 1 },
-        { id: 'r3', title: 'logs out', retries: 0, state: 'pending' },
+        { id: 'r3', title: 'logs out', retries: 0, state: 'skipped' },
+        { id: 'r4', title: 'stays logged in', state: 'pending' },
       ],
     })
   })
 
-  it('omits duration and retries of a test that has not run, defaults its state to pending, and round-trips through JSON', async () => {
+  it('omits duration and retries of a test that never ran, defaults its state to skipped, and round-trips through JSON', async () => {
     stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -73,7 +81,7 @@ describe('tap/commands/tests', () => {
     const outcome = await manager.exec('tests')
 
     expect(outcome).to.deep.eq({
-      result: [{ id: 'r2', title: 'logs in', state: 'pending' }],
+      result: [{ id: 'r2', title: 'logs in', state: 'skipped' }],
     })
 
     expect(Object.keys((outcome as { result: object[] }).result[0])).to.deep.eq(['id', 'title', 'state'])
@@ -178,9 +186,12 @@ describe('tap/commands/tests', () => {
           },
         },
       })
+
+      // A snapshot, not the driver's live timings object.
+      expect((outcome as { result: { timings: object } }).result.timings).to.not.equal(DETAIL_STATE.r2.timings)
     })
 
-    it('omits duration, timings, and error for a known test that has not run, defaults its state to pending, and round-trips through JSON', async () => {
+    it('omits duration, timings, and error for a known test that never ran, defaults its state to skipped, and round-trips through JSON', async () => {
       stubRunner({ getTestsState: () => DETAIL_STATE })
 
       const manager = new TapManager(CYPRESS_VERSION)
@@ -188,7 +199,7 @@ describe('tap/commands/tests', () => {
       const outcome = await manager.exec('tests', { test: 'r3' })
 
       expect(outcome).to.deep.eq({
-        result: { id: 'r3', title: 'logs out', fullTitle: 'auth > logout > logs out', state: 'pending' },
+        result: { id: 'r3', title: 'logs out', fullTitle: 'auth > logout > logs out', state: 'skipped' },
       })
 
       expect(Object.keys((outcome as { result: object }).result)).to.deep.eq(['id', 'title', 'fullTitle', 'state'])
@@ -203,7 +214,37 @@ describe('tap/commands/tests', () => {
       const outcome = await manager.exec('tests', { test: 'r2' })
 
       expect(outcome).to.deep.eq({
-        result: { id: 'r2', title: 'logs in', fullTitle: 'logs in', state: 'pending' },
+        result: { id: 'r2', title: 'logs in', fullTitle: 'logs in', state: 'skipped' },
+      })
+    })
+
+    it('treats null err and timings as absent rather than crashing on them', async () => {
+      stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in', state: 'passed', err: null, timings: null } }) })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r2' })
+
+      expect(outcome).to.deep.eq({
+        result: { id: 'r2', title: 'logs in', fullTitle: 'logs in', state: 'passed' },
+      })
+    })
+
+    it('drops non-string error props, which a non-Error user throw can carry', async () => {
+      stubRunner({
+        getTestsState: () => {
+          return {
+            r2: { id: 'r2', title: 'logs in', state: 'failed', err: { name: 42, message: 'thrown', stack: undefined } },
+          }
+        },
+      })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r2' })
+
+      expect(outcome).to.deep.eq({
+        result: { id: 'r2', title: 'logs in', fullTitle: 'logs in', state: 'failed', error: { message: 'thrown' } },
       })
     })
   })

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -81,7 +81,7 @@ describe('tap/commands/tests', () => {
   it('reports a state-less test as pending while the run is still going, skipped once it completes', async () => {
     const state = { r3: { id: 'r3', title: 'logs out' } }
 
-    stubRunner({ getTestsState: () => state, isRunComplete: () => false })
+    const getRunner = stubRunner({ getTestsState: () => state, isRunComplete: () => false })
 
     const manager = new TapManager(CYPRESS_VERSION)
 
@@ -89,7 +89,8 @@ describe('tap/commands/tests', () => {
       result: [{ id: 'r3', title: 'logs out', state: 'pending' }],
     })
 
-    stubRunner({ getTestsState: () => state, isRunComplete: () => true })
+    // Re-program the existing stub: a second cy.stub on the same method throws.
+    getRunner.returns({ getTestsState: () => state, isRunComplete: () => true })
 
     expect(await new TapManager(CYPRESS_VERSION).exec('tests')).to.deep.eq({
       result: [{ id: 'r3', title: 'logs out', state: 'skipped' }],

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -4,10 +4,8 @@ import { tapRunnerSource } from './test-state'
 const CYPRESS_VERSION = '15.0.0'
 
 describe('tap/commands/tests', () => {
-  // The serialized tests getTestsState returns carry far more than the
-  // lean entry fields — the fixture includes the extras to prove the
-  // handler strips them (notably `retries`, the configured max, which the
-  // output field of the same name must NOT carry).
+  // The fixture includes extras to prove the handler strips them — notably
+  // input `retries` (configured max), distinct from output `retries` (currentRetry).
   const TESTS_STATE = {
     r2: {
       id: 'r2',
@@ -29,8 +27,8 @@ describe('tap/commands/tests', () => {
     },
   }
 
-  // The spec window's own `window.Cypress` is the instance running this
-  // test, so every test stubs the runner seam instead of replacing it.
+  // The spec's own window.Cypress is the instance running this test, so stub
+  // the runner seam rather than replace it.
   const stubRunner = (runner: unknown) => cy.stub(tapRunnerSource, 'getRunner').returns(runner)
 
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
@@ -94,9 +92,8 @@ describe('tap/commands/tests', () => {
   })
 
   describe('with a test id', () => {
-    // A failed test carries the detail fields the list omits: the full title
-    // path, per-phase timings, and the latest attempt's error (itself trimmed
-    // to its messaging fields from a serialized error with extras).
+    // Includes fields the list omits plus error extras (codeFrame) to prove
+    // the detail trims the error down to its messaging fields.
     const DETAIL_STATE = {
       r2: {
         id: 'r2',
@@ -113,7 +110,6 @@ describe('tap/commands/tests', () => {
           codeFrame: { line: 3 },
         },
       },
-      // A known test that has not run yet — no duration, timings, or error.
       r3: {
         id: 'r3',
         title: 'logs out',
@@ -163,8 +159,7 @@ describe('tap/commands/tests', () => {
 
       const outcome = await manager.exec('tests', { test: 'r2' })
 
-      // '__never__' (not the test id) is the sentinel — getTestsState excludes
-      // the matching id and everything after it, so passing 'r2' would drop it.
+      // Must query with the sentinel, not 'r2': getTestsState excludes the matching id.
       expect(getTestsState).to.have.been.calledOnceWith('__never__')
 
       expect(outcome).to.deep.eq({

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -1,5 +1,5 @@
+import { tapManagerDataSource } from '../TapManagerDataSource'
 import { TapManager } from '../tap-manager'
-import { tapRunnerSource } from './test-state'
 
 const CYPRESS_VERSION = '15.0.0'
 
@@ -38,7 +38,7 @@ describe('tap/commands/tests', () => {
   // the runner seam rather than replace it. Fixtures stand for a completed run
   // by default; a test overrides isRunComplete to exercise the mid-run path.
   const stubRunner = (runner: unknown) => {
-    return cy.stub(tapRunnerSource, 'getRunner').returns(
+    return cy.stub(tapManagerDataSource, 'getRunner').returns(
       runner && typeof runner === 'object' ? { isRunComplete: () => true, ...runner } : runner,
     )
   }

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -25,8 +25,8 @@ describe('tap/commands/tests', () => {
       currentRetry: 0,
       body: 'function () {}',
     },
-    // The driver sets 'pending' explicitly for `it.skip` — distinct from the
-    // state-less r3, which never ran and comes back 'skipped'.
+    // The driver sets 'pending' explicitly for `it.skip` — distinct from r3,
+    // which has no state because it never ran and comes back 'skipped'.
     r4: {
       id: 'r4',
       title: 'stays logged in',
@@ -58,16 +58,16 @@ describe('tap/commands/tests', () => {
     })
   })
 
-  it('serializes every test via the __never__ sentinel, keeping only the lean entry fields', async () => {
-    const getTestsState = cy.stub().returns(TESTS_STATE)
+  it('serializes every test, keeping only the lean entry fields', async () => {
+    const getAllTestsState = cy.stub().returns(TESTS_STATE)
 
-    stubRunner({ getTestsState })
+    stubRunner({ getAllTestsState })
 
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('tests')
 
-    expect(getTestsState).to.have.been.calledOnceWith('__never__')
+    expect(getAllTestsState).to.have.been.calledOnce
 
     expect(outcome).to.deep.eq({
       result: [
@@ -78,10 +78,10 @@ describe('tap/commands/tests', () => {
     })
   })
 
-  it('reports a state-less test as pending while the run is still going, skipped once it completes', async () => {
+  it('reports a test with no state yet as pending while the run is still going, skipped once it completes', async () => {
     const state = { r3: { id: 'r3', title: 'logs out' } }
 
-    const getRunner = stubRunner({ getTestsState: () => state, isRunComplete: () => false })
+    const getRunner = stubRunner({ getAllTestsState: () => state, isRunComplete: () => false })
 
     const manager = new TapManager(CYPRESS_VERSION)
 
@@ -90,7 +90,7 @@ describe('tap/commands/tests', () => {
     })
 
     // Re-program the existing stub: a second cy.stub on the same method throws.
-    getRunner.returns({ getTestsState: () => state, isRunComplete: () => true })
+    getRunner.returns({ getAllTestsState: () => state, isRunComplete: () => true })
 
     expect(await new TapManager(CYPRESS_VERSION).exec('tests')).to.deep.eq({
       result: [{ id: 'r3', title: 'logs out', state: 'skipped' }],
@@ -98,7 +98,7 @@ describe('tap/commands/tests', () => {
   })
 
   it('omits duration and retries of a test that never ran, defaults its state to skipped, and round-trips through JSON', async () => {
-    stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
+    stubRunner({ getAllTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
 
     const manager = new TapManager(CYPRESS_VERSION)
 
@@ -113,7 +113,7 @@ describe('tap/commands/tests', () => {
   })
 
   it('fails dispatch without reading the runner when an unknown arg is given', async () => {
-    const getRunner = stubRunner({ getTestsState: () => ({}) })
+    const getRunner = stubRunner({ getAllTestsState: () => ({}) })
 
     const manager = new TapManager(CYPRESS_VERSION)
 
@@ -165,15 +165,15 @@ describe('tap/commands/tests', () => {
     })
 
     it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
-      const getTestsState = cy.stub().returns(DETAIL_STATE)
+      const getAllTestsState = cy.stub().returns(DETAIL_STATE)
 
-      stubRunner({ getTestsState })
+      stubRunner({ getAllTestsState })
 
       const manager = new TapManager(CYPRESS_VERSION)
 
       const outcome = await manager.exec('tests', { test: 'nope' })
 
-      expect(getTestsState).to.have.been.calledOnceWith('__never__')
+      expect(getAllTestsState).to.have.been.calledOnce
       expect(outcome).to.deep.eq({
         error: {
           code: 'TEST_NOT_FOUND',
@@ -182,17 +182,16 @@ describe('tap/commands/tests', () => {
       })
     })
 
-    it('returns the full title, timings, and trimmed error of the matching test via the __never__ sentinel', async () => {
-      const getTestsState = cy.stub().returns(DETAIL_STATE)
+    it('returns the full title, timings, and trimmed error of the matching test', async () => {
+      const getAllTestsState = cy.stub().returns(DETAIL_STATE)
 
-      stubRunner({ getTestsState })
+      stubRunner({ getAllTestsState })
 
       const manager = new TapManager(CYPRESS_VERSION)
 
       const outcome = await manager.exec('tests', { test: 'r2' })
 
-      // Must query with the sentinel, not 'r2': getTestsState excludes the matching id.
-      expect(getTestsState).to.have.been.calledOnceWith('__never__')
+      expect(getAllTestsState).to.have.been.calledOnce
 
       expect(outcome).to.deep.eq({
         result: {
@@ -216,7 +215,7 @@ describe('tap/commands/tests', () => {
     })
 
     it('omits duration, timings, and error for a known test that never ran, defaults its state to skipped, and round-trips through JSON', async () => {
-      stubRunner({ getTestsState: () => DETAIL_STATE })
+      stubRunner({ getAllTestsState: () => DETAIL_STATE })
 
       const manager = new TapManager(CYPRESS_VERSION)
 
@@ -231,7 +230,7 @@ describe('tap/commands/tests', () => {
     })
 
     it('falls back to the plain title when the test carries no title path', async () => {
-      stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
+      stubRunner({ getAllTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
 
       const manager = new TapManager(CYPRESS_VERSION)
 
@@ -243,7 +242,7 @@ describe('tap/commands/tests', () => {
     })
 
     it('treats null err and timings as absent rather than crashing on them', async () => {
-      stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in', state: 'passed', err: null, timings: null } }) })
+      stubRunner({ getAllTestsState: () => ({ r2: { id: 'r2', title: 'logs in', state: 'passed', err: null, timings: null } }) })
 
       const manager = new TapManager(CYPRESS_VERSION)
 
@@ -256,7 +255,7 @@ describe('tap/commands/tests', () => {
 
     it('drops non-string error props, which a non-Error user throw can carry', async () => {
       stubRunner({
-        getTestsState: () => {
+        getAllTestsState: () => {
           return {
             r2: { id: 'r2', title: 'logs in', state: 'failed', err: { name: 42, message: 'thrown', stack: undefined } },
           }

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -1,4 +1,4 @@
-import { tapManagerDataSource } from '../TapManagerDataSource'
+import { tapManagerDataSource } from '../tap-manager-data-source'
 import { TapManager } from '../tap-manager'
 
 const CYPRESS_VERSION = '15.0.0'

--- a/packages/app/src/tap/commands/tests.cy.ts
+++ b/packages/app/src/tap/commands/tests.cy.ts
@@ -1,0 +1,215 @@
+import { TapManager } from '../tap-manager'
+import { tapRunnerSource } from './test-state'
+
+const CYPRESS_VERSION = '15.0.0'
+
+describe('tap/commands/tests', () => {
+  // The serialized tests getTestsState returns carry far more than the
+  // lean entry fields — the fixture includes the extras to prove the
+  // handler strips them (notably `retries`, the configured max, which the
+  // output field of the same name must NOT carry).
+  const TESTS_STATE = {
+    r2: {
+      id: 'r2',
+      title: 'logs in',
+      duration: 120,
+      state: 'passed',
+      retries: 2,
+      currentRetry: 1,
+      body: 'function () {}',
+      timings: { lifecycle: 30 },
+      prevAttempts: [{ id: 'r2', state: 'failed' }],
+    },
+    r3: {
+      id: 'r3',
+      title: 'logs out',
+      retries: 2,
+      currentRetry: 0,
+      body: 'function () {}',
+    },
+  }
+
+  // The spec window's own `window.Cypress` is the instance running this
+  // test, so every test stubs the runner seam instead of replacing it.
+  const stubRunner = (runner: unknown) => cy.stub(tapRunnerSource, 'getRunner').returns(runner)
+
+  it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
+    stubRunner(undefined)
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('tests')
+
+    expect(outcome).to.deep.eq({
+      error: {
+        code: 'NO_RUN',
+        message: 'no spec has been run yet — use the run command to run a spec first',
+      },
+    })
+  })
+
+  it('serializes every test via the __never__ sentinel, keeping only the lean entry fields', async () => {
+    const getTestsState = cy.stub().returns(TESTS_STATE)
+
+    stubRunner({ getTestsState })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('tests')
+
+    expect(getTestsState).to.have.been.calledOnceWith('__never__')
+
+    expect(outcome).to.deep.eq({
+      result: [
+        { id: 'r2', title: 'logs in', duration: 120, state: 'passed', retries: 1 },
+        { id: 'r3', title: 'logs out', retries: 0, state: 'pending' },
+      ],
+    })
+  })
+
+  it('omits duration and retries of a test that has not run, defaults its state to pending, and round-trips through JSON', async () => {
+    stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('tests')
+
+    expect(outcome).to.deep.eq({
+      result: [{ id: 'r2', title: 'logs in', state: 'pending' }],
+    })
+
+    expect(Object.keys((outcome as { result: object[] }).result[0])).to.deep.eq(['id', 'title', 'state'])
+    expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+  })
+
+  it('fails dispatch without reading the runner when an unknown arg is given', async () => {
+    const getRunner = stubRunner({ getTestsState: () => ({}) })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('tests', { test: 'r2', extra: 'extra' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_ARGUMENTS')
+    expect(getRunner).not.to.have.been.called
+  })
+
+  describe('with a test id', () => {
+    // A failed test carries the detail fields the list omits: the full title
+    // path, per-phase timings, and the latest attempt's error (itself trimmed
+    // to its messaging fields from a serialized error with extras).
+    const DETAIL_STATE = {
+      r2: {
+        id: 'r2',
+        title: 'logs in',
+        _titlePath: ['auth', 'login', 'logs in'],
+        duration: 120,
+        state: 'failed',
+        currentRetry: 1,
+        timings: { lifecycle: 30, 'before each': [{ hookId: 'h1', fnDuration: 5 }] },
+        err: {
+          name: 'AssertionError',
+          message: 'expected true to be false',
+          stack: 'AssertionError: expected true to be false\n  at <anonymous>',
+          codeFrame: { line: 3 },
+        },
+      },
+      // A known test that has not run yet — no duration, timings, or error.
+      r3: {
+        id: 'r3',
+        title: 'logs out',
+        _titlePath: ['auth', 'logout', 'logs out'],
+      },
+    }
+
+    it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
+      stubRunner(undefined)
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r2' })
+
+      expect(outcome).to.deep.eq({
+        error: {
+          code: 'NO_RUN',
+          message: 'no spec has been run yet — use the run command to run a spec first',
+        },
+      })
+    })
+
+    it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
+      const getTestsState = cy.stub().returns(DETAIL_STATE)
+
+      stubRunner({ getTestsState })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'nope' })
+
+      expect(getTestsState).to.have.been.calledOnceWith('__never__')
+      expect(outcome).to.deep.eq({
+        error: {
+          code: 'TEST_NOT_FOUND',
+          message: 'no test of this run matches the id "nope" — use the tests command to list this run’s tests',
+        },
+      })
+    })
+
+    it('returns the full title, timings, and trimmed error of the matching test via the __never__ sentinel', async () => {
+      const getTestsState = cy.stub().returns(DETAIL_STATE)
+
+      stubRunner({ getTestsState })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r2' })
+
+      // '__never__' (not the test id) is the sentinel — getTestsState excludes
+      // the matching id and everything after it, so passing 'r2' would drop it.
+      expect(getTestsState).to.have.been.calledOnceWith('__never__')
+
+      expect(outcome).to.deep.eq({
+        result: {
+          id: 'r2',
+          title: 'logs in',
+          fullTitle: 'auth > login > logs in',
+          duration: 120,
+          state: 'failed',
+          retries: 1,
+          timings: { lifecycle: 30, 'before each': [{ hookId: 'h1', fnDuration: 5 }] },
+          error: {
+            name: 'AssertionError',
+            message: 'expected true to be false',
+            stack: 'AssertionError: expected true to be false\n  at <anonymous>',
+          },
+        },
+      })
+    })
+
+    it('omits duration, timings, and error for a known test that has not run, defaults its state to pending, and round-trips through JSON', async () => {
+      stubRunner({ getTestsState: () => DETAIL_STATE })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r3' })
+
+      expect(outcome).to.deep.eq({
+        result: { id: 'r3', title: 'logs out', fullTitle: 'auth > logout > logs out', state: 'pending' },
+      })
+
+      expect(Object.keys((outcome as { result: object }).result)).to.deep.eq(['id', 'title', 'fullTitle', 'state'])
+      expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+    })
+
+    it('falls back to the plain title when the test carries no title path', async () => {
+      stubRunner({ getTestsState: () => ({ r2: { id: 'r2', title: 'logs in' } }) })
+
+      const manager = new TapManager(CYPRESS_VERSION)
+
+      const outcome = await manager.exec('tests', { test: 'r2' })
+
+      expect(outcome).to.deep.eq({
+        result: { id: 'r2', title: 'logs in', fullTitle: 'logs in', state: 'pending' },
+      })
+    })
+  })
+})

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -7,10 +7,6 @@ export const testsCommand = defineCommand({
   params: [
     { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
   ],
-  // With no id, returns the run's tests. With one, returns that test's detail —
-  // full title, timings, and error. Throws NO_RUN — surfaced on stderr, never
-  // stdout — when no spec has mounted a runner (or one is mid-teardown), and
-  // TEST_NOT_FOUND when the run holds no test with the given id.
   handler: async ({ test }): Promise<TestStateEntry[] | TestDetailEntry> => {
     const runner = tapRunnerSource.getRunner()
 

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -25,6 +25,6 @@ export const testsCommand = defineCommand({
       throw new TapCommandError('TEST_NOT_FOUND', `no test of this run matches the id "${test}" — use the tests command to list this run’s tests`)
     }
 
-    return serializeTestDetail(found)
+    return serializeTestDetail(found, runner.isRunComplete())
   },
 })

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -1,0 +1,33 @@
+import { defineCommand, TapCommandError } from './definition'
+import { serializeTestDetail, serializeTestsState, tapRunnerSource } from './test-state'
+import type { TestDetailEntry, TestStateEntry } from './test-state'
+
+export const testsCommand = defineCommand({
+  description: 'list the tests of the active run and their state, or detail one by id',
+  params: [
+    { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
+  ],
+  // With no id, returns the run's tests. With one, returns that test's detail —
+  // full title, timings, and error. Throws NO_RUN — surfaced on stderr, never
+  // stdout — when no spec has mounted a runner (or one is mid-teardown), and
+  // TEST_NOT_FOUND when the run holds no test with the given id.
+  handler: async ({ test }): Promise<TestStateEntry[] | TestDetailEntry> => {
+    const runner = tapRunnerSource.getRunner()
+
+    if (!runner) {
+      throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+    }
+
+    if (test === undefined) {
+      return serializeTestsState(runner)
+    }
+
+    const detail = serializeTestDetail(runner, test)
+
+    if (detail === undefined) {
+      throw new TapCommandError('TEST_NOT_FOUND', `no test of this run matches the id "${test}" — use the tests command to list this run’s tests`)
+    }
+
+    return detail
+  },
+})

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -19,8 +19,7 @@ export const testsCommand = defineCommand({
       return serializeTestsState(runner)
     }
 
-    // '__never__' matches no id, so getTestsState returns every test to look one up.
-    const found = runner.getTestsState('__never__')[test]
+    const found = runner.getAllTestsState()[test]
 
     if (!found) {
       throw new TapCommandError('TEST_NOT_FOUND', `no test of this run matches the id "${test}" — use the tests command to list this run’s tests`)

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -18,12 +18,13 @@ export const testsCommand = defineCommand({
       return serializeTestsState(runner)
     }
 
-    const detail = serializeTestDetail(runner, test)
+    // '__never__' matches no id, so getTestsState returns every test to look one up.
+    const found = runner.getTestsState('__never__')[test]
 
-    if (detail === undefined) {
+    if (!found) {
       throw new TapCommandError('TEST_NOT_FOUND', `no test of this run matches the id "${test}" — use the tests command to list this run’s tests`)
     }
 
-    return detail
+    return serializeTestDetail(found)
   },
 })

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -1,4 +1,4 @@
-import { tapManagerDataSource } from '../TapManagerDataSource'
+import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
 import { serializeTestDetail, serializeTestsState } from './test-state'
 import type { TestDetailEntry, TestStateEntry } from '../types'

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -1,7 +1,7 @@
 import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand, TapCommandError } from './definition'
 import { serializeTestDetail, serializeTestsState } from './test-state'
-import type { TestDetailEntry, TestStateEntry } from './test-state'
+import type { TestDetailEntry, TestStateEntry } from '../types'
 
 export const testsCommand = defineCommand({
   description: 'list the tests of the active run and their state, or detail one by id',

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -1,5 +1,6 @@
+import { tapManagerDataSource } from '../TapManagerDataSource'
 import { defineCommand, TapCommandError } from './definition'
-import { serializeTestDetail, serializeTestsState, tapRunnerSource } from './test-state'
+import { serializeTestDetail, serializeTestsState } from './test-state'
 import type { TestDetailEntry, TestStateEntry } from './test-state'
 
 export const testsCommand = defineCommand({
@@ -8,7 +9,7 @@ export const testsCommand = defineCommand({
     { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
   ],
   handler: async ({ test }): Promise<TestStateEntry[] | TestDetailEntry> => {
-    const runner = tapRunnerSource.getRunner()
+    const runner = tapManagerDataSource.getRunner()
 
     if (!runner) {
       throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -2,8 +2,6 @@ import type { FoundSpec } from '@packages/types'
 
 import type { TapTestsRunner } from './types'
 
-// Every runner-window global a tap command reads (or writes) goes through this
-// one seam, so component tests stub a method here instead of the real globals.
 export const tapManagerDataSource = {
   getRunner (): TapTestsRunner | undefined {
     try {

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -15,28 +15,42 @@ export interface SpecListEntry {
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
 
 export interface TestStateEntry {
+  /** The runner's test id, e.g. `r2` — the handle other tap commands accept. */
   id: string
+  /** The test's own title, without its suite path. */
   title: string
+  /** Wall-clock run time in ms; absent until the test has run. */
   duration?: number
+  /** Final status, or the unreached placeholder (`pending` mid-run, `skipped` after). */
   state: TestStateValue
   /** Retries actually taken this run, not the configured maximum. */
   retries?: number
 }
 
 export interface TestError {
+  /** Error class name, e.g. `AssertionError`; absent on non-Error throws. */
   name?: string
+  /** The thrown message; absent on non-Error throws without one. */
   message?: string
+  /** The stack trace as the driver captured it. */
   stack?: string
 }
 
 export interface TestDetailEntry {
+  /** The runner's test id, e.g. `r2` — the handle other tap commands accept. */
   id: string
+  /** The test's own title, without its suite path. */
   title: string
   /** Suite titles leading to this test plus its own, joined with ` > `. */
   fullTitle: string
+  /** Wall-clock run time in ms; absent until the test has run. */
   duration?: number
+  /** Final status, or the unreached placeholder (`pending` mid-run, `skipped` after). */
   state: TestStateValue
+  /** Retries actually taken this run, not the configured maximum. */
   retries?: number
+  /** The driver's lifecycle/hook timing breakdown; absent until the test has run. */
   timings?: Record<string, unknown>
+  /** The failure that ended the test; absent unless it failed. */
   error?: TestError
 }

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -4,3 +4,32 @@ export interface TapTestsRunner {
   getTestsState (testId?: string): Record<string, SerializedTest>
   isRunComplete (): boolean
 }
+
+export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
+
+export interface TestStateEntry {
+  id: string
+  title: string
+  duration?: number
+  state: TestStateValue
+  /** Retries actually taken this run, not the configured maximum. */
+  retries?: number
+}
+
+export interface TestError {
+  name?: string
+  message?: string
+  stack?: string
+}
+
+export interface TestDetailEntry {
+  id: string
+  title: string
+  /** Suite titles leading to this test plus its own, joined with ` > `. */
+  fullTitle: string
+  duration?: number
+  state: TestStateValue
+  retries?: number
+  timings?: Record<string, unknown>
+  error?: TestError
+}

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -1,7 +1,7 @@
 import type { FoundSpec, SerializedTest } from '@packages/types'
 
 export interface TapTestsRunner {
-  getTestsState (testId?: string): Record<string, SerializedTest>
+  getAllTestsState (): Record<string, SerializedTest>
   isRunComplete (): boolean
 }
 

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -1,8 +1,15 @@
-import type { SerializedTest } from '@packages/types'
+import type { FoundSpec, SerializedTest } from '@packages/types'
 
 export interface TapTestsRunner {
   getTestsState (testId?: string): Record<string, SerializedTest>
   isRunComplete (): boolean
+}
+
+export interface SpecListEntry {
+  /** Project-relative spec path — the form `cypress run --spec` accepts. */
+  relativePath: string
+  /** Whether the spec is an end-to-end (integration) or component spec. */
+  specType: FoundSpec['specType']
 }
 
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -1,0 +1,6 @@
+import type { SerializedTest } from '@packages/types'
+
+export interface TapTestsRunner {
+  getTestsState (testId?: string): Record<string, SerializedTest>
+  isRunComplete (): boolean
+}

--- a/packages/driver/cypress/e2e/cypress/runner.cy.js
+++ b/packages/driver/cypress/e2e/cypress/runner.cy.js
@@ -46,6 +46,7 @@ describe('getAllTestsState', () => {
       expect(test.prevAttempts, 'prevAttempts is serialized').to.be.an('array')
     })
 
+    expect(byTitle['is not pending']._titlePath).to.deep.eq(['src/cypress/runner', 'pending tests', 'is not pending'])
     expect(byTitle['is not pending'].state).to.eq('passed')
     expect(byTitle['is pending 1'].state).to.eq('pending')
 

--- a/packages/driver/cypress/e2e/cypress/runner.cy.js
+++ b/packages/driver/cypress/e2e/cypress/runner.cy.js
@@ -36,6 +36,26 @@ describe('async timeouts', () => {
   })
 })
 
+describe('getAllTestsState', () => {
+  it('serializes every test of the spec keyed by id, run or not', () => {
+    const tests = Cypress.runner.getAllTestsState()
+    const byTitle = _.keyBy(_.values(tests), 'title')
+
+    _.each(tests, (test, id) => {
+      expect(test.id, 'key is the test id').to.eq(id)
+      expect(test.prevAttempts, 'prevAttempts is serialized').to.be.an('array')
+    })
+
+    expect(byTitle['is not pending'].state).to.eq('passed')
+    expect(byTitle['is pending 1'].state).to.eq('pending')
+
+    // Unlike getTestsState, the currently running test and tests that have
+    // not run yet are included — with no state set.
+    expect(byTitle['serializes every test of the spec keyed by id, run or not'].state).to.be.undefined
+    expect(byTitle['test 2'].state).to.be.undefined
+  })
+})
+
 // NOTE: this test must remain the last test in the spec
 // so we can test the root after hook
 // https://github.com/cypress-io/cypress/issues/2296

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -8,7 +8,8 @@ import $errUtils from './error_utils'
 import $stackUtils from './stack_utils'
 import { getResolvedTestConfigOverride } from '../cy/testConfigOverrides'
 import debugFn from 'debug'
-import type { Emissions, TestFilter } from '@packages/types'
+import { RUNNABLE_LOGS, RUNNABLE_PROPS } from '@packages/types'
+import type { Emissions, SerializedTest, TestFilter } from '@packages/types'
 import { SKIPPED_DUE_TO_BROWSER_MESSAGE } from './mocha'
 
 const mochaCtxKeysRe = /^(_runnable|test)$/
@@ -22,11 +23,6 @@ const TEST_BEFORE_AFTER_RUN_ASYNC_EVENT = 'runner:test:before:after:run:async'
 const TEST_AFTER_RUN_ASYNC_EVENT = 'runner:test:after:run:async'
 const TEST_AFTER_RUN_EVENT = 'runner:test:after:run'
 const RUNNABLE_AFTER_RUN_ASYNC_EVENT = 'runner:runnable:after:run:async'
-
-const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
-const RUNNABLE_PROPS = [
-  '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
-] as const
 
 const debug = debugFn('cypress:driver:runner')
 const debugErrors = debugFn('cypress:driver:errors')
@@ -1905,9 +1901,9 @@ export default {
         return _emissions
       },
 
-      getTestsState (testId?: string) {
+      getTestsState (testId?: string): Record<string, SerializedTest> {
         const id = testId ?? (_test != null ? _test.id : undefined)
-        const tests = {}
+        const tests: Record<string, SerializedTest> = {}
 
         // bail if we dont have a current test
         if (!id) {
@@ -2095,10 +2091,12 @@ const mixinLogs = (test) => {
   })
 }
 
-const serializeTest = (test) => {
+const serializeTest = (test): SerializedTest => {
   const wrappedTest = wrapAll(test)
 
   mixinLogs(wrappedTest)
 
-  return wrappedTest
+  // wrapAll assembles the object dynamically from the RUNNABLE_PROPS
+  // allowlist, so its type carries no named properties to check against.
+  return wrappedTest as SerializedTest
 }

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1934,6 +1934,10 @@ export default {
         for (let testRunnable of _tests) {
           const test = serializeTest(testRunnable)
 
+          // `_titlePath` is only stamped on the normalized runnable copy;
+          // `_tests` holds the raw runnables, so read it off the live runnable.
+          test._titlePath = testRunnable.titlePath()
+
           test.prevAttempts = _.map(testRunnable.prevAttempts, serializeTest)
 
           tests[test.id] = test

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1928,6 +1928,20 @@ export default {
         return tests
       },
 
+      getAllTestsState (): Record<string, SerializedTest> {
+        const tests: Record<string, SerializedTest> = {}
+
+        for (let testRunnable of _tests) {
+          const test = serializeTest(testRunnable)
+
+          test.prevAttempts = _.map(testRunnable.prevAttempts, serializeTest)
+
+          tests[test.id] = test
+        }
+
+        return tests
+      },
+
       stop () {
         if (_runner.stopped) {
           return

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -60,3 +60,13 @@ export const NPM_CYPRESS_REGISTRY_URL = 'https://registry.npmjs.org/cypress'
  * This number is fairly arbitrary.
  */
 export const MAX_VISIBILITY_CHECK_ELEMENTS = 10
+
+// The own-property allowlists the driver keeps when serializing a runnable
+// (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`). Shared here so
+// consumers of the serialized shape (e.g. `Cypress.runner.getTestsState`) use
+// one key source with the driver.
+export const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
+
+export const RUNNABLE_PROPS = [
+  '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
+] as const

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -61,10 +61,6 @@ export const NPM_CYPRESS_REGISTRY_URL = 'https://registry.npmjs.org/cypress'
  */
 export const MAX_VISIBILITY_CHECK_ELEMENTS = 10
 
-// The own-property allowlists the driver keeps when serializing a runnable
-// (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`). Shared here so
-// consumers of the serialized shape (e.g. `Cypress.runner.getTestsState`) use
-// one key source with the driver.
 export const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
 
 export const RUNNABLE_PROPS = [

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -39,19 +39,28 @@ export const RUNNABLE_PROPS = [
   '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
 ] as const
 
+// The subset of the serialized shape that is stable across driver versions.
+// `timings` and `err` stay opaque objects: their values are heterogeneous
+// (`err` carries whatever the user's thrown object had on it), so consumers
+// must narrow at runtime.
+interface SerializedTestStable {
+  id: string
+  title: string
+  _titlePath?: string[]
+  state?: 'passed' | 'failed' | 'pending'
+  duration?: number
+  currentRetry?: number
+  retries?: number
+  timings?: Record<string, unknown> | null
+  err?: Record<string, unknown> | null
+  prevAttempts?: SerializedTest[]
+}
+
 // A test as the driver serializes it: only allowlist keys (absent, not
 // undefined, when the runnable lacks them), typed only where stable.
 export type SerializedTest =
-  & { [K in typeof RUNNABLE_PROPS[number] | typeof RUNNABLE_LOGS[number]]?: unknown }
-  & {
-    id: string
-    title: string
-    state?: 'passed' | 'failed' | 'pending'
-    duration?: number
-    currentRetry?: number
-    retries?: number
-    prevAttempts?: SerializedTest[]
-  }
+  & Omit<{ [K in typeof RUNNABLE_PROPS[number] | typeof RUNNABLE_LOGS[number]]?: unknown }, keyof SerializedTestStable>
+  & SerializedTestStable
 
 export type Instrument = 'agent' | 'command' | 'route'
 

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -1,4 +1,5 @@
 import type { ReporterRunState } from './reporter'
+import type { RUNNABLE_LOGS, RUNNABLE_PROPS } from './constants'
 
 interface MochaRunnerState {
   startTime?: number
@@ -28,16 +29,6 @@ export type StoredSessions = Record<string, Cypress.ServerSessionData>
 export interface CachedTestState {
   activeSessions: StoredSessions
 }
-
-// The own-property allowlists the driver keeps when serializing a runnable
-// (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`). Shared here so
-// consumers of the serialized shape (e.g. `Cypress.runner.getTestsState`) use
-// one key source with the driver.
-export const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
-
-export const RUNNABLE_PROPS = [
-  '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
-] as const
 
 // The subset of the serialized shape that is stable across driver versions.
 // `timings` and `err` stay opaque objects: their values are heterogeneous

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -29,6 +29,38 @@ export interface CachedTestState {
   activeSessions: StoredSessions
 }
 
+/**
+ * The own-property allowlists the driver keeps when serializing a runnable
+ * (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`): RUNNABLE_PROPS
+ * are the runnable's own fields, RUNNABLE_LOGS the serialized log
+ * collections mixed in alongside them. They live here so consumers of the
+ * serialized shape (e.g. `Cypress.runner.getTestsState`) can share one
+ * key source with the driver.
+ */
+export const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
+
+export const RUNNABLE_PROPS = [
+  '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
+] as const
+
+/**
+ * A test as the driver serializes it: only keys from the two allowlists
+ * (absent rather than undefined when the runnable lacks them), plus the
+ * previous attempts serialized the same way. Values are typed only where
+ * stable and consumed; the rest stay `unknown`.
+ */
+export type SerializedTest =
+  & { [K in typeof RUNNABLE_PROPS[number] | typeof RUNNABLE_LOGS[number]]?: unknown }
+  & {
+    id: string
+    title: string
+    state?: 'passed' | 'failed' | 'pending'
+    duration?: number
+    currentRetry?: number
+    retries?: number
+    prevAttempts?: SerializedTest[]
+  }
+
 export type Instrument = 'agent' | 'command' | 'route'
 
 export type TestState = 'active' | 'failed' | 'pending' | 'passed' | 'processing' | 'warned'

--- a/packages/types/src/driver.ts
+++ b/packages/types/src/driver.ts
@@ -29,26 +29,18 @@ export interface CachedTestState {
   activeSessions: StoredSessions
 }
 
-/**
- * The own-property allowlists the driver keeps when serializing a runnable
- * (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`): RUNNABLE_PROPS
- * are the runnable's own fields, RUNNABLE_LOGS the serialized log
- * collections mixed in alongside them. They live here so consumers of the
- * serialized shape (e.g. `Cypress.runner.getTestsState`) can share one
- * key source with the driver.
- */
+// The own-property allowlists the driver keeps when serializing a runnable
+// (`wrapAll`/`mixinLogs` in driver `src/cypress/runner.ts`). Shared here so
+// consumers of the serialized shape (e.g. `Cypress.runner.getTestsState`) use
+// one key source with the driver.
 export const RUNNABLE_LOGS = ['routes', 'agents', 'commands', 'hooks'] as const
 
 export const RUNNABLE_PROPS = [
   '_cypressTestStatusInfo', '_testConfig', 'id', 'order', 'title', '_titlePath', 'root', 'hookName', 'hookId', 'err', 'state', 'pending', 'failedFromHookId', 'failedFromHookName', 'body', 'speed', 'type', 'duration', 'wallClockStartedAt', 'wallClockDuration', 'timings', 'file', 'originalTitle', 'invocationDetails', 'final', 'currentRetry', 'retries', '_slow',
 ] as const
 
-/**
- * A test as the driver serializes it: only keys from the two allowlists
- * (absent rather than undefined when the runnable lacks them), plus the
- * previous attempts serialized the same way. Values are typed only where
- * stable and consumed; the rest stay `unknown`.
- */
+// A test as the driver serializes it: only allowlist keys (absent, not
+// undefined, when the runnable lacks them), typed only where stable.
 export type SerializedTest =
   & { [K in typeof RUNNABLE_PROPS[number] | typeof RUNNABLE_LOGS[number]]?: unknown }
   & {


### PR DESCRIPTION
### Additional details

This PR adds the **`tests`** command to the `cypress tap` registry — reading the test state of the active run. It stacks on top of `run` (#34193): `run` triggers a spec, `tests` then reports what that run produced.

- **`tests` command** (`packages/app/src/tap/commands/tests.ts`). One optional `test` param: omitted, it lists every test of the active run as lean `{ id, title, duration, state, retries }` entries; given a test id, it details that one test (adds `fullTitle`, per-phase `timings`, and the latest attempt's `error`). Two domain failures throw `TapCommandError` and never reach stdout: `NO_RUN` when no spec has mounted a runner yet, `TEST_NOT_FOUND` when the run holds no test with that id.
- **Runner seam: `TapManagerDataSource.ts`**. All the window-global accessors the tap commands rely on live in one `tapManagerDataSource` object — `getRunner()`, `getRunnableSpecs()` (`__RUN_MODE_SPECS__`), and the `getHash`/`setHash` navigation pair — so the `specs`/`run` commands and the stub-based component specs all share a single seam instead of each command reaching into its own global. `getRunner()` resolves the driver runner from the **event manager**, not `window.Cypress` — under cypress-in-cypress, `window.Cypress` is the outer driver injected into the AUT, while the event manager only ever holds this app's instance.
- **Serialization** (`commands/test-state.ts`). `serializeTestsState` trims the driver's serialized tests to the lean list shape, and `serializeTestDetail` projects one already-looked-up test to the detail shape; both omit optional fields (absent, not `null`) so the in-memory result already equals its JSON form across the CDP boundary. The `getTestsState('__never__')` query returns every test — the driver serializes tests *up to (excluding)* the matching id, so a never-matching sentinel is required to get them all — and the `tests` handler runs that query once, then either lists the result or hands the matching test to `serializeTestDetail`. A test with no state yet is defaulted by run status — `pending` while the run is still in flight, `skipped` once it completes (mirroring the driver's own end-of-run summary); `getRunner()` composes that signal onto the seam from `EventManager.runComplete`.
- **Driver: shared serialized shape** (`packages/driver/src/cypress/runner.ts`, `packages/types/src/constants.ts`, `packages/types/src/driver.ts`). The `RUNNABLE_LOGS` / `RUNNABLE_PROPS` allowlists move from the driver into `@packages/types` (`src/constants.ts`, alongside the package’s other runtime constants) so consumers of the serialized test (here, the tap command) share one key source with the driver. A new `SerializedTest` type captures that shape; `getTestsState` and `serializeTest` are typed against it. No behavior change in the driver — only the allowlists' location and added types.
- **Tap types module** (`packages/app/src/tap/types.ts`). The wire shapes tap commands return (`TestStateEntry`, `TestDetailEntry`, `TestError`, `SpecListEntry`) and the `TapTestsRunner` seam type live in one types module; `test-state.ts` and `specs-list.ts` keep only the serializers, and the command handlers import their result types from `../types`.
- **Package docs + seam cleanup** (`packages/app/src/tap/AGENTS.md`, `commands/test-state.ts`). Adds an AGENTS.md for the tap package documenting its layout (including the data-source seam) and the rule that every command contract — result shapes, field sets, and failure codes — must be validated end-to-end in `tap-binding.cy.ts` against the real binding with no mocking, since the stub-based component specs are a supplement that cannot catch Cypress internals drifting. Also drops a now-unneeded `.bind(runner)` on the `getTestsState` seam, which closes over runner-local state and never uses `this`.

### Steps to test

App-side logic covered by a component spec (`cypress:run:ct`) and exercised end-to-end by the binding e2e:

- `packages/app/src/tap/commands/tests.cy.ts` — new spec: drives `exec('tests')` and `exec('tests', { test })` through `TapManager` with the runner seam stubbed, covering the list/detail projections (extras stripped, optional fields omitted), the `'__never__'` sentinel query, and the `NO_RUN` / `TEST_NOT_FOUND` domain failures.
- `packages/app/cypress/e2e/tap-binding.cy.ts` — updated: `tests` before any run returns `NO_RUN`; after running a spec, `tests` lists passing tests and `tests --test <id>` details one, while an unknown id returns `TEST_NOT_FOUND`.

Manual end-to-end is exercised by the top wiring layer (#34148): start a Cypress instance, `cypress tap run --spec <path>`, then `cypress tap tests` (and `cypress tap tests --test <id>`).

### How has the user experience changed?

No change to existing flows. This adds a new subcommand to the experimental `cypress tap` CLI (`cypress tap tests`); there is no change to the public `cypress` JS API or any GUI surface. The driver change is an internal refactor (allowlists relocated, types added) with no behavioral effect.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal/experimental tap CLI work; tracked by internal ticket, no public GitHub issue. -->
- [x] Have tests been added/updated? <!-- New: commands/tests.cy.ts. Updated: cypress/e2e/tap-binding.cy.ts. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Experimental internal feature; not yet publicly documented. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to the public `cypress` JS API; the new types are internal `@packages/types` definitions. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New coupling to driver runner internals (`getAllTestsState`, event manager) and a new public-ish tap wire contract; driver changes are typed/refactor plus one new API, not a broad behavior change.
> 
> **Overview**
> Adds **`tests`** to the experimental `cypress tap` binding so the CLI can read the active spec run: list lean `{ id, title, duration, state, retries }` entries, or pass **`test`** for detail (`fullTitle`, `timings`, trimmed `error`). Domain errors **`NO_RUN`** and **`TEST_NOT_FOUND`** are wired through the same `exec` surface as `specs`/`run`.
> 
> Tap commands no longer touch window globals directly — **`tapManagerDataSource`** resolves the runner via **`getEventManager` → `eventManager.runComplete`**, **`getAllTestsState`**, **`__RUN_MODE_SPECS__`**, and hash navigation (replacing the old `tapNavigation` helper on `run`). Serialization lives in **`test-state.ts`** with shared wire types in **`types.ts`**.
> 
> On the driver, **`runner.getAllTestsState()`** returns every test in the spec (including not-yet-run), with **`_titlePath`** taken from the live runnable; **`RUNNABLE_PROPS` / `RUNNABLE_LOGS`** and a **`SerializedTest`** type move into **`@packages/types`** (behavior of existing serialization unchanged). **`EventManager`** exposes **`runComplete`** for pending vs skipped unreached tests.
> 
> **`tap-binding.cy.ts`** asserts the real binding contract for `tests`; **`AGENTS.md`** documents that e2e coverage is mandatory for tap commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff7f3a705bc87bbe7830c7ddd46f97ba349e49e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




