### PR TITLE
refactor(driver): register jQuery selectors via $.expr.pseudos

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/focused.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/focused.cy.ts
@@ -31,6 +31,22 @@ describe('src/cy/commands/querying', () => {
       })
     })
 
+    // cy.focused() resolves via document.activeElement, but the `:focus` and
+    // `:focused` pseudo-selectors are Cypress overrides delegating to our own
+    // isFocused logic. Exercise them directly as literal selectors so a broken
+    // pseudo registration is caught independently of the activeElement path.
+    it('matches the focused element via the :focus / :focused pseudo-selectors', () => {
+      const $button = cy.$$('#button')
+      const $input = cy.$$(':text:first')
+
+      $button.get(0).focus()
+
+      expect($button.is(':focus')).to.be.true
+      expect($button.is(':focused')).to.be.true
+      expect($input.is(':focus')).to.be.false
+      expect($input.is(':focused')).to.be.false
+    })
+
     describe('assertion verification', () => {
       beforeEach(function () {
         cy.on('log:added', (attrs, log) => {

--- a/packages/driver/cypress/e2e/cypress/cypress.cy.js
+++ b/packages/driver/cypress/e2e/cypress/cypress.cy.js
@@ -36,6 +36,22 @@ describe('driver/src/cypress/index', () => {
         expect($el.get(0)).to.eq($foo.get(0))
       })
     })
+
+    // `$.expr[':']` is an alias for `$.expr.pseudos`; both reference the same
+    // table, so a custom selector registered through either one resolves.
+    it('aliases expr[\':\'] to expr.pseudos', () => {
+      expect(Cypress.$.expr[':']).to.equal(Cypress.$.expr.pseudos)
+
+      Cypress.$.expr.pseudos.foo = (elem) => {
+        return Boolean(elem.getAttribute('foo'))
+      }
+
+      const $foo = $('<div foo=\'bar\'>foo element</div>').appendTo(cy.$$('body'))
+
+      cy.get(':foo').then(($el) => {
+        expect($el.get(0)).to.eq($foo.get(0))
+      })
+    })
   })
 
   context('_', () => {

--- a/packages/driver/cypress/e2e/dom/jquery.cy.ts
+++ b/packages/driver/cypress/e2e/dom/jquery.cy.ts
@@ -113,3 +113,103 @@ describe('src/dom/jquery', () => {
     })
   })
 })
+
+describe('jQuery API behavior', () => {
+  beforeEach(() => {
+    cy.visit('fixtures/dom.html')
+  })
+
+  // `Cypress.$(el)` dimension methods report the CSS box model: `.width()` is
+  // the content box, `.inner*` adds padding, `.outer*` adds border, and
+  // `.outer*(true)` adds margin.
+  context('box-model dimensions', () => {
+    const appendBox = (doc: Document, boxSizing: string) => {
+      return Cypress.$('<div></div>')
+      .css({
+        position: 'absolute',
+        display: 'block',
+        boxSizing,
+        width: '100px',
+        height: '50px',
+        padding: '10px',
+        borderWidth: '2px',
+        borderStyle: 'solid',
+        margin: '5px',
+      })
+      .appendTo(doc.body)
+    }
+
+    it('reports content-box width/height across the box model', () => {
+      cy.document().then((doc) => {
+        const $el = appendBox(doc, 'content-box')
+
+        expect($el.width(), 'width').to.eq(100)
+        expect($el.height(), 'height').to.eq(50)
+        expect($el.innerWidth(), 'innerWidth').to.eq(120)
+        expect($el.innerHeight(), 'innerHeight').to.eq(70)
+        expect($el.outerWidth(), 'outerWidth').to.eq(124)
+        expect($el.outerHeight(), 'outerHeight').to.eq(74)
+        expect($el.outerWidth(true), 'outerWidth(true)').to.eq(134)
+        expect($el.outerHeight(true), 'outerHeight(true)').to.eq(84)
+
+        $el.remove()
+      })
+    })
+
+    it('reports border-box width/height across the box model', () => {
+      cy.document().then((doc) => {
+        const $el = appendBox(doc, 'border-box')
+
+        expect($el.width(), 'width').to.eq(76)
+        expect($el.height(), 'height').to.eq(26)
+        expect($el.innerWidth(), 'innerWidth').to.eq(96)
+        expect($el.innerHeight(), 'innerHeight').to.eq(46)
+        expect($el.outerWidth(), 'outerWidth').to.eq(100)
+        expect($el.outerHeight(), 'outerHeight').to.eq(50)
+        expect($el.outerWidth(true), 'outerWidth(true)').to.eq(110)
+        expect($el.outerHeight(true), 'outerHeight(true)').to.eq(60)
+
+        $el.remove()
+      })
+    })
+  })
+
+  // `.attr()` returns the attribute-name string for a present boolean
+  // attribute and `undefined` when absent, while `.prop()` returns a boolean.
+  // The chai-jquery `have.attr` layer depends on these `.attr()` return values.
+  context('.attr() / .prop() boolean attributes', () => {
+    it('returns the attribute name from .attr() and a boolean from .prop()', () => {
+      expect(Cypress.$('<input disabled>').attr('disabled'), 'disabled present .attr').to.eq('disabled')
+      expect(Cypress.$('<input>').attr('disabled'), 'disabled absent .attr').to.be.undefined
+      expect(Cypress.$('<input disabled>').prop('disabled'), 'disabled present .prop').to.be.true
+      expect(Cypress.$('<input>').prop('disabled'), 'disabled absent .prop').to.be.false
+
+      expect(Cypress.$('<input type="checkbox" checked>').attr('checked'), 'checked present .attr').to.eq('checked')
+      expect(Cypress.$('<input type="checkbox">').attr('checked'), 'checked absent .attr').to.be.undefined
+      expect(Cypress.$('<input type="checkbox" checked>').prop('checked'), 'checked present .prop').to.be.true
+
+      expect(Cypress.$('<input readonly>').attr('readonly'), 'readonly present .attr').to.eq('readonly')
+    })
+  })
+
+  // Attribute selectors resolve with both quote styles and with values that
+  // contain special characters such as an apostrophe (issue #8626).
+  context('attribute selectors', () => {
+    it('resolves [attr~="value"] with double and single quotes', () => {
+      cy.document().then((doc) => {
+        Cypress.$('<div data-cy-attr="alpha beta" id="attr-target">x</div>').appendTo(doc.body)
+      })
+
+      cy.get('[data-cy-attr~="beta"]').should('have.attr', 'id', 'attr-target')
+      cy.get(`[data-cy-attr~='beta']`).should('have.attr', 'id', 'attr-target')
+    })
+
+    it('resolves attribute selectors whose value contains an apostrophe', () => {
+      cy.document().then((doc) => {
+        Cypress.$(`<div data-cy-attr="o'brien" id="apostrophe-target">y</div>`).appendTo(doc.body)
+      })
+
+      cy.get(`[data-cy-attr="o'brien"]`).should('have.attr', 'id', 'apostrophe-target')
+    })
+  })
+})

--- a/packages/driver/src/config/jquery.ts
+++ b/packages/driver/src/config/jquery.ts
@@ -6,18 +6,17 @@ import $dom from '../dom'
 // Add missing types.
 interface ExtendedJQueryStatic extends JQueryStatic {
   find: any
-  expr: JQuery.Selectors & { filters: any }
+  expr: JQuery.Selectors
 }
 
 const $: ExtendedJQueryStatic = JQuery as any
 
 $.fn.scrollTo = scrollTo
 
-// see difference between 'filters' and 'pseudos'
-// https://api.jquery.com/filter/ and https://api.jquery.com/category/selectors/
-
+// Register custom pseudo-selectors on `$.expr.pseudos`, the canonical
+// extension point. jQuery 4 removed the `$.expr.filters` and `$.expr[':']`
+// aliases that older code wrote through, so we target `$.expr.pseudos` directly.
 $.expr.pseudos.focus = $dom.isFocused
-$.expr.filters.focus = $dom.isFocused
 $.expr.pseudos.focused = $dom.isFocused
 
 // force jquery to have the same visible
@@ -25,8 +24,14 @@ $.expr.pseudos.focused = $dom.isFocused
 // we have to add the arrow function here since
 // jquery calls this function with additional parameters
 // https://github.com/jquery/jquery/blob/master/src/selector.js#L1196
-$.expr.filters.visible = (el) => $dom.isVisible(el)
-$.expr.filters.hidden = (el) => $dom.isHidden(el)
+$.expr.pseudos.visible = (el) => $dom.isVisible(el)
+$.expr.pseudos.hidden = (el) => $dom.isHidden(el)
+
+// Back-compat shim: jQuery 4 removed the `$.expr[':']` alias for
+// `$.expr.pseudos`. Restore it by reference so custom selectors registered
+// through `Cypress.$.expr[':']` keep working. On jQuery 3 this reassigns the
+// alias to the same object it already points at, so it is a no-op there.
+$.expr[':'] = $.expr.pseudos
 
 $.expr.cacheLength = 1
 

--- a/packages/driver/src/dom/elements/find.ts
+++ b/packages/driver/src/dom/elements/find.ts
@@ -230,21 +230,12 @@ export const getElements = ($el) => {
 }
 
 /*
- * We add three custom expressions to jquery. These let us use custom
+ * We add three custom pseudo-selectors to jquery via `$.expr.pseudos`, the
+ * canonical extension point for the selector engine. These let us use custom
  * logic around case sensitivity, and match strings or regular expressions.
- * See https://github.com/jquery/sizzle/wiki/#-pseudo-selectors for
- * documentation on adding Sizzle selectors.
  *
- * Our use of
- *
- *   $.expr[':']['cy-contains'] = $.expr.createPseudo()
- *
- * is equivalent to
- *
- *   Sizzle.selectors.pseudos['cy-contains'] = Sizzle.selectors.createPseudo()
- *
- * in the documentation linked above. $.expr[':'] is jquery's alias for
- * Sizzle.selectors.pseudos.
+ * `$.expr.createPseudo` builds a pseudo-selector that captures its argument
+ * (the text inside the parentheses) when the selector is compiled.
  *
  * These custom expressions are used exclusively by cy.contains; see
  * `getContainsSelector` below.
@@ -252,7 +243,7 @@ export const getElements = ($el) => {
 
 // Example:
 // button:cy-contains("Login")
-$.expr[':']['cy-contains'] = $.expr.createPseudo((text) => {
+$.expr.pseudos['cy-contains'] = $.expr.createPseudo((text) => {
   text = JSON.parse(`"${ text }"`)
 
   return function (elem) {
@@ -264,7 +255,7 @@ $.expr[':']['cy-contains'] = $.expr.createPseudo((text) => {
 
 // Example:
 // .login-button:cy-contains-insensitive("login")
-$.expr[':']['cy-contains-insensitive'] = $.expr.createPseudo((text) => {
+$.expr.pseudos['cy-contains-insensitive'] = $.expr.createPseudo((text) => {
   text = JSON.parse(`"${ text }"`)
 
   return function (elem) {
@@ -283,7 +274,7 @@ function isSubmit (elem: Element): elem is HTMLInputElement {
 
 // Example:
 // #login>li:first:cy-contains-regex('/asdf 1/i')
-$.expr[':']['cy-contains-regex'] = $.expr.createPseudo((text) => {
+$.expr.pseudos['cy-contains-regex'] = $.expr.createPseudo((text) => {
   const lastSlash = text.lastIndexOf('/')
   const regex = new RegExp(text.slice(1, lastSlash), text.slice(lastSlash + 1))
 


### PR DESCRIPTION
- Closes N/A — internal refactor and test hardening; no associated issue.

### Additional details

Cypress registers its custom jQuery selector extensions — the `:focus` / `:focused` / `:visible` / `:hidden` overrides and the `cy-contains*` pseudos behind `cy.contains` — through the jQuery selector engine. This moves those registrations off the `$.expr.filters` and `$.expr[':']` aliases and onto `$.expr.pseudos`, the canonical extension point, and aliases `$.expr[':']` back to `$.expr.pseudos` so user selectors registered through `Cypress.$.expr[':']` continue to resolve.

The change is **behavior-preserving**: on the jQuery version Cypress currently ships, `$.expr.filters`, `$.expr[':']`, and `$.expr.pseudos` all reference the same table, so this is a no-op refactor today. It removes reliance on the two deprecated aliases and keeps the public `Cypress.$.expr[':']` extension point intact.

It also adds tests that pin the jQuery behavior Cypress depends on, using absolute expected values (which were measured against the patched jQuery the driver ships):

- custom selector resolution via `Cypress.$.expr.pseudos` / `Cypress.$.expr[':']`
- the `:focus` / `:focused` pseudo-selectors, independent of the `document.activeElement` path
- `Cypress.$(el)` box-model dimensions for content-box and border-box elements
- boolean-attribute `.attr()` / `.prop()` return values
- attribute-selector parsing with both quote styles and apostrophe-containing values (issue #8626)

What's affected:
- `packages/driver/src/config/jquery.ts`
- `packages/driver/src/dom/elements/find.ts`
- Driver E2E specs (new/updated tests only)

### Steps to test

Run the affected driver E2E specs:

```
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/dom/jquery.cy.ts
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/cypress/cypress.cy.js
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/querying/focused.cy.ts
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/querying/querying.cy.ts
```

### How has the user experience changed?

No change. This is an internal refactor with behavior-identical selector registration.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- internal, behavior-preserving refactor + test hardening -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- no user-facing change -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- no public API change -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2KBPhNVYDcYErGVEtfRE1

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2KBPhNVYDcYErGVEtfRE1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor on current jQuery; changes are limited to selector registration paths and new tests, with no user-facing API changes.
> 
> **Overview**
> **Internal jQuery selector registration** moves Cypress custom pseudos (`:focus`, `:focused`, `:visible`, `:hidden`, and the `cy-contains*` selectors used by `cy.contains`) from deprecated `$.expr.filters` / `$.expr[':']` onto **`$.expr.pseudos`**, with **`$.expr[':']` reassigned to the same table** so `Cypress.$.expr[':']` extensions keep working (relevant for jQuery 4).
> 
> **Test coverage** adds driver E2E specs that lock in behavior: `:focus` / `:focused` via `.is()`, the `expr[':']` ↔ `expr.pseudos` alias, box-model dimension helpers, boolean `.attr()` / `.prop()` semantics, and attribute selectors (quotes and apostrophe values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44182fef8bcdca73fddcb7a9cfc1eef93881c13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->