### PR TITLE
feat: add the tap reporter command with human-readable CLI rendering

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-07-13-2026
+07-29-2026

--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-07-29-2026
+07-13-2026

--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -127,6 +127,7 @@ const descriptions: any = {
   inspect: 'enable the Node.js inspector to debug the Cypress development process. only available when used with --dev',
   inspectBrk: 'enable the Node.js inspector and break before the Cypress development process starts. only available when used with --dev',
   instance: 'target a specific running Cypress instance by its server process id (pid)',
+  json: 'print the raw JSON result instead of the human-readable rendering',
   key: 'your secret Record Key. you can omit this if you set a CYPRESS_RECORD_KEY environment variable.',
   parallel: 'enables concurrent runs and automatic load balancing of specs across multiple machines or processes',
   passWithNoTests: 'pass when no tests are found',
@@ -589,10 +590,11 @@ const cliModule = {
     .helpOption(false)
     .allowUnknownOption(true)
     .option('--instance <pid>', text('instance'), coerceAnyStringToInt)
+    .option('--json', text('json'))
     .action(async function (this: any, opts: any, args: string[]) {
       try {
         const { default: tapModule } = await import('./exec/tap')
-        const code = await tapModule.start(args || [], _.pick(opts, ['instance']))
+        const code = await tapModule.start(args || [], _.pick(opts, ['instance', 'json']))
 
         process.exit(code)
       } catch (e: any) {

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -5,7 +5,7 @@ import { CypressInstanceError, resolveInstance } from '../cypress-instances'
 import { withTapSession, throwTapError, validateExecResult } from '../tap/tap-session'
 import type { TapSession } from '../tap/tap-session'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
-import { renderFailure, renderKnownFailure, renderResult, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
+import { renderFailure, renderKnownFailure, renderOutcome, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
 import type { TapCliCommand, TapCliOptions } from '../tap/types'
 import { TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
@@ -74,7 +74,7 @@ const runNativeCommand = async (native: TapCliCommand, positionals: string[], op
   return dispatchCode ?? 1
 }
 
-const execCommand = async (session: TapSession, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>): Promise<number> => {
+const execCommand = async (session: TapSession, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>, json: boolean | undefined): Promise<number> => {
   const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, [command, commandArgs, commandOptions]))
 
   if ('error' in outcome) {
@@ -83,7 +83,7 @@ const execCommand = async (session: TapSession, command: string, commandArgs: Re
     return 1
   }
 
-  renderResult(outcome.result)
+  renderOutcome(command, outcome.result, json)
 
   return 0
 }
@@ -117,8 +117,8 @@ const tapModule = {
         const schema = validateSchema(await session.call(TAP_SCHEMA_METHOD))
 
         let dispatchCode = 0
-        const program = buildTapProgram(schema, async (name, args, options) => {
-          dispatchCode = await execCommand(session, name, args, options)
+        const program = buildTapProgram(schema, async (name, args, commandOptions) => {
+          dispatchCode = await execCommand(session, name, args, commandOptions, options.json)
         })
 
         if (wantsHelp || !command) {

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -36,10 +36,11 @@ const declareOptions = (command: commander.Command, options: readonly TapCommand
     }
   }
 
-  // Every tap command accepts `--instance`; it is consumed by the top-level
-  // `cypress tap` command before a subprogram parses, so declaring it here is
-  // purely so it renders in each command's generated help.
+  // Every tap command accepts `--instance` and `--json`; both are consumed by
+  // the top-level `cypress tap` command before a subprogram parses, so declaring
+  // them here is purely so they render in each command's generated help.
   command.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
+  command.option('--json', 'print the raw JSON result instead of the human-readable rendering')
 }
 
 const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly string[]): Record<string, string> => {
@@ -122,10 +123,12 @@ const newProgram = (): commander.Command => {
 export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): commander.Command => {
   const program = newProgram()
 
-  // The outer `tap` command owns --instance and parses it before this program
-  // runs, so it never reaches here — declared only so help lists it. The outer
-  // command disables its own help, making this the sole place it surfaces.
+  // The outer `tap` command owns --instance/--json and parses them before this
+  // program runs, so they never reach here — declared only so help lists them.
+  // The outer command disables its own help, making this the sole place they
+  // surface.
   program.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
+  program.option('--json', 'print the raw JSON result instead of the human-readable rendering')
 
   for (const native of tapCliCommands) {
     declareCommand(program, native)

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -1,6 +1,7 @@
 import commander from 'commander'
 
 import logger from '../logger'
+import { renderingFor } from './render'
 import type { InstanceSelection } from '../cypress-instances'
 import type { TapSchema } from '@packages/cypress-instances'
 
@@ -14,6 +15,23 @@ export const renderKnownFailure = (err: { details: { description: string, soluti
 
 export const renderResult = (result: unknown): void => {
   logger.always(typeof result === 'string' ? result : JSON.stringify(result, null, 2))
+}
+
+/**
+ * Print a command's result: its human-readable rendering when the command
+ * defines one (see `./render`), the raw JSON otherwise or when `--json` asks
+ * for it explicitly.
+ */
+export const renderOutcome = (command: string, result: unknown, json: boolean | undefined): void => {
+  const rendering = json ? undefined : renderingFor(command)
+
+  if (rendering) {
+    logger.always(rendering.renderHuman(result))
+
+    return
+  }
+
+  renderResult(result)
 }
 
 export const renderNativeHelp = (program: commander.Command, command: string): void => {

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,0 +1,21 @@
+import type { TapCommandName, TapReporterView } from '@packages/cypress-instances'
+import { renderReporterHuman } from './reporter'
+
+/**
+ * The CLI-side rendering half of a tap command's definition. A command that
+ * declares `renderHuman` prints that rendering by default; `--json` bypasses it
+ * for the raw result. Commands without one keep printing JSON. The result shape
+ * a renderer receives is the command's typed interface from the shared
+ * `@packages/cypress-instances` contract.
+ */
+export interface TapCommandRendering {
+  renderHuman: (result: unknown) => string
+}
+
+const renderings: Partial<Record<TapCommandName, TapCommandRendering>> = {
+  reporter: { renderHuman: (result) => renderReporterHuman(result as TapReporterView) },
+}
+
+export const renderingFor = (command: string): TapCommandRendering | undefined => {
+  return renderings[command as TapCommandName]
+}

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import type { TapNetworkInfo, TapReporterCommand, TapReporterError, TapReporterView } from '@packages/cypress-instances'
+import type { TapNetworkInfo, TapReporterAgent, TapReporterCommand, TapReporterError, TapReporterSession, TapReporterView } from '@packages/cypress-instances'
 
 // The reporter's own palette (packages/reporter/src/lib/variables.scss and
 // commands.scss), so the CLI rendering matches the app: $pass/$fail map to
@@ -19,7 +19,9 @@ const color = {
   bad: chalk.hex('#c62b49'), // $red-500
   pending: chalk.hex('#6470f3'), // $indigo-400
   alias: chalk.hex('#c8a7f5'), // $purple-300
+  aliasDom: chalk.hex('#9aa2fc'), // $indigo-300 — the reporter colors dom aliases indigo
   muted: chalk.hex('#9095ad'), // $gray-500
+  fadedId: chalk.hex('#5a5f7a'), // $gray-700 — event ids sit back from the command numbers
 }
 
 const TEST_STATE = {
@@ -37,7 +39,11 @@ const INDICATORS: Record<NonNullable<TapNetworkInfo['indicator']>, string> = {
   bad: color.bad('●'),
 }
 
-const aliasBadge = (alias: string): string => color.alias(`@${alias}`)
+// The reporter's tag palette: dom aliases indigo, everything else
+// (route/agent/primitive) purple.
+const aliasColor = (aliasType: string | undefined) => (aliasType === 'dom' ? color.aliasDom : color.alias)
+
+const aliasBadge = (alias: string, aliasType?: string): string => aliasColor(aliasType)(`@${alias}`)
 
 // Driver messages emphasize with markdown-style `**`; render the emphasis
 // instead of the markers, on one line.
@@ -46,6 +52,20 @@ const emphasize = (message: string, strong: (part: string) => string): string =>
   .replace(/\s+/g, ' ')
   .trim()
   .replace(/\*\*([^*]+)\*\*/g, (_, part) => strong(part))
+}
+
+// The `@name`s a row references (cy.get('@x') / cy.wait('@x')) appear verbatim
+// in its message — give them the alias badge color in place.
+const colorizeAliasReferences = (message: string, command: TapReporterCommand): string => {
+  const { referencedAliases, aliasType } = command
+
+  if (!referencedAliases?.length) {
+    return message
+  }
+
+  const names = new Set(referencedAliases)
+
+  return message.replace(/@([\w-]+)/g, (match, name) => (names.has(name) ? aliasColor(aliasType)(match) : match))
 }
 
 // Asserts take the reporter's state colors — passing green, failing red —
@@ -67,12 +87,67 @@ const formatMessage = (command: TapReporterCommand): string => {
     }
   }
 
-  return emphasize(message, (part) => chalk.bold(part))
+  return colorizeAliasReferences(emphasize(message, (part) => chalk.bold(part)), command)
+}
+
+// Pad before coloring: the escape codes chalk adds would otherwise count
+// toward the column width.
+const panelTable = (title: string, header: string[], rows: string[][], colorize: (cells: string[]) => string[]): string[] => {
+  const widths = header.map((cell, column) => Math.max(cell.length, ...rows.map((row) => row[column].length)))
+  const pad = (cells: string[]) => cells.map((cell, column) => cell.padEnd(widths[column]))
+
+  return [
+    chalk.dim(`${title} (${rows.length})`),
+    `  ${pad(header).map((cell) => chalk.dim(cell)).join('  ')}`,
+    ...rows.map((row) => `  ${colorize(pad(row)).join('  ')}`),
+  ]
+}
+
+// The panel's status badge colors: red for a failed session, orange while one
+// is being recreated, the reporter's jade otherwise.
+const sessionStatus = (status: string | undefined): string => {
+  if (status === undefined) {
+    return ''
+  }
+
+  if (status === 'failed') {
+    return color.fail(status)
+  }
+
+  if (status.startsWith('recreat')) {
+    return color.aborted(status)
+  }
+
+  return color.passMessage(status)
+}
+
+const sessionsPanel = (sessions: TapReporterSession[]): string[] => {
+  return [
+    chalk.dim(`SESSIONS (${sessions.length})`),
+    ...sessions.map((session) => {
+      const global = session.global ? `  ${chalk.dim('(global)')}` : ''
+
+      return `  ${session.name}${global}  ${sessionStatus(session.status)}`
+    }),
+  ]
+}
+
+const agentsTable = (agents: TapReporterAgent[]): string[] => {
+  const rows = agents.map((agent) => {
+    return [
+      agent.type ?? '',
+      agent.functionName ?? '',
+      (agent.aliases ?? []).join(', '),
+      agent.callCount ? String(agent.callCount) : '-',
+    ]
+  })
+
+  return panelTable('SPIES / STUBS', ['TYPE', 'FUNCTION', 'ALIAS(ES)', 'CALLS'], rows, (cells) => {
+    return [chalk.bold(cells[0]), cells[1], color.alias(cells[2]), cells[3]]
+  })
 }
 
 const routesTable = (routes: TapReporterView['routes']): string[] => {
-  const header = ['METHOD', 'MATCHER', 'STUBBED', 'ALIAS', '#']
-
   const rows = routes.map((route) => {
     return [
       route.method ?? '',
@@ -83,12 +158,7 @@ const routesTable = (routes: TapReporterView['routes']): string[] => {
     ]
   })
 
-  const widths = header.map((title, column) => Math.max(title.length, ...rows.map((row) => row[column].length)))
-  const pad = (cells: string[]) => cells.map((cell, column) => cell.padEnd(widths[column]))
-
-  // Pad before coloring: the escape codes chalk adds would otherwise count
-  // toward the column width.
-  const colorize = (cells: string[]) => {
+  return panelTable('ROUTES', ['METHOD', 'MATCHER', 'STUBBED', 'ALIAS', '#'], rows, (cells) => {
     return [
       chalk.bold(cells[0]),
       cells[1],
@@ -96,13 +166,7 @@ const routesTable = (routes: TapReporterView['routes']): string[] => {
       color.alias(cells[3]),
       cells[4],
     ]
-  }
-
-  return [
-    chalk.dim('ROUTES') + chalk.dim(` (${routes.length})`),
-    `  ${pad(header).map((cell) => chalk.dim(cell)).join('  ')}`,
-    ...rows.map((row) => `  ${colorize(pad(row)).join('  ')}`),
-  ]
+  })
 }
 
 interface Section {
@@ -128,21 +192,20 @@ const sectionize = (commands: TapReporterCommand[]): Section[] => {
   return sections
 }
 
-const isNumbered = (command: TapReporterCommand): boolean => {
-  return command.event !== true && command.type !== 'system'
+const isEventRow = (command: TapReporterCommand): boolean => {
+  return command.event === true || command.type === 'system'
+}
+
+// A row's alias badge(s): its own aliases (`.as()` definitions, spy/stub call
+// rows) or the alias its request matched.
+const aliasSuffix = (command: TapReporterCommand, network: TapNetworkInfo | undefined): string => {
+  const names = command.aliases ?? (network?.alias != null ? [network.alias] : [])
+
+  return names.length ? `  ${names.map((name) => aliasBadge(name, command.aliasType)).join(' ')}` : ''
 }
 
 const networkSuffix = (network: TapNetworkInfo | undefined): string => {
-  if (!network) {
-    return ''
-  }
-
-  const parts = [
-    ...(network.alias ? [aliasBadge(network.alias)] : []),
-    ...(network.stubbed ? [chalk.dim('(stubbed)')] : []),
-  ]
-
-  return parts.length ? `  ${parts.join(' ')}` : ''
+  return network?.stubbed ? `  ${chalk.dim('(stubbed)')}` : ''
 }
 
 const stateSuffix = (command: TapReporterCommand): string => {
@@ -173,14 +236,19 @@ const rowParts = (command: TapReporterCommand): RowParts => {
   }
 }
 
-// Event logs render the way the reporter shows them: unnumbered, labeled by
-// their display name, as an annotation of the surrounding command.
-const renderEventRow = (command: TapReporterCommand, numberWidth: number): string => {
+// Event logs render the way the reporter shows them: labeled by their display
+// name, as an annotation of the surrounding command — but with their own tap id,
+// so an xhr or uncaught-exception row is referenceable like any command. A
+// failed event (an uncaught exception) takes the failure red, like the reporter.
+const renderEventRow = (command: TapReporterCommand, idWidth: number): string => {
   const { groupIndent, dot, message, cleaned } = rowParts(command)
-  const label = chalk.dim(`(${command.displayName ?? command.name ?? '?'})`)
-  const blank = ' '.repeat(numberWidth)
+  const failed = command.state === 'failed'
+  const labelColor = failed ? color.fail : chalk.dim
+  const label = labelColor(`(${command.displayName ?? command.name ?? '?'})`)
+  const id = color.fadedId(command.id.padStart(idWidth))
+  const text = failed ? color.fail(chalk.italic(message)) : chalk.italic(message)
 
-  return `  ${blank}  ${groupIndent}  ${label} ${dot}${chalk.italic(message)}${networkSuffix(command.network)}${cleaned}`
+  return `  ${id}  ${groupIndent}  ${label} ${dot}${text}${aliasSuffix(command, command.network)}${networkSuffix(command.network)}${stateSuffix(command)}${cleaned}`
 }
 
 // Child commands render dash-prefixed, the way the reporter marks a command
@@ -189,36 +257,31 @@ const commandLabel = (command: TapReporterCommand): string => {
   return `${command.type === 'child' ? '-' : ''}${command.name ?? ''}`
 }
 
-const renderCommandRow = (command: TapReporterCommand, number: number, numberWidth: number, nameWidth: number): string => {
+const renderCommandRow = (command: TapReporterCommand, idWidth: number, nameWidth: number): string => {
   const { groupIndent, dot, message, cleaned } = rowParts(command)
-  const num = chalk.dim(String(number).padStart(numberWidth))
+  const id = chalk.dim(command.id.padStart(idWidth))
   const name = commandLabel(command).padEnd(nameWidth)
   const styledName = command.state === 'failed' ? color.fail.bold(name) : chalk.bold(name)
 
-  return `  ${num}  ${groupIndent}${styledName}  ${dot}${message}${networkSuffix(command.network)}${stateSuffix(command)}${cleaned}`
+  return `  ${id}  ${groupIndent}${styledName}  ${dot}${message}${aliasSuffix(command, command.network)}${networkSuffix(command.network)}${stateSuffix(command)}${cleaned}`
 }
 
-const renderRow = (command: TapReporterCommand, number: number, numberWidth: number, nameWidth: number): string => {
-  return isNumbered(command)
-    ? renderCommandRow(command, number, numberWidth, nameWidth)
-    : renderEventRow(command, numberWidth)
+const renderRow = (command: TapReporterCommand, idWidth: number, nameWidth: number): string => {
+  return isEventRow(command)
+    ? renderEventRow(command, idWidth)
+    : renderCommandRow(command, idWidth, nameWidth)
 }
 
-const renderSection = (section: Section, hookName: string, numberWidth: number): string[] => {
-  const numbered = section.rows.filter(isNumbered)
-  const nameWidth = Math.max(0, ...numbered.map((command) => commandLabel(command).length))
-
-  let number = 0
+// The hook id in the title is the qualifier a duplicated row number needs
+// (`pin r8 h1:1`), since numbers restart per section.
+const renderSection = (section: Section, hookName: string, idWidth: number): string[] => {
+  const commandRows = section.rows.filter((command) => !isEventRow(command))
+  const nameWidth = Math.max(0, ...commandRows.map((command) => commandLabel(command).length))
+  const qualifier = section.hookId ? ` · ${section.hookId}` : ''
 
   return [
-    chalk.dim(hookName.toUpperCase()),
-    ...section.rows.map((command) => {
-      if (isNumbered(command)) {
-        number += 1
-      }
-
-      return renderRow(command, number, numberWidth, nameWidth)
-    }),
+    chalk.dim(`${hookName.toUpperCase()}${qualifier}`),
+    ...section.rows.map((command) => renderRow(command, idWidth, nameWidth)),
   ]
 }
 
@@ -251,12 +314,14 @@ export const renderReporterHuman = (view: TapReporterView): string => {
   const hookNames = new Map(view.hooks.map(({ hookId, hookName }) => [hookId, hookName]))
   const sections = sectionize(view.commands)
 
-  const numberWidth = Math.max(1, ...sections.map((section) => String(section.rows.filter(isNumbered).length).length))
+  const idWidth = Math.max(2, ...view.commands.map((command) => command.id.length))
 
   const blocks: string[][] = [
     [`${icon} ${chalk.bold(view.test.fullTitle)}  ${word}`],
+    ...(view.sessions.length ? [sessionsPanel(view.sessions)] : []),
+    ...(view.agents.length ? [agentsTable(view.agents)] : []),
     ...(view.routes.length ? [routesTable(view.routes)] : []),
-    ...sections.map((section) => renderSection(section, hookNames.get(section.hookId ?? '') ?? 'commands', numberWidth)),
+    ...sections.map((section) => renderSection(section, hookNames.get(section.hookId ?? '') ?? 'commands', idWidth)),
   ]
 
   if (!view.commands.length) {

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -154,7 +154,7 @@ const routesTable = (routes: TapReporterView['routes']): string[] => {
       route.url ?? '',
       route.stubbed ? 'yes' : 'no',
       route.alias ? `@${route.alias}` : '',
-      String(route.numResponses ?? 0),
+      route.numResponses ? String(route.numResponses) : '-',
     ]
   })
 

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -1,0 +1,271 @@
+import chalk from 'chalk'
+
+import type { TapNetworkInfo, TapReporterCommand, TapReporterError, TapReporterView } from '@packages/cypress-instances'
+
+// The reporter's own palette (packages/reporter/src/lib/variables.scss and
+// commands.scss), so the CLI rendering matches the app: $pass/$fail map to
+// jade-400/red-400, assert messages render jade-300/red-400 with jade-200/
+// red-300 emphasis, the network dots use the command-message-indicator colors,
+// and aliases take the purple badge hue. chalk downsamples the hex values on
+// terminals without truecolor.
+const color = {
+  pass: chalk.hex('#1fa971'), // $jade-400
+  fail: chalk.hex('#e45770'), // $red-400
+  passMessage: chalk.hex('#69d3a7'), // $jade-300
+  passStrong: chalk.hex('#a3e7cb'), // $jade-200
+  failStrong: chalk.hex('#f59aa9'), // $red-300
+  errHeaderText: chalk.hex('#f59aa9'), // $err-header-text = $red-300
+  aborted: chalk.hex('#db7903'), // $orange-400
+  bad: chalk.hex('#c62b49'), // $red-500
+  pending: chalk.hex('#6470f3'), // $indigo-400
+  alias: chalk.hex('#c8a7f5'), // $purple-300
+  muted: chalk.hex('#9095ad'), // $gray-500
+}
+
+const TEST_STATE = {
+  passed: { icon: color.pass('✓'), word: color.pass('passed') },
+  failed: { icon: color.fail('✖'), word: color.fail('failed') },
+  pending: { icon: color.pending('○'), word: color.pending('pending') },
+  skipped: { icon: color.muted('-'), word: color.muted('skipped') },
+} as const
+
+// The reporter's status dot for a network row.
+const INDICATORS: Record<NonNullable<TapNetworkInfo['indicator']>, string> = {
+  successful: color.pass('●'),
+  pending: color.pending('○'),
+  aborted: color.aborted('●'),
+  bad: color.bad('●'),
+}
+
+const aliasBadge = (alias: string): string => color.alias(`@${alias}`)
+
+// Driver messages emphasize with markdown-style `**`; render the emphasis
+// instead of the markers, on one line.
+const emphasize = (message: string, strong: (part: string) => string): string => {
+  return message
+  .replace(/\s+/g, ' ')
+  .trim()
+  .replace(/\*\*([^*]+)\*\*/g, (_, part) => strong(part))
+}
+
+// Asserts take the reporter's state colors — passing green, failing red —
+// while other messages keep the default text with bold emphasis.
+const formatMessage = (command: TapReporterCommand): string => {
+  const message = command.message ?? ''
+
+  if (!message) {
+    return ''
+  }
+
+  if (command.name === 'assert') {
+    if (command.state === 'passed') {
+      return color.passMessage(emphasize(message, (part) => color.passStrong.bold(part)))
+    }
+
+    if (command.state === 'failed') {
+      return color.fail(emphasize(message, (part) => color.failStrong.bold(part)))
+    }
+  }
+
+  return emphasize(message, (part) => chalk.bold(part))
+}
+
+const routesTable = (routes: TapReporterView['routes']): string[] => {
+  const header = ['METHOD', 'MATCHER', 'STUBBED', 'ALIAS', '#']
+
+  const rows = routes.map((route) => {
+    return [
+      route.method ?? '',
+      route.url ?? '',
+      route.stubbed ? 'yes' : 'no',
+      route.alias ? `@${route.alias}` : '',
+      String(route.numResponses ?? 0),
+    ]
+  })
+
+  const widths = header.map((title, column) => Math.max(title.length, ...rows.map((row) => row[column].length)))
+  const pad = (cells: string[]) => cells.map((cell, column) => cell.padEnd(widths[column]))
+
+  // Pad before coloring: the escape codes chalk adds would otherwise count
+  // toward the column width.
+  const colorize = (cells: string[]) => {
+    return [
+      chalk.bold(cells[0]),
+      cells[1],
+      cells[2].startsWith('yes') ? color.aborted(cells[2]) : cells[2],
+      color.alias(cells[3]),
+      cells[4],
+    ]
+  }
+
+  return [
+    chalk.dim('ROUTES') + chalk.dim(` (${routes.length})`),
+    `  ${pad(header).map((cell) => chalk.dim(cell)).join('  ')}`,
+    ...rows.map((row) => `  ${colorize(pad(row)).join('  ')}`),
+  ]
+}
+
+interface Section {
+  hookId: string | undefined
+  rows: TapReporterCommand[]
+}
+
+// Consecutive rows sharing a hookId form one section, preserving the true
+// chronology of the log rather than re-bucketing it.
+const sectionize = (commands: TapReporterCommand[]): Section[] => {
+  const sections: Section[] = []
+
+  for (const command of commands) {
+    const current = sections[sections.length - 1]
+
+    if (current && current.hookId === command.hookId) {
+      current.rows.push(command)
+    } else {
+      sections.push({ hookId: command.hookId, rows: [command] })
+    }
+  }
+
+  return sections
+}
+
+const isNumbered = (command: TapReporterCommand): boolean => {
+  return command.event !== true && command.type !== 'system'
+}
+
+const networkSuffix = (network: TapNetworkInfo | undefined): string => {
+  if (!network) {
+    return ''
+  }
+
+  const parts = [
+    ...(network.alias ? [aliasBadge(network.alias)] : []),
+    ...(network.stubbed ? [chalk.dim('(stubbed)')] : []),
+  ]
+
+  return parts.length ? `  ${parts.join(' ')}` : ''
+}
+
+const stateSuffix = (command: TapReporterCommand): string => {
+  if (command.state === 'failed') {
+    return ` ${color.fail('✖')}`
+  }
+
+  if (command.state === 'pending') {
+    return ` ${chalk.dim('…')}`
+  }
+
+  return ''
+}
+
+interface RowParts {
+  groupIndent: string
+  dot: string
+  message: string
+  cleaned: string
+}
+
+const rowParts = (command: TapReporterCommand): RowParts => {
+  return {
+    groupIndent: '  '.repeat(command.groupLevel ?? 0),
+    dot: command.network?.indicator ? `${INDICATORS[command.network.indicator]} ` : '',
+    message: formatMessage(command),
+    cleaned: command.cleanedUp ? `  ${chalk.dim('(cleaned up)')}` : '',
+  }
+}
+
+// Event logs render the way the reporter shows them: unnumbered, labeled by
+// their display name, as an annotation of the surrounding command.
+const renderEventRow = (command: TapReporterCommand, numberWidth: number): string => {
+  const { groupIndent, dot, message, cleaned } = rowParts(command)
+  const label = chalk.dim(`(${command.displayName ?? command.name ?? '?'})`)
+  const blank = ' '.repeat(numberWidth)
+
+  return `  ${blank}  ${groupIndent}  ${label} ${dot}${chalk.italic(message)}${networkSuffix(command.network)}${cleaned}`
+}
+
+// Child commands render dash-prefixed, the way the reporter marks a command
+// chained off the previous subject.
+const commandLabel = (command: TapReporterCommand): string => {
+  return `${command.type === 'child' ? '-' : ''}${command.name ?? ''}`
+}
+
+const renderCommandRow = (command: TapReporterCommand, number: number, numberWidth: number, nameWidth: number): string => {
+  const { groupIndent, dot, message, cleaned } = rowParts(command)
+  const num = chalk.dim(String(number).padStart(numberWidth))
+  const name = commandLabel(command).padEnd(nameWidth)
+  const styledName = command.state === 'failed' ? color.fail.bold(name) : chalk.bold(name)
+
+  return `  ${num}  ${groupIndent}${styledName}  ${dot}${message}${networkSuffix(command.network)}${stateSuffix(command)}${cleaned}`
+}
+
+const renderRow = (command: TapReporterCommand, number: number, numberWidth: number, nameWidth: number): string => {
+  return isNumbered(command)
+    ? renderCommandRow(command, number, numberWidth, nameWidth)
+    : renderEventRow(command, numberWidth)
+}
+
+const renderSection = (section: Section, hookName: string, numberWidth: number): string[] => {
+  const numbered = section.rows.filter(isNumbered)
+  const nameWidth = Math.max(0, ...numbered.map((command) => commandLabel(command).length))
+
+  let number = 0
+
+  return [
+    chalk.dim(hookName.toUpperCase()),
+    ...section.rows.map((command) => {
+      if (isNumbered(command)) {
+        number += 1
+      }
+
+      return renderRow(command, number, numberWidth, nameWidth)
+    }),
+  ]
+}
+
+// The reporter's error panel: name, message, and the code frame with its
+// `>`-marked failing line.
+const renderError = (error: TapReporterError): string[] => {
+  const lines = [`${color.fail('✖')} ${color.fail.bold(error.name ?? 'Error')}`]
+
+  if (error.message) {
+    lines.push(...error.message.split('\n').map((line) => `  ${color.errHeaderText(line)}`))
+  }
+
+  const { codeFrame } = error
+
+  if (codeFrame?.file) {
+    lines.push('', `  ${chalk.dim([codeFrame.file, codeFrame.line, codeFrame.column].filter((part) => part != null).join(':'))}`)
+  }
+
+  if (codeFrame?.frame) {
+    lines.push(...codeFrame.frame.replace(/\n+$/, '').split('\n').map((line) => {
+      return `  ${line.startsWith('>') ? color.fail(line) : color.muted(line)}`
+    }))
+  }
+
+  return lines
+}
+
+export const renderReporterHuman = (view: TapReporterView): string => {
+  const { icon, word } = TEST_STATE[view.test.state]
+  const hookNames = new Map(view.hooks.map(({ hookId, hookName }) => [hookId, hookName]))
+  const sections = sectionize(view.commands)
+
+  const numberWidth = Math.max(1, ...sections.map((section) => String(section.rows.filter(isNumbered).length).length))
+
+  const blocks: string[][] = [
+    [`${icon} ${chalk.bold(view.test.fullTitle)}  ${word}`],
+    ...(view.routes.length ? [routesTable(view.routes)] : []),
+    ...sections.map((section) => renderSection(section, hookNames.get(section.hookId ?? '') ?? 'commands', numberWidth)),
+  ]
+
+  if (!view.commands.length) {
+    blocks.push([chalk.dim('No commands were logged for this test.')])
+  }
+
+  if (view.error) {
+    blocks.push(renderError(view.error))
+  }
+
+  return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
+}

--- a/cli/lib/tap/types.ts
+++ b/cli/lib/tap/types.ts
@@ -3,6 +3,8 @@ import type { TapNativeCommandSchema } from '@packages/cypress-instances'
 /** Options `cypress tap` accepts from the top-level CLI. */
 export interface TapCliOptions {
   instance?: number
+  /** Print the raw JSON result even when the command has a human-readable rendering. */
+  json?: boolean
 }
 
 /**

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -173,6 +173,47 @@ describe('lib/exec/tap', () => {
       expect(JSON.parse(logger.print())).toEqual({ status: 'ok', browsers: 2 })
     })
 
+    const reporterSchema: TapSchema = {
+      ...schema,
+      commands: [
+        ...schema.commands,
+        {
+          name: 'reporter',
+          description: 'render a test’s full reporter view',
+          params: [],
+          options: [{ name: 'test', type: 'string', required: true, description: 'test id' }],
+        },
+      ],
+    }
+
+    const reporterView = {
+      test: { id: 'r2', title: 'loads', fullTitle: 'App > loads', state: 'passed' },
+      hooks: [{ hookId: 'r2', hookName: 'test body' }],
+      routes: [],
+      commands: [{ id: 'log-1', name: 'visit', message: '/', state: 'passed', type: 'parent', hookId: 'r2' }],
+    }
+
+    it('prints a command’s human-readable rendering by default when it defines one', async () => {
+      const call = mockSession(reporterSchema, { result: reporterView })
+
+      expect(await tap.start(['reporter', '--test', 'r2'], {})).toBe(0)
+      expect(call).toHaveBeenCalledWith('exec', ['reporter', {}, { test: 'r2' }])
+
+      const output = logger.print()
+
+      expect(output).toContain('App > loads')
+      expect(output).toContain('TEST BODY')
+      expect(output).toContain('visit')
+      expect(() => JSON.parse(output)).toThrow()
+    })
+
+    it('prints the raw JSON result when --json is passed', async () => {
+      mockSession(reporterSchema, { result: reporterView })
+
+      expect(await tap.start(['reporter', '--test', 'r2'], { json: true })).toBe(0)
+      expect(JSON.parse(logger.print())).toEqual(reporterView)
+    })
+
     it('resolves the target from --instance and the cwd, then opens a session against it', async () => {
       mockSession()
       const { instance } = mockResolved()
@@ -946,6 +987,8 @@ describe('lib/exec/tap', () => {
         Options:
           --instance <pid>                target a specific running Cypress instance by
                                           its server process id (pid)
+          --json                          print the raw JSON result instead of the
+                                          human-readable rendering
           -h, --help                      display help for command
 
         Commands:
@@ -970,6 +1013,8 @@ describe('lib/exec/tap', () => {
                                           state, or detail one by id
           commands [options]              list the command log entries of a test of
                                           the active run
+          reporter [options]              render a test’s full reporter view: its
+                                          routes, hooks, and command log
           pin [options] [test] [command]  pin a command’s DOM snapshot into the live
                                           app-under-test frame so the dom/aria/inspect
                                           commands can read it; pass --clear to release
@@ -1007,6 +1052,8 @@ describe('lib/exec/tap', () => {
                                latest
           --instance <pid>     target a specific running Cypress instance by its server
                                process id (pid)
+          --json               print the raw JSON result instead of the human-readable
+                               rendering
           -h, --help           display help for command
         "
       `)

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -189,6 +189,8 @@ describe('lib/exec/tap', () => {
     const reporterView = {
       test: { id: 'r2', title: 'loads', fullTitle: 'App > loads', state: 'passed' },
       hooks: [{ hookId: 'r2', hookName: 'test body' }],
+      sessions: [],
+      agents: [],
       routes: [],
       commands: [{ id: 'log-1', name: 'visit', message: '/', state: 'passed', type: 'parent', hookId: 'r2' }],
     }

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderReporterHuman } from '../../../lib/tap/render/reporter'
+import type { TapReporterView } from '@packages/cypress-instances'
+
+// chalk's color level depends on where the suite runs, so strip any escape
+// codes before snapshotting — the assertions target the layout, not the colors.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (text: string): string => text.replace(/\[\d+m/g, '')
+
+const renderPlain = (input: TapReporterView): string => stripAnsi(renderReporterHuman(input))
+
+// Modeled on a real `reporter` result for the kitchensink network_requests
+// spec: three intercepts (one stubbed), before-each visit, event xhr rows,
+// markdown-emphasized assert messages.
+const view: TapReporterView = {
+  test: {
+    id: 'r8',
+    title: 'cy.intercept() - route responses to matching requests',
+    fullTitle: 'Network Requests > cy.intercept() - route responses to matching requests',
+    state: 'passed',
+  },
+  hooks: [
+    { hookId: 'h1', hookName: 'before each' },
+    { hookId: 'r8', hookName: 'test body' },
+  ],
+  routes: [
+    { id: 'log-60', method: 'GET', url: '**/comments/*', stubbed: false, numResponses: 1, alias: 'getComment' },
+    { id: 'log-77', method: 'PUT', url: '**/comments/*', stubbed: true, status: 404, numResponses: 1, alias: 'putComment' },
+  ],
+  commands: [
+    { id: 'log-59', name: 'visit', message: 'http://localhost:8080/commands/network-requests', state: 'passed', type: 'parent', hookId: 'h1' },
+    { id: 'log-61', name: 'get', message: '.network-btn', state: 'passed', type: 'parent', hookId: 'r8' },
+    { id: 'log-62', name: 'click', message: '', state: 'passed', type: 'child', hookId: 'r8' },
+    {
+      id: 'log-63', name: 'request', displayName: 'xhr', message: 'GET 200 https://jsonplaceholder.cypress.io/comments/1',
+      state: 'passed', type: 'parent', hookId: 'r8', event: true,
+      network: { method: 'GET', url: 'https://jsonplaceholder.cypress.io/comments/1', indicator: 'successful', stubbed: false, alias: 'getComment' },
+    },
+    { id: 'log-64', name: 'wait', message: '@getComment', state: 'passed', type: 'parent', hookId: 'r8' },
+    { id: 'log-66', name: 'assert', message: 'expected **200** to be one of **[ 200, 304 ]**', state: 'passed', type: 'child', hookId: 'r8' },
+    {
+      id: 'log-80', name: 'request', displayName: 'xhr', message: 'PUT 404 https://jsonplaceholder.cypress.io/comments/1',
+      state: 'passed', type: 'parent', hookId: 'r8', event: true,
+      network: { method: 'PUT', url: 'https://jsonplaceholder.cypress.io/comments/1', indicator: 'bad', stubbed: true, alias: 'putComment' },
+    },
+    { id: 'log-82', name: 'get', message: '.network-put-comment', state: 'failed', type: 'parent', hookId: 'r8' },
+    { id: 'log-83', name: 'session', message: 'user', state: 'passed', type: 'parent', hookId: 'r8', group: 'log-82', groupLevel: 1 },
+  ],
+}
+
+describe('lib/tap/render/reporter', () => {
+  it('renders the reporter panel: header, routes table, hook sections, numbered commands, event annotations', () => {
+    expect(renderPlain(view)).toMatchInlineSnapshot(`
+      "✓ Network Requests > cy.intercept() - route responses to matching requests  passed
+
+      ROUTES (2)
+        METHOD  MATCHER        STUBBED  ALIAS        #
+        GET     **/comments/*  no       @getComment  1
+        PUT     **/comments/*  yes      @putComment  1
+
+      BEFORE EACH
+        1  visit  http://localhost:8080/commands/network-requests
+
+      TEST BODY
+        1  get      .network-btn
+        2  -click
+             (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  @getComment
+        3  wait     @getComment
+        4  -assert  expected 200 to be one of [ 200, 304 ]
+             (xhr) ● PUT 404 https://jsonplaceholder.cypress.io/comments/1  @putComment (stubbed)
+        5  get      .network-put-comment ✖
+        6    session  user"
+    `)
+  })
+
+  it('renders the error panel — name, message, and marked code frame — for a failed test', () => {
+    const failed: TapReporterView = {
+      test: { id: 'r6', title: '.clear() - clears an input', fullTitle: 'Actions > .clear() - clears an input', state: 'failed' },
+      hooks: [{ hookId: 'r6', hookName: 'test body' }],
+      routes: [],
+      commands: [
+        { id: 'log-1', name: 'get', message: '.action-clear', state: 'passed', type: 'parent', hookId: 'r6' },
+        { id: 'log-2', name: 'assert', message: 'expected **<input>** to have value **Clear this text**', state: 'failed', type: 'child', hookId: 'r6' },
+      ],
+      error: {
+        name: 'AssertionError',
+        message: `Timed out retrying after 4000ms: expected '<input#description>' to have value 'Clear this text', but the value was ''`,
+        stack: 'AssertionError: Timed out retrying…\n  at <anonymous>',
+        codeFrame: {
+          file: 'cypress/e2e/2-advanced-examples/actions.cy.js',
+          line: 58,
+          column: 29,
+          frame: `  56 |     // https://on.cypress.io/clear\n  57 |     cy.get(".action-select").type("Clear this text");\n> 58 |     cy.get(".action-clear").should("have.value", "Clear this text");\n     |                             ^\n  59 |     cy.get(".action-clear").clear();\n`,
+        },
+      },
+    }
+
+    expect(renderPlain(failed)).toMatchInlineSnapshot(`
+      "✖ Actions > .clear() - clears an input  failed
+
+      TEST BODY
+        1  get      .action-clear
+        2  -assert  expected <input> to have value Clear this text ✖
+
+      ✖ AssertionError
+        Timed out retrying after 4000ms: expected '<input#description>' to have value 'Clear this text', but the value was ''
+
+        cypress/e2e/2-advanced-examples/actions.cy.js:58:29
+          56 |     // https://on.cypress.io/clear
+          57 |     cy.get(".action-select").type("Clear this text");
+        > 58 |     cy.get(".action-clear").should("have.value", "Clear this text");
+             |                             ^
+          59 |     cy.get(".action-clear").clear();"
+    `)
+  })
+
+  it('renders an unreached test as its header and an empty-log note', () => {
+    const empty: TapReporterView = {
+      test: { id: 'r1', title: 'never ran', fullTitle: 'never ran', state: 'skipped' },
+      hooks: [{ hookId: 'r1', hookName: 'test body' }],
+      routes: [],
+      commands: [],
+    }
+
+    expect(renderPlain(empty)).toMatchInlineSnapshot(`
+      "- never ran  skipped
+
+      No commands were logged for this test."
+    `)
+  })
+})

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -24,28 +24,47 @@ const view: TapReporterView = {
     { hookId: 'h1', hookName: 'before each' },
     { hookId: 'r8', hookName: 'test body' },
   ],
+  sessions: [
+    { name: 'all-commands-user', status: 'restored' },
+    { name: 'admin-user', status: 'failed', global: true },
+  ],
+  agents: [
+    { type: 'spy-1', functionName: 'beep', aliases: ['beep'], callCount: 1 },
+    { type: 'stub-1', functionName: 'boop' },
+  ],
+  // Route registrations aren't commands, so they carry no id; numbered rows
+  // carry the reporter's own per-section numbers, and event rows take the
+  // attempt-wide `e` sequence.
   routes: [
-    { id: 'log-60', method: 'GET', url: '**/comments/*', stubbed: false, numResponses: 1, alias: 'getComment' },
-    { id: 'log-77', method: 'PUT', url: '**/comments/*', stubbed: true, status: 404, numResponses: 1, alias: 'putComment' },
+    { method: 'GET', url: '**/comments/*', stubbed: false, numResponses: 1, alias: 'getComment' },
+    { method: 'PUT', url: '**/comments/*', stubbed: true, status: 404, numResponses: 1, alias: 'putComment' },
   ],
   commands: [
-    { id: 'log-59', name: 'visit', message: 'http://localhost:8080/commands/network-requests', state: 'passed', type: 'parent', hookId: 'h1' },
-    { id: 'log-61', name: 'get', message: '.network-btn', state: 'passed', type: 'parent', hookId: 'r8' },
-    { id: 'log-62', name: 'click', message: '', state: 'passed', type: 'child', hookId: 'r8' },
+    { id: '1', name: 'visit', message: 'http://localhost:8080/commands/network-requests', state: 'passed', type: 'parent', hookId: 'h1' },
+    { id: '1', name: 'get', message: '.network-btn', state: 'passed', type: 'parent', hookId: 'r8' },
+    { id: '2', name: 'click', message: '', state: 'passed', type: 'child', hookId: 'r8' },
     {
-      id: 'log-63', name: 'request', displayName: 'xhr', message: 'GET 200 https://jsonplaceholder.cypress.io/comments/1',
+      id: 'e1', name: 'request', displayName: 'xhr', message: 'GET 200 https://jsonplaceholder.cypress.io/comments/1',
       state: 'passed', type: 'parent', hookId: 'r8', event: true,
       network: { method: 'GET', url: 'https://jsonplaceholder.cypress.io/comments/1', indicator: 'successful', stubbed: false, alias: 'getComment' },
     },
-    { id: 'log-64', name: 'wait', message: '@getComment', state: 'passed', type: 'parent', hookId: 'r8' },
-    { id: 'log-66', name: 'assert', message: 'expected **200** to be one of **[ 200, 304 ]**', state: 'passed', type: 'child', hookId: 'r8' },
+    { id: '3', name: 'wait', message: '@getComment', state: 'passed', type: 'parent', hookId: 'r8', referencedAliases: ['getComment'], aliasType: 'route' },
+    { id: '4', name: 'assert', message: 'expected **200** to be one of **[ 200, 304 ]**', state: 'passed', type: 'child', hookId: 'r8' },
     {
-      id: 'log-80', name: 'request', displayName: 'xhr', message: 'PUT 404 https://jsonplaceholder.cypress.io/comments/1',
+      id: 'e2', name: 'request', displayName: 'xhr', message: 'PUT 404 https://jsonplaceholder.cypress.io/comments/1',
       state: 'passed', type: 'parent', hookId: 'r8', event: true,
       network: { method: 'PUT', url: 'https://jsonplaceholder.cypress.io/comments/1', indicator: 'bad', stubbed: true, alias: 'putComment' },
     },
-    { id: 'log-82', name: 'get', message: '.network-put-comment', state: 'failed', type: 'parent', hookId: 'r8' },
-    { id: 'log-83', name: 'session', message: 'user', state: 'passed', type: 'parent', hookId: 'r8', group: 'log-82', groupLevel: 1 },
+    { id: '5', name: 'get', message: '.network-put-comment', state: 'failed', type: 'parent', hookId: 'r8' },
+    { id: '6', name: 'session', message: 'user', state: 'passed', type: 'parent', hookId: 'r8', group: '5', groupLevel: 1 },
+    {
+      id: 'e3', name: 'spy-1', displayName: 'spy-1', message: 'beep()', state: 'passed', type: 'parent', hookId: 'r8', event: true,
+      aliases: ['beep'], aliasType: 'agent',
+    },
+    { id: '7', name: 'get', message: '@beep', state: 'passed', type: 'parent', hookId: 'r8', referencedAliases: ['beep'], aliasType: 'agent' },
+    { id: '8', name: 'wrap', message: '{ table: 1 }', state: 'passed', type: 'parent', hookId: 'r8' },
+    { id: '9', name: 'as', message: 'table', state: 'passed', type: 'child', hookId: 'r8', aliases: ['table'], aliasType: 'dom' },
+    { id: 'e4', name: 'uncaught exception', message: 'Error: boom', state: 'failed', type: 'parent', hookId: 'r8', event: true },
   ],
 }
 
@@ -54,23 +73,37 @@ describe('lib/tap/render/reporter', () => {
     expect(renderPlain(view)).toMatchInlineSnapshot(`
       "✓ Network Requests > cy.intercept() - route responses to matching requests  passed
 
+      SESSIONS (2)
+        all-commands-user  restored
+        admin-user  (global)  failed
+
+      SPIES / STUBS (2)
+        TYPE    FUNCTION  ALIAS(ES)  CALLS
+        spy-1   beep      beep       1
+        stub-1  boop                 -
+
       ROUTES (2)
         METHOD  MATCHER        STUBBED  ALIAS        #
         GET     **/comments/*  no       @getComment  1
         PUT     **/comments/*  yes      @putComment  1
 
-      BEFORE EACH
-        1  visit  http://localhost:8080/commands/network-requests
+      BEFORE EACH · h1
+         1  visit  http://localhost:8080/commands/network-requests
 
-      TEST BODY
-        1  get      .network-btn
-        2  -click
-             (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  @getComment
-        3  wait     @getComment
-        4  -assert  expected 200 to be one of [ 200, 304 ]
-             (xhr) ● PUT 404 https://jsonplaceholder.cypress.io/comments/1  @putComment (stubbed)
-        5  get      .network-put-comment ✖
-        6    session  user"
+      TEST BODY · r8
+         1  get      .network-btn
+         2  -click
+        e1    (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  @getComment
+         3  wait     @getComment
+         4  -assert  expected 200 to be one of [ 200, 304 ]
+        e2    (xhr) ● PUT 404 https://jsonplaceholder.cypress.io/comments/1  @putComment  (stubbed)
+         5  get      .network-put-comment ✖
+         6    session  user
+        e3    (spy-1) beep()  @beep
+         7  get      @beep
+         8  wrap     { table: 1 }
+         9  -as      table  @table
+        e4    (uncaught exception) Error: boom ✖"
     `)
   })
 
@@ -78,10 +111,12 @@ describe('lib/tap/render/reporter', () => {
     const failed: TapReporterView = {
       test: { id: 'r6', title: '.clear() - clears an input', fullTitle: 'Actions > .clear() - clears an input', state: 'failed' },
       hooks: [{ hookId: 'r6', hookName: 'test body' }],
+      sessions: [],
+      agents: [],
       routes: [],
       commands: [
-        { id: 'log-1', name: 'get', message: '.action-clear', state: 'passed', type: 'parent', hookId: 'r6' },
-        { id: 'log-2', name: 'assert', message: 'expected **<input>** to have value **Clear this text**', state: 'failed', type: 'child', hookId: 'r6' },
+        { id: '1', name: 'get', message: '.action-clear', state: 'passed', type: 'parent', hookId: 'r6' },
+        { id: '2', name: 'assert', message: 'expected **<input>** to have value **Clear this text**', state: 'failed', type: 'child', hookId: 'r6' },
       ],
       error: {
         name: 'AssertionError',
@@ -99,9 +134,9 @@ describe('lib/tap/render/reporter', () => {
     expect(renderPlain(failed)).toMatchInlineSnapshot(`
       "✖ Actions > .clear() - clears an input  failed
 
-      TEST BODY
-        1  get      .action-clear
-        2  -assert  expected <input> to have value Clear this text ✖
+      TEST BODY · r6
+         1  get      .action-clear
+         2  -assert  expected <input> to have value Clear this text ✖
 
       ✖ AssertionError
         Timed out retrying after 4000ms: expected '<input#description>' to have value 'Clear this text', but the value was ''
@@ -119,6 +154,8 @@ describe('lib/tap/render/reporter', () => {
     const empty: TapReporterView = {
       test: { id: 'r1', title: 'never ran', fullTitle: 'never ran', state: 'skipped' },
       hooks: [{ hookId: 'r1', hookName: 'test body' }],
+      sessions: [],
+      agents: [],
       routes: [],
       commands: [],
     }

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
 
 import { renderReporterHuman } from '../../../lib/tap/render/reporter'
 import type { TapReporterView } from '@packages/cypress-instances'
 
 // chalk's color level depends on where the suite runs, so strip any escape
 // codes before snapshotting — the assertions target the layout, not the colors.
-// eslint-disable-next-line no-control-regex
-const stripAnsi = (text: string): string => text.replace(/\[\d+m/g, '')
-
 const renderPlain = (input: TapReporterView): string => stripAnsi(renderReporterHuman(input))
 
 // Modeled on a real `reporter` result for the kitchensink network_requests

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -34,7 +34,7 @@ const view: TapReporterView = {
   // carry the reporter's own per-section numbers, and event rows take the
   // attempt-wide `e` sequence.
   routes: [
-    { method: 'GET', url: '**/comments/*', stubbed: false, numResponses: 1, alias: 'getComment' },
+    { method: 'GET', url: '**/comments/*', stubbed: false, alias: 'getComment' },
     { method: 'PUT', url: '**/comments/*', stubbed: true, status: 404, numResponses: 1, alias: 'putComment' },
   ],
   commands: [
@@ -82,7 +82,7 @@ describe('lib/tap/render/reporter', () => {
 
       ROUTES (2)
         METHOD  MATCHER        STUBBED  ALIAS        #
-        GET     **/comments/*  no       @getComment  1
+        GET     **/comments/*  no       @getComment  -
         PUT     **/comments/*  yes      @putComment  1
 
       BEFORE EACH · h1

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -116,7 +116,9 @@ describe('tap binding', () => {
 
       for (const command of commands) {
         expect(Object.keys(command), `command ${command.id}`).to.include.members(['id', 'name'])
-        expect(Object.keys(command)).to.satisfy((keys: string[]) => keys.every((key) => ['id', 'name', 'message', 'state', 'type'].includes(key)))
+        // cy.visit's document load logs a request row, so `network` is part of
+        // the contract even here; the dedicated network spec below asserts its shape.
+        expect(Object.keys(command)).to.satisfy((keys: string[]) => keys.every((key) => ['id', 'name', 'message', 'state', 'type', 'network', 'cleanedUp'].includes(key)))
       }
 
       const missing = await getBinding(win).exec('commands', {}, { test: 'not-a-test' })
@@ -370,5 +372,93 @@ describe('tap binding pin lifecycle', () => {
     pinClickAtBefore()
     cy.contains('li.command-name-click', 'click').find('.command-pin-target').first().click()
     expectReleased()
+  })
+})
+
+// The network fixture lives in the dedicated tap project too (see above): it
+// needs a served page and an intercept, which would perturb the shared
+// cypress-in-cypress project's exact spec/command counts.
+describe('tap binding with network activity', () => {
+  beforeEach(() => {
+    cy.scaffoldProject('tap-retries')
+    cy.openProject('tap-retries')
+    cy.startAppServer('e2e')
+    cy.visitApp()
+    cy.specsPageIsVisible()
+  })
+
+  const ENTRY_KEYS = ['id', 'name', 'message', 'state', 'type', 'network', 'cleanedUp']
+  const NETWORK_KEYS = ['method', 'url', 'indicator', 'status', 'stubbed', 'numResponses', 'alias']
+
+  const withinKeys = (allowed: string[]) => {
+    return (keys: string[]) => keys.every((key) => allowed.includes(key))
+  }
+
+  it('surfaces high-level network detail on request, intercept, and cy.request rows', () => {
+    cy.window().then(async (win) => {
+      const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/network.cy.js' })
+
+      expect('result' in outcome).to.eq(true)
+    })
+
+    cy.waitForSpecToFinish({ passCount: 1 })
+
+    cy.window().then(async (win) => {
+      const binding = getBinding(win)
+
+      const tests = ((await binding.exec('tests')) as { result: Array<Record<string, unknown>> }).result
+      const testId = tests[0].id as string
+
+      const commands = ((await binding.exec('commands', {}, { test: testId })) as { result: Array<Record<string, any>> }).result
+
+      // Nothing internal leaks: every row stays within the wire contract, and
+      // every network object stays within its typed field set.
+      for (const command of commands) {
+        expect(Object.keys(command), `row ${command.id}`).to.satisfy(withinKeys(ENTRY_KEYS))
+
+        if (command.network) {
+          expect(Object.keys(command.network), `network ${command.id}`).to.satisfy(withinKeys(NETWORK_KEYS))
+        }
+      }
+
+      expect(commands.filter((command) => command.network), 'rows carrying network detail').to.have.length.greaterThan(0)
+
+      // The cy.intercept registration is bucketed under routes; it merges into
+      // the command log as a route row with the stubbed flag, matcher, alias,
+      // and match count.
+      const route = commands.find((command) => command.name === 'route')
+
+      expect(route, 'the intercept route row').to.exist
+      expect(route!.network.method).to.eq('GET')
+      expect(route!.network.url).to.contain('/api/users')
+      expect(route!.network.stubbed).to.eq(true)
+      expect(route!.network.alias).to.eq('getUsers')
+      expect(route!.network.numResponses).to.be.greaterThan(0)
+
+      // The stubbed request itself: served by the stub, so it did not go to
+      // origin. Carries method, URL, the reporter's status indicator, and alias.
+      const stubbed = commands.find((command) => command.name === 'request' && command.network?.stubbed === true && command.network?.alias === 'getUsers')
+
+      expect(stubbed, 'the stubbed request row').to.exist
+      expect(stubbed!.network.method).to.eq('GET')
+      expect(stubbed!.network.url).to.contain('/api/users')
+      expect(stubbed!.network.indicator).to.eq('successful')
+      expect(stubbed!.message, 'the reporter display message').to.contain('/api/users')
+
+      // A real request that went to origin (the page fetching itself).
+      const real = commands.find((command) => command.name === 'request' && command.network?.stubbed === false)
+
+      expect(real, 'a real request row').to.exist
+      expect(real!.network.method).to.be.a('string')
+      expect(real!.network.indicator).to.be.a('string')
+
+      // cy.request keeps its method/URL in the display message, exposing only
+      // the status indicator as a structured field (no request URL on the log).
+      const cyRequest = commands.find((command) => command.name === 'request' && command.network && !command.network.url && !command.network.method && command.network.indicator)
+
+      expect(cyRequest, 'the cy.request row').to.exist
+      expect(cyRequest!.network.indicator).to.eq('successful')
+      expect(cyRequest!.message, 'the cy.request display message').to.match(/^GET \d+ /)
+    })
   })
 })

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -297,7 +297,7 @@ describe('tap binding pin lifecycle', () => {
 
       expect(clearNoop).to.deep.eq({ result: { cleared: false } })
 
-      const beforeRun = await binding.exec('pin', { test: 'r2', command: 'log-1' })
+      const beforeRun = await binding.exec('pin', { test: 'r2', command: '1' })
 
       expect((beforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
     })
@@ -485,7 +485,7 @@ describe('tap binding with network activity', () => {
     })
   })
 
-  const REPORTER_COMMAND_KEYS = ['id', 'name', 'displayName', 'message', 'state', 'type', 'hookId', 'event', 'group', 'groupLevel', 'network', 'cleanedUp']
+  const REPORTER_COMMAND_KEYS = ['id', 'name', 'displayName', 'message', 'state', 'type', 'hookId', 'event', 'group', 'groupLevel', 'aliases', 'aliasType', 'referencedAliases', 'network', 'cleanedUp']
   const REPORTER_ROUTE_KEYS = ['id', 'method', 'url', 'stubbed', 'status', 'numResponses', 'alias']
 
   it('renders the full reporter view for a test: header, hooks, routes, and enriched commands', () => {
@@ -510,7 +510,7 @@ describe('tap binding with network activity', () => {
       const outcome = (await binding.exec('reporter', {}, { test: testId })) as { result: Record<string, any> }
       const view = outcome.result
 
-      expect(Object.keys(view)).to.deep.eq(['test', 'hooks', 'routes', 'commands'])
+      expect(Object.keys(view)).to.deep.eq(['test', 'hooks', 'sessions', 'agents', 'routes', 'commands'])
       expect(view.test).to.deep.eq({
         id: testId,
         title: 'records intercept, real request, and cy.request detail',

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -43,6 +43,10 @@ describe('tap binding', () => {
 
       expect((commandsBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
+      const reporterBeforeRun = await binding.exec('reporter', {}, { test: 'r1' })
+
+      expect((reporterBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
+
       // specs and run are CLI-native commands now — the CLI reads the spec list and
       // triggers runs directly over the instance's GraphQL — so the binding no longer serves them.
       const specsOutcome = await binding.exec('specs')
@@ -208,6 +212,25 @@ describe('tap binding with a retrying spec', () => {
       const commandsOutOfRange = await binding.exec('commands', {}, { test: testId, attempt: '3' })
 
       expect((commandsOutOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
+
+      // reporter selects attempts through the same machinery: the first
+      // attempt's view carries its failed state, its error panel, and
+      // out-of-range still fails.
+      const firstReporter = (await binding.exec('reporter', {}, { test: testId, attempt: '1' })) as { result: Record<string, any> }
+
+      expect(firstReporter.result.test.state).to.eq('failed')
+      expect(firstReporter.result.commands.some((command: Record<string, unknown>) => command.state === 'failed')).to.eq(true)
+      expect(Object.keys(firstReporter.result.error)).to.satisfy((keys: string[]) => keys.every((key) => ['name', 'message', 'stack', 'codeFrame'].includes(key)))
+      expect(firstReporter.result.error.message).to.be.a('string')
+
+      // The passing latest attempt has no error panel.
+      const latestReporter = (await binding.exec('reporter', {}, { test: testId })) as { result: Record<string, unknown> }
+
+      expect(latestReporter.result.error).to.be.undefined
+
+      const reporterOutOfRange = await binding.exec('reporter', {}, { test: testId, attempt: '3' })
+
+      expect((reporterOutOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
     })
   })
 })
@@ -459,6 +482,69 @@ describe('tap binding with network activity', () => {
       expect(cyRequest, 'the cy.request row').to.exist
       expect(cyRequest!.network.indicator).to.eq('successful')
       expect(cyRequest!.message, 'the cy.request display message').to.match(/^GET \d+ /)
+    })
+  })
+
+  const REPORTER_COMMAND_KEYS = ['id', 'name', 'displayName', 'message', 'state', 'type', 'hookId', 'event', 'group', 'groupLevel', 'network', 'cleanedUp']
+  const REPORTER_ROUTE_KEYS = ['id', 'method', 'url', 'stubbed', 'status', 'numResponses', 'alias']
+
+  it('renders the full reporter view for a test: header, hooks, routes, and enriched commands', () => {
+    cy.window().then(async (win) => {
+      const outcome = await getBinding(win).exec('run', { spec: 'cypress/e2e/network.cy.js' })
+
+      expect('result' in outcome).to.eq(true)
+    })
+
+    cy.waitForSpecToFinish({ passCount: 1 })
+
+    cy.window().then(async (win) => {
+      const binding = getBinding(win)
+
+      const missing = await binding.exec('reporter', {}, { test: 'not-a-test' })
+
+      expect((missing as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+
+      const tests = ((await binding.exec('tests')) as { result: Array<Record<string, unknown>> }).result
+      const testId = tests[0].id as string
+
+      const outcome = (await binding.exec('reporter', {}, { test: testId })) as { result: Record<string, any> }
+      const view = outcome.result
+
+      expect(Object.keys(view)).to.deep.eq(['test', 'hooks', 'routes', 'commands'])
+      expect(view.test).to.deep.eq({
+        id: testId,
+        title: 'records intercept, real request, and cy.request detail',
+        fullTitle: 'Network > records intercept, real request, and cy.request detail',
+        state: 'passed',
+      })
+
+      // The fixture has no before/after hooks, so the sections are just the
+      // synthesized test body — the reporter's bucket for the test's own commands.
+      expect(view.hooks).to.deep.eq([{ hookId: testId, hookName: 'test body' }])
+
+      // The cy.intercept registration lives in the ROUTES table, not the log.
+      expect(view.routes).to.have.length(1)
+      expect(Object.keys(view.routes[0])).to.satisfy((keys: string[]) => keys.every((key) => REPORTER_ROUTE_KEYS.includes(key)))
+      expect(view.routes[0].method).to.eq('GET')
+      expect(view.routes[0].url).to.contain('/api/users')
+      expect(view.routes[0].stubbed).to.eq(true)
+      expect(view.routes[0].alias).to.eq('getUsers')
+      expect(view.routes[0].numResponses).to.be.greaterThan(0)
+      expect(view.commands.some((command: Record<string, unknown>) => command.name === 'route')).to.eq(false)
+
+      for (const command of view.commands as Array<Record<string, any>>) {
+        expect(Object.keys(command), `row ${command.id}`).to.satisfy((keys: string[]) => keys.every((key) => REPORTER_COMMAND_KEYS.includes(key)))
+        expect(command.hookId, `hookId of ${command.id}`).to.eq(testId)
+      }
+
+      // The stubbed fetch surfaces as an event row labeled by its displayName,
+      // carrying the same network detail the commands command reports.
+      const eventRow = (view.commands as Array<Record<string, any>>).find((command) => command.event === true && command.network?.stubbed === true)
+
+      expect(eventRow, 'the stubbed request event row').to.exist
+      expect(eventRow!.displayName).to.be.a('string')
+      expect(eventRow!.network.indicator).to.eq('successful')
+      expect(eventRow!.network.alias).to.eq('getUsers')
     })
   })
 })

--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -14,7 +14,7 @@ async, JSON-only methods — `getSchema()` and `exec(command, args?, options?)`.
 - `commands/index.ts` — the command registry, the single source of truth for available subcommands.
 - `commands/definition.ts` — `defineCommand` authoring helper and `TapCommandError` (domain failures).
 - `commands/*.ts` — one module per subcommand (`tests`, `commands`, `pin`, …); nothing but commands lives here.
-- `test-state.ts` — serialization of runner test state, shared by the `tests`, `commands`, `run-state`, and `pin` commands.
+- `test-state.ts` — serialization of runner test state, shared by the `tests`, `commands`, `reporter`, `run-state`, and `pin` commands.
 
 ## Contracts MUST be validated in the e2e tests, without mocking
 

--- a/packages/app/src/tap/commands/commands.cy.ts
+++ b/packages/app/src/tap/commands/commands.cy.ts
@@ -102,6 +102,91 @@ describe('tap/commands/commands', () => {
     })
   })
 
+  // Mirrors the serialized log shapes the driver emits for network commands:
+  // a cy.intercept registration is bucketed under `routes` (instrument 'route'),
+  // while the stubbed request, real request, and cy.request are `commands`. Each
+  // carries its display detail on renderProps the way the reporter reads it, and
+  // createdAtTimestamp drives the merge back into the run order the reporter
+  // shows. r5 also holds an ordinary get to prove network fields stay absent on
+  // non-network rows.
+  const NETWORK_STATE = {
+    r5: {
+      id: 'r5',
+      title: 'exercises the network',
+      state: 'passed',
+      routes: [
+        {
+          id: 'log-int', name: 'route', state: 'passed', type: 'parent', createdAtTimestamp: 1,
+          instrument: 'route', method: 'GET', url: '/api/users',
+          isStubbed: true, numResponses: 1, alias: 'getUsers', status: 200,
+          message: undefined, renderProps: {},
+        },
+      ],
+      commands: [
+        {
+          id: 'log-real', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 3,
+          displayName: 'xhr', message: '', method: 'POST', url: 'http://localhost:2121/track',
+          renderProps: {
+            indicator: 'bad', message: 'POST 500 /track', wentToOrigin: true, interceptions: [],
+          },
+        },
+        {
+          id: 'log-stub', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 4,
+          displayName: 'fetch', message: '', method: 'GET',
+          url: 'http://localhost:2121/api/users', alias: 'getUsers', aliasType: 'route',
+          renderProps: {
+            indicator: 'successful', message: 'GET 200 /api/users',
+            wentToOrigin: false,
+            interceptions: [{ command: 'intercept', alias: 'getUsers', type: 'stub' }],
+          },
+        },
+        { id: 'log-get', name: 'get', message: '#user', state: 'passed', type: 'parent', createdAtTimestamp: 5, url: 'http://localhost:2121/' },
+        {
+          id: 'log-req', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 6,
+          message: '', url: 'http://localhost:2121/',
+          renderProps: { indicator: 'successful', message: 'GET 200 /api/data' },
+        },
+      ],
+    },
+  }
+
+  it('merges intercept routes into the command log and surfaces high-level network info, leaving ordinary rows unchanged', async () => {
+    stubRunner({ getTestState: (id: string) => NETWORK_STATE[id] })
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('commands', {}, { test: 'r5' })
+
+    // The route registration (from `routes`) sorts to the front by timestamp,
+    // ahead of the request rows it later matches.
+    expect(outcome).to.deep.eq({
+      result: [
+        {
+          id: 'log-int', name: 'route', state: 'passed', type: 'parent',
+          network: { method: 'GET', url: '/api/users', status: 200, stubbed: true, numResponses: 1, alias: 'getUsers' },
+        },
+        {
+          id: 'log-real', name: 'request', message: 'POST 500 /track', state: 'passed', type: 'parent',
+          network: { method: 'POST', url: 'http://localhost:2121/track', indicator: 'bad', stubbed: false },
+        },
+        {
+          id: 'log-stub', name: 'request', message: 'GET 200 /api/users', state: 'passed', type: 'parent',
+          network: { method: 'GET', url: 'http://localhost:2121/api/users', indicator: 'successful', stubbed: true, alias: 'getUsers' },
+        },
+        // The page URL on an ordinary get is not a request URL, so no network object.
+        { id: 'log-get', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+        // cy.request never sets a top-level method/request URL, so those stay in
+        // the display message; only the status indicator is a structured field.
+        {
+          id: 'log-req', name: 'request', message: 'GET 200 /api/data', state: 'passed', type: 'parent',
+          network: { indicator: 'successful' },
+        },
+      ],
+    })
+
+    expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+  })
+
   it('drops command fields nulled by the driver’s memory cleanup and marks the entry cleanedUp', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id] })
 

--- a/packages/app/src/tap/commands/commands.cy.ts
+++ b/packages/app/src/tap/commands/commands.cy.ts
@@ -14,7 +14,7 @@ describe('tap/commands/commands', () => {
       state: 'passed',
       commands: [
         { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent', displayName: 'visit', hookId: 'h1' },
-        { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+        { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent', hookId: 'r2' },
       ],
       prevAttempts: [
         {
@@ -94,10 +94,12 @@ describe('tap/commands/commands', () => {
 
     expect(getTestState).to.have.been.calledOnceWith('r2')
 
+    // Ids are the reporter's own numbers, counted per hook section — the visit
+    // (before-each) and the get (test body) are each row 1 of their section.
     expect(outcome).to.deep.eq({
       result: [
-        { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
-        { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+        { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
+        { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent' },
       ],
     })
   })
@@ -124,14 +126,14 @@ describe('tap/commands/commands', () => {
       ],
       commands: [
         {
-          id: 'log-real', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 3,
+          id: 'log-real', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 3, event: true,
           displayName: 'xhr', message: '', method: 'POST', url: 'http://localhost:2121/track',
           renderProps: {
             indicator: 'bad', message: 'POST 500 /track', wentToOrigin: true, interceptions: [],
           },
         },
         {
-          id: 'log-stub', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 4,
+          id: 'log-stub', name: 'request', state: 'passed', type: 'parent', createdAtTimestamp: 4, event: true,
           displayName: 'fetch', message: '', method: 'GET',
           url: 'http://localhost:2121/api/users', alias: 'getUsers', aliasType: 'route',
           renderProps: {
@@ -158,27 +160,29 @@ describe('tap/commands/commands', () => {
     const outcome = await manager.exec('commands', {}, { test: 'r5' })
 
     // The route registration (from `routes`) sorts to the front by timestamp,
-    // ahead of the request rows it later matches.
+    // ahead of the request rows it later matches — but routes aren't commands,
+    // so it carries no id. The proxy request rows are events, taking `e` ids;
+    // the ordinary get and the cy.request are the numbered rows.
     expect(outcome).to.deep.eq({
       result: [
         {
-          id: 'log-int', name: 'route', state: 'passed', type: 'parent',
+          name: 'route', state: 'passed', type: 'parent',
           network: { method: 'GET', url: '/api/users', status: 200, stubbed: true, numResponses: 1, alias: 'getUsers' },
         },
         {
-          id: 'log-real', name: 'request', message: 'POST 500 /track', state: 'passed', type: 'parent',
+          id: 'e1', name: 'request', message: 'POST 500 /track', state: 'passed', type: 'parent',
           network: { method: 'POST', url: 'http://localhost:2121/track', indicator: 'bad', stubbed: false },
         },
         {
-          id: 'log-stub', name: 'request', message: 'GET 200 /api/users', state: 'passed', type: 'parent',
+          id: 'e2', name: 'request', message: 'GET 200 /api/users', state: 'passed', type: 'parent',
           network: { method: 'GET', url: 'http://localhost:2121/api/users', indicator: 'successful', stubbed: true, alias: 'getUsers' },
         },
         // The page URL on an ordinary get is not a request URL, so no network object.
-        { id: 'log-get', name: 'get', message: '#user', state: 'passed', type: 'parent' },
+        { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent' },
         // cy.request never sets a top-level method/request URL, so those stay in
         // the display message; only the status indicator is a structured field.
         {
-          id: 'log-req', name: 'request', message: 'GET 200 /api/data', state: 'passed', type: 'parent',
+          id: '2', name: 'request', message: 'GET 200 /api/data', state: 'passed', type: 'parent',
           network: { indicator: 'successful' },
         },
       ],
@@ -196,7 +200,7 @@ describe('tap/commands/commands', () => {
 
     expect(outcome).to.deep.eq({
       result: [
-        { id: 'log-c', name: 'visit', state: 'passed', type: 'parent', cleanedUp: true },
+        { id: '1', name: 'visit', state: 'passed', type: 'parent', cleanedUp: true },
       ],
     })
   })
@@ -206,10 +210,12 @@ describe('tap/commands/commands', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
+    // Ids are per attempt, so the failed first attempt numbers from 1 again
+    // (its two rows share a section, unlike the latest attempt's).
     expect(await manager.exec('commands', {}, { test: 'r2', attempt: '1' })).to.deep.eq({
       result: [
-        { id: 'log-a', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
-        { id: 'log-b', name: 'get', message: '#user', state: 'failed', type: 'parent' },
+        { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
+        { id: '2', name: 'get', message: '#user', state: 'failed', type: 'parent' },
       ],
     })
 

--- a/packages/app/src/tap/commands/index.ts
+++ b/packages/app/src/tap/commands/index.ts
@@ -1,6 +1,7 @@
 import { commandsCommand } from './commands'
 import type { TapCommandDefinition } from './definition'
 import { pinCommand } from './pin'
+import { reporterCommand } from './reporter'
 import { runStateCommand } from './run-state'
 import { testsCommand } from './tests'
 import type { TapCommandName } from '../contract'
@@ -13,6 +14,7 @@ import type { TapCommandName } from '../contract'
 export const tapCommands: { [K in TapCommandName]: TapCommandDefinition & { name: K } } = {
   tests: testsCommand,
   commands: commandsCommand,
+  reporter: reporterCommand,
   pin: pinCommand,
   'run-state': runStateCommand,
 }

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -486,4 +486,66 @@ describe('tap/commands/pin', () => {
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_UNAVAILABLE')
   })
+
+  // Per-attempt ids restart from 1, so command `1` names a different log on each
+  // attempt; --attempt must pick the right one (defaulting to the latest) rather
+  // than always resolving against the latest and pinning the wrong snapshot.
+  const RETRIED_STATE = {
+    r6: {
+      id: 'r6',
+      title: 'flakes then passes',
+      state: 'passed',
+      prevAttempts: [
+        { id: 'r6', state: 'failed', commands: [{ id: 'log-a1', name: 'get', message: '#first-try', state: 'failed', type: 'parent', hookId: 'r6' }] },
+      ],
+      commands: [{ id: 'log-a2', name: 'get', message: '#retry', state: 'passed', type: 'parent', hookId: 'r6' }],
+    },
+  }
+
+  const stubRetriedSource = () => {
+    return stubSource({ runner: {
+      getTestState: (id: string) => RETRIED_STATE[id as keyof typeof RETRIED_STATE],
+      getSnapshotPropsForLog: () => SNAPSHOT_PROPS,
+    } })
+  }
+
+  it('resolves command ids against the latest attempt by default', async () => {
+    const { pinSnapshot } = stubRetriedSource()
+
+    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' })
+
+    expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a2')
+  })
+
+  it('resolves command ids against the attempt named by --attempt', async () => {
+    const { pinSnapshot } = stubRetriedSource()
+
+    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' }, { attempt: '1' })
+
+    expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a1')
+  })
+
+  it('fails with ATTEMPT_NOT_FOUND when --attempt is out of range', async () => {
+    const { pinSnapshot } = stubRetriedSource()
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' }, { attempt: '5' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
+    expect(pinSnapshot).not.to.have.been.called
+  })
+
+  it('re-pinning the same command id on a different attempt starts a fresh pin, not a move', async () => {
+    const { pinSnapshot, changeSnapshotState, detachDom } = stubRetriedSource()
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    await manager.exec('pin', { test: 'r6', command: '1' }, { attempt: '1' })
+    await manager.exec('pin', { test: 'r6', command: '1' }, { attempt: '2' })
+
+    expect(detachDom).to.have.been.calledOnce
+    expect(changeSnapshotState).not.to.have.been.called
+    expect(pinSnapshot).to.have.been.calledTwice
+    expect(pinSnapshot.firstCall.args[3]).to.eq('log-a1')
+    expect(pinSnapshot.secondCall.args[3]).to.eq('log-a2')
+  })
 })

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -51,11 +51,12 @@ describe('tap/commands/pin', () => {
   it('pins the last snapshot by default: captures the original, drives the app pin, listens for unpin', async () => {
     const { detachDom, pinSnapshot, onUnpinned, restoreDom } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
 
     expect(detachDom).to.have.been.calledOnce
     // Default --at is the last snapshot (the command's final state), index 1.
-    // The test/command ids are forwarded so the reporter can reflect the pin.
+    // The tap id '1' resolved to the driver log id, which is what the app pin
+    // and reporter key on.
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r2', 'log-1')
     expect(onUnpinned).to.have.been.calledOnce
     // The render goes through the app pin, so we never restore directly here.
@@ -63,7 +64,7 @@ describe('tap/commands/pin', () => {
 
     expect(outcome).to.deep.eq({
       result: {
-        pinned: { test: 'r2', command: 'log-1', at: { index: 2, name: 'after' } },
+        pinned: { test: 'r2', command: '1', at: { index: 2, name: 'after' } },
         url: 'http://localhost:8080/index.html',
       },
     })
@@ -74,7 +75,7 @@ describe('tap/commands/pin', () => {
   it('pins a named snapshot via --at', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' }, { at: 'before' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' }, { at: 'before' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 0, 'r2', 'log-1')
     expect((outcome as { result: any }).result.pinned.at).to.deep.eq({ index: 1, name: 'before' })
@@ -83,7 +84,7 @@ describe('tap/commands/pin', () => {
   it('fails with SNAPSHOT_NOT_FOUND when --at matches nothing, without touching the iframe', async () => {
     const { detachDom, pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' }, { at: 'during' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' }, { at: 'during' })
 
     expect(outcome).to.deep.eq({
       error: { code: 'SNAPSHOT_NOT_FOUND', message: 'no snapshot of this command matches "during" — available snapshots: "before" (1), "after" (2)' },
@@ -98,10 +99,10 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
-    const switched = await manager.exec('pin', { test: 'r2', command: 'log-2' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
+    const switched = await manager.exec('pin', { test: 'r2', command: '2' })
 
-    expect((switched as { result: any }).result.pinned.command).to.eq('log-2')
+    expect((switched as { result: any }).result.pinned.command).to.eq('2')
     // No re-capture and no second listener: the original DOM and unpin listener
     // from the first pin stand, so clearing still restores the true live app.
     expect(detachDom).to.have.been.calledOnce
@@ -118,11 +119,11 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
-    const failed = await manager.exec('pin', { test: 'r2', command: 'log-2' }, { at: 'during' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
+    const failed = await manager.exec('pin', { test: 'r2', command: '2' }, { at: 'during' })
 
     expect((failed as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
-    // The failed switch touched nothing — the log-1 pin is still live, proven by a
+    // The failed switch touched nothing — the '1' pin is still live, proven by a
     // clear that restores its captured DOM rather than a no-op.
     expect(detachDom).to.have.been.calledOnce
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -138,8 +139,8 @@ describe('tap/commands/pin', () => {
     const manager = new TapManager(CYPRESS_VERSION)
 
     // First pin lands on the last snapshot (index 1, "after").
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
-    const moved = await manager.exec('pin', { test: 'r2', command: 'log-1' }, { at: 'before' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
+    const moved = await manager.exec('pin', { test: 'r2', command: '1' }, { at: 'before' })
 
     // The move re-selects the snapshot in place: no second capture, no re-pin,
     // no new unpin listener — only a state switch to "before" (index 0).
@@ -149,7 +150,7 @@ describe('tap/commands/pin', () => {
     expect(changeSnapshotState).to.have.been.calledOnceWith(0)
 
     expect((moved as { result: any }).result.pinned).to.deep.eq({
-      test: 'r2', command: 'log-1', at: { index: 1, name: 'before' },
+      test: 'r2', command: '1', at: { index: 1, name: 'before' },
     })
   })
 
@@ -158,8 +159,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
-    const outcome = await manager.exec('pin', { test: 'r2', command: 'log-1' }, { at: 'during' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
+    const outcome = await manager.exec('pin', { test: 'r2', command: '1' }, { at: 'during' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
     // The pin never moved, so no state switch happened.
@@ -171,7 +172,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
 
     expect(restoreDom).to.have.been.calledOnceWith('ORIGINAL-DOM')
@@ -180,9 +181,9 @@ describe('tap/commands/pin', () => {
     expect(cleared).to.deep.eq({ result: { cleared: true } })
 
     // Pin state is released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
 
-    expect((outcome as { result: any }).result.pinned.command).to.eq('log-1')
+    expect((outcome as { result: any }).result.pinned.command).to.eq('1')
   })
 
   it('restores the captured DOM and drops the pin when the runner unpins externally (the ✕)', async () => {
@@ -190,7 +191,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
 
     // Fire the handler the pin registered, as the runner's ✕ unpin would.
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -202,9 +203,9 @@ describe('tap/commands/pin', () => {
     expect(unpinSnapshot).not.to.have.been.called
 
     // The pin is released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
 
-    expect((outcome as { result: any }).result.pinned.command).to.eq('log-1')
+    expect((outcome as { result: any }).result.pinned.command).to.eq('1')
   })
 
   it('drops the pin without restoring when --clear arrives while a spec is running', async () => {
@@ -212,7 +213,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     isRunning.returns(true)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -229,7 +230,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     getRunner.returns(undefined)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -245,7 +246,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     isRunning.returns(true)
 
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -260,7 +261,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     getRunner.returns(undefined)
 
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -277,11 +278,11 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
 
     const outcome = await manager.exec('run-state')
 
-    expect((outcome as { result: any }).result.pinned).to.deep.eq({ command: 'log-1', at: { index: 2, name: 'after' } })
+    expect((outcome as { result: any }).result.pinned).to.deep.eq({ command: '1', at: { index: 2, name: 'after' } })
   })
 
   it('run-state omits the pin while there is no runner to verify it against (runner being replaced)', async () => {
@@ -290,7 +291,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
 
     expect(await manager.exec('run-state')).to.deep.eq({ result: { spec: null, totalSpecs: 0 } })
   })
@@ -322,7 +323,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
     expect(pinSnapshot).to.have.been.calledOnce // the pin was rendered via the app pin
 
     // Simulate a re-run: the command id is reused, but its snapshots are fresh
@@ -353,7 +354,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    await manager.exec('pin', { test: 'r2', command: '1' })
 
     // Simulate a re-run: the command id is reused, but its snapshots are fresh
     // objects — the captured DOM now belongs to the dead run.
@@ -368,9 +369,9 @@ describe('tap/commands/pin', () => {
     expect(restoreDom).not.to.have.been.called // never a stale restore over the live AUT
 
     // The stale pin was released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
 
-    expect((outcome as { result: any }).result.pinned.command).to.eq('log-1')
+    expect((outcome as { result: any }).result.pinned.command).to.eq('1')
   })
 
   it('requires a test and command (or --clear) before attempting a pin', async () => {
@@ -387,7 +388,7 @@ describe('tap/commands/pin', () => {
   it('fails with NO_RUN when no runner has mounted', async () => {
     stubSource({ runner: undefined })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('NO_RUN')
   })
@@ -395,7 +396,7 @@ describe('tap/commands/pin', () => {
   it('refuses to pin while a spec is running', async () => {
     stubSource({ running: true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('RUN_IN_PROGRESS')
   })
@@ -405,8 +406,74 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    expect((await manager.exec('pin', { test: 'nope', command: 'log-1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
-    expect((await manager.exec('pin', { test: 'r2', command: 'log-9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
+    expect((await manager.exec('pin', { test: 'nope', command: '1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+    expect((await manager.exec('pin', { test: 'r2', command: '9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
+  })
+
+  // Numbers restart per hook section, so a plain handle can be duplicated —
+  // resolution prefers the test body, accepts a `<hookId>:<number>` qualifier,
+  // and refuses to guess between hooks.
+  const HOOKED_STATE = {
+    r5: {
+      id: 'r5',
+      title: 'with hooks',
+      state: 'passed',
+      timings: { 'before each': [{ hookId: 'h1' }, { hookId: 'h2' }], test: { fnDuration: 1 } },
+      commands: [
+        { id: 'log-h1a', name: 'visit', message: '/a', state: 'passed', type: 'parent', hookId: 'h1' },
+        { id: 'log-h1b', name: 'get', message: '#a', state: 'passed', type: 'parent', hookId: 'h1' },
+        { id: 'log-h2a', name: 'visit', message: '/b', state: 'passed', type: 'parent', hookId: 'h2' },
+        { id: 'log-h2b', name: 'get', message: '#b', state: 'passed', type: 'parent', hookId: 'h2' },
+        { id: 'log-t1', name: 'get', message: '#x', state: 'passed', type: 'parent', hookId: 'r5' },
+      ],
+    },
+  }
+
+  const stubHookedSource = () => {
+    return stubSource({ runner: {
+      getTestState: (id: string) => HOOKED_STATE[id as keyof typeof HOOKED_STATE],
+      getSnapshotPropsForLog: () => SNAPSHOT_PROPS,
+    } })
+  }
+
+  it('resolves a duplicated plain number to the test body row', async () => {
+    const { pinSnapshot } = stubHookedSource()
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: '1' })
+
+    expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-t1')
+    expect((outcome as { result: any }).result.pinned.command).to.eq('1')
+  })
+
+  it('resolves a hook-qualified handle to that section’s row', async () => {
+    const { pinSnapshot } = stubHookedSource()
+
+    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: 'h2:1' })
+
+    expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-h2a')
+  })
+
+  it('refuses to guess between hooks: a number duplicated outside the test body is AMBIGUOUS_COMMAND', async () => {
+    const { pinSnapshot } = stubHookedSource()
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: '2' })
+
+    expect(outcome).to.deep.eq({
+      error: {
+        code: 'AMBIGUOUS_COMMAND',
+        message: '"2" matches h1:2 (before each) and h2:2 (before each) — qualify the id with its section, e.g. "h1:2"',
+      },
+    })
+
+    expect(pinSnapshot).not.to.have.been.called
+  })
+
+  it('fails with COMMAND_NOT_FOUND for a qualifier that matches no section', async () => {
+    stubHookedSource()
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: 'h9:1' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
   })
 
   it('fails with SNAPSHOT_UNAVAILABLE when the command has no snapshot', async () => {
@@ -415,7 +482,7 @@ describe('tap/commands/pin', () => {
       getSnapshotPropsForLog: () => ({ snapshots: null }),
     } })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: 'log-1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_UNAVAILABLE')
   })

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -1,5 +1,5 @@
 import { defineCommand, TapCommandError } from './definition'
-import { attemptSelectionError, selectTestAttempt, serializeTestCommands } from '../test-state'
+import { attemptSelectionError, resolveCommandLogId, selectTestAttempt } from '../test-state'
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import type { PinSnapshotEntry, PinSnapshotProps, PinSnapshotRunner } from '../types'
 
@@ -20,6 +20,9 @@ export interface ClearResult {
 interface PinnedState {
   test: string
   command: string
+  // The driver's log id behind the tap command id — what the runner's
+  // snapshot APIs key on.
+  logId: string
   at: SnapshotRef
   original: unknown
   snapshot: PinSnapshotEntry
@@ -73,7 +76,7 @@ export const reconcilePin = (runner: PinSnapshotRunner): void => {
     return
   }
 
-  const stillLive = liveSnapshots(runner.getSnapshotPropsForLog(pinned.test, pinned.command)).includes(pinned.snapshot)
+  const stillLive = liveSnapshots(runner.getSnapshotPropsForLog(pinned.test, pinned.logId)).includes(pinned.snapshot)
 
   if (!stillLive) {
     releasePin()
@@ -112,7 +115,7 @@ const resolveAt = (snapshots: PinSnapshotEntry[], at: string | undefined): numbe
 
 const movePin = (runner: PinSnapshotRunner, at: string | undefined): PinResult => {
   const current = pinned!
-  const props = runner.getSnapshotPropsForLog(current.test, current.command)
+  const props = runner.getSnapshotPropsForLog(current.test, current.logId)
   const snapshots = liveSnapshots(props)
   const index = resolveAt(snapshots, at)
 
@@ -181,13 +184,13 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
     throw attemptSelectionError(selection, test)
   }
 
-  const commands = serializeTestCommands(selection.attempt)
+  const logId = resolveCommandLogId(selection.attempt, command, test)
 
-  if (!commands.some((entry) => entry.id === command)) {
+  if (logId === undefined) {
     throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the commands command to list this test’s commands`)
   }
 
-  const props = runner.getSnapshotPropsForLog(test, command)
+  const props = runner.getSnapshotPropsForLog(test, logId)
   const snapshots = liveSnapshots(props)
 
   if (snapshots.length === 0) {
@@ -204,7 +207,7 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
 
   const original = pinned ? pinned.original : autIframe.detachDom()
 
-  tapManagerDataSource.pinSnapshot({ ...props, snapshots }, index, test, command)
+  tapManagerDataSource.pinSnapshot({ ...props, snapshots }, index, test, logId)
 
   if (!pinned) {
     stopListeningForUnpin = tapManagerDataSource.onSnapshotUnpinned(onExternalUnpin)
@@ -212,7 +215,7 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
 
   const at_ = toRef(snapshots[index], index)
 
-  pinned = { test, command, at: at_, original, snapshot: snapshots[index] }
+  pinned = { test, command, logId, at: at_, original, snapshot: snapshots[index] }
 
   return {
     pinned: { test, command, at: at_ },

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -20,6 +20,10 @@ export interface ClearResult {
 interface PinnedState {
   test: string
   command: string
+  // The attempt the command id was resolved against — part of the pin's
+  // identity, since per-attempt ids restart from 1 and the same number names
+  // a different command on another attempt.
+  attempt: number | undefined
   // The driver's log id behind the tap command id — what the runner's
   // snapshot APIs key on.
   logId: string
@@ -145,7 +149,7 @@ const clearPin = (): ClearResult => {
   return { cleared: true }
 }
 
-export const pinCommand = defineCommand('pin', async ({ test, command }, { at, clear }): Promise<PinResult | ClearResult> => {
+export const pinCommand = defineCommand('pin', async ({ test, command }, { at, clear, attempt }): Promise<PinResult | ClearResult> => {
   const runner = tapManagerDataSource.getSnapshotRunner()
 
   if (runner) {
@@ -174,11 +178,11 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
     throw new TapCommandError('RUN_IN_PROGRESS', 'a spec is currently running — wait for it to finish before pinning a snapshot')
   }
 
-  if (pinned && pinned.test === test && pinned.command === command) {
+  if (pinned && pinned.test === test && pinned.command === command && pinned.attempt === attempt) {
     return movePin(runner, at)
   }
 
-  const selection = selectTestAttempt(runner, test)
+  const selection = selectTestAttempt(runner, test, attempt)
 
   if ('error' in selection) {
     throw attemptSelectionError(selection, test)
@@ -215,7 +219,7 @@ export const pinCommand = defineCommand('pin', async ({ test, command }, { at, c
 
   const at_ = toRef(snapshots[index], index)
 
-  pinned = { test, command, logId, at: at_, original, snapshot: snapshots[index] }
+  pinned = { test, command, attempt, logId, at: at_, original, snapshot: snapshots[index] }
 
   return {
     pinned: { test, command, at: at_ },

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -108,6 +108,15 @@ describe('tap/commands/reporter', () => {
         'after all': [{ hookId: 'h-aa', fnDuration: 3, afterFnDuration: 1 }],
       },
     },
+    // A non-Error throw (`throw { message: 42 }`): the error fields aren't
+    // strings, so they must not reach the wire — the CLI renderer treats them
+    // as strings (e.g. message.split).
+    r6: {
+      id: 'r6',
+      title: 'throws a non-error',
+      state: 'failed',
+      err: { name: 500, message: 42, stack: { frames: [] } },
+    },
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
@@ -210,6 +219,14 @@ describe('tap/commands/reporter', () => {
         frame: '> 12 |   expect(1).to.eq(2)\n',
       },
     })
+  })
+
+  it('drops non-string error fields from a non-Error throw', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r6' })
+
+    expect((outcome as { result: { error: Record<string, unknown> } }).result.error).to.deep.eq({})
   })
 
   it('reports an unreached test with empty collections and just the test-body pseudo-hook', async () => {

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -1,0 +1,172 @@
+import { tapManagerDataSource } from '../tap-manager-data-source'
+import { TapManager } from '../tap-manager'
+
+const CYPRESS_VERSION = '15.0.0'
+
+describe('tap/commands/reporter', () => {
+  // Mirrors the serialized shapes the driver emits: hook runs recorded under
+  // their hook name in `timings`, cy.intercept registrations bucketed under
+  // `routes`, and commands carrying the display-level attrs the reporter panel
+  // reads (hookId, displayName, event, group/groupLevel, renderProps). Extra
+  // attrs (chainerId, timeout) prove the serializer keeps only the typed fields.
+  const TESTS_STATE = {
+    r2: {
+      id: 'r2',
+      title: 'loads users',
+      _titlePath: ['Users', 'loads users'],
+      state: 'passed',
+      timings: {
+        lifecycle: 30,
+        'before each': [{ hookId: 'h1', fnDuration: 5, afterFnDuration: 1 }],
+        test: { fnDuration: 20, afterFnDuration: 1 },
+      },
+      routes: [
+        {
+          id: 'log-int', name: 'route', state: 'pending', instrument: 'route',
+          method: 'GET', url: '**/api/users', isStubbed: true, status: 200,
+          numResponses: 1, alias: 'getUsers', chainerId: 'ch1',
+        },
+      ],
+      commands: [
+        { id: 'log-1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1', event: false, timeout: 4000 },
+        { id: 'log-2', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2', event: false },
+        {
+          id: 'log-3', name: 'request', displayName: 'xhr', state: 'passed', type: 'parent', hookId: 'r2',
+          event: true, message: '',
+          renderProps: {
+            indicator: 'successful', message: 'GET 200 /api/users', wentToOrigin: false,
+            interceptions: [{ command: 'intercept', alias: 'getUsers', type: 'stub' }],
+          },
+          method: 'GET', url: 'http://localhost:2121/api/users', alias: 'getUsers',
+        },
+        { id: 'log-4', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: 'log-2', groupLevel: 1 },
+      ],
+    },
+    r3: {
+      id: 'r3',
+      title: 'never ran',
+    },
+    // A failed test: err carries messaging fields plus a code frame; extras on
+    // both (parsedStack, absoluteFile, language) prove the error serializes down
+    // to the typed panel fields.
+    r4: {
+      id: 'r4',
+      title: 'fails',
+      state: 'failed',
+      commands: [
+        { id: 'log-f', name: 'assert', message: 'expected **1** to eq **2**', state: 'failed', type: 'child', hookId: 'r4' },
+      ],
+      err: {
+        name: 'AssertionError',
+        message: 'expected 1 to eq 2',
+        stack: 'AssertionError: expected 1 to eq 2\n  at <anonymous>',
+        parsedStack: [{ line: 3 }],
+        codeFrame: {
+          line: 12,
+          column: 8,
+          relativeFile: 'cypress/e2e/fails.cy.js',
+          absoluteFile: '/projects/app/cypress/e2e/fails.cy.js',
+          frame: '> 12 |   expect(1).to.eq(2)\n',
+          language: 'js',
+        },
+      },
+    },
+  }
+
+  // The spec's own window.Cypress is the instance running this test, so stub
+  // the runner seam rather than replace it.
+  const stubRunner = (runner: unknown) => cy.stub(tapManagerDataSource, 'getRunner').returns(runner)
+
+  it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
+    stubRunner(undefined)
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r2' })
+
+    expect(outcome).to.deep.eq({
+      error: {
+        code: 'NO_RUN',
+        message: 'no spec has been run yet — use the run command to run a spec first',
+      },
+    })
+  })
+
+  it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
+    stubRunner({ getTestState: () => undefined, isRunComplete: () => false })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'nope' })
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+  })
+
+  it('fails dispatch without reading the runner when the required test option is missing', async () => {
+    const getRunner = stubRunner({ getTestState: () => undefined, isRunComplete: () => false })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+
+    expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect(getRunner).not.to.have.been.called
+  })
+
+  it('returns the full reporter view: test header, hooks with a synthesized test body, routes, and enriched commands', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => false })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r2' })
+
+    expect(outcome).to.deep.eq({
+      result: {
+        test: { id: 'r2', title: 'loads users', fullTitle: 'Users > loads users', state: 'passed' },
+        hooks: [
+          { hookId: 'h1', hookName: 'before each' },
+          { hookId: 'r2', hookName: 'test body' },
+        ],
+        routes: [
+          { id: 'log-int', method: 'GET', url: '**/api/users', stubbed: true, status: 200, numResponses: 1, alias: 'getUsers' },
+        ],
+        commands: [
+          { id: 'log-1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1' },
+          { id: 'log-2', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2' },
+          {
+            id: 'log-3', name: 'request', displayName: 'xhr', message: 'GET 200 /api/users', state: 'passed', type: 'parent', hookId: 'r2', event: true,
+            network: { method: 'GET', url: 'http://localhost:2121/api/users', indicator: 'successful', stubbed: true, alias: 'getUsers' },
+          },
+          { id: 'log-4', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: 'log-2', groupLevel: 1 },
+        ],
+      },
+    })
+
+    expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+  })
+
+  it('carries a failed attempt’s error panel — messaging fields and code frame, extras trimmed', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r4' })
+
+    expect((outcome as { result: Record<string, unknown> }).result.error).to.deep.eq({
+      name: 'AssertionError',
+      message: 'expected 1 to eq 2',
+      stack: 'AssertionError: expected 1 to eq 2\n  at <anonymous>',
+      codeFrame: {
+        file: 'cypress/e2e/fails.cy.js',
+        line: 12,
+        column: 8,
+        frame: '> 12 |   expect(1).to.eq(2)\n',
+      },
+    })
+  })
+
+  it('reports an unreached test with empty collections and just the test-body pseudo-hook', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r3' })
+
+    expect(outcome).to.deep.eq({
+      result: {
+        test: { id: 'r3', title: 'never ran', fullTitle: 'never ran', state: 'skipped' },
+        hooks: [{ hookId: 'r3', hookName: 'test body' }],
+        routes: [],
+        commands: [],
+      },
+    })
+  })
+})

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -22,24 +22,46 @@ describe('tap/commands/reporter', () => {
       },
       routes: [
         {
-          id: 'log-int', name: 'route', state: 'pending', instrument: 'route',
+          id: 'log-int', name: 'route', state: 'pending', instrument: 'route', createdAtTimestamp: 2,
           method: 'GET', url: '**/api/users', isStubbed: true, status: 200,
           numResponses: 1, alias: 'getUsers', chainerId: 'ch1',
         },
       ],
+      // The agents bucket mirrors the driver's serialized `instrument: 'agent'`
+      // logs — the SPIES / STUBS panel, apart from the command log.
+      agents: [
+        {
+          id: 'log-agent', name: 'spy-1', instrument: 'agent', functionName: 'beep',
+          alias: 'beep', aliasType: 'agent', callCount: 2, count: 1,
+        },
+      ],
       commands: [
-        { id: 'log-1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1', event: false, timeout: 4000 },
-        { id: 'log-2', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2', event: false },
+        { id: 'log-1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1', event: false, timeout: 4000, createdAtTimestamp: 1 },
+        { id: 'log-2', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2', event: false, createdAtTimestamp: 3 },
         {
           id: 'log-3', name: 'request', displayName: 'xhr', state: 'passed', type: 'parent', hookId: 'r2',
-          event: true, message: '',
+          event: true, message: '', createdAtTimestamp: 4,
           renderProps: {
             indicator: 'successful', message: 'GET 200 /api/users', wentToOrigin: false,
             interceptions: [{ command: 'intercept', alias: 'getUsers', type: 'stub' }],
           },
           method: 'GET', url: 'http://localhost:2121/api/users', alias: 'getUsers',
         },
-        { id: 'log-4', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: 'log-2', groupLevel: 1 },
+        { id: 'log-4', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: 'log-2', groupLevel: 1, createdAtTimestamp: 5 },
+        // A cy.session group log: an ordinary command carrying sessionInfo — the
+        // driver has no session instrument, this is what feeds the SESSIONS panel.
+        {
+          id: 'log-5', name: 'session', message: 'user-1', state: 'passed', type: 'parent', hookId: 'r2', createdAtTimestamp: 6,
+          sessionInfo: { id: 'user-1', isGlobalSession: true, status: 'restored' },
+        },
+        {
+          id: 'log-6', name: 'spy-1', displayName: 'spy-1', message: 'beep()', state: 'passed', type: 'parent', hookId: 'r2',
+          event: true, createdAtTimestamp: 7, alias: ['beep'], aliasType: 'agent',
+        },
+        {
+          id: 'log-7', name: 'wait', message: '@getUsers', state: 'passed', type: 'parent', hookId: 'r2', createdAtTimestamp: 8,
+          referencesAlias: [{ name: 'getUsers', cardinal: 1, ordinal: '1st' }], aliasType: 'route',
+        },
       ],
     },
     r3: {
@@ -119,17 +141,37 @@ describe('tap/commands/reporter', () => {
           { hookId: 'h1', hookName: 'before each' },
           { hookId: 'r2', hookName: 'test body' },
         ],
+        // Ids are the reporter's own numbers, counted per hook section, while
+        // event rows take the attempt-wide `e` sequence; the route registration
+        // isn't a command, so it carries no id, and the group reference is
+        // remapped into the same id space.
+        sessions: [
+          { name: 'user-1', status: 'restored', global: true },
+        ],
+        agents: [
+          { type: 'spy-1', functionName: 'beep', aliases: ['beep'], callCount: 2 },
+        ],
         routes: [
-          { id: 'log-int', method: 'GET', url: '**/api/users', stubbed: true, status: 200, numResponses: 1, alias: 'getUsers' },
+          { method: 'GET', url: '**/api/users', stubbed: true, status: 200, numResponses: 1, alias: 'getUsers' },
         ],
         commands: [
-          { id: 'log-1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1' },
-          { id: 'log-2', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2' },
+          { id: '1', name: 'visit', message: '/users', state: 'passed', type: 'parent', hookId: 'h1' },
+          { id: '1', name: 'get', message: '#list', state: 'passed', type: 'parent', hookId: 'r2' },
           {
-            id: 'log-3', name: 'request', displayName: 'xhr', message: 'GET 200 /api/users', state: 'passed', type: 'parent', hookId: 'r2', event: true,
+            id: 'e1', name: 'request', displayName: 'xhr', message: 'GET 200 /api/users', state: 'passed', type: 'parent', hookId: 'r2', event: true,
+            aliases: ['getUsers'],
             network: { method: 'GET', url: 'http://localhost:2121/api/users', indicator: 'successful', stubbed: true, alias: 'getUsers' },
           },
-          { id: 'log-4', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: 'log-2', groupLevel: 1 },
+          { id: '2', name: 'session-group', message: 'user', state: 'passed', type: 'parent', hookId: 'r2', group: '1', groupLevel: 1 },
+          { id: '3', name: 'session', message: 'user-1', state: 'passed', type: 'parent', hookId: 'r2' },
+          {
+            id: 'e2', name: 'spy-1', displayName: 'spy-1', message: 'beep()', state: 'passed', type: 'parent', hookId: 'r2', event: true,
+            aliases: ['beep'], aliasType: 'agent',
+          },
+          {
+            id: '4', name: 'wait', message: '@getUsers', state: 'passed', type: 'parent', hookId: 'r2',
+            referencedAliases: ['getUsers'], aliasType: 'route',
+          },
         ],
       },
     })
@@ -164,6 +206,8 @@ describe('tap/commands/reporter', () => {
       result: {
         test: { id: 'r3', title: 'never ran', fullTitle: 'never ran', state: 'skipped' },
         hooks: [{ hookId: 'r3', hookName: 'test body' }],
+        sessions: [],
+        agents: [],
         routes: [],
         commands: [],
       },

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -93,6 +93,21 @@ describe('tap/commands/reporter', () => {
         },
       },
     },
+    // Ran the full hook lifecycle: the driver records each hook under its name
+    // in `timings` in run order, so the test body belongs between the `before`
+    // and `after` hooks.
+    r5: {
+      id: 'r5',
+      title: 'full lifecycle',
+      state: 'passed',
+      timings: {
+        'before all': [{ hookId: 'h-ba', fnDuration: 3, afterFnDuration: 1 }],
+        'before each': [{ hookId: 'h-be', fnDuration: 3, afterFnDuration: 1 }],
+        test: { fnDuration: 20, afterFnDuration: 1 },
+        'after each': [{ hookId: 'h-ae', fnDuration: 3, afterFnDuration: 1 }],
+        'after all': [{ hookId: 'h-aa', fnDuration: 3, afterFnDuration: 1 }],
+      },
+    },
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
@@ -212,5 +227,19 @@ describe('tap/commands/reporter', () => {
         commands: [],
       },
     })
+  })
+
+  it('orders the synthesized test body between the before and after hooks', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r5' })
+
+    expect((outcome as { result: { hooks: unknown } }).result.hooks).to.deep.eq([
+      { hookId: 'h-ba', hookName: 'before all' },
+      { hookId: 'h-be', hookName: 'before each' },
+      { hookId: 'r5', hookName: 'test body' },
+      { hookId: 'h-ae', hookName: 'after each' },
+      { hookId: 'h-aa', hookName: 'after all' },
+    ])
   })
 })

--- a/packages/app/src/tap/commands/reporter.ts
+++ b/packages/app/src/tap/commands/reporter.ts
@@ -1,0 +1,20 @@
+import { tapManagerDataSource } from '../tap-manager-data-source'
+import { defineCommand, TapCommandError } from './definition'
+import { attemptSelectionError, selectTestAttempt, serializeReporterView } from '../test-state'
+import type { TapReporterView } from '../contract'
+
+export const reporterCommand = defineCommand('reporter', async (_params, { test, attempt }): Promise<TapReporterView> => {
+  const runner = tapManagerDataSource.getRunner()
+
+  if (!runner) {
+    throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+  }
+
+  const selection = selectTestAttempt(runner, test, attempt)
+
+  if ('error' in selection) {
+    throw attemptSelectionError(selection, test)
+  }
+
+  return serializeReporterView(selection.test, selection.attempt, runner.isRunComplete())
+})

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -20,6 +20,8 @@ export type {
   TapCoercedOptions,
   TapSchema,
   TapExecResult,
+  TapNetworkInfo,
+  TapReporterView,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 // Reserved dispatch-level failure codes `exec` itself produces; domain failures

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -34,10 +34,15 @@ const cloneReferenceObject = <T>(value: T): T => {
   return typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value))
 }
 
-const serializeTestError = (err: Record<string, unknown>): TestError => {
-  const { name, message, stack } = err as TestError
+const asString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
 
-  return omitNullish({ name, message, stack })
+// A test can throw a non-Error (`throw { message: 42 }`), so keep name/message/
+// stack only when they're actually strings — the CLI renderer treats them as
+// such (e.g. `message.split('\n')`).
+const serializeTestError = (err: Record<string, unknown>): TestError => {
+  const { name, message, stack } = err
+
+  return omitNullish({ name: asString(name), message: asString(message), stack: asString(stack) })
 }
 
 const attemptsOf = (test: SerializedTest): SerializedTest[] => {

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -2,7 +2,8 @@ import type { SerializedCommandLog, SerializedTest } from '@packages/types'
 import { TapCommandError } from './commands/definition'
 import { omitNullish } from './utils'
 
-import type { CommandEntry, NetworkCommandInfo, TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from './types'
+import type { TapNetworkInfo, TapReporterView } from './contract'
+import type { CommandEntry, TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from './types'
 
 // A test with no final status state set yet was never reached: 'pending' while
 // the run is still going, 'skipped' once it is complete (matching the driver's
@@ -108,7 +109,7 @@ export const serializeTestDetail = (test: SerializedTest, attempt: SerializedTes
 // serializes) is where request/xhr/`cy.request` rows carry their display detail.
 interface NetworkRenderProps {
   message?: string
-  indicator?: NetworkCommandInfo['indicator']
+  indicator?: TapNetworkInfo['indicator']
   status?: string | number
   wentToOrigin?: boolean
   interceptions?: unknown[]
@@ -133,7 +134,7 @@ interface NetworkLog {
 // and request commands attach (a status `indicator`, or the `interceptions`
 // list) — rather than by name, since `cy.request` and proxy requests both log
 // as `request`.
-const serializeNetworkInfo = (command: SerializedCommandLog): NetworkCommandInfo | undefined => {
+const serializeNetworkInfo = (command: SerializedCommandLog): TapNetworkInfo | undefined => {
   const { instrument, method, url, isStubbed, numResponses, alias, status, renderProps } = command as NetworkLog
   const isRouteRow = instrument === 'route'
   const isRequestRow = renderProps?.indicator != null || Array.isArray(renderProps?.interceptions)
@@ -146,7 +147,7 @@ const serializeNetworkInfo = (command: SerializedCommandLog): NetworkCommandInfo
   // stubbed-vs-real fact as `wentToOrigin` on its renderProps.
   const stubbed = isStubbed ?? (renderProps?.wentToOrigin != null ? !renderProps.wentToOrigin : undefined)
 
-  const info = omitNullish<NetworkCommandInfo>({
+  const info = omitNullish<TapNetworkInfo>({
     method,
     // The base log defaults `url` to the page URL, so only a route matcher or a
     // real request's URL is a trustworthy request URL — `cy.request` never
@@ -204,6 +205,108 @@ export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] =
   .sort((a, b) => createdAt(a) - createdAt(b))
 
   return logs.map(serializeCommandEntry)
+}
+
+// The display-level slice of a log's attrs the reporter panel reads beyond the
+// lean CommandEntry fields.
+interface ReporterLog {
+  displayName?: string
+  hookId?: string
+  event?: boolean
+  group?: string
+  groupLevel?: number
+}
+
+const serializeReporterCommand = (command: SerializedCommandLog): TapReporterView['commands'][number] => {
+  const { id, name, message, state, type, _hasBeenCleanedUp } = command
+  const { displayName, hookId, event, group, groupLevel } = command as ReporterLog
+
+  const displayMessage = (command.renderProps as NetworkRenderProps | undefined)?.message ?? message
+
+  return omitNullish({
+    id,
+    name,
+    displayName,
+    message: displayMessage,
+    state,
+    type,
+    hookId,
+    // The driver defaults `event` to false on every command log; only true is signal.
+    event: event === true ? true : undefined,
+    group,
+    groupLevel,
+    network: serializeNetworkInfo(command),
+    cleanedUp: _hasBeenCleanedUp === true ? true : undefined,
+  })
+}
+
+const serializeReporterRoute = (log: SerializedCommandLog): TapReporterView['routes'][number] => {
+  const { id } = log
+  const { method, url, isStubbed, numResponses, alias, status } = log as NetworkLog
+
+  return omitNullish({
+    id,
+    method,
+    url,
+    stubbed: isStubbed,
+    status,
+    numResponses,
+    alias,
+  })
+}
+
+const serializeReporterHooks = (test: SerializedTest, attempt: SerializedTest): TapReporterView['hooks'] => {
+  // Suite-level hooks never serialize onto a test (the reporter unions them in
+  // from the runnables tree), but every hook that ran left its hookId under its
+  // hook name in the test's timings — derive the sections from there, in run
+  // order. Non-hook timings (`lifecycle`, `test`) aren't arrays, so they drop out.
+  const hooks = Object.entries(attempt.timings ?? {}).flatMap(([hookName, entries]) => {
+    return Array.isArray(entries)
+      ? (entries as Array<{ hookId: string }>).map(({ hookId }) => ({ hookId, hookName }))
+      : []
+  })
+
+  return [
+    ...hooks,
+    // The test's own commands carry its id as their hookId; the reporter
+    // synthesizes this same pseudo-hook to render them as the "test body".
+    { hookId: test.id, hookName: 'test body' },
+  ]
+}
+
+const serializeReporterError = (err: Record<string, unknown>): TapReporterView['error'] => {
+  const { codeFrame } = err as { codeFrame?: { relativeFile?: string, line?: number, column?: number, frame?: string } }
+
+  return omitNullish({
+    ...serializeTestError(err),
+    codeFrame: codeFrame != null
+      ? omitNullish({ file: codeFrame.relativeFile, line: codeFrame.line, column: codeFrame.column, frame: codeFrame.frame })
+      : undefined,
+  })
+}
+
+/**
+ * Everything the open-mode reporter renders for one test attempt: the ROUTES
+ * table (`cy.intercept` registrations, which the driver buckets under `routes`),
+ * the hook sections, the command log with its display-level fields
+ * (hook membership, event flag, grouping, network detail), and — when the
+ * attempt failed — the error panel with its code frame.
+ */
+export const serializeReporterView = (test: SerializedTest, attempt: SerializedTest, runComplete: boolean): TapReporterView => {
+  const titlePath = test._titlePath
+
+  return omitNullish({
+    test: {
+      id: test.id,
+      title: test.title,
+      fullTitle: Array.isArray(titlePath) ? titlePath.join(' > ') : test.title,
+      state: attempt.state ?? unreachedState(runComplete),
+    },
+    hooks: serializeReporterHooks(test, attempt),
+    routes: asCommandLogs(attempt.routes).map(serializeReporterRoute),
+    commands: asCommandLogs(attempt.commands).map(serializeReporterCommand),
+    error: attempt.err != null ? serializeReporterError(attempt.err) : undefined,
+  })
 }
 
 export interface RunResults {

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -170,8 +170,8 @@ const serializeNetworkInfo = (command: SerializedCommandLog): TapNetworkInfo | u
 // wire contract's optional fields absent-not-null. Its _hasBeenCleanedUp marker
 // is surfaced as `cleanedUp` so consumers can tell eviction apart from fields
 // that were never set.
-const serializeCommandEntry = (command: SerializedCommandLog): CommandEntry => {
-  const { id, name, message, state, type, _hasBeenCleanedUp } = command
+const serializeCommandEntry = (command: SerializedCommandLog, id: string | undefined): CommandEntry => {
+  const { name, message, state, type, _hasBeenCleanedUp } = command
 
   // Mirror the reporter's displayed row text: network rows leave the base
   // message empty and carry their summary (e.g. `GET 200 /api`) on renderProps.
@@ -196,15 +196,103 @@ const createdAt = (log: SerializedCommandLog): number => {
   return typeof log.createdAtTimestamp === 'number' ? log.createdAtTimestamp : 0
 }
 
-export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] => {
-  // The driver buckets cy.intercept registrations under `routes`, apart from
-  // `commands`, but the reporter shows both interleaved in one command log.
-  // Merge them back into the order the developer sees, keyed on each log's
-  // creation timestamp (stable for the timestamp-less rows in synthetic input).
-  const logs = [...asCommandLogs(attempt.commands), ...asCommandLogs(attempt.routes)]
+// The driver buckets cy.intercept registrations under `routes`, apart from
+// `commands`, but the reporter shows both interleaved in one command log.
+// Merge them back into the order the developer sees, keyed on each log's
+// creation timestamp (stable for the timestamp-less rows in synthetic input).
+const orderedAttemptLogs = (attempt: SerializedTest): SerializedCommandLog[] => {
+  return [...asCommandLogs(attempt.commands), ...asCommandLogs(attempt.routes)]
   .sort((a, b) => createdAt(a) - createdAt(b))
+}
 
-  return logs.map(serializeCommandEntry)
+const isRouteLog = (log: SerializedCommandLog): boolean => {
+  return (log as NetworkLog).instrument === 'route'
+}
+
+// The reporter's numbering rule (hook-model addCommand): event and system rows
+// are unnumbered annotations, everything else counts.
+const isNumberedLog = (log: SerializedCommandLog): boolean => {
+  const { event } = log as ReporterLog
+
+  return event !== true && log.type !== 'system'
+}
+
+// Tap command ids reproduce the numbers the app reporter shows: a per-hook
+// counter over the numbered rows (so `12` here is row 12 of that section in the
+// UI), derived at read time so every command that serializes or resolves an id
+// agrees by construction. The reporter leaves event/system rows unnumbered, so
+// those take an attempt-wide `e1`..`eN` of their own. Keyed by the driver's log
+// id. Route registrations aren't commands and stay id-less.
+const tapCommandIds = (logs: SerializedCommandLog[]): Map<string, string> => {
+  const ids = new Map<string, string>()
+  const hookCounters = new Map<string | undefined, number>()
+  let eventCount = 0
+
+  for (const log of logs) {
+    if (isRouteLog(log)) {
+      continue
+    }
+
+    if (isNumberedLog(log)) {
+      const { hookId } = log as ReporterLog
+      const number = (hookCounters.get(hookId) ?? 0) + 1
+
+      hookCounters.set(hookId, number)
+      ids.set(log.id, String(number))
+    } else {
+      ids.set(log.id, `e${++eventCount}`)
+    }
+  }
+
+  return ids
+}
+
+const hookIdOf = (log: SerializedCommandLog): string | undefined => (log as ReporterLog).hookId
+
+/**
+ * Resolves a command handle to the driver's log id. A handle is the row's id
+ * as displayed (`12` or `e3`), optionally qualified with its hook section
+ * (`h1:12`) since the reporter's numbers restart per section. A plain number
+ * prefers the test body, then a unique match anywhere; a remaining tie is
+ * ambiguous rather than silently guessed.
+ */
+export const resolveCommandLogId = (attempt: SerializedTest, tapId: string, testId: string): string | undefined => {
+  const logs = orderedAttemptLogs(attempt)
+  const ids = tapCommandIds(logs)
+  const colon = tapId.indexOf(':')
+  const hookQualifier = colon === -1 ? undefined : tapId.slice(0, colon)
+  const rowId = colon === -1 ? tapId : tapId.slice(colon + 1)
+
+  const candidates = logs.filter((log) => {
+    return ids.get(log.id) === rowId && (hookQualifier === undefined || hookIdOf(log) === hookQualifier)
+  })
+
+  if (candidates.length <= 1) {
+    return candidates[0]?.id
+  }
+
+  const testBody = candidates.find((log) => hookIdOf(log) === testId)
+
+  if (testBody) {
+    return testBody.id
+  }
+
+  const hookNames = new Map(attemptHooks(attempt).map(({ hookId, hookName }) => [hookId, hookName]))
+  const qualified = candidates.map((log) => {
+    const hookId = hookIdOf(log)
+    const hookName = hookId != null ? hookNames.get(hookId) : undefined
+
+    return `${hookId}:${rowId}${hookName ? ` (${hookName})` : ''}`
+  })
+
+  throw new TapCommandError('AMBIGUOUS_COMMAND', `"${tapId}" matches ${qualified.join(' and ')} — qualify the id with its section, e.g. "${qualified[0].split(' ')[0]}"`)
+}
+
+export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] => {
+  const logs = orderedAttemptLogs(attempt)
+  const ids = tapCommandIds(logs)
+
+  return logs.map((log) => serializeCommandEntry(log, ids.get(log.id)))
 }
 
 // The display-level slice of a log's attrs the reporter panel reads beyond the
@@ -215,16 +303,32 @@ interface ReporterLog {
   event?: boolean
   group?: string
   groupLevel?: number
+  alias?: string | string[]
+  aliasType?: string
+  referencesAlias?: { name: string } | Array<{ name: string }>
+  sessionInfo?: { id?: string, isGlobalSession?: boolean, status?: string }
+  functionName?: string
+  callCount?: number
 }
 
-const serializeReporterCommand = (command: SerializedCommandLog): TapReporterView['commands'][number] => {
-  const { id, name, message, state, type, _hasBeenCleanedUp } = command
-  const { displayName, hookId, event, group, groupLevel } = command as ReporterLog
+const asArray = <T>(value: T | T[] | undefined): T[] | undefined => {
+  if (value == null) {
+    return undefined
+  }
+
+  const array = Array.isArray(value) ? value : [value]
+
+  return array.length ? array : undefined
+}
+
+const serializeReporterCommand = (command: SerializedCommandLog, ids: Map<string, string>): TapReporterView['commands'][number] => {
+  const { name, message, state, type, _hasBeenCleanedUp } = command
+  const { displayName, hookId, event, group, groupLevel, alias, aliasType, referencesAlias } = command as ReporterLog
 
   const displayMessage = (command.renderProps as NetworkRenderProps | undefined)?.message ?? message
 
   return omitNullish({
-    id,
+    id: ids.get(command.id) as string,
     name,
     displayName,
     message: displayMessage,
@@ -233,19 +337,53 @@ const serializeReporterCommand = (command: SerializedCommandLog): TapReporterVie
     hookId,
     // The driver defaults `event` to false on every command log; only true is signal.
     event: event === true ? true : undefined,
-    group,
+    // The driver's `group` holds the enclosing group command's log id — remap it
+    // into the same tap id space the rows use.
+    group: group != null ? ids.get(group) : undefined,
     groupLevel,
+    aliases: asArray(alias),
+    aliasType,
+    referencedAliases: asArray(referencesAlias)?.map((ref) => ref.name),
     network: serializeNetworkInfo(command),
     cleanedUp: _hasBeenCleanedUp === true ? true : undefined,
   })
 }
 
+const serializeReporterAgent = (log: SerializedCommandLog): TapReporterView['agents'][number] => {
+  const { name } = log
+  const { functionName, alias, callCount } = log as ReporterLog
+
+  return omitNullish({
+    type: name,
+    functionName,
+    aliases: asArray(alias),
+    callCount,
+  })
+}
+
+// The reporter's SESSIONS panel isn't fed by an instrument of its own — a
+// `cy.session` group log is an ordinary command carrying `sessionInfo`, and
+// each such log is one panel row.
+const serializeReporterSessions = (logs: SerializedCommandLog[]): TapReporterView['sessions'] => {
+  return logs.flatMap((log) => {
+    const { sessionInfo } = log as ReporterLog
+
+    if (sessionInfo?.id == null) {
+      return []
+    }
+
+    return [omitNullish<TapReporterView['sessions'][number]>({
+      name: sessionInfo.id,
+      status: sessionInfo.status,
+      global: sessionInfo.isGlobalSession === true ? true : undefined,
+    })]
+  })
+}
+
 const serializeReporterRoute = (log: SerializedCommandLog): TapReporterView['routes'][number] => {
-  const { id } = log
   const { method, url, isStubbed, numResponses, alias, status } = log as NetworkLog
 
   return omitNullish({
-    id,
     method,
     url,
     stubbed: isStubbed,
@@ -255,19 +393,21 @@ const serializeReporterRoute = (log: SerializedCommandLog): TapReporterView['rou
   })
 }
 
-const serializeReporterHooks = (test: SerializedTest, attempt: SerializedTest): TapReporterView['hooks'] => {
-  // Suite-level hooks never serialize onto a test (the reporter unions them in
-  // from the runnables tree), but every hook that ran left its hookId under its
-  // hook name in the test's timings — derive the sections from there, in run
-  // order. Non-hook timings (`lifecycle`, `test`) aren't arrays, so they drop out.
-  const hooks = Object.entries(attempt.timings ?? {}).flatMap(([hookName, entries]) => {
+// Suite-level hooks never serialize onto a test (the reporter unions them in
+// from the runnables tree), but every hook that ran left its hookId under its
+// hook name in the test's timings — derive the sections from there, in run
+// order. Non-hook timings (`lifecycle`, `test`) aren't arrays, so they drop out.
+const attemptHooks = (attempt: SerializedTest): TapReporterView['hooks'] => {
+  return Object.entries(attempt.timings ?? {}).flatMap(([hookName, entries]) => {
     return Array.isArray(entries)
       ? (entries as Array<{ hookId: string }>).map(({ hookId }) => ({ hookId, hookName }))
       : []
   })
+}
 
+const serializeReporterHooks = (test: SerializedTest, attempt: SerializedTest): TapReporterView['hooks'] => {
   return [
-    ...hooks,
+    ...attemptHooks(attempt),
     // The test's own commands carry its id as their hookId; the reporter
     // synthesizes this same pseudo-hook to render them as the "test body".
     { hookId: test.id, hookName: 'test body' },
@@ -294,6 +434,10 @@ const serializeReporterError = (err: Record<string, unknown>): TapReporterView['
  */
 export const serializeReporterView = (test: SerializedTest, attempt: SerializedTest, runComplete: boolean): TapReporterView => {
   const titlePath = test._titlePath
+  // Splitting the canonical order back apart (rather than mapping the driver's
+  // buckets directly) keeps the tap ids ascending within each list.
+  const logs = orderedAttemptLogs(attempt)
+  const ids = tapCommandIds(logs)
 
   return omitNullish({
     test: {
@@ -303,8 +447,10 @@ export const serializeReporterView = (test: SerializedTest, attempt: SerializedT
       state: attempt.state ?? unreachedState(runComplete),
     },
     hooks: serializeReporterHooks(test, attempt),
-    routes: asCommandLogs(attempt.routes).map(serializeReporterRoute),
-    commands: asCommandLogs(attempt.commands).map(serializeReporterCommand),
+    sessions: serializeReporterSessions(logs),
+    agents: asCommandLogs(attempt.agents).map(serializeReporterAgent),
+    routes: logs.filter(isRouteLog).map(serializeReporterRoute),
+    commands: logs.filter((log) => !isRouteLog(log)).map((log) => serializeReporterCommand(log, ids)),
     error: attempt.err != null ? serializeReporterError(attempt.err) : undefined,
   })
 }

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -406,11 +406,18 @@ const attemptHooks = (attempt: SerializedTest): TapReporterView['hooks'] => {
 }
 
 const serializeReporterHooks = (test: SerializedTest, attempt: SerializedTest): TapReporterView['hooks'] => {
+  const hooks = attemptHooks(attempt)
+  // The test body runs after the `before` hooks and before the `after` hooks,
+  // so splice it into that slot to keep `hooks` in run order. The test's own
+  // commands carry its id as their hookId; the reporter synthesizes this same
+  // pseudo-hook to render them as the "test body".
+  const firstAfter = hooks.findIndex(({ hookName }) => hookName.startsWith('after'))
+  const at = firstAfter === -1 ? hooks.length : firstAfter
+
   return [
-    ...attemptHooks(attempt),
-    // The test's own commands carry its id as their hookId; the reporter
-    // synthesizes this same pseudo-hook to render them as the "test body".
+    ...hooks.slice(0, at),
     { hookId: test.id, hookName: 'test body' },
+    ...hooks.slice(at),
   ]
 }
 

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -1,7 +1,8 @@
-import type { SerializedTest } from '@packages/types'
+import type { SerializedCommandLog, SerializedTest } from '@packages/types'
 import { TapCommandError } from './commands/definition'
+import { omitNullish } from './utils'
 
-import type { CommandEntry, TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from './types'
+import type { CommandEntry, NetworkCommandInfo, TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from './types'
 
 // A test with no final status state set yet was never reached: 'pending' while
 // the run is still going, 'skipped' once it is complete (matching the driver's
@@ -15,13 +16,13 @@ export const serializeTestsState = (runner: TapTestsRunner): TestStateEntry[] =>
   const runComplete = runner.isRunComplete()
 
   return tests.map(({ id, title, duration, state, currentRetry }): TestStateEntry => {
-    return {
+    return omitNullish({
       id,
       title,
-      ...(duration !== undefined ? { duration } : {}),
+      duration,
       state: state ?? unreachedState(runComplete),
-      ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
-    }
+      retries: currentRetry,
+    })
   })
 }
 
@@ -33,13 +34,9 @@ const cloneReferenceObject = <T>(value: T): T => {
 }
 
 const serializeTestError = (err: Record<string, unknown>): TestError => {
-  const { name, message, stack } = err
+  const { name, message, stack } = err as TestError
 
-  return {
-    ...(typeof name === 'string' ? { name } : {}),
-    ...(typeof message === 'string' ? { message } : {}),
-    ...(typeof stack === 'string' ? { stack } : {}),
-  }
+  return omitNullish({ name, message, stack })
 }
 
 const attemptsOf = (test: SerializedTest): SerializedTest[] => {
@@ -95,36 +92,118 @@ export const serializeTestDetail = (test: SerializedTest, attempt: SerializedTes
   const titlePath = test._titlePath
   const { duration, state, currentRetry, timings, err } = attempt
 
-  return {
+  return omitNullish({
     id: test.id,
     title: test.title,
     fullTitle: Array.isArray(titlePath) ? titlePath.join(' > ') : test.title,
-    ...(duration !== undefined ? { duration } : {}),
+    duration,
     state: state ?? unreachedState(runComplete),
-    ...(currentRetry !== undefined ? { retries: currentRetry } : {}),
-    ...(timings != null ? { timings: cloneReferenceObject(timings) } : {}),
-    ...(err != null ? { error: serializeTestError(err) } : {}),
+    retries: currentRetry,
+    timings: timings != null ? cloneReferenceObject(timings) : undefined,
+    error: err != null ? serializeTestError(err) : undefined,
+  })
+}
+
+// The reporter's `renderProps` (resolved to an object by the time a log
+// serializes) is where request/xhr/`cy.request` rows carry their display detail.
+interface NetworkRenderProps {
+  message?: string
+  indicator?: NetworkCommandInfo['indicator']
+  status?: string | number
+  wentToOrigin?: boolean
+  interceptions?: unknown[]
+}
+
+// The network-relevant slice of a log's attrs. The driver types these behind an
+// index signature, so name the shape we read rather than narrow each access.
+interface NetworkLog {
+  instrument?: string
+  method?: string
+  url?: string
+  isStubbed?: boolean
+  numResponses?: number
+  alias?: string
+  status?: string | number
+  renderProps?: NetworkRenderProps
+}
+
+// A row is network-instrumented when it is a `cy.intercept` registration
+// (instrument `route`) or a request/xhr/fetch/`cy.request` log. The latter is
+// identified the way the reporter does — by the `renderProps` the proxy-logging
+// and request commands attach (a status `indicator`, or the `interceptions`
+// list) — rather than by name, since `cy.request` and proxy requests both log
+// as `request`.
+const serializeNetworkInfo = (command: SerializedCommandLog): NetworkCommandInfo | undefined => {
+  const { instrument, method, url, isStubbed, numResponses, alias, status, renderProps } = command as NetworkLog
+  const isRouteRow = instrument === 'route'
+  const isRequestRow = renderProps?.indicator != null || Array.isArray(renderProps?.interceptions)
+
+  if (!isRouteRow && !isRequestRow) {
+    return undefined
   }
+
+  // A route row carries `isStubbed`; a request row reports the same
+  // stubbed-vs-real fact as `wentToOrigin` on its renderProps.
+  const stubbed = isStubbed ?? (renderProps?.wentToOrigin != null ? !renderProps.wentToOrigin : undefined)
+
+  const info = omitNullish<NetworkCommandInfo>({
+    method,
+    // The base log defaults `url` to the page URL, so only a route matcher or a
+    // real request's URL is a trustworthy request URL — `cy.request` never
+    // overrides it, keeping its URL in `message` instead.
+    url: isRouteRow || Array.isArray(renderProps?.interceptions) ? url : undefined,
+    indicator: renderProps?.indicator,
+    status: status ?? renderProps?.status,
+    stubbed,
+    numResponses,
+    alias,
+  })
+
+  // A memory-evicted row can trip the route/request check while every detail
+  // field was nulled; drop the empty object so the contract stays absent-not-empty.
+  return Object.keys(info).length ? info : undefined
+}
+
+// The driver's reduceMemory nulls (not deletes) non-preserved command attrs
+// once a test falls out of numTestsKeptInMemory; omitNullish then keeps the
+// wire contract's optional fields absent-not-null. Its _hasBeenCleanedUp marker
+// is surfaced as `cleanedUp` so consumers can tell eviction apart from fields
+// that were never set.
+const serializeCommandEntry = (command: SerializedCommandLog): CommandEntry => {
+  const { id, name, message, state, type, _hasBeenCleanedUp } = command
+
+  // Mirror the reporter's displayed row text: network rows leave the base
+  // message empty and carry their summary (e.g. `GET 200 /api`) on renderProps.
+  const displayMessage = (command.renderProps as NetworkRenderProps | undefined)?.message ?? message
+
+  return omitNullish<CommandEntry>({
+    id,
+    name,
+    message: displayMessage,
+    state,
+    type,
+    network: serializeNetworkInfo(command),
+    cleanedUp: _hasBeenCleanedUp === true ? true : undefined,
+  })
+}
+
+const asCommandLogs = (value: unknown): SerializedCommandLog[] => {
+  return Array.isArray(value) ? value as SerializedCommandLog[] : []
+}
+
+const createdAt = (log: SerializedCommandLog): number => {
+  return typeof log.createdAtTimestamp === 'number' ? log.createdAtTimestamp : 0
 }
 
 export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] => {
-  const commands = attempt.commands ?? []
+  // The driver buckets cy.intercept registrations under `routes`, apart from
+  // `commands`, but the reporter shows both interleaved in one command log.
+  // Merge them back into the order the developer sees, keyed on each log's
+  // creation timestamp (stable for the timestamp-less rows in synthetic input).
+  const logs = [...asCommandLogs(attempt.commands), ...asCommandLogs(attempt.routes)]
+  .sort((a, b) => createdAt(a) - createdAt(b))
 
-  // The driver's reduceMemory nulls (not deletes) non-preserved command attrs
-  // once a test falls out of numTestsKeptInMemory, so treat null as absent to
-  // keep the wire contract's optional fields absent-not-null. Its
-  // _hasBeenCleanedUp marker is surfaced as `cleanedUp` so consumers can tell
-  // eviction apart from fields that were never set.
-  return commands.map(({ id, name, message, state, type, _hasBeenCleanedUp }): CommandEntry => {
-    return {
-      id,
-      ...(name != null ? { name } : {}),
-      ...(message != null ? { message } : {}),
-      ...(state != null ? { state } : {}),
-      ...(type != null ? { type } : {}),
-      ...(_hasBeenCleanedUp === true ? { cleanedUp: true } : {}),
-    }
-  })
+  return logs.map(serializeCommandEntry)
 }
 
 export interface RunResults {

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -81,17 +81,53 @@ export interface TestDetailEntry {
   error?: TestError
 }
 
+/**
+ * The high-level network detail the reporter renders inline on a
+ * request / xhr / fetch / `cy.intercept` row. Present on `CommandEntry` only
+ * for network-instrumented commands, so its very presence is how a consumer
+ * tells a network row from an ordinary command row — that is why the row does
+ * not also serialize the driver's raw `instrument`. Each field stays absent
+ * when the underlying row doesn't carry it, matching the serializer's
+ * absent-not-null discipline.
+ */
+export interface NetworkCommandInfo {
+  /** HTTP method, or `*` for a wildcard `cy.intercept` matcher. Absent on `cy.request` rows, where the method lives in `message`. */
+  method?: string
+  /** The request URL, or a `cy.intercept`'s display matcher. Absent on `cy.request` rows, where the URL lives in `message`. */
+  url?: string
+  /** The reporter's status-dot semantics for a request. Absent on the `cy.intercept` registration row. */
+  indicator?: 'successful' | 'pending' | 'aborted' | 'bad'
+  /** A stubbed route's response code, or the reporter's `req`/`res modified` label. */
+  status?: string | number
+  /** Whether a stub served the request instead of hitting origin (`isStubbed` on intercept rows, `!wentToOrigin` on request rows). */
+  stubbed?: boolean
+  /** How many requests a `cy.intercept` has matched — the reporter's count badge. */
+  numResponses?: number
+  /** The route alias set via `.as()`, e.g. `getUsers`. */
+  alias?: string
+}
+
 export interface CommandEntry {
   /** The driver's command log id, e.g. `log-<origin>-3`. */
   id: string
   /** The command name as logged, e.g. `visit`, `get`, `assert`. */
   name?: string
-  /** The command log's display message — arguments/assertion text, not output. */
+  /**
+   * The reporter's display text for the row: the command arguments/assertion
+   * text, or — for a network row whose base message is empty — the request
+   * summary the reporter shows in its place (e.g. `GET 200 /api/users`).
+   */
   message?: string
   /** `pending` while the command runs, then `passed` or `failed`. */
   state?: SerializedCommandLog['state']
   /** `parent` starts a chain, `child` is chained off a subject, `system` is driver-emitted. */
   type?: SerializedCommandLog['type']
+  /**
+   * High-level network detail — method, URL, status/indicator, stubbed flag,
+   * response count, alias — matching what the reporter renders inline on
+   * request / xhr / `cy.intercept` rows. Absent on ordinary command rows.
+   */
+  network?: NetworkCommandInfo
   /**
    * Present (always `true`) only when the driver evicted this test's command
    * details from memory (numTestsKeptInMemory), so scrubbed fields like

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -83,8 +83,14 @@ export interface TestDetailEntry {
 }
 
 export interface CommandEntry {
-  /** The driver's command log id, e.g. `log-<origin>-3`. */
-  id: string
+  /**
+   * The command id the pin command accepts. Numbered rows carry the exact
+   * number the app reporter shows (a per-hook-section counter, qualifiable as
+   * `<hookId>:<number>` when duplicated); event and system rows carry an
+   * attempt-wide `e1`..`eN` instead. Absent on `cy.intercept` registration
+   * rows — routes aren't commands.
+   */
+  id?: string
   /** The command name as logged, e.g. `visit`, `get`, `assert`. */
   name?: string
   /**

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -1,4 +1,5 @@
 import type { SerializedCommandLog, SerializedTest } from '@packages/types'
+import type { TapNetworkInfo } from './contract'
 
 export interface TapTestsRunner {
   /** Serializes every test of the run, keyed by id. */
@@ -81,32 +82,6 @@ export interface TestDetailEntry {
   error?: TestError
 }
 
-/**
- * The high-level network detail the reporter renders inline on a
- * request / xhr / fetch / `cy.intercept` row. Present on `CommandEntry` only
- * for network-instrumented commands, so its very presence is how a consumer
- * tells a network row from an ordinary command row — that is why the row does
- * not also serialize the driver's raw `instrument`. Each field stays absent
- * when the underlying row doesn't carry it, matching the serializer's
- * absent-not-null discipline.
- */
-export interface NetworkCommandInfo {
-  /** HTTP method, or `*` for a wildcard `cy.intercept` matcher. Absent on `cy.request` rows, where the method lives in `message`. */
-  method?: string
-  /** The request URL, or a `cy.intercept`'s display matcher. Absent on `cy.request` rows, where the URL lives in `message`. */
-  url?: string
-  /** The reporter's status-dot semantics for a request. Absent on the `cy.intercept` registration row. */
-  indicator?: 'successful' | 'pending' | 'aborted' | 'bad'
-  /** A stubbed route's response code, or the reporter's `req`/`res modified` label. */
-  status?: string | number
-  /** Whether a stub served the request instead of hitting origin (`isStubbed` on intercept rows, `!wentToOrigin` on request rows). */
-  stubbed?: boolean
-  /** How many requests a `cy.intercept` has matched — the reporter's count badge. */
-  numResponses?: number
-  /** The route alias set via `.as()`, e.g. `getUsers`. */
-  alias?: string
-}
-
 export interface CommandEntry {
   /** The driver's command log id, e.g. `log-<origin>-3`. */
   id: string
@@ -127,7 +102,7 @@ export interface CommandEntry {
    * response count, alias — matching what the reporter renders inline on
    * request / xhr / `cy.intercept` rows. Absent on ordinary command rows.
    */
-  network?: NetworkCommandInfo
+  network?: TapNetworkInfo
   /**
    * Present (always `true`) only when the driver evicted this test's command
    * details from memory (numTestsKeptInMemory), so scrubbed fields like

--- a/packages/app/src/tap/utils.ts
+++ b/packages/app/src/tap/utils.ts
@@ -1,0 +1,13 @@
+// Build a wire entry by assigning every field, then drop the null/undefined
+// ones in one pass. The driver nulls evicted attrs and leaves unset fields
+// undefined, and the wire contract's optional fields are absent-not-null — so
+// pruning here beats guarding each assignment at its key.
+export const omitNullish = <T extends object>(entry: T): T => {
+  return (Object.keys(entry) as Array<keyof T>).reduce((pruned, key) => {
+    if (entry[key] != null) {
+      pruned[key] = entry[key]
+    }
+
+    return pruned
+  }, {} as T)
+}

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -4,9 +4,11 @@ import {
   recordFileName,
   parseRecordPid,
   instancesProbePath,
+  buildTapSchema,
   INSTANCES_ROUTE_PREFIX,
   INSTANCES_DIRNAME,
   SCHEMA_VERSION,
+  TAP_COMMANDS,
 } from '../index'
 
 const validRecord = {
@@ -60,5 +62,19 @@ describe('cypress-instances contract', () => {
 
   it('exposes the instances dir name', () => {
     expect(INSTANCES_DIRNAME).toBe('instances')
+  })
+
+  describe('tap command contract', () => {
+    it('lists reporter as a command taking --test and --attempt, advertised on the wire schema', () => {
+      const reporter = TAP_COMMANDS.find(({ name }) => name === 'reporter')!
+
+      expect(reporter.params).toEqual([])
+      expect(reporter.options.map(({ name, required }) => ({ name, required }))).toEqual([
+        { name: 'test', required: true },
+        { name: 'attempt', required: false },
+      ])
+
+      expect(buildTapSchema('15.0.0').commands.map(({ name }) => name)).toContain('reporter')
+    })
   })
 })

--- a/packages/cypress-instances/lib/contracts/reporter.ts
+++ b/packages/cypress-instances/lib/contracts/reporter.ts
@@ -44,9 +44,30 @@ export interface TapReporterHook {
   hookName: string
 }
 
+/** One row of the reporter's SESSIONS panel — a `cy.session` this attempt used. */
+export interface TapReporterSession {
+  /** The session id passed to `cy.session()`, e.g. `all-commands-user`. */
+  name: string
+  /** The reporter's status badge: `created`, `restored`, `recreated`, `failed`, or an in-flight `-ing` form. */
+  status?: string
+  /** Present (always `true`) only for a global session (`cacheAcrossSpecs`). */
+  global?: true
+}
+
+/** One row of the reporter's SPIES / STUBS panel — a `cy.spy` / `cy.stub` agent. */
+export interface TapReporterAgent {
+  /** The agent's log name, e.g. `spy-1` or `stub-2` — the reporter's Type column. */
+  type?: string
+  /** The wrapped method's name. */
+  functionName?: string
+  /** Aliases set via `.as()`. */
+  aliases?: string[]
+  /** How many times the agent was invoked. */
+  callCount?: number
+}
+
 /** One row of the reporter's ROUTES table — a `cy.intercept` registration. */
 export interface TapReporterRoute {
-  id: string
   /** HTTP method, or `*` for a wildcard matcher. */
   method?: string
   /** The route's display matcher, e.g. `**\/comments/*`. */
@@ -62,7 +83,15 @@ export interface TapReporterRoute {
 }
 
 export interface TapReporterCommand {
-  /** The driver's command log id, e.g. `log-<origin>-3`. */
+  /**
+   * The command id the pin command accepts. Numbered rows carry the exact
+   * number the app reporter shows (a per-hook-section counter, so it restarts
+   * each section); event and system rows, which the reporter leaves
+   * unnumbered, carry an attempt-wide `e1`..`eN` instead. A duplicated number
+   * resolves to the test body first, then a unique match; qualify it with the
+   * section's hookId (`h1:3`) to target a hook row directly. Route
+   * registrations aren't commands and have no id.
+   */
   id: string
   /** The command name as logged, e.g. `visit`, `get`, `assert`. */
   name?: string
@@ -78,10 +107,16 @@ export interface TapReporterCommand {
   hookId?: string
   /** Event log — the reporter renders these unnumbered, as annotations of the surrounding command. */
   event?: true
-  /** Id of the enclosing log group's command, when nested (e.g. inside cy.session). */
+  /** Tap command id of the enclosing log group's command, when nested (e.g. inside cy.session). */
   group?: string
   /** Nesting depth within log groups. */
   groupLevel?: number
+  /** Aliases this row defines via `.as()` — the reporter's badge on the row. Also set on spy/stub call rows. */
+  aliases?: string[]
+  /** What the alias points at: `route`, `agent`, `primitive`, `dom`, or `intercept` — the reporter colors `dom` indigo, the rest purple. */
+  aliasType?: string
+  /** Alias names this row references, e.g. `cy.get('@x')` / `cy.wait('@x')` — the `@name`s in `message`. */
+  referencedAliases?: string[]
   /** High-level network detail; absent on ordinary command rows. */
   network?: TapNetworkInfo
   /** Present (always `true`) only when the driver evicted this test's command details from memory. */
@@ -116,6 +151,8 @@ export interface TapReporterError {
 export interface TapReporterView {
   test: TapReporterTest
   hooks: TapReporterHook[]
+  sessions: TapReporterSession[]
+  agents: TapReporterAgent[]
   routes: TapReporterRoute[]
   commands: TapReporterCommand[]
   /** Present only when the attempt failed. */

--- a/packages/cypress-instances/lib/contracts/reporter.ts
+++ b/packages/cypress-instances/lib/contracts/reporter.ts
@@ -1,0 +1,123 @@
+// The `reporter` command's result contract. A command's result interface lives
+// here in `contracts/`, next to the command metadata in `../tap-contract`, so
+// the app-side serializer and the CLI-side rendering type against the same
+// shape. Optional fields are absent, never null, on the wire.
+
+/**
+ * The high-level network detail the reporter renders inline on a
+ * request / xhr / fetch / `cy.intercept` row. Present on a command entry only
+ * for network-instrumented commands, so its very presence is how a consumer
+ * tells a network row from an ordinary command row.
+ */
+export interface TapNetworkInfo {
+  /** HTTP method, or `*` for a wildcard `cy.intercept` matcher. Absent on `cy.request` rows, where the method lives in `message`. */
+  method?: string
+  /** The request URL, or a `cy.intercept`'s display matcher. Absent on `cy.request` rows, where the URL lives in `message`. */
+  url?: string
+  /** The reporter's status-dot semantics for a request. Absent on the `cy.intercept` registration row. */
+  indicator?: 'successful' | 'pending' | 'aborted' | 'bad'
+  /** A stubbed route's response code, or the reporter's `req`/`res modified` label. */
+  status?: string | number
+  /** Whether a stub served the request instead of hitting origin. */
+  stubbed?: boolean
+  /** How many requests a `cy.intercept` has matched — the reporter's count badge. */
+  numResponses?: number
+  /** The route alias set via `.as()`, e.g. `getUsers`. */
+  alias?: string
+}
+
+export interface TapReporterTest {
+  /** The runner's test id, e.g. `r2` — the handle other tap commands accept. */
+  id: string
+  /** The test's own title, without its suite path. */
+  title: string
+  /** Suite titles leading to this test plus its own, joined with ` > `. */
+  fullTitle: string
+  /** Final status, or the unreached placeholder (`pending` mid-run, `skipped` after). */
+  state: 'passed' | 'failed' | 'pending' | 'skipped'
+}
+
+/** One section of the reporter panel; commands reference it by `hookId`. */
+export interface TapReporterHook {
+  hookId: string
+  /** e.g. `before each`, `after all`, or `test body` for the test's own commands. */
+  hookName: string
+}
+
+/** One row of the reporter's ROUTES table — a `cy.intercept` registration. */
+export interface TapReporterRoute {
+  id: string
+  /** HTTP method, or `*` for a wildcard matcher. */
+  method?: string
+  /** The route's display matcher, e.g. `**\/comments/*`. */
+  url?: string
+  /** Whether the route serves a stubbed response instead of hitting origin. */
+  stubbed?: boolean
+  /** A stubbed response's status code. */
+  status?: string | number
+  /** How many requests the route has matched. */
+  numResponses?: number
+  /** The route alias set via `.as()`. */
+  alias?: string
+}
+
+export interface TapReporterCommand {
+  /** The driver's command log id, e.g. `log-<origin>-3`. */
+  id: string
+  /** The command name as logged, e.g. `visit`, `get`, `assert`. */
+  name?: string
+  /** Label the reporter shows in place of `name` on event rows, e.g. `xhr`, `fetch`, `document`. */
+  displayName?: string
+  /** The reporter's display text for the row. */
+  message?: string
+  /** `pending` while the command runs, then `passed` or `failed`. */
+  state?: 'pending' | 'passed' | 'failed'
+  /** `parent` starts a chain, `child` is chained off a subject, `system` is driver-emitted. */
+  type?: 'parent' | 'child' | 'system'
+  /** The section this row renders under; the test's own id for the test body. */
+  hookId?: string
+  /** Event log — the reporter renders these unnumbered, as annotations of the surrounding command. */
+  event?: true
+  /** Id of the enclosing log group's command, when nested (e.g. inside cy.session). */
+  group?: string
+  /** Nesting depth within log groups. */
+  groupLevel?: number
+  /** High-level network detail; absent on ordinary command rows. */
+  network?: TapNetworkInfo
+  /** Present (always `true`) only when the driver evicted this test's command details from memory. */
+  cleanedUp?: true
+}
+
+/** The source location and snippet the reporter's error panel points at. */
+export interface TapReporterCodeFrame {
+  /** Project-relative spec path. */
+  file?: string
+  line?: number
+  column?: number
+  /** The rendered snippet, with line numbers and a `>` marker on the failing line. */
+  frame?: string
+}
+
+/** The failure that ended the attempt — the reporter's error panel. */
+export interface TapReporterError {
+  /** Error class name, e.g. `AssertionError`; absent on non-Error throws. */
+  name?: string
+  /** The thrown message; absent on non-Error throws without one. */
+  message?: string
+  /** The stack trace as the driver captured it. */
+  stack?: string
+  codeFrame?: TapReporterCodeFrame
+}
+
+/**
+ * The `reporter` command's result: everything the open-mode reporter renders
+ * for one test attempt — enough to reconstruct the panel 1-1.
+ */
+export interface TapReporterView {
+  test: TapReporterTest
+  hooks: TapReporterHook[]
+  routes: TapReporterRoute[]
+  commands: TapReporterCommand[]
+  /** Present only when the attempt failed. */
+  error?: TapReporterError
+}

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -118,7 +118,7 @@ const pinMeta = {
   description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
   params: [
     { ...testIdField, required: false },
-    { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command' },
+    { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' },
   ],
   options: [
     { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -103,6 +103,16 @@ const commandsMeta = {
   ],
 } as const satisfies TapCommandSchema
 
+const reporterMeta = {
+  name: 'reporter',
+  description: 'render a test’s full reporter view: its routes, hooks, and command log',
+  params: [],
+  options: [
+    { ...testIdField, required: true },
+    attemptField,
+  ],
+} as const satisfies TapCommandSchema
+
 const pinMeta = {
   name: 'pin',
   description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
@@ -131,6 +141,7 @@ const runStateMeta = {
 export const TAP_COMMANDS = [
   testsMeta,
   commandsMeta,
+  reporterMeta,
   pinMeta,
   runStateMeta,
 ] as const satisfies readonly TapCommandSchema[]
@@ -242,3 +253,7 @@ export const TAP_NATIVE_COMMANDS = [
 ] as const satisfies readonly TapNativeCommandSchema[]
 
 export type TapNativeCommandName = typeof TAP_NATIVE_COMMANDS[number]['name']
+
+// Per-command result contracts live in `./contracts/`; re-exported here so the
+// app's deep import of this module and the package barrel both reach them.
+export * from './contracts/reporter'

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -121,6 +121,7 @@ const pinMeta = {
     { name: 'command', type: 'string', required: false, description: 'command id, as listed by the commands command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' },
   ],
   options: [
+    attemptField,
     { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
     { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
   ],

--- a/system-tests/projects/tap-retries/cypress/e2e/network.cy.js
+++ b/system-tests/projects/tap-retries/cypress/e2e/network.cy.js
@@ -1,0 +1,15 @@
+describe('Network', () => {
+  // Exercises the three network shapes the reporter renders inline: a stubbed
+  // cy.intercept, a real request to origin, and a cy.request. tap commands
+  // should surface the same high-level detail for each.
+  it('records intercept, real request, and cy.request detail', () => {
+    cy.intercept('GET', '/api/users', { statusCode: 200, body: { ok: true } }).as('getUsers')
+    cy.visit('cypress/e2e/network.html')
+    cy.wait('@getUsers')
+    cy.get('#status').should('have.text', 'stubbed-ok')
+
+    cy.location('href').then((href) => {
+      cy.request(href).its('status').should('eq', 200)
+    })
+  })
+})

--- a/system-tests/projects/tap-retries/cypress/e2e/network.html
+++ b/system-tests/projects/tap-retries/cypress/e2e/network.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div id="status">idle</div>
+  <script>
+    async function load () {
+      try {
+        // A real request back to the file server (this page), so the run has a
+        // request that goes to origin.
+        await fetch(window.location.href)
+        // A request cy.intercept stubs, so it never reaches origin.
+        const res = await fetch('/api/users')
+        const body = await res.json()
+
+        document.getElementById('status').textContent = body.ok ? 'stubbed-ok' : 'stubbed-no'
+      } catch (err) {
+        document.getElementById('status').textContent = 'error'
+      }
+    }
+
+    load()
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- Closes N/A (stacked POC off `feat/tap-cli-integration`; network detail covers services 14048)

### Additional details

`cypress tap` could already dump a test's command log as data, but nothing rendered it the way the open-mode reporter panel does. This adds `tap reporter --test <id>`, which reproduces the reporter's view for a single test in the terminal, and gives the CLI the rendering seam the rest of the tap commands will grow into.

- **New `reporter` command.** Renders a header, the ROUTES table, hook sections (BEFORE EACH / TEST BODY, derived from the test's timings), the command log with its display-level fields (hookId, displayName, event, group nesting, network detail), and, when the attempt failed, the error panel with its code frame. Rows follow the reporter's conventions: bold command names, dash-prefixed child commands (`-assert`), asserts colored by state, and the app's own palette (`variables.scss`) throughout.
- **Rendering seam.** A command definition may declare `renderHuman`, which the CLI prints by default; `--json` bypasses it for the raw result. `reporter` is the first adopter.
- **Numbering mirrors the app.** Command handles are the exact numbers the app reporter shows (the per-hook-section counter from `hook-model`), with unnumbered event/system rows taking an attempt-wide `e1..eN` rendered a step more faded. Route registrations aren't commands and carry no id. The driver's raw `log-<origin>-N` id no longer crosses the wire at all: `pin` resolves handles app-side, preferring the test body for a duplicated number, accepting a `<hookId>:<n>` qualifier (surfaced in each section title, e.g. `BEFORE EACH · h1`), and refusing to guess between hooks with `AMBIGUOUS_COMMAND`.
- **Remaining instrument panels.** SESSIONS (derived from command logs carrying `sessionInfo`, since sessions are not a driver instrument) and SPIES / STUBS (from the attempt's agents bucket), plus alias detail on rows: `aliases`/`aliasType` for a row's own badge, `referencedAliases` to color `@name` mentions in messages, matching the reporter's tag palette (dom indigo, everything else purple). Failed event rows (uncaught exceptions) take the failure red.
- **Network detail on `tap commands`.** Rows for network-instrumented logs (`cy.intercept` registrations, proxied requests, `cy.request`) now carry the same high-level detail the reporter renders inline: method, url, status/indicator, stubbed flag, response count, and alias. Route registrations merge into the command list in creation order, and the row message mirrors the reporter's display text (e.g. `GET 200 /api`). Non-network rows are unchanged; new fields stay absent, not null.

The result contract lives in the new `lib/contracts/` directory in `@packages/cypress-instances`, typed by both sides.

### Steps to test

Open Cypress against a project and run a spec, then:

```
cypress tap tests                              # pick a test id
cypress tap reporter --test <id>               # rendered reporter view
cypress tap reporter --test <id> --json        # raw result, no rendering
cypress tap reporter --test <id> --attempt 1   # an earlier retry
```

For the network rows, run a spec that uses `cy.intercept` / `cy.request` (the `tap-retries` project gains a `network.cy.js` fixture for this) and confirm `cypress tap commands` shows method, url, status, and alias on those rows.

For the numbering, pick a number that appears in more than one hook section and confirm `cypress tap pin <n>` resolves to the test body, that `pin <hookId>:<n>` targets the other section, and that an ambiguous pin between two hooks fails with `AMBIGUOUS_COMMAND` rather than guessing.

### How has the user experience changed?

`cypress tap reporter --test <id>` is new: it prints in the terminal what the reporter panel shows for that test, including routes, hooks, the command log, the instrument panels, and the failure output. `cypress tap commands` rows for network logs now carry request detail they previously dropped. Command handles now match the numbers visible in the app reporter rather than the driver's internal log ids.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- POC / stacked exploration branch -->
- [x] Have tests been added/updated? <!-- CLI render snapshots, app command specs, tap-binding e2e -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- `cypress tap` is not yet publicly documented -->
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tap wire contract and command/pin id semantics across CLI and app; behavior is heavily covered by unit and e2e tests but consumers depending on old log ids would break.
> 
> **Overview**
> Adds **`cypress tap reporter --test <id>`** so a single test’s open-mode reporter panel can be fetched from a running instance and printed in the terminal (or as raw JSON via **`--json`**). The CLI gains a **`renderOutcome`** path: commands with a human renderer (starting with **`reporter`**) print that by default; **`--json`** skips it.
> 
> **Wire and app behavior** are expanded together: a shared **`TapReporterView`** contract in `@packages/cypress-instances`, a new app **`reporter`** tap command, and **`serializeReporterView`** / richer **`serializeTestCommands`** (hooks, routes table, sessions/agents panels, enriched command rows, failure code frames). **`tap commands`** now merges **`cy.intercept`** route logs into chronological order and attaches **`network`** detail plus reporter-style display messages on network rows.
> 
> **Command handles no longer use driver `log-*` ids.** Rows use the same numbers as the app reporter (per-hook counters, **`eN`** for events); **`pin`** resolves those handles (test body preferred, **`hookId:n`** qualifiers, **`AMBIGUOUS_COMMAND`** when ambiguous) and accepts **`--attempt`** like **`reporter`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241ba2d53b56b3e7539b99a32fb45a0ccc36943c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->