### PR TITLE
fix: tap run returns a running-status ack, not the spec object (13993)

### DIFF
--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -72,9 +72,12 @@ describe('tap binding', () => {
     cy.window().then(async (win) => {
       const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })
 
-      expect(outcome).to.deep.eq({
-        result: { relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' },
-      })
+      const ack = (outcome as { result: Record<string, unknown> }).result
+
+      expect(ack.spec).to.eq('cypress/e2e/dom-content.spec.js')
+      expect(ack.status).to.eq('running')
+      expect(ack.totalTests).to.eq(1)
+      expect(ack.message).to.contain('cypress tap status')
     })
 
     cy.location('hash')

--- a/packages/app/src/tap/commands/run.cy.ts
+++ b/packages/app/src/tap/commands/run.cy.ts
@@ -29,6 +29,21 @@ describe('tap/commands/run', () => {
     })
   }
 
+  const stubStartedRun = (relative: string, testCount: number) => {
+    cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
+    const tests = Object.fromEntries(
+      Array.from({ length: testCount }, (_, index) => [`r${index + 1}`, { id: `r${index + 1}`, state: 'passed' }]),
+    )
+
+    cy.stub(tapManagerDataSource, 'getRunner').returns({
+      getAllTestsState: () => tests,
+      getTestState: () => undefined,
+      isRunComplete: () => false,
+    })
+  }
+
+  const RUN_ACK_MESSAGE = 'spec is running — poll `cypress tap status` for progress'
+
   afterEach(() => {
     delete (window as any).__RUN_MODE_SPECS__
   })
@@ -82,7 +97,30 @@ describe('tap/commands/run', () => {
     expect(setHash).not.to.have.been.called
   })
 
-  it('navigates to the runner URL and resolves with the lean entry of the started spec', async () => {
+  it('navigates to the runner URL and acknowledges the started spec with its test count', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const setHash = stubNavigation()
+
+    stubStartedRun('cypress/e2e/login.cy.ts', 2)
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
+
+    expect(outcome).to.deep.eq({
+      result: {
+        spec: 'cypress/e2e/login.cy.ts',
+        status: 'running',
+        totalTests: 2,
+        message: RUN_ACK_MESSAGE,
+      },
+    })
+
+    expect(setHash).to.have.been.calledOnce
+    expect(setHash.firstCall.args[0]).to.match(/^\/specs\/runner\?file=cypress\/e2e\/login\.cy\.ts&tapRun=\d+$/)
+  })
+
+  it('omits the test count when the started run does not register tests in time', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
     const setHash = stubNavigation()
@@ -91,17 +129,22 @@ describe('tap/commands/run', () => {
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
     expect(outcome).to.deep.eq({
-      result: { relativePath: 'cypress/e2e/login.cy.ts', specType: 'integration' },
+      result: {
+        spec: 'cypress/e2e/login.cy.ts',
+        status: 'running',
+        message: RUN_ACK_MESSAGE,
+      },
     })
 
     expect(setHash).to.have.been.calledOnce
-    expect(setHash.firstCall.args[0]).to.match(/^\/specs\/runner\?file=cypress\/e2e\/login\.cy\.ts&tapRun=\d+$/)
   })
 
   it('advances the tapRun nonce so rerunning the same spec changes the query', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
     const setHash = stubNavigation()
+
+    stubStartedRun('cypress/e2e/login.cy.ts', 1)
     const manager = new TapManager(CYPRESS_VERSION)
 
     const readNonce = (href: string) => Number(href.match(/tapRun=(\d+)$/)?.[1])
@@ -120,6 +163,8 @@ describe('tap/commands/run', () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
     const setHash = stubNavigation('#/specs/runner?file=cypress/e2e/login.cy.ts&tapRun=7')
+
+    stubStartedRun('cypress/e2e/login.cy.ts', 1)
     const manager = new TapManager(CYPRESS_VERSION)
 
     await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
@@ -131,12 +176,19 @@ describe('tap/commands/run', () => {
     window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress\\e2e\\login.cy.ts' }]
 
     const setHash = stubNavigation()
+
+    stubStartedRun('cypress\\e2e\\login.cy.ts', 3)
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/login.cy.ts' })
 
     expect(outcome).to.deep.eq({
-      result: { relativePath: 'cypress\\e2e\\login.cy.ts', specType: 'integration' },
+      result: {
+        spec: 'cypress\\e2e\\login.cy.ts',
+        status: 'running',
+        totalTests: 3,
+        message: RUN_ACK_MESSAGE,
+      },
     })
 
     expect(setHash.firstCall.args[0]).to.contain('file=cypress/e2e/login.cy.ts')
@@ -146,6 +198,8 @@ describe('tap/commands/run', () => {
     window.__RUN_MODE_SPECS__ = [{ ...RUN_MODE_SPECS[0], relative: 'cypress/e2e/a&b?c+d%e.cy.ts' }]
 
     const setHash = stubNavigation()
+
+    stubStartedRun('cypress/e2e/a&b?c+d%e.cy.ts', 1)
     const manager = new TapManager(CYPRESS_VERSION)
 
     const outcome = await manager.exec('run', { spec: 'cypress/e2e/a&b?c+d%e.cy.ts' })

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -1,8 +1,8 @@
 import { posixify } from '../../paths'
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
-import { toSpecListEntry } from './specs-list'
-import type { SpecListEntry } from '../types'
+import { aggregateResults } from './test-state'
+import type { RunAck } from '../types'
 
 const nextTapRunNonce = () => {
   const query = tapManagerDataSource.getHash().split('?')[1] ?? ''
@@ -11,12 +11,40 @@ const nextTapRunNonce = () => {
   return (Number.isInteger(current) ? current : 0) + 1
 }
 
+const RUN_TESTS_WAIT_MS = 5000
+const RUN_TESTS_POLL_MS = 50
+
+// Mocha registers every test at spec-parse time, before the first command runs,
+// so the count is readable shortly after firing — and before any cross-origin
+// cy.visit could swap the runner frame out from under us. Poll until the newly
+// started run has registered its tests, giving up (count omitted) on timeout.
+const countStartedTests = async (wanted: string): Promise<number | undefined> => {
+  const deadline = Date.now() + RUN_TESTS_WAIT_MS
+
+  while (Date.now() < deadline) {
+    const runner = tapManagerDataSource.getRunner()
+    const active = tapManagerDataSource.getActiveSpecRelative()
+
+    if (runner && active && posixify(active) === wanted) {
+      const { totalTests } = aggregateResults(runner)
+
+      if (totalTests > 0) {
+        return totalTests
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, RUN_TESTS_POLL_MS))
+  }
+
+  return undefined
+}
+
 export const runCommand = defineCommand({
   description: 'run (or rerun) a spec by its project-relative path',
   params: [
     { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
   ],
-  handler: async ({ spec }): Promise<SpecListEntry> => {
+  handler: async ({ spec }): Promise<RunAck> => {
     if (spec.length === 0) {
       throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
     }
@@ -34,6 +62,13 @@ export const runCommand = defineCommand({
 
     tapManagerDataSource.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
 
-    return toSpecListEntry(match)
+    const totalTests = await countStartedTests(wanted)
+
+    return {
+      spec: match.relative,
+      status: 'running',
+      ...(totalTests !== undefined ? { totalTests } : {}),
+      message: 'spec is running — poll `cypress tap status` for progress',
+    }
   },
 })

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -15,6 +15,15 @@ export interface SpecListEntry {
   specType: FoundSpec['specType']
 }
 
+export interface RunAck {
+  /** Project-relative spec path, as listed by the specs command. */
+  spec: string
+  status: 'running'
+  /** Total tests in the started spec; absent if the run hadn't registered them yet. */
+  totalTests?: number
+  message: string
+}
+
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'
 
 export interface TestStateEntry {


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13993

### Additional details

`cypress tap run <spec>` returned the raw spec object (`{ relativePath, specType }`), which is redundant with `tap specs` and doesn't tell the caller anything about the run it just started. It now returns a concise **running acknowledgement**:

- `spec` — the started spec's project-relative path
- `status` — `"running"`
- `totalTests` — the started spec's test count, read by reusing `aggregateResults` (the same rollup `tap status` uses). Mocha registers every test at spec-parse time, before the first command runs, so the count is available within ~1s of firing — and before any cross-origin `cy.visit` could swap the runner frame. If the run hasn't registered tests within a short window, `totalTests` is omitted rather than blocking.
- `message` — points the caller at `cypress tap status` for progress

Run stays fire-and-poll (a blocking `run --wait` remains deferred, #13692).

### Steps to test

1. `cypress open --e2e --browser electron --project <project>` and wait for the browser to attach.
2. `cypress tap run <spec>` → returns the running ack with `totalTests`, not the spec object.
3. `cypress tap status` → shows progress/results.

### How has the user experience changed?

Live run against a browser-attached open-mode instance (`math.cy.js` has 2 tests):

**Before:**

```console
$ cypress tap run "cypress/e2e/math.cy.js"
{
  "relativePath": "cypress/e2e/math.cy.js",
  "specType": "integration"
}
```

**After:**

```console
$ cypress tap run "cypress/e2e/math.cy.js"
{
  "spec": "cypress/e2e/math.cy.js",
  "status": "running",
  "totalTests": 2,
  "message": "spec is running — poll `cypress tap status` for progress"
}

$ cypress tap status
{ "status": "passed", …, "spec": "cypress/e2e/math.cy.js", "totalTests": 2,
  "results": { "passed": 2, "failed": 0, "pending": 0, "skipped": 0 } }
```

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — internal issue cypress-io/cypress-services#13993 (tap CLI epic #13624)
- [x] Have tests been added/updated? — `run.cy.ts` rewritten for the ack shape (incl. a test-count-omitted case); `tap-binding` e2e asserts the ack. Component/e2e specs run in CI (cypress-in-cypress); behavior verified live (above).
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.

> Note: overlaps with #13987 (drop testing type from `tap specs`) in `run.cy.ts` / `tap-binding.cy.ts` — this PR reworks `tap run`'s return entirely, superseding that file's `run` output change. Merge order-independent; expect a trivial conflict resolution in the tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tap CLI contract for `run` and adds async polling against runner state; behavior is covered by tests but any external tap consumers must expect the new response shape.
> 
> **Overview**
> **`cypress tap run`** no longer returns the same `{ relativePath, specType }` object as **`tap specs`**. It now returns a **`RunAck`**: `spec`, `status: "running"`, an optional **`totalTests`**, and a **`message`** directing callers to poll **`cypress tap status`**.
> 
> After navigation to the runner URL, the handler **polls** (up to ~5s) for the active spec and runner test registration, using **`aggregateResults`** (same rollup as status). If tests appear in time, **`totalTests`** is included; otherwise the ack is returned without it so the command stays non-blocking.
> 
> Unit and e2e tests were updated for the new shape, including a case where the count is omitted when the runner never registers tests in time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5204924c53c35bdb388ff911c6e37f58a83775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->