### PR TITLE
chore: translate hosts into Chromium host resolver rules when the proxy is disabled (HTTP/2)

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -205,6 +205,41 @@ const _normalizeArgExtensions = function (extPath, args, pluginExtensions, brows
   return args
 }
 
+const HOST_RESOLVER_RULES = '--host-resolver-rules='
+
+/**
+ * Merge multiple `--host-resolver-rules` arguments into one.
+ *
+ * Cypress pushes its own rules in `_getArgs` (translated from `hosts` when the
+ * MITM proxy is disabled) and users may add their own via
+ * `before:browser:launch`. Chromium only honors the last occurrence of the
+ * switch, so the values must be combined. Within the merged value the first
+ * matching rule wins, so later (user-supplied) arguments are placed first to
+ * let them override the rules derived from `hosts`.
+ */
+const _normalizeHostResolverRules = function (args: string[]): string[] {
+  const ruleArgs = args.filter((arg) => arg.startsWith(HOST_RESOLVER_RULES))
+
+  if (ruleArgs.length <= 1) {
+    return args
+  }
+
+  // Empty values are dropped rather than merged — Chromium only honors the
+  // last occurrence of the switch, so a trailing empty value would otherwise
+  // clear the rules derived from `hosts`.
+  const values = ruleArgs
+  .map((arg) => arg.slice(HOST_RESOLVER_RULES.length))
+  .filter(Boolean)
+
+  const rest = args.filter((arg) => !arg.startsWith(HOST_RESOLVER_RULES))
+
+  if (!values.length) {
+    return rest
+  }
+
+  return rest.concat(`${HOST_RESOLVER_RULES}${values.reverse().join(',')}`)
+}
+
 // we now store the extension in each browser profile
 const _removeRootExtension = () => {
   return fs
@@ -320,6 +355,8 @@ export = {
 
   _normalizeArgExtensions,
 
+  _normalizeHostResolverRules,
+
   _removeRootExtension,
 
   _recordVideo,
@@ -377,6 +414,21 @@ export = {
 
     if (ps) {
       args.push(`--proxy-server=${ps}`)
+    }
+
+    // With the MITM proxy disabled the browser performs origin fetches itself,
+    // so the Node-side DNS remap (evil-dns) can't honor `hosts` — translate it
+    // into Chromium resolver rules at launch instead.
+    if (!_.isEmpty(options.hosts)) {
+      const rules = _.map(options.hosts, (ip, host) => {
+        // Chromium parses the replacement's last `:` as an optional port, so
+        // IPv6 literals must be bracketed.
+        const replacement = ip.includes(':') && !ip.startsWith('[') ? `[${ip}]` : ip
+
+        return `MAP ${host} ${replacement}`
+      }).join(',')
+
+      args.push(`${HOST_RESOLVER_RULES}${rules}`)
     }
 
     if (options.chromeWebSecurity === false) {
@@ -648,8 +700,9 @@ export = {
       _writeChromePreferences(userDir, rawPreferences, finalPreferences),
     ])
     // normalize the --load-extensions argument by
-    // massaging what the user passed into our own
-    const args = _normalizeArgExtensions(extDest, launchOptions.args, launchOptions.extensions, browser)
+    // massaging what the user passed into our own, and merge any
+    // user-supplied --host-resolver-rules with the ones derived from `hosts`
+    const args = _normalizeHostResolverRules(_normalizeArgExtensions(extDest, launchOptions.args, launchOptions.extensions, browser))
 
     // this overrides any previous user-data-dir args
     // by being the last one

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -89,6 +89,7 @@ export class OpenProject extends EventEmitter {
       userAgent: cfg.userAgent,
       proxyUrl: cfg.proxyUrl,
       ...(isProxyEnabled() ? { proxyServer: ensureProxyServer(cfg) } : {
+        hosts: cfg.hosts,
         onPageCriClientReady: (client, isAUTFrame) => {
           return this.projectBase!.server.createCdpFetchNetworkRuntime(client, isAUTFrame)
         },

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -1035,6 +1035,110 @@ describe('lib/browsers/chrome', () => {
 
       expect(args).to.include(arg)
     })
+
+    it('translates hosts into host resolver rules', () => {
+      const args = chrome._getArgs({
+        majorVersion: '89',
+      }, {
+        hosts: {
+          'foobar.com': '127.0.0.1',
+          '*.foobar.com': '127.0.0.1',
+        },
+      })
+
+      expect(args).to.include('--host-resolver-rules=MAP foobar.com 127.0.0.1,MAP *.foobar.com 127.0.0.1')
+    })
+
+    it('omits host resolver rules when hosts is not set', () => {
+      const args = chrome._getArgs({
+        majorVersion: '89',
+      }, {})
+
+      expect(args.find((arg) => arg.startsWith('--host-resolver-rules'))).to.be.undefined
+    })
+
+    it('brackets IPv6 literals in host resolver rules', () => {
+      const args = chrome._getArgs({
+        majorVersion: '89',
+      }, {
+        hosts: {
+          'foobar.com': '::1',
+          'baz.com': '[2001:db8::1]',
+        },
+      })
+
+      expect(args).to.include('--host-resolver-rules=MAP foobar.com [::1],MAP baz.com [2001:db8::1]')
+    })
+
+    it('omits host resolver rules when hosts is empty', () => {
+      const args = chrome._getArgs({
+        majorVersion: '89',
+      }, {
+        hosts: {},
+      })
+
+      expect(args.find((arg) => arg.startsWith('--host-resolver-rules'))).to.be.undefined
+    })
+  })
+
+  describe('#_normalizeHostResolverRules', () => {
+    it('returns args unchanged when no host resolver rules are present', () => {
+      const args = ['--foo', '--bar=baz']
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq(args)
+    })
+
+    it('returns args unchanged when a single host resolver rules arg is present', () => {
+      const args = ['--foo', '--host-resolver-rules=MAP foobar.com 127.0.0.1']
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq(args)
+    })
+
+    it('merges multiple host resolver rules args with later (user-supplied) rules first', () => {
+      const args = [
+        '--host-resolver-rules=MAP foobar.com 127.0.0.1',
+        '--foo',
+        '--host-resolver-rules=MAP example.com 10.0.0.1,MAP foobar.com 10.0.0.2',
+      ]
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq([
+        '--foo',
+        '--host-resolver-rules=MAP example.com 10.0.0.1,MAP foobar.com 10.0.0.2,MAP foobar.com 127.0.0.1',
+      ])
+    })
+
+    it('drops empty host resolver rules args when merging', () => {
+      const args = [
+        '--host-resolver-rules=',
+        '--host-resolver-rules=MAP foobar.com 127.0.0.1',
+        '--host-resolver-rules=MAP example.com 10.0.0.1',
+      ]
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq([
+        '--host-resolver-rules=MAP example.com 10.0.0.1,MAP foobar.com 127.0.0.1',
+      ])
+    })
+
+    it('does not let a trailing empty arg clobber a single non-empty rule', () => {
+      const args = [
+        '--host-resolver-rules=MAP foobar.com 127.0.0.1',
+        '--host-resolver-rules=',
+      ]
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq([
+        '--host-resolver-rules=MAP foobar.com 127.0.0.1',
+      ])
+    })
+
+    it('drops the switch entirely when every value is empty', () => {
+      const args = [
+        '--foo',
+        '--host-resolver-rules=',
+        '--host-resolver-rules=',
+      ]
+
+      expect(chrome._normalizeHostResolverRules(args)).to.deep.eq(['--foo'])
+    })
   })
 
   describe('#_getChromePreferences', () => {

--- a/packages/types/src/server.ts
+++ b/packages/types/src/server.ts
@@ -92,6 +92,9 @@ export type BrowserLaunchOpts = {
   relaunchBrowser?: () => Promise<any>
   protocolManager?: ProtocolManagerShape
   onPageCriClientReady?: (client: CdpClientShape, isAUTFrame?: (frameId: string) => Promise<boolean>) => Promise<void>
+  // Only set when the MITM proxy is disabled: `hosts` is translated into
+  // browser-level resolver rules instead of the Node-side DNS remap.
+  hosts?: { [host: string]: string } | null
 } & Partial<OpenProjectLaunchOpts> // TODO: remove the `Partial` here by making it impossible for openProject.launch to be called w/o OpenProjectLaunchOpts
 & Pick<ReceivedCypressOptions, 'userAgent' | 'proxyUrl' | 'socketIoRoute' | 'chromeWebSecurity' | 'downloadsFolder' | 'experimentalModifyObstructiveThirdPartyCode' | 'experimentalWebKitSupport'>
 


### PR DESCRIPTION
- Partially addresses https://github.com/cypress-io/cypress/issues/34306 (ports `ad0565caa2` from `bill/cdp-fetch-legacy-pipeline`, hardened for production)

### Additional details

Adds [`hosts`](https://docs.cypress.io/app/references/configuration#hosts) config support for HTTP/2 (proxy-disabled) runs. We leverage Chromium's [`--host-resolver-rules`](https://peter.sh/experiments/chromium-command-line-switches/#host-resolver-rules) launch switch — it is Chromium-only, which matches the scope of the HTTP/2 MVP per the plan of record.

**Why this is needed:** `hosts` is implemented as a Node-process DNS remap (evil-dns), which only applies when the Node process makes the origin connection. With the MITM proxy disabled, the browser performs origin fetches itself under CDP Fetch, so the remap never applies — requests to mapped hosts (e.g. `www.foobar.com` in the driver specs) fail at the network level with Fetch `errorReason: Failed`. This was blocking essentially all of the cookie and `cy.origin` driver suites in proxy-disabled mode.

**How it works:**

- `open_project` passes `cfg.hosts` through launch options **only when the proxy is disabled** — proxy-enabled runs never receive `options.hosts`, so no resolver-rules arg is ever added there and the evil-dns path is untouched.
- `chrome._getArgs` translates it to `--host-resolver-rules=MAP <host> <ip>,...`. Chromium resolver rules support wildcard patterns, matching evil-dns semantics. IPv6 replacements are bracketed (`MAP foo [::1]`) since Chromium parses the replacement's trailing colon segment as an optional port.
- **Merge, don't clobber:** users may pass their own `--host-resolver-rules` (e.g. via `before:browser:launch`). Chromium only honors the last occurrence of a switch, so a new `_normalizeHostResolverRules` step (modeled after `_normalizeArgExtensions`) merges all occurrences into one after the user hook runs. Within a rule list the first match wins, so user-supplied rules are placed first and override the `hosts`-derived rules on conflict. Empty values are dropped so a trailing empty switch cannot clear the rules.

**Known scope limits** (follow-ups tracked outside this PR, per the plan of record):

- Chromium-family only. Electron needs `app.commandLine.appendSwitch` before app-ready — long before project config is known. Firefox/WebKit need their own mechanism (and don't support the h2 work yet anyway).
- Launch-time only: `hosts` changes require a browser relaunch, same as other launch args.
- evil-dns remains in place for server-side requests (`cy.request`, `resolve:url`), which still originate in Node.

### Steps to test

1. In a project with `hosts: { '*.foobar.com': '127.0.0.1' }`, run with `CYPRESS_INTERNAL_DISABLE_PROXY=1` against Chrome and confirm navigations/fetches to `www.foobar.com` resolve to the local server (driver origin/cookie specs exercise this heavily).
2. Add `--host-resolver-rules=MAP example.com 10.0.0.1` in `before:browser:launch` and confirm the launched args contain a single merged `--host-resolver-rules` with the user rule first.
3. Run proxy-enabled (default) and confirm no `--host-resolver-rules` arg is added.

### How has the user experience changed?

No change for default (proxy-enabled) runs. In proxy-disabled CDP Fetch mode, the documented `hosts` config option now works in Chromium browsers.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- https://github.com/cypress-io/cypress/issues/34306 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser launch and DNS resolution for an experimental proxy-disabled path; mistakes could misroute traffic or break `before:browser:launch` resolver overrides, but scope is limited to Chromium when the proxy is off.
> 
> **Overview**
> When the MITM proxy is disabled (CDP Fetch / HTTP/2 mode), the documented **`hosts`** config now works in Chromium browsers. Node’s evil-dns remap no longer applies to browser-origin traffic, so Cypress translates **`hosts`** into **`--host-resolver-rules`** at Chrome launch instead.
> 
> **`open_project`** passes **`cfg.hosts`** on launch options only when the proxy is disabled; default proxy-enabled runs are unchanged. **`chrome._getArgs`** builds `MAP <host> <ip>` rules (wildcard-friendly, IPv6 bracketed). After **`before:browser:launch`**, **`_normalizeHostResolverRules`** merges any user-supplied **`--host-resolver-rules`** into a single switch so Cypress rules are not clobbered, with user rules ordered first so they win on conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd4a94157c086472c8f754353fd827cb121e253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->