### PR TITLE
dependency: commit the deduplicated yarn.lock and fix v8 snapshot generation

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-06-11-2026
+07-30-2026

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1828,6 +1828,16 @@ jobs:
     steps:
       - restore_cached_workspace
       - run:
+          name: Check yarn.lock is deduplicated 🧬
+          command: |
+            if ! yarn check-lockfile; then
+              echo ""
+              echo "yarn.lock has duplicates that the local postinstall would collapse on its own,"
+              echo "so the committed lockfile does not match the tree contributors actually install."
+              echo "Run 'yarn-deduplicate --strategy=highest' and commit the resulting yarn.lock."
+              exit 1
+            fi
+      - run:
           name: Linting 🧹
           command: |
             yarn clean

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -11,6 +11,7 @@ linux-x64:
           pattern: /^electron\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
       - equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
+      - equal: [ 'v8-snapshot-force-norewrite-all-bundles', << pipeline.git.branch >> ]
   jobs:
     - node_modules_install:
         build-better-sqlite3: true

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 **Dependency Updates:**
 
 - Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).
+- Upgraded `ws` from `8.18.3` to `8.21.1`. Addressed in [#34392](https://github.com/cypress-io/cypress/pull/34392).
 
 ## 15.19.0
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build-v8-snapshot-dev": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev",
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",
     "check-binary-on-cdn": "node ./scripts/binary.js checkIfBinaryExistsOnCdn",
+    "check-lockfile": "yarn-deduplicate --strategy=highest --list --fail",
     "check-node-version": "node scripts/check-node-version.js",
     "check-terminal": "node scripts/check-terminal.js",
     "check-ts": "yarn lerna run check-ts",

--- a/tooling/v8-snapshot/src/doctor/determine-deferred.ts
+++ b/tooling/v8-snapshot/src/doctor/determine-deferred.ts
@@ -173,8 +173,10 @@ export async function determineDeferred (
     )
   }
 
+  // The `*/`-prefixed entries are filtered out of the persisted metafile, but the
+  // bundle we are about to create still has to honor them, so add them back here.
   return {
-    norewrite: filteredNorewrite,
+    norewrite: Array.from(new Set([...filteredNorewrite, ...opts.forceNorewrite])),
     deferred: updatedDeferred,
     healthy: updatedHealthy,
   }

--- a/tooling/v8-snapshot/src/doctor/snapshot-doctor.ts
+++ b/tooling/v8-snapshot/src/doctor/snapshot-doctor.ts
@@ -326,8 +326,9 @@ export class SnapshotDoctor {
     bundle: Buffer
     meta: Metadata
   }> {
-    // 1. Generate the metadata not deferring anything yet
-    const { meta } = await this._createScript()
+    // 1. Generate the metadata not deferring anything yet, but still honoring
+    //    forceNorewrite since those modules break the bundler when rewritten
+    const { meta } = await this._createScript(undefined, this.forceNorewrite)
 
     // 2. Extract all module inputs from the metadata and detect circular
     // imports

--- a/tooling/v8-snapshot/src/generator/snapshot-generate-entry-via-dependencies.ts
+++ b/tooling/v8-snapshot/src/generator/snapshot-generate-entry-via-dependencies.ts
@@ -21,6 +21,7 @@ class SnapshotEntryGeneratorViaWalk {
     readonly nodeModulesOnly: boolean,
     readonly pathsMapper: PathsMapper,
     readonly integrityCheckSource: string | undefined,
+    readonly forceNorewrite: string[],
   ) {
     this.bundlerPath = getBundlerPath()
   }
@@ -61,6 +62,10 @@ class SnapshotEntryGeneratorViaWalk {
       sourcemap: false,
       supportTypeScript: this.nodeModulesOnly,
       integrityCheckSource: this.integrityCheckSource,
+      // The bundle produced here is discarded — we only want its metadata — but
+      // the bundler still rewrites every module, so modules that cannot survive
+      // rewriting have to be excluded or the bundler fails outright.
+      norewrite: this.forceNorewrite,
     }
     const { meta } = await createBundleAsync(opts)
 
@@ -81,6 +86,7 @@ type GenerateDepsDataOpts = {
   nodeModulesOnly?: boolean
   pathsMapper?: PathsMapper
   integrityCheckSource: string | undefined
+  forceNorewrite?: string[]
 }
 
 export type BundlerMetadata = Metadata & { projectBaseDir: string }
@@ -98,6 +104,7 @@ export async function generateBundlerMetadata (
     fullConf.nodeModulesOnly,
     fullConf.pathsMapper,
     config.integrityCheckSource,
+    config.forceNorewrite ?? [],
   )
   const meta = await generator.getMetadata()
 
@@ -125,6 +132,7 @@ export async function generateSnapshotEntryFromEntryDependencies (
     fullConf.nodeModulesOnly,
     fullConf.pathsMapper,
     config.integrityCheckSource,
+    config.forceNorewrite ?? [],
   )
 
   try {

--- a/tooling/v8-snapshot/src/setup/force-no-rewrite.ts
+++ b/tooling/v8-snapshot/src/setup/force-no-rewrite.ts
@@ -19,6 +19,9 @@ export default [
   // `address instanceof (__get_URL2__())` -- right hand side not an object
   // even though function is in scope
   '*/node_modules/ws/lib/websocket.js',
+  // `const { types: { isUint8Array } } = require('util')` -- the bundler cannot
+  // build a lazy accessor for a nested binding and panics
+  '*/node_modules/ws/lib/sender.js',
   // defers PassThroughStream which is then not accepted as a constructor
   '*/node_modules/get-stream/buffer-stream.js',
   // deferring should be fine as it just reexports `process` which in the

--- a/tooling/v8-snapshot/src/setup/generate-entry.ts
+++ b/tooling/v8-snapshot/src/setup/generate-entry.ts
@@ -2,6 +2,7 @@ import { generateSnapshotEntryFromEntryDependencies } from '../generator/snapsho
 import debug from 'debug'
 import { ensureDirSync } from '../utils'
 import path from 'path'
+import forceNorewrite from './force-no-rewrite'
 
 const logInfo = debug('cypress:snapgen:info')
 const logError = debug('cypress:snapgen:error')
@@ -40,6 +41,7 @@ export async function generateEntry ({
         pathsMapper,
         nodeModulesOnly,
         integrityCheckSource,
+        forceNorewrite,
       },
     )
 

--- a/tooling/v8-snapshot/src/setup/generate-metadata.ts
+++ b/tooling/v8-snapshot/src/setup/generate-metadata.ts
@@ -3,6 +3,7 @@ import { BundlerMetadata, generateBundlerMetadata } from '../generator/snapshot-
 import debug from 'debug'
 import { ensureDirSync } from 'fs-extra'
 import path from 'path'
+import forceNorewrite from './force-no-rewrite'
 
 const logInfo = debug('cypress:snapgen:info')
 const logDebug = debug('cypress:snapgen:debug')
@@ -21,6 +22,7 @@ async function createMeta ({
     pathsMapper,
     nodeModulesOnly,
     integrityCheckSource,
+    forceNorewrite,
   })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,7 +3085,7 @@
     minimist "^1.2.8"
     postject "^1.0.0-alpha.6"
 
-"@emnapi/core@1.11.2":
+"@emnapi/core@1.11.2", "@emnapi/core@^1.1.0", "@emnapi/core@^1.4.3":
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.2.tgz#fab0a0f3c492d11f5a9ac9065d0d73955ee1c1c9"
   integrity sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==
@@ -3093,7 +3093,7 @@
     "@emnapi/wasi-threads" "1.2.2"
     tslib "^2.4.0"
 
-"@emnapi/core@1.9.1", "@emnapi/core@^1.1.0", "@emnapi/core@^1.4.3":
+"@emnapi/core@1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
   integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
@@ -3101,14 +3101,14 @@
     "@emnapi/wasi-threads" "1.2.0"
     tslib "^2.4.0"
 
-"@emnapi/runtime@1.11.2":
+"@emnapi/runtime@1.11.2", "@emnapi/runtime@^1.1.0", "@emnapi/runtime@^1.4.3":
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.2.tgz#eb22f04d76febfdf4f87fdaff54c8a53f6bf0dbd"
   integrity sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/runtime@1.9.1", "@emnapi/runtime@^1.1.0", "@emnapi/runtime@^1.4.3":
+"@emnapi/runtime@1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
   integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
@@ -5489,14 +5489,7 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@napi-rs/wasm-runtime@^1.1.2":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz#1eeb8699770481306e5fcd84471f20fcb6177336"
-  integrity sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==
-  dependencies:
-    "@tybys/wasm-util" "^0.10.1"
-
-"@napi-rs/wasm-runtime@^1.1.6":
+"@napi-rs/wasm-runtime@^1.1.2", "@napi-rs/wasm-runtime@^1.1.6":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz#d7aa398845e3ab1c9c8f81ea50f527ed37d16715"
   integrity sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==
@@ -6661,14 +6654,6 @@
     "@percy/client" "1.31.14"
     "@percy/logger" "1.31.14"
 
-"@percy/client@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.27.6.tgz#abc72d477f531201744bf223d5cb6519c223707d"
-  integrity sha512-Q+fv/iYJ2QSMOPXJ69skyWn/ob6w+tVk6gtMXmiBYi5K4EqEehHhJkBCm7oATo+cE3h+/W2Hu9/o18WutD+uCw==
-  dependencies:
-    "@percy/env" "1.27.6"
-    "@percy/logger" "1.27.6"
-
 "@percy/client@1.31.14":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.31.14.tgz#dc850b8e490118194efa9ef428ef971480674ca9"
@@ -6680,16 +6665,6 @@
     pac-proxy-agent "^7.0.2"
     pako "^2.1.0"
 
-"@percy/config@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.27.6.tgz#047ba923943058c63fc9a880ac22e8ba5731a170"
-  integrity sha512-2hvGq4FL2m6H/XrnCemQqsOUjNsoCL1sSCfWiKffvY74lfZ/YTtIHKL3qUjgW70a/xXhjy8kfAb9qCppNJ7AmQ==
-  dependencies:
-    "@percy/logger" "1.27.6"
-    ajv "^8.6.2"
-    cosmiconfig "^8.0.0"
-    yaml "^2.0.0"
-
 "@percy/config@1.31.14":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.31.14.tgz#6ba0d312b51556e85e07d207a9abccbf5075daa7"
@@ -6700,7 +6675,7 @@
     cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.31.14":
+"@percy/core@1.31.14", "@percy/core@^1.0.0-beta.48":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.31.14.tgz#76eb027e6a6df2cb5990196e899d357d5612ae9b"
   integrity sha512-c6QTjqaKs7UxL9HK6VJJl5B57hywFNn+l22vES4dFkegrkdE0maAz7rG88X2Xp2sYrsR3qf9n9CKCDy511/KYw==
@@ -6725,26 +6700,6 @@
   optionalDependencies:
     "@percy/cli-doctor" "1.31.14"
 
-"@percy/core@^1.0.0-beta.48":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.27.6.tgz#20a29d11619e6aac5f5fdb1d1451303ec474e1c3"
-  integrity sha512-Gp6cqpu7vSDzeG40SPXGeqJoHlF8dVzspgRTiUNQLhY0OEo71VMu1r0kZ/O3gQJQvgZwepi0FdbW9h7sts8RZw==
-  dependencies:
-    "@percy/client" "1.27.6"
-    "@percy/config" "1.27.6"
-    "@percy/dom" "1.27.6"
-    "@percy/logger" "1.27.6"
-    "@percy/webdriver-utils" "1.27.6"
-    content-disposition "^0.5.4"
-    cross-spawn "^7.0.3"
-    extract-zip "^2.0.1"
-    fast-glob "^3.2.11"
-    micromatch "^4.0.4"
-    mime-types "^2.1.34"
-    path-to-regexp "^6.2.0"
-    rimraf "^3.0.2"
-    ws "^8.0.0"
-
 "@percy/cypress@^3.1.7":
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/@percy/cypress/-/cypress-3.1.7.tgz#438cc8707a8340df7430620765eb7e852e63e6a2"
@@ -6752,22 +6707,10 @@
   dependencies:
     "@percy/sdk-utils" "1.31.4"
 
-"@percy/dom@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.27.6.tgz#3cee3af64d5b8fad4e2ddb6bab7097e21412c2f4"
-  integrity sha512-EZi2mGsAdBwb6gfPGI4cupcgFOOP8kaXHZbn/wY+zNyXf2y4AHo7sptp75r1RXfbjgbK+Ubj80KmoAXiw2ytRA==
-
 "@percy/dom@1.31.14":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.31.14.tgz#bb8506014589d1d76d148f31410f259554389757"
   integrity sha512-Ilz9qSf9Z80jHah9b7OfX2M2N9vmY4hkGEhMO953ui3NSQhXZsezr4aIPREYdyZdo11pEWm+JWU1AEZw54CbbA==
-
-"@percy/env@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.27.6.tgz#ae952f3bd45e0921c8026d791b0fb32321ca67b9"
-  integrity sha512-JslAEIdyMxEDq+FPxNZyBTUQA0wsjQ9nZi76qg9O75Ypfh69DYc6udzNneTowZMCsO1OwmpW5jpK+H8TH4T8iQ==
-  dependencies:
-    "@percy/logger" "1.27.6"
 
 "@percy/env@1.31.14":
   version "1.31.14"
@@ -6775,11 +6718,6 @@
   integrity sha512-eRW4Ot2Z5WESKPJHcdLc9JFLtjxJaALzRxGa7Z+0R5t5wOlqbEVQytLBzgFWWTVa2XEejR4Sffs5cYqM+ldgEA==
   dependencies:
     "@percy/logger" "1.31.14"
-
-"@percy/logger@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.27.6.tgz#3dd40a2426db34edeeade29d688c55b35fe270ba"
-  integrity sha512-Thbc9vWc626n+m3+LDKXTUBs3LqtwomI+rA/gajTOegd9ENsLLi8kTVM7AwwIlHp6TqLdBw0vXFlGEi+F2okUA==
 
 "@percy/logger@1.31.14":
   version "1.31.14"
@@ -6796,11 +6734,6 @@
     "@percy/sdk-utils" "1.31.14"
     systeminformation "^5.25.11"
 
-"@percy/sdk-utils@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.27.6.tgz#f6daa7f81fde65d61e7c2817ad1215eda4eed7fe"
-  integrity sha512-oZwd9u+KnFdMbA8HmisiWY5un4qB00kNUJtn/6CsXSpLwMi4qhOiBp8xjex0Aq5dqQc3vklWdlPu7JFxGwQq4Q==
-
 "@percy/sdk-utils@1.31.14":
   version "1.31.14"
   resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.31.14.tgz#f86e0451a5931d5a1d2bf1daa2438f543c70936e"
@@ -6814,14 +6747,6 @@
   integrity sha512-IBzSQZ8jx1pnSyyn7tF4UX8BVffbw0xjsNsPl/MuYuFuE5rW/D8arc+sH6xI1Kog0+tECt2XdAf4hMGWij2lxw==
   dependencies:
     pac-proxy-agent "^7.0.2"
-
-"@percy/webdriver-utils@1.27.6":
-  version "1.27.6"
-  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.27.6.tgz#26c5b11de0433a45dd19620f8acc35d2d09f3363"
-  integrity sha512-ol/ESe08UDmMQq9qYMOKPgrQ4g8vjpfQ8/kKpmnkI8JNsHlxfXi85uMA8hmBzSNG9Iis6kQT7CFXdDBaWVhiOA==
-  dependencies:
-    "@percy/config" "1.27.6"
-    "@percy/sdk-utils" "1.27.6"
 
 "@percy/webdriver-utils@1.31.14":
   version "1.31.14"
@@ -8500,14 +8425,7 @@
     "@tufjs/canonical-json" "2.0.0"
     minimatch "^9.0.5"
 
-"@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
-  dependencies:
-    tslib "^2.4.0"
-
-"@tybys/wasm-util@^0.10.3":
+"@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
   integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
@@ -18084,17 +18002,10 @@ get-tsconfig@4.10.0:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
-get-tsconfig@4.14.0:
+get-tsconfig@4.14.0, get-tsconfig@^4.10.0, get-tsconfig@^4.10.1:
   version "4.14.0"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.14.0.tgz#985d85c52a9903864280ccc2448d413fbf1efed8"
   integrity sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==
-  dependencies:
-    resolve-pkg-maps "^1.0.0"
-
-get-tsconfig@^4.10.0, get-tsconfig@^4.10.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
-  integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -26024,12 +25935,7 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^6.2.0, path-to-regexp@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
-  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
-
-path-to-regexp@^6.3.0:
+path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
@@ -26159,12 +26065,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
-  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
-
-picomatch@^4.0.5:
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4, picomatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
@@ -30325,15 +30226,10 @@ syntax-error@1.4.0:
   dependencies:
     acorn-node "^1.2.0"
 
-systeminformation@^5.25.11:
+systeminformation@^5.25.11, systeminformation@^5.27.7, systeminformation@^5.31.1:
   version "5.33.1"
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.33.1.tgz#499f06a859d2abeafaae6d69f71dd3516919f0f4"
   integrity sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==
-
-systeminformation@^5.27.7, systeminformation@^5.31.1:
-  version "5.31.1"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.31.1.tgz#5f88aa1db7470af87b6288baf1738603cafd1c4a"
-  integrity sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==
 
 systemjs@^6.15.1:
   version "6.15.1"
@@ -30740,15 +30636,7 @@ tinyexec@^0.3.1, tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.12, tinyglobby@^0.2.13, tinyglobby@^0.2.14, tinyglobby@^0.2.15:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
-  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
-  dependencies:
-    fdir "^6.5.0"
-    picomatch "^4.0.3"
-
-tinyglobby@^0.2.17:
+tinyglobby@^0.2.12, tinyglobby@^0.2.13, tinyglobby@^0.2.14, tinyglobby@^0.2.15, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
@@ -33170,15 +33058,15 @@ ws@8.2.2:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.0.0, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0, ws@~8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
-
-ws@^8.17.1:
+ws@^8.17.1, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0:
   version "8.21.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
   integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
+
+ws@~8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"
@@ -33358,12 +33246,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.0.0, yaml@^2.2.2, yaml@^2.3.4, yaml@^2.4.1, yaml@^2.6.0, yaml@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
-
-yaml@^2.9.0:
+yaml@^2.0.0, yaml@^2.2.2, yaml@^2.3.4, yaml@^2.4.1, yaml@^2.6.0, yaml@^2.8.1, yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
- Also completed this https://github.com/cypress-io/cypress/issues/30052

### Additional details

Found while investigating a local `yarn build-v8-snapshot-dev` failure.

Three commits that have to land together, explained below.

#### 1. `dependency:` check in the deduplicated yarn.lock

`yarn-deduplicate --strategy=highest` runs in the `local` postinstall ([`scripts/run-postInstall.js`](https://github.com/cypress-io/cypress/blob/develop/scripts/run-postInstall.js)), so every local install rewrites `yarn.lock`, but the result was not committed. This is not long-standing drift — running yarn-deduplicate against the lockfile at each recent commit shows it appeared in two specific ones:

| commit | dedupe drift | |
|---|---|---|
| `01e556d8cb~1` | **0** | fully deduped, no drift |
| `01e556d8cb` | 39 | `chore: bump @percy/cli to 1.31.14` (#34338) |
| `0f0a8a1ff9` | 39 | tar CVE upgrade — no change |
| `f745449171` | **88** | `chore: upgrade knip to 6.29.0` (#34373) |
| `c8a5ba93cc` | 88 | develop tip — no further change |

- **#34338** — `@percy/cli@1.31.14` pulled in `@percy/core@1.31.14`, which requires `ws@^8.17.1`; yarn resolved that as a **new** lockfile entry at `ws@8.21.1` instead of reusing the existing 8.18.3. Contributed the `@percy/core`, `ws`, `path-to-regexp` and `systeminformation` dedupe opportunities.
- **#34373** — `knip@6.29.0` added `@emnapi/*`, `@napi-rs/wasm-runtime`, `@tybys/wasm-util`, `get-tsconfig`, `picomatch`, `tinyglobby` and `yaml`.

The diff is pure spec consolidation: 19 insertions, 136 deletions, **no new `resolved` or `integrity` lines**. It adds no dependency version to the tree — every version it references is already on `develop`. What it changes is which copy is **hoisted**. Re-running `yarn-deduplicate --strategy=highest` against the result is a no-op.

Of everything consolidated, **`ws` is the only package whose bundled copy actually changes**. Before, `ws@^8.18.0`/`^8.5.0`/`^8.8.0` resolved to 8.18.3 (hoisted, bundled into the binary) while `ws@^8.17.1` resolved to 8.21.1 (reachable only from `@percy/*`, so dev-only and never bundled). The dedupe collapses those four specs onto 8.21.1, promoting it into the hoisted slot and therefore into the snapshot bundle; only `ws@~8.18.3` stays behind on 8.18.3. I checked each of the others against the generated snapshot bundle and their bundled copies are pinned or nested at unaffected versions:

| package | bundled copy | affected by the dedupe? |
|---|---|---|
| `ws` | `node_modules/ws` → **8.18.3 to 8.21.1** | **yes** |
| `path-to-regexp` | express's pinned `0.1.12` | no — the `^6.x` specs moved |
| `get-tsconfig` | data-context's pinned `4.10.0` | no — the `^4.10.x` specs moved (eslint tooling only) |
| `picomatch` | `2.3.1` | no — the `^4.0.x` specs moved (build tooling only) |
| `systeminformation` | hoisted `5.33.1`, unchanged | no — only the `@percy` nested copy moved |
| `@percy/*`, `@emnapi/*`, `@napi-rs/wasm-runtime`, `@tybys/wasm-util`, `tinyglobby`, `yaml` | not in the bundle | no |

Hence the `dependency:` prefix and a changelog entry naming only `ws`.

#### 2. `chore:` honor forceNorewrite in every v8 snapshot bundle

Committing the lockfile alone would break local snapshot generation for everyone, which is why the fix is in the same PR. With `ws@8.21.1` hoisted, `yarn build-v8-snapshot-dev` dies with a Go panic out of the snapshot bundler, before any of our own error handling gets a say:

```
cypress:snapgen:error panic: Expected a BIdentifier for binding value
cypress:snapgen:error goroutine 15606 [running]:
cypress:snapgen:error github.com/evanw/esbuild/internal/snap_printer.(*printer).extractBinding(...)
cypress:snapgen:error 	.../snap_printer/snap_printer_common.go:181 +0x1ec
```

The trigger is `ws@8.21.1`'s `lib/sender.js`, which `ws@8.18.3` did not have:

```js
const {
  types: { isUint8Array }
} = require('util');
```

For a require that stays external (a Node built-in), the bundler rewrites the declaration into a lazy accessor — `let types; function __get_types__() { return types = types || (require("util", …).types) }` — so the require does not execute while `mksnapshot` is building the heap. It needs a plain identifier to name the accessor after, and a nested binding does not give it one, so it panics. That is a bug in [`cypress-io/esbuild`](https://github.com/cypress-io/esbuild)'s snapshot printer and is worth fixing there too, but that needs a new `@cypress/snapbuild-*` release across all 13 platform packages. This PR is the in-repo half.

`force-no-rewrite.ts` exists for exactly this situation, but it could not help: snapshot generation creates **four** bundles, and only the doctor's inner heal loop was passing the overrides to the bundler. The metadata pass, the entry-file pass, the doctor's initial metadata bundle, and the final script were all bundled with an empty `norewrite` list, so the bundler crashed before `force-no-rewrite.ts` was ever consulted. Adding a `force-no-rewrite.ts` entry on its own does nothing — the plumbing is the fix.

- `snapshot-generate-entry-via-dependencies.ts` — `SnapshotEntryGeneratorViaWalk` takes `forceNorewrite` and passes it as `opts.norewrite`. The bundle these passes build is discarded (only its metadata is wanted), but the bundler still rewrites every module, so unrewritable modules have to be excluded regardless.
- `generate-metadata.ts` / `generate-entry.ts` — forward `forceNorewrite`.
- `snapshot-doctor.ts` — `heal()` step 1 was `this._createScript()`; now `this._createScript(undefined, this.forceNorewrite)`. Deferring nothing on the first pass is deliberate, but norewrite still has to be honored.
- `determine-deferred.ts` — the returned `norewrite` no longer drops the `*/`-prefixed entries. `filterForceNorewrite` keeps them out of the *persisted* metafile on purpose, but the same filtered list was also being handed to the final bundle. `determineDeferred`'s cached early-return path already re-added them; the doctor path now matches. Without this, a from-scratch run only passed by luck (the doctor happened to resolve the wildcard to a concrete path) and the cached run still panicked.
- `force-no-rewrite.ts` — add `*/node_modules/ws/lib/sender.js`. The bundler already understands the `*/` suffix wildcard in the form `argumentify` produces.

Scanning all 4,055 modules in the generated bundle, `ws/lib/sender.js` is the only one with a nested destructure of a built-in require. The other 61 nested-destructure sites all require in-bundle modules, which take a different (non-panicking) path in the printer and are unaffected.

#### 3. `chore:` fail CI when yarn.lock is not deduplicated

This is the guard for the class of bug above. Because the local postinstall dedupes and CI does not, a lockfile with collapsible duplicates means contributors install a different tree than CI, and nothing surfaces it — the `ws` hoist sat on `develop` for three commits that way.

`yarn check-lockfile` (`yarn-deduplicate --strategy=highest --list --fail`) reports exactly the duplicates postinstall would collapse and exits non-zero; the `lint` job runs it on every PR, internal and external. It only flags spec sets that `--strategy=highest` can actually merge, so legitimately incompatible duplicates — `ws@~8.18.3` alongside `ws@^8.17.1`, for instance — do not trip it. Verified: silent and exit 0 against this PR's lockfile, exit 1 with a per-package diagnosis against `develop`'s:

```
$ yarn check-lockfile     # against develop's yarn.lock
Package "ws" wants ^8.18.0 and could get 8.21.1, but got 8.18.3
Package "@percy/core" wants ^1.0.0-beta.48 and could get 1.31.14, but got 1.27.6
... 30 more
```

It has to land with the lockfile commit rather than separately — added on its own it would put CI red immediately.

#### Reviewer notes

- **The v8 snapshot cache is now stale on all three platforms.** `snapshot-meta.json`'s `deferredHash` is a hash of `yarn.lock` (`determine-deferred.ts`), so changing the lockfile invalidates `tooling/v8-snapshot/cache/{darwin,linux,win32}/`. This is not a failure — the doctor falls back to determining the classification from scratch, which is what I verified locally — but it is slower until the [Update V8 Snapshot Cache](https://github.com/cypress-io/cypress/actions/workflows/update_v8_snapshot_cache.yml) workflow is run against this branch. Worth doing before merge.
- **This branch is on the full-CI allowlist** (`&full-workflow-filters` in `.circleci/src/pipeline/workflows/@main.yml`) so `v8-integration-tests` run on Linux, macOS, and Windows. Windows coverage matters here because `argumentify` rewrites norewrite paths with `path.sep`. Happy to drop that entry before merge if reviewers prefer to keep the allowlist reserved for the automated cache PRs.
- Happy to split this into two PRs if preferred, but the fix must land before or with the lockfile — the reverse order breaks local snapshot generation on `develop`.
- The `ws@8.21.1` resolution has been on `develop` since #34338, so the snapshot build has been one local `yarn` away from breaking since then. It was not caught because the `ci` postinstall does not run `yarn-deduplicate`, so CI never sees the hoisted 8.21.1.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the committed lockfile and the bundled `ws` version inside the V8 snapshot binary, plus snapshot bundler behavior; mitigated by v8 integration tests and the new lockfile guard.
> 
> **Overview**
> Commits a **deduplicated `yarn.lock`** so it matches what local postinstall already produces, and adds **`yarn check-lockfile`** plus a **lint job** that fails CI when duplicates remain. The meaningful runtime change from that dedupe is hoisting **`ws` to 8.21.1** (changelogged); other consolidated packages keep the same effective versions in the binary.
> 
> **V8 snapshot tooling** is updated so **`forceNorewrite`** applies on every bundler pass (metadata, entry generation, doctor heal), **`determine-deferred`** merges wildcard `*/` norewrite entries into the final bundle list, and **`ws/lib/sender.js`** is added to **`force-no-rewrite`** so the bundler skips rewriting nested `util` destructuring that otherwise panics with hoisted `ws@8.21.1`.
> 
> CI cache version is bumped and this branch is on the **full-workflow** allowlist for multi-platform v8 integration coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee52a70714e4d3edf02423a3c3ff64710df9094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

```sh
# The new guard — passes here, fails on develop
yarn check-lockfile

# Confirm the lockfile is stable — this should produce no diff
yarn --frozen-lockfile && npx yarn-deduplicate --strategy=highest && git diff --exit-code yarn.lock

# Confirm the hoisted ws is the new one
node -e "console.log(require('ws/package.json').version)"   # 8.21.1

# Snapshot generation, cached path. On develop with this lockfile: panics during
# "Creating snapshot metadata". With this PR: completes and installs.
DEBUG='*snap*' node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js --env=dev

# And the from-scratch path, which takes a different route through determineDeferred
V8_SNAPSHOT_FROM_SCRATCH=1 yarn build-v8-snapshot-dev
```

Both snapshot paths verified locally on darwin-arm64 (exit 0 through `mksnapshot` and install). `ws/lib/sender.js` appears in the resulting `snapshot.js` with its nested destructure intact and no `__get_*__` accessor. `yarn workspace @tooling/v8-snapshot test-unit` passes (12 passing, 1 pending — unchanged from `develop`).

### How has the user experience changed?

No visible change. The bundled `ws` moves from `8.18.3` to `8.21.1` (a patch/minor bump within the same major, changelogged); everything else in the lockfile keeps the version it already shipped.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Lockfile hygiene plus a build-tooling fix for a local snapshot-generation crash. Details in the description above. -->
- [na] Have tests been added/updated? <!-- Reproducing the panic requires a specific hoisted dependency version rather than a fixture; the existing @tooling/v8-snapshot suite plus multi-platform v8-integration-tests cover the change, and CI now exercises the fixed path because the lockfile lands here. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
