### PR TITLE
chore: fix changelog section ordering

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,10 +1,6 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.18.1
 
-**Dependency Updates:**
-
-- Upgraded `esbuild` from `0.28.0` to `0.28.1` to address a [Resources Downloaded over Insecure Protocol](https://security.snyk.io/vuln/SNYK-JS-ESBUILD-17750822) vulnerability reported in security scans. Addressed in [#34211](https://github.com/cypress-io/cypress/pull/34211).
-
 **Performance:**
 
 - Verifying that the Cypress binary can run, which happens the first time a newly installed version is used (before `cypress open` or `cypress run`) and whenever `cypress verify` is invoked, now completes more quickly. Addressed in [#34133](https://github.com/cypress-io/cypress/pull/34133).
@@ -20,6 +16,10 @@
 - Fixed an issue where opening an unconfigured project from a git repository sub-directory (such as a monorepo package) skipped project setup. Additionally, the component testing setup wizard now reliably displays the auto-detected framework and bundler. Fixes [#27410](https://github.com/cypress-io/cypress/issues/27410) and [#29544](https://github.com/cypress-io/cypress/issues/29544). Fixed in [#34129](https://github.com/cypress-io/cypress/pull/34129) and [#34212](https://github.com/cypress-io/cypress/pull/34212).
 - Fixed an issue where interacting with an element inside a horizontally-scrollable container could scroll the element to the container's right edge, placing it underneath a right-floating `position: sticky` or `position: fixed` element and causing the action to fail or land on the wrong element. Elements are now scrolled to their top, leftmost point as documented. Fixes [#33884](https://github.com/cypress-io/cypress/issues/33884). Fixed in [#34108](https://github.com/cypress-io/cypress/pull/34108).
 - Fixed a regression in [15.17.0](#15-17-0) where `cypress run --spec` printed a spurious `The following --spec pattern did not match any spec files and will be ignored` warning for patterns that actually did match spec files, such as patterns using regex-style alternation groups (for example `cypress/e2e/(a|b)/*.js`). Fixes [#34160](https://github.com/cypress-io/cypress/issues/34160).
+
+**Dependency Updates:**
+
+- Upgraded `esbuild` from `0.28.0` to `0.28.1` to address a [Resources Downloaded over Insecure Protocol](https://security.snyk.io/vuln/SNYK-JS-ESBUILD-17750822) vulnerability reported in security scans. Addressed in [#34211](https://github.com/cypress-io/cypress/pull/34211).
 
 ## 15.18.0
 


### PR DESCRIPTION
- Closes N/A

### Additional details

The pending `15.18.1` changelog section had its subsections out of order — `Dependency Updates` appeared before `Performance` and `Bug Fixes`. Per [`guides/writing-the-cypress-changelog.md`](https://github.com/cypress-io/cypress/blob/develop/guides/writing-the-cypress-changelog.md), change sections must be listed in order of impact: Performance → Features → Bugfixes → Misc → Dependency Updates.

This moves the `Dependency Updates` section below `Bug Fixes` to match the guide. No entries were added or changed — only reordered.

### Steps to test

N/A — documentation/changelog-only change.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- purely mechanical changelog ordering fix -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog reordering with no runtime or dependency changes in this PR.
> 
> **Overview**
> Reorders the pending **15.18.1** section in `cli/CHANGELOG.md` so subsections follow the documented impact order: **Performance** → **Bugfixes** → **Dependency Updates**.
> 
> The **Dependency Updates** block (esbuild `0.28.0` → `0.28.1`) is moved from the top of the release to after **Bugfixes**. No changelog copy or entries were edited—only section order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd12b01bec279d8b7d191065b3af9e01a6a569aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->