### PR TITLE
chore(v8-snapshot): surface bundler and mksnapshot stderr on snapshot generation failure

### DIFF
--- a/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
+++ b/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
@@ -355,17 +355,17 @@ const makePackherdCreateBundle: (opts: CreateBundleOpts) => CreateBundle =
 
         return Promise.resolve(result)
       } catch (err: any) {
-        if (err.stderr != null) {
-          logError(err.stderr.toString())
-        }
-
         if (err.stdout != null) {
           logDebug(err.stdout.toString())
         }
 
-        logError(err)
+        // The bundler's stderr names the exact offending file, so surface it on
+        // the rejected error rather than routing it through a DEBUG-gated logger
+        // that CI (DEBUG=cypress:snapgen:info) doesn't enable.
+        const stderr = err.stderr?.toString().trim()
+        const detail = stderr ? `\n${stderr}` : `\n${err}`
 
-        return Promise.reject(new Error(`Failed command: "${cmd}"`))
+        return Promise.reject(new Error(`Failed command: "${cmd}"${detail}`))
       } finally {
         if (!keepConfig) {
           const err = tryRemoveFileSync(configPath)

--- a/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
+++ b/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
@@ -359,8 +359,7 @@ const makePackherdCreateBundle: (opts: CreateBundleOpts) => CreateBundle =
           logDebug(err.stdout.toString())
         }
 
-        // The bundler's stderr names the exact offending file, so surface it on
-        // the rejected error rather than routing it through a DEBUG-gated logger.
+        // The bundler's stderr names the exact offending file, so surface it on the rejected error.
         const stderr = err.stderr?.toString().trim()
         const detail = stderr ? `\n${stderr}` : `\n${err}`
 

--- a/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
+++ b/tooling/v8-snapshot/src/generator/create-snapshot-script.ts
@@ -360,8 +360,7 @@ const makePackherdCreateBundle: (opts: CreateBundleOpts) => CreateBundle =
         }
 
         // The bundler's stderr names the exact offending file, so surface it on
-        // the rejected error rather than routing it through a DEBUG-gated logger
-        // that CI (DEBUG=cypress:snapgen:info) doesn't enable.
+        // the rejected error rather than routing it through a DEBUG-gated logger.
         const stderr = err.stderr?.toString().trim()
         const detail = stderr ? `\n${stderr}` : `\n${err}`
 

--- a/tooling/v8-snapshot/src/generator/snapshot-generator.ts
+++ b/tooling/v8-snapshot/src/generator/snapshot-generator.ts
@@ -507,22 +507,21 @@ export class SnapshotGenerator {
 
       return { v8ContextFile: this.v8ContextFile, snapshotBinDir: this.snapshotBinDir }
     } catch (err: any) {
-      if (err.stderr || err.stdout) {
-        if (err.stderr != null) {
-          logError(err.stderr.toString())
-        }
-
-        if (err.stdout != null) {
-          logDebug(err.stdout.toString())
-        }
-      } else {
-        logError(err.toString())
+      if (err.stdout != null) {
+        logDebug(err.stdout.toString())
       }
 
       // If things went wrong print instructions on how to execute the
       // `mksnapshot` command directly to trouble shoot
       runInstructions()
-      throw new Error('Failed `mksnapshot` command')
+
+      // mksnapshot's stderr explains why it failed, so surface it on the thrown
+      // error rather than routing it through a DEBUG-gated logger that CI
+      // (DEBUG=cypress:snapgen:info) doesn't enable.
+      const stderr = err.stderr?.toString().trim()
+      const detail = stderr || err.toString()
+
+      throw new Error(`Failed \`mksnapshot\` command\n${detail}`)
     }
   }
 

--- a/tooling/v8-snapshot/src/generator/snapshot-generator.ts
+++ b/tooling/v8-snapshot/src/generator/snapshot-generator.ts
@@ -515,9 +515,7 @@ export class SnapshotGenerator {
       // `mksnapshot` command directly to trouble shoot
       runInstructions()
 
-      // mksnapshot's stderr explains why it failed, so surface it on the thrown
-      // error rather than routing it through a DEBUG-gated logger that CI
-      // (DEBUG=cypress:snapgen:info) doesn't enable.
+      // mksnapshot's stderr explains why it failed, so surface it on the thrown error.
       const stderr = err.stderr?.toString().trim()
       const detail = stderr || err.toString()
 

--- a/tooling/v8-snapshot/test/unit/create-bundle.spec.ts
+++ b/tooling/v8-snapshot/test/unit/create-bundle.spec.ts
@@ -1,0 +1,44 @@
+import os from 'os'
+import path from 'path'
+import fs from 'fs-extra'
+import { expect, use } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { createBundleAsync } from '../../src/generator/create-snapshot-script'
+
+use(chaiAsPromised)
+
+describe('create-bundle', () => {
+  // NOTE: the fake bundler is executed via its shebang, which Windows does not honor.
+  const itSurfacesStderr = process.platform === 'win32' ? it.skip : it
+
+  itSurfacesStderr('rejects with the bundler stderr when the bundler exits non-zero', async () => {
+    const projectBaseDir = path.join(__dirname, '..', 'fixtures', 'minimal')
+    const entryFilePath = path.join(projectBaseDir, 'entry.js')
+    const fakeBundler = path.join(os.tmpdir(), `failing-bundler-${process.pid}.js`)
+
+    // The bundler is spawned with a replaced env (no PATH), so point the shebang
+    // straight at the running node binary rather than relying on `/usr/bin/env`.
+    await fs.writeFile(
+      fakeBundler,
+      [
+        `#!${process.execPath}`,
+        `process.stderr.write('bundler failed on ./offending-module.js\\n')`,
+        'process.exit(1)',
+      ].join('\n'),
+      { mode: 0o755 },
+    )
+
+    try {
+      await expect(createBundleAsync({
+        baseDirPath: projectBaseDir,
+        entryFilePath,
+        bundlerPath: fakeBundler,
+        nodeModulesOnly: false,
+        supportTypeScript: false,
+        integrityCheckSource: undefined,
+      })).to.be.rejectedWith(/bundler failed on \.\/offending-module\.js/)
+    } finally {
+      await fs.remove(fakeBundler)
+    }
+  })
+})


### PR DESCRIPTION
- Closes N/A — internal build-tooling diagnostics improvement, no associated issue.

### Additional details

When the Go bundler or `mksnapshot` exits non-zero during V8 snapshot generation, their `stderr` (which names the exact offending file / reason) was routed through `debug('cypress:snapgen:error')`. CI runs with `DEBUG=cypress:snapgen:info`, and the `debug` library matches namespaces literally — `:info` never enables `:error` — so the real cause was discarded and only the generic `Failed command: "<cmd>"` / ``Failed `mksnapshot` command`` propagated. Diagnosing a failure required knowing to re-run locally with `DEBUG=cypress:snapgen:*`.

This attaches `stderr` to the rejected/thrown `Error` so it surfaces regardless of the `DEBUG` configuration. `stdout` stays on `logDebug` since it is the normal result channel and only useful when debugging.

Affected files:
- `tooling/v8-snapshot/src/generator/create-snapshot-script.ts` — Go bundler `execSync` catch now appends `stderr` to the rejected `Error` message.
- `tooling/v8-snapshot/src/generator/snapshot-generator.ts` — `mksnapshot` catch gets the same treatment on the thrown `Error`.
- `tooling/v8-snapshot/test/unit/create-bundle.spec.ts` — new unit test that points the bundler at a fake executable which writes to `stderr` and exits non-zero, then asserts `createBundleAsync` rejects with a message containing that `stderr`.

There is no change to successful snapshot generation — only the failure diagnostics improve. `@tooling/v8-snapshot` is a private, unpublished build package, so this is not user-facing and no changelog entry is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal build-tooling diagnostics only; successful snapshot generation is unchanged.
> 
> **Overview**
> When the Go bundler or `mksnapshot` fails during V8 snapshot generation, their **stderr** (which usually names the offending file or reason) is now **appended to the rejected/thrown `Error`**, so CI and other runs see the real cause without setting `DEBUG=cypress:snapgen:error`. **Stdout** still goes through `logDebug` only.
> 
> The bundler path in `create-snapshot-script.ts` stops routing stderr through `logError` on failure and instead builds `Failed command: "<cmd>"` plus trimmed stderr (or the raw error if stderr is empty). `snapshot-generator.ts` does the same for `mksnapshot`, replacing a generic ``Failed `mksnapshot` command`` with a message that includes stderr when present.
> 
> A new unit test drives `createBundleAsync` with a fake failing bundler and asserts the rejection message includes the bundler’s stderr (skipped on Windows where the shebang-based fake executable isn’t honored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049802fe33d194468dc9a50efbd11c26c15ea820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```bash
yarn workspace @tooling/v8-snapshot test-unit -- test/unit/create-bundle.spec.ts
```

The new test builds a fake bundler that fails, and asserts the resulting rejection message includes the bundler's `stderr` (`bundler failed on ./offending-module.js`) rather than only the generic `Failed command` text. It calls `createBundleAsync` directly to exercise the bundler-invocation catch without spinning up the doctor's worker pool, and is skipped on Windows (the fake bundler runs via a shebang).

### How has the user experience changed?

No change — this is internal build tooling. The only difference is that snapshot-generation failures in CI now name their cause in the thrown error instead of being swallowed.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical/internal diagnostics change to private build tooling; no user-facing behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RsoQGnyNwUKL25UbgfQsb)_