### PR TITLE
chore: make content-encoding a per-pipeline driven port (HTTP/2)

### DIFF
--- a/packages/network-interception/lib/core/network-interception-core.ts
+++ b/packages/network-interception/lib/core/network-interception-core.ts
@@ -1,6 +1,8 @@
 import type {
+  BodyEncoding,
   ForBrowserNetworkAutomation,
   ForCommandLog,
+  ForContentEncoding,
   ForCookieState,
   ForDocumentPreparation,
   ForNetworkCapture,
@@ -26,6 +28,9 @@ export type NetworkInterceptionCoreOptions = {
   networkCapture?: ForNetworkCapture
   cookieState?: ForCookieState
   commandLog?: ForCommandLog
+  // One implementation per BodyEncoding a pipeline can declare; requests
+  // select by ctx.bodyEncoding (default 'wire').
+  contentEncoding?: Partial<Record<BodyEncoding, ForContentEncoding>>
   browserNetworkAutomation?: ForBrowserNetworkAutomation
 }
 
@@ -199,6 +204,25 @@ export class NetworkInterceptionCore {
     }
 
     return port.notifyResponseStreamReceived(ctx)
+  }
+
+  constrainAcceptEncoding (ctx: unknown): void {
+    return this.contentEncodingFor(ctx).constrainAcceptEncoding(ctx)
+  }
+
+  async compressBody (ctx: unknown): Promise<void> {
+    return this.contentEncodingFor(ctx).compressBody(ctx)
+  }
+
+  private contentEncodingFor (ctx: unknown): ForContentEncoding {
+    const { bodyEncoding = 'wire' } = ctx as { bodyEncoding?: BodyEncoding }
+    const port = this.options.contentEncoding?.[bodyEncoding]
+
+    if (!port) {
+      throw new Error(`NetworkInterceptionCore.contentEncoding.${bodyEncoding} is not configured`)
+    }
+
+    return port
   }
 
   notifyResponseEndedWithEmptyBody (ctx: unknown, options: { isCached: boolean }): void {

--- a/packages/network-interception/lib/ports/driven-ports.ts
+++ b/packages/network-interception/lib/ports/driven-ports.ts
@@ -37,9 +37,31 @@ export interface ForDocumentPreparation {
 }
 
 /**
+ * The state the pipeline's outgoing body must be in: `wire` re-encodes the
+ * body to match its content-encoding header (a real socket and a decoding
+ * netstack sit downstream), `identity` hands it back fully decoded (nothing
+ * downstream will decode, e.g. CDP Fetch.fulfillRequest). Declared per
+ * pipeline; a proxy-disabled runtime serves wire (express) and identity (CDP)
+ * pipelines side by side.
+ */
+export type BodyEncoding = 'wire' | 'identity'
+
+/**
+ * Driven port: content-encoding negotiation. The implementation is selected
+ * per request by the pipeline's declared {@link BodyEncoding}.
+ */
+export interface ForContentEncoding {
+  // Implementations advance the middleware stage themselves (ctx.next()).
+  constrainAcceptEncoding (ctx: unknown): void
+
+  compressBody (ctx: unknown): Promise<void>
+}
+
+/**
  * Driven port: Test Replay / protocol capture at the proxy boundary.
  */
 export interface ForNetworkCapture {
+  // Advances the middleware stage itself (ctx.next()).
   notifyResponseStreamReceived (ctx: unknown): Promise<void>
 
   notifyResponseEndedWithEmptyBody (ctx: unknown, options: { isCached: boolean }): void

--- a/packages/network-interception/test/unit/network-interception-core.spec.ts
+++ b/packages/network-interception/test/unit/network-interception-core.spec.ts
@@ -318,4 +318,48 @@ describe('NetworkInterceptionCore', () => {
     expect(notifyResponseStreamReceived).toHaveBeenCalledWith(ctx)
     expect(notifyResponseEndedWithEmptyBody).toHaveBeenCalledWith(ctx, { isCached: false })
   })
+
+  describe('content-encoding selection', () => {
+    function encodingPorts () {
+      return {
+        wire: { constrainAcceptEncoding: vi.fn(), compressBody: vi.fn() },
+        identity: { constrainAcceptEncoding: vi.fn(), compressBody: vi.fn() },
+      }
+    }
+
+    it('selects the wire implementation when the ctx declares no bodyEncoding', async () => {
+      const contentEncoding = encodingPorts()
+      const core = new NetworkInterceptionCore({ contentEncoding })
+      const ctx = {}
+
+      core.constrainAcceptEncoding(ctx)
+      await core.compressBody(ctx)
+
+      expect(contentEncoding.wire.constrainAcceptEncoding).toHaveBeenCalledWith(ctx)
+      expect(contentEncoding.wire.compressBody).toHaveBeenCalledWith(ctx)
+      expect(contentEncoding.identity.constrainAcceptEncoding).not.toHaveBeenCalled()
+      expect(contentEncoding.identity.compressBody).not.toHaveBeenCalled()
+    })
+
+    it('selects the implementation the ctx bodyEncoding declares', async () => {
+      const contentEncoding = encodingPorts()
+      const core = new NetworkInterceptionCore({ contentEncoding })
+      const ctx = { bodyEncoding: 'identity' }
+
+      core.constrainAcceptEncoding(ctx)
+      await core.compressBody(ctx)
+
+      expect(contentEncoding.identity.constrainAcceptEncoding).toHaveBeenCalledWith(ctx)
+      expect(contentEncoding.identity.compressBody).toHaveBeenCalledWith(ctx)
+      expect(contentEncoding.wire.constrainAcceptEncoding).not.toHaveBeenCalled()
+      expect(contentEncoding.wire.compressBody).not.toHaveBeenCalled()
+    })
+
+    it('throws when the declared bodyEncoding has no implementation', async () => {
+      const core = new NetworkInterceptionCore({})
+
+      expect(() => core.constrainAcceptEncoding({})).toThrow('NetworkInterceptionCore.contentEncoding.wire is not configured')
+      await expect(core.compressBody({ bodyEncoding: 'identity' })).rejects.toThrow('NetworkInterceptionCore.contentEncoding.identity is not configured')
+    })
+  })
 })

--- a/packages/proxy/lib/adapters/content-encoding.ts
+++ b/packages/proxy/lib/adapters/content-encoding.ts
@@ -1,0 +1,93 @@
+import zlib from 'zlib'
+import { telemetry } from '@packages/telemetry'
+import { getSupportedAcceptEncoding } from '@packages/network-tools'
+import { isVerboseTelemetry as isVerbose } from '../http'
+import type { ForContentEncoding } from '@packages/network-interception'
+import type { RequestInterceptionMiddlewareCtx, ResponseInterceptionMiddlewareCtx } from './types'
+
+const zlibGzipCompressOptions = {
+  flush: zlib.constants.Z_SYNC_FLUSH,
+  // Compression must use Z_FINISH so the gzip trailer (CRC + size) is written; otherwise
+  // gunzip fails with "unexpected end of file" when decoding layered encoding (e.g. gzip, br).
+  finishFlush: zlib.constants.Z_FINISH,
+  level: zlib.constants.Z_BEST_SPEED,
+}
+
+const zlibBrotliCompressOptions = {
+  flush: zlib.constants.BROTLI_OPERATION_FLUSH,
+  finishFlush: zlib.constants.BROTLI_OPERATION_FINISH,
+  params: {
+    // Brotli default quality is 11 (slowest). Use quality 1 for fast re-compression in the proxy.
+    [zlib.constants.BROTLI_PARAM_QUALITY]: 1,
+  },
+}
+
+/**
+ * {@link ForContentEncoding} adapter for pipelines where Node performs the
+ * transfer: constrain what the origin may send to what Node can decode, and
+ * re-encode the body for the socket.
+ */
+export class ProxyContentEncodingAdapter implements ForContentEncoding {
+  constrainAcceptEncoding (context: unknown): void {
+    const ctx = context as RequestInterceptionMiddlewareCtx
+    const span = telemetry.startSpan({ name: 'strip:unsupported:accept:encoding', parentSpan: ctx.reqMiddlewareSpan, isVerbose })
+
+    const acceptEncoding = ctx.req.headers['accept-encoding']
+
+    if (acceptEncoding && !ctx.req.originalAcceptEncoding) {
+      ctx.req.originalAcceptEncoding = acceptEncoding
+    }
+
+    const supported = getSupportedAcceptEncoding(acceptEncoding)
+
+    span?.setAttributes({
+      acceptEncodingHeaderPresent: !!acceptEncoding,
+      doesAcceptHeadingIncludeGzip: !!acceptEncoding?.includes('gzip'),
+      doesAcceptHeadingIncludeBr: !!acceptEncoding?.includes('br'),
+    })
+
+    ctx.req.headers['accept-encoding'] = supported
+    ctx.debug(
+      acceptEncoding ? 'accept-encoding header present, setting to %s' : 'no accept-encoding header, setting to %s',
+      supported,
+    )
+
+    span?.end()
+    ctx.next()
+  }
+
+  async compressBody (context: unknown): Promise<void> {
+    const ctx = context as ResponseInterceptionMiddlewareCtx
+
+    // Re-compress in the same order as the original content-encoding (innermost first).
+    const order = ctx.contentEncodingOrder ?? []
+
+    for (const enc of order) {
+      if (enc === 'gzip' && ctx.isGunzipped) {
+        ctx.debug('regzipping response body')
+
+        const span = telemetry.startSpan({ name: 'gzip:body', parentSpan: ctx.resMiddlewareSpan, isVerbose })
+
+        ctx.incomingResStream = ctx.incomingResStream
+        .pipe(zlib.createGzip(zlibGzipCompressOptions))
+        .on('error', ctx.onError)
+        .once('close', () => {
+          span?.end()
+        })
+      } else if (enc === 'br' && ctx.isBrotliDecompressed) {
+        ctx.debug('re-compressing Brotli response body')
+
+        const span = telemetry.startSpan({ name: 'brotli:body', parentSpan: ctx.resMiddlewareSpan, isVerbose })
+
+        ctx.incomingResStream = ctx.incomingResStream
+        .pipe(zlib.createBrotliCompress(zlibBrotliCompressOptions))
+        .on('error', ctx.onError)
+        .once('close', () => {
+          span?.end()
+        })
+      }
+    }
+
+    ctx.next()
+  }
+}

--- a/packages/proxy/lib/adapters/create-proxy-network-interception.ts
+++ b/packages/proxy/lib/adapters/create-proxy-network-interception.ts
@@ -1,6 +1,8 @@
 import { NetworkInterceptionCore } from '@packages/network-interception'
 import type { ForNetworkPolicyRegistration } from '@packages/network-interception'
+import { IdentityContentEncodingAdapter } from './identity-content-encoding'
 import { ProxyCommandLogAdapter } from './proxy-command-log'
+import { ProxyContentEncodingAdapter } from './content-encoding'
 import { ProxyCookieStateAdapter } from './proxy-cookie-state'
 import { ProxyDocumentPreparationAdapter } from './proxy-document-preparation'
 import { ProxyNetworkCaptureAdapter } from './proxy-network-capture'
@@ -25,5 +27,14 @@ export function createProxyNetworkInterception (
     networkCapture: new ProxyNetworkCaptureAdapter(),
     cookieState: new ProxyCookieStateAdapter(),
     commandLog: new ProxyCommandLogAdapter(),
+    // Requests select by the pipeline's declared bodyEncoding ('wire' unless
+    // declared otherwise). 'wire' is the express path — MITM proxied traffic,
+    // and the express pipeline (studio/cy-prompt forwards) that still serves
+    // over a real socket when the proxy is disabled. 'identity' is the CDP
+    // path, where fulfilled bodies must ship fully decoded.
+    contentEncoding: {
+      wire: new ProxyContentEncodingAdapter(),
+      identity: new IdentityContentEncodingAdapter(),
+    },
   })
 }

--- a/packages/proxy/lib/adapters/identity-content-encoding.ts
+++ b/packages/proxy/lib/adapters/identity-content-encoding.ts
@@ -1,0 +1,154 @@
+import zlib from 'zlib'
+import type { Readable, Transform } from 'stream'
+import type { ForContentEncoding } from '@packages/network-interception'
+
+type RequestCtx = {
+  next: () => void
+}
+
+type ResponseCtx = {
+  incomingRes: { headers: Record<string, string | string[] | undefined> }
+  incomingResStream: Readable
+  isGunzipped?: boolean
+  isBrotliDecompressed?: boolean
+  res: { removeHeader: (name: string) => void, setHeader: (name: string, value: string) => void }
+  onError: (error: Error) => void
+  next: () => void
+}
+
+// Lenient flush options tolerate truncated or slightly invalid input, matching
+// the decompression the rest of the pipeline applies to upstream bodies.
+const zlibDecompressOptions = {
+  flush: zlib.constants.Z_SYNC_FLUSH,
+  finishFlush: zlib.constants.Z_SYNC_FLUSH,
+}
+
+const brotliDecompressOptions = {
+  flush: zlib.constants.BROTLI_OPERATION_FLUSH,
+  finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH,
+}
+
+// What this adapter can undo is its own property — a stub may declare any
+// encoding regardless of what the wire pipeline negotiates with origins.
+// Deliberately broader than the wire path's gzip/br set: this path only ever
+// decodes, while the wire path must also re-encode whatever it undoes. So
+// stub-declared x-gzip/deflate render correctly on this pipeline, while the
+// MITM pipeline still treats them as opaque (see cypress-io/cypress#34387).
+const STREAM_DECODERS: Record<string, () => Transform> = {
+  gzip: () => zlib.createGunzip(zlibDecompressOptions),
+  'x-gzip': () => zlib.createGunzip(zlibDecompressOptions),
+  deflate: () => zlib.createInflate(zlibDecompressOptions),
+  br: () => zlib.createBrotliDecompress(brotliDecompressOptions),
+}
+
+function parseContentEncoding (header?: string | string[]): string[] {
+  return ([] as string[]).concat(header ?? [])
+  .join(',')
+  .split(',')
+  .map((token) => token.trim().toLowerCase())
+  .filter((token) => token && token !== 'identity')
+}
+
+// makeResStreamPlainText decodes at most one gzip and one br layer, always the
+// outermost occurrence of each — mirror that when reporting what remains.
+function withoutPeeledLayers (encodings: string[], ctx: Pick<ResponseCtx, 'isGunzipped' | 'isBrotliDecompressed'>): string[] {
+  const remaining = [...encodings]
+  const peel = (token: string, peeled?: boolean) => {
+    const index = peeled ? remaining.lastIndexOf(token) : -1
+
+    if (index !== -1) {
+      remaining.splice(index, 1)
+    }
+  }
+
+  peel('gzip', ctx.isGunzipped)
+  peel('br', ctx.isBrotliDecompressed)
+
+  return remaining
+}
+
+/**
+ * {@link ForContentEncoding} implementation for pipelines where the browser
+ * performs the transfer: it negotiates its own `accept-encoding` and decodes
+ * what the origin sends, so the body handed back to it must be identity.
+ *
+ * Lives here rather than with the port: @packages/network-interception is
+ * isomorphic (the driver bundles its index into the browser), and this
+ * adapter needs node builtins.
+ */
+export class IdentityContentEncodingAdapter implements ForContentEncoding {
+  constrainAcceptEncoding (context: unknown): void {
+    // The browser owns accept-encoding negotiation on this pipeline.
+    const ctx = context as RequestCtx
+
+    ctx.next()
+  }
+
+  async compressBody (context: unknown): Promise<void> {
+    const ctx = context as ResponseCtx
+    // The transport strips the origin's encoding headers on the way in, so a
+    // surviving one was declared by a `cy.intercept` stub over a body this
+    // pipeline never decoded — e.g. replaying a recorded response verbatim:
+    //   req.reply({ headers: { 'content-encoding': 'gzip' }, body: recordedGzipBytes })
+    // Over a real socket the browser's netstack decodes that; a fulfilled
+    // response runs no decoders, so this adapter has to.
+    const contentEncoding = ctx.incomingRes.headers['content-encoding']
+
+    if (!contentEncoding) {
+      return ctx.next()
+    }
+
+    const encodings = parseContentEncoding(contentEncoding)
+
+    // A header that names nothing to decode (bare `identity`) just gets dropped.
+    if (!encodings.length) {
+      ctx.res.removeHeader('content-encoding')
+
+      return ctx.next()
+    }
+
+    // An encoding we cannot undo has to ship as the pair it arrived as — a body
+    // that lies about its encoding is worse than one the browser rejects. But
+    // makeResStreamPlainText may already have peeled the outermost gzip/br
+    // layer for earlier middleware, and this path cannot re-encode it the way
+    // the wire path does — so drop the peeled tokens from the header to keep
+    // the shipped pair consistent.
+    if (!encodings.every((encoding) => STREAM_DECODERS[encoding])) {
+      const remaining = withoutPeeledLayers(encodings, ctx)
+
+      if (remaining.length !== encodings.length) {
+        ctx.res.setHeader('content-encoding', remaining.join(', '))
+      }
+
+      return ctx.next()
+    }
+
+    // Earlier middleware may already have decoded the outermost gzip or br
+    // layer through makeResStreamPlainText (it decodes each of those at most
+    // once, tracked by these flags) — skip one matching layer so the stream is
+    // never decoded twice.
+    let gzipAlreadyDecoded = Boolean(ctx.isGunzipped)
+    let brotliAlreadyDecoded = Boolean(ctx.isBrotliDecompressed)
+
+    // Encodings are listed in the order applied — decode outermost first.
+    for (let i = encodings.length - 1; i >= 0; i--) {
+      const encoding = encodings[i]
+
+      if (encoding === 'gzip' && gzipAlreadyDecoded) {
+        gzipAlreadyDecoded = false
+        continue
+      }
+
+      if (encoding === 'br' && brotliAlreadyDecoded) {
+        brotliAlreadyDecoded = false
+        continue
+      }
+
+      ctx.incomingResStream = ctx.incomingResStream.pipe(STREAM_DECODERS[encoding]()).on('error', ctx.onError)
+    }
+
+    ctx.res.removeHeader('content-encoding')
+
+    ctx.next()
+  }
+}

--- a/packages/proxy/lib/adapters/index.ts
+++ b/packages/proxy/lib/adapters/index.ts
@@ -4,6 +4,10 @@ export { ProxyResponseInterceptionAdapter } from './proxy-response-interception'
 
 export { ProxyNetworkCaptureAdapter } from './proxy-network-capture'
 
+export { ProxyContentEncodingAdapter } from './content-encoding'
+
+export { IdentityContentEncodingAdapter } from './identity-content-encoding'
+
 export { ProxyCookieStateAdapter } from './proxy-cookie-state'
 
 export { ProxyCommandLogAdapter } from './proxy-command-log'

--- a/packages/proxy/lib/adapters/network-capture.ts
+++ b/packages/proxy/lib/adapters/network-capture.ts
@@ -9,7 +9,7 @@ import type { ResponseInterceptionMiddlewareCtx } from './types'
  */
 export async function notifyResponseStreamReceived (mw: ResponseInterceptionMiddlewareCtx): Promise<void> {
   if (!mw.protocolManager || !mw.req.browserPreRequest?.requestId) {
-    return
+    return mw.next()
   }
 
   const preRequest = mw.req.browserPreRequest
@@ -42,6 +42,8 @@ export async function notifyResponseStreamReceived (mw: ResponseInterceptionMidd
   } else {
     span?.end()
   }
+
+  mw.next()
 }
 
 /**

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -24,7 +24,7 @@ import type {
 } from '../types'
 import type { IncomingMessage } from 'http'
 import type { NetStubbingState } from '@packages/net-stubbing'
-import type { ForNetworkInterception, HttpResponse, InterceptMiddleware, NetworkInterceptionCore, TransportCodecPort } from '@packages/network-interception'
+import type { BodyEncoding, ForNetworkInterception, HttpResponse, InterceptMiddleware, NetworkInterceptionCore, TransportCodecPort } from '@packages/network-interception'
 import type { Readable } from 'stream'
 import type { Request, Response } from 'express'
 import type { RemoteStates } from '@packages/network-tools'
@@ -97,6 +97,7 @@ export type HttpMiddlewareCtx<T> = {
   setAUTUrl: Http['setAUTUrl']
   simulatedCookies: SerializableAutomationCookie[]
   protocolManager?: ProtocolManagerShape
+  bodyEncoding: BodyEncoding
 } & T
 
 export const defaultMiddleware = {
@@ -135,6 +136,7 @@ const READONLY_MIDDLEWARE_KEYS: (keyof HttpMiddlewareThis<{}>)[] = [
   'onError',
   'skipMiddleware',
   'onlyRunMiddleware',
+  'bodyEncoding',
 ]
 
 export type HttpMiddlewareThis<T> = HttpMiddlewareCtx<T> & ServerCtx & Readonly<{
@@ -388,10 +390,14 @@ export class Http {
     return onError
   }
 
-  createLegacyProxyPipeline (codec: TransportCodecPort<any, any>): InterceptMiddleware {
+  createLegacyProxyPipeline (codec: TransportCodecPort<any, any>, options: { bodyEncoding?: BodyEncoding } = {}): InterceptMiddleware {
     return async (request, next): Promise<HttpResponse> => {
       try {
         const ctx = codec.encodeRequest(request)
+
+        if (options.bodyEncoding) {
+          ctx.bodyEncoding = options.bodyEncoding
+        }
 
         const onError = this.buildOnError(ctx)
 
@@ -528,6 +534,9 @@ export class Http {
       },
       protocolManager: this.protocolManager,
       getCurrentBrowser: this.getCurrentBrowser,
+      // The outgoing body is re-encoded for the wire unless the pipeline the
+      // composition root builds over this ctx declares otherwise.
+      bodyEncoding: 'wire',
     }
 
     return ctx

--- a/packages/proxy/lib/http/request-middleware.ts
+++ b/packages/proxy/lib/http/request-middleware.ts
@@ -5,7 +5,7 @@ import { isVerboseTelemetry as isVerbose } from '.'
 import { doesTopNeedToBeSimulated } from './util/top-simulation'
 import { resourceTypeAndCredentialManager } from '../resourceTypeAndCredentialManager'
 import type { HttpMiddleware } from './'
-import { getSupportedAcceptEncoding, urlMatchesOriginProtectionSpace } from '@packages/network-tools'
+import { urlMatchesOriginProtectionSpace } from '@packages/network-tools'
 
 // do not use a debug namespace in this file - use the per-request `this.debug` instead
 // available as cypress-verbose:proxy:http
@@ -217,31 +217,10 @@ const EndRequestsToBlockedHosts: RequestMiddleware = async function () {
   return this.networkInterceptionCore.endRequestIfBlocked(this)
 }
 
+// Constraining accept-encoding only makes sense when Node decodes the response,
+// so the implementation is selected by the pipeline's declared bodyEncoding.
 const StripUnsupportedAcceptEncoding: RequestMiddleware = function () {
-  const span = telemetry.startSpan({ name: 'strip:unsupported:accept:encoding', parentSpan: this.reqMiddlewareSpan, isVerbose })
-
-  const acceptEncoding = this.req.headers['accept-encoding']
-
-  if (acceptEncoding && !this.req.originalAcceptEncoding) {
-    this.req.originalAcceptEncoding = acceptEncoding
-  }
-
-  const supported = getSupportedAcceptEncoding(acceptEncoding)
-
-  span?.setAttributes({
-    acceptEncodingHeaderPresent: !!acceptEncoding,
-    doesAcceptHeadingIncludeGzip: !!acceptEncoding?.includes('gzip'),
-    doesAcceptHeadingIncludeBr: !!acceptEncoding?.includes('br'),
-  })
-
-  this.req.headers['accept-encoding'] = supported
-  this.debug(
-    acceptEncoding ? 'accept-encoding header present, setting to %s' : 'no accept-encoding header, setting to %s',
-    supported,
-  )
-
-  span?.end()
-  this.next()
+  this.networkInterceptionCore.constrainAcceptEncoding(this)
 }
 
 function reqNeedsBasicAuthHeaders (req, { auth, origin }: Cypress.RemoteState) {

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -57,14 +57,6 @@ const zlibGzipDecompressOptions = {
   finishFlush: zlib.constants.Z_SYNC_FLUSH,
 }
 
-const zlibGzipCompressOptions = {
-  flush: zlib.constants.Z_SYNC_FLUSH,
-  // Compression must use Z_FINISH so the gzip trailer (CRC + size) is written; otherwise
-  // gunzip fails with "unexpected end of file" when decoding layered encoding (e.g. gzip, br).
-  finishFlush: zlib.constants.Z_FINISH,
-  level: zlib.constants.Z_BEST_SPEED,
-}
-
 // Brotli decompression: use BROTLI_OPERATION_FLUSH for lenient decompression of truncated or
 // slightly invalid brotli from upstream (same rationale as zlibGzipDecompressOptions for createGunzip).
 const zlibBrotliDecompressOptions = {
@@ -72,15 +64,10 @@ const zlibBrotliDecompressOptions = {
   finishFlush: zlib.constants.BROTLI_OPERATION_FLUSH,
 }
 
-const zlibBrotliCompressOptions = {
-  flush: zlib.constants.BROTLI_OPERATION_FLUSH,
-  finishFlush: zlib.constants.BROTLI_OPERATION_FINISH,
-  params: {
-    // Brotli default quality is 11 (slowest). Use quality 1 for fast re-compression in the proxy.
-    [zlib.constants.BROTLI_PARAM_QUALITY]: 1,
-  },
-}
-
+// The encodings makeResStreamPlainText can undo, and so the only ones an
+// encoding adapter can put back. Literal tokens only — x-gzip and deflate are
+// opaque to this pipeline (cypress-io/cypress#34387), though the identity
+// implementation decodes them since it never has to re-encode.
 const SUPPORTED_CONTENT_ENCODINGS = ['gzip', 'br'] as const
 
 type SupportedContentEncoding = typeof SUPPORTED_CONTENT_ENCODINGS[number]
@@ -202,6 +189,7 @@ const FilterNonProxiedResponse: ResponseMiddleware = function () {
       'MaybeSendRedirectToClient',
       'CopyResponseStatusCode',
       'MaybeEndWithEmptyBody',
+      'NotifyResponseStreamReceived',
       'CompressBody',
       'SendResponseBodyToClient',
     ])
@@ -619,39 +607,16 @@ const MaybeInjectServiceWorker: ResponseMiddleware = function () {
   })
 }
 
-const CompressBody: ResponseMiddleware = async function () {
-  await this.networkInterceptionCore.notifyResponseStreamReceived(this)
+// Runs on every pipeline, and must observe the stream before the encoding stage
+// re-encodes it — it may hand back a tee for that stage to pipe.
+const NotifyResponseStreamReceived: ResponseMiddleware = function () {
+  return this.networkInterceptionCore.notifyResponseStreamReceived(this)
+}
 
-  // Re-compress in the same order as the original content-encoding (innermost first).
-  const order = this.contentEncodingOrder ?? []
-
-  for (const enc of order) {
-    if (enc === 'gzip' && this.isGunzipped) {
-      this.debug('regzipping response body')
-
-      const span = telemetry.startSpan({ name: 'gzip:body', parentSpan: this.resMiddlewareSpan, isVerbose })
-
-      this.incomingResStream = this.incomingResStream
-      .pipe(zlib.createGzip(zlibGzipCompressOptions))
-      .on('error', this.onError)
-      .once('close', () => {
-        span?.end()
-      })
-    } else if (enc === 'br' && this.isBrotliDecompressed) {
-      this.debug('re-compressing Brotli response body')
-
-      const span = telemetry.startSpan({ name: 'brotli:body', parentSpan: this.resMiddlewareSpan, isVerbose })
-
-      this.incomingResStream = this.incomingResStream
-      .pipe(zlib.createBrotliCompress(zlibBrotliCompressOptions))
-      .on('error', this.onError)
-      .once('close', () => {
-        span?.end()
-      })
-    }
-  }
-
-  this.next()
+// What the outgoing body has to be encoded as is the pipeline's declared
+// bodyEncoding, which selects the implementation.
+const CompressBody: ResponseMiddleware = function () {
+  return this.networkInterceptionCore.compressBody(this)
 }
 
 const SendResponseBodyToClient: ResponseMiddleware = function () {
@@ -687,6 +652,7 @@ export default {
   MaybeInjectHtml,
   MaybeRemoveSecurity,
   MaybeInjectServiceWorker,
+  NotifyResponseStreamReceived,
   CompressBody,
   SendResponseBodyToClient,
 }

--- a/packages/proxy/lib/index.ts
+++ b/packages/proxy/lib/index.ts
@@ -10,6 +10,8 @@ export {
   ProxyNetworkCaptureAdapter,
   ProxyCookieStateAdapter,
   ProxyCommandLogAdapter,
+  ProxyContentEncodingAdapter,
+  IdentityContentEncodingAdapter,
   createSyntheticProxyCodec,
   createSyntheticExpressContext,
 } from './adapters'

--- a/packages/proxy/test/unit/adapters/content-encoding.spec.ts
+++ b/packages/proxy/test/unit/adapters/content-encoding.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Readable } from 'stream'
+import { ProxyContentEncodingAdapter } from '../../../lib/adapters/content-encoding'
+
+function requestCtx (headers: Record<string, any> = {}) {
+  return {
+    req: { headers: { ...headers } },
+    debug: () => {},
+    next: vi.fn(),
+  }
+}
+
+function responseCtx (props: Record<string, any> = {}) {
+  const { incomingResHeaders, ...rest } = props
+
+  return {
+    incomingRes: { headers: { ...incomingResHeaders } },
+    incomingResStream: Readable.from(['body']),
+    res: { removeHeader: vi.fn() },
+    makeResStreamPlainText: vi.fn(),
+    debug: () => {},
+    onError: () => {},
+    next: vi.fn(),
+    ...rest,
+  }
+}
+
+describe('adapters/content-encoding', () => {
+  describe('ProxyContentEncodingAdapter', () => {
+    const adapter = new ProxyContentEncodingAdapter()
+
+    it('narrows accept-encoding to what Node can decode', () => {
+      const ctx = requestCtx({ 'accept-encoding': 'gzip, deflate, br' })
+
+      adapter.constrainAcceptEncoding(ctx)
+
+      expect(ctx.req.headers['accept-encoding']).toEqual('gzip,br')
+      expect((ctx.req as any).originalAcceptEncoding).toEqual('gzip, deflate, br')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('synthesizes gzip,identity when the request carries no accept-encoding', () => {
+      const ctx = requestCtx()
+
+      adapter.constrainAcceptEncoding(ctx)
+
+      expect(ctx.req.headers['accept-encoding']).toEqual('gzip,identity')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-encodes a decoded body in the original encoding order', async () => {
+      const ctx = responseCtx({ contentEncodingOrder: ['gzip'], isGunzipped: true })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).not.toBe(original)
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('leaves a body the pipeline never decoded alone', async () => {
+      const ctx = responseCtx({ contentEncodingOrder: ['gzip'], isGunzipped: false })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/proxy/test/unit/adapters/identity-content-encoding.spec.ts
+++ b/packages/proxy/test/unit/adapters/identity-content-encoding.spec.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest'
+import zlib from 'zlib'
+import { Readable } from 'stream'
+import { IdentityContentEncodingAdapter } from '../../../lib/adapters/identity-content-encoding'
+
+function requestCtx (headers: Record<string, any> = {}) {
+  return {
+    req: { headers: { ...headers } },
+    next: vi.fn(),
+  }
+}
+
+function responseCtx (incomingResHeaders: Record<string, any> = {}, body: Buffer | string = 'body', flags: Record<string, boolean> = {}) {
+  return {
+    incomingRes: { headers: { ...incomingResHeaders } },
+    incomingResStream: Readable.from([body]),
+    res: { removeHeader: vi.fn(), setHeader: vi.fn() },
+    onError: (err: Error) => {
+      throw err
+    },
+    next: vi.fn(),
+    ...flags,
+  }
+}
+
+async function readStream (stream: Readable): Promise<string> {
+  const chunks: Buffer[] = []
+
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+
+  return Buffer.concat(chunks).toString()
+}
+
+describe('adapters/identity-content-encoding', () => {
+  const adapter = new IdentityContentEncodingAdapter()
+
+  describe('constrainAcceptEncoding', () => {
+    it('leaves accept-encoding untouched so the browser keeps its own negotiation', () => {
+      const ctx = requestCtx()
+
+      adapter.constrainAcceptEncoding(ctx)
+
+      expect(ctx.req.headers['accept-encoding']).toBeUndefined()
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not narrow an accept-encoding header the browser already set', () => {
+      const ctx = requestCtx({ 'accept-encoding': 'gzip, deflate, br, zstd' })
+
+      adapter.constrainAcceptEncoding(ctx)
+
+      expect(ctx.req.headers['accept-encoding']).toEqual('gzip, deflate, br, zstd')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('compressBody', () => {
+    it('leaves the stream and headers alone when no encoding survived the transport', async () => {
+      const ctx = responseCtx()
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.res.removeHeader).not.toHaveBeenCalled()
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('drops a bare identity header without touching the body', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'identity' })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('decodes a stub-declared gzip body', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'gzip' }, zlib.gzipSync(Buffer.from('plain')))
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('decodes a stub-declared x-gzip body', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'x-gzip' }, zlib.gzipSync(Buffer.from('plain')))
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('decodes a stub-declared deflate body', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'deflate' }, zlib.deflateSync(Buffer.from('plain')))
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('decodes a layered stub-declared encoding outermost first', async () => {
+      const layered = zlib.gzipSync(zlib.brotliCompressSync(Buffer.from('plain')))
+      const ctx = responseCtx({ 'content-encoding': 'br, gzip' }, layered)
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('decodes every layer of a repeated encoding', async () => {
+      const doubled = zlib.gzipSync(zlib.gzipSync(Buffer.from('plain')))
+      const ctx = responseCtx({ 'content-encoding': 'gzip, gzip' }, doubled)
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips a gzip layer earlier middleware already decoded', async () => {
+      // makeResStreamPlainText decoded the outer layer and set isGunzipped;
+      // only the inner layer is still encoded
+      const inner = zlib.gzipSync(Buffer.from('plain'))
+      const ctx = responseCtx({ 'content-encoding': 'gzip, gzip' }, inner, { isGunzipped: true })
+
+      await adapter.compressBody(ctx)
+
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not decode again when earlier middleware already decoded the only layer', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'br' }, 'plain', { isBrotliDecompressed: true })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(await readStream(ctx.incomingResStream)).toBe('plain')
+      expect(ctx.res.removeHeader).toHaveBeenCalledWith('content-encoding')
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the body and header pair when the encoding cannot be undone', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'zstd' })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.res.removeHeader).not.toHaveBeenCalled()
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the pair when only part of a layered encoding can be undone', async () => {
+      const ctx = responseCtx({ 'content-encoding': 'gzip, zstd' })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.res.removeHeader).not.toHaveBeenCalled()
+      expect(ctx.res.setHeader).not.toHaveBeenCalled()
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+
+    it('drops a peeled layer from the header when the rest cannot be undone', async () => {
+      // makeResStreamPlainText already peeled the outer gzip for earlier
+      // middleware; the zstd core cannot be undone or re-encoded here, so the
+      // shipped header must describe what the body actually still is
+      const ctx = responseCtx({ 'content-encoding': 'zstd, gzip' }, 'still-zstd-encoded', { isGunzipped: true })
+      const original = ctx.incomingResStream
+
+      await adapter.compressBody(ctx)
+
+      expect(ctx.incomingResStream).toBe(original)
+      expect(ctx.res.setHeader).toHaveBeenCalledWith('content-encoding', 'zstd')
+      expect(ctx.res.removeHeader).not.toHaveBeenCalled()
+      expect(ctx.next).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/proxy/test/unit/http/helpers.ts
+++ b/packages/proxy/test/unit/http/helpers.ts
@@ -18,6 +18,8 @@ export function testMiddleware (middleware: TestMiddlewareStack, ctx: Record<str
     req: {},
     res: {},
     config: {},
+    // No bodyEncoding declared, so encoding stages default to 'wire',
+    // matching createMiddlewareContext
     networkInterceptionCore: createTestNetworkInterceptionCore(),
 
     middleware: {

--- a/packages/proxy/test/unit/http/index.spec.ts
+++ b/packages/proxy/test/unit/http/index.spec.ts
@@ -147,6 +147,38 @@ describe('http', function () {
       return http
     }
 
+    it('stamps the pipeline-declared bodyEncoding on the ctx, defaulting to wire', async function () {
+      const seen: string[] = []
+
+      incomingRequest.mockImplementation(function () {
+        seen.push(this.bodyEncoding)
+        this.incomingRes = {}
+        this.end()
+      })
+
+      incomingResponse.mockImplementation(function () {
+        this.end()
+      })
+
+      const defaultHttp = new Http(httpOpts)
+      const defaultIntercept = new HttpIntercept(proxyHttpCodec)
+
+      defaultIntercept.use(defaultHttp.createLegacyProxyPipeline(proxyHttpCodec))
+      defaultHttp.networkInterception = defaultIntercept
+      // @ts-expect-error
+      await defaultHttp.handleHttpRequest({}, { on, off })
+
+      const identityHttp = new Http(httpOpts)
+      const identityIntercept = new HttpIntercept(proxyHttpCodec)
+
+      identityIntercept.use(identityHttp.createLegacyProxyPipeline(proxyHttpCodec, { bodyEncoding: 'identity' }))
+      identityHttp.networkInterception = identityIntercept
+      // @ts-expect-error
+      await identityHttp.handleHttpRequest({}, { on, off })
+
+      expect(seen).toEqual(['wire', 'identity'])
+    })
+
     it('calls IncomingRequest stack, then IncomingResponse stack', async function () {
       incomingRequest.mockImplementation(function () {
         expect(incomingResponse).not.toHaveBeenCalled()

--- a/packages/proxy/test/unit/http/request-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/request-middleware.spec.ts
@@ -753,6 +753,22 @@ describe('http/request-middleware', () => {
       expect(ctx.req.originalAcceptEncoding).toBe('gzip, deflate, br')
     })
 
+    it('leaves accept-encoding untouched when the pipeline declares identity bodies', async () => {
+      const ctx = { ...prepareContext({ 'accept-encoding': 'gzip, deflate, br, zstd' }), bodyEncoding: 'identity' }
+
+      await testMiddleware([StripUnsupportedAcceptEncoding], ctx)
+      expect(ctx.req.headers!['accept-encoding']).toBe('gzip, deflate, br, zstd')
+    })
+
+    it('does not synthesize a header when the pipeline declares identity bodies', async () => {
+      // the browser appends its own accept-encoding after interception; a
+      // synthesized one would ride out as a continueRequest override
+      const ctx = { ...prepareContext(), bodyEncoding: 'identity' }
+
+      await testMiddleware([StripUnsupportedAcceptEncoding], ctx)
+      expect(ctx.req.headers!['accept-encoding']).toBeUndefined()
+    })
+
     it('strips to br only when client sends only br', async () => {
       const ctx = prepareContext({ 'accept-encoding': 'br' })
 

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -51,6 +51,7 @@ describe('http/response-middleware', function () {
       'MaybeInjectHtml',
       'MaybeRemoveSecurity',
       'MaybeInjectServiceWorker',
+      'NotifyResponseStreamReceived',
       'CompressBody',
       'SendResponseBodyToClient',
     ])
@@ -2727,8 +2728,8 @@ describe('http/response-middleware', function () {
     }
   })
 
-  describe('CompressBody', function () {
-    const { CompressBody } = ResponseMiddleware
+  describe('NotifyResponseStreamReceived and CompressBody', function () {
+    const { CompressBody, NotifyResponseStreamReceived } = ResponseMiddleware
     let ctx
     let responseStreamReceivedStub: Mock
 
@@ -2766,7 +2767,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',
@@ -2810,7 +2811,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',
@@ -2843,7 +2844,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).not.toHaveBeenCalled()
     })
 
@@ -2868,7 +2869,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).not.toHaveBeenCalled()
     })
 
@@ -2903,7 +2904,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',
@@ -2946,6 +2947,37 @@ describe('http/response-middleware', function () {
 
       expect(output).toBe(plaintext)
       expect(zlib.gzipSync(Buffer.from(plaintext)).toString()).not.toBe(plaintext)
+    })
+
+    it('does not re-encode a decoded body when the pipeline declares identity bodies', async function () {
+      const plaintext = 'foo'
+      const stream = Readable.from([plaintext])
+      const res = {
+        on: (_e: string, _l: () => void) => {},
+        off: (_e: string, _l: () => void) => {},
+      }
+
+      // the wire implementation would re-gzip this decoded body
+      prepareContext({
+        req: {},
+        res,
+        incomingRes: { headers: {} },
+        isGunzipped: true,
+        isBrotliDecompressed: false,
+        contentEncodingOrder: ['gzip'],
+        incomingResStream: stream,
+        bodyEncoding: 'identity',
+      })
+
+      await testMiddleware([CompressBody], ctx)
+
+      const chunks: Buffer[] = []
+
+      for await (const chunk of ctx.incomingResStream) {
+        chunks.push(Buffer.from(chunk))
+      }
+
+      expect(Buffer.concat(chunks).toString()).toBe(plaintext)
     })
 
     it('does not re-compress br when contentEncodingOrder includes br but isBrotliDecompressed is false', async function () {
@@ -3001,6 +3033,7 @@ describe('http/response-middleware', function () {
         contentEncodingOrder: order,
         incomingResStream: props.incomingResStream,
         makeResStreamPlainText: props.makeResStreamPlainText,
+        bodyEncoding: props.bodyEncoding,
       }
     }
   })

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -1,4 +1,3 @@
-import zlib from 'zlib'
 import type {
   HttpHeaders,
   HttpRequest,
@@ -71,13 +70,6 @@ function toResponseBody (body?: string | Buffer): string | undefined {
 const WIRE_LENGTH_HEADERS = new Set(['content-length', 'transfer-encoding'])
 const WIRE_ENCODING_HEADERS = new Set(['content-encoding', ...WIRE_LENGTH_HEADERS])
 
-const CONTENT_DECODERS: Record<string, (body: Buffer) => Buffer> = {
-  gzip: (body) => zlib.gunzipSync(body),
-  'x-gzip': (body) => zlib.gunzipSync(body),
-  br: (body) => zlib.brotliDecompressSync(body),
-  deflate: (body) => zlib.inflateSync(body),
-}
-
 function stripWireEncodingHeaders (headers?: HttpHeaders): HttpHeaders | undefined {
   if (!headers) {
     return undefined
@@ -94,51 +86,6 @@ function stripWireEncodingHeaders (headers?: HttpHeaders): HttpHeaders | undefin
 
 function stripHeaderEntries (headers: CdpFetchTransportResponse['responseHeaders'], names: ReadonlySet<string>): CdpFetchTransportResponse['responseHeaders'] {
   return headers?.filter(({ name }) => !names.has(name.toLowerCase()))
-}
-
-// Fetch.fulfillRequest hands the body to the renderer as-is — content
-// decoders do not run for fulfilled responses. The pipeline may emit encoded
-// bodies (CompressBody re-encodes rewritten documents), so decode fulfilled
-// bodies back to identity and drop the encoding headers. If an encoding
-// cannot be decoded, keep the body/header pair intact rather than shipping a
-// body that lies about its encoding.
-function toIdentityResponse (transportResponse: CdpFetchTransportResponse): CdpFetchTransportResponse {
-  const headers = transportResponse.responseHeaders
-  const contentEncoding = headers?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
-  const encodings = (contentEncoding ?? '')
-  .split(',')
-  .map((token) => token.trim().toLowerCase())
-  .filter((token) => token && token !== 'identity')
-
-  if (!transportResponse.body || !encodings.length) {
-    return {
-      ...transportResponse,
-      responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
-    }
-  }
-
-  let body = Buffer.from(transportResponse.body, 'base64')
-
-  try {
-    // encodings are listed in the order applied — decode outermost first
-    for (let i = encodings.length - 1; i >= 0; i--) {
-      const decode = CONTENT_DECODERS[encodings[i]]
-
-      if (!decode) {
-        throw new Error(`no decoder for content-encoding ${encodings[i]}`)
-      }
-
-      body = decode(body)
-    }
-  } catch (err) {
-    return transportResponse
-  }
-
-  return {
-    ...transportResponse,
-    body: body.toString('base64'),
-    responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
-  }
 }
 
 function toNetworkHeaders (headers?: HttpHeaders): Protocol.Network.Headers {
@@ -186,16 +133,6 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
     }
 
     return request as CdpFetchTransportRequest & { requestId: string }
-  }
-
-  const requireResponse = (id: string): CdpFetchTransportResponse => {
-    const response = inFlightResponses.get(id)
-
-    if (!response) {
-      throw new Error(`No CDP Fetch response pause found for ${id}. HttpIntercept middleware must call next() before returning a response.`)
-    }
-
-    return response
   }
 
   return {
@@ -247,11 +184,10 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
       const response = httpResponse as CdpFetchHttpResponse
       const pausedResponse = inFlightResponses.get(httpResponse.id)
       const fulfilled = response.body !== undefined
-      // Middleware headers describe the body the pipeline produced — including
-      // any re-encoding by CompressBody — so keep their content-encoding and
-      // only drop stale length headers. The pause-header fallback describes
-      // the wire body, not the decoded body we fulfill with, so its encoding
-      // headers are stripped too.
+      // Middleware headers describe the identity body this pipeline produces,
+      // so only stale length headers need dropping. The pause-header fallback
+      // describes the wire body, not the decoded body we fulfill with, so its
+      // encoding headers are stripped too.
       const fulfilledHeaders = (headers?: HttpHeaders, pauseHeaders?: CdpFetchTransportResponse['responseHeaders']) => {
         const middlewareHeaders = toResponseHeaders(headers)
 
@@ -278,7 +214,7 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
       transportResponse.url = httpResponse.url
       inFlightResponses.delete(httpResponse.id)
 
-      return transportResponse.fulfilled ? toIdentityResponse(transportResponse) : transportResponse
+      return transportResponse
     },
 
     releaseRequest (id: string): void {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -19,6 +19,21 @@ type CdpFetchRequest = Protocol.Fetch.RequestPausedEvent['request']
 const RESPONSE_PAUSE_TIMEOUT_MS = 30000
 const brotliDecompress = promisify(zlib.brotliDecompress)
 
+// Encodings Fetch.getResponseBody hands back still encoded — see
+// decodeUndeliveredEncodings. Derived by enumeration: Chrome's netstack
+// accepts gzip/deflate/br/zstd and getResponseBody undoes gzip/deflate, so
+// this is the complement — complete today, but revisit whenever either side
+// grows. Arrow wrappers keep this table free of module-init evaluation: the
+// v8 snapshot rewriter defers `promisify(...)` behind lazy getters, and
+// touching them while the snapshot is being created fails the build.
+// zlib.zstdDecompress landed in Node 22.15 — the binary's Electron always has
+// it, but this module also loads under older host Nodes (system-test
+// harnesses), so it must not be touched until a zstd body actually arrives.
+const UNDELIVERED_DECODERS: Record<string, (body: Buffer) => Promise<Buffer>> = {
+  br: (body) => brotliDecompress(body),
+  zstd: (body) => promisify(zlib.zstdDecompress)(body),
+}
+
 type CdpFetchTransportOptions = {
   isAUTFrame?: (frameId: string) => Promise<boolean>
 }
@@ -399,11 +414,20 @@ export class CdpFetchTransport {
   }
 
   /**
-   * Fetch.getResponseBody delivers gzip/deflate content-decoded, but brotli
-   * arrives still encoded (and continueRequest cannot constrain
-   * accept-encoding — the network stack owns that header). Decode br here so
-   * the middleware's decoded-body premise holds. Falls back to the raw bytes
-   * if decompression fails, in case a newer CDP starts decoding br itself.
+   * Compensates for a CDP inconsistency. At a paused response the buffered
+   * body is still wire-encoded: content decoding normally happens as the
+   * network service streams to the renderer, a point a Fetch pause never
+   * reaches. Fetch.getResponseBody runs DevTools' own decoder over those
+   * buffered bytes instead, and its allowlist only covers gzip/deflate — so
+   * brotli and zstd arrive still encoded and are decoded here, keeping the
+   * pipeline's decoded-body premise intact. Falls back to the raw bytes if
+   * decompression fails, in case a newer CDP starts decoding them itself.
+   *
+   * The allowlist is the `devtools_accepted_stream_types` field DevTools
+   * sends the network service, populated in
+   * https://source.chromium.org/chromium/chromium/src/+/main:content/browser/devtools/devtools_url_loader_interceptor.cc
+   * and declared in
+   * https://source.chromium.org/chromium/chromium/src/+/main:services/network/public/mojom/url_request.mojom
    */
   private decodeUndeliveredEncodings = async (body: Buffer, responseHeaders?: Protocol.Fetch.HeaderEntry[]): Promise<Buffer> => {
     const contentEncoding = responseHeaders?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
@@ -418,14 +442,16 @@ export class CdpFetchTransport {
     let decoded = body
 
     for (const encoding of encodings) {
-      if (encoding !== 'br') {
+      const decode = UNDELIVERED_DECODERS[encoding]
+
+      if (!decode) {
         continue
       }
 
       try {
-        decoded = await brotliDecompress(decoded)
+        decoded = await decode(decoded)
       } catch (err) {
-        debug('brotli decompression failed, using body as delivered: %s', (err as Error).message)
+        debug('%s decompression failed, using body as delivered: %s', encoding, (err as Error).message)
 
         return body
       }

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -2,7 +2,7 @@ import type EventEmitter from 'events'
 import { NetworkProxy, BrowserPreRequest, createProxyNetworkInterception, createSyntheticProxyCodec, defaultMiddleware } from '@packages/proxy'
 import { netStubbingState, NetStubbingState } from '@packages/net-stubbing'
 import { HttpIntercept, registerDefaultNetworkPolicies } from '@packages/network-interception'
-import type { NetworkInterceptionRuntime, ForNetworkPolicyRegistration, NetworkInterceptionCore, TransportCodecPort } from '@packages/network-interception'
+import type { BodyEncoding, NetworkInterceptionRuntime, ForNetworkPolicyRegistration, NetworkInterceptionCore, TransportCodecPort } from '@packages/network-interception'
 import { blocked } from '@packages/network'
 import type { SocketBroadcaster } from '@packages/socket'
 import type { RemoteStates } from '@packages/network-tools'
@@ -105,6 +105,7 @@ export function createProxyRuntime (deps: CreateProxyRuntimeDeps): ProxyNetworkR
   }))
 
   networkInterception.use(networkProxy.http.createLegacyProxyPipeline(networkProxy.codec))
+
   networkProxy.withIntercept(networkInterception)
 
   return {
@@ -171,12 +172,19 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     request: deps.request,
   })
 
+  // The outgoing body is a per-pipeline declaration: express traffic still
+  // goes back over a real socket (re-encoded for the wire), while a body
+  // fulfilled over CDP must be handed back fully decoded — Fetch.fulfillRequest
+  // runs no decoders, the browser renders the bytes as-is.
+  // `serveInternalRoutes` short-circuits ahead of the onion and reaches
+  // neither encoding stage — the adapter owns encoding on its own loopback leg.
   const attachStages = <TRequest, TResponse>(
     intercept: HttpIntercept<TRequest, TResponse>,
     pipelineCodec: TransportCodecPort<any, any>,
+    bodyEncoding?: BodyEncoding,
   ) => {
     intercept.use(serveInternalRoutes)
-    intercept.use(networkProxy.http.createLegacyProxyPipeline(pipelineCodec))
+    intercept.use(networkProxy.http.createLegacyProxyPipeline(pipelineCodec, { bodyEncoding }))
 
     return intercept
   }
@@ -193,6 +201,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     createSyntheticProxyCodec({
       createMiddlewareContext: (req, res) => networkProxy.http.createMiddlewareContext(req, res),
     }),
+    'identity',
   )
 
   const fetchTransport = new CdpFetchTransport(deps.client, networkInterception, {

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -472,16 +472,15 @@ describe('CdpFetchTransport', () => {
       })
     })
 
-    it('normalizes pipeline re-encoded fulfilled bodies to identity', async () => {
+    // Identity is guaranteed upstream by IdentityContentEncodingAdapter, so the
+    // transport hands the pipeline body to fulfillRequest as-is.
+    it('fulfills pipeline bodies verbatim', async () => {
       const client = createClient()
       const httpIntercept = new HttpIntercept(createCdpFetchCodec())
       const { transport } = createTransport(client, { httpIntercept })
       const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
       const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
-      const gzippedBody = zlib.gzipSync(Buffer.from('<html>compressed</html>'))
 
-      // the legacy pipeline (CompressBody) may re-encode the outgoing body;
-      // fulfillRequest delivers bodies as-is, so it must go out as identity
       httpIntercept.use(async (req, next) => {
         const res = await next(req)
 
@@ -489,10 +488,9 @@ describe('CdpFetchTransport', () => {
           ...res,
           headers: {
             'content-type': 'text/html',
-            'content-encoding': 'gzip',
             'content-length': '9999',
           },
-          body: gzippedBody,
+          body: Buffer.from('<html>plain</html>'),
         }
       })
 
@@ -510,44 +508,7 @@ describe('CdpFetchTransport', () => {
           name: 'content-type',
           value: 'text/html',
         }],
-        body: Buffer.from('<html>compressed</html>').toString('base64'),
-      })
-    })
-
-    it('keeps the body and header pair when a fulfilled encoding cannot be decoded', async () => {
-      const client = createClient()
-      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
-      const { transport } = createTransport(client, { httpIntercept })
-      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
-      const response = createPausedRequest({ requestId: 'fetch-response', networkId: 'network-1', responseStatusCode: 200 })
-
-      httpIntercept.use(async (req, next) => {
-        const res = await next(req)
-
-        return {
-          ...res,
-          headers: {
-            'content-encoding': 'zstd',
-          },
-          body: Buffer.from('opaque-bytes'),
-        }
-      })
-
-      const onRequestPaused = await startTransport(transport, client)
-      const handled = onRequestPaused(request)
-
-      await tick()
-      await onRequestPaused(response)
-      await handled
-
-      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
-        requestId: 'fetch-response',
-        responseCode: 200,
-        responseHeaders: [{
-          name: 'content-encoding',
-          value: 'zstd',
-        }],
-        body: Buffer.from('opaque-bytes').toString('base64'),
+        body: Buffer.from('<html>plain</html>').toString('base64'),
       })
     })
 
@@ -1221,6 +1182,64 @@ describe('CdpFetchTransport', () => {
 
       response.responseHeaders = [
         { name: 'Content-Encoding', value: 'br' },
+        { name: 'Content-Type', value: 'text/html' },
+      ]
+
+      await onRequestPaused(response)
+      await handled
+
+      expect(seenBody).to.equal('<html>origin</html>')
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-response',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/html',
+        }],
+        body: Buffer.from('<html>origin</html>-rewritten').toString('base64'),
+      })
+    })
+
+    it('decompresses zstd response bodies before middleware reads them', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: zlib.zstdCompressSync(Buffer.from('<html>origin</html>')).toString('base64'),
+        base64Encoded: true,
+      })
+
+      let seenBody
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        seenBody = await readStream(response.bodyStream!)
+
+        return {
+          ...response,
+          body: `${seenBody}-rewritten`,
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      const response = createPausedRequest({
+        requestId: 'fetch-response',
+        networkId: 'network-1',
+        responseStatusCode: 200,
+      })
+
+      response.responseHeaders = [
+        { name: 'Content-Encoding', value: 'zstd' },
         { name: 'Content-Type', value: 'text/html' },
       ]
 

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -1,38 +1,43 @@
-import { NetworkProxy } from '@packages/proxy'
+import { IdentityContentEncodingAdapter, NetworkProxy, ProxyContentEncodingAdapter } from '@packages/proxy'
+import { Http } from '@packages/proxy/lib/http'
 import { NetworkInterceptionCore } from '@packages/network-interception'
 import type { Protocol } from 'devtools-protocol'
 import { createCdpFetchRuntime, createProxyRuntime } from '../../lib/network-runtime'
 import '../spec_helper'
 
 describe('lib/network-runtime', () => {
-  const baseDeps = () => ({
-    config: {
-      clientRoute: '/__/',
-      responseTimeout: 30000,
-    } as Cypress.Config,
-    remoteStates: {
-      hasPrimary: sinon.stub().returns(false),
-      getPrimary: sinon.stub().returns({ origin: 'https://example.test', strategy: 'http', props: {} }),
-      get: sinon.stub().returns(undefined),
-      current: sinon.stub().returns({ origin: 'https://example.test', strategy: 'http', props: {} }),
-      isPrimarySuperDomainBasedOrigin: sinon.stub().returns(false),
-      isPrimarySuperDomainOrigin: sinon.stub().returns(false),
-      getByStrategy: sinon.stub(),
-      reset: sinon.stub(),
-    } as any,
-    getFileServerToken: () => 'token',
-    getCookieJar: () => ({
-      getCookies: sinon.stub().returns([]),
-    }) as any,
-    socket: {
-      toDriver: sinon.stub(),
-    } as any,
-    request: {
-      rp: sinon.stub(),
-    } as any,
-    serverBus: { emit: sinon.stub() } as any,
-    getCurrentBrowser: () => ({}) as any,
-  })
+  const baseDeps = () => {
+    return {
+      config: {
+        clientRoute: '/__/',
+        responseTimeout: 30000,
+      } as Cypress.Config,
+      remoteStates: {
+        hasPrimary: sinon.stub().returns(false),
+        getPrimary: sinon.stub().returns({ origin: 'https://example.test', strategy: 'http', props: {} }),
+        get: sinon.stub().returns(undefined),
+        current: sinon.stub().returns({ origin: 'https://example.test', strategy: 'http', props: {} }),
+        isPrimarySuperDomainBasedOrigin: sinon.stub().returns(false),
+        isPrimarySuperDomainOrigin: sinon.stub().returns(false),
+        getByStrategy: sinon.stub(),
+        reset: sinon.stub(),
+      } as any,
+      getFileServerToken: () => 'token',
+      getCookieJar: () => {
+        return {
+          getCookies: sinon.stub().returns([]),
+        } as any
+      },
+      socket: {
+        toDriver: sinon.stub(),
+      } as any,
+      request: {
+        rp: sinon.stub(),
+      } as any,
+      serverBus: { emit: sinon.stub() } as any,
+      getCurrentBrowser: () => ({}) as any,
+    }
+  }
 
   function createPausedRequest (options: {
     requestId: string
@@ -87,6 +92,40 @@ describe('lib/network-runtime', () => {
     expect(runtime.networkProxy).to.be.instanceOf(NetworkProxy)
     expect(runtime.netStubbingState.routes).to.deep.equal([])
     expect(runtime.netStubbingState.requests).to.deep.equal({})
+  })
+
+  const contentEncodingOf = (core: any) => core?.options?.contentEncoding
+
+  it('composes both content-encoding implementations into the runtime core', () => {
+    const createLegacyProxyPipeline = sinon.spy(Http.prototype, 'createLegacyProxyPipeline')
+
+    const runtime = createProxyRuntime(baseDeps())
+
+    expect(createLegacyProxyPipeline).to.be.calledOnce
+    // no declaration: the pipeline's requests default to 'wire'
+    expect(createLegacyProxyPipeline.firstCall.args[1]?.bodyEncoding).to.be.undefined
+    expect(contentEncodingOf(runtime.networkInterceptionCore)?.wire).to.be.instanceOf(ProxyContentEncodingAdapter)
+    expect(contentEncodingOf(runtime.networkInterceptionCore)?.identity).to.be.instanceOf(IdentityContentEncodingAdapter)
+  })
+
+  // The proxy-disabled runtime serves express traffic over a real socket
+  // (re-encoded for the wire) alongside CDP responses that must be handed
+  // back fully decoded, so the outgoing body is declared per pipeline.
+  it('createCdpFetchRuntime declares identity bodies only on the CDP pipeline', () => {
+    const createLegacyProxyPipeline = sinon.spy(Http.prototype, 'createLegacyProxyPipeline')
+
+    createCdpFetchRuntime({
+      ...baseDeps(),
+      client: {
+        send: sinon.stub(),
+        on: sinon.stub(),
+        off: sinon.stub(),
+      },
+    })
+
+    const declarations = createLegacyProxyPipeline.getCalls().map((call) => call.args[1]?.bodyEncoding)
+
+    expect(declarations).to.deep.equal([undefined, 'identity'])
   })
 
   it('registers default configurator network policies at startup', () => {


### PR DESCRIPTION
- Closes #34363

### Additional details

This PR fixes three things:

1. **Tech debt**: `NotifyResponseStreamReceived` moves out of `CompressBody` into its own response middleware — it's protocol (Test Replay) capture and has nothing to do with compressing the body. It should really be its own PR, but it's short enough to ride along here.
2. `CompressBody` (response middleware) is refactored to delegate through the interception core: `this.networkInterceptionCore.compressBody(this)`.
3. `StripUnsupportedAcceptEncoding` (request middleware) is refactored the same way: `this.networkInterceptionCore.constrainAcceptEncoding(this)`.

There are now two implementations behind those two stages, selected by the pipeline's declared `bodyEncoding` (`'wire'` by default, `'identity'` for CDP — declared via `createLegacyProxyPipeline(codec, { bodyEncoding })`):

- **`ProxyContentEncodingAdapter`** (`'wire'` — the express path, both with the MITM proxy and when the proxy is disabled): keeps today's behavior. Node performs the transfer, so it narrows `accept-encoding` to what Node can decode and re-encodes the body for the socket before it goes back out.
- **`IdentityContentEncodingAdapter`** (`'identity'` — the CDP path): the browser negotiates `accept-encoding` and decodes for itself, and `Fetch.fulfillRequest` runs no content decoders, so this implementation leaves the request header alone and guarantees the outgoing body is identity. This is also the bug fix: the wire implementation running on the CDP path synthesized `gzip,identity` into a `continueRequest` override, so origins that ignore `Accept-Encoding` and serve brotli were killed with `net::ERR_FAILED`.

#### Request flow

| | Express / proxy path (`'wire'`) | CDP path (`'identity'`) |
|---|---|---|
| Header in | the browser's real `accept-encoding` arrives with the request | the Fetch pause carries no `accept-encoding` (Chrome appends it after interception) |
| `StripUnsupportedAcceptEncoding` | narrows the header to what Node can decode (`gzip,br`), stashing the original | no-op — the browser owns negotiation, nothing rides out on `continueRequest` |
| Out to origin | Node's origin request carries the narrowed header | Chrome's netstack sends its own header, untouched |

#### Response flow

| | Express / proxy path (`'wire'`) | CDP path (`'identity'`) |
|---|---|---|
| Body in | origin bytes arrive encoded; `makeResStreamPlainText` decodes only when middleware needs the body | `Fetch.getResponseBody` returns gzip/deflate already decoded; the transport decodes br/zstd and strips the encoding headers, so the middleware always sees an identity body |
| `NotifyResponseStreamReceived` | Test Replay observes the stream before any re-encoding | same stage, same guarantee |
| `CompressBody` | re-encodes a decoded body in its original encoding order before the socket | asserts identity: decodes a stub-declared `content-encoding` layer by layer when it can (skipping any layer earlier middleware already decoded), ships the intact header+body pair when it can't (e.g. `zstd`) |
| Delivery | real socket → the browser's netstack decodes | `Fetch.fulfillRequest` → no decoders run downstream, the bytes are final |

#### Notes

- `IdentityContentEncodingAdapter` decodes stub-declared encodings with its own stream decoders (`gzip`, `x-gzip`, `deflate`, `br` — parity with the codec decoders this PR deletes). Its set is deliberately broader than the wire path's `gzip`/`br`: the wire path can only undo what it can re-encode, while this path only ever decodes.
- Both content-encoding implementations live in `@packages/proxy`. The identity adapter can't ship with the port in `@packages/network-interception` because that package is isomorphic — the driver bundles its index into the browser — and the decoders need node builtins (`zlib`, `stream`), which breaks the runner's webpack build. Long term these likely belong in a newer browser-automation package; I'll work with @cacieprins  on alignment there and file a tech-debt ticket.
- Identified during review, deliberately **not addressed here** (kept behavior-neutral for MITM): #34387 — `content-encoding: x-gzip` is not treated as gzip by the proxy pipeline.
- Only affects the in-development HTTP/2 / proxy-disabled pipeline plus behavior-preserving refactors of the MITM path, hence `chore` and no changelog entry. New modules join the v8 snapshot graph; darwin `build-v8-snapshot-prod` passes locally and the linux-x64 pipeline jobs cover mksnapshot validation.

### Steps to test

`scripts/validate-proxy-middleware-transport.sh both` runs the unit suites and driver e2e specs on both transports. Expected:

- MITM: all unit suites green; `encoding.cy.ts` 17/17 (behavior unchanged).
- Proxy disabled: unit suites green; `encoding.cy.ts` 10 passing / 7 failing — the 7 are pre-existing classes owned by #34379 (intercepted-visit 500s, also the csp_headers/proxy-logging failures), #34384 (netstack-rejected observability), and #34386 (insecure-host brotli expectations). Before this PR the proxy-disabled state was 4 passing / 13 failing.

### How has the user experience changed?

No change with the MITM proxy (the default and only released pipeline). With the proxy disabled, br/zstd survive end to end: pages served with brotli by origins that don't honor `Accept-Encoding` load instead of failing with `net::ERR_FAILED`, and `cy.intercept` reports the decoded view (no `content-encoding` header) — the accepted drift documented in #34379.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? #34363
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core proxy/CDP response streaming, compression, and Fetch fulfillment paths; behavior change is intentional for proxy-disabled/CDP but MITM wire path is meant to stay equivalent.
> 
> **Overview**
> Introduces a **`ForContentEncoding`** driven port and **`bodyEncoding`** (`wire` | `identity`) so accept-encoding negotiation and outgoing body handling are chosen per pipeline, not hard-coded in proxy middleware.
> 
> **Request/response middleware** now delegates **`StripUnsupportedAcceptEncoding`** and **`CompressBody`** to **`NetworkInterceptionCore`**, which picks **`ProxyContentEncodingAdapter`** (wire) or **`IdentityContentEncodingAdapter`** (identity). Test Replay capture moves to a dedicated **`NotifyResponseStreamReceived`** stage before re-encoding; capture adapters call **`ctx.next()`** like other port implementations.
> 
> **Wire** (MITM / express socket): unchanged behavior—narrow **`Accept-Encoding`**, re-gzip/br after middleware decodes. **Identity** (CDP Fetch): leaves **`Accept-Encoding`** alone (fixes synthesized headers on **`continueRequest`** breaking brotli origins) and ensures fulfilled bodies are identity, including decoding stub-declared **`content-encoding`** layers. **`createCdpFetchRuntime`** wires the CDP pipeline with **`bodyEncoding: 'identity'`**; sync identity decoding is removed from **`cdp-fetch-codec`** in favor of the adapter. **CDP transport** also decodes **zstd** (and br) when **`getResponseBody`** still returns encoded bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f05c21fae9721d7026ef7d5195d9419285e08f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->