### PR TITLE
test: use junction-safe removal for fixture cleanup on Windows

### DIFF
--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -13,6 +13,7 @@ linux-x64:
       - equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
       # temporary branches that can be removed after merging
       - equal: [ 'mschile/electron_41', << pipeline.git.branch >> ]
+      - equal: [ 'fix/windows-junction-safe-fixture-cleanup', << pipeline.git.branch >> ]
   jobs:
     - node_modules_install:
         build-better-sqlite3: true

--- a/system-tests/lib/fixtures.ts
+++ b/system-tests/lib/fixtures.ts
@@ -22,10 +22,14 @@ const projectFixtureDirs = fs.readdirSync(projectFixtures, { withFileTypes: true
 
 const safeRemove = (path) => {
   try {
-    // Use native fs.rmSync with retries to absorb transient filesystem races
-    // (ENOTEMPTY/EBUSY/EPERM) caused by child processes still writing to a
-    // subdirectory at cleanup time.
-    fs.rmSync(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    // fs-extra's lstat-based removeSync unlinks junctions/symlinks instead of
+    // recursing into them. Native fs.rmSync must not be used here: under
+    // Electron's libc++-built Node 24+, std::filesystem::remove_all classifies
+    // Windows junctions (created when scaffolding project node_modules) as
+    // plain directories and deletes their target contents — including the
+    // monorepo dirs they point to. removeSync also retries transient Windows
+    // races (ENOTEMPTY/EBUSY/EPERM) internally.
+    fs.removeSync(path)
   } catch (_err) {
     const err = _err as NodeJS.ErrnoException
 


### PR DESCRIPTION
- Closes N/A — no open issue; this fixes a CI-only test-harness failure on `release/16.0.0` (maintainer-authored).

### Additional details

The Windows app/launchpad integration test jobs on `release/16.0.0` were failing with `ENOENT` errors scaffolding fixture projects (`system-tests/projects/*` missing), missing `packages/ts/tsconfig.json`, and `EPERM, Permission denied: \\?\...` errors during cleanup.

Root cause: Electron 41 embeds Node 24, where `fs.rmSync` is implemented with `std::filesystem::remove_all`. In Electron's libc++ build, that classifies NTFS junctions as plain directories and recurses **into** them. The fixture scaffolding creates junctions pointing at the shared `node_modules` cache and at monorepo dirs (`@tooling/system-tests` → `system-tests/`, `@packages/ts` → `packages/ts/`, etc.), so recursive cleanup in `safeRemove` was deleting the monorepo source tree out from under the job. develop is unaffected because Electron 37's Node 22 uses the lstat-based JS rimraf.

Fix: use fs-extra 9's `removeSync` (also lstat-based) in `safeRemove`, which unlinks junctions without traversing them and retries transient Windows races internally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness cleanup only; no product runtime behavior. The prior `fs.rmSync` path was actively dangerous on Windows under Electron 41.
> 
> **Overview**
> Fixes **Windows CI failures** on Electron 41 / Node 24 where system-test fixture teardown could delete monorepo source trees.
> 
> `safeRemove` in `system-tests/lib/fixtures.ts` now uses **fs-extra `removeSync`** instead of native **`fs.rmSync`**. Node 24’s `remove_all` treats NTFS junctions (used when scaffolding fixture `node_modules` links to the monorepo) as real directories and recursively deletes their targets; lstat-based removal only unlinks the junction.
> 
> CircleCI **`@main.yml`** temporarily adds branch `fix/windows-junction-safe-fixture-cleanup` to the full workflow filter so the fix is exercised in CI before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e594ca173a24047b5fe01ddb6d7f896d8f42d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

CI is the real test: `windows-run-app-integration-tests-chrome` and `windows-run-launchpad-integration-tests-chrome` should pass on this branch (they consistently fail on `release/16.0.0` without this change).

### How has the user experience changed?

No change — test harness only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- CI-only harness fix, explained above -->
- [na] Have tests been added/updated? <!-- verified via the previously-failing Windows CI jobs -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)