### PR TITLE
chore: disable Blink cache-aware font loading when the proxy is disabled

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -431,6 +431,21 @@ export = {
       args.push(`${HOST_RESOLVER_RULES}${rules}`)
     }
 
+    // Blink's cache-aware font loading hard-fails uncached @font-face loads
+    // (net::ERR_FAILED) when a CDP Fetch response-stage pause is attached,
+    // which the proxy-disabled transport always enables (crbug.com/1196004).
+    // Web fonts do not load at all with the proxy disabled unless this flag
+    // stays — do not remove it.
+    if (isProxyDisabled()) {
+      const disableFeaturesIndex = args.findIndex((arg) => arg.startsWith('--disable-features='))
+
+      if (disableFeaturesIndex === -1) {
+        args.push('--disable-features=WebFontsCacheAwareTimeoutAdaption')
+      } else {
+        args[disableFeaturesIndex] += ',WebFontsCacheAwareTimeoutAdaption'
+      }
+    }
+
     if (options.chromeWebSecurity === false) {
       args.push('--disable-web-security')
       args.push('--allow-running-insecure-content')

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -1079,6 +1079,28 @@ describe('lib/browsers/chrome', () => {
 
       expect(args.find((arg) => arg.startsWith('--host-resolver-rules'))).to.be.undefined
     })
+
+    context('cache-aware font loading', () => {
+      afterEach(() => {
+        delete process.env.CYPRESS_INTERNAL_DISABLE_PROXY
+      })
+
+      it('disables it when the proxy is disabled', () => {
+        process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
+        const args = chrome._getArgs({}, {})
+        const disableFeatures = args.find((arg) => arg.startsWith('--disable-features='))
+
+        expect(disableFeatures).to.include('WebFontsCacheAwareTimeoutAdaption')
+        expect(args.filter((arg) => arg.startsWith('--disable-features='))).to.have.length(1)
+      })
+
+      it('keeps it when the proxy is enabled', () => {
+        const args = chrome._getArgs({}, {})
+
+        expect(args.find((arg) => arg.startsWith('--disable-features='))).not.to.include('WebFontsCacheAwareTimeoutAdaption')
+      })
+    })
   })
 
   describe('#_normalizeHostResolverRules', () => {


### PR DESCRIPTION
- Closes #34361

### Additional details

With the MITM proxy disabled (`CYPRESS_INTERNAL_DISABLE_PROXY=1`), `@font-face` fonts never load: Blink issues uncached font loads in a cache-preferring mode (`WebFontsCacheAwareTimeoutAdaption`) that Chromium's CDP Fetch response-stage interception cannot service. The netstack fails them with `net::ERR_FAILED` before the interceptor ever sees a response pause, the renderer walks the `src` fallback chain, and every attempt dies — fonts render as fallbacks in the AUT and show up as duplicated, never-completing requests in Test Replay. This is a known upstream Chromium bug (crbug.com/1196004, access-restricted; public trail in puppeteer/puppeteer#7038). See #34361 for the full investigation, including a minimal reproduction against plain Chrome with no Cypress in the path.

The fix appends `WebFontsCacheAwareTimeoutAdaption` to the `--disable-features=` launch arg whenever the proxy is disabled — the workaround suggested by Chromium on the crbug. Cache-aware font loading is a disk-latency optimization only, and the flag is not added when the proxy is enabled, so current behavior is untouched. This only affects the in-development HTTP/2 / proxy-disabled pipeline, hence `chore` and no changelog entry.

### Steps to test

With this branch, run any spec that visits a page using web fonts with the proxy disabled, e.g. against https://example.cypress.io:

```
CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run --project <project> --browser chrome
```

- Without this change: the Fira Sans font faces end in `document.fonts` status `error`, and the CDP Fetch transport sees `responseErrorReason: 'Failed'` pauses for each font (woff, then the ttf fallback).
- With this change: all font faces report `loaded` and the transport fulfills them like any other resource. I verified both directions with a spec asserting `document.fonts` statuses (cold cache — a warm font cache masks the bug).


#### Before (fonts not seen in AUT in open mode or in TR)

<img width="1690" height="845" alt="Screenshot 2026-07-27 at 10 58 48 AM" src="https://github.com/user-attachments/assets/1a2fbb6b-4bcc-4b70-ac35-3da7acad29a5" />


#### After (fonts now being loaded correctly in TR and in AUT in open mode)

<img width="1690" height="845" alt="Screenshot 2026-07-27 at 10 55 53 AM" src="https://github.com/user-attachments/assets/e7583b3b-e02d-4019-a4d1-96e8537afe2b" />

### How has the user experience changed?

No change with the proxy enabled (the flag is only added when the proxy is disabled). Under the proxy-disabled pipeline, web fonts now load in the AUT and are captured by Test Replay.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? #34361
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to an internal env flag and Chrome launch args only; default proxy-enabled runs are unchanged.
> 
> **Overview**
> When **`CYPRESS_INTERNAL_DISABLE_PROXY=1`**, Chrome launch args now disable Blink’s **`WebFontsCacheAwareTimeoutAdaption`** feature so **`@font-face`** loads are not hard-failed under CDP Fetch response-stage pauses (workaround for crbug.com/1196004).
> 
> The flag is appended to an existing **`--disable-features=`** arg or added as its own switch; it is **not** applied when the MITM proxy is enabled. Unit tests cover proxy-disabled vs proxy-enabled **`_getArgs`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe6880da8a37e00c0fa57ea75aab69503bfc556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->