### PR TITLE
chore: repair the lint-types job broken by the TypeScript 7 stable release

### DIFF
--- a/cli/patches/dtslint+4.2.1.dev.patch
+++ b/cli/patches/dtslint+4.2.1.dev.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/dtslint/bin/lint.js b/node_modules/dtslint/bin/lint.js
+--- a/node_modules/dtslint/bin/lint.js
++++ b/node_modules/dtslint/bin/lint.js
+@@ -196,7 +196,13 @@ function range(minVersion, maxVersion) {
+     const minIdx = typescript_versions_1.TypeScriptVersion.shipped.indexOf(minVersion);
+     assert(minIdx >= 0);
+     if (maxVersion === typescript_versions_1.TypeScriptVersion.latest) {
+-        return [...typescript_versions_1.TypeScriptVersion.shipped.slice(minIdx), typescript_versions_1.TypeScriptVersion.latest];
++        // PATCHED (cypress): with the @definitelytyped/typescript-versions patch, `latest`
++        // equals the last shipped version; avoid testing it twice
++        const versions = typescript_versions_1.TypeScriptVersion.shipped.slice(minIdx);
++        if (versions[versions.length - 1] !== typescript_versions_1.TypeScriptVersion.latest) {
++            versions.push(typescript_versions_1.TypeScriptVersion.latest);
++        }
++        return versions;
+     }
+     const maxIdx = typescript_versions_1.TypeScriptVersion.shipped.indexOf(maxVersion);
+     assert(maxIdx >= minIdx);

--- a/patches/@definitelytyped+typescript-versions+0.1.9.dev.patch
+++ b/patches/@definitelytyped+typescript-versions+0.1.9.dev.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@definitelytyped/typescript-versions/dist/index.js b/node_modules/@definitelytyped/typescript-versions/dist/index.js
+--- a/node_modules/@definitelytyped/typescript-versions/dist/index.js
++++ b/node_modules/@definitelytyped/typescript-versions/dist/index.js
+@@ -10,7 +10,11 @@ var TypeScriptVersion;
+     /** Add to this list when a version actually ships.  */
+     TypeScriptVersion.shipped = ["5.2", "5.3", "5.4", "5.5", "5.6", "5.7", "5.8", "5.9"];
+     /** Add to this list when a version is available as typescript@next */
+-    TypeScriptVersion.supported = [...TypeScriptVersion.shipped, "6.0"];
++    // PATCHED (cypress): only test against shipped TypeScript versions. The unshipped entry
++    // made TypeScriptVersion.latest map to the typescript@next dist-tag, which now resolves
++    // to the TypeScript 7 native compiler — its package has no `main`, so dtslint's
++    // require() of the install directory crashes ("Cannot find module .../node_modules/typescript").
++    TypeScriptVersion.supported = [...TypeScriptVersion.shipped];
+     /** Add to this list when it will no longer be supported on Definitely Typed */
+     TypeScriptVersion.unsupported = [
+         "2.0",


### PR DESCRIPTION
- Closes N/A — repo-wide CI break, fixed same-day (details below)

### Additional details

The `lint-types` job started failing on **every branch** on 2026-07-08 with:

```
Error: Cannot find module '/home/circleci/.dts/typescript-installs/6.0/node_modules/typescript'
```

**Root cause:** dtslint tests `cypress.d.ts` against every TypeScript version from the types' minimum through `@definitelytyped/typescript-versions`' `latest` — which sits one slot past the shipped list and maps to the **`typescript@next` dist-tag** (installed into a directory named for `latest`, hence the misleading "6.0"). TypeScript published **7.0.2 — the first stable native-compiler release — at 15:55 UTC on 2026-07-08**, moving `next` to `7.1.0-dev`. The TS 7 package has no `main` entry (only an `exports` map), and dtslint loads TS by `require()`ing the install *directory path*, which bypasses `exports` — so the require crashes. Jobs earlier that same day passed; everything after fails. No stable 6.x was ever published (Microsoft skipped from 5.9 to 7.0), so no version-list shuffle can avoid this — the deprecated dtslint 4.x simply cannot load TS ≥ 7.

**The fix — two patch-package patches** (extending the existing mitigation: `@definitelytyped/typescript-versions` is already pinned via `resolutions`, and `cli/patches/` already patches other packages in this lint pipeline):

- `patches/@definitelytyped+typescript-versions+0.1.9.dev.patch` — `supported` no longer carries the unshipped tail entry, so `latest` is the newest shipped version (5.9) and the `typescript@next` install becomes a no-op. dtslint now tests only shipped, requireable TypeScript versions.
- `cli/patches/dtslint+4.2.1.dev.patch` — `range()` no longer appends `latest` when it already equals the last shipped version, avoiding a duplicate 5.9 pass.

**Both are `.dev.patch` files, and that suffix is load-bearing:** the binary build copies `patches/` into its dist and installs with `--production`, filtering `*.dev.patch` out of the patch set (`scripts/binary/build.ts`). `dtslint` and `@definitelytyped/typescript-versions` only exist in dev installs, so a plain `.patch` for them makes `patch-package` fail the publish-binary pipeline with "patch file found but no corresponding package" (this bit an earlier revision of this PR). Same convention as the existing `@types+*` dev patches in `cli/patches/`.

**Trade-off, stated plainly:** we stop testing the types against `typescript@next`. That stopped being possible today regardless — testing against TS 7 requires migrating from the deprecated `dtslint` to `@definitelytyped/dtslint`, which is worth doing as a follow-up but is not a same-day fix.

**No CI cache bump needed:** the node_modules cache key (`scripts/circle-cache.js`) already hashes all `*.patch` files, so adding these patches invalidates the cache and forces a fresh install that applies them. dtslint's own `~/.dts` install cache is not persisted in CI.

### Steps to test

```
rm -rf ~/.dts/typescript-installs   # reproduce CI's fresh state
cd cli && yarn dtslint
```

Verified locally: installs exactly 5.2–5.9 (no `6.0`/`next` directory) and passes; a deliberately injected type error in `cypress.d.ts` still fails the run, confirming the linter genuinely executes.

### How has the user experience changed?

No change — CI-only fix.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — same-day repo-wide CI break
- [na] Have tests been added/updated? — CI tooling patch; verified by the lint-types job itself
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
