### PR TITLE
fix: continue unmodified CDP Fetch responses instead of fulfilling

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -35,7 +35,9 @@ npm_schematic_tests=false
 
 # Opt-in only — never enabled by path filtering or emit_all_true. Set via
 # Trigger Pipeline → run-proxy-disabled-tests=true (setup config forwards it).
-run_proxy_disabled_tests=false
+# Temporary for #34352: force on so the narrowed downloads *-cdp system-tests
+# jobs run on this branch without a manual Trigger Pipeline flag.
+run_proxy_disabled_tests=true
 if [[ "${RUN_PROXY_DISABLED_TESTS:-false}" == "true" || "${RUN_PROXY_DISABLED_TESTS:-}" == "1" ]]; then
   run_proxy_disabled_tests=true
 fi

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1079,19 +1079,26 @@ commands:
           command: |
             if << parameters.disable-proxy >> ; then
               export CYPRESS_INTERNAL_DISABLE_PROXY=1
-            fi
-
-            ALL_SPECS=`circleci tests glob "/root/cypress/system-tests/test/*spec*"`
-            SPECS=
-            for file in $ALL_SPECS; do
-              # filter out non_root tests, they have their own stage
-              if [[ "$file" == *"non_root"* ]]; then
-                echo "Skipping $file"
-                continue
+              # Temporary for #34352: only downloads until the full CDP
+              # system-tests matrix is green under proxy-disabled.
+              SPECS="/root/cypress/system-tests/test/downloads_spec.ts"
+              if [[ "${CIRCLE_NODE_INDEX:-0}" != "0" ]]; then
+                echo "Skipping — downloads_spec.ts runs on node 0 only under disable-proxy"
+                circleci-agent step halt
               fi
-              SPECS="$SPECS $file"
-            done
-            SPECS=`echo $SPECS | xargs -n 1 | circleci tests split --split-by=timings`
+            else
+              ALL_SPECS=`circleci tests glob "/root/cypress/system-tests/test/*spec*"`
+              SPECS=
+              for file in $ALL_SPECS; do
+                # filter out non_root tests, they have their own stage
+                if [[ "$file" == *"non_root"* ]]; then
+                  echo "Skipping $file"
+                  continue
+                fi
+                SPECS="$SPECS $file"
+              done
+              SPECS=`echo $SPECS | xargs -n 1 | circleci tests split --split-by=timings`
+            fi
             echo SPECS=$SPECS
             yarn workspace @tooling/system-tests test:ci $SPECS --browser <<parameters.browser>>
       - sanitize-verify-and-store-mocha-results

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -272,35 +272,37 @@ jobs:
       requires:
         - system-tests-node-modules-install
 
-  # Proxy-disabled (CDP Fetch) coverage — off by default.
-  # Enable with Trigger Pipeline → run-proxy-disabled-tests=true.
-  # Still omitted from all-jobs-passed so failures stay non-blocking when enabled.
-  - unit-tests-proxy-disabled:
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome:
-      name: driver-integration-tests-chrome-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome-inject-document-domain:
-      name: driver-integration-tests-chrome-inject-document-domain-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-tests-electron:
-      name: driver-integration-tests-electron-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-memory-tests:
-      name: driver-integration-memory-tests-cdp
-      disable-proxy: true
-      requires:
-        - ready-to-test
+  # Proxy-disabled (CDP Fetch) coverage for #34352 — temporarily forced on via
+  # generate-pipeline-parameters.sh (run-proxy-disabled-tests=true). Only the
+  # downloads system-tests jobs run; the rest of the *-cdp matrix stays commented
+  # until those suites are green under CYPRESS_INTERNAL_DISABLE_PROXY=1.
+  # Included in all-jobs-passed so downloads regressions block the PR.
+  # - unit-tests-proxy-disabled:
+  #     requires:
+  #       - ready-to-test
+  # - driver-integration-tests-chrome:
+  #     name: driver-integration-tests-chrome-cdp
+  #     context: test-runner:cypress-record-key
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
+  # - driver-integration-tests-chrome-inject-document-domain:
+  #     name: driver-integration-tests-chrome-inject-document-domain-cdp
+  #     context: test-runner:cypress-record-key
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
+  # - driver-integration-tests-electron:
+  #     name: driver-integration-tests-electron-cdp
+  #     context: test-runner:cypress-record-key
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
+  # - driver-integration-memory-tests:
+  #     name: driver-integration-memory-tests-cdp
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
   - system-tests-chrome:
       name: system-tests-chrome-cdp
       context: test-runner:performance-tracking
@@ -313,28 +315,28 @@ jobs:
       disable-proxy: true
       requires:
         - system-tests-node-modules-install
-  - run-app-integration-tests-chrome:
-      name: run-app-integration-tests-chrome-cdp
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - run-launchpad-integration-tests-chrome:
-      name: run-launchpad-integration-tests-chrome-cdp
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      disable-proxy: true
-      requires:
-        - ready-to-test
+  # - run-app-integration-tests-chrome:
+  #     name: run-app-integration-tests-chrome-cdp
+  #     context:
+  #       [
+  #         test-runner:cypress-record-key,
+  #         test-runner:launchpad-tests,
+  #         test-runner:percy
+  #       ]
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
+  # - run-launchpad-integration-tests-chrome:
+  #     name: run-launchpad-integration-tests-chrome-cdp
+  #     context:
+  #       [
+  #         test-runner:cypress-record-key,
+  #         test-runner:launchpad-tests,
+  #         test-runner:percy
+  #       ]
+  #     disable-proxy: true
+  #     requires:
+  #       - ready-to-test
 
   - create-and-trigger-packaging-artifacts:
       context:
@@ -441,8 +443,8 @@ jobs:
 
   # Fan-in aggregator — the only required GitHub status check for PRs.
   # Required jobs fan into this one. Jobs that halt early (pipeline parameter
-  # false) still complete successfully. Proxy-disabled *-cdp jobs above are
-  # opt-in (run-proxy-disabled-tests) and intentionally omitted from this gate.
+  # false) still complete successfully. Proxy-disabled downloads *-cdp jobs
+  # (#34352) are required; the rest of the *-cdp matrix stays commented out.
   - all-jobs-passed:
       requires:
         # Always-run jobs
@@ -462,6 +464,8 @@ jobs:
         - system-tests-firefox
         - system-tests-webkit
         - system-tests-non-root
+        - system-tests-chrome-cdp
+        - system-tests-electron-cdp
         - h2-dual-stack-tests
         - driver-integration-tests-chrome
         - driver-integration-tests-chrome-inject-document-domain

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where file downloads and other unmodified responses were always fulfilled through CDP Fetch when the MITM proxy was disabled (`CYPRESS_INTERNAL_DISABLE_PROXY=1`), which prevented Chromium's native download handling from running. Unmodified responses now continue natively; only rewritten bodies are fulfilled. Fixes [#34352](https://github.com/cypress-io/cypress/issues/34352).
 - Fixed an issue where, during a [`cy.origin()`](https://on.cypress.io/origin) block, session cookies set on the primary origin by the first page visited in a test were not included in the identity provider's callback request back to the primary origin (for example, `POST /auth/callback` in an OAuth Authorization Code flow). Fixes [#29719](https://github.com/cypress-io/cypress/issues/29719). Fixed in [#34287](https://github.com/cypress-io/cypress/pull/34287).
 - Fixed an issue where the configuration validation error shown when `passesRequired` is omitted from the experimental `detect-flake-and-pass-on-threshold` retry strategy reported the value of an unrelated option instead of the `passesRequired` value. Fixed in [#34202](https://github.com/cypress-io/cypress/pull/34202).
 - Fixed an issue where the configuration validation error for an absolute `ca` filepath in `clientCertificates` referenced the wrong certificate. Fixed in [#34201](https://github.com/cypress-io/cypress/pull/34201).

--- a/packages/net-stubbing/lib/server/handle-intercept-response.ts
+++ b/packages/net-stubbing/lib/server/handle-intercept-response.ts
@@ -78,6 +78,18 @@ export async function handleInterceptResponse (mw: InterceptResponseMiddleware):
 
   mergeChanges(request.res as any, modifiedRes)
 
+  // The CDP Fetch transport can only Fetch.continueResponse (native) when the
+  // body is byte-identical to what the origin sent — throttling/delay require
+  // rewriting the stream's timing, so those force a fulfill too. Only ever
+  // latch this on: an earlier stage may have replaced the body with one that
+  // happens to match the origin's bytes.
+  const originalBuffer = Buffer.isBuffer(res.body) ? res.body : Buffer.from(res.body)
+  const modifiedBuffer = Buffer.isBuffer(modifiedRes.body) ? modifiedRes.body : Buffer.from(modifiedRes.body ?? '')
+
+  if (!originalBuffer.equals(modifiedBuffer) || modifiedRes.throttleKbps || modifiedRes.delay) {
+    mw.res.bodyModified = true
+  }
+
   const bodyStream = await getBodyStream(modifiedRes.body, _.pick(modifiedRes, ['throttleKbps', 'delay']) as any)
 
   return request.continueResponse!(bodyStream)

--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -168,6 +168,10 @@ export async function sendStaticResponse (backendRequest: Pick<InterceptedReques
   const headers = staticResponse.headers || {}
   const body = backendRequest.res.body = _.isUndefined(staticResponse.body) ? '' : staticResponse.body
 
+  // A static response replaces the body outright, so there are never origin
+  // bytes for the CDP Fetch transport to continue — it must fulfill with these.
+  backendRequest.res.bodyModified = true
+
   const incomingRes = _getFakeClientResponse({
     statusCode,
     headers,

--- a/packages/net-stubbing/test/unit/util.spec.ts
+++ b/packages/net-stubbing/test/unit/util.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
-import { getBodyEncoding, getBodyStream, parseContentType } from '../../lib/server/util'
+import { getBodyEncoding, getBodyStream, parseContentType, sendStaticResponse } from '../../lib/server/util'
 import { Readable } from 'stream'
 import { join } from 'path'
 import { readFileSync } from 'fs'
@@ -153,6 +153,48 @@ describe('net-stubbing util', () => {
 
       await vi.advanceTimersByTimeAsync(1)
       expect(await bodyPromise).toEqual(payload)
+    })
+  })
+
+  describe('sendStaticResponse', () => {
+    // A stub never reaches the origin, so the CDP Fetch transport has no wire
+    // bytes to continueResponse with — it must fulfill with the stubbed body.
+    it('marks the body as modified so the response is fulfilled, not continued', async () => {
+      const res: any = {}
+
+      await sendStaticResponse({
+        res,
+        onError: vi.fn(),
+        onResponse: vi.fn(),
+      } as any, { body: 'stubbed' })
+
+      expect(res.bodyModified).toBe(true)
+    })
+
+    it('marks an empty stubbed body as modified', async () => {
+      const res: any = {}
+
+      await sendStaticResponse({
+        res,
+        onError: vi.fn(),
+        onResponse: vi.fn(),
+      } as any, { statusCode: 204 })
+
+      expect(res.bodyModified).toBe(true)
+    })
+
+    it('does not mark the body when forcing a network error', async () => {
+      const res: any = {}
+      const onResponse = vi.fn()
+
+      await sendStaticResponse({
+        res,
+        onError: vi.fn(),
+        onResponse,
+      } as any, { forceNetworkError: true })
+
+      expect(res.bodyModified).toBeUndefined()
+      expect(onResponse).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/proxy/lib/adapters/inject-html.ts
+++ b/packages/proxy/lib/adapters/inject-html.ts
@@ -62,6 +62,7 @@ export async function injectHtml (mw: ResponseInterceptionMiddlewareCtx): Promis
     pt.end()
 
     mw.incomingResStream = pt
+    mw.res.bodyModified = true
 
     streamSpan?.end()
     mw.next()

--- a/packages/proxy/lib/adapters/remove-security.ts
+++ b/packages/proxy/lib/adapters/remove-security.ts
@@ -40,6 +40,8 @@ export async function removeSecurity (mw: ResponseInterceptionMiddlewareCtx): Pr
     streamSpan?.end()
   })
 
+  mw.res.bodyModified = true
+
   span?.end()
   mw.next()
 }

--- a/packages/proxy/lib/adapters/synthetic-express-context.ts
+++ b/packages/proxy/lib/adapters/synthetic-express-context.ts
@@ -123,6 +123,7 @@ class SyntheticResponse extends Writable {
   // every synthetic response.
   wantsInjection: CypressOutgoingResponseLike['wantsInjection'] = null
   wantsSecurityRemoved: null | boolean = null
+  bodyModified?: boolean
   body?: string | Readable
   statusCode = 200
   statusMessage = ''

--- a/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
@@ -56,7 +56,10 @@ export function createSyntheticProxyCodec (
 
       return {
         ...response,
-        body: res.getCapturedBody(),
+        // Only attach a body when middleware actually rewrote it — an
+        // unmodified body lets the CDP Fetch transport continueResponse
+        // natively (downloads, native decoders) instead of fulfilling.
+        ...(res.bodyModified ? { body: res.getCapturedBody() } : {}),
         headers: res.getCapturedHeaders(),
         statusCode: res.getCapturedStatusCode(),
       }

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -612,6 +612,7 @@ const MaybeInjectServiceWorker: ResponseMiddleware = function () {
     pt.end()
 
     this.incomingResStream = pt
+    this.res.bodyModified = true
 
     this.next()
   })).on('error', this.onError).once('close', () => {

--- a/packages/proxy/lib/types.ts
+++ b/packages/proxy/lib/types.ts
@@ -43,6 +43,10 @@ export interface CypressOutgoingResponseLike extends Writable {
   // null = undecided; SetInjectionLevel only determines a level when unset
   wantsInjection: CypressWantsInjection | null
   wantsSecurityRemoved: null | boolean
+  // Set by middleware that rewrites the response body. The CDP Fetch transport
+  // can only Fetch.continueResponse (native, browser-decoded) when unset —
+  // otherwise it must Fetch.fulfillRequest with the rewritten bytes.
+  bodyModified?: boolean
   body?: string | Readable
   destroyed: boolean
   writableFinished: boolean

--- a/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
@@ -235,6 +235,7 @@ describe('createSyntheticProxyCodec', () => {
 
     ctx.res.status(203)
     ctx.res.set('x-result', 'synthetic')
+    ctx.res.bodyModified = true
     ctx.res.end('final')
 
     await finished
@@ -244,5 +245,50 @@ describe('createSyntheticProxyCodec', () => {
     expect(response.statusCode).to.equal(203)
     expect(response.headers).to.deep.equal({ 'x-result': 'synthetic' })
     expect(response.body?.toString()).to.equal('final')
+  })
+
+  it('omits the response body when nothing marked it modified', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => ({ req, res } as any),
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-1',
+      url: 'https://example.test/',
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    // Real requests always reach here via SendResponseBodyToClient piping
+    // incomingResStream into res, whether or not any middleware rewrote it.
+    ctx.res.end('untouched')
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body).to.be.undefined
+  })
+
+  it('includes the response body when middleware marked it modified', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => ({ req, res } as any),
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-1',
+      url: 'https://example.test/',
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.bodyModified = true
+    ctx.res.end('rewritten')
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('rewritten')
   })
 })

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -188,16 +188,6 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
     return request as CdpFetchTransportRequest & { requestId: string }
   }
 
-  const requireResponse = (id: string): CdpFetchTransportResponse => {
-    const response = inFlightResponses.get(id)
-
-    if (!response) {
-      throw new Error(`No CDP Fetch response pause found for ${id}. HttpIntercept middleware must call next() before returning a response.`)
-    }
-
-    return response
-  }
-
   return {
     decodeRequest (transportRequest: CdpFetchTransportRequest): HttpRequest {
       inFlightRequests.set(transportRequest.id, transportRequest)
@@ -259,13 +249,28 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
           ? stripHeaderEntries(middlewareHeaders, WIRE_LENGTH_HEADERS)
           : stripHeaderEntries(pauseHeaders, WIRE_ENCODING_HEADERS)
       }
+      // continueResponse delivers the origin's untouched wire bytes, so any
+      // header edits the middleware made (CSP/cookie/cache-control, etc.) must
+      // ride alongside the original wire framing headers — middleware never
+      // sees those, since they're stripped when the pause is decoded.
+      const continueHeaders = (headers?: HttpHeaders, pauseHeaders?: CdpFetchTransportResponse['responseHeaders']) => {
+        const middlewareHeaders = toResponseHeaders(headers)
+
+        if (!middlewareHeaders) {
+          return pauseHeaders
+        }
+
+        const wireHeaders = pauseHeaders?.filter(({ name }) => WIRE_ENCODING_HEADERS.has(name.toLowerCase()))
+
+        return [...middlewareHeaders, ...(wireHeaders ?? [])]
+      }
       const transportResponse = pausedResponse ? {
         ...pausedResponse,
         fulfilled,
         responseCode: response.statusCode ?? pausedResponse.responseCode,
         responseHeaders: fulfilled
           ? fulfilledHeaders(response.headers, pausedResponse.responseHeaders)
-          : pausedResponse.responseHeaders,
+          : continueHeaders(response.headers, pausedResponse.responseHeaders),
         ...(fulfilled ? { body: toResponseBody(response.body) } : {}),
       } : {
         ...requireRequestPause(httpResponse.id),

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -573,11 +573,11 @@ describe('CdpFetchTransport', () => {
         requestId: 'fetch-response',
         responseCode: 200,
         responseHeaders: [{
+          name: 'content-type',
+          value: 'text/html',
+        }, {
           name: 'Content-Encoding',
           value: 'gzip',
-        }, {
-          name: 'Content-Type',
-          value: 'text/html',
         }],
       })
     })
@@ -781,7 +781,7 @@ describe('CdpFetchTransport', () => {
         requestId: 'fetch-response',
         responseCode: 200,
         responseHeaders: [{
-          name: 'Content-Type',
+          name: 'content-type',
           value: 'text/plain',
         }, {
           name: 'set-cookie',
@@ -874,7 +874,7 @@ describe('CdpFetchTransport', () => {
         requestId: 'fetch-response',
         responseCode: 200,
         responseHeaders: [{
-          name: 'Content-Type',
+          name: 'content-type',
           value: 'text/plain',
         }],
       })

--- a/scripts/validate-proxy-middleware-transport.sh
+++ b/scripts/validate-proxy-middleware-transport.sh
@@ -46,7 +46,7 @@ run_unit_suite() {
 }
 
 run_driver_suite() {
-  local specs="cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.js"
+  local specs="cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.js"
 
   yarn workspace @packages/driver cypress:run -- \
     --browser "$BROWSER" --headless --spec "$specs"


### PR DESCRIPTION
- Closes #34352

### Additional details

Under `CYPRESS_INTERNAL_DISABLE_PROXY=1`, the CDP Fetch transport was `Fetch.fulfillRequest`ing every response because the synthetic codec always attached a body. That replaced Chromium's native response handling and broke native downloads (`Page.downloadWillBegin` / Electron `will-download` never fire).

This change:

- Tracks `bodyModified` at body-rewrite sites (HTML injection, security rewrite, service-worker injection, `cy.intercept` response mutation, static stubs)
- Omits `body` from the synthetic codec decode when unmodified, so the existing `fulfilled: body !== undefined` branch takes `Fetch.continueResponse`
- Carries middleware header/status edits on the continue path while preserving origin wire encoding headers
- Latches `bodyModified` (never clears it) so a later intercept stage cannot undo a static stub
- Enables narrowed bugbash coverage: `system-tests-{chrome,electron}-cdp` run only `downloads_spec.ts`, forced on for this branch, and required via `all-jobs-passed`

<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. With `CYPRESS_INTERNAL_DISABLE_PROXY=1`, run:
   ```bash
   yarn workspace @tooling/system-tests test test/downloads_spec.ts --browser chrome
   yarn workspace @tooling/system-tests test test/downloads_spec.ts --browser electron
   ```
2. Confirm downloads land and `Page.downloadWillBegin` / Electron `will-download` fire.
3. Confirm static `cy.intercept` stubs and response-body mutations still fulfill correctly.
4. Confirm CI jobs `system-tests-chrome-cdp` and `system-tests-electron-cdp` run downloads only and gate `all-jobs-passed`.

### How has the user experience changed?

No public API change. On the proxy-disabled CDP Fetch path, unmodified responses (including file downloads) are handled natively by the browser again.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


Made with [Cursor](https://cursor.com)