### PR TITLE
chore: defer Percy snapshot uploads until run completion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,49 @@ commands:
                     exit 0
                   fi
 
-                  # otherwise, the build is not a PR so we cancel it 
+                  # otherwise, the build is not a PR so we cancel it
                   cancel_build
+
+  # Halt superseded pipelines before the primary workflow (and its Percy
+  # snapshot jobs) launch. When several commits are pushed to a PR in quick
+  # succession, only the pipeline for the current PR head does real work; older
+  # ones stop here so we don't re-bill the full Percy snapshot fan-out per push.
+  # Fails open: any uncertainty about the head SHA lets the build run.
+  cancel-superseded-commits:
+    steps:
+      - when:
+          condition:
+            not:
+              or:
+                - equal: [<<pipeline.trigger_source>>, 'api']
+                - equal: [<<pipeline.git.branch>>, 'develop']
+                - matches:
+                    pattern: /^release\/.*/
+                    value: <<pipeline.git.branch>>
+          steps:
+            - run:
+                name: Halt if a newer commit exists on this PR
+                command: |
+                  # Only PR-triggered pipelines can be superseded by a newer push.
+                  if [ -z "${CIRCLE_PULL_REQUEST:-}" ]; then
+                    echo "Not a PR pipeline - skipping superseded-commit check."
+                    exit 0
+                  fi
+
+                  PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+                  HEAD_SHA=$(curl --silent "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r '.head.sha')
+
+                  if [ -z "${HEAD_SHA}" ] || [ "${HEAD_SHA}" == "null" ]; then
+                    echo "Could not determine PR head SHA - running build."
+                    exit 0
+                  fi
+
+                  if [ "${HEAD_SHA}" != "${CIRCLE_SHA1}" ]; then
+                    echo "Pipeline commit ${CIRCLE_SHA1} is superseded by PR head ${HEAD_SHA} - halting to avoid redundant Percy snapshots and CI usage."
+                    circleci-agent step halt
+                  fi
+
+                  echo "Pipeline commit is the current PR head - continuing."
 
 jobs:
   pack-workflows:
@@ -136,6 +177,7 @@ jobs:
     resource_class: small.gen2
     steps:
         - cancel-draft-prs
+        - cancel-superseded-commits
         - checkout:
             method: blobless
         - restore-src-checksum-cache
@@ -150,6 +192,7 @@ jobs:
       resource_class: small.gen2
       steps:
           - cancel-draft-prs
+          - cancel-superseded-commits
           - checkout:
               method: blobless
           - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,49 +126,8 @@ commands:
                     exit 0
                   fi
 
-                  # otherwise, the build is not a PR so we cancel it
+                  # otherwise, the build is not a PR so we cancel it 
                   cancel_build
-
-  # Halt superseded pipelines before the primary workflow (and its Percy
-  # snapshot jobs) launch. When several commits are pushed to a PR in quick
-  # succession, only the pipeline for the current PR head does real work; older
-  # ones stop here so we don't re-bill the full Percy snapshot fan-out per push.
-  # Fails open: any uncertainty about the head SHA lets the build run.
-  cancel-superseded-commits:
-    steps:
-      - when:
-          condition:
-            not:
-              or:
-                - equal: [<<pipeline.trigger_source>>, 'api']
-                - equal: [<<pipeline.git.branch>>, 'develop']
-                - matches:
-                    pattern: /^release\/.*/
-                    value: <<pipeline.git.branch>>
-          steps:
-            - run:
-                name: Halt if a newer commit exists on this PR
-                command: |
-                  # Only PR-triggered pipelines can be superseded by a newer push.
-                  if [ -z "${CIRCLE_PULL_REQUEST:-}" ]; then
-                    echo "Not a PR pipeline - skipping superseded-commit check."
-                    exit 0
-                  fi
-
-                  PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
-                  HEAD_SHA=$(curl --silent "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r '.head.sha')
-
-                  if [ -z "${HEAD_SHA}" ] || [ "${HEAD_SHA}" == "null" ]; then
-                    echo "Could not determine PR head SHA - running build."
-                    exit 0
-                  fi
-
-                  if [ "${HEAD_SHA}" != "${CIRCLE_SHA1}" ]; then
-                    echo "Pipeline commit ${CIRCLE_SHA1} is superseded by PR head ${HEAD_SHA} - halting to avoid redundant Percy snapshots and CI usage."
-                    circleci-agent step halt
-                  fi
-
-                  echo "Pipeline commit is the current PR head - continuing."
 
 jobs:
   pack-workflows:
@@ -177,7 +136,6 @@ jobs:
     resource_class: small.gen2
     steps:
         - cancel-draft-prs
-        - cancel-superseded-commits
         - checkout:
             method: blobless
         - restore-src-checksum-cache
@@ -192,7 +150,6 @@ jobs:
       resource_class: small.gen2
       steps:
           - cancel-draft-prs
-          - cancel-superseded-commits
           - checkout:
               method: blobless
           - attach_workspace:

--- a/.percy.yml
+++ b/.percy.yml
@@ -1,4 +1,11 @@
 version: 2
+percy:
+  # Hold snapshots locally and upload them only when the run completes, rather
+  # than streaming each one to Percy as it is captured. Percy bills per snapshot
+  # at upload time, so when a parallel shard is canceled early (e.g. fail-fast on
+  # a detected failure) its already-captured snapshots are discarded instead of
+  # billed. See BrowserStack/Percy parallel troubleshooting for context.
+  defer-uploads: true
 snapshot:
   widths:
     - 1280

--- a/npm/vite-dev-server/.percy.yml
+++ b/npm/vite-dev-server/.percy.yml
@@ -1,4 +1,8 @@
 version: 2
+percy:
+  # Upload snapshots only once the run completes so canceled parallel shards
+  # don't bill snapshots that were captured but never finalized.
+  defer-uploads: true
 snapshot:
   widths:
     - 1280

--- a/npm/webpack-dev-server/.percy.yml
+++ b/npm/webpack-dev-server/.percy.yml
@@ -1,4 +1,8 @@
 version: 2
+percy:
+  # Upload snapshots only once the run completes so canceled parallel shards
+  # don't bill snapshots that were captured but never finalized.
+  defer-uploads: true
 snapshot:
   widths:
     - 1280

--- a/packages/app/.percy.yml
+++ b/packages/app/.percy.yml
@@ -1,4 +1,8 @@
 version: 2
+percy:
+  # Upload snapshots only once the run completes so canceled parallel shards
+  # don't bill snapshots that were captured but never finalized.
+  defer-uploads: true
 snapshot:
   widths:
     - 1280

--- a/packages/launchpad/.percy.yml
+++ b/packages/launchpad/.percy.yml
@@ -1,4 +1,8 @@
 version: 2
+percy:
+  # Upload snapshots only once the run completes so canceled parallel shards
+  # don't bill snapshots that were captured but never finalized.
+  defer-uploads: true
 snapshot:
   widths:
     - 1280

--- a/packages/reporter/.percy.yml
+++ b/packages/reporter/.percy.yml
@@ -1,4 +1,8 @@
 version: 2
+percy:
+  # Upload snapshots only once the run completes so canceled parallel shards
+  # don't bill snapshots that were captured but never finalized.
+  defer-uploads: true
 snapshot:
   widths:
     - 400


### PR DESCRIPTION
### Additional details

**Why was this change necessary?**

Percy bills per snapshot **at the moment it is uploaded**, and with the default configuration uploads happen incrementally as each `cy.percySnapshot()` runs. When a parallel test shard is canceled early or hangs (fail-fast on a detected failure), every snapshot it had already captured has *also already been uploaded* — so it is billed even though the build never finalizes and the snapshots are never viewable. Across our parallel integration runs this produces a steady stream of unfinalized ("receiving") builds that each contribute some fraction of the 400+ snapshots/run to usage with zero value to us.

**What this changes**

Sets `defer-uploads: true` in the `percy` section of every `.percy.yml`. Per Percy support/engineering's recommendation, this holds captured snapshots in the local Percy server and uploads them only when the run completes, rather than streaming each one as it is taken. A shard that is canceled mid-run is killed before that flush, so its captured snapshots are **discarded instead of billed**. Completed/finalized builds are unaffected — they still upload and diff every snapshot as before.

#### Before

snapshots upload as tests run, even if the run hangs or does not complete or is cancelled

#### After

<img width="1277" height="360" alt="Screenshot 2026-07-22 at 3 46 34 PM" src="https://github.com/user-attachments/assets/f971d9a0-b637-49c4-98a5-2241e8d85eac" />


**What is affected**

- All six Percy config files: root `.percy.yml`, `packages/app`, `packages/launchpad`, `packages/reporter`, `npm/vite-dev-server`, `npm/webpack-dev-server` (applied to all so the option is active regardless of which config a given job resolves).
- No test code, no application code. `defer-uploads` is a recognized property of the `percy` config section (confirmed against the `@percy/cli` config schema; supported by our pinned `@percy/cli@1.27.4`).

### Steps to test

1. **Config is parsed & applied** (no token needed):
   ```
   npx -p @percy/cli@1.27.4 percy config:validate .percy.yml
   ```
   The resolved config output includes `percy: { deferUploads: true }` (a typo'd key is rejected as `unknown property`, confirming the schema recognizes it).
2. **Uploads are deferred** — run a Percy suite with `PERCY_LOGLEVEL=debug`; the build is now created and snapshots uploaded at the **end** of the run (after Cypress exits) rather than near the start.
3. **Canceled run bills nothing** — interrupt a Percy run mid-suite and confirm in the Percy dashboard that the resulting unfinalized build shows **0 snapshots**. With `defer-uploads: false` (control), the interrupted build shows the snapshots that had already streamed up.
4. **No coverage lost** — let a run finalize normally and confirm the finalized build shows all expected snapshots and diffs as before.

### How has the user experience changed?

No change. This only affects Percy snapshot upload timing in CI; there is no user-facing or behavioral change to Cypress.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI/cost configuration change; no code behavior change. -->
- [na] Have tests been added/updated? <!-- Percy config-only change; no test surface. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No user-facing change. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdZSAEADhvAtpK4GCJfUDt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Percy configuration; no product code, auth, or data paths. Risk is limited to visual regression upload timing if defer behavior misbehaves on successful runs.
> 
> **Overview**
> Enables **`defer-uploads: true`** under the `percy` section in all six `.percy.yml` files (repo root, `packages/app`, `packages/launchpad`, `packages/reporter`, `npm/vite-dev-server`, `npm/webpack-dev-server`).
> 
> Snapshots are held locally and sent to Percy only when the run finishes, instead of uploading as each snapshot is captured. **Canceled parallel shards** (e.g. fail-fast) should no longer bill snapshots from unfinalized builds; completed runs should still upload and diff as before. No test or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f873caf40f2121f6b70c40b1a33888e23678af9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->