### PR TITLE
fix: tap --help must not require an attached browser (13990)

### DIFF
--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -121,10 +121,6 @@ const tapModule = {
       })
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
-        // Help must never require a live instance or an attached browser. When
-        // discovery can't reach an instance to produce schema help — for any
-        // reason (none running, stale, or up but no browser) — fall back to the
-        // static command listing instead of surfacing the discovery error.
         if (wantsHelp || !command) {
           return renderGenericHelp(wantsHelp, tapCliCommands)
         }

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -121,7 +121,11 @@ const tapModule = {
       })
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
-        if ((wantsHelp || !command) && err.code === 'NO_INSTANCE') {
+        // Help must never require a live instance or an attached browser. When
+        // discovery can't reach an instance to produce schema help — for any
+        // reason (none running, stale, or up but no browser) — fall back to the
+        // static command listing instead of surfacing the discovery error.
+        if (wantsHelp || !command) {
           return renderGenericHelp(wantsHelp, tapCliCommands)
         }
 

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -578,21 +578,36 @@ describe('lib/exec/tap', () => {
       expect(logger.print()).toContain('Usage: cypress tap')
     })
 
-    it('surfaces a specific discovery error on a bare invocation instead of generic help', async () => {
+    it('falls back to generic help for --help when an instance is up but has no browser', async () => {
+      failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
+
+      expect(await tap.start(['--help'], {})).toBe(0)
+      expect(logger.print()).toContain('Usage: cypress tap')
+      expect(logger.print()).not.toContain('NO_BROWSER_ATTACHED')
+    })
+
+    it('falls back to generic help for `<command> --help` when an instance is up but has no browser', async () => {
+      failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
+
+      expect(await tap.start(['specs', '--help'], {})).toBe(0)
+      expect(logger.print()).toContain('Usage: cypress tap')
+      expect(logger.print()).not.toContain('NO_BROWSER_ATTACHED')
+    })
+
+    it('falls back to generic help for --help when the matched instance is stale', async () => {
+      failResolve(new CypressInstanceError('STALE_INSTANCE', 'Cypress was previously running, but is no longer responding.'))
+
+      expect(await tap.start(['--help'], {})).toBe(0)
+      expect(logger.print()).toContain('Usage: cypress tap')
+      expect(logger.print()).not.toContain('STALE_INSTANCE')
+    })
+
+    it('falls back to generic help (exit 1) for a bare invocation when an instance is up but has no browser', async () => {
       failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
 
       expect(await tap.start([], {})).toBe(1)
-      expect(logger.print()).toContain('NO_BROWSER_ATTACHED')
-      expect(logger.print()).toContain('no test browser is open')
-      expect(logger.print()).not.toContain('Usage: cypress tap')
-    })
-
-    it('surfaces a specific discovery error for explicit --help instead of generic help', async () => {
-      failResolve(new CypressInstanceError('STALE_INSTANCE', 'Cypress was previously running, but is no longer responding.'))
-
-      expect(await tap.start(['--help'], {})).toBe(1)
-      expect(logger.print()).toContain('STALE_INSTANCE')
-      expect(logger.print()).not.toContain('Usage: cypress tap')
+      expect(logger.print()).toContain('Usage: cypress tap')
+      expect(logger.print()).not.toContain('NO_BROWSER_ATTACHED')
     })
 
     it('still surfaces the discovery error when an actual command was requested', async () => {


### PR DESCRIPTION
### Additional details

`cypress tap --help` must never require a live instance or an attached browser — it's the one command an agent runs *before* it knows the state of the world.

Today, when a Cypress instance is running in open mode but no test browser has been launched yet, `resolveInstance` throws `NO_BROWSER_ATTACHED` (`cli/lib/cypress-instances/index.ts`). The help path in `cli/lib/exec/tap.ts` only fell back to the static command listing for `NO_INSTANCE`, so every other discovery failure (`NO_BROWSER_ATTACHED`, `STALE_INSTANCE`) surfaced as an error instead of printing help.

The fix broadens the help fallback: when help is requested (`--help`, `<command> --help`) or the CLI is invoked bare, **any** `CypressInstanceError` falls back to generic help rather than surfacing the discovery error. When a browser *is* attached, the richer schema-based help is unchanged. A real command invocation (e.g. `tap specs`) still surfaces the discovery error, since that genuinely needs a browser.

### Steps to test

1. `cypress open --e2e --project <project>` and **do not** launch a browser.
2. `cypress tap --help` → prints help (previously errored with `NO_BROWSER_ATTACHED`).

### How has the user experience changed?

Live run against a browserless open-mode instance (`browserAttached: false`):

**Before** — help commands surface the discovery error and exit non-zero:

```console
$ cypress tap --help
NO_BROWSER_ATTACHED: Cypress is running (pid 82446, …/tap-verify), but no test browser is open. Open a browser in Cypress and try again.
[exit 1]

$ cypress tap specs --help
NO_BROWSER_ATTACHED: Cypress is running (pid 82446, …/tap-verify), but no test browser is open. Open a browser in Cypress and try again.
[exit 1]

$ cypress tap
NO_BROWSER_ATTACHED: Cypress is running (pid 82446, …/tap-verify), but no test browser is open. Open a browser in Cypress and try again.
[exit 1]
```

**After** — help prints regardless of browser state:

```console
$ cypress tap --help
Usage: cypress tap [command] [args...] [options]

Interacts with a running Cypress instance over its tap binding.

Commands:
  instances  list the running Cypress instances this CLI can reach
  status     report where a running Cypress instance is in its lifecycle

Other commands are discovered from the running Cypress instance — start
Cypress (e.g. `cypress open`), then run `cypress tap` to see them.

Options:
  --instance <pid>  target a specific running Cypress instance by its pid
[exit 0]

$ cypress tap specs --help
Usage: cypress tap [command] [args...] [options]
… (same help)
[exit 0]

$ cypress tap          # bare invocation still exits 1 (usage), but prints help
Usage: cypress tap [command] [args...] [options]
…
[exit 1]
```

`cypress tap status` continued to work in both cases (it's a CLI-native command that never required a browser).

### PR Tasks

- [x] Have tests been added/updated? — `cli/test/lib/exec/tap.spec.ts`: rewrote the two cases that locked in the old behavior and added a `<command> --help` case; 52/52 pass.
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal; docs live in the `agent-remote-cypress` skill.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only help routing change with updated unit tests; no auth, data, or runtime test execution paths affected beyond error-vs-help display.
> 
> **Overview**
> **`cypress tap --help`**, **`<command> --help`**, and a **bare `cypress tap`** no longer fail when instance resolution throws `NO_BROWSER_ATTACHED` or `STALE_INSTANCE`—they print the static generic help instead of the discovery error.
> 
> Previously, only **`NO_INSTANCE`** triggered that fallback; other **`CypressInstanceError`** codes surfaced as failures even for help. The catch block now uses **`wantsHelp || !command`** for any instance error, without checking **`err.code`**.
> 
> **Actual tap commands** (e.g. **`tap health`**) are unchanged: discovery errors still render and exit non-zero. When resolution succeeds, schema-based help behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e21900ec47b88d1aacf7935aa811864c1dbc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->