### PR TITLE
test: de-flake browser_reset system test on Firefox

### DIFF
--- a/system-tests/projects/e2e/cypress/e2e/browser_reset_first_spec.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/browser_reset_first_spec.cy.js
@@ -22,17 +22,17 @@ const indexedDB = (win) => {
     const DBOpenRequest = win.indexedDB.open('toDoList', 1)
 
     DBOpenRequest.onupgradeneeded = (e) => {
-      console.log('on upgrade needed')
-      const db = e.target.result
+      e.target.result.createObjectStore('toDoList')
+    }
 
-      try {
-        db.createObjectStore('toDoList')
-      } catch (error) {
-        console.log(error)
-      }
-
+    // close the connection so it can't block the browser state reset
+    // from deleting the database
+    DBOpenRequest.onsuccess = (e) => {
+      e.target.result.close()
       resolve(win)
     }
+
+    DBOpenRequest.onerror = () => reject(DBOpenRequest.error)
   })
 }
 

--- a/system-tests/projects/e2e/cypress/e2e/browser_reset_second_spec.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/browser_reset_second_spec.cy.js
@@ -24,10 +24,17 @@ const indexedDB = (win) => {
     DBOpenRequest.onsuccess = (e) => {
       const db = e.target.result
 
-      expect(db.objectStoreNames.contains('toDoList')).to.be.false
-
-      resolve(win)
+      try {
+        expect(db.objectStoreNames.contains('toDoList')).to.be.false
+        resolve(win)
+      } catch (err) {
+        reject(err)
+      } finally {
+        db.close()
+      }
     }
+
+    DBOpenRequest.onerror = () => reject(DBOpenRequest.error)
   })
 }
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34216

### Additional details

The `e2e browser reset executes two specs with a cached call [firefox]` system test flaked on develop with:

```
CypressError: `cy.then()` timed out after waiting `4000ms`.
Your callback function returned a promise that never resolved.
```

**Root cause:** On Firefox, `reset:browser:state` is not implemented in BiDi ([`bidi_automation.ts`](https://github.com/cypress-io/cypress/blob/develop/packages/server/lib/browsers/bidi_automation.ts#L645-L653)) and falls back to the web extension's `browsingData.remove({ indexedDB: true, ... })`. IndexedDB deletion blocks while any connection to the database is open, and `browser_reset_first_spec.cy.js` guaranteed a lingering connection:

1. It resolved its promise inside `onupgradeneeded` — mid versionchange transaction, before the open request completed — so the spec could finish while the transaction was still committing.
2. It never called `db.close()`, leaving the connection to be torn down lazily by Gecko when the tab was recycled.

When the extension's IndexedDB clear raced with that lazy teardown, the deletion blocked, and the second spec's `indexedDB.open('toDoList')` queued behind the blocked delete until the command timeout.

**Fix (test fixtures only, no product change):**

- `browser_reset_first_spec.cy.js`: create the object store in `onupgradeneeded`, but resolve in `onsuccess` and explicitly `close()` the connection so nothing can block the browser-state reset.
- `browser_reset_second_spec.cy.js`: reject on `onerror` and on assertion failure instead of hanging silently, so any future failure surfaces as a real error message rather than an opaque `cy.then()` timeout.

Verified locally: 6/6 consecutive passing Firefox runs, plus Chrome and Electron (which also exercise the service-worker cache assertions).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Cypress e2e fixture files; no product or runtime behavior is modified.
> 
> **Overview**
> **Test-only** updates to the `browser_reset` two-spec Cypress fixtures so IndexedDB setup/teardown does not leave open connections that block Firefox’s extension-based `indexedDB` clear between specs.
> 
> In **`browser_reset_first_spec.cy.js`**, the IndexedDB helper now creates the object store in `onupgradeneeded` but **resolves only in `onsuccess`**, explicitly **`close()`s** the database, and **rejects on `onerror`** instead of resolving mid-upgrade with a lingering connection.
> 
> In **`browser_reset_second_spec.cy.js`**, the verification helper **rejects on assertion failure and `onerror`**, and always **`close()`s** the DB in a `finally` block so failures surface as real errors instead of a `cy.then()` timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9760623e6e71df9a0673b039fb7119c20d255979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
cd system-tests
node ./scripts/run.js --glob-in-dir=test browser_reset --browser firefox
```

### How has the user experience changed?

No change — test-only fix.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- https://github.com/cypress-io/cypress/issues/34216 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)