### PR TITLE
docs: fix content-type typo in VisitOptions.body type definition

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4053,7 +4053,7 @@ declare namespace Cypress {
     method: 'GET' | 'POST'
 
     /**
-     * An optional body to send along with a `POST` request. If it is a string, it will be passed along unmodified. If it is an object, it will be URL encoded to a string and sent with a `Content-Type: application/x-www-urlencoded` header.
+     * An optional body to send along with a `POST` request. If it is a string, it will be passed along unmodified. If it is an object, it will be URL encoded to a string and sent with a `Content-Type: application/x-www-form-urlencoded` header.
      *
      * @example
      *    cy.visit({


### PR DESCRIPTION
- Closes [na] <!-- Purely mechanical change (documentation/type-comment typo). Per the PR template, an associated issue is not required for typo/documentation corrections; details below. -->

### Additional details

The JSDoc for `Cypress.VisitOptions.body` in the public type definitions documents the request content type for an object body as `application/x-www-urlencoded`, which is missing `form-`. The correct MIME type for URL-encoded form data is `application/x-www-form-urlencoded`.

Cypress itself already uses the correct value at runtime, e.g. `packages/driver/src/cy/commands/request.ts` matches `application/x-www-form-urlencoded` and `packages/server/test/unit/request_spec.ts` asserts it. This corrects the shipped type-definition comment so editor tooltips match the actual behavior.

### Steps to test

No behavior change. The type definitions still type-check cleanly:

```
yarn workspace cypress types   # dtslint, passes on TS 5.8 / 5.9 / 6.0
```

### How has the user experience changed?

No change to runtime behavior. In an editor, hovering `cy.visit({ body })` now shows the correct `application/x-www-form-urlencoded` content type instead of the malformed `application/x-www-urlencoded`.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical documentation/typo correction; see PR template note. -->
- [na] Have tests been added/updated? <!-- Documentation-only comment change; no runtime behavior to test. dtslint validates the type definitions. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- This corrects an in-repo type-definition comment, not docs-site content. -->
- [x] Have API changes been updated in the `type definitions`? <!-- This PR is the type-definition correction. -->
