### PR TITLE
fix: prevent intermittent cy.origin crash during config synchronization

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where a [`cy.origin()`](https://on.cypress.io/origin) block could intermittently fail with `TypeError: Cannot read properties of undefined (reading 'applied')`, incorrectly reported as originating from your test code. Addressed in [#34376](https://github.com/cypress-io/cypress/pull/34376).
 - Fixed an issue where, during a [`cy.origin()`](https://on.cypress.io/origin) block, session cookies set on the primary origin by the first page visited in a test were not included in the identity provider's callback request back to the primary origin (for example, `POST /auth/callback` in an OAuth Authorization Code flow). Fixes [#29719](https://github.com/cypress-io/cypress/issues/29719). Fixed in [#34287](https://github.com/cypress-io/cypress/pull/34287).
 - Fixed an issue where the configuration validation error shown when `passesRequired` is omitted from the experimental `detect-flake-and-pass-on-threshold` retry strategy reported the value of an unrelated option instead of the `passesRequired` value. Fixed in [#34202](https://github.com/cypress-io/cypress/pull/34202).
 - Fixed an issue where the configuration validation error for an absolute `ca` filepath in `clientCertificates` referenced the wrong certificate. Fixed in [#34201](https://github.com/cypress-io/cypress/pull/34201).

--- a/packages/driver/src/util/config.ts
+++ b/packages/driver/src/util/config.ts
@@ -87,9 +87,11 @@ export const getMochaOverrideLevel = (state): MochaOverrideLevel | undefined => 
   const test = state('test')
 
   if (!state('duringUserTestExecution') && test && !Object.keys(test?._fired || {}).length) {
-    // In a cy.origin spec bridge the `test` in state is a placeholder object
-    // that never has `_testConfig` assigned, so guard against dereferencing it
-    // when config is synced to the secondary origin outside of test execution.
+    // A secondary-origin spec bridge sets `state('test')` to a bare placeholder
+    // object (via `cy.reset({})`) rather than a real Mocha test, so `_testConfig`
+    // is absent. That path only runs `Cypress.config()` to sync config from the
+    // primary origin — there is no Mocha override level to report — so optional
+    // chaining yields `undefined` instead of throwing on the missing `_testConfig`.
     return test._testConfig?.applied
   }
 

--- a/packages/driver/src/util/config.ts
+++ b/packages/driver/src/util/config.ts
@@ -87,7 +87,10 @@ export const getMochaOverrideLevel = (state): MochaOverrideLevel | undefined => 
   const test = state('test')
 
   if (!state('duringUserTestExecution') && test && !Object.keys(test?._fired || {}).length) {
-    return test._testConfig.applied
+    // In a cy.origin spec bridge the `test` in state is a placeholder object
+    // that never has `_testConfig` assigned, so guard against dereferencing it
+    // when config is synced to the secondary origin outside of test execution.
+    return test._testConfig?.applied
   }
 
   return undefined

--- a/packages/driver/test/unit/util/config.spec.ts
+++ b/packages/driver/test/unit/util/config.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { getMochaOverrideLevel } from '../../../src/util/config'
+
+const makeState = (values: Record<string, any>) => {
+  return (key: string) => values[key]
+}
+
+describe('src/util/config', () => {
+  describe('getMochaOverrideLevel', () => {
+    it('returns the applied override level when outside of user test execution', () => {
+      const state = makeState({
+        duringUserTestExecution: false,
+        test: { _testConfig: { applied: 'suite' } },
+      })
+
+      expect(getMochaOverrideLevel(state)).toEqual('suite')
+    })
+
+    it('returns undefined during user test execution', () => {
+      const state = makeState({
+        duringUserTestExecution: true,
+        test: { _testConfig: { applied: 'suite' } },
+      })
+
+      expect(getMochaOverrideLevel(state)).toBeUndefined()
+    })
+
+    it('returns undefined once the test has fired lifecycle events', () => {
+      const state = makeState({
+        duringUserTestExecution: false,
+        test: { _fired: { 'test:before:run': true }, _testConfig: { applied: 'suite' } },
+      })
+
+      expect(getMochaOverrideLevel(state)).toBeUndefined()
+    })
+
+    // Reproduces the cross-origin flake where config is synced to a secondary
+    // origin spec bridge whose `test` is a placeholder object without `_testConfig`.
+    // Previously this threw `Cannot read properties of undefined (reading 'applied')`.
+    it('does not throw when the test object has no _testConfig (secondary origin)', () => {
+      const state = makeState({
+        duringUserTestExecution: false,
+        test: {},
+      })
+
+      expect(() => getMochaOverrideLevel(state)).not.toThrow()
+      expect(getMochaOverrideLevel(state)).toBeUndefined()
+    })
+  })
+})

--- a/packages/driver/test/unit/util/config.spec.ts
+++ b/packages/driver/test/unit/util/config.spec.ts
@@ -39,9 +39,6 @@ describe('src/util/config', () => {
       expect(getMochaOverrideLevel(state)).toBeUndefined()
     })
 
-    // Reproduces the cross-origin flake where config is synced to a secondary
-    // origin spec bridge whose `test` is a placeholder object without `_testConfig`.
-    // Previously this threw `Cannot read properties of undefined (reading 'applied')`.
     it('does not throw when the test object has no _testConfig (secondary origin)', () => {
       const state = makeState({
         duringUserTestExecution: false,


### PR DESCRIPTION
- Closes <!-- No associated issue. Discovered while investigating a flaky `config_env_expose.cy.ts` failure in CI; see Additional details. Related failure shape (different root cause): #23937. -->

### Additional details

While synchronizing Cypress configuration into a `cy.origin()` secondary origin, a test could intermittently fail with:

```
TypeError: Cannot read properties of undefined (reading 'applied')
```

Cypress reports this as *"The following error originated from your test code"*, misattributing it to the user's spec.

**Root cause:** every `cy.origin()` call syncs config into the secondary origin's spec bridge via `Cypress.config(...)`, which runs config validation. Validation reads the current Mocha override level through `getMochaOverrideLevel(state)`. In a secondary-origin spec bridge, `state('test')` is a bare placeholder object (set via `cy.reset({})`), so it has no `_testConfig` property. When that sync happened outside of user test execution, the code dereferenced `test._testConfig.applied` and threw. Because it depends on the timing of an internal state sync between the primary and secondary origins, it surfaced as a flake.

**Fix:** guard the access with optional chaining (`test._testConfig?.applied`). The secondary-origin placeholder has no Mocha override level to report, so this yields `undefined` — the same result the non-racy path already produced. Primary-origin behavior is unchanged.

**Originating flaky test:** this was surfaced by a flaky CircleCI job (pipeline 84440 / job 3822616). The recurring flake was identified in this repo's own Cypress Cloud dogfood runs on `develop`:

- **Spec:** `packages/driver/cypress/e2e/e2e/origin/config_env_expose.cy.ts` (line 134)
- **Test:** `cy.origin- Cypress.config()` › serializable › *"overwrites different values in secondary, even if the Cypress.config() value does not exist in the primary"*
- **Failure:** `TypeError: Cannot read properties of undefined (reading 'applied')` at `config_env_expose.cy.ts:134:11` — always failed attempt 1, passed on retry.
- Recorded flake attempts (all in the `Cypress.config()` variant of the suite, consistent with the root cause — only the config sync runs validation, whereas the `env`/`expose` variants do not):
  - Run 72775 (2026-07-28, Chrome): [replay 1](https://cloud.cypress.io/projects/ypt4pf/runs/72775/overview/12ea5116-1263-4bfc-96fe-809063988348/replay), [replay 2](https://cloud.cypress.io/projects/ypt4pf/runs/72775/overview/32a7d717-9afd-4aeb-b331-6899093478fd/replay)
  - Run 72748 (2026-07-27, Chrome Beta / Chrome): [replay 3](https://cloud.cypress.io/projects/ypt4pf/runs/72748/overview/b7fafd89-1a59-4e62-8f00-f830c745c057/replay), [replay 4](https://cloud.cypress.io/projects/ypt4pf/runs/72748/overview/a1e573f5-29b5-4f23-91a8-82fa667f2b1e/replay)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive guard in config validation with unit tests; no change when a real Mocha test is present.
> 
> **Overview**
> Fixes intermittent **`cy.origin()`** failures during cross-origin **`Cypress.config()`** synchronization that surfaced as `TypeError: Cannot read properties of undefined (reading 'applied')` and was misreported as test code.
> 
> **`getMochaOverrideLevel`** in `packages/driver/src/util/config.ts` now reads **`test._testConfig?.applied`** instead of assuming a real Mocha test. On the secondary-origin spec bridge, `state('test')` is a placeholder without `_testConfig`, so validation during config sync returns **`undefined`** (no override level) instead of throwing. Primary-origin behavior is unchanged when `_testConfig` exists.
> 
> Adds **`packages/driver/test/unit/util/config.spec.ts`** for override-level cases including the secondary-origin placeholder, and documents the fix in **`cli/CHANGELOG.md`** (15.19.1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01397313c5de689c9c9f849f03124193a75e9ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

A unit test was added at `packages/driver/test/unit/util/config.spec.ts` covering `getMochaOverrideLevel`, including the secondary-origin case (a `test` object with no `_testConfig`). To verify it guards the regression:

1. Revert the fix (`test._testConfig?.applied` → `test._testConfig.applied`).
2. Run `yarn workspace @packages/driver test -- test/unit/util/config.spec.ts` — the "does not throw when the test object has no _testConfig (secondary origin)" case fails with the `reading 'applied'` TypeError.
3. Restore the fix — all 4 cases pass.

### How has the user experience changed?

No visible UI change. `cy.origin()` blocks will no longer intermittently fail with `TypeError: Cannot read properties of undefined (reading 'applied')` during configuration synchronization.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No filed issue; found via CI flake investigation. Small, targeted crash fix in cross-origin config sync. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)