### PR TITLE
chore: restore SBOM generation on releases

### DIFF
--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -1,41 +1,74 @@
 name: Upload SBOM as Release Asset
-# This workflow triggers whenever there is a new release published.  The 
-# action generates a Software Bill of Materials and uploads it as a
-# release artifact.  This satisfies compliance initiatives.
+
+# Generates an SPDX Software Bill of Materials (SBOM) for the repository and
+# attaches it to every published GitHub release, so SBOMs stay discoverable for
+# customer security reviews.
+#
+# The asset is named SBOM.rpt with SPDX tag-value (text) content, matching the
+# artifact the previous FOSSA workflow produced, so it is a drop-in replacement
+# for the SBOM.rpt already shared with customers.
+#
+# Least privilege: the workflow defaults to contents: read. Only the
+# attach-to-release job (which runs on release events only) elevates to
+# contents: write, so a manual workflow_dispatch run never holds a write-scoped
+# token. The SBOM is passed between jobs as a workflow artifact.
+
 on:
   release:
     types:
       - published
+  # Allow an operator to generate an SBOM on demand (e.g. an ad-hoc customer
+  # request) without cutting a release. On a manual run only the read-only
+  # generate job runs; the SBOM is available as the SBOM.rpt workflow artifact.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
-  generate_SBOM:
+  generate_sbom:
     runs-on: ubuntu-latest
-    env:
-          FOSSA_API_KEY: ${{secrets.FOSSAAPIKEY}}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Download Fossa binary and install
-# This step utilizes a curl of the latest install pkg from Fossa.  Using a git action from 
-# Fossa doesn't produce the SBOM artifact needed. This manual approach is the only way to 
-# create the report to upload as a release artifact.
-        run:  |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-      - name: Generate SBOM
-        run:  |
-          fossa analyze 
-          fossa report attribution --debug --format spdx >> SBOM.rpt
-      - name: Verify report
-        run:  |
-          ls -lht|head
-          cat SBOM.rpt      
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
+
+      - name: Generate SBOM (SPDX tag-value) as SBOM.rpt
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./SBOM.rpt
-          asset_name: SBOM.rpt
-          asset_content_type: text/plain
+          # Scan the checked-out source. Syft reads the committed lockfiles
+          # (yarn.lock / package.json) across all workspaces, so no install or
+          # build step is needed to enumerate resolved dependency versions.
+          path: .
+          # SPDX tag-value (text), the same content the old FOSSA report emitted.
+          format: spdx-tag-value
+          output-file: SBOM.rpt
+          # We upload the artifact and attach the release ourselves (below), with
+          # version-pinned actions — disable the action's own uploads.
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Upload SBOM.rpt as a workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SBOM.rpt
+          path: SBOM.rpt
+          if-no-files-found: error
+
+  attach_to_release:
+    # Only on a real release event: this is the only job that needs (and gets)
+    # contents: write, so workflow_dispatch runs stay read-only.
+    if: github.event_name == 'release'
+    needs: generate_sbom
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to upload the SBOM as a release asset
+    steps:
+      - name: Download the generated SBOM.rpt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: SBOM.rpt
+
+      - name: Attach SBOM.rpt to the release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          files: SBOM.rpt


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

SBOM generation has been broken on every release since v15.13.1. The workflow
generated the SBOM with the FOSSA CLI, which depends on an external FOSSA
subscription and a long-lived API credential that is no longer available, so the
"Generate SBOM" step fails on every run. The last release to ship an SBOM was
v15.13.0.

This swaps FOSSA for a native generator — no external subscription, no
long-lived credential:

- `anchore/sbom-action` (Syft) produces an SPDX tag-value report, `SBOM.rpt`.
- `softprops/action-gh-release` attaches it to each published release.
- Retires the archived `actions/upload-release-asset@v1`.

The output is a drop-in replacement: same `SBOM.rpt` filename and SPDX
tag-value content as the previous artifact, so anything already consuming it
keeps working.

**Least privilege.** The workflow defaults to `contents: read`. It's split into
two jobs: `generate_sbom` (read-only, always runs, uploads `SBOM.rpt` as a
workflow artifact) and `attach_to_release` (`contents: write`, guarded to
`github.event_name == 'release'`). A `workflow_dispatch` run never mints a
write-scoped token, and `workflow_dispatch` is write-access-gated by GitHub, so
it is not publicly invocable.

All actions are SHA-pinned per repo convention (`anchore/sbom-action@v0.24.0`,
`softprops/action-gh-release@v2.6.2`; existing pins reused for checkout /
upload-artifact / download-artifact).

### Steps to test

1. Merge to the default branch (the "Run workflow" button requires the file to
   exist there).
2. Actions → **Upload SBOM as Release Asset** → **Run workflow**. Confirm:
   - Only `generate_sbom` runs; `attach_to_release` is skipped.
   - The run's token is read-only (no `contents: write`).
   - `SBOM.rpt` is produced as a workflow-run artifact, SPDX tag-value format.
3. On the next published release, confirm both jobs run and `SBOM.rpt` is
   attached to the release as an asset.

### How has the user experience changed?

No change to the Cypress app or CLI. Restores the `SBOM.rpt` asset attached to
each GitHub release.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Maintainer CI/infrastructure change. -->
- [na] Have tests been added/updated? <!-- GitHub Actions workflow; no unit-testable surface. Validated via workflow_dispatch + next release (see Steps to test). -->
- [na] Has a PR for user-facing changes been opened in cypress-documentation? <!-- No user-facing change. -->
- [na] Have API changes been updated in the type definitions? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release SBOM attachment; no application runtime, auth, or data paths affected. Residual risk is SBOM content parity vs the old FOSSA report for customer compliance reviews.
> 
> **Overview**
> Restores **SBOM.rpt** on GitHub releases by replacing the broken FOSSA CLI flow (missing API key/subscription) with **anchore/sbom-action** (Syft), which emits the same **SPDX tag-value** filename and format customers already use.
> 
> The workflow is split into **`generate_sbom`** (checkout, generate, upload as a workflow artifact) and **`attach_to_release`** (download artifact, attach via **softprops/action-gh-release**), replacing archived **upload-release-asset@v1**. **`workflow_dispatch`** is added for on-demand SBOMs without a release.
> 
> **Least privilege:** workflow-level **`contents: read`**; only **`attach_to_release`** gets **`contents: write`**, and that job runs when **`github.event_name == 'release'`**, so manual runs stay read-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10829b3a01865cba152179513a0ffabfeb288f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->