### PR TITLE
perf: read cgroup v1 memory files directly instead of spawning subprocesses

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.19.1
 
+**Performance:**
+
+- Reduced the sampling overhead of [`experimentalMemoryManagement`](https://on.cypress.io/experiments) when Cypress runs inside a memory-limited container using cgroup v1. Memory readings no longer spawn helper subprocesses on every sampling interval, which lowers CPU usage that previously competed with the tests, most noticeably on constrained CI machines. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105).
+
 **Bugfixes:**
 
 - Fixed an issue where, during a [`cy.origin()`](https://on.cypress.io/origin) block, session cookies set on the primary origin by the first page visited in a test were not included in the identity provider's callback request back to the primary origin (for example, `POST /auth/callback` in an OAuth Authorization Code flow). Fixes [#29719](https://github.com/cypress-io/cypress/issues/29719). Fixed in [#34287](https://github.com/cypress-io/cypress/pull/34287).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Performance:**
 
-- Reduced the sampling overhead of [`experimentalMemoryManagement`](https://on.cypress.io/experiments) when Cypress runs inside a memory-limited container using cgroup v1. Memory readings no longer spawn helper subprocesses on every sampling interval, which lowers CPU usage that previously competed with the tests, most noticeably on constrained CI machines. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105).
+- Reduced the sampling overhead of [`experimentalMemoryManagement`](https://on.cypress.io/experiments) when Cypress runs inside a memory-limited container using cgroup v1. Memory readings no longer spawn helper subprocesses on every sampling interval, which lowers CPU usage that previously competed with the tests, most noticeably on constrained CI machines. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105). Fixed in [#34331](https://github.com/cypress-io/cypress/pull/34331).
 
 **Bugfixes:**
 

--- a/packages/server/lib/browsers/memory/cgroup-v1.ts
+++ b/packages/server/lib/browsers/memory/cgroup-v1.ts
@@ -1,24 +1,21 @@
-import { exec } from 'child_process'
-import util from 'util'
+import fs from 'fs-extra'
 import { parseMemoryStat, availableFromWorkingSet } from './cgroup-util'
 import type { MemoryLog } from './cgroup-util'
 
-const execAsync = util.promisify(exec)
-
 // Returns the total memory limit in bytes from the memory cgroup.
 const getTotalMemoryLimit = async () => {
-  return Number((await execAsync('cat /sys/fs/cgroup/memory/memory.limit_in_bytes', { encoding: 'utf8' })).stdout)
+  return Number(await fs.readFile('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8'))
 }
 
 // Returns the available memory in bytes from the memory cgroup.
 const getAvailableMemory = async (totalMemoryLimit: number, log?: MemoryLog) => {
   // retrieve the memory usage and memory stats from the memory cgroup
-  const [usageExec, rawStats] = await Promise.all([
-    execAsync('cat /sys/fs/cgroup/memory/memory.usage_in_bytes', { encoding: 'utf8' }),
-    execAsync('cat /sys/fs/cgroup/memory/memory.stat', { encoding: 'utf8' }),
+  const [usage, rawStats] = await Promise.all([
+    fs.readFile('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'utf8'),
+    fs.readFile('/sys/fs/cgroup/memory/memory.stat', 'utf8'),
   ])
 
-  return availableFromWorkingSet(totalMemoryLimit, Number(usageExec.stdout), parseMemoryStat(rawStats.stdout).total_inactive_file, log)
+  return availableFromWorkingSet(totalMemoryLimit, Number(usage), parseMemoryStat(rawStats).total_inactive_file, log)
 }
 
 export default {

--- a/packages/server/lib/browsers/memory/cgroup-v1.ts
+++ b/packages/server/lib/browsers/memory/cgroup-v1.ts
@@ -4,7 +4,7 @@ import type { MemoryLog } from './cgroup-util'
 
 // Returns the total memory limit in bytes from the memory cgroup.
 const getTotalMemoryLimit = async () => {
-  return Number(await fs.readFile('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8'))
+  return Number((await fs.readFile('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8')).trim())
 }
 
 // Returns the available memory in bytes from the memory cgroup.

--- a/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
+++ b/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
@@ -1,22 +1,21 @@
 const { expect, sinon } = require('../../../spec_helper')
 
-import util from 'util'
+import fs from 'fs-extra'
 
 describe('lib/browsers/memory/cgroup-v1', () => {
-  let mockExec
   let memory
 
   before(async () => {
-    mockExec = sinon.stub()
-
-    sinon.stub(util, 'promisify').returns(mockExec)
-
     memory = require('../../../../lib/browsers/memory/cgroup-v1').default
+  })
+
+  afterEach(() => {
+    sinon.restore()
   })
 
   context('#getTotalMemoryLimit', () => {
     it('returns total memory limit from limit_in_bytes', async () => {
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.limit_in_bytes', { encoding: 'utf8' }).resolves({ stdout: '100' })
+      sinon.stub(fs, 'readFile').withArgs('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8').resolves('100')
 
       expect(await memory.getTotalMemoryLimit()).to.eq(100)
     })
@@ -24,8 +23,10 @@ describe('lib/browsers/memory/cgroup-v1', () => {
 
   context('#getAvailableMemory', () => {
     it('returns available memory from cgroup', async () => {
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.usage_in_bytes').resolves({ stdout: '100' })
-      mockExec.withArgs('cat /sys/fs/cgroup/memory/memory.stat').resolves({ stdout: 'total_inactive_file 50' })
+      const readFile = sinon.stub(fs, 'readFile')
+
+      readFile.withArgs('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'utf8').resolves('100')
+      readFile.withArgs('/sys/fs/cgroup/memory/memory.stat', 'utf8').resolves('total_inactive_file 50')
 
       expect(await memory.getAvailableMemory(200)).to.eq(150)
     })

--- a/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
+++ b/packages/server/test/unit/browsers/memory/cgroup-v1_spec.ts
@@ -1,14 +1,9 @@
 const { expect, sinon } = require('../../../spec_helper')
 
 import fs from 'fs-extra'
+import memory from '../../../../lib/browsers/memory/cgroup-v1'
 
 describe('lib/browsers/memory/cgroup-v1', () => {
-  let memory
-
-  before(async () => {
-    memory = require('../../../../lib/browsers/memory/cgroup-v1').default
-  })
-
   afterEach(() => {
     sinon.restore()
   })


### PR DESCRIPTION
- Closes [#34105](https://github.com/cypress-io/cypress/issues/34105)

### Additional details

While [`experimentalMemoryManagement`](https://on.cypress.io/experiments) is active, the memory profiler samples memory roughly once per second for the entire run. On the cgroup v1 path, each sample shelled out to a helper process (`execAsync('cat …')`) for every file read — spawning two `/bin/sh` + two `/usr/bin/cat` processes **per sampling interval** (4 spawns/interval) for the whole run. Spawning processes on a tight loop is pure overhead that competes with the tests themselves, worst on the constrained CI machines where the feature matters most.

This replaces the three `execAsync('cat …')` reads in the cgroup v1 handler with direct `fs.readFile` calls, so sampling does the identical work with **zero process spawns** (just the `openat`/read syscalls). This mirrors the cgroup v2 handler, which already reads its interface files directly with `fs.readFile` and never had this overhead — so the two handlers are now consistent.

Per the issue's measurements on a real cgroup-v1 host:

| Approach | spawns / interval | ms / sample |
|---|---|---|
| current v1 (`execAsync('cat …')`) | 4 | 6.95 |
| fix (`fs.readFile`) | 0 | 0.40 |

The bytes read and the resulting memory math (`availableFromWorkingSet` over `memory.usage_in_bytes` and `total_inactive_file` from `memory.stat`) are unchanged — this is a behavior-preserving swap of the read mechanism only.

Scope note: the issue also raised two *optional* follow-ups (leaning on browser-native heap metrics, and consolidating/throttling the default handler's OS-level sampling). Those change *what* is measured and touch the GC-trigger heuristic, so they need before/after profiling on real constrained runs and are intentionally left out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving I/O swap in an experimental memory-management path; cgroup v2 and core test execution are untouched.
> 
> **Overview**
> **Reduces CPU overhead** for [`experimentalMemoryManagement`](https://on.cypress.io/experiments) on **cgroup v1** hosts (common in older containers): each ~1s memory sample no longer shells out via `execAsync('cat …')` for three cgroup files, and instead uses **`fs.readFile`** like the cgroup v2 handler already does.
> 
> The **available-memory math is unchanged** (`availableFromWorkingSet` over the same `memory.limit_in_bytes`, `memory.usage_in_bytes`, and `memory.stat` values). Unit tests now stub `fs.readFile` instead of `util.promisify`/`exec`. The **15.19.1 changelog** documents the performance fix ([#34105](https://github.com/cypress-io/cypress/issues/34105)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995a62da8536c83a87016c17be3a3b8ed14da959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

The `@packages/server` unit test `test/unit/browsers/memory/cgroup-v1_spec.ts` was updated to stub `fs.readFile` (instead of `util.promisify`/`exec`) and asserts the same computed values:

```bash
yarn workspace @packages/server test-unit -- browsers/memory/cgroup-v1_spec.ts
```

To confirm the spawn reduction on a cgroup-v1 host or container, drive the real handler under `strace -f -e trace=execve` as described in the issue and grep for `sh`/`cat` execs — the count drops from 4 per interval to 0.

### How has the user experience changed?

No visual change. On cgroup v1 hosts/containers, running with `experimentalMemoryManagement` enabled no longer spawns helper subprocesses on every ~1s sampling interval, reducing CPU overhead that previously competed with the tests (≈17× cheaper per sample in the issue's measurements). Behavior of the memory management itself is unchanged.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34105 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


---
_Generated by [Claude Code](https://claude.ai/code/session_01RsufN5TMT7b9amMsgVCnMB)_