### PR TITLE
chore: Add github action to rate issue complexity with Claude

### DIFF
--- a/.github/prompts/rate-issue-complexity.md
+++ b/.github/prompts/rate-issue-complexity.md
@@ -1,0 +1,14 @@
+You rate the implementation complexity of a software engineering ticket for the Cypress monorepo on a scale of 1 to 5, based on the nature of the change required, not how long it would take.
+
+Use the Read, Grep, and Glob tools (and `git log`/`git blame` via Bash) to look at the relevant code before rating, when the ticket points at specific files, packages, or behavior. Only explore as much as it takes to judge the change confidently — don't exhaustively search the whole repo.
+
+Scale:
+- 1: Trivial change requiring no logic change (typo, copy, config tweak).
+- 2: Simple, isolated logic change confined to a single function or file with no ambiguity.
+- 3: Moderate change spanning multiple files or a non-trivial algorithm, with a clear but non-obvious solution.
+- 4: Complex change touching multiple subsystems or packages, requiring design decisions and careful handling of edge cases.
+- 5: Highly complex, cross-cutting change affecting core architecture or several packages at once, with significant design uncertainty and broad test coverage implications.
+
+Use "?" only if the ticket has too little information to judge, even after checking the code.
+
+Respond with ONLY a JSON object, no other text: {"weight": "1-5 or ?", "explanation": "one or two sentence explanation"}

--- a/.github/workflows/rate_issue_complexity.yml
+++ b/.github/workflows/rate_issue_complexity.yml
@@ -52,7 +52,7 @@ jobs:
             '{
               model: "claude-sonnet-5",
               max_tokens: 300,
-              system: "You rate the implementation complexity of software engineering tickets on a scale of 1 to 5. 1 is a trivial change requiring no logic change (typo, copy, config tweak). 5 is a complex change a developer would need a week or more to complete. Use \"?\" only if the ticket has too little information to judge. Respond with ONLY a JSON object: {\"weight\": \"1-5 or ?\", \"explanation\": \"one or two sentence explanation\"}. No other text.",
+              system: "You rate the implementation complexity of software engineering tickets on a scale of 1 to 5, based on the nature of the change, not how long it would take. 1 is a trivial change requiring no logic change (typo, copy, config tweak). 2 is a simple, isolated logic change confined to a single function or file with no ambiguity. 3 is a moderate change spanning multiple files or a non-trivial algorithm, with a clear but non-obvious solution. 4 is a complex change touching multiple subsystems or packages, requiring design decisions and careful handling of edge cases. 5 is a highly complex, cross-cutting change affecting core architecture or several packages at once, with significant design uncertainty and broad test coverage implications. Use \"?\" only if the ticket has too little information to judge. Respond with ONLY a JSON object: {\"weight\": \"1-5 or ?\", \"explanation\": \"one or two sentence explanation\"}. No other text.",
               messages: [{
                 role: "user",
                 content: ("Title: " + $title + "\n\nDescription:\n" + $body)
@@ -99,4 +99,23 @@ jobs:
           LABEL="complexity: ${{ steps.claude.outputs.weight }}"
           gh label create "$LABEL" --repo "${{ github.repository }}" --color BFD4F2 2>/dev/null || true
           gh issue edit "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --add-label "$LABEL"
+
+      # Requires a PAT with `project` scope stored as PROJECTS_TOKEN — the default
+      # github.token cannot read or write Projects v2 data.
+      - name: Set Estimate field in the App project
+        if: steps.claude.outputs.weight != '?'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+        run: |
+          PROJECT_ID="PVT_kwDOAIfu4c4ABf7H"
+          ESTIMATE_FIELD_ID="PVTF_lADOAIfu4c4ABf7HzhY_PGk"
+
+          ITEM_ID=$(gh project item-add 10 --owner cypress-io \
+            --url "${{ steps.issue.outputs.url }}" --format json | jq -r '.id')
+
+          gh project item-edit \
+            --id "$ITEM_ID" \
+            --field-id "$ESTIMATE_FIELD_ID" \
+            --project-id "$PROJECT_ID" \
+            --number "${{ steps.claude.outputs.weight }}"
           

--- a/.github/workflows/rate_issue_complexity.yml
+++ b/.github/workflows/rate_issue_complexity.yml
@@ -98,4 +98,5 @@ jobs:
         run: |
           LABEL="complexity: ${{ steps.claude.outputs.weight }}"
           gh label create "$LABEL" --repo "${{ github.repository }}" --color BFD4F2 2>/dev/null || true
-          gh issue edit "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --add-label "$LABEL
+          gh issue edit "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --add-label "$LABEL"
+          

--- a/.github/workflows/rate_issue_complexity.yml
+++ b/.github/workflows/rate_issue_complexity.yml
@@ -1,0 +1,101 @@
+name: Rate Issue Complexity
+ 
+# Manually triggered from the Actions tab: pick this workflow, click "Run workflow",
+# and enter the issue number you want rated.
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to rate"
+        required: true
+        type: number
+ 
+permissions:
+  issues: write
+  contents: read
+ 
+jobs:
+  rate-complexity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch issue details
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue view "${{ inputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --json title,body,url > issue.json
+ 
+          {
+            echo 'title<<EOF'
+            jq -r '.title' issue.json
+            echo EOF
+            echo 'body<<EOF'
+            jq -r '.body // "(no description provided)"' issue.json
+            echo EOF
+            echo 'url<<EOF'
+            jq -r '.url' issue.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+ 
+      - name: Ask Claude to rate complexity
+        id: claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_TITLE: ${{ steps.issue.outputs.title }}
+          ISSUE_BODY: ${{ steps.issue.outputs.body }}
+        run: |
+          jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg body "$ISSUE_BODY" \
+            '{
+              model: "claude-sonnet-5",
+              max_tokens: 300,
+              system: "You rate the implementation complexity of software engineering tickets on a scale of 1 to 5. 1 is a trivial change requiring no logic change (typo, copy, config tweak). 5 is a complex change a developer would need a week or more to complete. Use \"?\" only if the ticket has too little information to judge. Respond with ONLY a JSON object: {\"weight\": \"1-5 or ?\", \"explanation\": \"one or two sentence explanation\"}. No other text.",
+              messages: [{
+                role: "user",
+                content: ("Title: " + $title + "\n\nDescription:\n" + $body)
+              }]
+            }' > payload.json
+ 
+          curl -sS https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d @payload.json > response.json
+ 
+          # Extract Claude's text reply, then pull the JSON object out of it.
+          RAW_TEXT=$(jq -r '.content[0].text' response.json)
+          WEIGHT=$(echo "$RAW_TEXT" | jq -r '.weight // "?"' 2>/dev/null || echo "?")
+          EXPLANATION=$(echo "$RAW_TEXT" | jq -r '.explanation // "Could not parse a rating from the model response."' 2>/dev/null || echo "Could not parse a rating from the model response.")
+ 
+          {
+            echo "weight=$WEIGHT"
+            echo 'explanation<<EOF'
+            echo "$EXPLANATION"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+ 
+      - name: Post comment with the rating
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEIGHT: ${{ steps.claude.outputs.weight }}
+          EXPLANATION: ${{ steps.claude.outputs.explanation }}
+        run: |
+          gh issue comment "${{ inputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --body "**Complexity rating (via Claude): ${WEIGHT}/5**
+ 
+          ${EXPLANATION}
+ 
+          _Automated rating, use judgment before relying on it._"
+ 
+      - name: Apply complexity label
+        if: steps.claude.outputs.weight != '?'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABEL="complexity: ${{ steps.claude.outputs.weight }}"
+          gh label create "$LABEL" --repo "${{ github.repository }}" --color BFD4F2 2>/dev/null || true
+          gh issue edit "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --add-label "$LABEL

--- a/.github/workflows/rate_issue_complexity.yml
+++ b/.github/workflows/rate_issue_complexity.yml
@@ -1,5 +1,5 @@
 name: Rate Issue Complexity
- 
+
 # Manually triggered from the Actions tab: pick this workflow, click "Run workflow",
 # and enter the issue number you want rated.
 on:
@@ -9,15 +9,34 @@ on:
         description: "Issue number to rate"
         required: true
         type: number
- 
+
 permissions:
+  id-token: write
   issues: write
   contents: read
- 
+
 jobs:
   rate-complexity:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Fetch issue details
         id: issue
         env:
@@ -26,57 +45,46 @@ jobs:
           gh issue view "${{ inputs.issue_number }}" \
             --repo "${{ github.repository }}" \
             --json title,body,url > issue.json
- 
-          {
-            echo 'title<<EOF'
-            jq -r '.title' issue.json
-            echo EOF
-            echo 'body<<EOF'
-            jq -r '.body // "(no description provided)"' issue.json
-            echo EOF
-            echo 'url<<EOF'
-            jq -r '.url' issue.json
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
- 
+
+          echo "url=$(jq -r '.url' issue.json)" >> "$GITHUB_OUTPUT"
+
       - name: Ask Claude to rate complexity
         id: claude
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ISSUE_TITLE: ${{ steps.issue.outputs.title }}
-          ISSUE_BODY: ${{ steps.issue.outputs.body }}
+          CLAUDE_CODE_USE_BEDROCK: "1"
+          ANTHROPIC_MODEL: global.anthropic.claude-opus-4-6-v1
         run: |
-          jq -n \
-            --arg title "$ISSUE_TITLE" \
-            --arg body "$ISSUE_BODY" \
-            '{
-              model: "claude-sonnet-5",
-              max_tokens: 300,
-              system: "You rate the implementation complexity of software engineering tickets on a scale of 1 to 5, based on the nature of the change, not how long it would take. 1 is a trivial change requiring no logic change (typo, copy, config tweak). 2 is a simple, isolated logic change confined to a single function or file with no ambiguity. 3 is a moderate change spanning multiple files or a non-trivial algorithm, with a clear but non-obvious solution. 4 is a complex change touching multiple subsystems or packages, requiring design decisions and careful handling of edge cases. 5 is a highly complex, cross-cutting change affecting core architecture or several packages at once, with significant design uncertainty and broad test coverage implications. Use \"?\" only if the ticket has too little information to judge. Respond with ONLY a JSON object: {\"weight\": \"1-5 or ?\", \"explanation\": \"one or two sentence explanation\"}. No other text.",
-              messages: [{
-                role: "user",
-                content: ("Title: " + $title + "\n\nDescription:\n" + $body)
-              }]
-            }' > payload.json
- 
-          curl -sS https://api.anthropic.com/v1/messages \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -H "content-type: application/json" \
-            -d @payload.json > response.json
- 
+          jq -r '.title' issue.json > /tmp/issue-title.txt
+          jq -r '.body // "(no description provided)"' issue.json > /tmp/issue-body.txt
+
+          {
+            cat .github/prompts/rate-issue-complexity.md
+            echo
+            echo "## Issue title"
+            cat /tmp/issue-title.txt
+            echo
+            echo "## Issue description"
+            cat /tmp/issue-body.txt
+          } > /tmp/prompt.md
+
+          claude -p "$(cat /tmp/prompt.md)" \
+            --allowedTools "Read Grep Glob Bash(git:*)" \
+            --max-turns 20 \
+            --output-format text \
+            > /tmp/rating.txt
+
           # Extract Claude's text reply, then pull the JSON object out of it.
-          RAW_TEXT=$(jq -r '.content[0].text' response.json)
+          RAW_TEXT=$(cat /tmp/rating.txt)
           WEIGHT=$(echo "$RAW_TEXT" | jq -r '.weight // "?"' 2>/dev/null || echo "?")
           EXPLANATION=$(echo "$RAW_TEXT" | jq -r '.explanation // "Could not parse a rating from the model response."' 2>/dev/null || echo "Could not parse a rating from the model response.")
- 
+
           {
             echo "weight=$WEIGHT"
             echo 'explanation<<EOF'
             echo "$EXPLANATION"
             echo EOF
           } >> "$GITHUB_OUTPUT"
- 
+
       - name: Post comment with the rating
         env:
           GH_TOKEN: ${{ github.token }}
@@ -86,19 +94,10 @@ jobs:
           gh issue comment "${{ inputs.issue_number }}" \
             --repo "${{ github.repository }}" \
             --body "**Complexity rating (via Claude): ${WEIGHT}/5**
- 
+
           ${EXPLANATION}
- 
+
           _Automated rating, use judgment before relying on it._"
- 
-      - name: Apply complexity label
-        if: steps.claude.outputs.weight != '?'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          LABEL="complexity: ${{ steps.claude.outputs.weight }}"
-          gh label create "$LABEL" --repo "${{ github.repository }}" --color BFD4F2 2>/dev/null || true
-          gh issue edit "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --add-label "$LABEL"
 
       # Requires a PAT with `project` scope stored as PROJECTS_TOKEN — the default
       # github.token cannot read or write Projects v2 data.
@@ -118,4 +117,3 @@ jobs:
             --field-id "$ESTIMATE_FIELD_ID" \
             --project-id "$PROJECT_ID" \
             --number "${{ steps.claude.outputs.weight }}"
-          


### PR DESCRIPTION
This is an Experiment to enable Claude to automatically rate complexity of PRs via a GH action. 

It only uses the issue text to determine this currently, but could be expanded to review the code. 

This requires write access to the repo to run, and it must be run manually, so should have limited impact externally.

It also sets the Estimate value in App project if the complexity can be determiend.