### PR TITLE
docs: correct reporterOptions default in type definitions

### DIFF
--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3039,7 +3039,7 @@ declare namespace Cypress {
     reporter: string
     /**
      * Some reporters accept [reporterOptions](https://on.cypress.io/reporters) that customize their behavior
-     * @default "spec"
+     * @default null
      */
     reporterOptions: { [key: string]: any }
     /**


### PR DESCRIPTION
- Closes [na] <!-- Purely mechanical documentation/type-comment correction. Per the PR template, an associated issue is not required for documentation corrections; details below. -->

### Additional details

The JSDoc `@default` tag for `Cypress.reporterOptions` in the public type definitions says `@default "spec"`, but `"spec"` is the default for the sibling `reporter` option. The runtime default for `reporterOptions` is `null` (see `packages/config/src/options.ts`, where `reporterOptions` has `defaultValue: null`). This looks like a copy/paste from the `reporter` block just above.

This corrects only the `@default` tag to `null`.

### Steps to test

No behavior change. The type definitions still type-check cleanly:

```
yarn workspace cypress types   # dtslint, passes on TS 5.8 / 5.9 / 6.0
```

### How has the user experience changed?

No change to runtime behavior. In an editor, hovering `reporterOptions` now shows the correct default (`null`) instead of `"spec"`.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical documentation correction; see PR template note. -->
- [na] Have tests been added/updated? <!-- Documentation-only comment change; dtslint validates the type definitions. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- Corrects an in-repo type-definition comment, not docs-site content. -->
- [x] Have API changes been updated in the `type definitions`? <!-- This PR is the type-definition correction. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only fix in generated type definitions; no runtime or API behavior change.
> 
> **Overview**
> Corrects a copy/paste mistake in the public Cypress config types: the `reporterOptions` JSDoc `@default` was `"spec"` (the default for `reporter`), but runtime config uses `null` for `reporterOptions`.
> 
> Only the `@default` comment on `reporterOptions` in `cli/types/cypress.d.ts` changes. Editor hovers and IntelliSense will show the right default; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b01cbfcca1c91ff0ff8ecb744537e9195024a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->