### PR TITLE
chore: fix release/16 CI failures from TS7 and Electron 41 upgrades

### DIFF
--- a/npm/webpack-batteries-included-preprocessor/tsconfig.json
+++ b/npm/webpack-batteries-included-preprocessor/tsconfig.json
@@ -3,7 +3,6 @@
     "outDir": "./dist",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/system-tests/test/network_error_handling_spec.js
+++ b/system-tests/test/network_error_handling_spec.js
@@ -397,9 +397,8 @@ describe('e2e network error handling', function () {
           },
         })
         .then(() => {
-          // Only count CONNECTs to the test server. The browser also makes
-          // background component/Widevine downloads to *.gvt1.com that tunnel
-          // through HTTP_PROXY, and their count is timing-dependent.
+          // Only count CONNECTs to the test server. The browser may also make
+          // additional requests, and their count is timing-dependent.
           const connectsToServer = onConnect.getCalls().filter((call) => {
             return call.args[0].host === 'localhost' && call.args[0].port === HTTPS_PORT
           })

--- a/system-tests/test/network_error_handling_spec.js
+++ b/system-tests/test/network_error_handling_spec.js
@@ -397,19 +397,16 @@ describe('e2e network error handling', function () {
           },
         })
         .then(() => {
-          expect(onConnect).to.be.calledTwice
+          // Only count CONNECTs to the test server. The browser also makes
+          // background component/Widevine downloads to *.gvt1.com that tunnel
+          // through HTTP_PROXY, and their count is timing-dependent.
+          const connectsToServer = onConnect.getCalls().filter((call) => {
+            return call.args[0].host === 'localhost' && call.args[0].port === HTTPS_PORT
+          })
 
           // 1st request: verifying base url
-          expect(onConnect.firstCall).to.be.calledWithMatch({
-            host: 'localhost',
-            port: HTTPS_PORT,
-          })
-
           // 2nd request: <img> load from spec
-          expect(onConnect.secondCall).to.be.calledWithMatch({
-            host: 'localhost',
-            port: HTTPS_PORT,
-          })
+          expect(connectsToServer).to.have.length(2)
         })
       })
     })


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

Fixes two CI failures on the `release/16.0.0` line surfaced by the TypeScript 7 and Electron 41 (Chromium 146) upgrades:

1. **`check-ts` (`@cypress/webpack-batteries-included-preprocessor`)** — the package's `tsc` now resolves to TypeScript 7, which removed the `node`/`node10` `moduleResolution` value and errors with `TS5108`. The recently added `"moduleResolution": "node"` line is removed; `module: commonjs` already implies node-style resolution, so type-checking passes unchanged.

2. **`network_error_handling` system test** — *"does not connect to the upstream proxy for the SNI server request"* asserted the debug proxy's `onConnect` spy was `calledTwice`. Under Chromium 146 the browser makes background component/Widevine downloads to `*.gvt1.com` that tunnel through the test's `HTTP_PROXY`, inflating the call count non-deterministically. The assertion now counts only CONNECTs to the test server (`localhost:HTTPS_PORT`) and expects exactly two, preserving the test's original intent while ignoring background noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/tsconfig and test-only changes with no product behavior impact.
> 
> **Overview**
> Unblocks **release/16** CI after the TypeScript 7 and Electron 41 (Chromium 146) upgrades with two targeted fixes.
> 
> **`@cypress/webpack-batteries-included-preprocessor`** — Drops `"moduleResolution": "node"` from `tsconfig.json` so `check-ts` no longer hits **TS5108** under TS7; `module: commonjs` already implies node-style resolution.
> 
> **`network_error_handling` system test** — The SNI upstream-proxy case no longer requires `onConnect` to be called exactly twice overall. It filters CONNECT calls to `localhost` on the test HTTPS port and still expects **two** (base URL check + spec image load), ignoring extra proxy CONNECTs from Chromium background traffic (e.g. `*.gvt1.com`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906772a46dacff857392b4529826ef1fd46a1ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- `check-ts`: from `npm/webpack-batteries-included-preprocessor`, run `yarn check-ts` — it passes (previously failed with `TS5108`).
- system test: re-run the `network_error_handling` system test in CI on Electron; the SNI upstream-proxy test passes regardless of background `*.gvt1.com` traffic.

### How has the user experience changed?

No change — CI/build and test-only fixes.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI/build fixes for the release/16 upgrade; no user-facing behavior change. -->
- [x] Have tests been added/updated? <!-- Hardened the SNI upstream-proxy system test assertion. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
