### PR TITLE
fix(server): don't trash the project when an assets folder resolves to it

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where setting [`downloadsFolder`](https://on.cypress.io/configuration#Downloads) to a value that resolves to the project root or a parent directory — such as an empty string or `../` — could delete the entire project (including the `.git` directory) during `cypress run`. Cypress now leaves such folders untouched instead of trashing them. This also applies to the [`videosFolder`](https://on.cypress.io/configuration#Videos) and [`screenshotsFolder`](https://on.cypress.io/configuration#Screenshots) configuration options. Fixes [#26393](https://github.com/cypress-io/cypress/issues/26393).
 - Fixed an issue where, on Windows, enhancing a test failure stack could throw a secondary `TypeError: Cannot read properties of undefined (reading 'replaceAll')` and mask the original error. Fixed in [#34252](https://github.com/cypress-io/cypress/pull/34252).
 - Fixed an issue where [`experimentalMemoryManagement`](https://on.cypress.io/experiments) could fail to prevent the browser from running out of memory and crashing when Cypress was running inside a memory-limited container. Memory is now managed correctly in these environments. Fixes [#34104](https://github.com/cypress-io/cypress/issues/34104). Addressed in [#34123](https://github.com/cypress-io/cypress/pull/34123).
 

--- a/packages/server/lib/modes/run.ts
+++ b/packages/server/lib/modes/run.ts
@@ -225,11 +225,29 @@ async function trashAssets (config: Cfg) {
     return
   }
 
+  const trashAssetFolder = (folder: string | false | undefined) => {
+    if (typeof folder !== 'string') {
+      return Promise.resolve()
+    }
+
+    // A misconfigured assets folder (e.g. `downloadsFolder: ''` resolves to the
+    // project root and `'../'` to its parent) would trash the user's project.
+    // Warn and skip rather than deleting it.
+    // See https://github.com/cypress-io/cypress/issues/26393
+    if (trash.wouldTrashProjectRoot(folder, config.projectRoot)) {
+      errors.warning('CANNOT_TRASH_ASSETS', new Error(`Refusing to trash '${folder}' because it is the project root or a parent of it.`))
+
+      return Promise.resolve()
+    }
+
+    return trash.folder(folder)
+  }
+
   try {
     await Promise.all([
-      trash.folder(config.videosFolder),
-      typeof config.screenshotsFolder === 'string' ? trash.folder(config.screenshotsFolder) : Promise.resolve(),
-      trash.folder(config.downloadsFolder),
+      trashAssetFolder(config.videosFolder),
+      trashAssetFolder(config.screenshotsFolder),
+      trashAssetFolder(config.downloadsFolder),
     ])
   } catch (err) {
     // dont make trashing assets fail the build

--- a/packages/server/lib/util/trash.ts
+++ b/packages/server/lib/util/trash.ts
@@ -20,6 +20,27 @@ const trashItem = async (itemPath: string): Promise<void> => {
   }
 }
 
+// True when trashing `folderToTrash` would remove the project itself — i.e. the
+// folder is the project root or an ancestor of it. Guards against a
+// misconfigured assets folder, e.g. `downloadsFolder: ''` resolves to the
+// project root and `'../'` to its parent, either of which would empty the whole
+// project (including .git). See https://github.com/cypress-io/cypress/issues/26393
+export const wouldTrashProjectRoot = (folderToTrash: string, projectRoot: string): boolean => {
+  const resolvedFolder = path.resolve(folderToTrash)
+  const resolvedProjectRoot = path.resolve(projectRoot)
+
+  if (resolvedFolder === resolvedProjectRoot) {
+    return true
+  }
+
+  // The project root resolves to a location inside the folder we are about to
+  // trash, so the folder is an ancestor of the project. Mirrors the isInsideDir
+  // path-traversal idiom used elsewhere in the server package.
+  const relativeToFolder = path.relative(resolvedFolder, resolvedProjectRoot)
+
+  return relativeToFolder !== '' && !relativeToFolder.startsWith('..') && !path.isAbsolute(relativeToFolder)
+}
+
 // Moves a folder's contents to the trash (or empties it on Linux)
 export const folder = async (pathToFolder: string): Promise<void> => {
   try {
@@ -47,4 +68,5 @@ export const folder = async (pathToFolder: string): Promise<void> => {
 
 export default {
   folder,
+  wouldTrashProjectRoot,
 }

--- a/packages/server/test/unit/util/trash_spec.ts
+++ b/packages/server/test/unit/util/trash_spec.ts
@@ -124,4 +124,44 @@ describe('lib/util/trash', () => {
       fs.rmdirSync(basePath)
     })
   })
+
+  context('.wouldTrashProjectRoot', () => {
+    // Guards against https://github.com/cypress-io/cypress/issues/26393, where a
+    // misconfigured assets folder resolves to the project root (or an ancestor)
+    // and trashing it wipes the whole project. These are pure path checks, so no
+    // directories need to exist on disk.
+    let projectRoot: string
+
+    beforeEach(() => {
+      projectRoot = path.join(tempDir, 'my-project')
+    })
+
+    it('returns true when the folder is the project root (e.g. downloadsFolder: "")', () => {
+      expect(trash.wouldTrashProjectRoot(projectRoot, projectRoot)).to.be.true
+    })
+
+    it('returns true when the folder is the parent of the project root (e.g. downloadsFolder: "../")', () => {
+      expect(trash.wouldTrashProjectRoot(path.resolve(projectRoot, '..'), projectRoot)).to.be.true
+    })
+
+    it('returns true when the folder is a distant ancestor of the project root', () => {
+      expect(trash.wouldTrashProjectRoot(path.resolve(projectRoot, '..', '..'), projectRoot)).to.be.true
+    })
+
+    it('returns false for a folder nested inside the project root', () => {
+      expect(trash.wouldTrashProjectRoot(path.join(projectRoot, 'cypress', 'downloads'), projectRoot)).to.be.false
+    })
+
+    it('returns false for a child folder whose name starts with ".."', () => {
+      expect(trash.wouldTrashProjectRoot(path.join(projectRoot, '..downloads'), projectRoot)).to.be.false
+    })
+
+    it('returns false for a sibling folder outside the project root', () => {
+      expect(trash.wouldTrashProjectRoot(path.resolve(projectRoot, '..', 'other-downloads'), projectRoot)).to.be.false
+    })
+
+    it('returns false for an unrelated absolute path', () => {
+      expect(trash.wouldTrashProjectRoot(path.resolve(tempDir, 'somewhere', 'else'), path.join(tempDir, 'project'))).to.be.false
+    })
+  })
 })


### PR DESCRIPTION
- Closes #26393

### Additional details

Setting `downloadsFolder` to a value that resolves to the project root or a parent directory — for example an empty string (`downloadsFolder: ''`) or `'../'` — could delete the entire project, including the `.git` directory, when running `cypress run`.

**Why this happens:** every `isFolder` config option is resolved with `path.resolve(projectRoot, value)`, so `downloadsFolder: ''` resolves to exactly the project root and `'../'` to its parent. When `trashAssetsBeforeRuns` is enabled (the default), `trashAssets()` in `packages/server/lib/modes/run.ts` calls `trash.folder()` on that path, which empties the directory (`fs.emptyDir` on Linux, item-by-item trash elsewhere) — wiping the project. `videosFolder` had the same exposure; only `screenshotsFolder` had a partial guard.

**The fix:** a new pure helper `trash.wouldTrashProjectRoot(folderToTrash, projectRoot)` returns `true` when a folder is the project root or an ancestor of it (mirroring the existing `isInsideDir` path idiom used in the server package). `trashAssets` now routes all three asset folders through a guard that skips any unsafe folder and emits the existing `CANNOT_TRASH_ASSETS` warning instead of deleting it. The run continues; only the unsafe trash operation is skipped. No new error template is introduced.

### Steps to test

1. In a Cypress project's config, set `downloadsFolder: ''` (or `'../'`) with `trashAssetsBeforeRuns` enabled (the default).
2. Run `npx cypress run`.
3. **Before this change:** the project directory is emptied (including `.git`) and the run fails to find spec files.
4. **After this change:** the project is left intact; a `CANNOT_TRASH_ASSETS` warning notes that the folder was not trashed because it is the project root or a parent of it.

Unit tests for the new guard:

```
yarn workspace @packages/server test-unit -- packages/server/test/unit/util/trash_spec.ts
```

### How has the user experience changed?

No visual change. Behaviorally, a misconfigured `downloadsFolder`/`videosFolder`/`screenshotsFolder` that resolves to the project root or a parent directory no longer causes `cypress run` to delete the user's project; the unsafe trash is skipped and a warning is emitted.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #26393 is maintainer-triaged and confirmed (labels: Triaged, type: bug, type: unexpected behavior). Submitted as a data-loss safety fix for maintainer review. -->
- [x] Have tests been added/updated? <!-- Unit tests added in packages/server/test/unit/util/trash_spec.ts -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- Bug/safety fix; no new or changed documented API. Changelog entry added in cli/CHANGELOG.md. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No public API or type-definition changes; internal safety guard only. -->