### PR TITLE
chore: merge develop into release/16.0.0

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -5,10 +5,10 @@ version: 2.1
 # the new location and/or names:
 # - ./scripts/github-actions/update-browser-versions.js
 
-chrome-stable-version: &chrome-stable-version "150.0.7871.114"
-chrome-beta-version: &chrome-beta-version "151.0.7922.19"
+chrome-stable-version: &chrome-stable-version "150.0.7871.124"
+chrome-beta-version: &chrome-beta-version "151.0.7922.34"
 # Pin from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json (channels.Stable)
-chrome-for-testing-stable-version: &chrome-for-testing-stable-version "150.0.7871.115"
+chrome-for-testing-stable-version: &chrome-for-testing-stable-version "151.0.7922.34"
 firefox-stable-version: &firefox-stable-version "152.0.5"
 base-internal-trixie: &base-internal-trixie cypress/base-internal:22.19.0-trixie
 base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Features:**
 
 - Added support for TypeScript 7 when preprocessing TypeScript spec and support files. The component testing setup wizard now accepts TypeScript 7 as well. Addresses [#34258](https://github.com/cypress-io/cypress/issues/34258). Addressed in [#34277](https://github.com/cypress-io/cypress/pull/34277).
+- Added support for additional assertion aliases: `.exists` (alias of `.exist`), `.greaterThanOrEqual` and `.lessThanOrEqual` (aliases of `.least` and `.most`), and `.oneOf` chained with `.contain` (for example `expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy'])`). These can be used anywhere Cypress assertions are written, such as `expect`, `assert`, and `cy.get(...).should(...)`. This comes from upgrading the bundled `chai` assertion library from `4.2.0` to `4.5.0`; all existing assertions and their messages behave the same. Addressed in [#34178](https://github.com/cypress-io/cypress/pull/34178).
 
 **Bugfixes:**
 

--- a/cli/types/cy-chai.d.ts
+++ b/cli/types/cy-chai.d.ts
@@ -6,6 +6,17 @@ declare namespace Chai {
     html(html: string): Assertion
     text(text: string): Assertion
     value(text: string): Assertion
+
+    /**
+     * Asserts that the target contains one of the values in the given list.
+     * Available when `.oneOf` is chained with `.contain` or `.include`.
+     *
+     * @example
+     *    expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy'])
+     *    expect([1, 2, 3]).to.contain.oneOf([3, 4, 5])
+     * @see http://chaijs.com/api/bdd/#method_oneof
+     */
+    oneOf(list: ReadonlyArray<any>, message?: string): Assertion
   }
 
   interface Assertion {
@@ -28,5 +39,35 @@ declare namespace Chai {
      * @see http://chaijs.com/plugins/chai-jquery/#focus
      */
     focused: Assertion
+
+    /**
+     * Asserts that the target is neither `null` nor `undefined`. Alias of `.exist`.
+     *
+     * @example
+     *    expect(0).to.exists
+     *    expect('').to.exists
+     * @see http://chaijs.com/api/bdd/#method_exist
+     */
+    exists: Assertion
+
+    /**
+     * Asserts that the target is a number or a date greater than or equal to the
+     * given number or date. Alias of `.least` (`.gte`).
+     *
+     * @example
+     *    expect(2).to.be.greaterThanOrEqual(1)
+     * @see http://chaijs.com/api/bdd/#method_least
+     */
+    greaterThanOrEqual: NumberComparer
+
+    /**
+     * Asserts that the target is a number or a date less than or equal to the
+     * given number or date. Alias of `.most` (`.lte`).
+     *
+     * @example
+     *    expect(1).to.be.lessThanOrEqual(2)
+     * @see http://chaijs.com/api/bdd/#method_most
+     */
+    lessThanOrEqual: NumberComparer
   }
 }

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -4300,6 +4300,16 @@ declare namespace Cypress {
      */
     (chainer: 'be.gte', value: number): Chainable<Subject>
     /**
+     * Asserts that the target is a number or a `n` date greater than or equal to the given number or date n respectively.
+     * However, it's often best to assert that the target is equal to its expected value.
+     * @example
+     *    cy.wrap(6).should('be.greaterThanOrEqual', 5)
+     * @alias least
+     * @see http://chaijs.com/api/bdd/#method_least
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.greaterThanOrEqual', value: number): Chainable<Subject>
+    /**
      * Asserts that the target is a number or a `n` date less than or equal to the given number or date n respectively.
      * However, it's often best to assert that the target is equal to its expected value.
      * @example
@@ -4329,6 +4339,16 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'be.lte', value: number): Chainable<Subject>
+    /**
+     * Asserts that the target is a number or a date less than or equal to the given number or date n respectively.
+     * However, it's often best to assert that the target is equal to its expected value.
+     * @example
+     *    cy.wrap(4).should('be.lessThanOrEqual', 5)
+     * @alias most
+     * @see http://chaijs.com/api/bdd/#method_most
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'be.lessThanOrEqual', value: number): Chainable<Subject>
     /**
      * Asserts that the target is loosely (`==`) equal to `true`. However, it's often best to assert that the target is strictly (`===`) or deeply equal to its expected value.
      * @example
@@ -4909,6 +4929,16 @@ declare namespace Cypress {
      */
     (chainer: 'not.be.gte', value: number): Chainable<Subject>
     /**
+     * Asserts that the target is not a number or a `n` date greater than or equal to the given number or date n respectively.
+     * However, it's often best to assert that the target is equal to its expected value.
+     * @example
+     *    cy.wrap(6).should('not.be.greaterThanOrEqual', 7)
+     * @alias least
+     * @see http://chaijs.com/api/bdd/#method_least
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.greaterThanOrEqual', value: number): Chainable<Subject>
+    /**
      * Asserts that the target is not a number or a `n` date less than or equal to the given number or date n respectively.
      * However, it's often best to assert that the target is equal to its expected value.
      * @example
@@ -4938,6 +4968,16 @@ declare namespace Cypress {
      * @see https://on.cypress.io/assertions
      */
     (chainer: 'not.be.lte', value: number): Chainable<Subject>
+    /**
+     * Asserts that the target is not a number or a date less than or equal to the given number or date n respectively.
+     * However, it's often best to assert that the target is equal to its expected value.
+     * @example
+     *    cy.wrap(4).should('not.be.lessThanOrEqual', 3)
+     * @alias most
+     * @see http://chaijs.com/api/bdd/#method_most
+     * @see https://on.cypress.io/assertions
+     */
+    (chainer: 'not.be.lessThanOrEqual', value: number): Chainable<Subject>
     /**
      * Asserts that the target is not loosely (`==`) equal to `true`. However, it's often best to assert that the target is strictly (`===`) or deeply equal to its expected value.
      * @example

--- a/cli/types/tests/chainer-examples.ts
+++ b/cli/types/tests/chainer-examples.ts
@@ -156,6 +156,16 @@ expect(Cypress.$('#result')).to.be.focused
 expect(Cypress.$('#result')).to.not.have.focus
 expect(Cypress.$('#result')).to.not.be.focused
 
+// Ensure the chai assertion aliases are typed
+expect(1).to.exists
+expect(2).to.be.greaterThanOrEqual(1)
+expect(1).to.be.lessThanOrEqual(2)
+expect('foo').to.contain.oneOf(['foo', 'bar'])
+cy.wrap(6).should('be.greaterThanOrEqual', 5)
+cy.wrap(4).should('be.lessThanOrEqual', 5)
+cy.wrap(6).should('not.be.greaterThanOrEqual', 7)
+cy.wrap(4).should('not.be.lessThanOrEqual', 3)
+
 cy.wrap([1, 2, 3]).should('include.members', [1, 2])
 ;
 () => {

--- a/packages/app/cypress/e2e/runner/reporter-ct-generator.ts
+++ b/packages/app/cypress/e2e/runner/reporter-ct-generator.ts
@@ -363,7 +363,7 @@ export const generateCtErrorTests = (server: 'Webpack' | 'Vite', configFile: str
 
       verify('from chai assert', {
         column: [12, 13],
-        message: 'object tested must be an array',
+        message: 'is invalid for this assertion',
       })
     })
 

--- a/packages/app/cypress/e2e/runner/reporter.command_errors.cy.ts
+++ b/packages/app/cypress/e2e/runner/reporter.command_errors.cy.ts
@@ -372,7 +372,7 @@ describe('errors ui', {
 
     verify('from chai assert', {
       column: 12,
-      message: 'object tested must be an array',
+      message: 'is invalid for this assertion',
     })
   })
 

--- a/packages/app/cypress/e2e/studio/helper.ts
+++ b/packages/app/cypress/e2e/studio/helper.ts
@@ -1,10 +1,14 @@
 import type { ProjectFixtureDir } from '@tooling/system-tests'
 
-export function loadProjectAndRunSpec ({ projectName = 'studio' as ProjectFixtureDir, specName = 'spec.cy.js', cliArgs = [''], specSelector = 'data-cy-row' } = {}) {
+export function loadProjectAndRunSpec ({ projectName = 'studio' as ProjectFixtureDir, specName = 'spec.cy.js', cliArgs = [''], specSelector = 'data-cy-row', shouldLogin = false } = {}) {
   cy.viewport(1500, 1000)
 
   cy.scaffoldProject(projectName)
   cy.openProject(projectName, cliArgs)
+
+  if (shouldLogin) {
+    cy.loginUser()
+  }
 
   cy.startAppServer('e2e')
   cy.visitApp()
@@ -20,8 +24,8 @@ export function openNewTestFromSpecHeader () {
   cy.get('[data-cy="runnable-popover-new-test"]').click()
 }
 
-export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite = false, createNewTestFromSpecHeader = false, cliArgs = [''] } = {}) {
-  loadProjectAndRunSpec({ specName, cliArgs })
+export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite = false, createNewTestFromSpecHeader = false, cliArgs = [''], afterLaunch = () => {}, shouldLogin = false }: { specName?: string, createNewTestFromSuite?: boolean, createNewTestFromSpecHeader?: boolean, cliArgs?: string[], afterLaunch?: () => void, shouldLogin?: boolean } = {}) {
+  loadProjectAndRunSpec({ specName, cliArgs, shouldLogin })
 
   const testTitle = 'visits a basic html page'
 
@@ -33,6 +37,8 @@ export function launchStudio ({ specName = 'spec.cy.js', createNewTestFromSuite 
 
   cy.get('@item')
   .closest('.runnable-wrapper').as('runnable-wrapper')
+
+  afterLaunch?.()
 
   if (createNewTestFromSuite || createNewTestFromSpecHeader) {
     if (createNewTestFromSpecHeader) {

--- a/packages/app/cypress/e2e/studio/studio-ui.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-ui.cy.ts
@@ -173,7 +173,7 @@ describe('studio functionality', () => {
     cy.location().its('hash').should('contain', 'suiteId=r1').and('not.contain', 'testId=')
   })
 
-  it('opens a cloud studio session with AI enabled', () => {
+  it('opens a cloud studio session with AI enabled for a logged in user', () => {
     cy.mockNodeCloudRequest({
       url: '/studio/config?projectSlug=n69px6',
       method: 'get',
@@ -208,7 +208,7 @@ describe('studio functionality', () => {
       url: 'http://localhost:3000/cypress/e2e/index.html',
     })
 
-    launchStudio()
+    launchStudio({ shouldLogin: true })
 
     // expand the recommendation
     cy.get('[aria-label="Expand recommendation"]').first().click()

--- a/packages/driver/cypress/e2e/commands/assertions.cy.js
+++ b/packages/driver/cypress/e2e/commands/assertions.cy.js
@@ -800,6 +800,37 @@ describe('src/cy/commands/assertions', () => {
     })
   })
 
+  // Smoke tests for vanilla chai assertion aliases (chai owns their behavior);
+  // we only verify they're reachable through Cypress's expect/assert/should
+  // surfaces.
+  context('chai aliases', () => {
+    it('exists is an alias of exist', () => {
+      expect(0).to.exists
+      expect(null).to.not.exists
+      cy.wrap('foo').should('exist')
+    })
+
+    it('greaterThanOrEqual is an alias of least/gte', () => {
+      expect(2).to.be.greaterThanOrEqual(1)
+      expect(2).to.be.greaterThanOrEqual(2)
+      expect(2).to.not.be.greaterThanOrEqual(3)
+      cy.wrap(2).should('be.greaterThanOrEqual', 2)
+    })
+
+    it('lessThanOrEqual is an alias of most/lte', () => {
+      expect(1).to.be.lessThanOrEqual(2)
+      expect(2).to.be.lessThanOrEqual(2)
+      expect(2).to.not.be.lessThanOrEqual(1)
+      cy.wrap(1).should('be.lessThanOrEqual', 2)
+    })
+
+    it('oneOf can be chained with contain', () => {
+      expect('Today is sunny').to.contain.oneOf(['sunny', 'cloudy'])
+      expect([1, 2, 3]).to.contain.oneOf([3, 4, 5])
+      expect([1, 2, 3]).to.not.contain.oneOf([4, 5, 6])
+    })
+  })
+
   context('#assert', () => {
     beforeEach(function () {
       this.logs = []
@@ -1326,6 +1357,51 @@ describe('src/cy/commands/assertions', () => {
         )
       })
     })
+
+    // Cypress renders and truncates values in assertion messages with its own
+    // inspector rather than chai's built-in one. These render differently under
+    // chai's inspector (e.g. `[Function foo]`, ISO-8601 dates, and
+    // `{ name: 'Joe', …(1) }` instead of `{ Object (name, ...) }` once past the
+    // truncateThreshold), so these assertions catch a regression that would
+    // change failure messages.
+    describe('uses Cypress value inspection', () => {
+      const getAssertionError = (test) => {
+        try {
+          test()
+        } catch (err) {
+          return err
+        }
+
+        throw new Error('expected the assertion to throw, but it did not')
+      }
+
+      it('renders functions as [Function: name]', () => {
+        const foo = function foo () {}
+        const bar = function bar () {}
+
+        const err = getAssertionError(() => expect(foo).to.equal(bar))
+
+        expect(err.message).to.eq('expected [Function: foo] to equal [Function: bar]')
+      })
+
+      it('renders dates with toUTCString', () => {
+        const err = getAssertionError(() => expect(new Date(0)).to.equal(new Date(1)))
+
+        expect(err.message).to.eq('expected Thu, 01 Jan 1970 00:00:00 GMT to equal Thu, 01 Jan 1970 00:00:00 GMT')
+      })
+
+      it('truncates long objects past the truncateThreshold', () => {
+        const err = getAssertionError(() => expect({ name: 'Joe', age: 20, email: 'joe@example.com' }).to.equal(null))
+
+        expect(err.message).to.eq('expected { Object (name, age, ...) } to equal null')
+      })
+
+      it('truncates long arrays past the truncateThreshold', () => {
+        const err = getAssertionError(() => expect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]).to.equal(null))
+
+        expect(err.message).to.eq('expected [ Array(15) ] to equal null')
+      })
+    })
   })
 
   context('chai overrides', () => {
@@ -1430,6 +1506,28 @@ describe('src/cy/commands/assertions', () => {
         })
 
         cy.get('#does-not-exist').should('not.exist')
+      })
+
+      // chai's `exists` alias is a separate property from `exist`, so verify it
+      // gets Cypress's DOM-aware existence behavior and not chai's nullish check
+      // (an empty jQuery object is non-null, so vanilla chai would pass `exists`).
+      it('uses DOM existence behavior for the exists alias', (done) => {
+        cy.on('log:added', (attrs, log) => {
+          if (attrs.name === 'assert') {
+            cy.removeAllListeners('log:added')
+
+            expect(log.get('message')).to.eq('expected **#does-not-exist** not to exist in the DOM')
+
+            done()
+          }
+        })
+
+        cy.get('#does-not-exist').should('not.exists')
+      })
+
+      it('fails the exists alias for a detached jQuery subject', () => {
+        cy.wrap(cy.$$('<div></div>').appendTo('body')).should('exists')
+        cy.wrap(cy.$$('.non-existent')).should('not.exists')
       })
     })
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -50,7 +50,7 @@
     "bluebird": "3.5.3",
     "body-parser": "1.20.3",
     "bytes": "3.1.2",
-    "chai": "4.2.0",
+    "chai": "4.5.0",
     "chai-subset": "1.6.0",
     "clone": "2.1.2",
     "common-tags": "1.8.0",

--- a/packages/driver/src/cy/chai.ts
+++ b/packages/driver/src/cy/chai.ts
@@ -82,6 +82,7 @@ chai.use((chai, u) => {
   const lengthProto = (chai.Assertion.prototype as any).__methods.length.method
   const containProto = (chai.Assertion.prototype as any).__methods.contain.method
   const existProto = Object.getOwnPropertyDescriptor(chai.Assertion.prototype, 'exist')!.get
+  const existsProto = Object.getOwnPropertyDescriptor(chai.Assertion.prototype, 'exists')!.get
   const { objDisplay } = chai.util
 
   const getMessage = chai.util.getMessage
@@ -172,8 +173,9 @@ chai.use((chai, u) => {
     (chai.Assertion.prototype as any).match = matchProto;
     (chai.Assertion.prototype as any).__methods.length.method = lengthProto;
     (chai.Assertion.prototype as any).__methods.contain.method = containProto
+    Object.defineProperty(chai.Assertion.prototype, 'exist', { get: existProto })
 
-    return Object.defineProperty(chai.Assertion.prototype, 'exist', { get: existProto })
+    return Object.defineProperty(chai.Assertion.prototype, 'exists', { get: existsProto })
   }
 
   const overrideChaiInspect = () => {
@@ -242,9 +244,7 @@ chai.use((chai, u) => {
       return (flagMsg ? `${flagMsg}: ${msg}` : msg)
     }
 
-    // There are 2 types of getMessage. And we're overriding the second one.
-    // But TypeScript wants us to do both. So we're ignoring this.
-    // @ts-ignore
+    // @ts-expect-error chai's getMessage has two overloads; we only override the (obj, args) one.
     chaiUtils.getMessage = function (assert, args) {
       const obj = assert._obj
 
@@ -312,9 +312,7 @@ chai.use((chai, u) => {
       })
     }
 
-    // `makeMethodChainable` doesn't match any type definition,
-    // but it is necessary to make the method chainable.
-    // @ts-ignore
+    // @ts-expect-error `makeMethodChainable` is necessary to make the method chainable but does not match the type definition.
     chai.Assertion.overwriteChainableMethod('contain', containFn1, makeMethodChainable)
 
     chai.Assertion.overwriteChainableMethod('length',
@@ -382,14 +380,12 @@ chai.use((chai, u) => {
           }
         })
       },
-      // `makeMethodChainable` doesn't match any type definition,
-      // but it is necessary to make the method chainable.
-      // @ts-ignore
+      // @ts-expect-error `makeMethodChainable` is necessary to make the method chainable but does not match the type definition.
       makeMethodChainable)
 
-    // _super is not documented.
-    // @ts-ignore
-    chai.Assertion.overwriteProperty('exist', (_super) => {
+    // chai registers `exist` and its `exists` alias as separate properties, so
+    // overwrite both to keep Cypress's DOM-aware existence behavior consistent.
+    const existAssertion = (_super) => {
       return (function () {
         const obj = this._obj
 
@@ -441,7 +437,10 @@ chai.use((chai, u) => {
           }
         }
       })
-    })
+    }
+
+    chai.Assertion.overwriteProperty('exist', existAssertion)
+    chai.Assertion.overwriteProperty('exists', existAssertion)
   }
 
   const captureUserInvocationStack = (specWindow: SpecWindow, state: StateFunc, ssfi) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12699,18 +12699,6 @@ chai-uuid@1.0.6:
   resolved "https://registry.yarnpkg.com/chai-uuid/-/chai-uuid-1.0.6.tgz#353a3b817dd66aa2608a0660faf68593fb918c8b"
   integrity sha1-NTo7gX3WaqJgigZg+vaFk/uRjIs=
 
-chai@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.0"
-    type-detect "^4.0.5"
-
 chai@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,7 +1539,7 @@
   dependencies:
     "@babel/types" "^7.24.7"
 
-"@babel/helper-member-expression-to-functions@^7.27.1", "@babel/helper-member-expression-to-functions@^7.29.7":
+"@babel/helper-member-expression-to-functions@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
   integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
@@ -1564,7 +1564,7 @@
     "@babel/helper-validator-identifier" "^7.29.7"
     "@babel/traverse" "^7.29.7"
 
-"@babel/helper-optimise-call-expression@^7.27.1", "@babel/helper-optimise-call-expression@^7.29.7":
+"@babel/helper-optimise-call-expression@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
   integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
@@ -1653,7 +1653,7 @@
   dependencies:
     "@babel/types" "^7.28.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.16.4", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.25.4", "@babel/parser@^7.26.9", "@babel/parser@^7.27.2", "@babel/parser@^7.27.5", "@babel/parser@^7.28.0", "@babel/parser@^7.28.3", "@babel/parser@^7.28.4", "@babel/parser@^7.29.7":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.16.4", "@babel/parser@^7.20.7", "@babel/parser@^7.23.0", "@babel/parser@^7.23.9", "@babel/parser@^7.25.4", "@babel/parser@^7.26.9", "@babel/parser@^7.27.5", "@babel/parser@^7.28.0", "@babel/parser@^7.28.4", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -2530,7 +2530,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.18.9", "@babel/traverse@^7.26.9", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.3", "@babel/traverse@^7.28.4", "@babel/traverse@^7.29.7":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.18.9", "@babel/traverse@^7.26.9", "@babel/traverse@^7.27.1", "@babel/traverse@^7.28.0", "@babel/traverse@^7.28.4", "@babel/traverse@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
   integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
@@ -2559,7 +2559,7 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.24.7", "@babel/types@^7.25.4", "@babel/types@^7.26.9", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.0", "@babel/types@^7.28.2", "@babel/types@^7.28.4", "@babel/types@^7.29.7", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.24.7", "@babel/types@^7.25.4", "@babel/types@^7.26.9", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.0", "@babel/types@^7.28.4", "@babel/types@^7.29.7", "@babel/types@^7.4.4":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
   integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
@@ -14581,13 +14581,6 @@ dedent@^1.6.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.0.tgz#c1f9445335f0175a96587be245a282ff451446ca"
   integrity sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==
 
-deep-eql@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
-  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
-  dependencies:
-    type-detect "^4.0.0"
-
 deep-eql@^4.1.3:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
@@ -17762,7 +17755,7 @@ get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.0:
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz#9bc4caa131702b4b61729cb7e42735bc550c9ee6"
   integrity sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==
 
-get-func-name@^2.0.0, get-func-name@^2.0.1, get-func-name@^2.0.2:
+get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -25859,7 +25852,7 @@ pathe@^2.0.1, pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-pathval@^1.1.0, pathval@^1.1.1:
+pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
@@ -31043,7 +31036,7 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8, type-detect@^4.1.0:
+type-detect@^4.0.0, type-detect@^4.0.8, type-detect@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
   integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
@@ -32554,9 +32547,9 @@ webpack@^5, webpack@^5.39.0, webpack@^5.88.2:
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
- Closes N/A

### Additional details

Routine merge of `develop` into `release/16.0.0` to keep the release branch up to date.

Merging `origin/develop` (`72cef528bf`) into `release/16.0.0` (`e7eb028ce5`) produced a single conflicting file:

- **`yarn.lock`** — three conflict hunks, all on the same pattern: the resolved-version block for `@babel/parser@7.29.7`, `@babel/traverse@7.29.7`, and `@babel/types@7.29.7` each had a semver-range key list that differed only in whether `^7.26.9` was present (added on the `develop` side). In every case the resolved `version`/`resolved`/`integrity` values were identical between the two sides — `develop`'s range-key list was a strict superset of `release/16.0.0`'s. Resolved by keeping `develop`'s (superset) range-key line for each of the three blocks, so the lockfile still correctly satisfies dependents from both branches. No other files conflicted; all other files merged automatically.

### Steps to test

- CI should pass as normal for this merge commit.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd3f8eNpAavRY7crpqVUu9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading chai and extending assertion overrides touches core `expect`/`should` behavior for all users; risk is mitigated by targeted overrides and regression tests but still warrants careful release QA.
> 
> **Overview**
> Syncs **`release/16.0.0`** with **`develop`**, bringing in the bundled **chai `4.2.0` → `4.5.0`** upgrade and related assertion work.
> 
> **Assertions:** Users gain chai **4.5** aliases (`.exists`, `.greaterThanOrEqual`, `.lessThanOrEqual`, `.contain.oneOf`) with updated **`cy-chai.d.ts`** / **`cypress.d.ts`** and changelog notes. The driver now applies Cypress’s **DOM-aware `exist` logic to the separate `exists` property** as well, with driver e2e coverage for aliases, DOM `exists` behavior, and **Cypress-specific failure message formatting** (functions, dates, truncated objects/arrays). Reporter specs expect a **generic chai assert error** (`is invalid for this assertion`) instead of the old array-specific message.
> 
> **Other:** Studio e2e helpers gain optional **`shouldLogin`** / **`afterLaunch`**; the cloud Studio AI test logs in before launch. CI pins **newer Chrome / Chrome-for-testing** versions. **`yarn.lock`** reflects the chai bump, broader `@babel/*` range keys, and minor transitive updates (e.g. **`websocket-driver`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550dfd4ed325a487df26044a9dc71fe2733e05ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->