### PR TITLE
feat: render the spec-level reporter overview when tap reporter has no --test

### DIFF
--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -71,6 +71,15 @@ const renderHelp = (program: commander.Command, schema: TapSchema, command: stri
       return 1
     }
 
+    // Standalone help is the only place a schema command's full `details` prose
+    // renders, so it stands in for the one-line `description` — the same swap
+    // buildNativeProgram does for CLI-native commands.
+    const details = schema.commands.find(({ name }) => name === command)?.details
+
+    if (details) {
+      subcommand.description(details)
+    }
+
     logger.always(`${prefix}${subcommand.helpInformation()}`)
 
     return 0

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,5 +1,5 @@
-import type { TapCommandName, TapReporterView } from '@packages/cypress-instances'
-import { renderReporterHuman } from './reporter'
+import type { TapCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
+import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -13,7 +13,14 @@ export interface TapCommandRendering {
 }
 
 const renderings: Partial<Record<TapCommandName, TapCommandRendering>> = {
-  reporter: { renderHuman: (result) => renderReporterHuman(result as TapReporterView) },
+  reporter: {
+    renderHuman: (result) => {
+      // Only the no-test spec overview carries `stats`; the single-test view never does.
+      const view = result as TapReporterView | TapReporterSpecView
+
+      return 'stats' in view ? renderReporterSpecHuman(view) : renderReporterHuman(view)
+    },
+  },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import type { TapNetworkInfo, TapReporterAgent, TapReporterCommand, TapReporterError, TapReporterSession, TapReporterView } from '@packages/cypress-instances'
+import type { TapNetworkInfo, TapReporterAgent, TapReporterCommand, TapReporterError, TapReporterSession, TapReporterSpecTest, TapReporterSpecView, TapReporterStats, TapReporterSuite, TapReporterView } from '@packages/cypress-instances'
 
 // The reporter's own palette (packages/reporter/src/lib/variables.scss and
 // commands.scss), so the CLI rendering matches the app: $pass/$fail map to
@@ -331,6 +331,98 @@ export const renderReporterHuman = (view: TapReporterView): string => {
   if (view.error) {
     blocks.push(renderError(view.error))
   }
+
+  return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
+}
+
+// The reporter header's clock format (packages/reporter/src/lib/util.ts
+// formatDuration, inlined — the CLI can't import the reporter bundle).
+const formatDuration = (duration: number | undefined): string => {
+  if (!duration) {
+    return '--'
+  }
+
+  if (duration < 1000) {
+    return `${duration}ms`
+  }
+
+  const seconds = Math.round(duration / 1000)
+  const displaySeconds = String(seconds % 60).padStart(2, '0')
+  const displayMinutes = String(Math.floor((seconds / 60) % 60)).padStart(2, '0')
+  const displayHours = String(Math.floor(seconds / (60 * 60)))
+
+  return displayHours === '0' ? `${displayMinutes}:${displaySeconds}` : `${displayHours}:${displayMinutes}:${displaySeconds}`
+}
+
+// The app header renders a zero count as `--` (its stats strip's `count`
+// helper); skipped has no strip slot there, so it only appears when non-zero.
+const count = (num: number): string => (num > 0 ? String(num) : '--')
+
+const statsLine = (stats: TapReporterStats): string => {
+  return [
+    `${TEST_STATE.passed.icon} ${count(stats.passed)}`,
+    `${TEST_STATE.failed.icon} ${count(stats.failed)}`,
+    `${TEST_STATE.pending.icon} ${count(stats.pending)}`,
+    ...(stats.skipped > 0 ? [`${TEST_STATE.skipped.icon} ${stats.skipped}`] : []),
+    chalk.dim(formatDuration(stats.duration)),
+  ].join('  ')
+}
+
+// Sub-second durations keep their ms precision; longer ones read as seconds,
+// the way the run-mode spec output reports test times.
+const testDuration = (duration: number | undefined): string => {
+  if (duration == null) {
+    return ''
+  }
+
+  return `  ${chalk.dim(duration < 1000 ? `${duration}ms` : `${+(duration / 1000).toFixed(1)}s`)}`
+}
+
+const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[] => {
+  return tests.flatMap((test) => {
+    const retries = test.retries ? `  ${color.aborted(`(${test.retries} ${test.retries === 1 ? 'retry' : 'retries'})`)}` : ''
+
+    return [
+      `${indent}${chalk.dim(test.id.padStart(3))}  ${TEST_STATE[test.state].icon} ${test.title}${testDuration(test.duration)}${retries}`,
+      // Nested under the title, the way the app reporter lists a retried
+      // test's attempts; the id column stays empty so the rows read as one test.
+      ...(test.attempts ?? []).map((attempt) => {
+        return `${indent}       ${TEST_STATE[attempt.state].icon} ${chalk.dim(`attempt ${attempt.attempt}`)}${testDuration(attempt.duration)}`
+      }),
+    ]
+  })
+}
+
+// The app reporter renders each suite as its own section headed by the full
+// suite path — depth shows in the breadcrumb, not in indentation — styled here
+// like the single-test view's hook section titles. A suite whose tests all
+// live in child suites gets no section of its own.
+const specSuiteSections = (suites: TapReporterSuite[], path: string[]): string[][] => {
+  return suites.flatMap((suite) => {
+    const fullPath = [...path, suite.title]
+    const section = suite.tests.length
+      ? [[chalk.dim(fullPath.join(' > ').toUpperCase()), ...renderSpecTests(suite.tests, '  ')]]
+      : []
+
+    return [...section, ...specSuiteSections(suite.suites, fullPath)]
+  })
+}
+
+export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {
+  const header = [
+    ...(view.spec ? [chalk.bold(view.spec)] : []),
+    statsLine(view.stats),
+  ]
+
+  const sections = [
+    ...(view.tests.length ? [renderSpecTests(view.tests, '  ')] : []),
+    ...specSuiteSections(view.suites, []),
+  ]
+
+  const blocks: string[][] = [
+    header,
+    ...(sections.length ? sections : [[chalk.dim('No tests were found in this spec.')]]),
+  ]
 
   return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
 }

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -395,17 +395,10 @@ const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[]
 
 // The app reporter renders each suite as its own section headed by the full
 // suite path — depth shows in the breadcrumb, not in indentation — styled here
-// like the single-test view's hook section titles. A suite whose tests all
-// live in child suites gets no section of its own.
-const specSuiteSections = (suites: TapReporterSuite[], path: string[]): string[][] => {
-  return suites.flatMap((suite) => {
-    const fullPath = [...path, suite.title]
-    const section = suite.tests.length
-      ? [[chalk.dim(fullPath.join(' > ').toUpperCase()), ...renderSpecTests(suite.tests, '  ')]]
-      : []
-
-    return [...section, ...specSuiteSections(suite.suites, fullPath)]
-  })
+// like the single-test view's hook section titles. The wire shape is already
+// flattened that way: one entry per suite with direct tests, title pre-joined.
+const specSuiteSections = (suites: TapReporterSuite[]): string[][] => {
+  return suites.map((suite) => [chalk.dim(suite.title.toUpperCase()), ...renderSpecTests(suite.tests, '  ')])
 }
 
 export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {
@@ -416,7 +409,7 @@ export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {
 
   const sections = [
     ...(view.tests.length ? [renderSpecTests(view.tests, '  ')] : []),
-    ...specSuiteSections(view.suites, []),
+    ...specSuiteSections(view.suites),
   ]
 
   const blocks: string[][] = [

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1015,8 +1015,10 @@ describe('lib/exec/tap', () => {
                                           state, or detail one by id
           commands [options]              list the command log entries of a test of
                                           the active run
-          reporter [options]              render a test’s full reporter view: its
-                                          routes, hooks, and command log
+          reporter [options]              render a test’s full reporter view — its
+                                          routes, hooks, and command log — or, without
+                                          --test, the spec-level overview: run stats
+                                          and the suite tree
           pin [options] [test] [command]  pin a command’s DOM snapshot into the live
                                           app-under-test frame so the dom/aria/inspect
                                           commands can read it; pass --clear to release

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1038,7 +1038,7 @@ describe('lib/exec/tap', () => {
           reporter [options]              render a test’s full reporter view — its
                                           routes, hooks, and command log — or, without
                                           --test, the spec-level overview: run stats
-                                          and the suite tree
+                                          and every suite’s tests
           pin [options] [test] [command]  pin a command’s DOM snapshot into the live
                                           app-under-test frame so the dom/aria/inspect
                                           commands can read it; pass --clear to release

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -347,6 +347,26 @@ describe('lib/exec/tap', () => {
       expect(call.mock.calls).toEqual([['getSchema']])
     })
 
+    it('renders a schema command’s details prose in place of its one-liner for `<command> --help`', async () => {
+      mockSession({
+        ...schema,
+        commands: [
+          ...schema.commands,
+          {
+            name: 'detailed-command',
+            description: 'a one-line summary for the listing',
+            details: 'A longer, friendlier block of prose\nthat only standalone help shows.',
+            params: [],
+            options: [],
+          },
+        ],
+      } satisfies TapSchema)
+
+      expect(await tap.start(['detailed-command', '--help'], {})).toBe(0)
+      expect(logger.print()).toContain('A longer, friendlier block of prose\nthat only standalone help shows.')
+      expect(logger.print()).not.toContain('a one-line summary for the listing')
+    })
+
     it('fails when help is requested for a command the instance does not advertise', async () => {
       mockSession()
 

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -171,7 +171,7 @@ describe('lib/tap/render/reporter spec overview', () => {
 
   const emptyStats = { passed: 0, failed: 0, pending: 0, skipped: 0 }
 
-  it('renders the spec header, stats, and the suite tree with per-state icons', () => {
+  it('renders the spec header, stats, and the suite sections with per-state icons', () => {
     const view: TapReporterSpecView = {
       spec: 'cypress/e2e/actions.cy.js',
       stats: { passed: 2, failed: 1, pending: 1, skipped: 1, duration: 17400 },
@@ -183,26 +183,23 @@ describe('lib/tap/render/reporter spec overview', () => {
             { id: 't2', title: 'a1', state: 'passed', duration: 10 },
             { id: 't4', title: 'a2', state: 'pending' },
           ],
-          suites: [
-            {
-              title: 'B',
-              tests: [{
-                id: 't3',
-                title: 'b1',
-                state: 'failed',
-                duration: 30,
-                retries: 2,
-                attempts: [
-                  { attempt: 1, state: 'failed', duration: 4476 },
-                  { attempt: 2, state: 'failed', duration: 4400 },
-                  { attempt: 3, state: 'failed', duration: 30 },
-                ],
-              }],
-              suites: [],
-            },
-          ],
         },
-        { title: 'C', tests: [{ id: 't5', title: 'c1', state: 'skipped' }], suites: [] },
+        {
+          title: 'A > B',
+          tests: [{
+            id: 't3',
+            title: 'b1',
+            state: 'failed',
+            duration: 30,
+            retries: 2,
+            attempts: [
+              { attempt: 1, state: 'failed', duration: 4476 },
+              { attempt: 2, state: 'failed', duration: 4400 },
+              { attempt: 3, state: 'failed', duration: 30 },
+            ],
+          }],
+        },
+        { title: 'C', tests: [{ id: 't5', title: 'c1', state: 'skipped' }] },
       ],
     }
 

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import stripAnsi from 'strip-ansi'
 
-import { renderReporterHuman } from '../../../lib/tap/render/reporter'
-import type { TapReporterView } from '@packages/cypress-instances'
+import { renderReporterHuman, renderReporterSpecHuman } from '../../../lib/tap/render/reporter'
+import type { TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
 
 // chalk's color level depends on where the suite runs, so strip any escape
 // codes before snapshotting — the assertions target the layout, not the colors.
@@ -162,6 +162,100 @@ describe('lib/tap/render/reporter', () => {
       "- never ran  skipped
 
       No commands were logged for this test."
+    `)
+  })
+})
+
+describe('lib/tap/render/reporter spec overview', () => {
+  const renderSpecPlain = (input: TapReporterSpecView): string => stripAnsi(renderReporterSpecHuman(input))
+
+  const emptyStats = { passed: 0, failed: 0, pending: 0, skipped: 0 }
+
+  it('renders the spec header, stats, and the suite tree with per-state icons', () => {
+    const view: TapReporterSpecView = {
+      spec: 'cypress/e2e/actions.cy.js',
+      stats: { passed: 2, failed: 1, pending: 1, skipped: 1, duration: 17400 },
+      tests: [{ id: 't1', title: 'root test', state: 'passed', duration: 20 }],
+      suites: [
+        {
+          title: 'A',
+          tests: [
+            { id: 't2', title: 'a1', state: 'passed', duration: 10 },
+            { id: 't4', title: 'a2', state: 'pending' },
+          ],
+          suites: [
+            {
+              title: 'B',
+              tests: [{
+                id: 't3',
+                title: 'b1',
+                state: 'failed',
+                duration: 30,
+                retries: 2,
+                attempts: [
+                  { attempt: 1, state: 'failed', duration: 4476 },
+                  { attempt: 2, state: 'failed', duration: 4400 },
+                  { attempt: 3, state: 'failed', duration: 30 },
+                ],
+              }],
+              suites: [],
+            },
+          ],
+        },
+        { title: 'C', tests: [{ id: 't5', title: 'c1', state: 'skipped' }], suites: [] },
+      ],
+    }
+
+    expect(renderSpecPlain(view)).toMatchInlineSnapshot(`
+      "cypress/e2e/actions.cy.js
+      ✓ 2  ✖ 1  ○ 1  - 1  00:17
+
+         t1  ✓ root test  20ms
+
+      A
+         t2  ✓ a1  10ms
+         t4  ○ a2
+
+      A > B
+         t3  ✖ b1  30ms  (2 retries)
+               ✖ attempt 1  4.5s
+               ✖ attempt 2  4.4s
+               ✖ attempt 3  30ms
+
+      C
+         t5  - c1"
+    `)
+  })
+
+  it('renders zero counts as -- the way the app header does', () => {
+    const view: TapReporterSpecView = {
+      stats: { ...emptyStats, passed: 3, duration: 900 },
+      tests: [{ id: 'r1', title: 'only test', state: 'passed', duration: 4476 }],
+      suites: [],
+    }
+
+    expect(renderSpecPlain(view)).toMatchInlineSnapshot(`
+      "✓ 3  ✖ --  ○ --  900ms
+
+         r1  ✓ only test  4.5s"
+    `)
+  })
+
+  it('renders the run clock across the duration formats', () => {
+    const clockLine = (duration?: number) => renderSpecPlain({ stats: { ...emptyStats, duration }, tests: [], suites: [] }).split('\n')[0]
+
+    expect(clockLine(undefined)).toMatchInlineSnapshot(`"✓ --  ✖ --  ○ --  --"`)
+    expect(clockLine(817)).toMatchInlineSnapshot(`"✓ --  ✖ --  ○ --  817ms"`)
+    expect(clockLine(17400)).toMatchInlineSnapshot(`"✓ --  ✖ --  ○ --  00:17"`)
+    expect(clockLine(3723000)).toMatchInlineSnapshot(`"✓ --  ✖ --  ○ --  1:02:03"`)
+  })
+
+  it('renders an empty spec as its header and a no-tests note', () => {
+    expect(renderSpecPlain({ spec: 'cypress/e2e/empty.cy.js', stats: emptyStats, tests: [], suites: [] })).toMatchInlineSnapshot(`
+      "cypress/e2e/empty.cy.js
+      ✓ --  ✖ --  ○ --  --
+
+      No tests were found in this spec."
     `)
   })
 })

--- a/packages/app/src/tap/commands/definition.ts
+++ b/packages/app/src/tap/commands/definition.ts
@@ -45,6 +45,7 @@ export const defineCommand = <N extends TapCommandName>(
 export interface TapCommandDefinition {
   name: TapCommandName
   description: string
+  details?: string
   params: readonly TapCommandParamSchema[]
   options?: readonly TapCommandOptionSchema[]
   hidden?: boolean

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -252,8 +252,8 @@ describe('tap/commands/reporter', () => {
   })
 
   describe('without a test id (spec overview)', () => {
-    // Document order exercising the tree rebuild: a root-level test, a return
-    // to suite A after nested B closes, and an unreached test in C.
+    // Document order exercising the suite flattening: a root-level test, a
+    // return to suite A after nested B closes, and an unreached test in C.
     const TREE_STATE = {
       t1: { id: 't1', title: 'root test', _titlePath: ['root test'], state: 'passed', duration: 20 },
       t2: { id: 't2', title: 'a1', _titlePath: ['A', 'a1'], state: 'passed', duration: 10 },
@@ -279,7 +279,7 @@ describe('tap/commands/reporter', () => {
       }
     }
 
-    it('returns the spec overview mid-run: stats, the suite tree, and unreached tests as pending', async () => {
+    it('returns the spec overview mid-run: stats, the flattened suites, and unreached tests as pending', async () => {
       stubRunner(treeRunner())
       stubSpec('cypress/e2e/actions.cy.js')
 
@@ -299,29 +299,25 @@ describe('tap/commands/reporter', () => {
                 { id: 't2', title: 'a1', state: 'passed', duration: 10 },
                 { id: 't4', title: 'a2', state: 'pending' },
               ],
-              suites: [
-                {
-                  title: 'B',
-                  tests: [{
-                    id: 't3',
-                    title: 'b1',
-                    state: 'failed',
-                    duration: 30,
-                    retries: 2,
-                    attempts: [
-                      { attempt: 1, state: 'failed', duration: 12 },
-                      { attempt: 2, state: 'failed', duration: 18 },
-                      { attempt: 3, state: 'failed', duration: 30 },
-                    ],
-                  }],
-                  suites: [],
-                },
-              ],
+            },
+            {
+              title: 'A > B',
+              tests: [{
+                id: 't3',
+                title: 'b1',
+                state: 'failed',
+                duration: 30,
+                retries: 2,
+                attempts: [
+                  { attempt: 1, state: 'failed', duration: 12 },
+                  { attempt: 2, state: 'failed', duration: 18 },
+                  { attempt: 3, state: 'failed', duration: 30 },
+                ],
+              }],
             },
             {
               title: 'C',
               tests: [{ id: 't5', title: 'c1', state: 'pending' }],
-              suites: [],
             },
           ],
         },
@@ -338,7 +334,7 @@ describe('tap/commands/reporter', () => {
       const { stats, suites } = (outcome as { result: { stats: unknown, suites: Array<{ tests: Array<{ state: string }> }> } }).result
 
       expect(stats).to.deep.eq({ passed: 2, failed: 1, pending: 1, skipped: 1 })
-      expect(suites[1].tests[0].state).to.eq('skipped')
+      expect(suites[2].tests[0].state).to.eq('skipped')
     })
 
     it('measures a running spec’s duration from the run start to now', async () => {

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -144,15 +144,6 @@ describe('tap/commands/reporter', () => {
     expect((outcome as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
   })
 
-  it('fails dispatch without reading the runner when the required test option is missing', async () => {
-    const getRunner = stubRunner({ getTestState: () => undefined, isRunComplete: () => false })
-
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
-
-    expect((outcome as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
-    expect(getRunner).not.to.have.been.called
-  })
-
   it('returns the full reporter view: test header, hooks with a synthesized test body, routes, and enriched commands', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => false })
 
@@ -258,5 +249,140 @@ describe('tap/commands/reporter', () => {
       { hookId: 'h-ae', hookName: 'after each' },
       { hookId: 'h-aa', hookName: 'after all' },
     ])
+  })
+
+  describe('without a test id (spec overview)', () => {
+    // Document order exercising the tree rebuild: a root-level test, a return
+    // to suite A after nested B closes, and an unreached test in C.
+    const TREE_STATE = {
+      t1: { id: 't1', title: 'root test', _titlePath: ['root test'], state: 'passed', duration: 20 },
+      t2: { id: 't2', title: 'a1', _titlePath: ['A', 'a1'], state: 'passed', duration: 10 },
+      t3: {
+        id: 't3', title: 'b1', _titlePath: ['A', 'B', 'b1'], state: 'failed', duration: 30, currentRetry: 2,
+        prevAttempts: [
+          { id: 't3', title: 'b1', state: 'failed', duration: 12 },
+          { id: 't3', title: 'b1', state: 'failed', duration: 18 },
+        ],
+      },
+      t4: { id: 't4', title: 'a2', _titlePath: ['A', 'a2'], state: 'pending' },
+      t5: { id: 't5', title: 'c1', _titlePath: ['C', 'c1'] },
+    }
+
+    const stubSpec = (relative: string | undefined) => cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
+
+    const treeRunner = (overrides: Record<string, unknown> = {}) => {
+      return {
+        getAllTestsState: () => TREE_STATE,
+        isRunComplete: () => false,
+        getStartTime: () => null,
+        ...overrides,
+      }
+    }
+
+    it('returns the spec overview mid-run: stats, the suite tree, and unreached tests as pending', async () => {
+      stubRunner(treeRunner())
+      stubSpec('cypress/e2e/actions.cy.js')
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+
+      expect(outcome).to.deep.eq({
+        result: {
+          spec: 'cypress/e2e/actions.cy.js',
+          stats: { passed: 2, failed: 1, pending: 2, skipped: 0 },
+          tests: [
+            { id: 't1', title: 'root test', state: 'passed', duration: 20 },
+          ],
+          suites: [
+            {
+              title: 'A',
+              tests: [
+                { id: 't2', title: 'a1', state: 'passed', duration: 10 },
+                { id: 't4', title: 'a2', state: 'pending' },
+              ],
+              suites: [
+                {
+                  title: 'B',
+                  tests: [{
+                    id: 't3',
+                    title: 'b1',
+                    state: 'failed',
+                    duration: 30,
+                    retries: 2,
+                    attempts: [
+                      { attempt: 1, state: 'failed', duration: 12 },
+                      { attempt: 2, state: 'failed', duration: 18 },
+                      { attempt: 3, state: 'failed', duration: 30 },
+                    ],
+                  }],
+                  suites: [],
+                },
+              ],
+            },
+            {
+              title: 'C',
+              tests: [{ id: 't5', title: 'c1', state: 'pending' }],
+              suites: [],
+            },
+          ],
+        },
+      })
+
+      expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
+    })
+
+    it('reports unreached tests as skipped once the run is complete', async () => {
+      stubRunner(treeRunner({ isRunComplete: () => true }))
+      stubSpec(undefined)
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+      const { stats, suites } = (outcome as { result: { stats: unknown, suites: Array<{ tests: Array<{ state: string }> }> } }).result
+
+      expect(stats).to.deep.eq({ passed: 2, failed: 1, pending: 1, skipped: 1 })
+      expect(suites[1].tests[0].state).to.eq('skipped')
+    })
+
+    it('measures a running spec’s duration from the run start to now', async () => {
+      const start = new Date('2026-01-01T00:00:00.000Z')
+
+      stubRunner(treeRunner({ getStartTime: () => start.toISOString() }))
+      stubSpec(undefined)
+      cy.stub(Date, 'now').returns(start.getTime() + 17400)
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+
+      expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(17400)
+    })
+
+    it('freezes a completed spec’s duration at the last test’s recorded end', async () => {
+      stubRunner(treeRunner({
+        isRunComplete: () => true,
+        getStartTime: () => '2026-01-01T00:00:00.000Z',
+        getAllTestsState: () => {
+          return {
+            t1: { ...TREE_STATE.t1, wallClockStartedAt: '2026-01-01T00:00:05.000Z', wallClockDuration: 1000 },
+            t2: { ...TREE_STATE.t2, wallClockStartedAt: '2026-01-01T00:00:10.000Z', wallClockDuration: 400 },
+          }
+        },
+      }))
+
+      stubSpec(undefined)
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+
+      expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(10400)
+    })
+
+    it('rejects --attempt without --test', async () => {
+      stubRunner(treeRunner())
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { attempt: '1' })
+
+      expect(outcome).to.deep.eq({
+        error: {
+          code: 'ATTEMPT_NOT_FOUND',
+          message: 'the --attempt option applies only when rendering a single test; pass --test <id>',
+        },
+      })
+    })
   })
 })

--- a/packages/app/src/tap/commands/reporter.ts
+++ b/packages/app/src/tap/commands/reporter.ts
@@ -1,13 +1,21 @@
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
-import { attemptSelectionError, selectTestAttempt, serializeReporterView } from '../test-state'
-import type { TapReporterView } from '../contract'
+import { attemptSelectionError, selectTestAttempt, serializeReporterSpecView, serializeReporterView } from '../test-state'
+import type { TapReporterSpecView, TapReporterView } from '../contract'
 
-export const reporterCommand = defineCommand('reporter', async (_params, { test, attempt }): Promise<TapReporterView> => {
+export const reporterCommand = defineCommand('reporter', async (_params, { test, attempt }): Promise<TapReporterView | TapReporterSpecView> => {
   const runner = tapManagerDataSource.getRunner()
 
   if (!runner) {
     throw new TapCommandError('NO_RUN', 'no spec has been run yet — use the run command to run a spec first')
+  }
+
+  if (test === undefined) {
+    if (attempt !== undefined) {
+      throw new TapCommandError('ATTEMPT_NOT_FOUND', 'the --attempt option applies only when rendering a single test; pass --test <id>')
+    }
+
+    return serializeReporterSpecView(runner, tapManagerDataSource.getActiveSpecRelative())
   }
 
   const selection = selectTestAttempt(runner, test, attempt)

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -22,6 +22,10 @@ export type {
   TapExecResult,
   TapNetworkInfo,
   TapReporterView,
+  TapReporterSpecView,
+  TapReporterSpecTest,
+  TapReporterSpecAttempt,
+  TapReporterSuite,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 // Reserved dispatch-level failure codes `exec` itself produces; domain failures

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -31,6 +31,7 @@ export const tapManagerDataSource = {
         getAllTestsState: runner.getAllTestsState,
         getTestState: runner.getTestState,
         isRunComplete: () => em.runComplete,
+        getStartTime: runner.getStartTime,
       }
     } catch {
       return undefined

--- a/packages/app/src/tap/tap-manager.cy.ts
+++ b/packages/app/src/tap/tap-manager.cy.ts
@@ -51,6 +51,7 @@ describe('tap/tap-manager', () => {
         const definition = tapCommands[command.name as keyof typeof tapCommands]
 
         expect(command.description).to.eq(definition.description)
+        expect(command.details).to.eq((definition as TapCommandDefinition).details)
         expect(command.params).to.deep.eq(definition.params)
         expect(command.options).to.deep.eq((definition as TapCommandDefinition).options ?? [])
       }

--- a/packages/app/src/tap/tap-manager.ts
+++ b/packages/app/src/tap/tap-manager.ts
@@ -31,11 +31,12 @@ export class TapManager implements TapBindingContract {
       cypressVersion: this.cypressVersion,
       commands: Object.entries(tapCommands).map(([name, definition]) => {
         // Widen past the `satisfies` literal type so the optional `options` is readable.
-        const { description, params, options, hidden } = definition as TapCommandDefinition
+        const { description, details, params, options, hidden } = definition as TapCommandDefinition
 
         return {
           name,
           description,
+          ...(details ? { details } : {}),
           params: params.map((param) => ({ ...param })),
           options: (options ?? []).map((option) => ({ ...option })),
           ...(hidden ? { hidden: true } : {}),

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -500,10 +500,6 @@ const suitePathOf = (test: SerializedTest): string[] => {
   return Array.isArray(test._titlePath) ? test._titlePath.slice(0, -1) : []
 }
 
-const isPathPrefix = (prefix: string[], path: string[]): boolean => {
-  return prefix.every((title, index) => path[index] === title)
-}
-
 // The driver stores no run end time (the reporter freezes its own clock), so a
 // completed run's wall clock ends at the last test's recorded end.
 const testEndMs = (test: SerializedTest): number | undefined => {
@@ -559,33 +555,31 @@ const serializeSpecTest = (test: SerializedTest, runComplete: boolean): TapRepor
 
 /**
  * The spec-level overview the app reporter shows above any single test: the
- * header stats and the suite tree. The driver does not retain its normalized
- * runnables tree, so the tree is rebuilt from the flat test list via each
- * test's `_titlePath`; the flat list is in document order, so a stack of open
- * suites reproduces the nesting. Direct tests precede nested suites within a
- * node, matching the reporter's child ordering.
+ * header stats, the root-level tests, and one flattened suite section per
+ * suite path with direct tests — nesting lives in the joined title, matching
+ * how the CLI displays the sections. Each test's `_titlePath` names its suite
+ * path; the flat test list is in document order, so grouping by first
+ * appearance reproduces the reporter's section order.
  */
 export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string | undefined): TapReporterSpecView => {
   const tests = Object.values(runner.getAllTestsState())
   const runComplete = runner.isRunComplete()
-  const root: TapReporterSuite = { title: '', tests: [], suites: [] }
-  const stack: Array<{ path: string[], node: TapReporterSuite }> = [{ path: [], node: root }]
+  const rootTests: TapReporterSpecTest[] = []
+  const suites = new Map<string, TapReporterSuite>()
 
   for (const test of tests) {
     const path = suitePathOf(test)
 
-    while (stack.length > 1 && !isPathPrefix(stack[stack.length - 1].path, path)) {
-      stack.pop()
+    if (!path.length) {
+      rootTests.push(serializeSpecTest(test, runComplete))
+      continue
     }
 
-    for (let depth = stack[stack.length - 1].path.length; depth < path.length; depth++) {
-      const node: TapReporterSuite = { title: path[depth], tests: [], suites: [] }
+    const title = path.join(' > ')
+    const suite = suites.get(title) ?? { title, tests: [] }
 
-      stack[stack.length - 1].node.suites.push(node)
-      stack.push({ path: path.slice(0, depth + 1), node })
-    }
-
-    stack[stack.length - 1].node.tests.push(serializeSpecTest(test, runComplete))
+    suites.set(title, suite)
+    suite.tests.push(serializeSpecTest(test, runComplete))
   }
 
   const { results } = aggregateResults(runner)
@@ -593,7 +587,7 @@ export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string |
   return omitNullish({
     spec,
     stats: omitNullish({ ...results, duration: runDuration(runner, tests) }),
-    tests: root.tests,
-    suites: root.suites,
+    tests: rootTests,
+    suites: [...suites.values()],
   })
 }

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -2,7 +2,7 @@ import type { SerializedCommandLog, SerializedTest } from '@packages/types'
 import { TapCommandError } from './commands/definition'
 import { omitNullish } from './utils'
 
-import type { TapNetworkInfo, TapReporterView } from './contract'
+import type { TapNetworkInfo, TapReporterSpecAttempt, TapReporterSpecTest, TapReporterSpecView, TapReporterSuite, TapReporterView } from './contract'
 import type { CommandEntry, TapTestsRunner, TestDetailEntry, TestError, TestStateEntry, TestStateValue } from './types'
 
 // A test with no final status state set yet was never reached: 'pending' while
@@ -494,4 +494,106 @@ export const aggregateResults = (runner: TapTestsRunner): { results: RunResults,
   }
 
   return { results, totalTests: tests.length }
+}
+
+const suitePathOf = (test: SerializedTest): string[] => {
+  return Array.isArray(test._titlePath) ? test._titlePath.slice(0, -1) : []
+}
+
+const isPathPrefix = (prefix: string[], path: string[]): boolean => {
+  return prefix.every((title, index) => path[index] === title)
+}
+
+// The driver stores no run end time (the reporter freezes its own clock), so a
+// completed run's wall clock ends at the last test's recorded end.
+const testEndMs = (test: SerializedTest): number | undefined => {
+  const { wallClockStartedAt, wallClockDuration } = test as { wallClockStartedAt?: string, wallClockDuration?: number }
+
+  return wallClockStartedAt != null ? new Date(wallClockStartedAt).getTime() + (wallClockDuration ?? 0) : undefined
+}
+
+const runDuration = (runner: TapTestsRunner, tests: SerializedTest[]): number | undefined => {
+  const startTime = runner.getStartTime()
+
+  if (startTime == null) {
+    return undefined
+  }
+
+  const start = new Date(startTime).getTime()
+
+  if (!runner.isRunComplete()) {
+    return Date.now() - start
+  }
+
+  const ends = tests.map(testEndMs).filter((end): end is number => end != null)
+
+  return ends.length ? Math.max(...ends) - start : undefined
+}
+
+const serializeSpecAttempts = (test: SerializedTest, runComplete: boolean): TapReporterSpecAttempt[] | undefined => {
+  const attempts = attemptsOf(test)
+
+  if (attempts.length < 2) {
+    return undefined
+  }
+
+  return attempts.map((attempt, index) => {
+    return omitNullish({
+      attempt: index + 1,
+      state: attempt.state ?? unreachedState(runComplete),
+      duration: attempt.duration,
+    })
+  })
+}
+
+const serializeSpecTest = (test: SerializedTest, runComplete: boolean): TapReporterSpecTest => {
+  return omitNullish({
+    id: test.id,
+    title: test.title,
+    state: test.state ?? unreachedState(runComplete),
+    duration: test.duration,
+    retries: test.currentRetry,
+    attempts: serializeSpecAttempts(test, runComplete),
+  })
+}
+
+/**
+ * The spec-level overview the app reporter shows above any single test: the
+ * header stats and the suite tree. The driver does not retain its normalized
+ * runnables tree, so the tree is rebuilt from the flat test list via each
+ * test's `_titlePath`; the flat list is in document order, so a stack of open
+ * suites reproduces the nesting. Direct tests precede nested suites within a
+ * node, matching the reporter's child ordering.
+ */
+export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string | undefined): TapReporterSpecView => {
+  const tests = Object.values(runner.getAllTestsState())
+  const runComplete = runner.isRunComplete()
+  const root: TapReporterSuite = { title: '', tests: [], suites: [] }
+  const stack: Array<{ path: string[], node: TapReporterSuite }> = [{ path: [], node: root }]
+
+  for (const test of tests) {
+    const path = suitePathOf(test)
+
+    while (stack.length > 1 && !isPathPrefix(stack[stack.length - 1].path, path)) {
+      stack.pop()
+    }
+
+    for (let depth = stack[stack.length - 1].path.length; depth < path.length; depth++) {
+      const node: TapReporterSuite = { title: path[depth], tests: [], suites: [] }
+
+      stack[stack.length - 1].node.suites.push(node)
+      stack.push({ path: path.slice(0, depth + 1), node })
+    }
+
+    stack[stack.length - 1].node.tests.push(serializeSpecTest(test, runComplete))
+  }
+
+  const { results } = aggregateResults(runner)
+
+  return omitNullish({
+    spec,
+    stats: omitNullish({ ...results, duration: runDuration(runner, tests) }),
+    tests: root.tests,
+    suites: root.suites,
+  })
 }

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -7,6 +7,8 @@ export interface TapTestsRunner {
   /** Serializes one test by id lookup, skipping the whole-run serialization cost. */
   getTestState (testId: string): SerializedTest | undefined
   isRunComplete (): boolean
+  /** ISO start time of the run; null before the first test runs. */
+  getStartTime (): string | null
 }
 
 /**

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -70,11 +70,14 @@ describe('cypress-instances contract', () => {
 
       expect(reporter.params).toEqual([])
       expect(reporter.options.map(({ name, required }) => ({ name, required }))).toEqual([
-        { name: 'test', required: true },
+        { name: 'test', required: false },
         { name: 'attempt', required: false },
       ])
 
-      expect(buildTapSchema('15.0.0').commands.map(({ name }) => name)).toContain('reporter')
+      const advertised = buildTapSchema('15.0.0').commands.find(({ name }) => name === 'reporter')
+
+      expect(advertised).toBeDefined()
+      expect(advertised!.details).toBe(reporter.details)
     })
   })
 })

--- a/packages/cypress-instances/lib/contracts/reporter.ts
+++ b/packages/cypress-instances/lib/contracts/reporter.ts
@@ -185,13 +185,15 @@ export interface TapReporterSpecTest {
 }
 
 /**
- * One suite of the spec overview's tree. Direct tests render before nested
- * suites, the way the app reporter orders a suite's children.
+ * One suite section of the spec overview, flattened the way the CLI displays
+ * it: nesting is expressed in the joined title, not by recursion, and a suite
+ * whose tests all live in deeper suites gets no entry of its own.
  */
 export interface TapReporterSuite {
+  /** The full suite path, joined with ` > `, e.g. `A > B`. */
   title: string
+  /** The suite's direct tests, in document order. */
   tests: TapReporterSpecTest[]
-  suites: TapReporterSuite[]
 }
 
 /**
@@ -209,8 +211,8 @@ export interface TapReporterStats {
 
 /**
  * The `reporter` command's result when no test is given: the spec-level
- * overview the app reporter shows — header stats and the suite tree.
- * `tests` and `suites` are the root-level runnables.
+ * overview the app reporter shows — header stats, the root-level tests, and
+ * one flattened section per suite with direct tests, in document order.
  */
 export interface TapReporterSpecView {
   /** Project-relative spec path; absent only if the active spec can't be read. */

--- a/packages/cypress-instances/lib/contracts/reporter.ts
+++ b/packages/cypress-instances/lib/contracts/reporter.ts
@@ -158,3 +158,64 @@ export interface TapReporterView {
   /** Present only when the attempt failed. */
   error?: TapReporterError
 }
+
+/** One attempt of a retried test. */
+export interface TapReporterSpecAttempt {
+  /** 1-based attempt number (attempt 1 = first run) — the value the `--attempt` option accepts. */
+  attempt: number
+  state: 'passed' | 'failed' | 'pending' | 'skipped'
+  /** Wall-clock run time in ms; absent until the attempt has run. */
+  duration?: number
+}
+
+/** One test row of the spec overview. */
+export interface TapReporterSpecTest {
+  /** The runner's test id, e.g. `r2` — the handle other tap commands accept. */
+  id: string
+  /** The test's own title, without its suite path. */
+  title: string
+  /** Final status, or the unreached placeholder (`pending` mid-run, `skipped` after). */
+  state: 'passed' | 'failed' | 'pending' | 'skipped'
+  /** Wall-clock run time in ms; absent until the test has run. */
+  duration?: number
+  /** Retries actually taken this run, not the configured maximum. */
+  retries?: number
+  /** Every attempt in run order, last one final; present only when the test was retried. */
+  attempts?: TapReporterSpecAttempt[]
+}
+
+/**
+ * One suite of the spec overview's tree. Direct tests render before nested
+ * suites, the way the app reporter orders a suite's children.
+ */
+export interface TapReporterSuite {
+  title: string
+  tests: TapReporterSpecTest[]
+  suites: TapReporterSuite[]
+}
+
+/**
+ * The app reporter's header stats. Unreached tests count as `pending` mid-run
+ * and `skipped` once the run completes.
+ */
+export interface TapReporterStats {
+  passed: number
+  failed: number
+  pending: number
+  skipped: number
+  /** Wall-clock run duration in ms, frozen at the last test's end once the run completes; absent before the run starts. */
+  duration?: number
+}
+
+/**
+ * The `reporter` command's result when no test is given: the spec-level
+ * overview the app reporter shows — header stats and the suite tree.
+ * `tests` and `suites` are the root-level runnables.
+ */
+export interface TapReporterSpecView {
+  /** Project-relative spec path; absent only if the active spec can't be read. */
+  spec?: string
+  stats: TapReporterStats
+  tests: TapReporterSpecTest[]
+  suites: TapReporterSuite[]
+}

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -108,7 +108,7 @@ const commandsMeta = {
 
 const reporterMeta = {
   name: 'reporter',
-  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test, the spec-level overview: run stats and the suite tree',
+  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test, the spec-level overview: run stats and every suite’s tests',
   details: `Shows test results the way the Cypress app's reporter panel does, right in
 your terminal. Pass --test <id> (ids come from the tests command) to see one
 test's full story: its network routes, the hooks that ran, the complete
@@ -116,7 +116,7 @@ command log, and the failure output when something went wrong. Add --attempt
 to view an earlier retry.
 
 Leave --test off to get the spec-level overview instead: the run's pass/fail
-stats and the whole suite tree at a glance.`,
+stats and every suite's tests at a glance.`,
   params: [],
   options: [
     { ...testIdField, required: false },

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -105,10 +105,10 @@ const commandsMeta = {
 
 const reporterMeta = {
   name: 'reporter',
-  description: 'render a test’s full reporter view: its routes, hooks, and command log',
+  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test, the spec-level overview: run stats and the suite tree',
   params: [],
   options: [
-    { ...testIdField, required: true },
+    { ...testIdField, required: false },
     attemptField,
   ],
 } as const satisfies TapCommandSchema

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -24,6 +24,9 @@ export interface TapCommandOptionSchema {
 export interface TapCommandSchema {
   name: string
   description: string
+  // Longer prose for the command's standalone `--help`; the one-line
+  // `description` still renders in the command listing.
+  details?: string
   params: readonly TapCommandParamSchema[]
   options: readonly TapCommandOptionSchema[]
   // Absent ⇒ visible. A hidden command stays exec-able but the CLI omits it from
@@ -106,6 +109,14 @@ const commandsMeta = {
 const reporterMeta = {
   name: 'reporter',
   description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test, the spec-level overview: run stats and the suite tree',
+  details: `Shows test results the way the Cypress app's reporter panel does, right in
+your terminal. Pass --test <id> (ids come from the tests command) to see one
+test's full story: its network routes, the hooks that ran, the complete
+command log, and the failure output when something went wrong. Add --attempt
+to view an earlier retry.
+
+Leave --test off to get the spec-level overview instead: the run's pass/fail
+stats and the whole suite tree at a glance.`,
   params: [],
   options: [
     { ...testIdField, required: false },
@@ -154,6 +165,7 @@ export const buildTapSchema = (cypressVersion: string): TapSchema => {
     return {
       name: command.name,
       description: command.description,
+      ...('details' in command ? { details: command.details } : {}),
       params: command.params.map((param) => ({ ...param })),
       options: command.options.map((option) => ({ ...option })),
       ...('hidden' in command && command.hidden ? { hidden: true } : {}),


### PR DESCRIPTION
- Closes N/A (stacked POC off `feat/tap-cli-integration`)

### Additional details

Stacked on #34380, which added `tap reporter --test <id>`. That command required `--test`, so there was no way to ask the reporter what the spec as a whole did. This makes `--test` optional and renders the spec-level overview when it is omitted: the run's header stats and each suite's tests, the way the app reporter shows them before you drill into a test.

- **Spec overview result.** `TapReporterSpecView` carries the spec path, the header stats (`passed` / `failed` / `pending` / `skipped` plus the run clock), the root-level tests, and a flat `suites` list — one entry per suite with direct tests, titled by its full joined path (`A > B`), no nesting on the wire. Entries are grouped from each runnable's `_titlePath` in document order, so the JSON mirrors the rendered sections one to one; a suite whose tests all live in deeper suites gets no entry of its own.
- **Unreached tests.** They count as `pending` mid-run and `skipped` once the run completes, consistent with how the rest of tap reports them.
- **Retries.** A retried test carries every attempt in run order, last one final, and renders them indented under the test row so you can see which attempt failed.
- **Header formatting matches the app.** Zero counts render as `--` rather than `0`, and the run clock spans the same duration formats (`817ms`, `00:17`, `1:02:03`).
- **Command help.** The tap command schema gains an optional `details` field, swapped in for the one-line `description` when rendering `<command> --help`. This is the same swap `buildNativeProgram` already does for CLI-native commands. `reporter` uses it to explain both of its modes, since the one-liner cannot carry that on its own. `TapManager.getSchema` hand-builds the advertised schema from the command registry, so it carries `details` through too; without that an attached CLI would fall back to the one-line description and the field would only work offline.

This also fixes the `@packages/cypress-instances` contract spec, which still asserted `--test` was required.

### Steps to test

Open Cypress against a project with a few suites and at least one retried test, run the spec, then:

```
cypress tap reporter            # spec-level overview
cypress tap reporter --json     # raw result
cypress tap reporter --test <id># unchanged single-test view
cypress tap reporter --help     # the longer details prose
```

Confirm each suite section is headed by its full joined path the way the app reporter's breadcrumbs read (and that `--json` returns the same flat sections), that a retried test lists its attempts, and that tests not yet reached show as pending mid-run and skipped once the run finishes.

### How has the user experience changed?

`cypress tap reporter` with no `--test` used to fail on a missing required option. It now prints the spec overview:

```
cypress/e2e/actions.cy.js
✓ 2  ✖ 1  ○ 1  - 1  00:17

   t1  ✓ root test  20ms

A
   t2  ✓ a1  10ms
   t4  ○ a2

A > B
   t3  ✖ b1  30ms  (2 retries)
         ✖ attempt 1  4.5s
         ✖ attempt 2  4.4s
         ✖ attempt 3  30ms

C
   t5  - c1
```

`cypress tap reporter --help` also now renders the longer prose instead of the one-line summary. The `--test` view is unchanged.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- POC / stacked exploration branch -->
- [x] Have tests been added/updated? <!-- CLI render snapshots, app reporter component specs, contract spec -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- `cypress tap` is not yet publicly documented -->
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive tap CLI and reporter serialization with broad test coverage; no auth or persistence changes, and the single-test **`--test`** path is unchanged.
> 
> **Overview**
> **`cypress tap reporter`** no longer requires **`--test`**. With no test id, it returns a **`TapReporterSpecView`**: spec path, pass/fail/pending/skipped stats (plus run duration from **`getStartTime`**), root-level tests, and flat suite sections keyed by joined paths like **`A > B`**, including retry attempts and the same pending-vs-skipped rules for unreached tests. **`--attempt`** without **`--test`** is rejected.
> 
> The CLI picks **`renderReporterSpecHuman`** when the result includes **`stats`**, matching app reporter header formatting (zero counts as **`--`**, duration formats). **`cypress tap <command> --help`** swaps schema **`details`** in place of the one-line **`description`**, with **`details`** on the wire schema and **`TapManager.getSchema`**.
> 
> The shared contract documents **`TapReporterSpecView`** and related types; **`reporter`** help text describes both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d7fb79bbb69316a1c82ed83b55db4968ce6dfcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->