### PR TITLE
fix: reset contains regex state per element

### DIFF
--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -289,6 +289,12 @@ $.expr[':']['cy-contains-regex'] = $.expr.createPseudo((text) => {
 
   // taken from jquery's normal contains method
   return function (elem) {
+    // regex is shared across every candidate element in the selector match,
+    // so global/sticky flags leave `lastIndex` set after a previous test call.
+    // Reset it before each use or matches can be skipped depending on
+    // element iteration order. https://github.com/cypress-io/cypress/issues/34303
+    regex.lastIndex = 0
+
     if (isSubmit(elem)) {
       return regex.test(elem.value)
     }

--- a/packages/driver/test/unit/dom/find.spec.ts
+++ b/packages/driver/test/unit/dom/find.spec.ts
@@ -1,0 +1,43 @@
+import $ from 'jquery'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { getContainsSelector } from '../../../src/dom/elements/find'
+
+describe('dom/elements/find', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  describe('cy-contains-regex pseudo', () => {
+    // https://github.com/cypress-io/cypress/issues/34303
+    it('matches every candidate element when the regex has the global flag', () => {
+      document.body.innerHTML = `
+        <ul>
+          <li>asdf 1</li>
+          <li>asdf 2</li>
+          <li>asdf 3</li>
+        </ul>
+      `
+
+      const selector = getContainsSelector(/asdf \d/g, 'li')
+      const $matches = $(selector, document.body)
+
+      expect($matches).toHaveLength(3)
+    })
+
+    it('matches every candidate element when the regex has the sticky flag', () => {
+      document.body.innerHTML = `
+        <ul>
+          <li>asdf 1</li>
+          <li>asdf 2</li>
+          <li>asdf 3</li>
+        </ul>
+      `
+
+      const selector = getContainsSelector(/^asdf \d/y, 'li')
+      const $matches = $(selector, document.body)
+
+      expect($matches).toHaveLength(3)
+    })
+  })
+})


### PR DESCRIPTION
- Closes #34303

### Additional details

Fixes `cy.contains(regex)` when the supplied regular expression has mutable state through the `g` or `y` flags.

Root cause: the `cy-contains-regex` selector pseudo reuses the parsed `RegExp` while Sizzle evaluates each candidate element. `RegExp#test()` mutates `lastIndex` for global/sticky regexes, so candidate matching can depend on which element was tested first.

This PR resets `lastIndex` before testing each candidate element and adds focused unit coverage for both global and sticky regexes.

cc @jennifer-shehane for the driver contains-selector path.

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

Local checks run:

- `corepack yarn workspace @packages/driver test test/unit/dom/find.spec.ts`
- `./node_modules/.bin/eslint packages/driver/src/dom/elements/find.ts packages/driver/test/unit/dom/find.spec.ts`
- `git diff --check`

CI evidence currently visible on the PR:

- `license/cla` passed
- `add-contributor-pr-comment` passed
- `Add to triage project` passed
- Snyk and semantic PR checks are still waiting

### How has the user experience changed?

`cy.contains(/.../g)` and `cy.contains(/.../y)` now evaluate each DOM candidate independently instead of leaking `lastIndex` across candidates. No visual change.

### AI-assisted contribution

AI assistance was used while preparing this patch. Harsh reviewed the diff, kept the change focused, and ran the checks listed above.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? Issue #34303 exists; maintainer approval is pending.
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? No docs change needed for this bug fix.
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? No API/type changes.
