### PR TITLE
fix: truncate long assertion messages in tap commands (13997)

### DIFF
--- a/packages/app/src/tap/commands/commands.cy.ts
+++ b/packages/app/src/tap/commands/commands.cy.ts
@@ -42,6 +42,14 @@ describe('tap/commands/commands', () => {
         { id: 'log-c', name: 'visit', message: null, state: 'passed', type: 'parent', _hasBeenCleanedUp: true },
       ],
     },
+    r5: {
+      id: 'r5',
+      title: 'long assertion message',
+      state: 'passed',
+      commands: [
+        { id: 'log-long', name: 'assert', message: 'x'.repeat(250), state: 'passed', type: 'child' },
+      ],
+    },
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
@@ -98,6 +106,30 @@ describe('tap/commands/commands', () => {
       result: [
         { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
         { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+      ],
+    })
+  })
+
+  it('truncates a long command message by default and marks the entry truncated', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id] })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('commands', {}, { test: 'r5' })).to.deep.eq({
+      result: [
+        { id: 'log-long', name: 'assert', message: 'x'.repeat(200), truncated: true, state: 'passed', type: 'child' },
+      ],
+    })
+  })
+
+  it('returns the full command message when --full is set', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id] })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('commands', {}, { test: 'r5', full: 'true' })).to.deep.eq({
+      result: [
+        { id: 'log-long', name: 'assert', message: 'x'.repeat(250), state: 'passed', type: 'child' },
       ],
     })
   })

--- a/packages/app/src/tap/commands/commands.ts
+++ b/packages/app/src/tap/commands/commands.ts
@@ -9,8 +9,9 @@ export const commandsCommand = defineCommand({
   options: [
     { name: 'test', type: 'string', required: true, description: 'test id, as listed by the tests command' },
     { name: 'attempt', type: 'number', required: false, description: '1-based attempt to read (attempt 1 = first run); defaults to the latest' },
+    { name: 'full', type: 'boolean', required: false, description: 'return full command messages instead of truncating long ones' },
   ],
-  handler: async (_params, { test, attempt }): Promise<CommandEntry[]> => {
+  handler: async (_params, { test, attempt, full }): Promise<CommandEntry[]> => {
     const runner = tapManagerDataSource.getRunner()
 
     if (!runner) {
@@ -23,6 +24,6 @@ export const commandsCommand = defineCommand({
       throw attemptSelectionError(selection, test)
     }
 
-    return serializeTestCommands(selection.attempt)
+    return serializeTestCommands(selection.attempt, { full })
   },
 })

--- a/packages/app/src/tap/commands/test-state.ts
+++ b/packages/app/src/tap/commands/test-state.ts
@@ -107,7 +107,21 @@ export const serializeTestDetail = (test: SerializedTest, attempt: SerializedTes
   }
 }
 
-export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] => {
+const MAX_COMMAND_MESSAGE_LENGTH = 200
+
+const messageField = (message: string | null | undefined, full: boolean): Pick<CommandEntry, 'message' | 'truncated'> => {
+  if (message == null) {
+    return {}
+  }
+
+  if (!full && message.length > MAX_COMMAND_MESSAGE_LENGTH) {
+    return { message: message.slice(0, MAX_COMMAND_MESSAGE_LENGTH), truncated: true }
+  }
+
+  return { message }
+}
+
+export const serializeTestCommands = (attempt: SerializedTest, { full = false }: { full?: boolean } = {}): CommandEntry[] => {
   const commands = attempt.commands ?? []
 
   // The driver's reduceMemory nulls (not deletes) non-preserved command attrs
@@ -119,7 +133,7 @@ export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] =
     return {
       id,
       ...(name != null ? { name } : {}),
-      ...(message != null ? { message } : {}),
+      ...messageField(message, full),
       ...(state != null ? { state } : {}),
       ...(type != null ? { type } : {}),
       ...(_hasBeenCleanedUp === true ? { cleanedUp: true } : {}),

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -65,6 +65,8 @@ export interface CommandEntry {
   name?: string
   /** The command log's display message — arguments/assertion text, not output. */
   message?: string
+  /** Present (always `true`) when `message` was truncated; re-run with `--full` for the whole message. */
+  truncated?: true
   /** `pending` while the command runs, then `passed` or `failed`. */
   state?: SerializedCommandLog['state']
   /** `parent` starts a chain, `child` is chained off a subject, `system` is driver-emitted. */


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13997

### Additional details

`cypress tap commands` returned each command's full message. Assertion messages in particular can be thousands of characters (the full expected/actual values), which blows up the output an agent has to read.

Command messages longer than **200 characters** are now truncated by default, and the entry is marked `truncated: true` so the caller knows there's more. Pass **`--full`** to retrieve the whole message. Truncation is per-entry, so short commands are unaffected.

> Default length (200) and the `--full` flag name are my choices — easy to adjust if you'd prefer different values.

### Steps to test

1. Run a spec with a long assertion (e.g. `expect(longString).to.equal(longString)`).
2. `cypress tap commands --test <id>` → long messages are cut to 200 chars with `truncated: true`.
3. `cypress tap commands --test <id> --full` → full messages, no `truncated` flag.

### How has the user experience changed?

Live run against a browser-attached instance; the spec's assertion message is 2381 characters:

**Before** — the full 2381-char message ships every time:

```console
$ cypress tap commands --test r3
[ { "id": "…-1", "name": "assert", "state": "passed", "message": "<2381 chars>" }, … ]
```

**After** — truncated by default, full on demand:

```console
$ cypress tap commands --test r3
# assert entry: message length 200, truncated: true

$ cypress tap commands --test r3 --full
# assert entry: message length 2381, no truncated flag
```

### PR Tasks

- [x] Have tests been added/updated? — `commands.cy.ts` adds a truncate-by-default case and a `--full` case; 200-char boundary asserted. Component specs run in CI (cypress-in-cypress); behavior verified live (above).
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-shaping change to internal tap CLI serialization only; no auth, persistence, or runner behavior changes.
> 
> **Overview**
> **`cypress tap commands`** now caps each command log **`message`** at **200 characters** by default, so huge assertion expected/actual strings no longer flood agent-facing output.
> 
> Entries that were shortened include **`truncated: true`** on the wire type. Pass **`--full`** on the tap **`commands`** command to return the full message with no truncation flag. Short messages and existing behavior (lean fields, **`cleanedUp`**, attempt selection) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c8222d2b883258c957ade0fe2be3c51cac97c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->