### PR TITLE
breaking: remove proxy and env vars from cypress info output

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753).
 
+**Bugfixes:**
+
+- The `cypress info` command no longer prints proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) or `CYPRESS_*` environment variables, which could expose credentials or other secrets in CI logs, screenshots, and support tickets. The command now reports only Cypress-specific details such as file paths, version, and system information. Addresses [#34103](https://github.com/cypress-io/cypress/issues/34103).
+
 **Dependency Updates:**
 
 - Upgraded `electron` from `37.6.0` to `41.7.0`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The `experimentalFastVisibility` boolean flag has been replaced with a new `visibilityStrategy` config option that accepts `'legacy'` or `'modern'`, defaulting to `'modern'`. The modern visibility algorithm (based on `Element.checkVisibility()`) is now the default for all users. The option is deprecated — set `visibilityStrategy: 'legacy'` only if you need the old algorithm when migrating to the modern visibility algorithm. Addressed in [#33794](https://github.com/cypress-io/cypress/pull/33794).
 - [`cy.getCookie()`](https://on.cypress.io/getcookie) and [`cy.getCookies()`](https://on.cypress.io/getcookies) are now query commands. They re-read the cookie(s) from the browser and retry any attached assertions until they pass or the command times out, so `cy.getCookie('token').should('exist')` now waits for a cookie that is set asynchronously (for example, after a login request resolves) instead of failing on the first read. As a result, their timeout now follows `defaultCommandTimeout` (default `4000`) rather than `responseTimeout` (default `30000`), and to overwrite these commands you must now use [`Cypress.Commands.overwriteQuery()`](https://on.cypress.io/api/cypress-api/custom-queries) instead of `Cypress.Commands.overwrite()`. Addresses [#4802](https://github.com/cypress-io/cypress/issues/4802).
 - Removed the `experimentalSourceRewriting` configuration option. The experimental AST-based source rewriting was removed in favor of the default regex-based source rewriting, so default behavior is unchanged. You can safely remove this option from your config. Addresses [#34213](https://github.com/cypress-io/cypress/issues/34213).
+- The `cypress info` command no longer prints proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) or `CYPRESS_*` environment variables. The command now reports only Cypress-specific details such as file paths, version, and system information. Addresses [#34103](https://github.com/cypress-io/cypress/issues/34103). Fixed in [#34314](https://github.com/cypress-io/cypress/pull/34314).
 
 **Deprecations:**
 
@@ -21,10 +22,6 @@
 **Features:**
 
 - `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753).
-
-**Bugfixes:**
-
-- The `cypress info` command no longer prints proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) or `CYPRESS_*` environment variables, which could expose credentials or other secrets in CI logs, screenshots, and support tickets. The command now reports only Cypress-specific details such as file paths, version, and system information. Addresses [#34103](https://github.com/cypress-io/cypress/issues/34103).
 
 **Dependency Updates:**
 

--- a/cli/lib/exec/info.ts
+++ b/cli/lib/exec/info.ts
@@ -1,48 +1,18 @@
-/* eslint-disable no-console */
 import { start as spawnStart } from './spawn'
 import util from '../util'
 import state from '../tasks/state'
 import os from 'os'
 import chalk from 'chalk'
 import prettyBytes from 'pretty-bytes'
-import _ from 'lodash'
 
 // color for numbers and show values
 const g = chalk.green
 // color for paths
 const p = chalk.cyan
 const red = chalk.red
-// urls
-const link = chalk.blue.underline
 
 // to be exported
 const methods: any = {}
-
-methods.findProxyEnvironmentVariables = (): any => {
-  return _.pick(process.env, ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'])
-}
-
-const maskSensitiveVariables = (obj: any): any => {
-  const masked = { ...obj }
-
-  if (masked.CYPRESS_RECORD_KEY) {
-    masked.CYPRESS_RECORD_KEY = '<redacted>'
-  }
-
-  return masked
-}
-
-methods.findCypressEnvironmentVariables = (): any => {
-  const isCyVariable = (val: any, key: string): boolean => key.startsWith('CYPRESS_')
-
-  return _.pickBy(process.env, isCyVariable)
-}
-
-const formatCypressVariables = (): any => {
-  const vars = methods.findCypressEnvironmentVariables()
-
-  return maskSensitiveVariables(vars)
-}
 
 methods.start = async (options: any = {}): Promise<void> => {
   const args = ['--mode=info']
@@ -50,33 +20,6 @@ methods.start = async (options: any = {}): Promise<void> => {
   await spawnStart(args, {
     dev: options.dev,
   })
-
-  console.log()
-  const proxyVars = methods.findProxyEnvironmentVariables()
-
-  if (_.isEmpty(proxyVars)) {
-    console.log('Proxy Settings: none detected')
-  } else {
-    console.log('Proxy Settings:')
-    _.forEach(proxyVars, (value: any, key: string) => {
-      console.log('%s: %s', key, g(value))
-    })
-
-    console.log()
-    console.log('Learn More: %s', link('https://on.cypress.io/proxy-configuration'))
-    console.log()
-  }
-
-  const cyVars = formatCypressVariables()
-
-  if (_.isEmpty(cyVars)) {
-    console.log('Environment Variables: none detected')
-  } else {
-    console.log('Environment Variables:')
-    _.forEach(cyVars, (value: any, key: string) => {
-      console.log('%s: %s', key, g(value))
-    })
-  }
 
   console.log()
   console.log('Application Data:', p(util.getApplicationDataFolder()))

--- a/cli/test/lib/exec/__snapshots__/info.spec.ts.snap
+++ b/cli/test/lib/exec/__snapshots__/info.spec.ts.snap
@@ -2,9 +2,6 @@
 
 exports[`exec info > logs additional info about pre-releases > logs additional info about pre-releases 1`] = `
 "
-Proxy Settings: none detected
-Environment Variables: none detected
-
 Application Data: [36m/user/app/data/path[39m
 Browser Profiles: [36m/user/app/data/path/to/browsers[39m
 Binary Caches: [36m/user/path/to/binary/cache[39m
@@ -23,9 +20,6 @@ Build info:
 
 exports[`exec info > logs if unbuilt development > logs additional info about development 1`] = `
 "
-Proxy Settings: none detected
-Environment Variables: none detected
-
 Application Data: [36m/user/app/data/path[39m
 Browser Profiles: [36m/user/app/data/path/to/browsers[39m
 Binary Caches: [36m/user/path/to/binary/cache[39m
@@ -38,53 +32,8 @@ This is the [31mdevelopment[39m (un-built) Cypress CLI.
 "
 `;
 
-exports[`exec info > prints collected info without env vars > cypress info without browsers or vars 1`] = `
+exports[`exec info > prints collected info > cypress info 1`] = `
 "
-Proxy Settings: none detected
-Environment Variables: none detected
-
-Application Data: [36m/user/app/data/path[39m
-Browser Profiles: [36m/user/app/data/path/to/browsers[39m
-Binary Caches: [36m/user/path/to/binary/cache[39m
-
-Cypress Version: [32m0.0.0-development[39m [32m(stable)[39m
-System Platform: [32mlinux[39m ([32mFoo - OsVersion[39m)
-System Memory: [32m1.2 GB[39m free [32m400 MB[39m
-"
-`;
-
-exports[`exec info > prints proxy and cypress env vars > cypress info with proxy and vars 1`] = `
-"
-Proxy Settings:
-HTTP_PROXY: [32msome proxy variable[39m
-HTTPS_PROXY: [32manother proxy variable[39m
-NO_PROXY: [32mno proxy variable[39m
-
-Learn More: [34m[4mhttps://on.cypress.io/proxy-configuration[24m[39m
-
-Environment Variables:
-CYPRESS_ENV_VAR1: [32mmy Cypress variable[39m
-CYPRESS_ENV_VAR2: [32mmy other Cypress variable[39m
-
-Application Data: [36m/user/app/data/path[39m
-Browser Profiles: [36m/user/app/data/path/to/browsers[39m
-Binary Caches: [36m/user/path/to/binary/cache[39m
-
-Cypress Version: [32m0.0.0-development[39m [32m(stable)[39m
-System Platform: [32mlinux[39m ([32mFoo - OsVersion[39m)
-System Memory: [32m1.2 GB[39m free [32m400 MB[39m
-"
-`;
-
-exports[`exec info > redacts sensitive cypress variables > cypress redacts sensitive vars 1`] = `
-"
-Proxy Settings: none detected
-Environment Variables:
-CYPRESS_ENV_VAR1: [32mmy Cypress variable[39m
-CYPRESS_ENV_VAR2: [32mmy other Cypress variable[39m
-CYPRESS_PROJECT_ID: [32mabc123[39m
-CYPRESS_RECORD_KEY: [32m<redacted>[39m
-
 Application Data: [36m/user/app/data/path[39m
 Browser Profiles: [36m/user/app/data/path/to/browsers[39m
 Binary Caches: [36m/user/path/to/binary/cache[39m

--- a/cli/test/lib/exec/info.spec.ts
+++ b/cli/test/lib/exec/info.spec.ts
@@ -68,7 +68,7 @@ vi.mock('../../../lib/tasks/state', async (importActual) => {
 describe('exec info', () => {
   const createStdoutCapture = () => {
     const logs: string[] = []
-    // eslint-disable-next-line no-console
+
     const originalOut = process.stdout.write
 
     vi.spyOn(process.stdout, 'write').mockImplementation((strOrBugger: string | Uint8Array<ArrayBufferLike>) => {
@@ -96,8 +96,6 @@ describe('exec info', () => {
     vi.unstubAllEnvs()
     vi.resetAllMocks()
 
-    vi.stubEnv('NO_PROXY', undefined)
-    vi.stubEnv('CYPRESS_COMMERCIAL_RECOMMENDATIONS', undefined)
     // common stubs
     vi.mocked(spawnStart).mockResolvedValue(null)
     vi.mocked(os.platform).mockReturnValue('linux')
@@ -129,42 +127,40 @@ describe('exec info', () => {
     chalk.level = previousChalkLevel
   })
 
-  it('prints collected info without env vars', async () => {
+  it('prints collected info', async () => {
     const output = createStdoutCapture()
 
     await info.start()
 
-    expect(output()).toMatchSnapshot('cypress info without browsers or vars')
+    expect(output()).toMatchSnapshot('cypress info')
 
     expect(spawnStart).toBeCalledWith(['--mode=info'], { dev: undefined })
   })
 
-  it('prints proxy and cypress env vars', async () => {
-    vi.stubEnv('HTTP_PROXY', 'some proxy variable')
-    vi.stubEnv('HTTPS_PROXY', 'another proxy variable')
+  it('does not print proxy or cypress env vars', async () => {
+    vi.stubEnv('HTTP_PROXY', 'http://username:password@proxy.example.com:8080')
+    vi.stubEnv('HTTPS_PROXY', 'https://token@secure-proxy.example.com')
     vi.stubEnv('NO_PROXY', 'no proxy variable')
 
-    vi.stubEnv('CYPRESS_ENV_VAR1', 'my Cypress variable')
-    vi.stubEnv('CYPRESS_ENV_VAR2', 'my other Cypress variable')
+    vi.stubEnv('CYPRESS_AUTH_TOKEN', 'example-token')
+    vi.stubEnv('CYPRESS_PASSWORD', 'example-password')
+    vi.stubEnv('CYPRESS_PROJECT_ID', 'abc123')
+    vi.stubEnv('CYPRESS_RECORD_KEY', 'really really secret stuff')
 
     const output = createStdoutCapture()
 
     await info.start()
 
-    expect(output()).toMatchSnapshot('cypress info with proxy and vars')
-  })
+    const result = output()
 
-  it('redacts sensitive cypress variables', async () => {
-    vi.stubEnv('CYPRESS_ENV_VAR1', 'my Cypress variable')
-    vi.stubEnv('CYPRESS_ENV_VAR2', 'my other Cypress variable')
-    vi.stubEnv('CYPRESS_PROJECT_ID', 'abc123') // not sensitive
-    vi.stubEnv('CYPRESS_RECORD_KEY', 'really really secret stuff') // should not be printed
-
-    const output = createStdoutCapture()
-
-    await info.start()
-
-    expect(output()).toMatchSnapshot('cypress redacts sensitive vars')
+    expect(result).not.toContain('proxy.example.com')
+    expect(result).not.toContain('secure-proxy.example.com')
+    expect(result).not.toContain('example-token')
+    expect(result).not.toContain('example-password')
+    expect(result).not.toContain('abc123')
+    expect(result).not.toContain('really really secret stuff')
+    expect(result).not.toContain('Proxy Settings')
+    expect(result).not.toContain('Environment Variables')
   })
 
   it('logs additional info about pre-releases', async () => {


### PR DESCRIPTION
- Closes [#34103](https://github.com/cypress-io/cypress/issues/34103)

### Additional details

`cypress info` printed a "Proxy Settings" section (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) and an "Environment Variables" section listing every `CYPRESS_*` variable. Proxy values were printed verbatim — including any URL userinfo credentials (`http://user:pass@host`) — and the only `CYPRESS_*` value masked was `CYPRESS_RECORD_KEY`. Teams commonly use names like `CYPRESS_AUTH_TOKEN`, `CYPRESS_API_KEY`, or `CYPRESS_PASSWORD`, so this output could leak secrets into CI logs, screenshots, issue templates, and support tickets.

As [decided by the team on the issue](https://github.com/cypress-io/cypress/issues/34103#issuecomment-4920921526), rather than attempting to redact (which is brittle and easy to miss), the proxy and environment-variable sections have been removed entirely. `cypress info` was really intended to surface Cypress-specific details, so it now reports only: application data / browser profile / binary cache paths, Cypress version, and system platform/memory (plus browser detection from the server-side `--mode=info`, which never printed secrets).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only diagnostic output change with no impact on test execution, config loading, or networking behavior.
> 
> **Overview**
> **`cypress info` no longer dumps process environment** — the Proxy Settings block (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) and the Environment Variables block (all `CYPRESS_*` keys) are removed from CLI output instead of redacting individual secrets.
> 
> The command still spawns `--mode=info` and prints **Application Data**, browser profiles, binary cache paths, Cypress version, and system platform/memory (plus pre-release/dev build details when applicable). The 16.0.0 changelog documents this as a breaking change for [#34103](https://github.com/cypress-io/cypress/issues/34103).
> 
> Tests were consolidated: snapshots no longer expect proxy/env sections, and a case asserts sensitive proxy and `CYPRESS_*` values never appear in stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d38bf7988b4c1592c6b8e7db3dca382b9bd2de4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run `cypress info` with proxy and sensitive `CYPRESS_*` variables set:

```shell
HTTP_PROXY="http://username:password@proxy.example.com:8080" \
HTTPS_PROXY="https://token@secure-proxy.example.com" \
CYPRESS_AUTH_TOKEN="example-token" \
CYPRESS_PASSWORD="example-password" \
npx cypress info
```

Confirm the output contains no "Proxy Settings" or "Environment Variables" section and none of the secret values above. The unit tests in `cli/test/lib/exec/info.spec.ts` cover this.

### How has the user experience changed?

`cypress info` no longer prints the "Proxy Settings" or "Environment Variables" sections.

Before:

```
Proxy Settings:
HTTP_PROXY: http://username:password@proxy.example.com:8080
...

Environment Variables:
CYPRESS_AUTH_TOKEN: example-token
CYPRESS_PASSWORD: example-password
...

Application Data: ...
Cypress Version: ...
```

After:

```
Application Data: ...
Browser Profiles: ...
Binary Caches: ...

Cypress Version: ...
System Platform: ...
System Memory: ...
```

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? [#34103](https://github.com/cypress-io/cypress/issues/34103)
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
