### PR TITLE
chore(server): wire CDP AUT bridge injection on the proxy-disabled path

### DIFF
--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -5,16 +5,19 @@ import Bluebird from 'bluebird'
 import type { Protocol } from 'devtools-protocol'
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
 import { parseDomain, isLocalhost as isLocalhostNetworkTools } from '@packages/network-tools'
+import type { DocumentDomainInjectionConfig } from '@packages/network-tools'
 import debugModule from 'debug'
 import { URL } from 'url'
 import { performance } from 'perf_hooks'
 
 import type { ResourceType, BrowserPreRequest, BrowserResponseReceived } from '@packages/proxy'
-import type { CDPClient, ProtocolManagerShape, WriteVideoFrame, AutomationMiddleware, AutomationCommands } from '@packages/types'
+import type { CDPClient, ProtocolManagerShape, WriteVideoFrame, AutomationMiddleware, AutomationCommands, BrowserLaunchOpts } from '@packages/types'
 import type { Automation } from '../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../automation/util'
 import { DEFAULT_NETWORK_ENABLE_OPTIONS, CriClient } from './cri-client'
 import { cdpKeyPress } from '../automation/commands/key_press'
+import { CdpBridgeInjectionAdapter } from '@packages/browser-automation'
+import { isProxyDisabled } from '../util/is-proxy-disabled'
 
 import { toSupportedKey, AUT_FRAME_NAME_IDENTIFIER } from '@packages/types'
 
@@ -177,8 +180,9 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
   private gettingFrameTree: Promise<void> | undefined | null
   private cachedDataUrlRequestIds: Set<string> = new Set()
   private executionContexts: Map<Protocol.Runtime.ExecutionContextId, Protocol.Runtime.ExecutionContextDescription> = new Map()
+  private autBridge: CdpBridgeInjectionAdapter | undefined
 
-  private constructor (private sendDebuggerCommandFn: SendDebuggerCommand, private onFn: OnFn, private offFn: OffFn, private sendCloseCommandFn: SendCloseCommand, private automation: Automation, private focusTabOnScreenshot: boolean = false, private isHeadless: boolean = false) {
+  private constructor (private sendDebuggerCommandFn: SendDebuggerCommand, private onFn: OnFn, private offFn: OffFn, private sendCloseCommandFn: SendCloseCommand, private automation: Automation, private focusTabOnScreenshot: boolean = false, private isHeadless: boolean = false, private browserLaunchOpts: BrowserLaunchOpts) {
     onFn('Network.requestWillBeSent', this.onNetworkRequestWillBeSent)
     onFn('Network.responseReceived', this.onResponseReceived)
     onFn('Network.requestServedFromCache', this.onRequestServedFromCache)
@@ -192,6 +196,30 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
     this.on = onFn
     this.off = offFn
     this.send = sendDebuggerCommandFn
+
+    // When the MITM proxy is disabled (HTTP/2 / proxy-bypass path) it can't rewrite AUT HTML to inject
+    // the Cypress bridge, so install it over CDP instead. Gated on the same flag that disables the proxy
+    // so the CDP and proxy injection paths are mutually exclusive and never double-inject.
+    if (isProxyDisabled()) {
+      // pick only the config keys the page-context injection needs. BrowserLaunchOpts doesn't type these,
+      // but open_project merges the resolved Cypress config into the launch options at runtime.
+      const { injectDocumentDomain, testingType, modifyObstructiveCode, experimentalModifyObstructiveThirdPartyCode } =
+        browserLaunchOpts as BrowserLaunchOpts & DocumentDomainInjectionConfig & { modifyObstructiveCode?: boolean, experimentalModifyObstructiveThirdPartyCode?: boolean }
+
+      const documentDomainConfig: DocumentDomainInjectionConfig = { injectDocumentDomain, testingType }
+
+      // cross-origin spec-bridge `cypressConfig` (mirrors the proxy's fullCrossOrigin options).
+      // simulatedCookies is hardcoded empty for now — it needs to be wired from the cookie jar separately
+      // (https://github.com/cypress-io/cypress/issues/33860).
+      const crossOriginConfig = {
+        shouldInjectDocumentDomain: !!injectDocumentDomain && testingType !== 'component',
+        modifyObstructiveThirdPartyCode: !!experimentalModifyObstructiveThirdPartyCode,
+        modifyObstructiveCode: !!modifyObstructiveCode,
+        simulatedCookies: [],
+      }
+
+      this.autBridge = new CdpBridgeInjectionAdapter(this.sendDebuggerCommandFn, documentDomainConfig, crossOriginConfig)
+    }
   }
 
   async startVideoRecording (writeVideoFrame: WriteVideoFrame, screencastOpts) {
@@ -210,8 +238,8 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
     await this.sendDebuggerCommandFn('Page.startScreencast', screencastOpts)
   }
 
-  static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, offFn: OffFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, protocolManager?: ProtocolManagerShape, focusTabOnScreenshot: boolean = false, isHeadless?: boolean): Promise<CdpAutomation> {
-    const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, offFn, sendCloseCommandFn, automation, focusTabOnScreenshot, isHeadless)
+  static async create (sendDebuggerCommandFn: SendDebuggerCommand, onFn: OnFn, offFn: OffFn, sendCloseCommandFn: SendCloseCommand, automation: Automation, browserLaunchOpts: BrowserLaunchOpts, protocolManager?: ProtocolManagerShape, focusTabOnScreenshot: boolean = false, isHeadless?: boolean): Promise<CdpAutomation> {
+    const cdpAutomation = new CdpAutomation(sendDebuggerCommandFn, onFn, offFn, sendCloseCommandFn, automation, focusTabOnScreenshot, isHeadless, browserLaunchOpts)
 
     await sendDebuggerCommandFn('Network.enable', protocolManager?.networkEnableOptions ?? DEFAULT_NETWORK_ENABLE_OPTIONS)
 
@@ -408,6 +436,8 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
     this.gettingFrameTree = new Promise<void>(async (resolve) => {
       try {
         this.frameTree = (await client.send('Page.getFrameTree')).frameTree
+        // inject the bridge into the AUT frame if the proxy is disabled
+        this.autBridge?.inject(this.frameTree.frame.url)
         debugVerbose('frame tree updated')
       } catch (err) {
         debugVerbose('failed to update frame tree:', err.stack)
@@ -543,6 +573,7 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
 
     client.on('Page.frameAttached', this._updateFrameTree(client, 'Page.frameAttached'))
     client.on('Page.frameDetached', this._updateFrameTree(client, 'Page.frameDetached'))
+    client.on('Page.frameNavigated', this._updateFrameTree(client, 'Page.frameNavigated'))
   }
 
   onRequest = async <T extends keyof AutomationCommands>(message: T, data: AutomationCommands[T]['dataType']): Promise<AutomationCommands[T]['returnType']> => {

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -303,7 +303,7 @@ const _handleDownloads = async function (client, downloadsFolder: string, automa
 let onReconnect: (client: CriClient) => Promise<void> = async () => undefined
 
 const _setAutomation = async (client: CriClient, automation: Automation, resetBrowserTargets: (shouldKeepTabOpen: boolean) => Promise<void>, options: BrowserLaunchOpts) => {
-  const cdpAutomation = await CdpAutomation.create(client.send, client.on, client.off, resetBrowserTargets, automation, options.protocolManager, true, options.isTextTerminal)
+  const cdpAutomation = await CdpAutomation.create(client.send, client.on, client.off, resetBrowserTargets, automation, options, options.protocolManager, true, options.isTextTerminal)
 
   automation.use(cdpAutomation)
 

--- a/packages/server/lib/browsers/electron.ts
+++ b/packages/server/lib/browsers/electron.ts
@@ -81,7 +81,7 @@ const _getAutomation = async function (win, options: BrowserLaunchOpts, parent) 
     win.destroy()
   }
 
-  const automation = await CdpAutomation.create(pageCriClient.send, pageCriClient.on, pageCriClient.off, sendClose, parent)
+  const automation = await CdpAutomation.create(pageCriClient.send, pageCriClient.on, pageCriClient.off, sendClose, parent, options)
 
   automation.onRequest = _.wrap(automation.onRequest, async (fn, message, data) => {
     switch (message) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -133,6 +133,7 @@
     "@cypress/sinon-chai": "2.9.1",
     "@cypress/webpack-dev-server": "0.0.0-development",
     "@electron/rebuild": "4.0.4",
+    "@packages/browser-automation": "0.0.0-development",
     "@packages/config": "0.0.0-development",
     "@packages/data-context": "0.0.0-development",
     "@packages/electron": "0.0.0-development",

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -29,7 +29,7 @@ context('lib/browsers/cdp_automation', () => {
 
         const localNetworkCommandStub = localCommand.withArgs('Network.enable', enabledObject).resolves()
 
-        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any, localManager)
+        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any, {} as any, localManager)
 
         expect(localNetworkCommandStub).to.have.been.calledWith('Network.enable', enabledObject)
       })
@@ -55,8 +55,8 @@ context('lib/browsers/cdp_automation', () => {
 
         const localCommandStub = localCommand.withArgs('Network.enable', disabledObject).resolves()
 
-        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any, localManager)
-        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any)
+        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any, {} as any, localManager)
+        await CdpAutomation.create(localCommand, localOnFn, localOffFn, localSendCloseTargetCommand, localAutomation as any, {} as any)
 
         expect(localCommandStub).to.have.been.calledTwice
         expect(localCommandStub).to.have.been.calledWithExactly('Network.enable', disabledObject)
@@ -77,7 +77,7 @@ context('lib/browsers/cdp_automation', () => {
         onServiceWorkerVersionUpdated: sinon.stub(),
       }
 
-      cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation)
+      cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation, {} as any)
       this.onRequest = cdpAutomation.onRequest
     })
 
@@ -517,7 +517,7 @@ context('lib/browsers/cdp_automation', () => {
           })
 
           it('does not try to comm with extension, simply brings page to front', async function () {
-            cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation, undefined, requireTabFocus, isHeadless)
+            cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation, {} as any, undefined, requireTabFocus, isHeadless)
             this.sendDebuggerCommand.withArgs('Page.captureScreenshot').resolves({ data: 'foo' })
 
             expect(cdpAutomation.onRequest('take:screenshot', undefined)).to.eventually.equal('data:image/png;base64,foo')
@@ -529,7 +529,7 @@ context('lib/browsers/cdp_automation', () => {
         describe('when not headless', () => {
           beforeEach(async function () {
             isHeadless = false
-            cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation, undefined, requireTabFocus, isHeadless)
+            cdpAutomation = await CdpAutomation.create(this.sendDebuggerCommand, this.onFn, this.offFn, this.sendCloseTargetCommand, this.automation, {} as any, undefined, requireTabFocus, isHeadless)
             this.sendDebuggerCommand.withArgs('Page.captureScreenshot').resolves({ data: 'foo' })
           })
 


### PR DESCRIPTION
> **Stack 4/4** — base is the browser-automation PR (`feat/browser-automation-adapter`). Review/merge the stack in order.

- Closes #33849, #33859

### Additional details

Wires the CDP AUT bridge injection into the server, completing the stack. Gated behind `CYPRESS_INTERNAL_DISABLE_PROXY` (from #33930), so the CDP and proxy injection paths are mutually exclusive and there's no change on the normal proxy path.

- `cdp_automation.create()` takes `browserLaunchOpts` and, when `isProxyDisabled()`, builds a `CdpBridgeInjectionAdapter` (document.domain + cross-origin config derived from the launch opts) and drives it off the cached frame tree: it injects against the top frame's url and re-injects as the top origin changes.
- `chrome.ts` / `electron.ts` pass the launch options through to `create()`.
- Exports `DocumentDomainInjectionConfig` from `@packages/network-tools` as a real source type (previously only in the built `.d.ts`), and adds `@packages/browser-automation` as a server dependency.

Part of the HTTP/2 program (#33919). Simulated cross-origin cookies are out of scope here (#33860).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core AUT bootstrap when the internal proxy-disable flag is on, but default runs are unchanged; incomplete cross-origin cookie wiring could limit parity with the proxy path until follow-up work lands.
> 
> **Overview**
> When **`CYPRESS_INTERNAL_DISABLE_PROXY`** is set, the server injects the Cypress AUT bridge over CDP instead of relying on MITM HTML rewriting, so the CDP and proxy paths stay mutually exclusive.
> 
> **`CdpAutomation.create()`** now takes **`browserLaunchOpts`**. If **`isProxyDisabled()`**, it builds a **`CdpBridgeInjectionAdapter`** from launch-time config (document.domain, obstructive-code flags, testing type) and calls **`inject()`** whenever the cached frame tree updates—including on **`Page.frameNavigated`**—using the top frame URL. **Chrome** and **Electron** pass full launch options into **`create()`**; unit tests pass a stub opts object. **`@packages/browser-automation`** is added as a server devDependency.
> 
> Cross-origin **`simulatedCookies`** is still an empty placeholder (tracked separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05bae3f5e93a17ab21525f5d0a49adce3d6be33e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- `yarn workspace @packages/server test-unit -- cdp_automation_spec`
- Manual (Chrome), proxy disabled: set `CYPRESS_INTERNAL_DISABLE_PROXY=1`, run a spec against a same-origin app, and confirm `window.Cypress` boots in the AUT frame (full injection). Navigate cross-origin (or a different subdomain with `injectDocumentDomain` off) and confirm the bridge re-registers against the new top origin. With the flag unset, confirm the normal proxy-injection path is unchanged.

### How has the user experience changed?

No change. The entire path is gated behind the internal `CYPRESS_INTERNAL_DISABLE_PROXY` flag; default behavior is unaffected.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- HTTP/2 program: #33919, #33849, #33859 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
