### PR TITLE
test: set experimentalMemoryManagement for vite-dev-server and webpack-dev-server

### DIFF
--- a/npm/vite-dev-server/cypress.config.ts
+++ b/npm/vite-dev-server/cypress.config.ts
@@ -6,6 +6,7 @@ const require = createRequire(import.meta.url)
 
 export default defineConfig({
   projectId: 'ypt4pf',
+  experimentalMemoryManagement: true,
   e2e: {
     defaultCommandTimeout: 10000, // these take a bit longer b/c they're e2e open mode test
     async setupNodeEvents (on, config) {

--- a/npm/webpack-dev-server/cypress.config.ts
+++ b/npm/webpack-dev-server/cypress.config.ts
@@ -3,6 +3,7 @@ import { setupCyInCyVariables } from '@packages/frontend-shared/cypress/tasks/cy
 
 export default defineConfig({
   projectId: 'ypt4pf',
+  experimentalMemoryManagement: true,
   e2e: {
     defaultCommandTimeout: 20000, // these take a bit longer b/c they're e2e open mode test
     async setupNodeEvents (on, config) {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes n/a

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Cypress configuration with no changes to application code, auth, or data handling.
> 
> **Overview**
> Enables Cypress **`experimentalMemoryManagement`** in the **`npm/vite-dev-server`** and **`npm/webpack-dev-server`** `cypress.config.ts` files (top-level `defineConfig` option).
> 
> This is a test-infra-only change aimed at reducing memory pressure during those nested E2E / Cypress-in-Cypress runs; no product runtime or user-facing behavior is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b340f8629fcb5af617c1f8f3bd16e753f1520cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->
n/a

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->
n/a

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [n/a] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [x] Have tests been added/updated?
- [n/a] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [n/a] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
