### PR TITLE
fix: address Bugbot findings on CDP legacy pipeline

### DIFF
--- a/packages/proxy/lib/adapters/synthetic-express-context.ts
+++ b/packages/proxy/lib/adapters/synthetic-express-context.ts
@@ -35,19 +35,41 @@ function parseCookieHeader (header?: string | string[]): Record<string, string> 
 
 function serializeCookie (name: string, value: string, options: CookieOptions = {}): string {
   const parts = [`${name}=${encodeURIComponent(value)}`]
+  const path = options.path == null ? '/' : options.path
+
+  parts.push(`Path=${path}`)
 
   if (options.domain) {
     parts.push(`Domain=${options.domain}`)
   }
 
-  if (options.expires) {
+  if (options.maxAge != null) {
+    const maxAgeMs = Number(options.maxAge)
+
+    if (!Number.isNaN(maxAgeMs)) {
+      parts.push(`Max-Age=${Math.floor(maxAgeMs / 1000)}`)
+      parts.push(`Expires=${new Date(Date.now() + maxAgeMs).toUTCString()}`)
+    }
+  } else if (options.expires) {
     parts.push(`Expires=${options.expires.toUTCString()}`)
+  }
+
+  if (options.httpOnly) {
+    parts.push('HttpOnly')
+  }
+
+  if (options.secure) {
+    parts.push('Secure')
+  }
+
+  if (options.sameSite) {
+    parts.push(`SameSite=${options.sameSite === true ? 'true' : options.sameSite}`)
   }
 
   return parts.join('; ')
 }
 
-function createRequestBodyStream (body?: string | Buffer): Readable {
+export function createRequestBodyStream (body?: string | Buffer): Readable {
   if (typeof body === 'undefined') {
     return Readable.from([])
   }

--- a/packages/proxy/lib/adapters/synthetic-http-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-http-codec.ts
@@ -1,11 +1,10 @@
-import { Readable } from 'stream'
 import type { HttpRequest, HttpResponse, TransportCodecPort } from '@packages/network-interception'
 import type { HttpMiddlewareCtx } from '../http'
 import { createProxyHttpCodec } from './http-codec'
 import {
+  createRequestBodyStream,
   createSyntheticExpressContext,
   createSyntheticIncomingResponse,
-
 } from './synthetic-express-context'
 import type { SyntheticCypressResponse } from './synthetic-express-context'
 
@@ -14,14 +13,6 @@ type SyntheticHttpCodecOptions = {
     request: ReturnType<typeof createSyntheticExpressContext>['req'],
     response: ReturnType<typeof createSyntheticExpressContext>['res'],
   ) => HttpMiddlewareCtx<any>
-}
-
-function createBodyStream (body?: string | Buffer): Readable {
-  if (typeof body === 'undefined') {
-    return Readable.from([])
-  }
-
-  return Readable.from([body])
 }
 
 export function createSyntheticHttpCodec (
@@ -48,7 +39,7 @@ export function createSyntheticHttpCodec (
       const ctx = coreCodec.encodeResponse(response)
 
       ctx.incomingRes = createSyntheticIncomingResponse(response)
-      ctx.incomingResStream = response.bodyStream ?? createBodyStream(response.body)
+      ctx.incomingResStream = response.bodyStream ?? createRequestBodyStream(response.body)
 
       return ctx
     },

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -9,7 +9,7 @@ import { setDefaultHeaders } from '@packages/net-stubbing/lib/server/util'
 import ErrorMiddleware from './error-middleware'
 import RequestMiddleware from './request-middleware'
 import ResponseMiddleware from './response-middleware'
-import { createFetchOrigin, proxyHttpCodec } from '../adapters/http-codec'
+import { createFetchOrigin } from '../adapters/http-codec'
 import { HttpBuffers } from './util/buffers'
 import { GetPreRequestCb, PendingRequest, PreRequests } from './util/prerequests'
 import { ServiceWorkerManager } from './util/service-worker-manager'
@@ -450,8 +450,6 @@ export class Http {
       return codec.decodeResponse(ctx)
     }
   }
-
-  runLegacyProxyPipeline: InterceptMiddleware = this.createLegacyProxyPipeline(proxyHttpCodec)
 
   createMiddlewareContext (req: CypressIncomingRequest, res: CypressOutgoingResponseLike, handleHttpRequestSpan?: Span): HttpMiddlewareCtx<any> {
     const colorFn = debugVerbose.enabled ? getRandomColorFn() : undefined

--- a/packages/proxy/test/unit/adapters/synthetic-http-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-http-codec.spec.ts
@@ -60,6 +60,32 @@ describe('createSyntheticExpressContext', () => {
 
     expect(res.getCapturedBody().toString()).to.equal('created')
   })
+
+  it('serializes cookies with Express-compatible Path and attributes', () => {
+    const { res } = createSyntheticExpressContext({
+      id: 'network-1',
+      url: 'https://example.test/',
+    })
+
+    res.cookie('session', 'abc', {
+      domain: 'example.test',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: 900000,
+    })
+
+    const setCookie = res.getHeader('Set-Cookie') as string
+
+    expect(setCookie).to.include('session=abc')
+    expect(setCookie).to.include('Path=/')
+    expect(setCookie).to.include('Domain=example.test')
+    expect(setCookie).to.include('Max-Age=900')
+    expect(setCookie).to.include('HttpOnly')
+    expect(setCookie).to.include('Secure')
+    expect(setCookie).to.include('SameSite=lax')
+    expect(setCookie).to.match(/Expires=/)
+  })
 })
 
 describe('createSyntheticHttpCodec', () => {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -250,7 +250,6 @@ export class CdpFetchTransport {
 
   private createResponseBodyStream = (requestId: string, sessionId?: string): Readable => {
     let reading = false
-    let stream: Protocol.IO.StreamHandle | undefined
     let bodyStream: Readable
 
     bodyStream = new Readable({
@@ -263,40 +262,25 @@ export class CdpFetchTransport {
 
         void (async () => {
           try {
-            if (!stream) {
-              const response = await this.client.send('Fetch.takeResponseBodyAsStream', {
-                requestId,
-              }, sessionId) as Protocol.Fetch.TakeResponseBodyAsStreamResponse
+            const response = await this.client.send('Fetch.getResponseBody', {
+              requestId,
+            }, sessionId) as Protocol.Fetch.GetResponseBodyResponse
 
-              stream = response.stream
+            const body = Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8')
+
+            if (body.length) {
+              bodyStream.push(body)
             }
 
-            const chunk = await this.client.send('IO.read', {
-              handle: stream,
-            }, sessionId) as Protocol.IO.ReadResponse
-
-            if (chunk.data) {
-              this.pushChunk(bodyStream, chunk)
-            }
-
-            if (chunk.eof) {
-              await this.safeSend('IO.close', { handle: stream }, sessionId)
-              bodyStream.push(null)
-            }
+            bodyStream.push(null)
           } catch (err) {
             bodyStream.destroy(err as Error)
-          } finally {
-            reading = false
           }
         })()
       },
     })
 
     return bodyStream
-  }
-
-  private pushChunk (readable: Readable, chunk: Protocol.IO.ReadResponse): void {
-    readable.push(Buffer.from(chunk.data, chunk.base64Encoded ? 'base64' : 'utf8'))
   }
 
   private safeSend = async (...args: Parameters<CdpFetchClient['send']>): Promise<void> => {

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -146,7 +146,9 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
   })
 
   networkInterception.use(networkProxy.http.createLegacyProxyPipeline(syntheticCodec))
-  networkProxy.http.networkInterception = networkInterception
+  // Keep the proxy-codec intercept for NetworkProxy.handleHttpRequest; the CDP
+  // codec intercept is owned by CdpFetchTransport and must not be shared.
+  networkProxy.withIntercept(new HttpIntercept(networkProxy.codec))
 
   const fetchTransport = new CdpFetchTransport(deps.client, networkInterception)
 

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -519,16 +519,9 @@ describe('CdpFetchTransport', () => {
       const transport = new CdpFetchTransport(client as any, httpIntercept)
       const onRequestPaused = await startTransport(transport, client)
 
-      client.send.withArgs('Fetch.takeResponseBodyAsStream').resolves({ stream: 'stream-1' })
-      client.send.withArgs('IO.read').onFirstCall().resolves({
-        data: Buffer.from('origin').toString('base64'),
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: Buffer.from('origin').toString('base64'),
         base64Encoded: true,
-        eof: false,
-      })
-
-      client.send.withArgs('IO.read').onSecondCall().resolves({
-        data: '',
-        eof: true,
       })
 
       httpIntercept.use(async (req, next) => {
@@ -559,17 +552,11 @@ describe('CdpFetchTransport', () => {
 
       await handled
 
-      expect(client.send).to.have.been.calledWith('Fetch.takeResponseBodyAsStream', {
+      expect(client.send).to.have.been.calledWith('Fetch.getResponseBody', {
         requestId: 'fetch-response',
       })
 
-      expect(client.send).to.have.been.calledWith('IO.read', {
-        handle: 'stream-1',
-      })
-
-      expect(client.send).to.have.been.calledWith('IO.close', {
-        handle: 'stream-1',
-      })
+      expect(client.send).not.to.have.been.calledWith('Fetch.takeResponseBodyAsStream')
 
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-response',
@@ -579,6 +566,60 @@ describe('CdpFetchTransport', () => {
           value: 'text/plain',
         }],
         body: Buffer.from('origin-rewritten').toString('base64'),
+      })
+    })
+
+    it('fulfills rewritten empty response bodies without stalling', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const onRequestPaused = await startTransport(transport, client)
+
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: '',
+        base64Encoded: true,
+      })
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        return {
+          ...response,
+          body: await readStream(response.bodyStream!),
+          headers: {
+            'content-type': 'text/plain',
+          },
+          statusCode: 204,
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      await onRequestPaused(createPausedRequest({
+        requestId: 'fetch-response',
+        networkId: 'network-1',
+        responseStatusCode: 204,
+      }))
+
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.getResponseBody', {
+        requestId: 'fetch-response',
+      })
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 204,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/plain',
+        }],
+        body: Buffer.from('').toString('base64'),
       })
     })
 

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -177,6 +177,8 @@ describe('lib/network-runtime', () => {
     expect(runtime.networkInterceptionCore.networkCapture).to.exist
     expect(runtime.networkInterceptionCore.cookieState).to.exist
     expect(runtime.networkInterceptionCore.commandLog).to.exist
+    expect(runtime.networkProxy.http.networkInterception).to.exist
+    expect(runtime.networkProxy.http.networkInterception).to.not.equal(runtime.networkInterception)
   })
 
   it('runs legacy request and response middleware over the CDP runtime', async () => {
@@ -208,16 +210,9 @@ describe('lib/network-runtime', () => {
       [HttpStages.Error]: {},
     }
 
-    client.send.withArgs('Fetch.takeResponseBodyAsStream').resolves({ stream: 'stream-1' })
-    client.send.withArgs('IO.read').onFirstCall().resolves({
-      data: Buffer.from('origin').toString('base64'),
+    client.send.withArgs('Fetch.getResponseBody').resolves({
+      body: Buffer.from('origin').toString('base64'),
       base64Encoded: true,
-      eof: false,
-    })
-
-    client.send.withArgs('IO.read').onSecondCall().resolves({
-      data: '',
-      eof: true,
     })
 
     const onRequestPaused = await startCdpRuntime(runtime, client)
@@ -239,6 +234,12 @@ describe('lib/network-runtime', () => {
       requestId: 'fetch-request',
       url: 'https://example.test/mutated',
     })
+
+    expect(client.send).to.have.been.calledWith('Fetch.getResponseBody', {
+      requestId: 'fetch-response',
+    })
+
+    expect(client.send).not.to.have.been.calledWith('Fetch.takeResponseBodyAsStream')
 
     expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
       requestId: 'fetch-response',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Closes N/A (follow-up to #34250 Bugbot review comments)

### Additional details

Addresses the open Cursor Bugbot findings on #34250:

1. **CDP body take blocks fulfill / stream stall** — `CdpFetchTransport` now uses `Fetch.getResponseBody` instead of `Fetch.takeResponseBodyAsStream` + `IO.read`, so the response pause stays open for `Fetch.fulfillRequest` and empty-chunk stalls are eliminated.
2. **CDP proxy handle path broken** — `createCdpFetchRuntime` wires a proxy-codec intercept via `networkProxy.withIntercept(...)` for `handleHttpRequest`, and keeps the CDP-codec intercept exclusive to `CdpFetchTransport`.
3. **Synthetic cookies omit Path** — `serializeCookie` now defaults `Path=/` and honors `httpOnly`, `secure`, `sameSite`, and `maxAge`/`expires`.
4. **Unused legacy pipeline export** — removed dead `runLegacyProxyPipeline`.
5. **Duplicated body stream helpers** — shared `createRequestBodyStream` across synthetic adapters.

The earlier "origin fetch after early end" finding was already fixed on the base branch.

### Steps to test

1. Run `yarn workspace @packages/proxy test -- test/unit/adapters/synthetic-http-codec.spec.ts`
2. Run `yarn workspace @packages/server test-unit -- test/unit/browsers/cdp-fetch-transport_spec.ts`
3. Run `yarn workspace @packages/server test-unit -- test/unit/network-runtime_spec.ts`

### How has the user experience changed?

No change — internal CDP Fetch / legacy pipeline wiring only; the CDP runtime is not yet the default proxy path.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- Follow-up to open PR #34250 Bugbot comments -->
- [x] Have tests been added/updated?
- [na] Have a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-632092aa-ddfb-4a9e-8190-1946c9b2c0b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-632092aa-ddfb-4a9e-8190-1946c9b2c0b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

