### PR TITLE
fix: avoid double-spacing inconsistently delimited BiDi cookies

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where cookie headers forwarded through the proxy for WebDriver BiDi browsers could be normalized with inconsistent double spacing (for example `foo=bar;  bar=baz`) when the incoming header mixed spaced and unspaced delimiters. Delimiters are now normalized to a single `; `. Fixed in [#34207](https://github.com/cypress-io/cypress/pull/34207).
 - Fixed an issue where, during a [`cy.origin()`](https://on.cypress.io/origin) block, session cookies set on the primary origin by the first page visited in a test were not included in the identity provider's callback request back to the primary origin (for example, `POST /auth/callback` in an OAuth Authorization Code flow). Fixes [#29719](https://github.com/cypress-io/cypress/issues/29719). Fixed in [#34287](https://github.com/cypress-io/cypress/pull/34287).
 - Fixed an issue where the configuration validation error shown when `passesRequired` is omitted from the experimental `detect-flake-and-pass-on-threshold` retry strategy reported the value of an unrelated option instead of the `passesRequired` value. Fixed in [#34202](https://github.com/cypress-io/cypress/pull/34202).
 - Fixed an issue where the configuration validation error for an absolute `ca` filepath in `clientCertificates` referenced the wrong certificate. Fixed in [#34201](https://github.com/cypress-io/cypress/pull/34201).

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -123,7 +123,7 @@ const FormatCookiesIfApplicable: RequestMiddleware = function () {
     const bidiStyleCookie = /;\S/gm
 
     if (cookies.match(bidiStyleCookie)) {
-      this.req.headers.cookie = cookies.replaceAll(';', '; ')
+      this.req.headers.cookie = cookies.replace(/;\s*/g, '; ')
     }
   }
 

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -332,6 +332,26 @@ describe('http/request-middleware', () => {
         expect(ctx.req.headers['cookie']).toEqual('foo=bar; bar=baz; qux=quux')
         expect(ctx.req.headers!['x-cypress-is-webdriver-bidi']).toBeUndefined()
       })
+
+      it('does not double-space cookies that are delimited inconsistently', async () => {
+        const ctx = {
+          req: {
+            headers: {
+              'x-cypress-is-webdriver-bidi': true,
+              cookie: 'foo=bar; bar=baz;qux=quux',
+            },
+          },
+          res: {
+            on: (event, listener) => {},
+            off: (event, listener) => {},
+          },
+        }
+
+        await testMiddleware([FormatCookiesIfApplicable], ctx)
+
+        expect(ctx.req.headers['cookie']).toEqual('foo=bar; bar=baz; qux=quux')
+        expect(ctx.req.headers!['x-cypress-is-webdriver-bidi']).toBeUndefined()
+      })
     })
   })
 


### PR DESCRIPTION
- Closes [na] <!-- Small self-identified bug fix with a regression test. Happy to open a tracking issue if the team prefers. -->

### Additional details

`FormatCookiesIfApplicable` in `packages/proxy/lib/http/request-middleware.ts` normalizes WebDriver BiDi cookie headers (which arrive as `foo=bar;bar=baz`) to `; `-delimited form. It did so with:

```js
this.req.headers.cookie = cookies.replaceAll(';', '; ')
```

When the header is delimited inconsistently (some pairs already spaced), this also expands the correct `; ` into `;  ` (double space). For example `foo=bar; bar=baz;qux=quux` becomes `foo=bar;  bar=baz; qux=quux`.

This normalizes each delimiter to a single `; ` (`replace(/;\s*/g, '; ')`) so mixed input is handled without double-spacing.

### Steps to test

```
yarn workspace @packages/proxy test -- test/unit/http/request-middleware.spec.ts
```

A regression test covers the inconsistently-delimited case (red->green); existing tests for no-header, already-formatted, and fully-unspaced cookies still pass.

### How has the user experience changed?

No visible behavior change; BiDi cookie headers forwarded by the proxy are normalized to single-spaced delimiters instead of occasionally double-spaced.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Small self-identified fix with a regression test; happy to open an issue if preferred. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in proxy request middleware with a regression test; affects only BiDi cookie header formatting.
> 
> **Overview**
> Fixes **WebDriver BiDi** cookie header normalization in the HTTP proxy so mixed `;` / `; ` delimiters become a single `; ` between pairs instead of occasionally producing double spaces.
> 
> `FormatCookiesIfApplicable` now uses `replace(/;\s*/g, '; ')` instead of replacing every semicolon with `; `, which had turned already-spaced segments like `; bar` into `;  bar`. A unit test covers inconsistently delimited input, and the change is noted in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afc98401b3fbe3ba0aaa1b6730a012275b9ed0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->