### PR TITLE
chore: enable --next validation for circleci configs (#34163)

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
     "system-tests/**/*.{js,jsx,ts,tsx,json,vue}": "eslint --fix",
     "tooling/**/*.{js,jsx,ts,tsx,json,vue}": "eslint --fix",
     "*.{js,jsx,ts,tsx,json,eslintrc,vue}": "eslint --fix",
-    ".circleci/*.yml": "circleci config validate"
+    ".circleci/*.yml": "circleci config validate --next"
   },
   "resolutions": {
     "**/@electron/get": "^4.0.1",

--- a/scripts/pack-ci.sh
+++ b/scripts/pack-ci.sh
@@ -44,7 +44,7 @@ fi
 # Validate the base config (only if --validate flag is set)
 if [ "$VALIDATE" = true ]; then
   echo "🔍 Validating base configuration..."
-  if ! circleci config validate "$base_config"; then
+  if ! circleci config validate --next "$base_config"; then
     echo "❌ Warning: Base config is not valid! Fix the base config in ./.circleci/config.yml."
     exit 1
   fi
@@ -121,7 +121,7 @@ for cfg_path in "${dirs_to_process[@]}"; do
       exit 1
     fi
     echo "  🔍 Validating ${output_file}"
-    if ! circleci config validate "$output_file"; then
+    if ! circleci config validate --next "$output_file"; then
       echo "    ❌ Validating ${output_file} failed"
       exit 1
     fi


### PR DESCRIPTION
- Closes #34163

### Additional details
**Why was this change necessary?**
CircleCI will enforce stricter config compilation rules (v2.1 semantics, stricter regex, blocking undeclared parameters) on August 17, 2026. 

**What is affected by this change?**
This change appends the `--next` flag to the `circleci config validate` commands within the repository's validation scripts (`package.json` lint-staged block and `scripts/pack-ci.sh`).

**Implementation Details:**
Local tests confirm that the existing compiled `.circleci/config.yml` already passes the strict validation. Injecting this flag locks the configuration state, ensuring no future commits can introduce deprecated pipeline syntax before the cutoff date.

### Steps to test
1. Pull down this branch.
2. Run `circleci config validate .circleci/config.yml --next` manually to verify the current configuration is valid.
3. (Optional) Intentionally introduce a v2.0 deprecation error (like an undeclared parameter) into a CircleCI config file, and run `bash scripts/pack-ci.sh`. The script should now successfully catch the error and fail.

### How has the user experience changed?
No change. (Internal CI/CD tooling only).

### PR Tasks
- [x] Is there an associated issue with maintainer approval for PR submission? - [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? - [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?