### PR TITLE
chore: Merge develop into release/16.0.0

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -9,7 +9,7 @@ chrome-stable-version: &chrome-stable-version "150.0.7871.114"
 chrome-beta-version: &chrome-beta-version "151.0.7922.19"
 # Pin from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json (channels.Stable)
 chrome-for-testing-stable-version: &chrome-for-testing-stable-version "150.0.7871.115"
-firefox-stable-version: &firefox-stable-version "151.0.1"
+firefox-stable-version: &firefox-stable-version "152.0.5"
 base-internal-trixie: &base-internal-trixie cypress/base-internal:22.19.0-trixie
 base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry
 # Lowest Node.js version we support of the minimum major version supported

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -5,10 +5,10 @@ version: 2.1
 # the new location and/or names:
 # - ./scripts/github-actions/update-browser-versions.js
 
-chrome-stable-version: &chrome-stable-version "150.0.7871.46"
-chrome-beta-version: &chrome-beta-version "151.0.7922.10"
+chrome-stable-version: &chrome-stable-version "150.0.7871.114"
+chrome-beta-version: &chrome-beta-version "151.0.7922.19"
 # Pin from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json (channels.Stable)
-chrome-for-testing-stable-version: &chrome-for-testing-stable-version "150.0.7871.46"
+chrome-for-testing-stable-version: &chrome-for-testing-stable-version "150.0.7871.115"
 firefox-stable-version: &firefox-stable-version "151.0.1"
 base-internal-trixie: &base-internal-trixie cypress/base-internal:22.19.0-trixie
 base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry

--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -1,41 +1,74 @@
 name: Upload SBOM as Release Asset
-# This workflow triggers whenever there is a new release published.  The 
-# action generates a Software Bill of Materials and uploads it as a
-# release artifact.  This satisfies compliance initiatives.
+
+# Generates an SPDX Software Bill of Materials (SBOM) for the repository and
+# attaches it to every published GitHub release, so SBOMs stay discoverable for
+# customer security reviews.
+#
+# The asset is named SBOM.rpt with SPDX tag-value (text) content, matching the
+# artifact the previous FOSSA workflow produced, so it is a drop-in replacement
+# for the SBOM.rpt already shared with customers.
+#
+# Least privilege: the workflow defaults to contents: read. Only the
+# attach-to-release job (which runs on release events only) elevates to
+# contents: write, so a manual workflow_dispatch run never holds a write-scoped
+# token. The SBOM is passed between jobs as a workflow artifact.
+
 on:
   release:
     types:
       - published
+  # Allow an operator to generate an SBOM on demand (e.g. an ad-hoc customer
+  # request) without cutting a release. On a manual run only the read-only
+  # generate job runs; the SBOM is available as the SBOM.rpt workflow artifact.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
-  generate_SBOM:
+  generate_sbom:
     runs-on: ubuntu-latest
-    env:
-          FOSSA_API_KEY: ${{secrets.FOSSAAPIKEY}}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - name: Download Fossa binary and install
-# This step utilizes a curl of the latest install pkg from Fossa.  Using a git action from 
-# Fossa doesn't produce the SBOM artifact needed. This manual approach is the only way to 
-# create the report to upload as a release artifact.
-        run:  |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-      - name: Generate SBOM
-        run:  |
-          fossa analyze 
-          fossa report attribution --debug --format spdx >> SBOM.rpt
-      - name: Verify report
-        run:  |
-          ls -lht|head
-          cat SBOM.rpt      
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
+
+      - name: Generate SBOM (SPDX tag-value) as SBOM.rpt
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./SBOM.rpt
-          asset_name: SBOM.rpt
-          asset_content_type: text/plain
+          # Scan the checked-out source. Syft reads the committed lockfiles
+          # (yarn.lock / package.json) across all workspaces, so no install or
+          # build step is needed to enumerate resolved dependency versions.
+          path: .
+          # SPDX tag-value (text), the same content the old FOSSA report emitted.
+          format: spdx-tag-value
+          output-file: SBOM.rpt
+          # We upload the artifact and attach the release ourselves (below), with
+          # version-pinned actions — disable the action's own uploads.
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Upload SBOM.rpt as a workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SBOM.rpt
+          path: SBOM.rpt
+          if-no-files-found: error
+
+  attach_to_release:
+    # Only on a real release event: this is the only job that needs (and gets)
+    # contents: write, so workflow_dispatch runs stay read-only.
+    if: github.event_name == 'release'
+    needs: generate_sbom
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to upload the SBOM as a release asset
+    steps:
+      - name: Download the generated SBOM.rpt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: SBOM.rpt
+
+      - name: Attach SBOM.rpt to the release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          files: SBOM.rpt

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where, on Windows, enhancing a test failure stack could throw a secondary `TypeError: Cannot read properties of undefined (reading 'replaceAll')` and mask the original error. Fixed in [#34252](https://github.com/cypress-io/cypress/pull/34252).
 - Fixed an issue where [`experimentalMemoryManagement`](https://on.cypress.io/experiments) could fail to prevent the browser from running out of memory and crashing when Cypress was running inside a memory-limited container. Memory is now managed correctly in these environments. Fixes [#34104](https://github.com/cypress-io/cypress/issues/34104). Addressed in [#34123](https://github.com/cypress-io/cypress/pull/34123).
 
 **Misc:**

--- a/packages/driver/cypress/e2e/e2e/focus_blur.cy.js
+++ b/packages/driver/cypress/e2e/e2e/focus_blur.cy.js
@@ -509,6 +509,10 @@ describe('polyfill programmatic blur events', () => {
   })
 })
 
+// Firefox 152 aligned with Chrome: moving focus from a text input to a
+// non-editable element no longer fires `selectionchange` on the document
+const isFirefoxBelow152 = Cypress.isBrowser({ family: 'firefox' }) && Cypress.browserMajorVersion() < 152
+
 // TODO(webkit): fix+unskip for webkit release
 describe('intercept blur methods correctly', { browser: '!webkit' }, () => {
   beforeEach(() => {
@@ -540,7 +544,7 @@ describe('intercept blur methods correctly', { browser: '!webkit' }, () => {
     cy.wrap($el[0]).focus()
     .should('have.focus')
 
-    if (Cypress.isBrowser('firefox')) {
+    if (isFirefoxBelow152) {
       cy.wait(0).get('@selectionchange').should('be.called')
 
       return
@@ -557,7 +561,7 @@ describe('intercept blur methods correctly', { browser: '!webkit' }, () => {
     cy.wrap($el[0]).focus()
     .should('have.focus')
 
-    if (Cypress.isBrowser('firefox')) {
+    if (isFirefoxBelow152) {
       cy.wait(0).get('@selectionchange').should('be.called')
 
       return
@@ -574,7 +578,7 @@ describe('intercept blur methods correctly', { browser: '!webkit' }, () => {
     cy.wrap($el[0]).focus()
     .should('have.focus')
 
-    if (Cypress.isBrowser('firefox')) {
+    if (isFirefoxBelow152) {
       cy.wait(0).get('@selectionchange').should('be.called')
 
       return
@@ -600,7 +604,7 @@ describe('intercept blur methods correctly', { browser: '!webkit' }, () => {
     $el.appendTo(cy.$$('body'))
     $el[0].focus()
 
-    if (Cypress.isBrowser('firefox')) {
+    if (isFirefoxBelow152) {
       cy.wait(0).get('@selectionchange').should('be.called')
 
       return

--- a/packages/driver/src/cypress/util/to_posix.ts
+++ b/packages/driver/src/cypress/util/to_posix.ts
@@ -1,4 +1,8 @@
 export const toPosix = (file: string) => {
+  if (file == null) {
+    return file
+  }
+
   return Cypress.config('platform') === 'win32'
     ? file.replaceAll('\\', '/')
     : file

--- a/packages/driver/test/unit/cypress/util/toPosix.spec.ts
+++ b/packages/driver/test/unit/cypress/util/toPosix.spec.ts
@@ -37,4 +37,9 @@ describe('toPosix', () => {
       expect(toPosix('/some/file')).toEqual('/some/file')
     })
   })
+
+  it('returns nullish inputs unchanged', () => {
+    expect(toPosix(undefined as any)).toEqual(undefined)
+    expect(toPosix(null as any)).toEqual(null)
+  })
 })

--- a/system-tests/projects/e2e/cypress/e2e/xhr.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/xhr.cy.js
@@ -7,7 +7,9 @@ describe('xhrs', () => {
       }
     }
 
-    cy.intercept(/api/, getResp()).as('getApi')
+    // Match only our app's /api/ path. A bare /api/ also matches Chrome
+    // background URLs such as clientservices.googleapis.com/... and flakes CI.
+    cy.intercept(/\/api\//, getResp()).as('getApi')
     cy.visit('/index.html')
     cy.window().then((win) => {
       const xhr = new win.XMLHttpRequest


### PR DESCRIPTION
- Closes N/A

### Additional details

Routine merge of `develop` into `release/16.0.0` to keep the release branch up to date. This merge required manual conflict resolution.

**Conflicting file:** `.circleci/src/pipeline/@pipeline.yml`

The conflict was in the CircleCI browser/base-image version anchors block:

- `chrome-for-testing-stable-version` and `firefox-stable-version` — `develop` had newer values from automated browser-update PRs (#34266, #34268) that hadn't yet been merged into `release/16.0.0`. Resolved by taking `develop`'s newer versions (`150.0.7871.115` / `152.0.5`).
- `base-internal-trixie` and `base-internal-yarn-berry` — `release/16.0.0` had `24.15.0-*` from a release-only Electron upgrade (#33895, "chore: upgrade electron to 41.7.0") bumping the bundled Node.js to 24.15.0, which has not landed on `develop` (still `22.19.0-*`). Resolved by keeping `release/16.0.0`'s `24.15.0-*` values, since these correspond to the release-only Electron/Node upgrade already present in this branch.

All other files (`.github/workflows/upload_release_asset.yml`, `cli/CHANGELOG.md`, `packages/driver/cypress/e2e/e2e/focus_blur.cy.js`, `packages/driver/src/cypress/util/to_posix.ts`, `packages/driver/test/unit/cypress/util/toPosix.spec.ts`, `system-tests/projects/e2e/cypress/e2e/xhr.cy.js`) merged automatically without conflicts.

Note: `yarn pack-ci --verify` could not be run in this sandbox (requires Node >=24.15.0 and the CircleCI CLI, neither available here), but the resulting YAML was validated for syntax correctness.

### Steps to test

- Confirm CI passes on this PR (in particular any jobs affected by `.circleci/src/pipeline/@pipeline.yml`, e.g. browser/base-image versions).
- Reviewer with the CircleCI CLI available can run `yarn pack-ci --verify` to fully validate the compiled pipeline config.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYMp6m9UrpihycAH1SLvax)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release compliance (SBOM generation method) and a small Windows-facing driver path in stack handling; changes are narrow and covered by tests, but the merge bundles multiple areas on the release branch.
> 
> **Overview**
> Brings **develop** into **release/16.0.0**, combining routine release-branch sync with several landed fixes and CI updates.
> 
> **Release SBOM workflow** replaces the FOSSA CLI with **anchore/sbom-action** (Syft, SPDX tag-value `SBOM.rpt`). The workflow splits into read-only **generate** and release-only **attach** jobs, adds **`workflow_dispatch`** for on-demand SBOMs, and tightens **GitHub token permissions** (`contents: read` by default; write only when attaching to a release).
> 
> **CircleCI** bumps pinned **Chrome** and **Firefox** versions (and related Chrome-for-testing anchor) used by browser install jobs.
> 
> **Driver / tests:** `toPosix` now returns **null/undefined** inputs unchanged so Windows failure stack enhancement no longer throws a secondary `replaceAll` error (noted in **15.18.2** changelog). **focus/blur** driver e2e expects **Firefox ≥152** to match Chrome for `selectionchange` when moving focus off text inputs. System-test **xhr** intercept uses **`/\/api\//`** so Chrome background requests do not match and flake CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c39b1f191cb9ab118c74345d572b51240e8f7a21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->