### PR TITLE
fix: correct misleading tap top-level usage string (13994)

### DIFF
--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -79,6 +79,7 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
   program.exitOverride()
   program.addHelpCommand(false)
   program.description('Interacts with a running Cypress instance')
+  program.usage('[command] [args...] [options]')
 
   // CLI-native commands register here only so the help listing includes them.
   // Their dispatch and excess-argument rejection run in exec/tap.ts, which

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -72,6 +72,14 @@ describe('lib/tap/build-program', () => {
     expect(subcommand(program, 'run').helpInformation()).toContain('Usage: cypress tap run [options] <spec>')
   })
 
+  it('sets a top-level usage reflecting that options follow the command, not precede it', () => {
+    const program = buildTapProgram(schema, vi.fn())
+
+    expect(program.usage()).toBe('[command] [args...] [options]')
+    expect(program.helpInformation()).toContain('Usage: cypress tap [command] [args...] [options]')
+    expect(program.helpInformation()).not.toContain('[options] [command]')
+  })
+
   it('derives positional grammar from each param schema (required <>, optional [])', () => {
     const program = buildTapProgram(schema, vi.fn())
 


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13994

### Additional details

The schema-based help for `cypress tap` (shown when an instance is connected) printed commander's default top-level usage, `Usage: cypress tap [options] [command]`. That ordering is misleading: tap options are supplied **after** the subcommand (`cypress tap run <spec> --headed`), not before it. The generic help (shown with no instance) already used the correct `[command] [args...] [options]`.

The fix sets the commander program's usage to `[command] [args...] [options]`, so both help paths read identically. Per-command usage (`cypress tap run --help` → `Usage: cypress tap run [options] <spec>`) is unchanged — options-before-positionals is accurate for a single command.

### Steps to test

1. `cypress open --e2e --browser electron --project <project>` and wait for the browser to attach.
2. `cypress tap --help` → top line reads `Usage: cypress tap [command] [args...] [options]`.

### How has the user experience changed?

Live run against a browser-attached open-mode instance:

**Before:**

```console
$ cypress tap --help
Target:
  …/tap-verify
  v15.19.0
  pid:1462

Usage: cypress tap [options] [command]

Interacts with a running Cypress instance
…
```

**After:**

```console
$ cypress tap --help
Target:
  …/tap-verify
  v15.19.0
  pid:1462

Usage: cypress tap [command] [args...] [options]

Interacts with a running Cypress instance
…
```

### PR Tasks

- [x] Have tests been added/updated? — `cli/test/lib/tap/build-program.spec.ts` asserts the top-level usage and that `[options] [command]` no longer appears; 24/24 pass.
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-text only; no parsing or dispatch behavior changes.
> 
> **Overview**
> When a Cypress instance is connected, `cypress tap --help` used commander’s default top-level usage (`[options] [command]`), which implied flags come before the subcommand. **Tap options actually follow the command** (e.g. `cypress tap run <spec> --headed`).
> 
> This change sets the tap program usage to **`[command] [args...] [options]`** in `buildTapProgram`, matching the generic no-instance help path. Per-subcommand help (e.g. `cypress tap run --help`) is unchanged.
> 
> Tests assert the new usage string and that `[options] [command]` no longer appears in top-level help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630358aaa8c49b37f2e4996b9898e820d7c9ca75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->