### PR TITLE
chore: inject and render documents correctly on the CDP Fetch path (HTTP/2)

### DIFF
--- a/packages/proxy/lib/adapters/inject-html.ts
+++ b/packages/proxy/lib/adapters/inject-html.ts
@@ -15,11 +15,13 @@ import type { ResponseInterceptionMiddlewareCtx } from './types'
 export async function injectHtml (mw: ResponseInterceptionMiddlewareCtx): Promise<void> {
   const span = telemetry.startSpan({ name: 'maybe:inject:html', parentSpan: mw.resMiddlewareSpan, isVerbose })
 
+  const { wantsInjection } = mw.res
+
   span?.setAttributes({
-    wantsInjection: mw.res.wantsInjection,
+    wantsInjection: wantsInjection ?? false,
   })
 
-  if (!mw.res.wantsInjection) {
+  if (!wantsInjection) {
     span?.end()
 
     return mw.next()
@@ -40,7 +42,7 @@ export async function injectHtml (mw: ResponseInterceptionMiddlewareCtx): Promis
     const injectedBody = await rewriter.html(decodedBody, {
       cspNonce: mw.res.injectionNonce,
       domainName: getDomainNameFromUrl(mw.req.proxiedUrl),
-      wantsInjection: mw.res.wantsInjection,
+      wantsInjection,
       wantsSecurityRemoved: mw.res.wantsSecurityRemoved,
       isNotJavascript: !resContentTypeIsJavaScript(mw.incomingRes),
       useAstSourceRewriting: mw.config.experimentalSourceRewriting,

--- a/packages/proxy/lib/adapters/synthetic-express-context.ts
+++ b/packages/proxy/lib/adapters/synthetic-express-context.ts
@@ -118,7 +118,10 @@ export type SyntheticCypressResponse = CypressOutgoingResponseLike & {
 class SyntheticResponse extends Writable {
   private readonly kOutHeaders = Symbol('kOutHeaders')
   isInitial: null | boolean = null
-  wantsInjection: CypressOutgoingResponseLike['wantsInjection'] = false
+  // null = undecided. SetInjectionLevel skips its determination for any
+  // non-null value, so defaulting to false silently disables injection for
+  // every synthetic response.
+  wantsInjection: CypressOutgoingResponseLike['wantsInjection'] = null
   wantsSecurityRemoved: null | boolean = null
   body?: string | Readable
   statusCode = 200

--- a/packages/proxy/lib/types.ts
+++ b/packages/proxy/lib/types.ts
@@ -40,7 +40,8 @@ export type CypressHeaderValue = string | string[] | number | undefined
 export interface CypressOutgoingResponseLike extends Writable {
   injectionNonce?: string
   isInitial: null | boolean
-  wantsInjection: CypressWantsInjection
+  // null = undecided; SetInjectionLevel only determines a level when unset
+  wantsInjection: CypressWantsInjection | null
   wantsSecurityRemoved: null | boolean
   body?: string | Readable
   destroyed: boolean

--- a/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
@@ -126,6 +126,16 @@ describe('createSyntheticExpressContext', () => {
     expect(res.getCapturedBody().toString()).to.equal('created')
   })
 
+  it('leaves the injection level undecided so SetInjectionLevel determines it', () => {
+    const { res } = createSyntheticExpressContext({
+      id: 'network-1',
+      url: 'https://example.test/',
+    })
+
+    expect(res.wantsInjection).to.be.null
+    expect(res.wantsSecurityRemoved).to.be.null
+  })
+
   it('exposes a Node-compatible kOutHeaders symbol for header patching', () => {
     const { res } = createSyntheticExpressContext({
       id: 'network-1',

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -1,3 +1,4 @@
+import zlib from 'zlib'
 import type {
   HttpHeaders,
   HttpRequest,
@@ -62,6 +63,82 @@ function toResponseBody (body?: string | Buffer): string | undefined {
   }
 
   return Buffer.from(body).toString('base64')
+}
+
+// The transport delivers bodies to the middleware content-decoded, so wire
+// headers describing the encoding must not reach the middleware view (it
+// would decompress plaintext). Length headers never survive re-encoding.
+const WIRE_LENGTH_HEADERS = new Set(['content-length', 'transfer-encoding'])
+const WIRE_ENCODING_HEADERS = new Set(['content-encoding', ...WIRE_LENGTH_HEADERS])
+
+const CONTENT_DECODERS: Record<string, (body: Buffer) => Buffer> = {
+  gzip: (body) => zlib.gunzipSync(body),
+  'x-gzip': (body) => zlib.gunzipSync(body),
+  br: (body) => zlib.brotliDecompressSync(body),
+  deflate: (body) => zlib.inflateSync(body),
+}
+
+function stripWireEncodingHeaders (headers?: HttpHeaders): HttpHeaders | undefined {
+  if (!headers) {
+    return undefined
+  }
+
+  return Object.entries(headers).reduce<HttpHeaders>((memo, [name, value]) => {
+    if (!WIRE_ENCODING_HEADERS.has(name)) {
+      memo[name] = value
+    }
+
+    return memo
+  }, {})
+}
+
+function stripHeaderEntries (headers: CdpFetchTransportResponse['responseHeaders'], names: ReadonlySet<string>): CdpFetchTransportResponse['responseHeaders'] {
+  return headers?.filter(({ name }) => !names.has(name.toLowerCase()))
+}
+
+// Fetch.fulfillRequest hands the body to the renderer as-is — content
+// decoders do not run for fulfilled responses. The pipeline may emit encoded
+// bodies (CompressBody re-encodes rewritten documents), so decode fulfilled
+// bodies back to identity and drop the encoding headers. If an encoding
+// cannot be decoded, keep the body/header pair intact rather than shipping a
+// body that lies about its encoding.
+function toIdentityResponse (transportResponse: CdpFetchTransportResponse): CdpFetchTransportResponse {
+  const headers = transportResponse.responseHeaders
+  const contentEncoding = headers?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
+  const encodings = (contentEncoding ?? '')
+  .split(',')
+  .map((token) => token.trim().toLowerCase())
+  .filter((token) => token && token !== 'identity')
+
+  if (!transportResponse.body || !encodings.length) {
+    return {
+      ...transportResponse,
+      responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
+    }
+  }
+
+  let body = Buffer.from(transportResponse.body, 'base64')
+
+  try {
+    // encodings are listed in the order applied — decode outermost first
+    for (let i = encodings.length - 1; i >= 0; i--) {
+      const decode = CONTENT_DECODERS[encodings[i]]
+
+      if (!decode) {
+        throw new Error(`no decoder for content-encoding ${encodings[i]}`)
+      }
+
+      body = decode(body)
+    }
+  } catch (err) {
+    return transportResponse
+  }
+
+  return {
+    ...transportResponse,
+    body: body.toString('base64'),
+    responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
+  }
 }
 
 function toNetworkHeaders (headers?: HttpHeaders): Protocol.Network.Headers {
@@ -161,7 +238,7 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
         id: transportResponse.id,
         url: transportResponse.url,
         bodyStream: transportResponse.bodyStream,
-        headers: toHttpHeaders(transportResponse.responseHeaders),
+        headers: stripWireEncodingHeaders(toHttpHeaders(transportResponse.responseHeaders)),
         statusCode: transportResponse.responseCode,
       }
     },
@@ -169,24 +246,39 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
     encodeResponse (httpResponse: HttpResponse): CdpFetchTransportResponse {
       const response = httpResponse as CdpFetchHttpResponse
       const pausedResponse = inFlightResponses.get(httpResponse.id)
+      const fulfilled = response.body !== undefined
+      // Middleware headers describe the body the pipeline produced — including
+      // any re-encoding by CompressBody — so keep their content-encoding and
+      // only drop stale length headers. The pause-header fallback describes
+      // the wire body, not the decoded body we fulfill with, so its encoding
+      // headers are stripped too.
+      const fulfilledHeaders = (headers?: HttpHeaders, pauseHeaders?: CdpFetchTransportResponse['responseHeaders']) => {
+        const middlewareHeaders = toResponseHeaders(headers)
+
+        return middlewareHeaders
+          ? stripHeaderEntries(middlewareHeaders, WIRE_LENGTH_HEADERS)
+          : stripHeaderEntries(pauseHeaders, WIRE_ENCODING_HEADERS)
+      }
       const transportResponse = pausedResponse ? {
         ...pausedResponse,
-        fulfilled: response.body !== undefined,
+        fulfilled,
         responseCode: response.statusCode ?? pausedResponse.responseCode,
-        responseHeaders: toResponseHeaders(response.headers) ?? pausedResponse.responseHeaders,
-        ...(response.body !== undefined ? { body: toResponseBody(response.body) } : {}),
+        responseHeaders: fulfilled
+          ? fulfilledHeaders(response.headers, pausedResponse.responseHeaders)
+          : pausedResponse.responseHeaders,
+        ...(fulfilled ? { body: toResponseBody(response.body) } : {}),
       } : {
         ...requireRequestPause(httpResponse.id),
         fulfilled: true,
         responseCode: response.statusCode ?? 200,
-        responseHeaders: toResponseHeaders(response.headers),
+        responseHeaders: fulfilledHeaders(response.headers),
         body: toResponseBody(response.body),
       }
 
       transportResponse.url = httpResponse.url
       inFlightResponses.delete(httpResponse.id)
 
-      return transportResponse
+      return transportResponse.fulfilled ? toIdentityResponse(transportResponse) : transportResponse
     },
 
     releaseRequest (id: string): void {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -199,6 +199,10 @@ export class CdpFetchTransport {
       })
 
       if (response.fulfilled) {
+        // base64 of the gzip magic bytes starts with 'H4sI' — an encoded body
+        // here with no content-encoding header means mangled rendering
+        debug('fulfilling %s: status %s, content-encoding %s, body prefix %s', event.request.url, response.responseCode, response.responseHeaders?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value, response.body?.slice(0, 8))
+
         await this.client.send('Fetch.fulfillRequest', {
           requestId: response.requestId,
           responseCode: response.responseCode,

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -2,6 +2,8 @@ import type { Protocol } from 'devtools-protocol'
 import debugModule from 'debug'
 import pDefer from 'p-defer'
 import { Readable } from 'stream'
+import { promisify } from 'util'
+import zlib from 'zlib'
 import type { ForHttpIntercept } from '@packages/network-interception'
 import { HttpIntercept } from '@packages/network-interception'
 import type { ICriClient } from './cri-client'
@@ -14,6 +16,7 @@ type CdpFetchClient = Pick<ICriClient, 'send' | 'on' | 'off'>
 
 type CdpFetchRequest = Protocol.Fetch.RequestPausedEvent['request']
 const RESPONSE_PAUSE_TIMEOUT_MS = 30000
+const brotliDecompress = promisify(zlib.brotliDecompress)
 
 type CdpFetchTransportOptions = {
   isAUTFrame?: (frameId: string) => Promise<boolean>
@@ -283,7 +286,7 @@ export class CdpFetchTransport {
       return
     }
 
-    const bodyStream = this.createResponseBodyStream(event.requestId, sessionId)
+    const bodyStream = this.createResponseBodyStream(event.requestId, event.responseHeaders, sessionId)
 
     deferred.resolve({
       ...event.request,
@@ -296,7 +299,7 @@ export class CdpFetchTransport {
     })
   }
 
-  private createResponseBodyStream = (requestId: string, sessionId?: string): Readable => {
+  private createResponseBodyStream = (requestId: string, responseHeaders?: Protocol.Fetch.HeaderEntry[], sessionId?: string): Readable => {
     let reading = false
     let bodyStream: Readable
 
@@ -314,7 +317,8 @@ export class CdpFetchTransport {
               requestId,
             }, sessionId) as Protocol.Fetch.GetResponseBodyResponse
 
-            const body = Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8')
+            const raw = Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8')
+            const body = await this.decodeUndeliveredEncodings(raw, responseHeaders)
 
             if (body.length) {
               bodyStream.push(body)
@@ -329,6 +333,42 @@ export class CdpFetchTransport {
     })
 
     return bodyStream
+  }
+
+  /**
+   * Fetch.getResponseBody delivers gzip/deflate content-decoded, but brotli
+   * arrives still encoded (and continueRequest cannot constrain
+   * accept-encoding — the network stack owns that header). Decode br here so
+   * the middleware's decoded-body premise holds. Falls back to the raw bytes
+   * if decompression fails, in case a newer CDP starts decoding br itself.
+   */
+  private decodeUndeliveredEncodings = async (body: Buffer, responseHeaders?: Protocol.Fetch.HeaderEntry[]): Promise<Buffer> => {
+    const contentEncoding = responseHeaders?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
+
+    if (!contentEncoding || !body.length) {
+      return body
+    }
+
+    // encodings are listed in the order applied, so decode in reverse;
+    // gzip/deflate layers were already decoded by CDP
+    const encodings = contentEncoding.split(',').map((token) => token.trim().toLowerCase()).reverse()
+    let decoded = body
+
+    for (const encoding of encodings) {
+      if (encoding !== 'br') {
+        continue
+      }
+
+      try {
+        decoded = await brotliDecompress(decoded)
+      } catch (err) {
+        debug('brotli decompression failed, using body as delivered: %s', (err as Error).message)
+
+        return body
+      }
+    }
+
+    return decoded
   }
 
   private toContinueRequestHeaders (headers: Protocol.Network.Headers): Protocol.Fetch.HeaderEntry[] {

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -406,6 +406,160 @@ describe('CdpFetchTransport', () => {
       await handled
     })
 
+    it('drops wire encoding headers from the middleware view and fulfilled responses', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
+      const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
+
+      response.responseHeaders = [
+        { name: 'Content-Encoding', value: 'gzip' },
+        { name: 'Content-Type', value: 'text/html' },
+      ]
+
+      let seenResponseHeaders
+
+      httpIntercept.use(async (req, next) => {
+        const res = await next(req)
+
+        seenResponseHeaders = { ...res.headers }
+
+        return { ...res, body: 'plain' }
+      })
+
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(request)
+
+      await tick()
+      await onRequestPaused(response)
+      await handled
+
+      expect(seenResponseHeaders).to.deep.equal({
+        'content-type': 'text/html',
+      })
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/html',
+        }],
+        body: Buffer.from('plain').toString('base64'),
+      })
+    })
+
+    it('normalizes pipeline re-encoded fulfilled bodies to identity', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
+      const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
+      const gzippedBody = zlib.gzipSync(Buffer.from('<html>compressed</html>'))
+
+      // the legacy pipeline (CompressBody) may re-encode the outgoing body;
+      // fulfillRequest delivers bodies as-is, so it must go out as identity
+      httpIntercept.use(async (req, next) => {
+        const res = await next(req)
+
+        return {
+          ...res,
+          headers: {
+            'content-type': 'text/html',
+            'content-encoding': 'gzip',
+            'content-length': '9999',
+          },
+          body: gzippedBody,
+        }
+      })
+
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(request)
+
+      await tick()
+      await onRequestPaused(response)
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/html',
+        }],
+        body: Buffer.from('<html>compressed</html>').toString('base64'),
+      })
+    })
+
+    it('keeps the body and header pair when a fulfilled encoding cannot be decoded', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
+      const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
+
+      httpIntercept.use(async (req, next) => {
+        const res = await next(req)
+
+        return {
+          ...res,
+          headers: {
+            'content-encoding': 'zstd',
+          },
+          body: Buffer.from('opaque-bytes'),
+        }
+      })
+
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(request)
+
+      await tick()
+      await onRequestPaused(response)
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-encoding',
+          value: 'zstd',
+        }],
+        body: Buffer.from('opaque-bytes').toString('base64'),
+      })
+    })
+
+    it('keeps wire encoding headers on pass-through continueResponse', async () => {
+      const client = createClient()
+      const transport = new CdpFetchTransport(client as any)
+      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
+      const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
+
+      response.responseHeaders = [
+        { name: 'Content-Encoding', value: 'gzip' },
+        { name: 'Content-Type', value: 'text/html' },
+      ]
+
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(request)
+
+      await tick()
+      await onRequestPaused(response)
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'Content-Encoding',
+          value: 'gzip',
+        }, {
+          name: 'Content-Type',
+          value: 'text/html',
+        }],
+      })
+    })
+
     it('matches request and response pauses by network id', async () => {
       const client = createClient()
       const transport = new CdpFetchTransport(client as any)

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -1,5 +1,6 @@
 const { expect, sinon } = require('../../spec_helper')
 
+import zlib from 'zlib'
 import type { Protocol } from 'devtools-protocol'
 import { HttpIntercept } from '@packages/network-interception'
 import { createCdpFetchCodec } from '../../../lib/browsers/cdp-protocol/cdp-fetch-codec'
@@ -762,6 +763,113 @@ describe('CdpFetchTransport', () => {
       })
 
       expect(client.send).not.to.have.been.calledWith('Fetch.continueResponse')
+    })
+
+    it('decompresses brotli response bodies before middleware reads them', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const onRequestPaused = await startTransport(transport, client)
+
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: zlib.brotliCompressSync(Buffer.from('<html>origin</html>')).toString('base64'),
+        base64Encoded: true,
+      })
+
+      let seenBody
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        seenBody = await readStream(response.bodyStream!)
+
+        return {
+          ...response,
+          body: `${seenBody}-rewritten`,
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      const response = createPausedRequest({
+        requestId: 'fetch-response',
+        networkId: 'network-1',
+        responseStatusCode: 200,
+      })
+
+      response.responseHeaders = [
+        { name: 'Content-Encoding', value: 'br' },
+        { name: 'Content-Type', value: 'text/html' },
+      ]
+
+      await onRequestPaused(response)
+      await handled
+
+      expect(seenBody).to.equal('<html>origin</html>')
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/html',
+        }],
+        body: Buffer.from('<html>origin</html>-rewritten').toString('base64'),
+      })
+    })
+
+    it('falls back to the delivered body when brotli decompression fails', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const transport = new CdpFetchTransport(client as any, httpIntercept)
+      const onRequestPaused = await startTransport(transport, client)
+
+      // headers claim br but the body is already plaintext (e.g. a newer CDP
+      // that decodes br itself)
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: Buffer.from('<html>already decoded</html>').toString('base64'),
+        base64Encoded: true,
+      })
+
+      let seenBody
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        seenBody = await readStream(response.bodyStream!)
+
+        return {
+          ...response,
+          body: seenBody,
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      const response = createPausedRequest({
+        requestId: 'fetch-response',
+        networkId: 'network-1',
+        responseStatusCode: 200,
+      })
+
+      response.responseHeaders = [
+        { name: 'Content-Encoding', value: 'br' },
+      ]
+
+      await onRequestPaused(response)
+      await handled
+
+      expect(seenBody).to.equal('<html>already decoded</html>')
     })
 
     it('exposes response pause bodies as a stream for middleware rewrites', async () => {


### PR DESCRIPTION
- Partially addresses https://github.com/cypress-io/cypress/issues/34306 (ports `0230eefb8f` and `f6c99d3d23` from `bill/cdp-fetch-legacy-pipeline`, extended for content encodings the spike never exercised)

Stacked on #34326 (hosts); targets its branch. Only the last 3 commits are new here. #34327 (cookies) stacks on top of this PR — the cookie suites need injected, correctly-rendered documents before they can give a reliable signal.

### Additional details

Before this PR, proxy-disabled (CDP Fetch) runs had two document-level defects: HTML injection never ran at all, and once enabled, documents could render as mangled bytes whenever any content encoding was involved — on the wire (brotli origins), or introduced by our own pipeline (`CompressBody` re-encoding rewritten documents, e.g. every buffered `cy.visit` document). This PR makes injection run and makes bodies and their encoding headers agree in both directions of the codec. Commit by commit:

**1. `fix: leave injection level undecided on synthetic responses`**
`SyntheticResponse` initialized `wantsInjection` to `false`, but `SetInjectionLevel` treats any non-null value as an upstream decision and skips its determination entirely — so no response on the synthetic codec path could ever receive `full` or `fullCrossOrigin` injection, and cross-origin AUT documents loaded without the spec bridge init script. Real Express responses start with the property unset, so the type now reflects `null` as the undecided state (a proxy-internal type; no `@packages/types` change). Debug tell for this failure mode: `already has injection: false` in the SetInjectionLevel logs.

**2. `fix: brotli-decompress CDP Fetch response bodies for the middleware`**
`Fetch.getResponseBody` delivers gzip/deflate content-decoded, but brotli arrives still encoded — and `Fetch.continueRequest` cannot constrain `accept-encoding` (the network stack owns that header; overrides are ignored on the wire), so origins serve br to the browser's native preferences. The transport now brotli-decompresses bodies when the wire `content-encoding` says br, before the middleware reads them, with a raw-bytes fallback if decompression fails (so a future CDP that decodes br itself degrades gracefully).

**3. `fix: reconcile CDP Fetch bodies with their encoding headers`**
Both directions of the codec must keep bodies and headers in agreement or documents render as mangled bytes:
- *Middleware view*: wire encoding headers are stripped from decoded response pauses, or the legacy response middleware gunzips plaintext (`Z_DATA_ERROR`) and serves documents uninjected via the error path. Pass-through `continueResponse` keeps wire headers untouched — the browser still holds the encoded network body there.
- *Fulfillment*: `Fetch.fulfillRequest` hands the body to the renderer **without running content decoders**, while the pipeline emits encoded bodies for rewritten documents (`CompressBody` re-encodes to match the original wire encoding — correct for the MITM wire, wrong for CDP fulfillment; buffered `cy.visit` documents hit this on every visit). Fulfilled bodies are decoded back to identity per the declared encoding chain and encoding headers dropped; undecodable encodings keep the body/header pair intact. A fulfill debug line (status, content-encoding, body prefix — gzip magic base64s to `H4sI`) makes consistency visible under `DEBUG=cypress:server:browsers:cdp-fetch-transport`.

Skipping `CompressBody` on this transport is a possible follow-up optimization; identity normalization keeps correctness independent of pipeline internals.

### Steps to test

This PR is about documents rendering and being injected — cookie behavior needs #34327 on top, so don't gauge it by login flows.

1. With `CYPRESS_INTERNAL_DISABLE_PROXY=1` in Chrome, `cy.visit` a page on the driver fixture servers (they run `compression()`, so the https server serves brotli to the browser and gzip to the `resolve:url` pre-flight — both encoding paths get exercised). The page renders normal text, not mojibake.
2. Confirm injection ran: the document has the Cypress injection (e.g. a `cy.origin` spec bridge loads, or `DEBUG=cypress-verbose:proxy:http*` shows `SetInjectionLevel` determining a level rather than `already has injection: false`).
3. `DEBUG=cypress:server:browsers:cdp-fetch-transport` shows `fulfilling <url>: … content-encoding undefined, body prefix <not H4sI>` for rewritten documents.
4. Proxy-enabled runs are unaffected: the codec is only used on the CDP Fetch path, and Express responses never had `wantsInjection` pre-set.

### How has the user experience changed?

No change for default (proxy-enabled) runs. In proxy-disabled CDP Fetch mode, externally-served HTML documents now receive Cypress injection and render correctly regardless of the origin's (or the pipeline's) content encoding.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- https://github.com/cypress-io/cypress/issues/34306 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP Fetch interception, response body decoding, and HTML injection gating—important for document rendering in proxy-disabled mode, but scoped to that path with extensive tests and proxy-enabled behavior unchanged.
> 
> **Overview**
> Fixes **proxy-disabled (CDP Fetch)** runs where HTML injection never ran and documents could render as garbage when **content-encoding** was involved.
> 
> **Injection on the synthetic codec path:** `SyntheticResponse` now starts with `wantsInjection: null` (type updated accordingly) so `SetInjectionLevel` is not skipped; it previously defaulted to `false`, which was treated as a final decision and blocked `full` / `fullCrossOrigin` injection.
> 
> **CDP Fetch body/encoding handling:** Incoming response pauses expose **decoded** bodies to middleware by stripping wire `content-encoding` (and related length) headers and **brotli-decompressing** `Fetch.getResponseBody` when headers say `br`. Outgoing **`Fetch.fulfillRequest`** paths decode pipeline re-encoded bodies back to **identity** and drop encoding headers (with a safe fallback when decoding is impossible); pass-through `continueResponse` keeps wire headers unchanged. Adds targeted unit coverage and fulfill debug logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1123fb5e5adb7555ad784144cd20be961689d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->