### PR TITLE
test: migrate dev-server e2e specs to the reporter iframe

### DIFF
--- a/npm/vite-dev-server/cypress/e2e/react.cy.ts
+++ b/npm/vite-dev-server/cypress/e2e/react.cy.ts
@@ -26,8 +26,7 @@ for (const project of VITE_REACT) {
       cy.visitApp()
       cy.specsPageIsVisible()
       cy.contains('App.cy.jsx').click()
-      cy.waitForSpecToFinish()
-      cy.reporter().find('.passed > .num').should('contain', 2)
+      cy.waitForSpecToFinish({ passCount: 2 })
     })
 
     // AFAICT, vite 8 with rolldown support bundles react differently, so it is available in the "missing react" components and passes
@@ -41,15 +40,14 @@ for (const project of VITE_REACT) {
         cy.visitApp()
         cy.specsPageIsVisible()
         cy.contains('MissingReact.cy.jsx').click()
-        cy.waitForSpecToFinish()
-        cy.reporter().find('.failed > .num').should('contain', 1)
+        cy.waitForSpecToFinish({ failCount: 1 })
         cy.withCtx(async (ctx) => {
           await ctx.actions.file.writeFileInProject(`src/MissingReact.jsx`,
         `import React from 'react';
         ${await ctx.file.readFileInProject('src/MissingReact.jsx')}`)
         })
 
-        cy.reporter().find('.passed > .num').should('contain', 1)
+        cy.waitForSpecToFinish({ passCount: 1 })
       })
     }
 
@@ -64,15 +62,14 @@ for (const project of VITE_REACT) {
         cy.visitApp()
         cy.specsPageIsVisible()
         cy.contains('MissingReactInSpec.cy.jsx').click()
-        cy.waitForSpecToFinish()
-        cy.reporter().find('.failed > .num').should('contain', 1)
+        cy.waitForSpecToFinish({ failCount: 1 })
         cy.reporter().find('.test-err-code-frame').should('be.visible')
         cy.withCtx(async (ctx) => {
           await ctx.actions.file.writeFileInProject(`src/MissingReactInSpec.cy.jsx`,
             await ctx.file.readFileInProject('src/App.cy.jsx'))
         })
 
-        cy.reporter().find('.passed > .num').should('contain', 2)
+        cy.waitForSpecToFinish({ passCount: 2 })
       })
     }
 
@@ -85,8 +82,7 @@ for (const project of VITE_REACT) {
       cy.visitApp()
       cy.specsPageIsVisible()
       cy.contains('AppCompilationError.cy.jsx').click()
-      cy.waitForSpecToFinish()
-      cy.reporter().find('.failed > .num').should('contain', 1)
+      cy.waitForSpecToFinish({ failCount: 1 })
       cy.reporter().contains('An uncaught error was detected outside of a test')
       cy.reporter().contains('The following error originated from your test code, not from Cypress.')
 
@@ -98,8 +94,7 @@ for (const project of VITE_REACT) {
         )
       })
 
-      cy.waitForSpecToFinish()
-      cy.reporter().find('.passed > .num').should('contain', 2)
+      cy.waitForSpecToFinish({ passCount: 2 })
 
       const appCompilationErrorSpec = dedent`
         import React from 'react'
@@ -121,8 +116,7 @@ for (const project of VITE_REACT) {
         )
       }, { appCompilationErrorSpec })
 
-      cy.waitForSpecToFinish()
-      cy.reporter().find('.failed > .num').should('contain', 1)
+      cy.waitForSpecToFinish({ failCount: 1 })
       cy.reporter().contains('An uncaught error was detected outside of a test')
       cy.reporter().contains('The following error originated from your test code, not from Cypress.')
     })

--- a/npm/vite-dev-server/cypress/e2e/react.cy.ts
+++ b/npm/vite-dev-server/cypress/e2e/react.cy.ts
@@ -27,7 +27,7 @@ for (const project of VITE_REACT) {
       cy.specsPageIsVisible()
       cy.contains('App.cy.jsx').click()
       cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 2)
+      cy.reporter().find('.passed > .num').should('contain', 2)
     })
 
     // AFAICT, vite 8 with rolldown support bundles react differently, so it is available in the "missing react" components and passes
@@ -42,14 +42,14 @@ for (const project of VITE_REACT) {
         cy.specsPageIsVisible()
         cy.contains('MissingReact.cy.jsx').click()
         cy.waitForSpecToFinish()
-        cy.get('.failed > .num').should('contain', 1)
+        cy.reporter().find('.failed > .num').should('contain', 1)
         cy.withCtx(async (ctx) => {
           await ctx.actions.file.writeFileInProject(`src/MissingReact.jsx`,
         `import React from 'react';
         ${await ctx.file.readFileInProject('src/MissingReact.jsx')}`)
         })
 
-        cy.get('.passed > .num').should('contain', 1)
+        cy.reporter().find('.passed > .num').should('contain', 1)
       })
     }
 
@@ -65,14 +65,14 @@ for (const project of VITE_REACT) {
         cy.specsPageIsVisible()
         cy.contains('MissingReactInSpec.cy.jsx').click()
         cy.waitForSpecToFinish()
-        cy.get('.failed > .num').should('contain', 1)
-        cy.get('.test-err-code-frame').should('be.visible')
+        cy.reporter().find('.failed > .num').should('contain', 1)
+        cy.reporter().find('.test-err-code-frame').should('be.visible')
         cy.withCtx(async (ctx) => {
           await ctx.actions.file.writeFileInProject(`src/MissingReactInSpec.cy.jsx`,
             await ctx.file.readFileInProject('src/App.cy.jsx'))
         })
 
-        cy.get('.passed > .num').should('contain', 2)
+        cy.reporter().find('.passed > .num').should('contain', 2)
       })
     }
 
@@ -86,9 +86,9 @@ for (const project of VITE_REACT) {
       cy.specsPageIsVisible()
       cy.contains('AppCompilationError.cy.jsx').click()
       cy.waitForSpecToFinish()
-      cy.get('.failed > .num').should('contain', 1)
-      cy.contains('An uncaught error was detected outside of a test')
-      cy.contains('The following error originated from your test code, not from Cypress.')
+      cy.reporter().find('.failed > .num').should('contain', 1)
+      cy.reporter().contains('An uncaught error was detected outside of a test')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.')
 
       // Correct the problem
       cy.withCtx(async (ctx) => {
@@ -99,7 +99,7 @@ for (const project of VITE_REACT) {
       })
 
       cy.waitForSpecToFinish()
-      cy.get('.passed > .num').should('contain', 2)
+      cy.reporter().find('.passed > .num').should('contain', 2)
 
       const appCompilationErrorSpec = dedent`
         import React from 'react'
@@ -122,9 +122,9 @@ for (const project of VITE_REACT) {
       }, { appCompilationErrorSpec })
 
       cy.waitForSpecToFinish()
-      cy.get('.failed > .num').should('contain', 1)
-      cy.contains('An uncaught error was detected outside of a test')
-      cy.contains('The following error originated from your test code, not from Cypress.')
+      cy.reporter().find('.failed > .num').should('contain', 1)
+      cy.reporter().contains('An uncaught error was detected outside of a test')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.')
     })
   })
 }

--- a/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
+++ b/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
@@ -12,7 +12,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 1)
+    cy.reporter().find('.passed > .num').should('contain', 1)
     cy.withCtx(async (ctx) => {
       // Add a new spec with bg-blue-100 that asserts the style is correct
       // If HMR + Tailwind is working properly, it'll pass.
@@ -40,7 +40,7 @@ describe('Config options', () => {
     })
 
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 2)
+    cy.reporter().find('.passed > .num').should('contain', 2)
   })
 
   it('supports supportFile = false', () => {
@@ -53,7 +53,7 @@ describe('Config options', () => {
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
     // no support file means there is no mount function registered, so all tests should fail
-    cy.get('.failed > .num').should('contain', 2)
+    cy.reporter().find('.failed > .num').should('contain', 2)
   })
 
   it('supports serving files with whitespace', () => {
@@ -73,7 +73,7 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains(specWithWhitespace).click()
-    cy.get('.passed > .num').should('contain', 2)
+    cy.reporter().find('.passed > .num').should('contain', 2)
   })
 
   it('supports @cypress/vite-dev-server', () => {
@@ -85,7 +85,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 2)
+    cy.reporter().find('.passed > .num').should('contain', 2)
   })
 
   it('supports viteConfig as an async function', () => {
@@ -97,7 +97,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 2)
+    cy.reporter().find('.passed > .num').should('contain', 2)
     cy.withCtx(async (ctx) => {
       const verifyFile = await ctx.file.readFileInProject('wrote-to-file')
 
@@ -156,14 +156,14 @@ describe('sourcemaps', () => {
       cy.specsPageIsVisible()
       cy.contains(specName).click()
       cy.waitForSpecToFinish()
-      cy.get('.failed > .num').should('contain', 2)
-      cy.get('.runnable-err-file-path').eq(1).should('contain', `${specName}:${line}:${column}`)
+      cy.reporter().find('.failed > .num').should('contain', 2)
+      cy.reporter().find('.runnable-err-file-path').eq(1).should('contain', `${specName}:${line}:${column}`)
       cy.window().then((win) => {
         // @ts-expect-error
         cy.stub(win.getEventManager(), 'emit').as('emit')
       })
 
-      cy.get('.runnable-err-file-path', { timeout: 250 }).eq(1).as('filePath')
+      cy.reporter().find('.runnable-err-file-path', { timeout: 250 }).eq(1).as('filePath')
       cy.get('@filePath').should('contain', `${specName}:${line}:${column}`)
       cy.get('@filePath').then(($el) => {
         $el.find('span').trigger('click')

--- a/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
+++ b/npm/vite-dev-server/cypress/e2e/vite-dev-server.cy.ts
@@ -11,8 +11,7 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
-    cy.waitForSpecToFinish()
-    cy.reporter().find('.passed > .num').should('contain', 1)
+    cy.waitForSpecToFinish({ passCount: 1 })
     cy.withCtx(async (ctx) => {
       // Add a new spec with bg-blue-100 that asserts the style is correct
       // If HMR + Tailwind is working properly, it'll pass.
@@ -39,8 +38,7 @@ describe('Config options', () => {
       )
     })
 
-    cy.waitForSpecToFinish()
-    cy.reporter().find('.passed > .num').should('contain', 2)
+    cy.waitForSpecToFinish({ passCount: 2 })
   })
 
   it('supports supportFile = false', () => {
@@ -51,9 +49,8 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
-    cy.waitForSpecToFinish()
     // no support file means there is no mount function registered, so all tests should fail
-    cy.reporter().find('.failed > .num').should('contain', 2)
+    cy.waitForSpecToFinish({ failCount: 2 })
   })
 
   it('supports serving files with whitespace', () => {
@@ -73,7 +70,7 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains(specWithWhitespace).click()
-    cy.reporter().find('.passed > .num').should('contain', 2)
+    cy.waitForSpecToFinish({ passCount: 2 })
   })
 
   it('supports @cypress/vite-dev-server', () => {
@@ -84,8 +81,7 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
-    cy.waitForSpecToFinish()
-    cy.reporter().find('.passed > .num').should('contain', 2)
+    cy.waitForSpecToFinish({ passCount: 2 })
   })
 
   it('supports viteConfig as an async function', () => {
@@ -96,8 +92,7 @@ describe('Config options', () => {
     cy.visitApp()
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
-    cy.waitForSpecToFinish()
-    cy.reporter().find('.passed > .num').should('contain', 2)
+    cy.waitForSpecToFinish({ passCount: 2 })
     cy.withCtx(async (ctx) => {
       const verifyFile = await ctx.file.readFileInProject('wrote-to-file')
 
@@ -155,8 +150,7 @@ describe('sourcemaps', () => {
       cy.visitApp()
       cy.specsPageIsVisible()
       cy.contains(specName).click()
-      cy.waitForSpecToFinish()
-      cy.reporter().find('.failed > .num').should('contain', 2)
+      cy.waitForSpecToFinish({ failCount: 2 })
       cy.reporter().find('.runnable-err-file-path').eq(1).should('contain', `${specName}:${line}:${column}`)
       cy.window().then((win) => {
         // @ts-expect-error

--- a/npm/vite-dev-server/cypress/support/commands.ts
+++ b/npm/vite-dev-server/cypress/support/commands.ts
@@ -1,4 +1,7 @@
 /// <reference types="cypress" />
+import type { ExpectedResults } from '@packages/app/cypress/e2e/support/execute-spec'
+import { waitForSpecToFinish } from '@packages/app/cypress/e2e/support/execute-spec'
+import '@packages/app/cypress/e2e/support/reporter'
 
 declare global {
   namespace Cypress {
@@ -6,29 +9,13 @@ declare global {
       /**
        * Adapter to wait for a spec to finish in a standard way. It
        *
-       * 1. Waits for the stats to reset which signifies that the test page has loaded
-       * 2. Waits for 'Your tests are loading...' to not be present so that we know the tests themselves have loaded
-       * 3. Waits (with a timeout of 30s) for the restart button to be present (Rerun all tests / Run test in Studio single-test mode). This ensures all tests have completed.
+       * 1. Waits for 'Your tests are loading...' to not be present so that we know the tests themselves have loaded
+       * 2. Waits (with a timeout of 30s) for the restart button to be present (Rerun all tests / Run test in Studio single-test mode). This ensures all tests have completed.
        *
        */
-      waitForSpecToFinish()
+      waitForSpecToFinish(expectedResults?: ExpectedResults, timeout?: number): void
     }
   }
-}
-
-// Here we export the function with no intention to import it
-// This only tells the typescript type checker that this definitely is a module
-// This way, we are allowed to use the global namespace declaration
-export const waitForSpecToFinish = () => {
-  // First ensure the test is loaded
-  cy.get('.passed > .num').should('contain', '--')
-  cy.get('.failed > .num').should('contain', '--')
-
-  // Then ensure the tests are running
-  cy.contains('Your tests are loading...').should('not.exist')
-
-  // Wait for the restart button (shows "Rerun all tests" or "Run test" in Studio single-test mode)
-  cy.get('button.restart', { timeout: 30000 })
 }
 
 Cypress.Commands.add('waitForSpecToFinish', waitForSpecToFinish)

--- a/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/angular.cy.ts
@@ -51,7 +51,7 @@ for (const project of WEBPACK_ANGULAR) {
         cy.contains('app.component.cy.ts').click()
         cy.waitForSpecToFinish({ passCount: 1 }, 60000)
 
-        cy.get('li.command')
+        cy.reporter().find('li.command')
         .first()
         .within(() => {
           cy.get('.command-method').should('contain', 'mount')
@@ -117,11 +117,9 @@ for (const project of WEBPACK_ANGULAR) {
 
         // The test should fail and the stack trace should appear in the command log
         cy.waitForSpecToFinish({ failCount: 1 }, 60000)
-        cy.contains(
-          'The following error originated from your test code, not from Cypress.',
-        ).should('exist')
+        cy.reporter().contains('The following error originated from your test code, not from Cypress.').should('exist')
 
-        cy.get('.test-err-code-frame').should('be.visible')
+        cy.reporter().find('.test-err-code-frame').should('be.visible')
       })
 
       // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23455

--- a/npm/webpack-dev-server/cypress/e2e/next.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/next.cy.ts
@@ -41,7 +41,7 @@ for (const project of NEXT_PROJECTS) {
       })
 
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.get('.test-err-code-frame').should('be.visible')
+      cy.reporter().find('.test-err-code-frame').should('be.visible')
 
       cy.withCtx(async (ctx) => {
         const indexTestPath = ctx.path.join('pages', 'index.cy.js')
@@ -74,7 +74,7 @@ for (const project of NEXT_PROJECTS) {
 
       // The test should fail and the stack trace should appear in the command log
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.contains('The following error originated from your test code, not from Cypress.').should('exist')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.').should('exist')
     })
 
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23417
@@ -145,9 +145,9 @@ for (const project of NEXT_PROJECTS_TSCONFIG_TAILWIND) {
       cy.waitForSpecToFinish({ failCount: 1 })
       if (project !== 'next-15-tsconfig-tailwind' && project !== 'next-16-tsconfig-tailwind') {
         // code frames not fully working with next 15/16
-        cy.get('.test-err-code-frame').should('be.visible')
+        cy.reporter().find('.test-err-code-frame').should('be.visible')
       } else {
-        cy.get('.runnable-err-message').should('be.visible')
+        cy.reporter().find('.runnable-err-message').should('be.visible')
       }
 
       cy.withCtx(async (ctx) => {
@@ -181,7 +181,7 @@ for (const project of NEXT_PROJECTS_TSCONFIG_TAILWIND) {
 
       // The test should fail and the stack trace should appear in the command log
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.contains('The following error originated from your test code, not from Cypress.').should('exist')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.').should('exist')
     })
 
     it('should detect new spec', { retries: 15 }, () => {

--- a/npm/webpack-dev-server/cypress/e2e/react.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/react.cy.ts
@@ -38,7 +38,7 @@ for (const project of WEBPACK_REACT) {
       cy.specsPageIsVisible()
       cy.contains('MissingReact.cy.jsx').click()
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.get('.test-err-code-frame').should('be.visible')
+      cy.reporter().find('.test-err-code-frame').should('be.visible')
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject(`src/MissingReact.jsx`,
         `import React from 'react';
@@ -58,7 +58,7 @@ for (const project of WEBPACK_REACT) {
       cy.specsPageIsVisible()
       cy.contains('MissingReactInSpec.cy.jsx').click()
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.get('.test-err-code-frame').should('be.visible')
+      cy.reporter().find('.test-err-code-frame').should('be.visible')
       cy.withCtx(async (ctx) => {
         await ctx.actions.file.writeFileInProject(`src/MissingReactInSpec.cy.jsx`,
           await ctx.file.readFileInProject('src/App.cy.jsx'))
@@ -77,8 +77,8 @@ for (const project of WEBPACK_REACT) {
       cy.specsPageIsVisible()
       cy.contains('AppCompilationError.cy.jsx').click()
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.contains('An uncaught error was detected outside of a test')
-      cy.contains('The following error originated from your test code, not from Cypress.')
+      cy.reporter().contains('An uncaught error was detected outside of a test')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.')
 
       // Correct the problem
       cy.withCtx(async (ctx) => {
@@ -111,8 +111,8 @@ for (const project of WEBPACK_REACT) {
       }, { appCompilationErrorSpec })
 
       cy.waitForSpecToFinish({ failCount: 1 })
-      cy.contains('An uncaught error was detected outside of a test')
-      cy.contains('The following error originated from your test code, not from Cypress.')
+      cy.reporter().contains('An uncaught error was detected outside of a test')
+      cy.reporter().contains('The following error originated from your test code, not from Cypress.')
     })
 
     // https://cypress-io.atlassian.net/browse/UNIFY-1697

--- a/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
+++ b/npm/webpack-dev-server/cypress/e2e/webpack-dev-server.cy.ts
@@ -12,7 +12,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 1)
+    cy.reporter().find('.passed > .num').should('contain', 1)
   })
 
   it('supports nested config', () => {
@@ -24,7 +24,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('foo.cy.js').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 1)
+    cy.reporter().find('.passed > .num').should('contain', 1)
   })
 
   it('supports @cypress/webpack-dev-server', () => {
@@ -36,7 +36,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 1)
+    cy.reporter().find('.passed > .num').should('contain', 1)
   })
 
   it('supports webpackConfig as an async function', () => {
@@ -48,7 +48,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('App.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 2)
+    cy.reporter().find('.passed > .num').should('contain', 2)
 
     cy.withCtx(async (ctx) => {
       const verifyFile = await ctx.file.readFileInProject('wrote-to-file')
@@ -85,7 +85,7 @@ describe('Config options', () => {
     cy.specsPageIsVisible()
     cy.contains('relative-url.cy.jsx').click()
     cy.waitForSpecToFinish()
-    cy.get('.passed > .num').should('contain', 1)
+    cy.reporter().find('.passed > .num').should('contain', 1)
   })
 })
 
@@ -129,13 +129,13 @@ describe('sourcemaps', () => {
       cy.specsPageIsVisible()
       cy.contains(specName).click()
       cy.waitForSpecToFinish()
-      cy.get('.failed > .num').should('contain', 2)
+      cy.reporter().find('.failed > .num').should('contain', 2)
       cy.window().then((win) => {
         // @ts-expect-error
         cy.stub(win.getEventManager(), 'emit').as('emit')
       })
 
-      cy.get('.runnable-err-file-path', { timeout: 250 }).eq(1).as('filePath')
+      cy.reporter().find('.runnable-err-file-path', { timeout: 250 }).eq(1).as('filePath')
       cy.get('@filePath').should('contain', `${specName}:${line}:${column}`)
       cy.get('@filePath').then(($el) => {
         $el.find('span').trigger('click')

--- a/npm/webpack-dev-server/cypress/support/commands.ts
+++ b/npm/webpack-dev-server/cypress/support/commands.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 import type { ExpectedResults } from '@packages/app/cypress/e2e/support/execute-spec'
 import { waitForSpecToFinish } from '@packages/app/cypress/e2e/support/execute-spec'
+import '@packages/app/cypress/e2e/support/reporter'
 
 declare global {
   namespace Cypress {


### PR DESCRIPTION
- Closes N/A

### Additional details

When the command log moved into the `#reporter-frame` iframe (#34242), the `@cypress/vite-dev-server` and `@cypress/webpack-dev-server` cypress-in-cypress e2e specs were missed — they still queried reporter elements (`.passed > .num`, `.failed > .num`, `button.restart`, error text, code frames) on the top document, which no longer contains the reporter.

This migrates those specs and their `waitForSpecToFinish` helper to resolve the reporter through `cy.reporter()`, matching how the app and system-tests suites were already migrated. `vite-dev-server`'s divergent local `waitForSpecToFinish` is dropped in favor of the shared helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to dev-server e2e helpers and selectors; no production or user-facing behavior.
> 
> **Overview**
> Updates **vite-dev-server** and **webpack-dev-server** cypress-in-cypress e2e specs so reporter UI is queried through **`cy.reporter()`** instead of the top document, matching the app/system-tests migration after the command log moved into `#reporter-frame`.
> 
> **`waitForSpecToFinish`** in vite’s support layer now delegates to the shared **`@packages/app`** helper (with optional **`passCount` / `failCount`**), and both packages import the shared **`reporter`** command. Specs replace ad hoc **`.passed` / `.failed`** checks with **`waitForSpecToFinish({ … })`** where appropriate, and scope error text, code frames, command log, and sourcemap paths to the reporter iframe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a4bae22928c36e9ff220153ea1c1e987fb3d02f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run the dev-server e2e suites — they should pass:

- `yarn workspace @cypress/vite-dev-server cypress:run`
- `yarn workspace @cypress/webpack-dev-server cypress:run`

### How has the user experience changed?

No change — test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
