### PR TITLE
chore: upgrade x86_64 CircleCI resource classes to gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
   pack-workflows:
     docker:
         - image: cimg/base:stable
-    resource_class: small
+    resource_class: small.gen2
     steps:
         - cancel-draft-prs
         - checkout:
@@ -153,7 +153,7 @@ jobs:
   launch-primary-workflow:
       docker:
           - image: cimg/base:stable
-      resource_class: small
+      resource_class: small.gen2
       steps:
           - cancel-draft-prs
           - checkout:

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -129,7 +129,7 @@ executors:
     docker:
       - image: *base-internal-trixie
     # by default, we use "medium" to balance performance + CI costs. bump or reduce on a per-job basis if needed.
-    resource_class: medium
+    resource_class: medium.gen2
     environment:
       PLATFORM: linux
 
@@ -137,7 +137,7 @@ executors:
   node-slim:
     docker:
       - image: cimg/node:22.19.0
-    resource_class: medium
+    resource_class: medium.gen2
     environment:
       PLATFORM: linux
 
@@ -145,7 +145,7 @@ executors:
     docker:
       - image: *base-internal-trixie
     # by default, we use "medium" to balance performance + CI costs. bump or reduce on a per-job basis if needed.
-    resource_class: medium
+    resource_class: medium.gen2
     environment:
       PLATFORM: linux
 
@@ -194,7 +194,7 @@ executors:
   linux-x64: &linux-x64-executor
     machine:
       image: ubuntu-2004:2024.11.1
-    resource_class: medium
+    resource_class: medium.gen2
     environment:
       PLATFORM: linux
 
@@ -1674,7 +1674,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
       build-better-sqlite3:
         type: boolean
         default: false
@@ -1703,7 +1703,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: large
+        default: large.gen2
     resource_class: << parameters.resource_class >>
     steps:
       - restore_cached_workspace
@@ -1762,7 +1762,7 @@ jobs:
   # a special job that closes the Percy build started by the required jobs
   percy-finalize:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     parameters:
       <<: *defaultsParameters
       required_env_var:
@@ -1810,7 +1810,7 @@ jobs:
   # verify accessibility scores from Cypress
   verify-accessibility-results:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       # Uses an inline when: not: or: instead of halt-if-skipped because this
       # job depends on multiple parameters. CircleCI boolean parameters cannot
@@ -1851,7 +1851,7 @@ jobs:
 
   ready-to-release:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     parameters:
       <<: *defaultsParameters
     steps:
@@ -1861,7 +1861,7 @@ jobs:
 
   cli-visual-tests:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-cli-tests >>
@@ -1892,7 +1892,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
     resource_class: << parameters.resource_class >>
     parallelism: 1
     steps:
@@ -1945,7 +1945,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
     resource_class: << parameters.resource_class >>
     parallelism: 1
     steps:
@@ -1985,7 +1985,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
       executor:
         type: executor
         default: linux-x64
@@ -2042,7 +2042,7 @@ jobs:
 
   verify-release-readiness:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     parallelism: 1
     environment:
       GITHUB_TOKEN: $GH_TOKEN
@@ -2089,7 +2089,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
     resource_class: << parameters.resource_class >>
     parallelism: 1
     steps:
@@ -2175,7 +2175,7 @@ jobs:
       # using `machine` gives us a Linux VM that can run Docker
       image: ubuntu-2004:2024.05.1
       docker_layer_caching: true
-    resource_class: medium
+    resource_class: medium.gen2
     steps:
       - maybe_skip_binary_jobs
       - run-binary-system-tests
@@ -2242,7 +2242,7 @@ jobs:
 
   system-tests-chrome:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 8
     steps:
       - run-system-tests:
@@ -2251,7 +2251,7 @@ jobs:
 
   system-tests-electron:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 8
     steps:
       - run-system-tests:
@@ -2260,7 +2260,7 @@ jobs:
 
   system-tests-firefox:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 8
     steps:
       - run-system-tests:
@@ -2269,7 +2269,7 @@ jobs:
 
   system-tests-webkit:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 8
     steps:
       - run-system-tests:
@@ -2297,7 +2297,7 @@ jobs:
         type: boolean
         default: false
     parallelism: 3
-    resource_class: large
+    resource_class: large.gen2
     steps:
       - run-new-ui-tests:
           browser: chrome
@@ -2331,7 +2331,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: large
+        default: large.gen2
       percy:
         type: boolean
         default: false
@@ -2352,7 +2352,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: large
+        default: large.gen2
       percy:
         type: boolean
         default: false
@@ -2373,7 +2373,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: large
+        default: large.gen2
       percy:
         type: boolean
         default: false
@@ -2391,7 +2391,7 @@ jobs:
   driver-integration-tests-chrome:
     <<: *defaults
     parallelism: 5
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - run-driver-integration-tests:
           browser: chrome
@@ -2401,7 +2401,7 @@ jobs:
   driver-integration-tests-chrome-inject-document-domain:
     <<: *defaults
     parallelism: 5
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - run-driver-integration-tests:
           browser: chrome
@@ -2411,7 +2411,7 @@ jobs:
 
   driver-integration-tests-chrome-beta:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 5
     steps:
       - run-driver-integration-tests:
@@ -2421,7 +2421,7 @@ jobs:
 
   driver-integration-tests-chrome-beta-inject-document-domain:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 5
     steps:
       - run-driver-integration-tests:
@@ -2432,7 +2432,7 @@ jobs:
 
   driver-integration-tests-firefox:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 5
     steps:
       - run-driver-integration-tests:
@@ -2441,7 +2441,7 @@ jobs:
 
   driver-integration-tests-electron:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 5
     steps:
       - run-driver-integration-tests:
@@ -2450,7 +2450,7 @@ jobs:
 
   driver-integration-tests-webkit:
     <<: *defaults
-    resource_class: large
+    resource_class: large.gen2
     parallelism: 5
     steps:
       - run-driver-integration-tests:
@@ -2478,7 +2478,7 @@ jobs:
 
   reporter-integration-tests:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 3
     steps:
       - halt-if-skipped:
@@ -2501,7 +2501,7 @@ jobs:
 
   run-webpack-dev-server-integration-tests:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     parallelism: 2
     steps:
       - halt-if-skipped:
@@ -2583,7 +2583,7 @@ jobs:
 
   npm-webpack-batteries-included-preprocessor:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-npm-webpack-batteries-tests >>
@@ -2702,7 +2702,7 @@ jobs:
 
   npm-grep:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-npm-grep-tests >>
@@ -2765,7 +2765,7 @@ jobs:
 
   npm-release:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - restore_cached_workspace
       - run:
@@ -2778,7 +2778,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: xlarge
+        default: xlarge.gen2
     resource_class: << parameters.resource_class >>
     steps:
       - restore_cached_workspace
@@ -2805,7 +2805,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: small
+        default: small.gen2
     resource_class: << parameters.resource_class >>
     steps:
       - maybe_skip_binary_jobs
@@ -2821,7 +2821,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium
+        default: medium.gen2
     resource_class: << parameters.resource_class >>
     steps:
       - maybe_skip_binary_jobs
@@ -2856,7 +2856,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium+
+        default: medium+.gen2
     resource_class: << parameters.resource_class >>
     steps:
       - restore_cached_workspace
@@ -2918,7 +2918,7 @@ jobs:
 
   test-npm-module-and-verify-binary:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - restore_cached_workspace
       # make sure we have cypress.zip received
@@ -2956,7 +2956,7 @@ jobs:
   # Test NPM module on minimum node version we support
   test-npm-module-on-minimum-node-version:
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     docker:
       - image: *base-internal-minimum-node
     steps:
@@ -3000,7 +3000,7 @@ jobs:
         type: string
         default: /root/test-cypress-and-jest
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - maybe_skip_binary_jobs
       - restore_workspace_binaries
@@ -3036,7 +3036,7 @@ jobs:
         type: executor
         default: cy-docker
     <<: *defaults
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - maybe_skip_binary_jobs
       - restore_workspace_binaries
@@ -3154,7 +3154,7 @@ jobs:
 
   test-binary-against-cypress-realworld-app:
     <<: *defaults
-    resource_class: medium+
+    resource_class: medium+.gen2
     steps:
       - test-binary-against-rwa:
           repo: cypress-realworld-app
@@ -3205,7 +3205,7 @@ jobs:
   all-jobs-passed:
     docker:
       - image: cimg/base:stable
-    resource_class: small
+    resource_class: small.gen2
     steps:
       - run:
           name: All jobs passed

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -194,7 +194,7 @@ executors:
   linux-x64: &linux-x64-executor
     machine:
       image: ubuntu-2004:2024.11.1
-    resource_class: medium.gen2
+    resource_class: medium
     environment:
       PLATFORM: linux
 
@@ -1985,7 +1985,7 @@ jobs:
       <<: *defaultsParameters
       resource_class:
         type: string
-        default: medium.gen2
+        default: medium
       executor:
         type: executor
         default: linux-x64
@@ -2175,7 +2175,7 @@ jobs:
       # using `machine` gives us a Linux VM that can run Docker
       image: ubuntu-2004:2024.05.1
       docker_layer_caching: true
-    resource_class: medium.gen2
+    resource_class: medium
     steps:
       - maybe_skip_binary_jobs
       - run-binary-system-tests


### PR DESCRIPTION
## Summary
This will optimize performance and cost on the affected resources. Announcement [here](https://circleci.com/changelog/introducing-gen2-docker-x86-resource-classes/).

- Upgrade all eligible x86 Docker and Linux VM resource classes from gen1 to gen2 (`small`, `medium`, `medium+`, `large`, `xlarge` → `*.gen2`)
- ARM (`arm.medium`), Windows (`windows.medium`/`windows.large`), and self-hosted Mac (`cypress-io/*-macstadium`) classes are unchanged
- Changes apply to setup jobs, executor defaults, parameterized job defaults, and hardcoded per-job overrides in `@pipeline.yml`

## Test plan
- [x] `yarn pack-ci --all --validate` passes locally
- [ ] CI runs on this PR (`.circleci/*` change should trigger all path-filtered jobs)
- [ ] Watch for remote Docker failures on `node_modules_install` (requires `medium.gen2` minimum)
- [ ] Watch for OOM or executor type errors on heavy jobs (`medium+.gen2`, `large.gen2`, `xlarge.gen2`)


Made with [Cursor](https://cursor.com)