### PR TITLE
feat: improve tap instances output and browser liveness (13753)

### DIFF
--- a/cli/lib/cypress-instances/liveness.ts
+++ b/cli/lib/cypress-instances/liveness.ts
@@ -18,6 +18,35 @@ export const isPidAlive = (pid: number): boolean => {
   }
 }
 
+// The server reports `cdpBrowserWsUrl` from in-memory state that it only clears
+// when the browser *process* exits, so a closed browser window whose process
+// lingers leaves the url stale. Hit the browser's own DevTools HTTP endpoint
+// (Chromium exposes `/json/version` whenever the CDP port is open) to confirm
+// the browser is really reachable before trusting the url.
+const cdpEndpointReachable = async (cdpBrowserWsUrl: string, timeoutMs: number): Promise<boolean> => {
+  let versionUrl: string
+
+  try {
+    const { protocol, host } = new URL(cdpBrowserWsUrl)
+
+    versionUrl = `${protocol === 'wss:' ? 'https:' : 'http:'}//${host}/json/version`
+  } catch (err) {
+    debug('could not derive a CDP version url from %s: %o', cdpBrowserWsUrl, err)
+
+    return false
+  }
+
+  try {
+    const response = await fetch(versionUrl, { signal: AbortSignal.timeout(timeoutMs) })
+
+    return response.ok
+  } catch (err) {
+    debug('CDP endpoint unreachable at %s: %o', versionUrl, err)
+
+    return false
+  }
+}
+
 export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS): Promise<LiveInstanceState | null> => {
   const url = `http://${PROBE_HOST}:${record.serverPort}${instancesProbePath(record.instanceId)}`
 
@@ -34,9 +63,11 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       return null
     }
 
+    const cdpBrowserWsUrl = typeof live.cdpBrowserWsUrl === 'string' ? live.cdpBrowserWsUrl : null
+
     return {
       ...record,
-      cdpBrowserWsUrl: typeof live.cdpBrowserWsUrl === 'string' ? live.cdpBrowserWsUrl : null,
+      cdpBrowserWsUrl: cdpBrowserWsUrl && await cdpEndpointReachable(cdpBrowserWsUrl, timeoutMs) ? cdpBrowserWsUrl : null,
     }
   } catch (err) {
     debug('liveness probe failed for pid %d on port %d: %o', record.pid, record.serverPort, err)

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -3,9 +3,7 @@ import { renderResult } from '../output'
 import type { TapCliCommand, TapCliOptions } from '../types'
 
 const INSTANCES_DETAILS = `Lists the running Cypress instances this CLI can reach, as a JSON array. Pass
-an instance's pid to \`--instance\` to target it with another tap command. When
-none are reachable, prints guidance on how to start one instead of an empty
-array.`
+an instance's pid to \`--instance\` to target it with another tap command.`
 
 const NO_INSTANCES_GUIDANCE = 'No running Cypress instance found. Start Cypress in open mode (e.g. `cypress open`) and select a testing type to get started.'
 

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -3,15 +3,25 @@ import { renderResult } from '../output'
 import type { TapCliCommand, TapCliOptions } from '../types'
 
 const INSTANCES_DETAILS = `Lists the running Cypress instances this CLI can reach, as a JSON array. Pass
-an instance's pid to \`--instance\` to target it with another tap command.`
+an instance's pid to \`--instance\` to target it with another tap command. When
+none are reachable, prints guidance on how to start one instead of an empty
+array.`
+
+const NO_INSTANCES_GUIDANCE = 'No running Cypress instance found. Start Cypress in open mode (e.g. `cypress open`) and select a testing type to get started.'
 
 const listInstances = async (options: TapCliOptions): Promise<number> => {
   const instances = await listLiveInstances({ instance: options.instance })
 
+  if (instances.length === 0) {
+    renderResult(NO_INSTANCES_GUIDANCE)
+
+    return 0
+  }
+
   renderResult(instances.map((instance) => ({
     pid: instance.pid,
     projectRoot: instance.projectRoot,
-    serverPort: instance.serverPort,
+    testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
   })))
 

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -46,7 +46,10 @@ const makeRecord = (overrides: Record<string, any> = {}) => {
   })
 }
 
-const CDP_WS_URL = 'ws://127.0.0.1:9222/devtools/browser/abc'
+// Set per-test to a reachable fake DevTools endpoint so the liveness probe's
+// CDP reachability check passes; tests that need an unreachable endpoint build
+// their own url from a closed port.
+let CDP_WS_URL!: string
 
 const stubKill = ({ alive = [], eperm = [] }: { alive?: number[], eperm?: number[] }) => {
   vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
@@ -88,6 +91,27 @@ describe('lib/cypress-instances', () => {
     return (server.address() as AddressInfo).port
   }
 
+  // A browser's DevTools HTTP endpoint answering /json/version, so the liveness
+  // probe's CDP reachability check treats CDP_WS_URL as a live browser.
+  const startFakeCdpEndpoint = async (): Promise<number> => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/json/version') {
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ webSocketDebuggerUrl: 'ws://127.0.0.1/devtools/browser/abc' }))
+
+        return
+      }
+
+      res.statusCode = 404
+      res.end()
+    })
+
+    servers.push(server)
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+
+    return (server.address() as AddressInfo).port
+  }
+
   const getClosedPort = async (): Promise<number> => {
     const server = http.createServer()
 
@@ -100,9 +124,11 @@ describe('lib/cypress-instances', () => {
     return port
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.restoreAllMocks()
     vi.mocked(state.getCacheDir).mockReturnValue(CACHE_DIR)
+
+    CDP_WS_URL = `ws://127.0.0.1:${await startFakeCdpEndpoint()}/devtools/browser/abc`
   })
 
   afterEach(async () => {
@@ -151,6 +177,19 @@ describe('lib/cypress-instances', () => {
 
     it('normalizes a missing or junk cdpBrowserWsUrl in the probe response to null', async () => {
       const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: 42 } })
+
+      expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
+    })
+
+    it('nulls the CDP endpoint when the browser is gone, even though the probe still echoes a url', async () => {
+      const deadCdpPort = await getClosedPort()
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc` } })
+
+      expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
+    })
+
+    it('nulls a malformed cdpBrowserWsUrl that has no reachable endpoint to derive', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: 'not-a-ws-url' } })
 
       expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
     })

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -333,24 +333,43 @@ describe('lib/exec/tap', () => {
 
     it('renders the live instances as a JSON summary and exits 0, without opening a session', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, projectRoot: '/projects/app', serverPort: 49200, cdpBrowserWsUrl: 'ws://x' }),
-        liveInstance({ pid: 222, projectRoot: '/projects/other', serverPort: 49201, cdpBrowserWsUrl: null }),
+        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x' }),
+        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null }),
       ])
 
       expect(await tap.start(['instances'], {})).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([
-        { pid: 111, projectRoot: '/projects/app', serverPort: 49200, browserAttached: true },
-        { pid: 222, projectRoot: '/projects/other', serverPort: 49201, browserAttached: false },
+        { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true },
+        { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false },
       ])
 
       expect(withTapSession).not.toHaveBeenCalled()
     })
 
-    it('renders an empty array when no instance is live', async () => {
+    it('reports the testing type as null for an instance that has not chosen one', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, testingType: null })])
+
+      expect(await tap.start(['instances'], {})).toBe(0)
+      expect(JSON.parse(logger.print())[0].testingType).toBeNull()
+    })
+
+    it('never exposes the internal serverPort', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, serverPort: 49200 })])
+
+      expect(await tap.start(['instances'], {})).toBe(0)
+      expect(JSON.parse(logger.print())[0]).not.toHaveProperty('serverPort')
+    })
+
+    it('prints guidance instead of an empty array when no instance is live', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([])
 
       expect(await tap.start(['instances'], {})).toBe(0)
-      expect(JSON.parse(logger.print())).toEqual([])
+
+      const output = logger.print()
+
+      expect(() => JSON.parse(output)).toThrow()
+      expect(output).toContain('No running Cypress instance found')
+      expect(output).toContain('select a testing type')
     })
 
     it('forwards --instance as the discovery filter', async () => {


### PR DESCRIPTION
- Closes cypress-io/cypress-services#13753

### Additional details

Improvements to the CLI-native `cypress tap instances` command:

- Drop `serverPort` from the output. It is an internal transport detail an agent never needs.
- Add `testingType` (`e2e` / `component` / `null`) so the listing shows which mode each instance is in.
- Print guidance on how to start Cypress instead of an empty array when nothing is reachable.
- Fix a stale `browserAttached`. The server clears `cdpBrowserWsUrl` only on the browser process exit, so closing the browser window while the process lingers left tap reporting `browserAttached: true`. The discovery probe now confirms the browser's DevTools endpoint (`/json/version`) is reachable before trusting the url.

Scope notes:

- The issue also asked to move instance-file creation before testing-type selection. Deferred to a follow-up: doing it right moves record ownership from the transient project server up to the session-long launchpad server (probe route plus CORS bypass, in-place updates instead of delete-and-recreate). The guidance message covers the user-facing gap in the meantime.
- The stale-browser symptom has a deeper Launchpad-facing root cause (browser liveness keyed only on the process exit event, so a window close that leaves the process alive never resets it). Filed separately as cypress-io/cypress-services#14031. This PR only mitigates the tap side.

### Steps to test

1. `cypress open`, pick E2E, let Chrome launch.
2. `cypress tap instances` lists `{ pid, projectRoot, testingType: "e2e", browserAttached: true }`, with no `serverPort`.
3. Close only the browser window, leave Launchpad open, then `cypress tap instances` reports `browserAttached: false`.
4. Quit Cypress, then `cypress tap instances` prints the guidance message.

Automated: `cd cli && yarn test-unit -- test/lib/cypress-instances.spec.ts test/lib/exec/tap.spec.ts` (97 tests).

### How has the user experience changed?

`cypress tap instances` output changed.

Before:
```json
[
  { "pid": 40391, "projectRoot": "/projects/app", "serverPort": 49200, "browserAttached": true }
]
```

After:
```json
[
  { "pid": 40391, "projectRoot": "/projects/app", "testingType": "e2e", "browserAttached": true }
]
```

When no instance is reachable it now prints guidance instead of `[]`:

`No running Cypress instance found. Start Cypress in open mode (e.g. cypress open) and select a testing type to get started.`

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only discovery and listing behavior with added HTTP probes and output field changes; no auth or core runner changes.
> 
> **Overview**
> Improves **`cypress tap instances`** for agents: drops internal **`serverPort`**, adds **`testingType`** (`e2e` / `component` / `null`), and prints **guidance** to run `cypress open` and pick a testing type instead of an empty JSON array when nothing is live.
> 
> Fixes **stale `browserAttached`**: instance discovery no longer trusts the server’s in-memory **`cdpBrowserWsUrl`** alone. **`verifyInstanceRecord`** now probes the browser’s DevTools HTTP **`/json/version`** (derived from the WebSocket URL) and clears the CDP URL when the endpoint is down or malformed, so a closed browser window with a lingering process reports **`browserAttached: false`**.
> 
> Tests add a fake CDP endpoint for happy paths and cover unreachable CDP, bad URLs, and the new CLI output shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2316303547bc8610d0d4b170ff2b1dac0a955c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->