### PR TITLE
fix: escape label target id in selectFile

### DIFF
--- a/packages/driver/cypress/e2e/commands/actions/selectFile.cy.ts
+++ b/packages/driver/cypress/e2e/commands/actions/selectFile.cy.ts
@@ -116,6 +116,19 @@ describe('src/cy/commands/actions/selectFile', () => {
       })
     })
 
+    it('selects files with an input from a label whose "for" attribute contains CSS-special characters', () => {
+      // https://github.com/cypress-io/cypress/issues/34304
+      // Ids like this are common with frameworks (Angular Material, Radix UI, etc)
+      // that generate ids containing `:`, `.`, `[`, and `]`.
+      cy.get('[id="css-escape-label"]').selectFile({ contents: '@foo' })
+
+      cy.get('[id="userForm:file[0].upload"]')
+      .then(getFileContents)
+      .then((contents) => {
+        expect(contents[0]).to.eql('foo')
+      })
+    })
+
     it('invokes change and input events on the input', (done) => {
       const $input = cy.$$('#basic')
 

--- a/packages/driver/cypress/fixtures/files-form.html
+++ b/packages/driver/cypress/fixtures/files-form.html
@@ -106,5 +106,10 @@
       <label for="scroll" id="scroll-label">Scroll Label</label>
       <input id="scroll" type="file" />
     </form>
+
+    <form>
+      <label for="userForm:file[0].upload" id="css-escape-label">CSS Escape Label</label>
+      <input id="userForm:file[0].upload" type="file" />
+    </form>
   </body>
 </html>

--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -339,7 +339,9 @@ export const getInputFromLabel = ($el: JQuery<HTMLElement>) => {
   if ($el.attr('for')) {
     // The parent().last() is the current document, which is where we want to
     // search from.
-    return $(`#${$el.attr('for')}`, $el.parents().last())
+    // CSS.escape the id since it can legally contain characters (e.g. `.`, `:`, `[`, spaces)
+    // that are otherwise special in a CSS selector.
+    return $(`#${CSS.escape($el.attr('for') as string)}`, $el.parents().last())
   }
 
   // Alternately, if a label contains inputs, clicking it focuses / activates


### PR DESCRIPTION
- Closes #34304

### Additional details

Fixes `cy.selectFile()` on `<label>` elements whose `for` target id contains CSS-special characters.

Root cause: `getInputFromLabel()` built a CSS selector with `#${forAttr}` directly. HTML ids may legally contain characters such as `:`, `.`, `[`, or `]`, but those characters are parsed as selector syntax unless escaped, so Cypress could fail to resolve a valid file input or throw while parsing the selector.

This PR escapes the label target id before querying and adds an e2e regression case for a label pointing at `userForm:file[0].upload`.

cc @jennifer-shehane for the driver action-command path.

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

Local checks run:

- `./node_modules/.bin/eslint packages/driver/src/dom/elements/find.ts packages/driver/cypress/e2e/commands/actions/selectFile.cy.ts`
- `git diff --check`

Attempted focused driver run:

```sh
corepack yarn workspace @packages/driver cypress:run --spec cypress/e2e/commands/actions/selectFile.cy.ts --browser electron
```

That was blocked in this checkout by missing generated `dist` artifacts for workspace packages such as `@packages/stderr-filtering` / `@packages/telemetry`. The PR includes the regression spec for CI.

CI evidence currently visible on the PR:

- `license/cla` passed
- `add-contributor-pr-comment` passed
- `Add to triage project` passed
- Snyk and semantic PR checks are still waiting

### How has the user experience changed?

`cy.selectFile()` now handles labels for valid file input ids that contain CSS-special characters instead of reporting that the label does not point to a file input or throwing on selector parsing. No visual change.

### AI-assisted contribution

AI assistance was used while preparing this patch. Harsh reviewed the diff, kept the change focused, and ran the checks listed above.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? Issue #34304 exists; maintainer approval is pending.
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? No docs change needed for this bug fix.
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? No API/type changes.
