### PR TITLE
dependency: stop shipping tslib to cypress consumers

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-06-11-2026
+07-30-2026

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 **Dependency Updates:**
 
 - Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).
-- Removed `tslib` (previously `1.14.1`) from the `cypress` package's runtime dependencies. It was installed into every project's `node_modules` but was never required at runtime, so installing `cypress` no longer pulls it in. Addressed in [#34372](https://github.com/cypress-io/cypress/pull/34372).
+- Removed `tslib` (previously `1.14.1`) from the `cypress` package's runtime dependencies. Addressed in [#34372](https://github.com/cypress-io/cypress/pull/34372).
 
 ## 15.19.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 **Dependency Updates:**
 
 - Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).
+- Removed `tslib` (previously `1.14.1`) from the `cypress` package's runtime dependencies. It was installed into every project's `node_modules` but was never required at runtime, so installing `cypress` no longer pulls it in. Addressed in [#34372](https://github.com/cypress-io/cypress/pull/34372).
 
 ## 15.19.0
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -59,7 +59,6 @@
     "supports-color": "^8.1.1",
     "systeminformation": "^5.31.1",
     "tmp": "~0.2.4",
-    "tslib": "1.14.1",
     "tree-kill": "1.2.2",
     "untildify": "^4.0.0",
     "yauzl": "^3.3.1"
@@ -101,6 +100,7 @@
     "semver": "^7.7.3",
     "shelljs": "0.8.5",
     "strip-ansi": "6.0.1",
+    "tslib": "^2.8.1",
     "tsx": "4.22.4",
     "typescript": "~5.9.2",
     "vitest": "^3.2.4"

--- a/cli/rollup.config.mjs
+++ b/cli/rollup.config.mjs
@@ -9,11 +9,14 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf8').toString())
 
 function external (id, parent, resolved) {
   // tslib is only a devDependency: @rollup/plugin-typescript force-enables importHelpers, so we
-  // must bundle the helpers here or the published package would require tslib at runtime
-  // (Windows resolves tslib to an absolute path with backslashes)
+  // must bundle the helpers here or the published package would require tslib at runtime.
+  // rollup calls external() again with the resolved absolute path, so match the tslib package
+  // dir rather than a specific entry file — the resolved entry varies by tslib version and
+  // resolver (tslib.es6.js, tslib.es6.mjs, tslib.js), and missing it would silently externalize
+  // tslib. (Windows resolves tslib to an absolute path with backslashes.)
   const idNorm = id.replace(/\\/g, '/')
 
-  if (id === 'tslib' || idNorm.startsWith('tslib') || idNorm.includes('tslib/tslib.es6.js')) {
+  if (id === 'tslib' || idNorm.startsWith('tslib') || idNorm.includes('/tslib/')) {
     return false
   }
 

--- a/cli/rollup.config.mjs
+++ b/cli/rollup.config.mjs
@@ -8,7 +8,9 @@ import path from 'path'
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8').toString())
 
 function external (id, parent, resolved) {
-  // Bundle tslib so that we include ts helpers (Windows resolves to absolute path with backslashes)
+  // tslib is only a devDependency: @rollup/plugin-typescript force-enables importHelpers, so we
+  // must bundle the helpers here or the published package would require tslib at runtime
+  // (Windows resolves tslib to an absolute path with backslashes)
   const idNorm = id.replace(/\\/g, '/')
 
   if (id === 'tslib' || idNorm.startsWith('tslib') || idNorm.includes('tslib/tslib.es6.js')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30952,11 +30952,6 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@1.14.1, tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
@@ -30967,10 +30962,20 @@ tslib@2.3.1, tslib@~2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.0.1:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6560,7 +6560,7 @@
     cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.31.14":
+"@percy/core@1.31.14", "@percy/core@^1.0.0-beta.48":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.31.14.tgz#76eb027e6a6df2cb5990196e899d357d5612ae9b"
   integrity sha512-c6QTjqaKs7UxL9HK6VJJl5B57hywFNn+l22vES4dFkegrkdE0maAz7rG88X2Xp2sYrsR3qf9n9CKCDy511/KYw==
@@ -6584,26 +6584,6 @@
     yaml "^2.4.1"
   optionalDependencies:
     "@percy/cli-doctor" "1.31.14"
-
-"@percy/core@^1.0.0-beta.48":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.27.6.tgz#20a29d11619e6aac5f5fdb1d1451303ec474e1c3"
-  integrity sha512-Gp6cqpu7vSDzeG40SPXGeqJoHlF8dVzspgRTiUNQLhY0OEo71VMu1r0kZ/O3gQJQvgZwepi0FdbW9h7sts8RZw==
-  dependencies:
-    "@percy/client" "1.27.6"
-    "@percy/config" "1.27.6"
-    "@percy/dom" "1.27.6"
-    "@percy/logger" "1.27.6"
-    "@percy/webdriver-utils" "1.27.6"
-    content-disposition "^0.5.4"
-    cross-spawn "^7.0.3"
-    extract-zip "^2.0.1"
-    fast-glob "^3.2.11"
-    micromatch "^4.0.4"
-    mime-types "^2.1.34"
-    path-to-regexp "^6.2.0"
-    rimraf "^3.0.2"
-    ws "^8.0.0"
 
 "@percy/cypress@^3.1.7":
   version "3.1.7"
@@ -25841,12 +25821,7 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^6.2.0, path-to-regexp@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
-  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
-
-path-to-regexp@^6.3.0:
+path-to-regexp@^6.2.0, path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
@@ -30137,15 +30112,10 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@^5.25.11:
+systeminformation@^5.25.11, systeminformation@^5.27.7, systeminformation@^5.31.1:
   version "5.33.1"
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.33.1.tgz#499f06a859d2abeafaae6d69f71dd3516919f0f4"
   integrity sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==
-
-systeminformation@^5.27.7, systeminformation@^5.31.1:
-  version "5.31.1"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.31.1.tgz#5f88aa1db7470af87b6288baf1738603cafd1c4a"
-  integrity sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==
 
 systemjs@^6.15.1:
   version "6.15.1"
@@ -30967,12 +30937,7 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@^2.8.1:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -32974,15 +32939,15 @@ ws@8.2.2:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.0.0, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0, ws@~8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
-
-ws@^8.17.1:
+ws@^8.0.0, ws@^8.17.1, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0:
   version "8.21.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
   integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
+
+ws@~8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Closes N/A — mechanical build-tooling / dependency cleanup (no behavioral change).

### Additional details

The `cypress` package declared `tslib` in its runtime `dependencies` (pinned at `1.14.1`, the lone 1.x holdout in the monorepo), so every `npm install cypress` installed `tslib` into the consumer's `node_modules`. Nothing in the published package requires it at runtime:

- The main CLI bundle is built with `@rollup/plugin-typescript`, which force-enables `importHelpers`. The rollup config inlines `tslib`'s helper source into the bundle, so the emitted `dist` contains the helpers directly and never calls `require('tslib')`.
- The bundled component-testing adapters (`react`, `vue`, `svelte`, `angular`, `angular-zoneless`, `mount-utils`) do not reference `tslib` in their built output, do not declare it, and are built with `rollup-plugin-typescript2` / `tsc` without `importHelpers`.

`tslib` is therefore only needed at build time (so rollup can resolve and inline the helpers). This PR moves it to `devDependencies` as `^2.8.1`. The publish step (`cli/scripts/prepare-package-json.ts`) strips `devDependencies`, so consumers no longer install `tslib`, while the build still inlines identical helper output.

### Steps to test

- `yarn workspace cypress build` succeeds.
- The emitted `cli/dist` contains zero `tslib` references (helpers remain inlined — e.g. `__awaiter` is defined locally).
- `yarn install --frozen-lockfile` stays consistent.

### How has the user experience changed?

No behavioral change. Users no longer receive the unused `tslib` package in their `node_modules` when installing `cypress`.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — mechanical dependency cleanup; rationale explained above.
- [na] Have tests been added/updated? — dependency-manifest-only change, verified via build output.
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015c2cmzjaUtoovY8xMhFtAo

---
_Generated by [Claude Code](https://claude.ai/code/session_015c2cmzjaUtoovY8xMhFtAo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no intended runtime behavior change; the main residual risk is a misconfigured Rollup external check leaving a runtime `tslib` require in published `dist`, which the broadened path matching is meant to prevent.
> 
> **Overview**
> **Stops installing `tslib` for `npm install cypress` consumers** by moving it from `dependencies` to `devDependencies` (`^2.8.1`, up from pinned `1.14.1`). The published CLI still inlines TypeScript helpers at build time via Rollup, so runtime behavior is unchanged.
> 
> **Rollup `external()`** now treats any resolved path under `/tslib/` as non-external so helpers stay bundled even when the resolved entry file differs by version or platform (including Windows backslash paths).
> 
> **Changelog** documents the dependency removal for 15.19.1; **yarn.lock** reflects the tslib resolution change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a4b34e2c56a178c20144869bd4d3df39521117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->