### PR TITLE
feat: Guard DOM instrospection mid run on tap

### DIFF
--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -2,10 +2,11 @@ import Debug from 'debug'
 import type CRI from 'chrome-remote-interface'
 
 import { CypressInstanceError, resolveInstance } from '../../cypress-instances'
-import { withTapSession } from '../tap-session'
+import { withTapSession, validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
 import { renderResult, renderFailure, renderKnownFailure } from '../output'
-import type { TapCliOptions } from '../types'
+import type { TapCliOptions, TapRunState } from '../types'
+import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
 
 const debug = Debug('cypress:cli:tap')
 
@@ -90,10 +91,38 @@ export const parsePositiveInt = (raw: string | undefined, fallback: number, labe
 }
 
 /**
+ * Gates the AUT-frame reads on the same run lifecycle `status` reports. The
+ * frame is only worth reading once a spec has settled: while a spec is running
+ * the app is in flux — commands are still executing, snapshots are swapping,
+ * the page may still be navigating — so a read captures a transient page; and
+ * with no spec run the resolved frame is the runner shell, not any app under
+ * test. Both are rejected with typed errors a poller can branch on, mirroring
+ * the `status` lifecycle contract (wait until `passed`/`failed`).
+ */
+export const assertFrameReadable = async (session: TapSession): Promise<void> => {
+  const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
+
+  if ('error' in outcome) {
+    throw new FrameCommandError(outcome.error.code, outcome.error.message)
+  }
+
+  const { state } = outcome.result as TapRunState
+
+  if (state === undefined) {
+    throw new FrameCommandError('NO_RUN', 'no spec has run — run a spec first, then read the app under test once the run has completed (status passed or failed)')
+  }
+
+  if (state === 'running') {
+    throw new FrameCommandError('RUN_IN_PROGRESS', 'a spec is currently running — the app under test is still in flux; wait for the run to complete (status passed or failed) before reading it')
+  }
+}
+
+/**
  * Shared flow for the AUT-frame commands: resolve a running instance, open a
- * tap session, locate the AUT frame, run `read`, and render the result. Maps
- * the CLI-native `FrameCommandError` and the discovery/transport failures to
- * the same rendered output the schema commands use.
+ * tap session, gate on the run lifecycle, locate the AUT frame, run `read`, and
+ * render the result. Maps the CLI-native `FrameCommandError` and the
+ * discovery/transport failures to the same rendered output the schema commands
+ * use.
  */
 export const withResolvedAutFrame = async (
   options: TapCliOptions,
@@ -103,9 +132,11 @@ export const withResolvedAutFrame = async (
     const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
 
     return await withTapSession(selection.instance, async (session) => {
-      const frame = await resolveAutFrame(session.client, session.sessionId)
-
       try {
+        await assertFrameReadable(session)
+
+        const frame = await resolveAutFrame(session.client, session.sessionId)
+
         renderResult(await read(session, frame))
 
         return 0

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -6,7 +6,7 @@ import { withTapSession, validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
 import { renderResult, renderFailure, renderKnownFailure } from '../output'
 import type { TapCliOptions, TapRunState } from '../types'
-import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
+import { TAP_EXEC_METHOD, TAP_RUN_IN_PROGRESS_MESSAGE } from '@packages/cypress-instances'
 
 const debug = Debug('cypress:cli:tap')
 
@@ -113,7 +113,7 @@ export const assertFrameReadable = async (session: TapSession): Promise<void> =>
   }
 
   if (state === 'running') {
-    throw new FrameCommandError('RUN_IN_PROGRESS', 'a spec is currently running — the app under test is still in flux; wait for the run to complete (status passed or failed) before reading it')
+    throw new FrameCommandError('RUN_IN_PROGRESS', TAP_RUN_IN_PROGRESS_MESSAGE)
   }
 }
 

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -76,6 +76,7 @@ describe('lib/tap/aut/frame assertFrameReadable', () => {
     await expect(assertFrameReadable(session)).rejects.toMatchObject({
       name: 'FrameCommandError',
       code: 'RUN_IN_PROGRESS',
+      message: 'a spec is currently running — call `cypress tap status` to check its current status; wait for it to finish before trying again',
     })
   })
 

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { resolveAutFrame, parsePositiveInt, FrameCommandError } from '../../../lib/tap/aut/frame'
+import { resolveAutFrame, assertFrameReadable, parsePositiveInt, FrameCommandError } from '../../../lib/tap/aut/frame'
+import type { TapSession } from '../../../lib/tap/tap-session'
 
 const SESSION_ID = 'S1'
 
@@ -46,6 +47,54 @@ describe('lib/tap/aut/frame resolveAutFrame', () => {
     await expect(resolveAutFrame(client as any, SESSION_ID)).rejects.toMatchObject({
       name: 'FrameCommandError',
       code: 'NO_AUT_FRAME',
+    })
+  })
+})
+
+describe('lib/tap/aut/frame assertFrameReadable', () => {
+  const sessionForRunState = (envelope: unknown) => {
+    return { call: vi.fn().mockResolvedValue(envelope) } as unknown as TapSession
+  }
+
+  it('resolves once the run has settled to passed', async () => {
+    const session = sessionForRunState({ result: { spec: 'login.cy.js', totalSpecs: 1, state: 'passed' } })
+
+    await expect(assertFrameReadable(session)).resolves.toBeUndefined()
+    // Gated on the run-state the status command also reads.
+    expect(session.call).toHaveBeenCalledWith('exec', ['run-state', {}, {}])
+  })
+
+  it('resolves once the run has settled to failed', async () => {
+    const session = sessionForRunState({ result: { spec: 'login.cy.js', totalSpecs: 1, state: 'failed' } })
+
+    await expect(assertFrameReadable(session)).resolves.toBeUndefined()
+  })
+
+  it('rejects mid-run with RUN_IN_PROGRESS so a poller waits for the app to settle', async () => {
+    const session = sessionForRunState({ result: { spec: 'login.cy.js', totalSpecs: 1, state: 'running' } })
+
+    await expect(assertFrameReadable(session)).rejects.toMatchObject({
+      name: 'FrameCommandError',
+      code: 'RUN_IN_PROGRESS',
+    })
+  })
+
+  it('rejects with NO_RUN — distinct from mid-run — when no spec has run', async () => {
+    const session = sessionForRunState({ result: { spec: null, totalSpecs: 3 } })
+
+    await expect(assertFrameReadable(session)).rejects.toMatchObject({
+      name: 'FrameCommandError',
+      code: 'NO_RUN',
+    })
+  })
+
+  it('surfaces an app-side run-state error envelope as a FrameCommandError', async () => {
+    const session = sessionForRunState({ error: { code: 'BOOM', message: 'run-state blew up' } })
+
+    await expect(assertFrameReadable(session)).rejects.toMatchObject({
+      name: 'FrameCommandError',
+      code: 'BOOM',
+      message: 'run-state blew up',
     })
   })
 })

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -397,7 +397,10 @@ describe('tap/commands/pin', () => {
 
     const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' })
 
-    expect((outcome as { error: { code: string } }).error.code).to.eq('RUN_IN_PROGRESS')
+    expect((outcome as { error: { code: string, message: string } }).error).to.deep.eq({
+      code: 'RUN_IN_PROGRESS',
+      message: 'a spec is currently running — call `cypress tap status` to check its current status; wait for it to finish before trying again',
+    })
   })
 
   it('fails with TEST_NOT_FOUND and COMMAND_NOT_FOUND for unknown ids', async () => {

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -2,6 +2,7 @@ import { defineCommand, TapCommandError } from './definition'
 import { attemptSelectionError, selectTestAttempt, serializeTestCommands } from '../test-state'
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import type { PinSnapshotEntry, PinSnapshotProps, PinSnapshotRunner } from '../types'
+import { TAP_RUN_IN_PROGRESS_MESSAGE } from '../contract'
 
 export interface SnapshotRef {
   index: number
@@ -168,7 +169,7 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
   }
 
   if (tapManagerDataSource.isRunning()) {
-    throw new TapCommandError('RUN_IN_PROGRESS', 'a spec is currently running — wait for it to finish before pinning a snapshot')
+    throw new TapCommandError('RUN_IN_PROGRESS', TAP_RUN_IN_PROGRESS_MESSAGE)
   }
 
   if (pinned && pinned.test === test && pinned.command === command) {

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -10,6 +10,7 @@ import type { TapSchema, TapExecResult } from '@packages/cypress-instances/lib/t
 export {
   TAP_SCHEMA_VERSION,
   TAP_COMMANDS,
+  TAP_RUN_IN_PROGRESS_MESSAGE,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 export type {

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -6,6 +6,8 @@ export const TAP_SCHEMA_METHOD = 'getSchema'
 
 export const TAP_EXEC_METHOD = 'exec'
 
+export const TAP_RUN_IN_PROGRESS_MESSAGE = 'a spec is currently running — call `cypress tap status` to check its current status; wait for it to finish before trying again'
+
 export interface TapCommandParamSchema {
   name: string
   type: 'string' | 'number' | 'boolean'


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> https://github.com/cypress-io/cypress-services/issues/14027

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral guardrails and user-facing error text for tap CLI; no auth, data, or core runner changes.
> 
> **Overview**
> **AUT-frame introspection** (`dom`, `aria`, `inspect`) is gated on the same run lifecycle as `cypress tap status`. Before resolving the AUT iframe, the CLI calls hidden `run-state` and rejects reads when no spec has finished (`NO_RUN`) or a spec is still **running** (`RUN_IN_PROGRESS`), so mid-run reads do not capture a transient page.
> 
> A shared **`TAP_RUN_IN_PROGRESS_MESSAGE`** is added to the cross-process tap contract; **`pin`** now uses it instead of a one-off string, and CLI/unit tests cover the new gate and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae64d4bb17a407dd1d3ea9cd771b3ecb9f9ffe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
