### PR TITLE
fix(server): read cgroup v1 memory stats without spawning subprocesses

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Fixed a regression in [14.0.0](#14-0-0) where each message sent from the Cypress server to a Chromium-based browser (including Electron) leaked a small amount of browser memory until the end of the spec. During long, command- or network-heavy specs, this buildup could crash the browser (`We detected that the Chrome Renderer process just crashed`). Fixes [#34226](https://github.com/cypress-io/cypress/issues/34226).
 - Fixed an issue where each [`cy.press()`](https://on.cypress.io/press) call in Chromium-based browsers retained a small amount of renderer memory for the remainder of the spec file, which could contribute to memory growth in specs with many `cy.press()` calls. Addressed in [#34240](https://github.com/cypress-io/cypress/pull/34240).
+- Reduced the CPU overhead of [`experimentalMemoryManagement`](https://on.cypress.io/experiments) on Linux systems using cgroup v1, such as older CI containers. The memory profiler samples memory roughly once per second for the entire run, and each sample is now significantly cheaper, so it competes less with the tests themselves for CPU. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105).
 
 **Features:**
 

--- a/packages/server/lib/browsers/memory/cgroup-v1.ts
+++ b/packages/server/lib/browsers/memory/cgroup-v1.ts
@@ -1,24 +1,21 @@
-import { exec } from 'child_process'
-import util from 'util'
+import fs from 'fs-extra'
 import { parseMemoryStat, availableFromWorkingSet } from './cgroup-util'
 import type { MemoryLog } from './cgroup-util'
 
-const execAsync = util.promisify(exec)
-
 // Returns the total memory limit in bytes from the memory cgroup.
 const getTotalMemoryLimit = async () => {
-  return Number((await execAsync('cat /sys/fs/cgroup/memory/memory.limit_in_bytes', { encoding: 'utf8' })).stdout)
+  return Number(await fs.readFile('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8'))
 }
 
 // Returns the available memory in bytes from the memory cgroup.
 const getAvailableMemory = async (totalMemoryLimit: number, log?: MemoryLog) => {
   // retrieve the memory usage and memory stats from the memory cgroup
-  const [usageExec, rawStats] = await Promise.all([
-    execAsync('cat /sys/fs/cgroup/memory/memory.usage_in_bytes', { encoding: 'utf8' }),
-    execAsync('cat /sys/fs/cgroup/memory/memory.stat', { encoding: 'utf8' }),
+  const [usage, rawStats] = await Promise.all([
+    fs.readFile('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'utf8'),
+    fs.readFile('/sys/fs/cgroup/memory/memory.stat', 'utf8'),
   ])
 
-  return availableFromWorkingSet(totalMemoryLimit, Number(usageExec.stdout), parseMemoryStat(rawStats.stdout).total_inactive_file, log)
+  return availableFromWorkingSet(totalMemoryLimit, Number(usage), parseMemoryStat(rawStats).total_inactive_file, log)
 }
 
 export default {

--- a/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
+++ b/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
@@ -1,22 +1,13 @@
 const { expect, sinon } = require('../../../spec_helper')
 
-import util from 'util'
+import fs from 'fs-extra'
+
+const memory = require('../../../../lib/browsers/memory/cgroup-v1').default
 
 describe('lib/browsers/memory/cgroup-v1', () => {
-  let mockExec
-  let memory
-
-  before(async () => {
-    mockExec = sinon.stub()
-
-    sinon.stub(util, 'promisify').returns(mockExec)
-
-    memory = require('../../../../lib/browsers/memory/cgroup-v1').default
-  })
-
   context('#getTotalMemoryLimit', () => {
     it('returns total memory limit from limit_in_bytes', async () => {
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.limit_in_bytes', { encoding: 'utf8' }).resolves({ stdout: '100' })
+      sinon.stub(fs, 'readFile').withArgs('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8').resolves('100\n')
 
       expect(await memory.getTotalMemoryLimit()).to.eq(100)
     })
@@ -24,8 +15,10 @@ describe('lib/browsers/memory/cgroup-v1', () => {
 
   context('#getAvailableMemory', () => {
     it('returns available memory from cgroup', async () => {
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.usage_in_bytes').resolves({ stdout: '100' })
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.stat').resolves({ stdout: 'total_inactive_file 50' })
+      const readFile = sinon.stub(fs, 'readFile')
+
+      readFile.withArgs('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'utf8').resolves('100\n')
+      readFile.withArgs('/sys/fs/cgroup/memory/memory.stat', 'utf8').resolves('total_inactive_file 50\n')
 
       expect(await memory.getAvailableMemory(200)).to.eq(150)
     })


### PR DESCRIPTION
- Closes #34105

### Additional details

While `experimentalMemoryManagement` is active, the cgroup v1 memory handler shells out to `cat` through `execAsync` to read `memory.usage_in_bytes` and `memory.stat` on every sampling interval, which happens roughly once per second for the whole run. Spawning subprocesses that often adds CPU overhead that competes with the tests themselves, especially on constrained CI machines. The cgroup v2 handler already reads these files directly with `fs.readFile`, so this applies the same approach to the v1 handler and drops the subprocess calls.

### Steps to test

Covered by the updated unit tests in `cgroup-v1_spec.ts`. Run `yarn workspace @packages/server test-unit -- cgroup-v1_spec`.

### How has the user experience changed?

No change. Memory readings are identical, just without the subprocess spawns.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?