### PR TITLE
fix: do not inject into commented-out head/body/html tags

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where the Cypress script was injected into a commented-out `<head>`, `<body>`, or `<html>` tag inside an HTML comment, corrupting the served page. Commented-out tags are no longer considered injection points. Fixes [#33000](https://github.com/cypress-io/cypress/issues/33000).
 - Fixed an issue where, on Windows, enhancing a test failure stack could throw a secondary `TypeError: Cannot read properties of undefined (reading 'replaceAll')` and mask the original error. Fixed in [#34252](https://github.com/cypress-io/cypress/pull/34252).
 - Fixed an issue where [`experimentalMemoryManagement`](https://on.cypress.io/experiments) could fail to prevent the browser from running out of memory and crashing when Cypress was running inside a memory-limited container. Memory is now managed correctly in these environments. Fixes [#34104](https://github.com/cypress-io/cypress/issues/34104). Addressed in [#34123](https://github.com/cypress-io/cypress/pull/34123).
 

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -28,6 +28,7 @@ const headRe = /<head(?!er).*?>/i
 const bodyRe = /<body.*?>/i
 const htmlRe = /<html.*?>/i
 const bootstrapScriptRe = /(<script[^>]*\bdata-cy-bootstrap\b[^>]*>)([\s\S]*?)(<\/script>)/i
+const htmlCommentRe = /<!--[\s\S]*?-->/g
 
 function getRewriter (useAstSourceRewriting: boolean) {
   return useAstSourceRewriting ? astRewriter : regexRewriter
@@ -66,6 +67,22 @@ function getHtmlToInject (opts: InjectionOpts & SecurityOpts) {
     default:
       return
   }
+}
+
+// replaces HTML comments with same-length whitespace so the injection point
+// regexes can't match tags inside comments, while every index stays aligned
+// with the original html
+const maskHtmlComments = (html: string) => {
+  let masked = html.replace(htmlCommentRe, (comment) => ' '.repeat(comment.length))
+
+  // an unterminated comment swallows the rest of the document
+  const openComment = masked.indexOf('<!--')
+
+  if (openComment !== -1) {
+    masked = masked.slice(0, openComment) + ' '.repeat(masked.length - openComment)
+  }
+
+  return masked
 }
 
 const insertBefore = (originalString, match, stringToInsert) => {
@@ -109,26 +126,30 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
 
   // TODO: move this into regex-rewriting and have ast-rewriting handle this in its own way
 
-  const headMatch = html.match(headRe)
+  // search a comment-masked copy so a commented-out tag can't become the
+  // injection point, then splice into the original html by index
+  const searchableHtml = maskHtmlComments(html)
+
+  const headMatch = searchableHtml.match(headRe)
 
   if (headMatch) {
     return insertAfter(html, headMatch, htmlToInject)
   }
 
-  const bodyMatch = html.match(bodyRe)
+  const bodyMatch = searchableHtml.match(bodyRe)
 
   if (bodyMatch) {
     return insertBefore(html, bodyMatch, `<head> ${htmlToInject} </head>`)
   }
 
-  const htmlMatch = html.match(htmlRe)
+  const htmlMatch = searchableHtml.match(htmlRe)
 
   if (htmlMatch) {
     return insertAfter(html, htmlMatch, `<head> ${htmlToInject} </head>`)
   }
 
   // if only <!DOCTYPE> content, inject <head> after doctype
-  if (doctypeRe.test(html)) {
+  if (doctypeRe.test(searchableHtml)) {
     return `${html}<head> ${htmlToInject} </head>`
   }
 

--- a/packages/proxy/lib/http/util/rewriter.ts
+++ b/packages/proxy/lib/http/util/rewriter.ts
@@ -28,7 +28,6 @@ const headRe = /<head(?!er).*?>/i
 const bodyRe = /<body.*?>/i
 const htmlRe = /<html.*?>/i
 const bootstrapScriptRe = /(<script[^>]*\bdata-cy-bootstrap\b[^>]*>)([\s\S]*?)(<\/script>)/i
-const htmlCommentRe = /<!--[\s\S]*?-->/g
 
 function getRewriter (useAstSourceRewriting: boolean) {
   return useAstSourceRewriting ? astRewriter : regexRewriter
@@ -71,18 +70,71 @@ function getHtmlToInject (opts: InjectionOpts & SecurityOpts) {
 
 // replaces HTML comments with same-length whitespace so the injection point
 // regexes can't match tags inside comments, while every index stays aligned
-// with the original html
+// with the original html. a small scanner tracks tag and quoted-attribute
+// state so `<!--` inside an attribute value is not mistaken for a comment,
+// comments may close with `-->`, `--!>` or abruptly (`<!-->`, `<!--->`), and
+// an unterminated comment blanks the rest of the document
 const maskHtmlComments = (html: string) => {
-  let masked = html.replace(htmlCommentRe, (comment) => ' '.repeat(comment.length))
+  const masked: string[] = []
+  let i = 0
+  let inTag = false
+  let quote = ''
 
-  // an unterminated comment swallows the rest of the document
-  const openComment = masked.indexOf('<!--')
+  while (i < html.length) {
+    const ch = html[i]
 
-  if (openComment !== -1) {
-    masked = masked.slice(0, openComment) + ' '.repeat(masked.length - openComment)
+    if (inTag) {
+      if (quote) {
+        if (ch === quote) {
+          quote = ''
+        }
+      } else if (ch === '"' || ch === '\'') {
+        quote = ch
+      } else if (ch === '>') {
+        inTag = false
+      }
+
+      masked.push(ch)
+      i++
+
+      continue
+    }
+
+    if (html.startsWith('<!--', i)) {
+      let end
+
+      if (html.startsWith('>', i + 4)) {
+        end = i + 5
+      } else if (html.startsWith('->', i + 4)) {
+        end = i + 6
+      } else {
+        const normalClose = html.indexOf('-->', i + 4)
+        const bangClose = html.indexOf('--!>', i + 4)
+
+        if (normalClose !== -1 && (bangClose === -1 || normalClose < bangClose)) {
+          end = normalClose + 3
+        } else if (bangClose !== -1) {
+          end = bangClose + 4
+        } else {
+          end = html.length
+        }
+      }
+
+      masked.push(' '.repeat(end - i))
+      i = end
+
+      continue
+    }
+
+    if (ch === '<' && /[a-zA-Z!/?]/.test(html[i + 1] || '')) {
+      inTag = true
+    }
+
+    masked.push(ch)
+    i++
   }
 
-  return masked
+  return masked.join('')
 }
 
 const insertBefore = (originalString, match, stringToInsert) => {
@@ -110,7 +162,11 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
     return html
   }
 
-  const bootstrapMatch = html.match(bootstrapScriptRe)
+  // search a comment-masked copy so a commented-out tag can't become the
+  // injection point, then splice into the original html by index
+  const searchableHtml = maskHtmlComments(html)
+
+  const bootstrapMatch = searchableHtml.match(bootstrapScriptRe)
 
   if (bootstrapMatch) {
     const contentToInject = htmlToInject.replace(/^<script[^>]*>|<\/script>$/g, '')
@@ -121,14 +177,13 @@ export async function html (html: string, opts: SecurityOpts & InjectionOpts) {
       openTag = openTag.replace(/>$/, ` nonce="${opts.cspNonce}">`)
     }
 
-    return html.replace(bootstrapScriptRe, `${openTag}${contentToInject}${bootstrapMatch[3]}`)
+    const start = bootstrapMatch.index || 0
+    const end = start + bootstrapMatch[0].length
+
+    return `${html.slice(0, start)}${openTag}${contentToInject}${bootstrapMatch[3]}${html.slice(end)}`
   }
 
   // TODO: move this into regex-rewriting and have ast-rewriting handle this in its own way
-
-  // search a comment-masked copy so a commented-out tag can't become the
-  // injection point, then splice into the original html by index
-  const searchableHtml = maskHtmlComments(html)
 
   const headMatch = searchableHtml.match(headRe)
 

--- a/packages/proxy/test/unit/http/util/rewriter.spec.ts
+++ b/packages/proxy/test/unit/http/util/rewriter.spec.ts
@@ -87,6 +87,77 @@ describe('http/util/rewriter', () => {
       expect(result).toContain('<html> <head> <script')
     })
 
+    it('does not inject into a commented-out bootstrap script', async () => {
+      const html = '<html><!-- <script data-cy-bootstrap></script> --><head><title>t</title></head><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      // The commented marker must survive untouched and the injection must
+      // land in the real head
+      expect(result).toContain('<!-- <script data-cy-bootstrap></script> -->')
+      expect(result).toContain('<head> <script')
+    })
+
+    it('does not treat <!-- inside a quoted attribute as a comment', async () => {
+      const html = '<html><head id="real" data-marker="<!--"><title>t</title></head><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      // The real head, including its attributes, must be the injection point
+      expect(result).toContain('<head id="real" data-marker="<!--"> <script')
+      expect(result).not.toContain('<html> <head> <script')
+    })
+
+    it('handles abruptly closed comments before the injection point', async () => {
+      const html = '<html><!--><head id="real"><title>t</title></head><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      expect(result).toContain('<head id="real"> <script')
+    })
+
+    it('handles comments closed with --!> before the injection point', async () => {
+      const html = '<html><!-- <head></head> --!><head id="real"><title>t</title></head><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      expect(result).toContain('<head id="real"> <script')
+    })
+
+    it('does not treat a commented-out <html> as the injection point', async () => {
+      const html = '<!-- <html> -->\n<html id="real"><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      expect(result).toContain('<!-- <html> -->')
+      expect(result.indexOf('<script')).toBeGreaterThan(result.indexOf('<html id="real">'))
+    })
+
     it('preserves existing attributes on developer-provided script tag', async () => {
       const html = '<html><head><script data-cy-bootstrap id="cy-bootstrap" nonce="existing"></script></head><body></body></html>'
       const opts = {

--- a/packages/proxy/test/unit/http/util/rewriter.spec.ts
+++ b/packages/proxy/test/unit/http/util/rewriter.spec.ts
@@ -42,6 +42,51 @@ describe('http/util/rewriter', () => {
       expect(result).toContain('document.domain')
     })
 
+    it('does not inject into a commented-out <head>', async () => {
+      // https://github.com/cypress-io/cypress/issues/33000
+      const html = '<html>\n<!-- <head>\n<title>Test</title>\n</head> -->\n</html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      // The comment must survive untouched, with the injection placed in a
+      // real <head> after the <html> tag
+      expect(result).toContain('<!-- <head>\n<title>Test</title>\n</head> -->')
+      expect(result).toContain('<html> <head> <script')
+    })
+
+    it('does not treat a commented-out <body> as the injection point', async () => {
+      const html = '<html><!-- <body></body> --><body></body></html>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      expect(result).toContain('<!-- <body></body> -->')
+      expect(result).toContain('</head> <body>')
+      expect(result.indexOf('<script')).toBeGreaterThan(result.indexOf('-->'))
+    })
+
+    it('ignores an unterminated comment when picking the injection point', async () => {
+      const html = '<html><!-- <head></head><body>'
+      const opts = {
+        domainName: 'localhost',
+        wantsInjection: 'full',
+        shouldInjectDocumentDomain: true,
+      } as any
+
+      const result = await rewriter.html(html, opts)
+
+      expect(result).toContain('<html> <head> <script')
+    })
+
     it('preserves existing attributes on developer-provided script tag', async () => {
       const html = '<html><head><script data-cy-bootstrap id="cy-bootstrap" nonce="existing"></script></head><body></body></html>'
       const opts = {


### PR DESCRIPTION
- Closes #33000

### Additional details

The proxy's html rewriter picks its injection point by running `headRe`/`bodyRe`/`htmlRe`/`doctypeRe` over the raw response body, so a `<head>` inside an HTML comment becomes the injection target: the Cypress script lands inside the comment and a stray real `<head></head>` gets emitted, corrupting the page.

Instead of trying to make each regex comment-aware (the direction previous attempts took), the rewriter now masks comment ranges with same-length whitespace, matches against the masked copy, and splices into the original string by index (the insert helpers only use `match.index`/`match[0].length`, which stay aligned). An unterminated `<!--` masks to the end of the document, matching how browsers treat it. The `data-cy-bootstrap` path is unchanged.

### Steps to test

Run the spec from the issue:

```js
cy.intercept('/app', { body: '<html><!-- <head><title>Test</title></head> --></html>' })
cy.visit('/app')
```

The comment now survives untouched and the injection lands in a real `<head>` placed after `<html>`. Unit coverage: `packages/proxy/test/unit/http/util/rewriter.spec.ts` (3 new specs covering commented head, commented body before a real body, and an unterminated comment; all 3 fail without the fix, 6/6 pass with it).

### How has the user experience changed?

Pages containing commented-out `<head>`/`<body>`/`<html>` tags are no longer corrupted by the proxy. Before/after of the served HTML for the issue's repro:

Before: `<html><!-- <head> <script>CYPRESS_INJECTION()</script><title>Test</title></head> --><head> </head></html>`
After: `<html> <head> <script>CYPRESS_INJECTION()</script> </head><!-- <head><title>Test</title></head> --></html>`

### PR Tasks

- [x] Have tests been added/updated?
- [x] Has the original issue or this PR been tagged in a release with [cypress-documentation](https://github.com/cypress-io/cypress-documentation)? N/A
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? N/A
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? N/A
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? N/A