### PR TITLE
feat: show the CLI's own tap command schema when no instance is attached

### DIFF
--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -5,11 +5,12 @@ import { CypressInstanceError, resolveInstance } from '../cypress-instances'
 import { withTapSession, throwTapError, validateExecResult } from '../tap/tap-session'
 import type { TapSession } from '../tap/tap-session'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
-import { renderFailure, renderKnownFailure, renderResult, renderGenericHelp, renderSchemaHelp, renderNativeHelp } from '../tap/output'
+import { renderFailure, renderKnownFailure, renderResult, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
 import type { TapCliCommand, TapCliOptions } from '../tap/types'
-import { TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD } from '@packages/cypress-instances'
+import { TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
 import type { TapSchema } from '@packages/cypress-instances'
+import util from '../util'
 import { errors } from '../errors'
 
 const debug = Debug('cypress:cli:tap')
@@ -87,6 +88,16 @@ const execCommand = async (session: TapSession, command: string, commandArgs: Re
   return 0
 }
 
+// With no instance to query, fall back to the schema this CLI ships with so the
+// help listing still reflects every command the CLI knows — the query path stays
+// authoritative when an instance is attached (it may run a different version).
+const renderOfflineHelp = (command: string | undefined, wantsHelp: boolean): number => {
+  const schema = buildTapSchema(util.pkgVersion())
+  const program = buildTapProgram(schema, () => {})
+
+  return renderStaticHelp(program, schema, command, wantsHelp)
+}
+
 const tapModule = {
   async start (operands: string[] = [], options: TapCliOptions = {}): Promise<number> {
     debug('tap invocation %o with options %o', operands, options)
@@ -129,7 +140,7 @@ const tapModule = {
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
         if (wantsHelp || !command) {
-          return renderGenericHelp(wantsHelp)
+          return renderOfflineHelp(command, wantsHelp)
         }
 
         debug('tap %s failed: %s %s', command || '(help)', err.code, err.message)

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -91,7 +91,7 @@ const execCommand = async (session: TapSession, command: string, commandArgs: Re
 // With no instance to query, fall back to the schema this CLI ships with so the
 // help listing still reflects every command the CLI knows — the query path stays
 // authoritative when an instance is attached (it may run a different version).
-const renderOfflineHelp = (command: string | undefined, wantsHelp: boolean): number => {
+const renderKnownSchema = (command: string | undefined, wantsHelp: boolean): number => {
   const schema = buildTapSchema(util.pkgVersion())
   const program = buildTapProgram(schema, () => {})
 
@@ -140,7 +140,7 @@ const tapModule = {
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
         if (wantsHelp || !command) {
-          return renderOfflineHelp(command, wantsHelp)
+          return renderKnownSchema(command, wantsHelp)
         }
 
         debug('tap %s failed: %s %s', command || '(help)', err.code, err.message)

--- a/cli/lib/tap/AGENTS.md
+++ b/cli/lib/tap/AGENTS.md
@@ -15,6 +15,6 @@ dom  read the app-under-test DOM over CDP, whole-page or by selector
 dom  read the app-under-test DOM as HTML, whole-page or by selector
 ```
 
-This text lives in the `description` / `details` fields in `commands/*.ts` and `GENERIC_TAP_USAGE` in `output.ts` — audit those when adding or editing a command.
+This text lives in the `description` / `details` fields in `commands/*.ts` and, for binding commands, the shared `TAP_COMMANDS` contract in `@packages/cypress-instances` — audit those when adding or editing a command.
 
 Internal mechanism belongs in code comments explaining *why*, not in help text.

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -122,6 +122,11 @@ const newProgram = (): commander.Command => {
 export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): commander.Command => {
   const program = newProgram()
 
+  // The outer `tap` command owns --instance and parses it before this program
+  // runs, so it never reaches here — declared only so help lists it. The outer
+  // command disables its own help, making this the sole place it surfaces.
+  program.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
+
   for (const native of tapCliCommands) {
     declareCommand(program, native)
   }

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -3,15 +3,11 @@ import type { AutFrame } from '../aut/frame'
 import { parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXProperty, AXValue } from '../aut/cdp'
-import type { TapCliCommand } from '../types'
+import { defineNativeCommand } from './definition'
 
 // The accessibility tree of a real app is deep; cap the projection so it stays
 // affordable for an LLM. A selector roots it at a subtree for finer reads.
 const DEFAULT_MAX_NODES = 200
-
-const ARIA_DETAILS = `Reads the accessibility (ARIA) tree of the app-under-test frame, or the
-subtree rooted at a CSS selector. Structural and text-only roles are dropped,
-leaving the compact role/name/state tree DevTools shows.`
 
 // Structural/text roles carry no semantic signal on their own — dropping them
 // yields the compact role/name tree DevTools shows, not the raw render tree.
@@ -193,13 +189,6 @@ export const extractAria = async (
   }
 }
 
-export const ariaCommand: TapCliCommand = {
-  name: 'aria',
-  description: 'read the accessibility (ARIA) tree of the app-under-test frame, or the subtree at a selector',
-  details: ARIA_DETAILS,
-  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector to root the tree at; omit for the whole frame' }],
-  options: [{ name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' }],
-  handler: (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-    return extractAria(session, frame, args.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
-  }),
-}
+export const ariaCommand = defineNativeCommand('aria', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
+  return extractAria(session, frame, args.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
+}))

--- a/cli/lib/tap/commands/definition.ts
+++ b/cli/lib/tap/commands/definition.ts
@@ -1,0 +1,12 @@
+import { TAP_NATIVE_COMMANDS } from '@packages/cypress-instances'
+import type { TapNativeCommandName } from '@packages/cypress-instances'
+import type { TapCliCommand } from '../types'
+
+// Pairs a CLI-native command's declarative schema — sourced from the shared
+// TAP_NATIVE_COMMANDS contract so it can't drift from the help it renders — with
+// its CLI-side handler. Mirrors the app's defineCommand for schema commands.
+export const defineNativeCommand = (name: TapNativeCommandName, handler: TapCliCommand['handler']): TapCliCommand => {
+  const meta = TAP_NATIVE_COMMANDS.find((command) => command.name === name)!
+
+  return { ...meta, handler }
+}

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -4,13 +4,9 @@ import { FrameCommandError, parsePositiveInt, withResolvedAutFrame } from '../au
 import { createFrameIsolatedWorld } from '../aut/cdp'
 import { readDom } from '../aut/scripts'
 import type { DomReadResult } from '../aut/scripts'
-import type { TapCliCommand } from '../types'
+import { defineNativeCommand } from './definition'
 
 const DEFAULT_MAX_CHARS = 30000
-
-const DOM_DETAILS = `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of
-each element matching a CSS selector (each match includes its full subtree).
-Output is capped browser-side so a heavy page never ships megabytes at once.`
 
 interface FrameDomResult {
   url?: string
@@ -53,13 +49,6 @@ export const extractDom = async (
   }
 }
 
-export const domCommand: TapCliCommand = {
-  name: 'dom',
-  description: 'read the app-under-test DOM as HTML: the whole page, or each element matching a selector (with its subtree)',
-  details: DOM_DETAILS,
-  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' }],
-  options: [{ name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' }],
-  handler: (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-    return extractDom(session, frame, args.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
-  }),
-}
+export const domCommand = defineNativeCommand('dom', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
+  return extractDom(session, frame, args.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
+}))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -5,10 +5,7 @@ import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXValue } from '../aut/cdp'
 import { readElementInfo } from '../aut/scripts'
 import type { ElementInfo } from '../aut/scripts'
-import type { TapCliCommand } from '../types'
-
-const INSPECT_DETAILS = `Inspects the first element matching the selector: its tag, attributes,
-curated computed styles, box model, and accessibility node.`
+import { defineNativeCommand } from './definition'
 
 // A full computed style is ~350 properties; this curated set answers the
 // "why does it look/behave this way" questions (layout, visibility, box).
@@ -123,12 +120,6 @@ export const extractInspect = async (
   }
 }
 
-export const inspectCommand: TapCliCommand = {
-  name: 'inspect',
-  description: 'inspect the first element matching a selector: its tag, attributes, computed styles, box model, and accessibility node',
-  details: INSPECT_DETAILS,
-  params: [{ name: 'selector', type: 'string', required: true, description: 'a CSS selector identifying the element to inspect' }],
-  handler: (options, args) => withResolvedAutFrame(options, (session, frame) => {
-    return extractInspect(session, frame, args.selector)
-  }),
-}
+export const inspectCommand = defineNativeCommand('inspect', (options, args) => withResolvedAutFrame(options, (session, frame) => {
+  return extractInspect(session, frame, args.selector)
+}))

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,9 +1,7 @@
 import { listLiveInstances } from '../../cypress-instances'
 import { renderResult } from '../output'
-import type { TapCliCommand, TapCliOptions } from '../types'
-
-const INSTANCES_DETAILS = `Lists the running Cypress instances this CLI can reach, as a JSON array. Pass
-an instance's pid to \`--instance\` to target it with another tap command.`
+import { defineNativeCommand } from './definition'
+import type { TapCliOptions } from '../types'
 
 const listInstances = async (options: TapCliOptions): Promise<number> => {
   const instances = await listLiveInstances({ instance: options.instance })
@@ -18,9 +16,4 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
   return 0
 }
 
-export const instancesCommand: TapCliCommand = {
-  name: 'instances',
-  description: 'list the running Cypress instances this CLI can reach',
-  details: INSTANCES_DETAILS,
-  handler: listInstances,
-}
+export const instancesCommand = defineNativeCommand('instances', listInstances)

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -3,14 +3,8 @@ import type { ReadyInstanceState } from '../../cypress-instances'
 import { withTapSession, validateExecResult } from '../tap-session'
 import { renderFailure, renderKnownFailure, renderResult } from '../output'
 import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
-import type { TapCliCommand, TapCliOptions, TapRunState, TapStatus } from '../types'
-
-const STATUS_DETAILS = `Reports where a running Cypress instance is in its lifecycle, as JSON — for
-polling and "where am I?" checks. Always exits 0 for a determinable stage
-(including "not connected"); a poller branches on the \`status\` field.
-
-Stages: not connected, browser not selected, spec not selected, running,
-passed, failed.`
+import { defineNativeCommand } from './definition'
+import type { TapCliOptions, TapRunState, TapStatus } from '../types'
 
 const mergeRunState = (base: TapStatus, runState: TapRunState): TapStatus => {
   if (runState.state === undefined) {
@@ -85,9 +79,4 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   }
 }
 
-export const statusCommand: TapCliCommand = {
-  name: 'status',
-  description: 'report where a running Cypress instance is in its lifecycle',
-  details: STATUS_DETAILS,
-  handler: reportStatus,
-}
+export const statusCommand = defineNativeCommand('status', reportStatus)

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -16,23 +16,6 @@ export const renderResult = (result: unknown): void => {
   logger.always(typeof result === 'string' ? result : JSON.stringify(result, null, 2))
 }
 
-const GENERIC_TAP_USAGE = `Usage: cypress tap [command] [args...] [options]
-
-Interacts with a running Cypress instance over its tap binding.
-
-Commands:
-  instances  list the running Cypress instances this CLI can reach
-  status     report where a running Cypress instance is in its lifecycle
-  dom        read the app-under-test DOM as HTML, whole-page or by selector
-  aria       read the accessibility (ARIA) tree of the app-under-test frame
-  inspect    inspect the first element a selector matches: attributes, styles, box model, ARIA node
-
-Other commands are discovered from the running Cypress instance — start
-Cypress (e.g. \`cypress open\`), then run \`cypress tap\` to see them.
-
-Options:
-  --instance <pid>  target a specific running Cypress instance by its pid`
-
 export const renderNativeHelp = (program: commander.Command, command: string): void => {
   logger.always(program.commands.find((subcommand) => subcommand.name() === command)!.helpInformation())
 }
@@ -56,7 +39,9 @@ const instanceBanner = (schema: TapSchema, selection: InstanceSelection): string
   return target
 }
 
-export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: InstanceSelection, command: string | undefined, wantsHelp: boolean): number => {
+const renderHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, wantsHelp: boolean, banner?: string): number => {
+  const prefix = banner ? `${banner}\n\n` : ''
+
   if (command) {
     const entry = schema.commands.find(({ name }) => name === command)
 
@@ -66,18 +51,20 @@ export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, 
       return 1
     }
 
-    logger.always(`${instanceBanner(schema, selection)}\n\n${program.commands.find((subcommand) => subcommand.name() === command)!.helpInformation()}`)
+    logger.always(`${prefix}${program.commands.find((subcommand) => subcommand.name() === command)!.helpInformation()}`)
 
     return 0
   }
 
-  logger.always(`${instanceBanner(schema, selection)}\n\n${program.helpInformation()}`)
+  logger.always(`${prefix}${program.helpInformation()}`)
 
   return wantsHelp ? 0 : 1
 }
 
-export const renderGenericHelp = (wantsHelp: boolean): number => {
-  logger.always(GENERIC_TAP_USAGE)
+export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: InstanceSelection, command: string | undefined, wantsHelp: boolean): number => {
+  return renderHelp(program, schema, command, wantsHelp, instanceBanner(schema, selection))
+}
 
-  return wantsHelp ? 0 : 1
+export const renderStaticHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, wantsHelp: boolean): number => {
+  return renderHelp(program, schema, command, wantsHelp)
 }

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -20,8 +20,10 @@ export const renderNativeHelp = (program: commander.Command, command: string): v
   logger.always(program.commands.find((subcommand) => subcommand.name() === command)!.helpInformation())
 }
 
-const unknownCommandMessage = (schema: TapSchema, command: string): string => {
-  return `"${command}" is not a command of this Cypress (v${schema.cypressVersion}). Available commands: ${schema.commands.filter(({ hidden }) => !hidden).map(({ name }) => name).join(', ')}.`
+const unknownCommandMessage = (program: commander.Command, schema: TapSchema, command: string): string => {
+  const available = program.commands.map((subcommand) => subcommand.name()).join(', ')
+
+  return `"${command}" is not a command of this Cypress (v${schema.cypressVersion}). Available commands: ${available}.`
 }
 
 const instanceBanner = (schema: TapSchema, selection: InstanceSelection): string => {
@@ -43,15 +45,15 @@ const renderHelp = (program: commander.Command, schema: TapSchema, command: stri
   const prefix = banner ? `${banner}\n\n` : ''
 
   if (command) {
-    const entry = schema.commands.find(({ name }) => name === command)
+    const subcommand = program.commands.find((sub) => sub.name() === command)
 
-    if (!entry || entry.hidden) {
-      renderFailure({ code: 'UNKNOWN_COMMAND', message: unknownCommandMessage(schema, command) })
+    if (!subcommand) {
+      renderFailure({ code: 'UNKNOWN_COMMAND', message: unknownCommandMessage(program, schema, command) })
 
       return 1
     }
 
-    logger.always(`${prefix}${program.commands.find((subcommand) => subcommand.name() === command)!.helpInformation()}`)
+    logger.always(`${prefix}${subcommand.helpInformation()}`)
 
     return 0
   }

--- a/cli/lib/tap/types.ts
+++ b/cli/lib/tap/types.ts
@@ -1,4 +1,4 @@
-import type { TapCommandOptionSchema, TapCommandParamSchema } from '@packages/cypress-instances'
+import type { TapNativeCommandSchema } from '@packages/cypress-instances'
 
 /** Options `cypress tap` accepts from the top-level CLI. */
 export interface TapCliOptions {
@@ -6,25 +6,14 @@ export interface TapCliOptions {
 }
 
 /**
- * A tap subcommand implemented entirely in the CLI, as opposed to the
- * commands discovered from the running Cypress instance's schema. Its
- * positionals and options are parsed CLI-side with the same commander grammar
- * the schema commands use, then handed to `handler` as raw strings.
+ * A tap subcommand implemented entirely in the CLI, as opposed to the commands
+ * discovered from the running Cypress instance's schema. Its declarative shape
+ * (description, params, options, help prose) comes from `TAP_NATIVE_COMMANDS`;
+ * its positionals and options are parsed CLI-side with the same commander
+ * grammar the schema commands use, then handed to `handler` as raw strings
+ * keyed by name.
  */
-export interface TapCliCommand {
-  name: string
-  description: string
-  /**
-   * Extended prose shown between the usage line and the generated
-   * Arguments/Options sections in `cypress tap <name> --help`. Everything
-   * else in the help output is derived from `description`, `params`, and
-   * `options` — this carries only what those fields can't express.
-   */
-  details?: string
-  /** Positional arguments, if any; parsed and forwarded keyed by param name. */
-  params?: readonly TapCommandParamSchema[]
-  /** Options, if any; parsed and forwarded keyed by option name. */
-  options?: readonly TapCommandOptionSchema[]
+export interface TapCliCommand extends TapNativeCommandSchema {
   handler: (options: TapCliOptions, args: Record<string, string>, commandOptions: Record<string, string>) => Promise<number>
 }
 

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -643,12 +643,70 @@ describe('lib/exec/tap', () => {
       expect(logger.print()).toContain(errors.tapBindingNotFound.description)
     })
 
-    it('falls back to generic help when no instance is found and help was wanted', async () => {
+    it('falls back to the baked-in CLI command help when no instance is found and help was wanted', async () => {
       failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
 
       expect(await tap.start(['--help'], {})).toBe(0)
-      expect(logger.print()).toContain('Usage: cypress tap')
-      expect(logger.print()).toContain('discovered from the running Cypress instance')
+      expect(logger.print()).toMatchInlineSnapshot(`
+        "Usage: cypress tap [command] [args...] [options]
+
+        Interacts with a running Cypress instance
+
+        Options:
+          --instance <pid>                target a specific running Cypress instance by
+                                          its server process id (pid)
+          -h, --help                      display help for command
+
+        Commands:
+          instances [options]             list the running Cypress instances this CLI
+                                          can reach
+          status [options]                report where a running Cypress instance is
+                                          in its lifecycle
+          dom [options] [selector]        read the app-under-test DOM as HTML: the
+                                          whole page, or each element matching a
+                                          selector (with its subtree)
+          aria [options] [selector]       read the accessibility (ARIA) tree of the
+                                          app-under-test frame, or the subtree at a
+                                          selector
+          inspect [options] <selector>    inspect the first element matching a
+                                          selector: its tag, attributes, computed
+                                          styles, box model, and accessibility node
+          specs [options]                 List all runnable specs for the selected
+                                          Cypress instance.
+          run [options] <spec>            run (or rerun) a spec by its
+                                          project-relative path
+          tests [options] [test]          list the tests of the active run and their
+                                          state, or detail one by id
+          commands [options]              list the command log entries of a test of
+                                          the active run
+          pin [options] [test] [command]  pin a command’s DOM snapshot into the live
+                                          app-under-test frame so the dom/aria/inspect
+                                          commands can read it; pass --clear to release
+        "
+      `)
+    })
+
+    it('renders the baked-in per-command help when no instance is found', async () => {
+      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+
+      expect(await tap.start(['tests', '--help'], {})).toBe(0)
+      expect(logger.print()).toMatchInlineSnapshot(`
+        "Usage: cypress tap tests [options] [test]
+
+        list the tests of the active run and their state, or detail one by id
+
+        Arguments:
+          test                 test id to detail (timings, error, full title); omit to
+                               list every test
+
+        Options:
+          --attempt <attempt>  1-based attempt to detail (attempt 1 = first run);
+                               defaults to the latest, requires a <test> id
+          --instance <pid>     target a specific running Cypress instance by its server
+                               process id (pid)
+          -h, --help           display help for command
+        "
+      `)
     })
 
     it('falls back to generic help (exit 1) for a bare invocation with no instance found', async () => {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -686,6 +686,19 @@ describe('lib/exec/tap', () => {
       `)
     })
 
+    it('lists both native and schema commands when an unknown command is requested offline', async () => {
+      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+
+      expect(await tap.start(['instancs', '--help'], {})).toBe(1)
+
+      const help = logger.print()
+
+      expect(help).toContain('UNKNOWN_COMMAND')
+      expect(help).toContain('"instancs" is not a command')
+      expect(help).toContain('instances')
+      expect(help).toContain('specs')
+    })
+
     it('renders the baked-in per-command help when no instance is found', async () => {
       failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
 

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -696,12 +696,11 @@ describe('lib/exec/tap', () => {
         list the tests of the active run and their state, or detail one by id
 
         Arguments:
-          test                 test id to detail (timings, error, full title); omit to
-                               list every test
+          test                 test id, as listed by the tests command
 
         Options:
-          --attempt <attempt>  1-based attempt to detail (attempt 1 = first run);
-                               defaults to the latest, requires a <test> id
+          --attempt <attempt>  1-based attempt (attempt 1 = first run); defaults to the
+                               latest
           --instance <pid>     target a specific running Cypress instance by its server
                                process id (pid)
           -h, --help           display help for command

--- a/packages/app/src/tap/commands/commands.ts
+++ b/packages/app/src/tap/commands/commands.ts
@@ -3,26 +3,18 @@ import { defineCommand, TapCommandError } from './definition'
 import { attemptSelectionError, selectTestAttempt, serializeTestCommands } from '../test-state'
 import type { CommandEntry } from '../types'
 
-export const commandsCommand = defineCommand({
-  description: 'list the command log entries of a test of the active run',
-  params: [],
-  options: [
-    { name: 'test', type: 'string', required: true, description: 'test id, as listed by the tests command' },
-    { name: 'attempt', type: 'number', required: false, description: '1-based attempt to read (attempt 1 = first run); defaults to the latest' },
-  ],
-  handler: async (_params, { test, attempt }): Promise<CommandEntry[]> => {
-    const runner = tapManagerDataSource.getRunner()
+export const commandsCommand = defineCommand('commands', async (_params, { test, attempt }): Promise<CommandEntry[]> => {
+  const runner = tapManagerDataSource.getRunner()
 
-    if (!runner) {
-      throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
-    }
+  if (!runner) {
+    throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+  }
 
-    const selection = selectTestAttempt(runner, test, attempt)
+  const selection = selectTestAttempt(runner, test, attempt)
 
-    if ('error' in selection) {
-      throw attemptSelectionError(selection, test)
-    }
+  if ('error' in selection) {
+    throw attemptSelectionError(selection, test)
+  }
 
-    return serializeTestCommands(selection.attempt)
-  },
+  return serializeTestCommands(selection.attempt)
 })

--- a/packages/app/src/tap/commands/definition.ts
+++ b/packages/app/src/tap/commands/definition.ts
@@ -1,4 +1,5 @@
-import type { TapCommandOptionSchema, TapCommandParamSchema } from '../contract'
+import { TAP_COMMANDS } from '../contract'
+import type { TapCommandName, TapCommandOptionSchema, TapCommandParamSchema } from '../contract'
 
 /**
  * Thrown by a handler to report a domain failure (no run mounted, no such test
@@ -30,28 +31,31 @@ type OptionsToObject<O extends readonly TapCommandOptionSchema[]> =
   { [E in O[number] as E extends { required: true } | { type: 'boolean' } ? E['name'] : never]: ScalarOf<E['type']> } &
   { [E in O[number] as E extends { required: true } | { type: 'boolean' } ? never : E['name']]?: ScalarOf<E['type']> }
 
+type CommandSchemas = typeof TAP_COMMANDS
+
 /**
- * Authoring helper for one `cypress tap` subcommand. Capturing `params`/`options`
- * as literal types (via `const` type params) types the handler against its own
- * schema with no annotations — `handler: async ({ spec }, { headed }) => …`.
- * Everything a handler takes or returns must be JSON-serializable per `../contract`.
+ * Authoring helper for one `cypress tap` subcommand. The command's schema (its
+ * params/options metadata) lives in the shared `TAP_COMMANDS` contract so the CLI
+ * can list it without an instance attached; this pairs that metadata with the
+ * app-side handler and types the handler against the named entry — no annotations,
+ * `handler: async ({ spec }, { headed }) => …`. Everything a handler takes or
+ * returns must be JSON-serializable per `../contract`.
  */
-export const defineCommand = <
-  const P extends readonly TapCommandParamSchema[],
-  const O extends readonly TapCommandOptionSchema[] = [],
->(definition: {
-  description: string
-  params: P
-  options?: O
-  hidden?: boolean
-  handler: (params: ParamsToObject<P>, options: OptionsToObject<O>) => Promise<unknown>
-}) => {
-  return definition
+export const defineCommand = <N extends TapCommandName>(
+  name: N,
+  handler: (
+    params: ParamsToObject<CommandSchemas[N]['params']>,
+    options: OptionsToObject<CommandSchemas[N]['options']>,
+  ) => Promise<unknown>,
+): TapCommandDefinition & { name: N } => {
+  return { name, ...TAP_COMMANDS[name], handler }
 }
 
 // The erased view the dispatcher reads through: `defineCommand` types each entry
 // precisely for authoring, but `TapManager` looks them up through this opaque shape.
+// `name` is recorded so the registry can be keyed by it and the two can't drift.
 export interface TapCommandDefinition {
+  name: TapCommandName
   description: string
   params: readonly TapCommandParamSchema[]
   options?: readonly TapCommandOptionSchema[]

--- a/packages/app/src/tap/commands/definition.ts
+++ b/packages/app/src/tap/commands/definition.ts
@@ -31,7 +31,7 @@ type OptionsToObject<O extends readonly TapCommandOptionSchema[]> =
   { [E in O[number] as E extends { required: true } | { type: 'boolean' } ? E['name'] : never]: ScalarOf<E['type']> } &
   { [E in O[number] as E extends { required: true } | { type: 'boolean' } ? never : E['name']]?: ScalarOf<E['type']> }
 
-type CommandSchemas = typeof TAP_COMMANDS
+type CommandByName<N extends TapCommandName> = Extract<typeof TAP_COMMANDS[number], { name: N }>
 
 /**
  * Authoring helper for one `cypress tap` subcommand. The command's schema (its
@@ -44,11 +44,13 @@ type CommandSchemas = typeof TAP_COMMANDS
 export const defineCommand = <N extends TapCommandName>(
   name: N,
   handler: (
-    params: ParamsToObject<CommandSchemas[N]['params']>,
-    options: OptionsToObject<CommandSchemas[N]['options']>,
+    params: ParamsToObject<CommandByName<N>['params']>,
+    options: OptionsToObject<CommandByName<N>['options']>,
   ) => Promise<unknown>,
 ): TapCommandDefinition & { name: N } => {
-  return { name, ...TAP_COMMANDS[name], handler }
+  const meta = TAP_COMMANDS.find((command) => command.name === name)!
+
+  return { ...meta, name, handler }
 }
 
 // The erased view the dispatcher reads through: `defineCommand` types each entry

--- a/packages/app/src/tap/commands/index.ts
+++ b/packages/app/src/tap/commands/index.ts
@@ -5,14 +5,18 @@ import { runCommand } from './run'
 import { runStateCommand } from './run-state'
 import { specsCommand } from './specs'
 import { testsCommand } from './tests'
+import type { TapCommandName } from '../contract'
 
 // The command registry — the single source of truth for the tap binding.
-// Adding a subcommand is one sibling module plus its entry here.
-export const tapCommands = {
+// Adding a subcommand is one sibling module plus its entry here. Keyed by
+// `TapCommandName`, each slot demanding a definition authored for that same
+// name, so the registry, the contract, and each `defineCommand` call can't
+// drift: a missing command or a key/name mismatch fails to compile.
+export const tapCommands: { [K in TapCommandName]: TapCommandDefinition & { name: K } } = {
   specs: specsCommand,
   run: runCommand,
   tests: testsCommand,
   commands: commandsCommand,
   pin: pinCommand,
   'run-state': runStateCommand,
-} satisfies Record<string, TapCommandDefinition>
+}

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -142,91 +142,80 @@ const clearPin = (): ClearResult => {
   return { cleared: true }
 }
 
-export const pinCommand = defineCommand({
-  description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
-  params: [
-    { name: 'test', type: 'string', required: false, description: 'test id, as listed by the tests command' },
-    { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command' },
-  ],
-  options: [
-    { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
-    { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
-  ],
-  handler: async ({ test, command }, { at, clear }): Promise<PinResult | ClearResult> => {
-    const runner = tapManagerDataSource.getSnapshotRunner()
+export const pinCommand = defineCommand('pin', async ({ test, command }, { at, clear }): Promise<PinResult | ClearResult> => {
+  const runner = tapManagerDataSource.getSnapshotRunner()
 
-    if (runner) {
-      reconcilePin(runner)
+  if (runner) {
+    reconcilePin(runner)
+  }
+
+  if (clear) {
+    if (!runner || tapManagerDataSource.isRunning()) {
+      releasePin()
+
+      return { cleared: false }
     }
 
-    if (clear) {
-      if (!runner || tapManagerDataSource.isRunning()) {
-        releasePin()
+    return clearPin()
+  }
 
-        return { cleared: false }
-      }
+  if (test === undefined || command === undefined) {
+    throw new TapCommandError('PIN_TARGET_REQUIRED', 'provide a test id and command id to pin (as listed by the tests and commands commands), or pass --clear to release the current pin')
+  }
 
-      return clearPin()
-    }
+  if (!runner) {
+    throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+  }
 
-    if (test === undefined || command === undefined) {
-      throw new TapCommandError('PIN_TARGET_REQUIRED', 'provide a test id and command id to pin (as listed by the tests and commands commands), or pass --clear to release the current pin')
-    }
+  if (tapManagerDataSource.isRunning()) {
+    throw new TapCommandError('RUN_IN_PROGRESS', 'a spec is currently running — wait for it to finish before pinning a snapshot')
+  }
 
-    if (!runner) {
-      throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
-    }
+  if (pinned && pinned.test === test && pinned.command === command) {
+    return movePin(runner, at)
+  }
 
-    if (tapManagerDataSource.isRunning()) {
-      throw new TapCommandError('RUN_IN_PROGRESS', 'a spec is currently running — wait for it to finish before pinning a snapshot')
-    }
+  const selection = selectTestAttempt(runner, test)
 
-    if (pinned && pinned.test === test && pinned.command === command) {
-      return movePin(runner, at)
-    }
+  if ('error' in selection) {
+    throw attemptSelectionError(selection, test)
+  }
 
-    const selection = selectTestAttempt(runner, test)
+  const commands = serializeTestCommands(selection.attempt)
 
-    if ('error' in selection) {
-      throw attemptSelectionError(selection, test)
-    }
+  if (!commands.some((entry) => entry.id === command)) {
+    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the commands command to list this test’s commands`)
+  }
 
-    const commands = serializeTestCommands(selection.attempt)
+  const props = runner.getSnapshotPropsForLog(test, command)
+  const snapshots = liveSnapshots(props)
 
-    if (!commands.some((entry) => entry.id === command)) {
-      throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the commands command to list this test’s commands`)
-    }
+  if (snapshots.length === 0) {
+    throw new TapCommandError('SNAPSHOT_UNAVAILABLE', 'this command has no DOM snapshot to pin — snapshots are captured in open mode and kept only for the most recent tests (numTestsKeptInMemory)')
+  }
 
-    const props = runner.getSnapshotPropsForLog(test, command)
-    const snapshots = liveSnapshots(props)
+  const index = resolveAt(snapshots, at)
 
-    if (snapshots.length === 0) {
-      throw new TapCommandError('SNAPSHOT_UNAVAILABLE', 'this command has no DOM snapshot to pin — snapshots are captured in open mode and kept only for the most recent tests (numTestsKeptInMemory)')
-    }
+  const autIframe = tapManagerDataSource.getAutIframe()
 
-    const index = resolveAt(snapshots, at)
+  if (!autIframe) {
+    throw new TapCommandError('NO_AUT', 'the app under test is not available to pin a snapshot into')
+  }
 
-    const autIframe = tapManagerDataSource.getAutIframe()
+  const original = pinned ? pinned.original : autIframe.detachDom()
 
-    if (!autIframe) {
-      throw new TapCommandError('NO_AUT', 'the app under test is not available to pin a snapshot into')
-    }
+  tapManagerDataSource.pinSnapshot({ ...props, snapshots }, index, test, command)
 
-    const original = pinned ? pinned.original : autIframe.detachDom()
+  if (!pinned) {
+    stopListeningForUnpin = tapManagerDataSource.onSnapshotUnpinned(onExternalUnpin)
+  }
 
-    tapManagerDataSource.pinSnapshot({ ...props, snapshots }, index, test, command)
+  const at_ = toRef(snapshots[index], index)
 
-    if (!pinned) {
-      stopListeningForUnpin = tapManagerDataSource.onSnapshotUnpinned(onExternalUnpin)
-    }
+  pinned = { test, command, at: at_, original, snapshot: snapshots[index] }
 
-    const at_ = toRef(snapshots[index], index)
-
-    pinned = { test, command, at: at_, original, snapshot: snapshots[index] }
-
-    return {
-      pinned: { test, command, at: at_ },
-      ...(props?.url !== undefined ? { url: props.url } : {}),
-    }
-  },
+  return {
+    pinned: { test, command, at: at_ },
+    ...(props?.url !== undefined ? { url: props.url } : {}),
+  }
 })

--- a/packages/app/src/tap/commands/run-state.ts
+++ b/packages/app/src/tap/commands/run-state.ts
@@ -14,38 +14,32 @@ export interface RunStateResult {
   pinned?: { command: string, at: { index: number, name?: string } }
 }
 
-export const runStateCommand = defineCommand({
-  description: 'report where the running Cypress instance is in its run lifecycle',
-  // The CLI surfaces this through the friendlier `status` command, not as its own.
-  hidden: true,
-  params: [],
-  handler: async (): Promise<RunStateResult> => {
-    const totalSpecs = tapManagerDataSource.getRunnableSpecs().length
-    const runner = tapManagerDataSource.getRunner()
+export const runStateCommand = defineCommand('run-state', async (): Promise<RunStateResult> => {
+  const totalSpecs = tapManagerDataSource.getRunnableSpecs().length
+  const runner = tapManagerDataSource.getRunner()
 
-    if (!runner) {
-      return { spec: null, totalSpecs }
-    }
+  if (!runner) {
+    return { spec: null, totalSpecs }
+  }
 
-    // Release a stale pin (from a previous run) so status never reports one that
-    // no longer exists.
-    const snapshotRunner = tapManagerDataSource.getSnapshotRunner()
+  // Release a stale pin (from a previous run) so status never reports one that
+  // no longer exists.
+  const snapshotRunner = tapManagerDataSource.getSnapshotRunner()
 
-    if (snapshotRunner) {
-      reconcilePin(snapshotRunner)
-    }
+  if (snapshotRunner) {
+    reconcilePin(snapshotRunner)
+  }
 
-    const pinned = getPinnedRef()
-    const { results, totalTests } = aggregateResults(runner)
-    const state = !runner.isRunComplete() ? 'running' : results.failed > 0 ? 'failed' : 'passed'
+  const pinned = getPinnedRef()
+  const { results, totalTests } = aggregateResults(runner)
+  const state = !runner.isRunComplete() ? 'running' : results.failed > 0 ? 'failed' : 'passed'
 
-    return {
-      spec: tapManagerDataSource.getActiveSpecRelative() ?? null,
-      totalSpecs,
-      state,
-      totalTests,
-      results,
-      ...(pinned ? { pinned } : {}),
-    }
-  },
+  return {
+    spec: tapManagerDataSource.getActiveSpecRelative() ?? null,
+    totalSpecs,
+    state,
+    totalTests,
+    results,
+    ...(pinned ? { pinned } : {}),
+  }
 })

--- a/packages/app/src/tap/commands/run.ts
+++ b/packages/app/src/tap/commands/run.ts
@@ -11,29 +11,23 @@ const nextTapRunNonce = () => {
   return (Number.isInteger(current) ? current : 0) + 1
 }
 
-export const runCommand = defineCommand({
-  description: 'run (or rerun) a spec by its project-relative path',
-  params: [
-    { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
-  ],
-  handler: async ({ spec }): Promise<SpecListEntry> => {
-    if (spec.length === 0) {
-      throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
-    }
+export const runCommand = defineCommand('run', async ({ spec }): Promise<SpecListEntry> => {
+  if (spec.length === 0) {
+    throw new TapCommandError('INVALID_SPEC', 'spec must be a non-empty string (a project-relative spec path)')
+  }
 
-    const wanted = posixify(spec)
-    const match = tapManagerDataSource.getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
+  const wanted = posixify(spec)
+  const match = tapManagerDataSource.getRunnableSpecs().find((entry) => posixify(entry.relative) === wanted)
 
-    if (!match) {
-      throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
-    }
+  if (!match) {
+    throw new TapCommandError('SPEC_NOT_FOUND', `no spec matches the path "${spec}" — use the specs command to list runnable specs`)
+  }
 
-    // Encode each segment but keep the slashes literal, since watchSpecs reads
-    // route.query.file back through getPathForPlatform.
-    const file = posixify(match.relative).split('/').map(encodeURIComponent).join('/')
+  // Encode each segment but keep the slashes literal, since watchSpecs reads
+  // route.query.file back through getPathForPlatform.
+  const file = posixify(match.relative).split('/').map(encodeURIComponent).join('/')
 
-    tapManagerDataSource.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
+  tapManagerDataSource.setHash(`/specs/runner?file=${file}&tapRun=${nextTapRunNonce()}`)
 
-    return toSpecListEntry(match)
-  },
+  return toSpecListEntry(match)
 })

--- a/packages/app/src/tap/commands/specs.ts
+++ b/packages/app/src/tap/commands/specs.ts
@@ -3,10 +3,6 @@ import { defineCommand } from './definition'
 import { toSpecListEntry } from '../specs-list'
 import type { SpecListEntry } from '../types'
 
-export const specsCommand = defineCommand({
-  description: 'List all runnable specs for the selected Cypress instance.',
-  params: [],
-  handler: async (): Promise<SpecListEntry[]> => {
-    return tapManagerDataSource.getRunnableSpecs().map(toSpecListEntry)
-  },
+export const specsCommand = defineCommand('specs', async (): Promise<SpecListEntry[]> => {
+  return tapManagerDataSource.getRunnableSpecs().map(toSpecListEntry)
 })

--- a/packages/app/src/tap/commands/tests.ts
+++ b/packages/app/src/tap/commands/tests.ts
@@ -21,23 +21,14 @@ const detailTest = (runner: TapTestsRunner, testId: string, attempt?: number): T
   return serializeTestDetail(selection.test, selection.attempt, runner.isRunComplete())
 }
 
-export const testsCommand = defineCommand({
-  description: 'list the tests of the active run and their state, or detail one by id',
-  params: [
-    { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
-  ],
-  options: [
-    { name: 'attempt', type: 'number', required: false, description: '1-based attempt to detail (attempt 1 = first run); defaults to the latest, requires a <test> id' },
-  ],
-  handler: async ({ test }, { attempt }): Promise<TestStateEntry[] | TestDetailEntry> => {
-    const runner = tapManagerDataSource.getRunner()
+export const testsCommand = defineCommand('tests', async ({ test }, { attempt }): Promise<TestStateEntry[] | TestDetailEntry> => {
+  const runner = tapManagerDataSource.getRunner()
 
-    if (!runner) {
-      throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
-    }
+  if (!runner) {
+    throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+  }
 
-    return test === undefined
-      ? listTests(runner, attempt)
-      : detailTest(runner, test, attempt)
-  },
+  return test === undefined
+    ? listTests(runner, attempt)
+    : detailTest(runner, test, attempt)
 })

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -9,11 +9,13 @@ import type { TapSchema, TapExecResult } from '@packages/cypress-instances/lib/t
 
 export {
   TAP_SCHEMA_VERSION,
+  TAP_COMMANDS,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 export type {
   TapCommandParamSchema,
   TapCommandOptionSchema,
+  TapCommandName,
   TapSchema,
   TapExecResult,
 } from '@packages/cypress-instances/lib/tap-contract'

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -21,7 +21,7 @@ export interface TapCommandOptionSchema {
   description: string
 }
 
-interface TapCommandSchema {
+export interface TapCommandSchema {
   name: string
   description: string
   params: readonly TapCommandParamSchema[]
@@ -40,3 +40,81 @@ export interface TapSchema {
 export type TapExecResult =
   | { result: unknown }
   | { error: { code: string, message: string } }
+
+// A command's metadata keyed by name — its `name` comes from the map key.
+type TapCommandMeta = Omit<TapCommandSchema, 'name'>
+
+// The canonical command metadata, the single source both sides build a schema
+// from: the running instance advertises it over the binding (see the app's
+// TapManager), and the CLI stamps it with its own version to render help with no
+// instance attached. Declaration order is the order commands list in help.
+export const TAP_COMMANDS = {
+  specs: {
+    description: 'List all runnable specs for the selected Cypress instance.',
+    params: [],
+    options: [],
+  },
+  run: {
+    description: 'run (or rerun) a spec by its project-relative path',
+    params: [
+      { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
+    ],
+    options: [],
+  },
+  tests: {
+    description: 'list the tests of the active run and their state, or detail one by id',
+    params: [
+      { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
+    ],
+    options: [
+      { name: 'attempt', type: 'number', required: false, description: '1-based attempt to detail (attempt 1 = first run); defaults to the latest, requires a <test> id' },
+    ],
+  },
+  commands: {
+    description: 'list the command log entries of a test of the active run',
+    params: [],
+    options: [
+      { name: 'test', type: 'string', required: true, description: 'test id, as listed by the tests command' },
+      { name: 'attempt', type: 'number', required: false, description: '1-based attempt to read (attempt 1 = first run); defaults to the latest' },
+    ],
+  },
+  pin: {
+    description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
+    params: [
+      { name: 'test', type: 'string', required: false, description: 'test id, as listed by the tests command' },
+      { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command' },
+    ],
+    options: [
+      { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
+      { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
+    ],
+  },
+  'run-state': {
+    description: 'report where the running Cypress instance is in its run lifecycle',
+    params: [],
+    options: [],
+    hidden: true,
+  },
+} as const satisfies Record<string, TapCommandMeta>
+
+export type TapCommandName = keyof typeof TAP_COMMANDS
+
+export const buildTapSchema = (cypressVersion: string): TapSchema => {
+  const commands = (Object.keys(TAP_COMMANDS) as TapCommandName[]).map((name): TapCommandSchema => {
+    const meta: TapCommandMeta = TAP_COMMANDS[name]
+
+    return {
+      name,
+      description: meta.description,
+      params: meta.params.map((param) => ({ ...param })),
+      options: meta.options.map((option) => ({ ...option })),
+      ...(meta.hidden ? { hidden: true } : {}),
+    }
+  })
+
+  return {
+    schemaVersion: TAP_SCHEMA_VERSION,
+    cypressVersion,
+    commands,
+  }
+}

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -41,74 +41,94 @@ export type TapExecResult =
   | { result: unknown }
   | { error: { code: string, message: string } }
 
-// A command's metadata keyed by name — its `name` comes from the map key.
-type TapCommandMeta = Omit<TapCommandSchema, 'name'>
+// Params/options that recur across commands, defined once so their name, type,
+// and help text can't drift between the commands that expose them. `test` is
+// required in some commands and optional in others, so each use spreads it and
+// sets `required`; `attempt` is identical everywhere and used directly.
+const testIdField = { name: 'test', type: 'string', description: 'test id, as listed by the tests command' } as const
+const attemptField = { name: 'attempt', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
+
+const specsMeta = {
+  name: 'specs',
+  description: 'List all runnable specs for the selected Cypress instance.',
+  params: [],
+  options: [],
+} as const satisfies TapCommandSchema
+
+const runMeta = {
+  name: 'run',
+  description: 'run (or rerun) a spec by its project-relative path',
+  params: [
+    { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
+  ],
+  options: [],
+} as const satisfies TapCommandSchema
+
+const testsMeta = {
+  name: 'tests',
+  description: 'list the tests of the active run and their state, or detail one by id',
+  params: [
+    { ...testIdField, required: false },
+  ],
+  options: [
+    attemptField,
+  ],
+} as const satisfies TapCommandSchema
+
+const commandsMeta = {
+  name: 'commands',
+  description: 'list the command log entries of a test of the active run',
+  params: [],
+  options: [
+    { ...testIdField, required: true },
+    attemptField,
+  ],
+} as const satisfies TapCommandSchema
+
+const pinMeta = {
+  name: 'pin',
+  description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
+  params: [
+    { ...testIdField, required: false },
+    { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command' },
+  ],
+  options: [
+    { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
+    { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
+  ],
+} as const satisfies TapCommandSchema
+
+const runStateMeta = {
+  name: 'run-state',
+  description: 'report where the running Cypress instance is in its run lifecycle',
+  params: [],
+  options: [],
+  hidden: true,
+} as const satisfies TapCommandSchema
 
 // The canonical command metadata, the single source both sides build a schema
 // from: the running instance advertises it over the binding (see the app's
 // TapManager), and the CLI stamps it with its own version to render help with no
-// instance attached. Declaration order is the order commands list in help.
-export const TAP_COMMANDS = {
-  specs: {
-    description: 'List all runnable specs for the selected Cypress instance.',
-    params: [],
-    options: [],
-  },
-  run: {
-    description: 'run (or rerun) a spec by its project-relative path',
-    params: [
-      { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the specs command' },
-    ],
-    options: [],
-  },
-  tests: {
-    description: 'list the tests of the active run and their state, or detail one by id',
-    params: [
-      { name: 'test', type: 'string', required: false, description: 'test id to detail (timings, error, full title); omit to list every test' },
-    ],
-    options: [
-      { name: 'attempt', type: 'number', required: false, description: '1-based attempt to detail (attempt 1 = first run); defaults to the latest, requires a <test> id' },
-    ],
-  },
-  commands: {
-    description: 'list the command log entries of a test of the active run',
-    params: [],
-    options: [
-      { name: 'test', type: 'string', required: true, description: 'test id, as listed by the tests command' },
-      { name: 'attempt', type: 'number', required: false, description: '1-based attempt to read (attempt 1 = first run); defaults to the latest' },
-    ],
-  },
-  pin: {
-    description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
-    params: [
-      { name: 'test', type: 'string', required: false, description: 'test id, as listed by the tests command' },
-      { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command' },
-    ],
-    options: [
-      { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
-      { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
-    ],
-  },
-  'run-state': {
-    description: 'report where the running Cypress instance is in its run lifecycle',
-    params: [],
-    options: [],
-    hidden: true,
-  },
-} as const satisfies Record<string, TapCommandMeta>
+// instance attached. Order here is the order commands list in help.
+export const TAP_COMMANDS = [
+  specsMeta,
+  runMeta,
+  testsMeta,
+  commandsMeta,
+  pinMeta,
+  runStateMeta,
+] as const satisfies readonly TapCommandSchema[]
 
-export type TapCommandName = keyof typeof TAP_COMMANDS
+export type TapCommandName = typeof TAP_COMMANDS[number]['name']
 
 export const buildTapSchema = (cypressVersion: string): TapSchema => {
-  const commands = (Object.keys(TAP_COMMANDS) as TapCommandName[]).map((name): TapCommandSchema => {
-    const meta: TapCommandMeta = TAP_COMMANDS[name]
-
+  const commands = TAP_COMMANDS.map((command): TapCommandSchema => {
     return {
-      name,
-      description: meta.description,
-      params: meta.params.map((param) => ({ ...param })),
-      options: meta.options.map((option) => ({ ...option })),
-      ...(meta.hidden ? { hidden: true } : {}),
+      name: command.name,
+      description: command.description,
+      params: command.params.map((param) => ({ ...param })),
+      options: command.options.map((option) => ({ ...option })),
+      ...('hidden' in command && command.hidden ? { hidden: true } : {}),
     }
   })
 
@@ -118,3 +138,71 @@ export const buildTapSchema = (cypressVersion: string): TapSchema => {
     commands,
   }
 }
+
+export interface TapNativeCommandSchema {
+  name: string
+  description: string
+  details: string
+  params?: readonly TapCommandParamSchema[]
+  options?: readonly TapCommandOptionSchema[]
+}
+
+const instancesMeta = {
+  name: 'instances',
+  description: 'list the running Cypress instances this CLI can reach',
+  details: `Lists the running Cypress instances this CLI can reach, as a JSON array. Pass
+an instance's pid to \`--instance\` to target it with another tap command.`,
+} as const satisfies TapNativeCommandSchema
+
+const statusMeta = {
+  name: 'status',
+  description: 'report where a running Cypress instance is in its lifecycle',
+  details: `Reports where a running Cypress instance is in its lifecycle, as JSON — for
+polling and "where am I?" checks. Always exits 0 for a determinable stage
+(including "not connected"); a poller branches on the \`status\` field.
+
+Stages: not connected, browser not selected, spec not selected, running,
+passed, failed.`,
+} as const satisfies TapNativeCommandSchema
+
+const domMeta = {
+  name: 'dom',
+  description: 'read the app-under-test DOM as HTML: the whole page, or each element matching a selector (with its subtree)',
+  details: `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of
+each element matching a CSS selector (each match includes its full subtree).
+Output is capped browser-side so a heavy page never ships megabytes at once.`,
+  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' }],
+  options: [{ name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' }],
+} as const satisfies TapNativeCommandSchema
+
+const ariaMeta = {
+  name: 'aria',
+  description: 'read the accessibility (ARIA) tree of the app-under-test frame, or the subtree at a selector',
+  details: `Reads the accessibility (ARIA) tree of the app-under-test frame, or the
+subtree rooted at a CSS selector. Structural and text-only roles are dropped,
+leaving the compact role/name/state tree DevTools shows.`,
+  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector to root the tree at; omit for the whole frame' }],
+  options: [{ name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' }],
+} as const satisfies TapNativeCommandSchema
+
+const inspectMeta = {
+  name: 'inspect',
+  description: 'inspect the first element matching a selector: its tag, attributes, computed styles, box model, and accessibility node',
+  details: `Inspects the first element matching the selector: its tag, attributes,
+curated computed styles, box model, and accessibility node.`,
+  params: [{ name: 'selector', type: 'string', required: true, description: 'a CSS selector identifying the element to inspect' }],
+} as const satisfies TapNativeCommandSchema
+
+// CLI-native tap commands: implemented entirely in the CLI (instance discovery
+// over the filesystem, DOM/ARIA reads over CDP), so — unlike TAP_COMMANDS — they
+// are never advertised by getSchema or exec'd on the instance. Listed here in the
+// order they appear in help, ahead of the schema-driven commands.
+export const TAP_NATIVE_COMMANDS = [
+  instancesMeta,
+  statusMeta,
+  domMeta,
+  ariaMeta,
+  inspectMeta,
+] as const satisfies readonly TapNativeCommandSchema[]
+
+export type TapNativeCommandName = typeof TAP_NATIVE_COMMANDS[number]['name']


### PR DESCRIPTION
- Closes N/A (stacked POC off `feat/tap-cli-integration`)

### Additional details

The tap command schema previously lived only inside the running Cypress instance (`@packages/app`) and was reachable solely by querying `getSchema` over the tap binding. With no instance running, `cypress tap --help` could only list the two CLI-native commands (`instances`, `status`) — the five schema-driven commands (`specs`, `run`, `tests`, `commands`, `run-state`) were invisible until Cypress was open and attached.

This hoists the command **metadata** into the shared, dependency-free contract package (`@packages/cypress-instances`) so it is the single source both sides build a schema from. Every tap command's declarative shape — schema-driven and CLI-native alike — now lives in one file:

- **`@packages/cypress-instances`** now owns `TAP_COMMANDS` (the schema-driven command metadata), `TAP_NATIVE_COMMANDS` (the CLI-native command metadata), and `buildTapSchema(cypressVersion)`. Both are declared as **ordered arrays**, so a command's position in `--help` is explicit array order rather than a reliance on object key-iteration order; the `TapCommandName` / `TapNativeCommandName` unions derive from the arrays.
- **App** keeps the handlers. `defineCommand(name, handler)` sources each schema command's params/options from `TAP_COMMANDS` (handler typing is still inferred per-command, via an `Extract`-by-name lookup), and `getSchema` is unchanged — it still advertises only the commands the instance can actually `exec`. The registry ↔ contract alignment is guarded by the existing `tap-manager` test.
- **CLI** builds a baked-in schema via `buildTapSchema(util.pkgVersion())` and renders the full command listing when no instance resolves. The live `getSchema` query stays authoritative when an instance **is** attached, so older/newer instances still drive the listing (handles past versions). The CLI-native commands (`instances`, `status`, `dom`, `aria`, `inspect`) now source their declarative shape from `TAP_NATIVE_COMMANDS` via a `defineNativeCommand(name, handler)` helper mirroring the app's `defineCommand`, so their schemas no longer sit inline in each command file.

Per review, the offline help renders with no "no instance" banner — we assume the CLI's command set matches the browser's — which also keeps the help output version-independent and snapshot-testable.

### Steps to test

With no Cypress instance running:

```
cypress tap --help          # now lists instances, status, specs, run, tests, commands
cypress tap tests --help    # renders the baked-in per-command help
```

Then `cypress open`, run `cypress tap --help` again, and confirm the live schema still drives the listing (with the instance banner) when attached.

### How has the user experience changed?

`cypress tap --help` (and `cypress tap <command> --help`) now list every command the CLI knows about even when no Cypress instance is running, instead of only the two CLI-native commands. When an instance is attached, behavior is unchanged.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- POC / stacked exploration branch -->
- [x] Have tests been added/updated? <!-- full inline-snapshot help tests + existing tap suite -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- `cypress tap` is not yet publicly documented -->
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly declarative metadata relocation and offline help paths; execution still goes through the live binding when an instance is attached, with existing schema version checks unchanged.
> 
> **Overview**
> **`cypress tap --help` and per-command help now work offline** by building help from a baked-in schema (`buildTapSchema`) instead of a short static blurb that only listed two CLI-native commands.
> 
> Tap command **metadata** moves into `@packages/cypress-instances`: `TAP_COMMANDS` (instance `exec` commands), `TAP_NATIVE_COMMANDS` (CLI-only `instances`, `status`, `dom`, `aria`, `inspect`), plus `buildTapSchema`. The app’s `defineCommand(name, handler)` and the CLI’s new `defineNativeCommand(name, handler)` pull descriptions, params, and options from those arrays so help text cannot drift. The app registry is keyed by `TapCommandName` for compile-time alignment with the contract.
> 
> When instance resolution fails but the user asked for help (or invoked tap with no subcommand), the CLI uses `renderStaticHelp` with no instance banner; live `getSchema` remains authoritative when Cypress is attached. Help rendering is unified via shared `renderHelp`, and unknown-command messages list commands from the built commander program (native + schema).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f385c85984dbb3aec0bab102c66416a82c99c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

