### PR TITLE
fix: tap specs/run read the live spec set, not a stale snapshot (13936)

### DIFF
--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -49,10 +49,11 @@ describe('tap binding', () => {
 
       const specs = (outcome as { result: Array<{ relativePath: string, specType: string }> }).result
 
-      expect(specs).to.deep.include({ relativePath: 'cypress/e2e/dom-content.spec.js', specType: 'integration' })
+      expect(specs.map((spec) => spec.relativePath)).to.include('cypress/e2e/dom-content.spec.js')
 
       for (const spec of specs) {
-        expect(Object.keys(spec), `entry ${spec.relativePath}`).to.deep.eq(['relativePath', 'specType'])
+        expect(spec, `entry ${spec.relativePath}`).to.include.keys(['relativePath', 'specType'])
+        expect(Object.keys(spec), `entry ${spec.relativePath}`).to.satisfy((keys: string[]) => keys.every((key) => ['relativePath', 'specType', 'lastModified'].includes(key)))
       }
 
       // With no run yet there is no runner to read, so run-state omits the run-only fields.

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -68,6 +68,40 @@ describe('tap binding', () => {
     })
   })
 
+  it('lists a spec added while the instance is open, with no runner reload', () => {
+    const added = 'cypress/e2e/added-while-open.spec.js'
+
+    const relativePaths = async (win: Cypress.AUTWindow): Promise<string[]> => {
+      const outcome = await getBinding(win).exec('specs')
+
+      return (outcome as { result: Array<{ relativePath: string }> }).result.map((spec) => spec.relativePath)
+    }
+
+    cy.window().then(async (win) => {
+      expect(await relativePaths(win), 'absent before it is written').not.to.include(added)
+    })
+
+    cy.withCtx(async (ctx, o) => {
+      await ctx.actions.file.writeFileInProject(o.added, `describe('added while open', () => { it('runs', () => { expect(true).to.be.true }) })`)
+    }, { added })
+
+    // The spec watcher pushes the new spec over GraphQL; tap reads it live, with
+    // no page reload. Poll the binding until the watcher-updated query reflects it.
+    cy.window().then((win) => {
+      return (async () => {
+        for (let attempt = 0; attempt < 20; attempt++) {
+          if ((await relativePaths(win)).includes(added)) {
+            return
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 250))
+        }
+
+        throw new Error(`spec "${added}" was never listed by tap specs after being written`)
+      })()
+    })
+  })
+
   it('runs and reruns a spec via the run command', () => {
     cy.window().then(async (win) => {
       const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/dom-content.spec.js' })

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -8,6 +8,7 @@ import { makeUrqlClient } from '@packages/frontend-shared/src/graphql/urqlClient
 import { createI18n } from '@cy/i18n'
 import { createRouter } from './router/router'
 import { TapManager } from './tap/tap-manager'
+import type { TapRuntime } from './tap/tap-runtime'
 import { injectBundle } from './runner/injectBundle'
 import { createPinia } from './store'
 import Toast, { POSITION } from 'vue-toastification'
@@ -29,7 +30,9 @@ const ws = createWebsocket(config)
 
 window.ws = ws
 
-window.__CYPRESS_TAP_BINDING__ = new TapManager(config.version)
+const tapRuntime: TapRuntime = { gqlClient: null }
+
+window.__CYPRESS_TAP_BINDING__ = new TapManager(config.version, tapRuntime)
 
 telemetry.attachWebSocket(ws)
 
@@ -45,6 +48,12 @@ app.use(Toast, {
 })
 
 await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute }).then((client) => {
+  // Open mode has a live spec set behind GraphQL; run mode does not, so tap
+  // there falls back to the served snapshot.
+  if (!config.isTextTerminal) {
+    tapRuntime.gqlClient = client
+  }
+
   app.use(urql, client)
   app.use(createRouter())
   app.use(createI18n())

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -48,11 +48,7 @@ app.use(Toast, {
 })
 
 await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute }).then((client) => {
-  // Open mode has a live spec set behind GraphQL; run mode does not, so tap
-  // there falls back to the served snapshot.
-  if (!config.isTextTerminal) {
-    tapRuntime.gqlClient = client
-  }
+  tapRuntime.gqlClient = client
 
   app.use(urql, client)
   app.use(createRouter())

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -8,7 +8,6 @@ import { makeUrqlClient } from '@packages/frontend-shared/src/graphql/urqlClient
 import { createI18n } from '@cy/i18n'
 import { createRouter } from './router/router'
 import { TapManager } from './tap/tap-manager'
-import type { TapRuntime } from './tap/tap-runtime'
 import { injectBundle } from './runner/injectBundle'
 import { createPinia } from './store'
 import Toast, { POSITION } from 'vue-toastification'
@@ -30,9 +29,9 @@ const ws = createWebsocket(config)
 
 window.ws = ws
 
-const tapRuntime: TapRuntime = { gqlClient: null }
+const tapManager = new TapManager(config.version)
 
-window.__CYPRESS_TAP_BINDING__ = new TapManager(config.version, tapRuntime)
+window.__CYPRESS_TAP_BINDING__ = tapManager
 
 telemetry.attachWebSocket(ws)
 
@@ -48,7 +47,7 @@ app.use(Toast, {
 })
 
 await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute }).then((client) => {
-  tapRuntime.gqlClient = client
+  tapManager.setGqlClient(client)
 
   app.use(urql, client)
   app.use(createRouter())

--- a/packages/app/src/tap/commands/definition.ts
+++ b/packages/app/src/tap/commands/definition.ts
@@ -1,4 +1,5 @@
 import type { TapCommandOptionSchema, TapCommandParamSchema } from '../contract'
+import type { TapRuntime } from '../tap-runtime'
 
 /**
  * Thrown by a handler to report a domain failure (no run mounted, no such test
@@ -44,7 +45,7 @@ export const defineCommand = <
   params: P
   options?: O
   hidden?: boolean
-  handler: (params: ParamsToObject<P>, options: OptionsToObject<O>) => Promise<unknown>
+  handler: (params: ParamsToObject<P>, options: OptionsToObject<O>, runtime: TapRuntime) => Promise<unknown>
 }) => {
   return definition
 }

--- a/packages/app/src/tap/commands/run-state.ts
+++ b/packages/app/src/tap/commands/run-state.ts
@@ -16,8 +16,8 @@ export const runStateCommand = defineCommand({
   // The CLI surfaces this through the friendlier `status` command, not as its own.
   hidden: true,
   params: [],
-  handler: async (): Promise<RunStateResult> => {
-    const totalSpecs = tapManagerDataSource.getRunnableSpecs().length
+  handler: async (_params, _options, runtime): Promise<RunStateResult> => {
+    const totalSpecs = (await tapManagerDataSource.getRunnableSpecs(runtime.gqlClient)).length
     const runner = tapManagerDataSource.getRunner()
 
     if (!runner) {

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -16,13 +16,14 @@ export const runCommand = defineCommand({
   params: [
     { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
   ],
-  handler: async ({ spec }): Promise<SpecListEntry> => {
+  handler: async ({ spec }, _options, runtime): Promise<SpecListEntry> => {
     if (spec.length === 0) {
       throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
     }
 
     const wanted = posixify(spec)
-    const match = tapManagerDataSource.getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
+    const specs = await tapManagerDataSource.getRunnableSpecs(runtime.gqlClient)
+    const match = specs.find((entry) => posixify(entry.relative) === wanted)
 
     if (!match) {
       throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -1,7 +1,5 @@
-import type { FoundSpec } from '@packages/types'
+import type { RunnableSpec, SpecListEntry } from '../types'
 
-import type { SpecListEntry } from '../types'
-
-export const toSpecListEntry = ({ relative, specType }: FoundSpec): SpecListEntry => {
+export const toSpecListEntry = ({ relative, specType }: RunnableSpec): SpecListEntry => {
   return { relativePath: relative, specType }
 }

--- a/packages/app/src/tap/commands/specs-list.ts
+++ b/packages/app/src/tap/commands/specs-list.ts
@@ -1,5 +1,9 @@
 import type { RunnableSpec, SpecListEntry } from '../types'
 
-export const toSpecListEntry = ({ relative, specType }: RunnableSpec): SpecListEntry => {
-  return { relativePath: relative, specType }
+export const toSpecListEntry = ({ relative, specType, lastModified }: RunnableSpec): SpecListEntry => {
+  return {
+    relativePath: relative,
+    specType,
+    ...(lastModified != null ? { lastModified } : {}),
+  }
 }

--- a/packages/app/src/tap/commands/specs.cy.ts
+++ b/packages/app/src/tap/commands/specs.cy.ts
@@ -2,11 +2,16 @@ import type { FoundSpec } from '@packages/types'
 import type { Client } from '@urql/core'
 
 import { TapManager } from '../tap-manager'
-import type { RunnableSpec } from '../types'
 
 const CYPRESS_VERSION = '15.0.0'
 
-const stubGqlClient = (specs: RunnableSpec[]): Client => {
+interface StubSpec {
+  relative: string
+  specType: 'integration' | 'component'
+  gitInfo?: { lastModifiedHumanReadable: string | null } | null
+}
+
+const stubGqlClient = (specs: StubSpec[]): Client => {
   return {
     query: () => ({ toPromise: async () => ({ data: { currentProject: { specs } } }) }),
   } as unknown as Client
@@ -40,17 +45,21 @@ describe('tap/commands/specs', () => {
     delete (window as any).__RUN_MODE_SPECS__
   })
 
-  it('lists specs from the live GraphQL client when one is provided (open mode)', async () => {
+  it('lists specs from the live GraphQL client, with git last-modified, when a client is set (open mode)', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
     const gqlClient = stubGqlClient([
-      { relative: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration' },
+      { relative: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration', gitInfo: { lastModifiedHumanReadable: '2 hours ago' } },
+      { relative: 'cypress/e2e/no-git.cy.ts', specType: 'integration', gitInfo: null },
     ])
-    const manager = new TapManager(CYPRESS_VERSION, { gqlClient })
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    manager.setGqlClient(gqlClient)
 
     expect(await manager.exec('specs')).to.deep.eq({
       result: [
-        { relativePath: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration' },
+        { relativePath: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration', lastModified: '2 hours ago' },
+        { relativePath: 'cypress/e2e/no-git.cy.ts', specType: 'integration' },
       ],
     })
   })

--- a/packages/app/src/tap/commands/specs.cy.ts
+++ b/packages/app/src/tap/commands/specs.cy.ts
@@ -1,8 +1,16 @@
 import type { FoundSpec } from '@packages/types'
+import type { Client } from '@urql/core'
 
 import { TapManager } from '../tap-manager'
+import type { RunnableSpec } from '../types'
 
 const CYPRESS_VERSION = '15.0.0'
+
+const stubGqlClient = (specs: RunnableSpec[]): Client => {
+  return {
+    query: () => ({ toPromise: async () => ({ data: { currentProject: { specs } } }) }),
+  } as unknown as Client
+}
 
 describe('tap/commands/specs', () => {
   const RUN_MODE_SPECS: FoundSpec[] = [
@@ -32,7 +40,22 @@ describe('tap/commands/specs', () => {
     delete (window as any).__RUN_MODE_SPECS__
   })
 
-  it('lists the server-embedded specs, keeping only the lean entry fields', async () => {
+  it('lists specs from the live GraphQL client when one is provided (open mode)', async () => {
+    window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
+
+    const gqlClient = stubGqlClient([
+      { relative: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration' },
+    ])
+    const manager = new TapManager(CYPRESS_VERSION, { gqlClient })
+
+    expect(await manager.exec('specs')).to.deep.eq({
+      result: [
+        { relativePath: 'cypress/e2e/added-while-open.cy.ts', specType: 'integration' },
+      ],
+    })
+  })
+
+  it('falls back to the server-embedded snapshot when there is no GraphQL client', async () => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -45,7 +68,7 @@ describe('tap/commands/specs', () => {
     })
   })
 
-  it('resolves an empty list when the specs global is not present', async () => {
+  it('resolves an empty list when neither a client nor the specs global is present', async () => {
     const manager = new TapManager(CYPRESS_VERSION)
 
     expect(await manager.exec('specs')).to.deep.eq({ result: [] })

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -6,7 +6,7 @@ import type { SpecListEntry } from '../types'
 export const specsCommand = defineCommand({
   description: 'List all runnable specs for the selected Cypress instance.',
   params: [],
-  handler: async (): Promise<SpecListEntry[]> => {
-    return tapManagerDataSource.getRunnableSpecs().map(toSpecListEntry)
+  handler: async (_params, _options, runtime): Promise<SpecListEntry[]> => {
+    return (await tapManagerDataSource.getRunnableSpecs(runtime.gqlClient)).map(toSpecListEntry)
   },
 })

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -1,6 +1,22 @@
+import { gql } from '@urql/vue'
+import type { Client } from '@urql/core'
 import type { FoundSpec } from '@packages/types'
 
-import type { TapTestsRunner } from './types'
+import { TapSpecsDocument } from '../generated/graphql'
+import type { RunnableSpec, TapTestsRunner } from './types'
+
+gql`
+query TapSpecs {
+  currentProject {
+    id
+    specs {
+      id
+      relative
+      specType
+    }
+  }
+}
+`
 
 export const tapManagerDataSource = {
   getRunner (): TapTestsRunner | undefined {
@@ -31,7 +47,16 @@ export const tapManagerDataSource = {
     }
   },
 
-  getRunnableSpecs (): FoundSpec[] {
+  async getRunnableSpecs (gqlClient: Client | null): Promise<RunnableSpec[]> {
+    if (gqlClient) {
+      const result = await gqlClient.query(TapSpecsDocument, {}, { requestPolicy: 'network-only' }).toPromise()
+      const specs = result.data?.currentProject?.specs
+
+      if (specs) {
+        return specs.map(({ relative, specType }) => ({ relative, specType }))
+      }
+    }
+
     return (window.__RUN_MODE_SPECS__ ?? []) as FoundSpec[]
   },
 

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -13,6 +13,9 @@ query TapSpecs {
       id
       relative
       specType
+      gitInfo {
+        lastModifiedHumanReadable
+      }
     }
   }
 }
@@ -53,7 +56,13 @@ export const tapManagerDataSource = {
       const specs = result.data?.currentProject?.specs
 
       if (specs) {
-        return specs.map(({ relative, specType }) => ({ relative, specType }))
+        return specs.map(({ relative, specType, gitInfo }) => {
+          return {
+            relative,
+            specType,
+            ...(gitInfo?.lastModifiedHumanReadable != null ? { lastModified: gitInfo.lastModifiedHumanReadable } : {}),
+          }
+        })
       }
     }
 

--- a/packages/app/src/tap/tap-manager.ts
+++ b/packages/app/src/tap/tap-manager.ts
@@ -4,6 +4,7 @@ import type { TapCommandDefinition } from './commands/definition'
 import { coerceCommandArgs, coerceCommandOptions } from './exec-args'
 import { TAP_SCHEMA_VERSION } from './contract'
 import type { TapBindingContract, TapExecResult, TapSchema } from './contract'
+import type { TapRuntime } from './tap-runtime'
 
 // Normalize a wire payload to a plain object, or null if malformed. `null` maps
 // to `{}` (absent); a primitive or array would otherwise slip past `Object.keys`
@@ -23,7 +24,7 @@ const normalizePayload = (value: unknown): Record<string, string> | null => {
 // The surface mounted at `window.__CYPRESS_TAP_BINDING__`, invoked by the CLI
 // over CDP `Runtime.callFunctionOn` — both methods are async and JSON-only per `./contract`.
 export class TapManager implements TapBindingContract {
-  constructor (private cypressVersion: string) {}
+  constructor (private cypressVersion: string, private runtime: TapRuntime = { gqlClient: null }) {}
 
   async getSchema (): Promise<TapSchema> {
     return {
@@ -92,7 +93,7 @@ export class TapManager implements TapBindingContract {
     }
 
     try {
-      return { result: await definition.handler(coercedArgs.args, coercedOptions.options) }
+      return { result: await definition.handler(coercedArgs.args, coercedOptions.options, this.runtime) }
     } catch (err) {
       // A handler's TapCommandError is a domain failure; surface it as { error }.
       // Any other throw is a real binding bug.

--- a/packages/app/src/tap/tap-manager.ts
+++ b/packages/app/src/tap/tap-manager.ts
@@ -5,6 +5,7 @@ import { coerceCommandArgs, coerceCommandOptions } from './exec-args'
 import { TAP_SCHEMA_VERSION } from './contract'
 import type { TapBindingContract, TapExecResult, TapSchema } from './contract'
 import type { TapRuntime } from './tap-runtime'
+import type { Client } from '@urql/core'
 
 // Normalize a wire payload to a plain object, or null if malformed. `null` maps
 // to `{}` (absent); a primitive or array would otherwise slip past `Object.keys`
@@ -24,7 +25,15 @@ const normalizePayload = (value: unknown): Record<string, string> | null => {
 // The surface mounted at `window.__CYPRESS_TAP_BINDING__`, invoked by the CLI
 // over CDP `Runtime.callFunctionOn` — both methods are async and JSON-only per `./contract`.
 export class TapManager implements TapBindingContract {
-  constructor (private cypressVersion: string, private runtime: TapRuntime = { gqlClient: null }) {}
+  private runtime: TapRuntime = { gqlClient: null }
+
+  constructor (private cypressVersion: string) {}
+
+  // Open mode threads its long-lived urql client in once it resolves; handlers
+  // read it off the runtime to query live project state (e.g. the spec set).
+  setGqlClient (client: Client): void {
+    this.runtime.gqlClient = client
+  }
 
   async getSchema (): Promise<TapSchema> {
     return {

--- a/packages/app/src/tap/tap-runtime.ts
+++ b/packages/app/src/tap/tap-runtime.ts
@@ -1,0 +1,9 @@
+import type { Client } from '@urql/core'
+
+// Ambient state the tap binding needs but that lives outside the command
+// modules. `gqlClient` is the app's long-lived urql client in open mode, or
+// null in run mode / before the client resolves — handlers treat null as
+// "fall back to the served snapshot".
+export interface TapRuntime {
+  gqlClient: Client | null
+}

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -9,14 +9,19 @@ export interface TapTestsRunner {
 }
 
 // The fields the tap commands read off a runnable spec, sourced live from
-// GraphQL in open mode or from the served snapshot as a fallback.
-export type RunnableSpec = Pick<FoundSpec, 'relative' | 'specType'>
+// GraphQL in open mode or from the served snapshot as a fallback. `lastModified`
+// comes from git and is only available over the live client (open mode).
+export type RunnableSpec = Pick<FoundSpec, 'relative' | 'specType'> & {
+  lastModified?: string
+}
 
 export interface SpecListEntry {
   /** Project-relative spec path — the form `cypress run --spec` accepts. */
   relativePath: string
   /** Whether the spec is an end-to-end (integration) or component spec. */
   specType: FoundSpec['specType']
+  /** Human-readable last-modified time from git (e.g. "2 hours ago"); absent in run mode. */
+  lastModified?: string
 }
 
 export type TestStateValue = 'passed' | 'failed' | 'pending' | 'skipped'

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -8,6 +8,10 @@ export interface TapTestsRunner {
   isRunComplete (): boolean
 }
 
+// The fields the tap commands read off a runnable spec, sourced live from
+// GraphQL in open mode or from the served snapshot as a fallback.
+export type RunnableSpec = Pick<FoundSpec, 'relative' | 'specType'>
+
 export interface SpecListEntry {
   /** Project-relative spec path — the form `cypress run --spec` accepts. */
   relativePath: string


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13936

### Additional details

`cypress tap specs` and `tap run` read `window.__RUN_MODE_SPECS__` — a point-in-time snapshot baked into the served HTML at page load (`HtmlDataSource.replaceBody`). A spec added while the instance is open was invisible to tap until the runner page reloaded, and `tap run` on a fresh spec failed with `SPEC_NOT_FOUND` — the painful half for agent workflows.

This threads the app's **existing** long-lived urql client into the tap binding (no second `makeUrqlClient`):

- New `TapRuntime` (`{ gqlClient: Client | null }`), owned by `TapManager` and forwarded to handlers as a third `exec` argument. Existing handlers are untouched.
- `TapManager.setGqlClient(client)` is called from `main.ts` once the client resolves; the null check in `getRunnableSpecs` doubles as the mode check.
- `getRunnableSpecs(gqlClient)` is now async: with a client, a `network-only` query of `currentProject { specs { relative gitInfo { lastModifiedHumanReadable } } }`; without one (before the client resolves), the `__RUN_MODE_SPECS__` snapshot fallback.
- `run` shares `getRunnableSpecs`, so its SPEC_NOT_FOUND-on-fresh-spec fixes itself.

**Also enriches `tap specs` with `lastModified`** — git's `lastModifiedHumanReadable` (e.g. `"2 hours ago"`), available over the live client; absent when there's no git info. Types come free from codegen: the `gql` `TapSpecs` query generates a typed `TapSpecsDocument`/`TapSpecsQuery`, so the response is strongly typed end-to-end. `generated/graphql.ts` is gitignored; CI regenerates it from the tracked query.

### Steps to test

1. `cypress open --e2e --browser electron --project <a git project>` and wait for the browser to attach.
2. `cypress tap specs` — note the list (entries include `lastModified`).
3. Add a new spec file to the project **without reloading**.
4. `cypress tap specs` lists it; `cypress tap run <new spec>` runs it (previously: absent / `SPEC_NOT_FOUND`).

### How has the user experience changed?

**Staleness fix** — a new spec (`added-while-open.cy.js`) written **while the instance is open** (no reload):

Before — stale snapshot; invisible and unrunnable:

```console
$ cypress tap specs            # after writing added-while-open.cy.js
[ { "relativePath": "cypress/e2e/greeting.cy.js" },
  { "relativePath": "cypress/e2e/math.cy.js" } ]

$ cypress tap run "cypress/e2e/added-while-open.cy.js"
SPEC_NOT_FOUND: no spec matches the path "cypress/e2e/added-while-open.cy.js" — use the specs command to list runnable specs
[exit 1]
```

After — live GraphQL; appears and runs, no reload:

```console
$ cypress tap specs            # after writing added-while-open.cy.js
[ { "relativePath": "cypress/e2e/added-while-open.cy.js", "lastModified": "5 seconds ago" },
  { "relativePath": "cypress/e2e/greeting.cy.js", "lastModified": "2 minutes ago" },
  { "relativePath": "cypress/e2e/math.cy.js", "lastModified": "2 minutes ago" } ]

$ cypress tap run "cypress/e2e/added-while-open.cy.js"
{ "relativePath": "cypress/e2e/added-while-open.cy.js", "lastModified": "5 seconds ago" }
[exit 0]
```

**`lastModified` enrichment** — live against a git-backed project:

```console
$ cypress tap specs
[ { "relativePath": "cypress/e2e/greeting.cy.js", "lastModified": "34 seconds ago" },
  { "relativePath": "cypress/e2e/math.cy.js", "lastModified": "34 seconds ago" } ]
```

### PR Tasks

- [x] Have tests been added/updated? — `specs.cy.ts` covers the live-client path (incl. `lastModified` present/absent) and the snapshot fallback via `setGqlClient`; `tap-binding.cy.ts` adds an e2e that writes a spec mid-session and asserts `exec('specs')` lists it with no reload. Component/e2e specs run in CI; behavior verified live (above).
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap CLI is unreleased/internal.
- [na] Have API changes been updated in the `type definitions`? — no public type changes.

> Note: overlapped `specs.ts`/`run.ts`/`specs-list.ts`/`tap-binding.cy.ts`/`types.ts` with #13987 (drop testing type) and #13993 (run ack) — independent branches off `feat/tap-cli-integration`. Now merged down from the base: `tap specs`/`run` no longer emit `specType`, so this PR only adds the optional `lastModified` field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tap resolves runnable specs for CLI/agent workflows (async GraphQL vs static snapshot), with a preserved fallback; adds an optional field to `tap specs` output rather than breaking existing keys.
> 
> **Overview**
> **Tap no longer relies on `window.__RUN_MODE_SPECS__` alone in open mode.** After the urql client starts, `TapManager` holds a `TapRuntime` with that client; `specs`, `run`, and `run-state` call an async `getRunnableSpecs` that runs a **network-only** `TapSpecs` GraphQL query and falls back to the embedded snapshot when there is no client.
> 
> **`tap specs` entries can include optional `lastModified`** (git `lastModifiedHumanReadable`) when the live query returns git info. `run` resolves specs through the same path, fixing **`SPEC_NOT_FOUND` for specs added after the runner page loaded**.
> 
> Tests cover the GraphQL path, snapshot fallback, and a new e2e that writes a spec mid-session and polls `exec('specs')` without reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a8b96717fc4051f4f1e0c17c4175e7fe45b1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
