### PR TITLE
fix: drop testing type from tap specs output (13987)

### DIFF
--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -47,12 +47,12 @@ describe('tap binding', () => {
 
       expect('result' in outcome).to.eq(true)
 
-      const specs = (outcome as { result: Array<{ relativePath: string, specType: string }> }).result
+      const specs = (outcome as { result: Array<{ relativePath: string }> }).result
 
-      expect(specs).to.deep.include({ relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' })
+      expect(specs).to.deep.include({ relativePath: 'cypress/e2e/dom-content.spec.js' })
 
       for (const spec of specs) {
-        expect(Object.keys(spec), `entry ${spec.relativePath}`).to.deep.eq(['relativePath', 'specType'])
+        expect(Object.keys(spec), `entry ${spec.relativePath}`).to.deep.eq(['relativePath'])
       }
 
       // With no run yet there is no runner to read, so run-state omits the run-only fields.
@@ -73,7 +73,7 @@ describe('tap binding', () => {
       const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })
 
       expect(outcome).to.deep.eq({
-        result: { relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' },
+        result: { relativePath: 'cypress/e2e/dom-content.spec.js' },
       })
     })
 

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -91,7 +91,7 @@ describe('tap/commands/run', () => {
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
     expect(outcome).to.deep.eq({
-      result: { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
+      result: { relativePath: 'cypress/e2e/login.cy.ts' },
     })
 
     expect(setHash).to.have.been.calledOnce
@@ -136,7 +136,7 @@ describe('tap/commands/run', () => {
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
     expect(outcome).to.deep.eq({
-      result: { relativePath: 'cypress\\e2e\\login.cy.ts', specType: 'integration' },
+      result: { relativePath: 'cypress\\e2e\\login.cy.ts' },
     })
 
     expect(setHash.firstCall.args[0]).to.contain('file=cypress/e2e/login.cy.ts')

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -2,6 +2,6 @@ import type { FoundSpec } from '@packages/types'
 
 import type { SpecListEntry } from '../types'
 
-export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
-  return { relativePath: relative, specType }
+export const toSpecListEntry = ({ relative }: FoundSpec): SpecListEntry => {
+  return { relativePath: relative }
 }

--- a/packages/app/src/tap/commands/specs.cy.ts
+++ b/packages/app/src/tap/commands/specs.cy.ts
@@ -39,8 +39,8 @@ describe('tap/commands/specs', () => {
 
     expect(await manager.exec('specs')).to.deep.eq({
       result: [
-        { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
-        { relativePath: 'src/Button.cy.tsx', specType: 'component' },
+        { relativePath: 'cypress/e2e/login.cy.ts' },
+        { relativePath: 'src/Button.cy.tsx' },
       ],
     })
   })

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -1,4 +1,4 @@
-import type { FoundSpec, SerializedCommandLog, SerializedTest } from '@packages/types'
+import type { SerializedCommandLog, SerializedTest } from '@packages/types'
 
 export interface TapTestsRunner {
   /** Serializes every test of the run, keyed by id. */
@@ -11,8 +11,6 @@ export interface TapTestsRunner {
 export interface SpecListEntry {
   /** Project-relative spec path — the form `cypress run --spec` accepts. */
   relativePath: string
-  /** Whether the spec is an end-to-end (integration) or component spec. */
-  specType: FoundSpec['specType']
 }
 
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13987

### Additional details

`cypress tap specs` echoed a per-spec `specType` (`integration`/`component`) on every entry. The testing type is fixed for the session (an instance is either e2e or CT), so repeating it on each spec is redundant noise for an agent. This drops the field from `SpecListEntry`, so both `tap specs` and the spec descriptor returned by `tap run` now carry only `relativePath`.

### Steps to test

1. `cypress open --e2e --browser electron --project <project>` and wait for the browser to attach.
2. `cypress tap specs` → entries contain only `relativePath`, no `specType`.

### How has the user experience changed?

Live run against a browser-attached open-mode instance:

**Before:**

```json
[
  { "relativePath": "cypress/e2e/greeting.cy.js", "specType": "integration" },
  { "relativePath": "cypress/e2e/math.cy.js", "specType": "integration" }
]
```

**After:**

```json
[
  { "relativePath": "cypress/e2e/greeting.cy.js" },
  { "relativePath": "cypress/e2e/math.cy.js" }
]
```

### PR Tasks

- [x] Have tests been added/updated? — updated the `specs`/`run` component-test assertions (`specs.cy.ts`, `run.cy.ts`) and the `tap-binding` e2e assertions to expect the lean entry. Component/e2e specs run in CI (cypress-in-cypress); behavior verified live (above).
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow tap CLI output change with no auth, security, or data-path impact; tests updated to match the slimmer contract.
> 
> **Overview**
> **Tap spec entries are leaner:** `SpecListEntry` no longer includes `specType` (`integration` / `component`). Both **`cypress tap specs`** and the descriptor returned by **`cypress tap run`** now expose only **`relativePath`**.
> 
> `toSpecListEntry` maps `FoundSpec` to that shape, and component/e2e tests (`specs.cy.ts`, `run.cy.ts`, `tap-binding.cy.ts`) assert the updated payloads and that each entry has exactly one key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a4e392eb25eccb4a38cbd9fd55a3e67bcf5ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->