### PR TITLE
feat: shared tap render/format module + reporter command

### DIFF
--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -4,7 +4,7 @@ import type CRI from 'chrome-remote-interface'
 import { CypressInstanceError, resolveInstance } from '../../cypress-instances'
 import { withTapSession, validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
-import { renderResult, renderFailure, renderKnownFailure } from '../output'
+import { renderOutcome, renderFailure, renderKnownFailure } from '../output'
 import type { TapCliOptions, TapRunState } from '../types'
 import { TAP_EXEC_METHOD, TAP_RUN_IN_PROGRESS_MESSAGE } from '@packages/cypress-instances'
 
@@ -127,6 +127,7 @@ export const assertFrameReadable = async (session: TapSession): Promise<void> =>
 export const withResolvedAutFrame = async (
   options: TapCliOptions,
   read: (session: TapSession, frame: AutFrame) => Promise<unknown>,
+  command: string,
 ): Promise<number> => {
   try {
     const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
@@ -137,7 +138,7 @@ export const withResolvedAutFrame = async (
 
         const frame = await resolveAutFrame(session.client, session.sessionId)
 
-        renderResult(await read(session, frame))
+        renderOutcome(command, await read(session, frame), options.json)
 
         return 0
       } catch (err: any) {

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -191,4 +191,4 @@ export const extractAria = async (
 
 export const ariaCommand = defineNativeCommand('aria', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
   return extractAria(session, frame, args.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
-}))
+}, 'aria'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -51,4 +51,4 @@ export const extractDom = async (
 
 export const domCommand = defineNativeCommand('dom', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
   return extractDom(session, frame, args.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
-}))
+}, 'dom'))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -122,4 +122,4 @@ export const extractInspect = async (
 
 export const inspectCommand = defineNativeCommand('inspect', (options, args) => withResolvedAutFrame(options, (session, frame) => {
   return extractInspect(session, frame, args.selector)
-}))
+}, 'inspect'))

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,5 +1,5 @@
 import { listLiveInstances } from '../../cypress-instances'
-import { renderResult } from '../output'
+import { renderOutcome, renderResult } from '../output'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 
@@ -14,12 +14,12 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  renderResult(instances.map((instance) => ({
+  renderOutcome('instances', instances.map((instance) => ({
     pid: instance.pid,
     projectRoot: instance.projectRoot,
     testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
-  })))
+  })), options.json)
 
   return 0
 }

--- a/cli/lib/tap/commands/run.ts
+++ b/cli/lib/tap/commands/run.ts
@@ -1,7 +1,7 @@
 import { CypressInstanceError, resolveLiveInstance } from '../../cypress-instances'
 import { LiveInstanceState, TapSpecsOperation, tapRunSpecOperation } from '@packages/cypress-instances'
 import { queryInstanceGraphql } from '../instance-gql'
-import { renderFailure, renderKnownFailure, renderResult } from '../output'
+import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 import { posixify } from '../../util'
@@ -30,11 +30,11 @@ const runSpec = async (options: TapCliOptions, args: { spec: string }): Promise<
     const { runSpec: result } = await queryInstanceGraphql(instance, tapRunSpecOperation(match.absolute), RUN_SPEC_TIMEOUT_MS)
 
     if (result?.__typename === 'RunSpecResponse') {
-      renderResult({
+      renderOutcome('run', {
         spec: result.spec.relative.replace(/\\/g, '/'),
         testingType: result.testingType,
         browser: result.browser.displayName,
-      })
+      }, options.json)
 
       return 0
     }

--- a/cli/lib/tap/commands/specs.ts
+++ b/cli/lib/tap/commands/specs.ts
@@ -1,7 +1,7 @@
 import { CypressInstanceError, resolveLiveInstance } from '../../cypress-instances'
 import { TapSpecsOperation } from '@packages/cypress-instances'
 import { queryInstanceGraphql } from '../instance-gql'
-import { renderFailure, renderKnownFailure, renderResult } from '../output'
+import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { defineNativeCommand } from './definition'
 import type { TapSpecsQuery } from '@packages/cypress-instances'
 import type { TapCliOptions } from '../types'
@@ -36,7 +36,7 @@ const listSpecs = async (options: TapCliOptions): Promise<number> => {
     const { instance } = await resolveLiveInstance({ instance: options.instance, cwd: process.cwd() })
     const data = await queryInstanceGraphql(instance, TapSpecsOperation)
 
-    renderResult(toSpecList(data))
+    renderOutcome('specs', toSpecList(data), options.json)
 
     return 0
   } catch (err: any) {

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -1,7 +1,7 @@
 import { CypressInstanceError, resolveLiveInstance } from '../../cypress-instances'
 import type { ReadyInstanceState } from '../../cypress-instances'
 import { withTapSession, validateExecResult } from '../tap-session'
-import { renderFailure, renderKnownFailure, renderResult } from '../output'
+import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions, TapRunState, TapStatus } from '../types'
@@ -32,7 +32,7 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   } catch (err) {
     // No live instance is a status a poller waits on, not a failure.
     if (err instanceof CypressInstanceError) {
-      renderResult({ status: 'not connected' } satisfies TapStatus)
+      renderOutcome('status', { status: 'not connected' } satisfies TapStatus, options.json)
 
       return 0
     }
@@ -52,7 +52,7 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   }
 
   if (!browserAttached) {
-    renderResult(base)
+    renderOutcome('status', base, options.json)
 
     return 0
   }
@@ -68,7 +68,7 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
       return 1
     }
 
-    renderResult(mergeRunState(base, outcome.result as TapRunState))
+    renderOutcome('status', mergeRunState(base, outcome.result as TapRunState), options.json)
 
     return 0
   } catch (err: any) {

--- a/cli/lib/tap/render/AGENTS.md
+++ b/cli/lib/tap/render/AGENTS.md
@@ -1,0 +1,65 @@
+# Tap render — CLI output conventions
+
+This directory turns each `cypress tap <command>`'s structured result into the
+human-readable output printed in the terminal. The goal: the CLI reads as the
+**same tool** as the Cypress app — same palette, same state icons, same shape —
+so someone who knows the reporter panel recognizes the terminal output instantly.
+
+## Principles
+
+- **`--json` is the contract; the human rendering is a view.** The structured
+  result a command returns is the source of truth and is always available via
+  `--json`. A renderer only reshapes it for reading — never add information the
+  JSON doesn't carry, and keep machine-facing fields (absolute timestamps, ids,
+  ports) in the JSON even when the human view abbreviates or omits them.
+- **Compose from the shared vocabulary, don't hand-roll.** Every renderer builds
+  its output from the primitives in [`format.ts`](./format.ts) and hands blocks
+  to `layout`. If you find yourself writing raw padding, `\n` joins, or `chalk`
+  calls in a `renderX.ts`, the primitive you need probably already exists (or
+  belongs in `format.ts` so the next command can share it).
+- **Match the reporter's palette.** Colors in `format.ts` are pulled from the
+  reporter's SCSS variables so the two surfaces agree by construction. Reach for
+  a named `color.*` / `stateBadge`, never a fresh hex.
+
+## The shared vocabulary (`format.ts`)
+
+- `layout(blocks)` — assembles `string[][]` blocks into the final string: lines
+  within a block on their own rows, blocks separated by a blank line, trailing
+  whitespace trimmed. Every renderer ends by returning `layout([...])`.
+- `heading(title, count?)` — a dim panel title, optionally carrying its row
+  count: `SPECS (26)`, `ROUTES (2)`.
+- `table` / `definitionList` — aligned columns and `label  value` rows. They
+  **pad before coloring** so ANSI escape codes never count toward column width;
+  keep that invariant if you extend them.
+- `titleLine`, `countsLine`, `stateBadge` — the reporter's bold icon-led titles
+  and the `✓ 2  ✖ 1  ○ 1  - 3` per-outcome strip. Zero counts render as `--`.
+- `color.*` — `pass`/`fail`/`pending`/`muted`/`alias`/… . `color.muted` is the
+  default for de-emphasized trailing detail (relative times, an absent value
+  shown as `—`).
+- `emptyState(msg)` — dim placeholder text, the **same** `chalk.dim` as
+  `heading`, so a placeholder sits in the header's gray.
+
+## Conventions worth keeping
+
+- **Empty states keep the frame.** Prefer the command's normal shape with a
+  placeholder over a bare sentence, so the output reads the same whether or not
+  there's data. `specs` with no specs renders the heading plus a dim
+  `[EMPTY PROJECT]` row (`SPECS (0)`), not "No specs found." Use `emptyState`
+  for the placeholder so it matches the heading gray.
+- **A count in the heading, not prose.** `heading('X', n)` over "There are n X".
+- **Muted for secondary, `—` for absent.** Missing testing type, no attached
+  browser, no timestamp — a muted em dash, never blank or "null".
+- **Guard/lifecycle messages are their own thing.** A "no instance / no browser"
+  guard is the discovery layer speaking, not the command's empty rendering;
+  don't dress it up as data.
+
+## Adding a command renderer
+
+1. Write `renderX.ts` exporting `renderXHuman(result: <TypedResult>): string`
+   that returns `layout([...blocks])` built from `format.ts` primitives.
+2. Register it in [`index.ts`](./index.ts) under the command name. Declaring
+   `renderHuman` makes the command print the rendering by default; `--json`
+   bypasses it. A command with no entry keeps printing JSON.
+3. The `result` shape is the command's typed interface from the shared
+   `@packages/cypress-instances` contract — render from that, and let anything
+   machine-facing stay reachable through `--json`.

--- a/cli/lib/tap/render/format.ts
+++ b/cli/lib/tap/render/format.ts
@@ -1,0 +1,107 @@
+import chalk from 'chalk'
+
+// The shared formatting vocabulary every tap command's human-readable renderer
+// borrows from, so their output reads as one tool: the reporter's palette, its
+// state icons, and the table / definition-list / heading / block primitives.
+// A renderer composes these into `string[][]` blocks and hands them to `layout`.
+
+// The reporter's own palette (packages/reporter/src/lib/variables.scss and
+// commands.scss), so the CLI rendering matches the app: $pass/$fail map to
+// jade-400/red-400, assert messages render jade-300/red-400 with jade-200/
+// red-300 emphasis, the network dots use the command-message-indicator colors,
+// and aliases take the purple badge hue. chalk downsamples the hex values on
+// terminals without truecolor.
+export const color = {
+  pass: chalk.hex('#1fa971'), // $jade-400
+  fail: chalk.hex('#e45770'), // $red-400
+  passMessage: chalk.hex('#69d3a7'), // $jade-300
+  passStrong: chalk.hex('#a3e7cb'), // $jade-200
+  failStrong: chalk.hex('#f59aa9'), // $red-300
+  errHeaderText: chalk.hex('#f59aa9'), // $err-header-text = $red-300
+  aborted: chalk.hex('#db7903'), // $orange-400
+  bad: chalk.hex('#c62b49'), // $red-500
+  pending: chalk.hex('#6470f3'), // $indigo-400
+  alias: chalk.hex('#c8a7f5'), // $purple-300
+  aliasDom: chalk.hex('#9aa2fc'), // $indigo-300 — the reporter colors dom aliases indigo
+  muted: chalk.hex('#9095ad'), // $gray-500
+  fadedId: chalk.hex('#5a5f7a'), // $gray-700 — event ids sit back from the command numbers
+}
+
+export type RenderState = 'passed' | 'failed' | 'pending' | 'skipped'
+
+export const stateBadge: Record<RenderState, { icon: string, word: string }> = {
+  passed: { icon: color.pass('✓'), word: color.pass('passed') },
+  failed: { icon: color.fail('✖'), word: color.fail('failed') },
+  pending: { icon: color.pending('○'), word: color.pending('pending') },
+  skipped: { icon: color.muted('-'), word: color.muted('skipped') },
+}
+
+export interface StateCounts {
+  passed: number
+  failed: number
+  pending: number
+  skipped: number
+}
+
+// The app header renders a zero count as `--` (its stats strip's `count`
+// helper); skipped has no strip slot there, so it only appears when non-zero.
+const count = (num: number): string => (num > 0 ? String(num) : '--')
+
+// The reporter's per-outcome strip: `✓ 2  ✖ 1  ○ 1  - 3`. Shared by the reporter
+// header and the status command's results line.
+export const countsLine = (counts: StateCounts): string => {
+  return [
+    `${stateBadge.passed.icon} ${count(counts.passed)}`,
+    `${stateBadge.failed.icon} ${count(counts.failed)}`,
+    `${stateBadge.pending.icon} ${count(counts.pending)}`,
+    ...(counts.skipped > 0 ? [`${stateBadge.skipped.icon} ${counts.skipped}`] : []),
+  ].join('  ')
+}
+
+// A dim panel title, optionally carrying its row count: `ROUTES (2)`.
+export const heading = (title: string, itemCount?: number): string => {
+  return chalk.dim(itemCount === undefined ? title : `${title} (${itemCount})`)
+}
+
+// A bold title line led by a state/action icon, e.g. `✓ App > loads  passed`.
+export const titleLine = (icon: string, text: string, suffix?: string): string => {
+  return `${icon} ${chalk.bold(text)}${suffix ? `  ${suffix}` : ''}`
+}
+
+// A dim note standing in for an absent panel, e.g. `No specs to run.`
+export const emptyState = (message: string): string => chalk.dim(message)
+
+export const indent = (depth: number): string => '  '.repeat(depth)
+
+// Pad before coloring: the escape codes chalk adds would otherwise count
+// toward the column width. `colorize` styles the padded cells; it defaults to
+// leaving them plain for the tables that don't tint any column.
+export const table = (
+  title: string,
+  header: string[],
+  rows: string[][],
+  colorize: (cells: string[]) => string[] = (cells) => cells,
+): string[] => {
+  const widths = header.map((cell, column) => Math.max(cell.length, ...rows.map((row) => row[column].length)))
+  const pad = (cells: string[]) => cells.map((cell, column) => cell.padEnd(widths[column]))
+
+  return [
+    heading(title, rows.length),
+    `  ${pad(header).map((cell) => chalk.dim(cell)).join('  ')}`,
+    ...rows.map((row) => `  ${colorize(pad(row)).join('  ')}`),
+  ]
+}
+
+// Aligned `label  value` rows. Values arrive already styled — callers color
+// them before padding matters, since only the labels share a column width.
+export const definitionList = (entries: Array<[string, string]>): string[] => {
+  const width = Math.max(0, ...entries.map(([label]) => label.length))
+
+  return entries.map(([label, value]) => `  ${label.padEnd(width)}  ${value}`)
+}
+
+// Assemble rendered blocks into the final string: lines within a block on their
+// own rows, blocks separated by a blank line, trailing whitespace trimmed.
+export const layout = (blocks: string[][]): string => {
+  return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
+}

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,4 +1,4 @@
-import type { TapCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
+import type { TapCommandName, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 
 /**
@@ -12,7 +12,7 @@ export interface TapCommandRendering {
   renderHuman: (result: unknown) => string
 }
 
-const renderings: Partial<Record<TapCommandName, TapCommandRendering>> = {
+const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapCommandRendering>> = {
   reporter: {
     renderHuman: (result) => {
       // Only the no-test spec overview carries `stats`; the single-test view never does.
@@ -24,5 +24,5 @@ const renderings: Partial<Record<TapCommandName, TapCommandRendering>> = {
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {
-  return renderings[command as TapCommandName]
+  return renderings[command as TapCommandName | TapNativeCommandName]
 }

--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -1,35 +1,7 @@
 import chalk from 'chalk'
 
 import type { TapNetworkInfo, TapReporterAgent, TapReporterCommand, TapReporterError, TapReporterSession, TapReporterSpecTest, TapReporterSpecView, TapReporterStats, TapReporterSuite, TapReporterView } from '@packages/cypress-instances'
-
-// The reporter's own palette (packages/reporter/src/lib/variables.scss and
-// commands.scss), so the CLI rendering matches the app: $pass/$fail map to
-// jade-400/red-400, assert messages render jade-300/red-400 with jade-200/
-// red-300 emphasis, the network dots use the command-message-indicator colors,
-// and aliases take the purple badge hue. chalk downsamples the hex values on
-// terminals without truecolor.
-const color = {
-  pass: chalk.hex('#1fa971'), // $jade-400
-  fail: chalk.hex('#e45770'), // $red-400
-  passMessage: chalk.hex('#69d3a7'), // $jade-300
-  passStrong: chalk.hex('#a3e7cb'), // $jade-200
-  failStrong: chalk.hex('#f59aa9'), // $red-300
-  errHeaderText: chalk.hex('#f59aa9'), // $err-header-text = $red-300
-  aborted: chalk.hex('#db7903'), // $orange-400
-  bad: chalk.hex('#c62b49'), // $red-500
-  pending: chalk.hex('#6470f3'), // $indigo-400
-  alias: chalk.hex('#c8a7f5'), // $purple-300
-  aliasDom: chalk.hex('#9aa2fc'), // $indigo-300 — the reporter colors dom aliases indigo
-  muted: chalk.hex('#9095ad'), // $gray-500
-  fadedId: chalk.hex('#5a5f7a'), // $gray-700 — event ids sit back from the command numbers
-}
-
-const TEST_STATE = {
-  passed: { icon: color.pass('✓'), word: color.pass('passed') },
-  failed: { icon: color.fail('✖'), word: color.fail('failed') },
-  pending: { icon: color.pending('○'), word: color.pending('pending') },
-  skipped: { icon: color.muted('-'), word: color.muted('skipped') },
-} as const
+import { color, countsLine, emptyState, heading, layout, stateBadge, table, titleLine } from './format'
 
 // The reporter's status dot for a network row.
 const INDICATORS: Record<NonNullable<TapNetworkInfo['indicator']>, string> = {
@@ -90,19 +62,6 @@ const formatMessage = (command: TapReporterCommand): string => {
   return colorizeAliasReferences(emphasize(message, (part) => chalk.bold(part)), command)
 }
 
-// Pad before coloring: the escape codes chalk adds would otherwise count
-// toward the column width.
-const panelTable = (title: string, header: string[], rows: string[][], colorize: (cells: string[]) => string[]): string[] => {
-  const widths = header.map((cell, column) => Math.max(cell.length, ...rows.map((row) => row[column].length)))
-  const pad = (cells: string[]) => cells.map((cell, column) => cell.padEnd(widths[column]))
-
-  return [
-    chalk.dim(`${title} (${rows.length})`),
-    `  ${pad(header).map((cell) => chalk.dim(cell)).join('  ')}`,
-    ...rows.map((row) => `  ${colorize(pad(row)).join('  ')}`),
-  ]
-}
-
 // The panel's status badge colors: red for a failed session, orange while one
 // is being recreated, the reporter's jade otherwise.
 const sessionStatus = (status: string | undefined): string => {
@@ -123,7 +82,7 @@ const sessionStatus = (status: string | undefined): string => {
 
 const sessionsPanel = (sessions: TapReporterSession[]): string[] => {
   return [
-    chalk.dim(`SESSIONS (${sessions.length})`),
+    heading('SESSIONS', sessions.length),
     ...sessions.map((session) => {
       const global = session.global ? `  ${chalk.dim('(global)')}` : ''
 
@@ -142,7 +101,7 @@ const agentsTable = (agents: TapReporterAgent[]): string[] => {
     ]
   })
 
-  return panelTable('SPIES / STUBS', ['TYPE', 'FUNCTION', 'ALIAS(ES)', 'CALLS'], rows, (cells) => {
+  return table('SPIES / STUBS', ['TYPE', 'FUNCTION', 'ALIAS(ES)', 'CALLS'], rows, (cells) => {
     return [chalk.bold(cells[0]), cells[1], color.alias(cells[2]), cells[3]]
   })
 }
@@ -158,7 +117,7 @@ const routesTable = (routes: TapReporterView['routes']): string[] => {
     ]
   })
 
-  return panelTable('ROUTES', ['METHOD', 'MATCHER', 'STUBBED', 'ALIAS', '#'], rows, (cells) => {
+  return table('ROUTES', ['METHOD', 'MATCHER', 'STUBBED', 'ALIAS', '#'], rows, (cells) => {
     return [
       chalk.bold(cells[0]),
       cells[1],
@@ -280,7 +239,7 @@ const renderSection = (section: Section, hookName: string, idWidth: number): str
   const qualifier = section.hookId ? ` · ${section.hookId}` : ''
 
   return [
-    chalk.dim(`${hookName.toUpperCase()}${qualifier}`),
+    heading(`${hookName.toUpperCase()}${qualifier}`),
     ...section.rows.map((command) => renderRow(command, idWidth, nameWidth)),
   ]
 }
@@ -310,14 +269,14 @@ const renderError = (error: TapReporterError): string[] => {
 }
 
 export const renderReporterHuman = (view: TapReporterView): string => {
-  const { icon, word } = TEST_STATE[view.test.state]
+  const { icon, word } = stateBadge[view.test.state]
   const hookNames = new Map(view.hooks.map(({ hookId, hookName }) => [hookId, hookName]))
   const sections = sectionize(view.commands)
 
   const idWidth = Math.max(2, ...view.commands.map((command) => command.id.length))
 
   const blocks: string[][] = [
-    [`${icon} ${chalk.bold(view.test.fullTitle)}  ${word}`],
+    [titleLine(icon, view.test.fullTitle, word)],
     ...(view.sessions.length ? [sessionsPanel(view.sessions)] : []),
     ...(view.agents.length ? [agentsTable(view.agents)] : []),
     ...(view.routes.length ? [routesTable(view.routes)] : []),
@@ -325,14 +284,14 @@ export const renderReporterHuman = (view: TapReporterView): string => {
   ]
 
   if (!view.commands.length) {
-    blocks.push([chalk.dim('No commands were logged for this test.')])
+    blocks.push([emptyState('No commands were logged for this test.')])
   }
 
   if (view.error) {
     blocks.push(renderError(view.error))
   }
 
-  return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
+  return layout(blocks)
 }
 
 // The reporter header's clock format (packages/reporter/src/lib/util.ts
@@ -354,18 +313,8 @@ const formatDuration = (duration: number | undefined): string => {
   return displayHours === '0' ? `${displayMinutes}:${displaySeconds}` : `${displayHours}:${displayMinutes}:${displaySeconds}`
 }
 
-// The app header renders a zero count as `--` (its stats strip's `count`
-// helper); skipped has no strip slot there, so it only appears when non-zero.
-const count = (num: number): string => (num > 0 ? String(num) : '--')
-
 const statsLine = (stats: TapReporterStats): string => {
-  return [
-    `${TEST_STATE.passed.icon} ${count(stats.passed)}`,
-    `${TEST_STATE.failed.icon} ${count(stats.failed)}`,
-    `${TEST_STATE.pending.icon} ${count(stats.pending)}`,
-    ...(stats.skipped > 0 ? [`${TEST_STATE.skipped.icon} ${stats.skipped}`] : []),
-    chalk.dim(formatDuration(stats.duration)),
-  ].join('  ')
+  return `${countsLine(stats)}  ${chalk.dim(formatDuration(stats.duration))}`
 }
 
 // Sub-second durations keep their ms precision; longer ones read as seconds,
@@ -383,11 +332,11 @@ const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[]
     const retries = test.retries ? `  ${color.aborted(`(${test.retries} ${test.retries === 1 ? 'retry' : 'retries'})`)}` : ''
 
     return [
-      `${indent}${chalk.dim(test.id.padStart(3))}  ${TEST_STATE[test.state].icon} ${test.title}${testDuration(test.duration)}${retries}`,
+      `${indent}${chalk.dim(test.id.padStart(3))}  ${stateBadge[test.state].icon} ${test.title}${testDuration(test.duration)}${retries}`,
       // Nested under the title, the way the app reporter lists a retried
       // test's attempts; the id column stays empty so the rows read as one test.
       ...(test.attempts ?? []).map((attempt) => {
-        return `${indent}       ${TEST_STATE[attempt.state].icon} ${chalk.dim(`attempt ${attempt.attempt}`)}${testDuration(attempt.duration)}`
+        return `${indent}       ${stateBadge[attempt.state].icon} ${chalk.dim(`attempt ${attempt.attempt}`)}${testDuration(attempt.duration)}`
       }),
     ]
   })
@@ -398,7 +347,7 @@ const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[]
 // like the single-test view's hook section titles. The wire shape is already
 // flattened that way: one entry per suite with direct tests, title pre-joined.
 const specSuiteSections = (suites: TapReporterSuite[]): string[][] => {
-  return suites.map((suite) => [chalk.dim(suite.title.toUpperCase()), ...renderSpecTests(suite.tests, '  ')])
+  return suites.map((suite) => [heading(suite.title.toUpperCase()), ...renderSpecTests(suite.tests, '  ')])
 }
 
 export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {
@@ -414,8 +363,8 @@ export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {
 
   const blocks: string[][] = [
     header,
-    ...(sections.length ? sections : [[chalk.dim('No tests were found in this spec.')]]),
+    ...(sections.length ? sections : [[emptyState('No tests were found in this spec.')]]),
   ]
 
-  return blocks.map((block) => block.map((line) => line.trimEnd()).join('\n')).join('\n\n')
+  return layout(blocks)
 }

--- a/cli/test/lib/tap/render-format.spec.ts
+++ b/cli/test/lib/tap/render-format.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { countsLine, definitionList, emptyState, heading, indent, layout, stateBadge, table, titleLine } from '../../../lib/tap/render/format'
+
+// chalk's color level depends on where the suite runs, so strip escape codes
+// before asserting — these target the shared layout, not the colors.
+const plain = (value: string): string => stripAnsi(value)
+const plainLines = (lines: string[]): string[] => lines.map(plain)
+
+describe('lib/tap/render/format', () => {
+  describe('heading', () => {
+    it('renders a bare title, and a title with its count', () => {
+      expect(plain(heading('ROUTES'))).toBe('ROUTES')
+      expect(plain(heading('ROUTES', 3))).toBe('ROUTES (3)')
+    })
+  })
+
+  describe('titleLine', () => {
+    it('leads with the icon and appends the suffix when present', () => {
+      expect(plain(titleLine('▶', 'login.cy.ts'))).toBe('▶ login.cy.ts')
+      expect(plain(titleLine('✓', 'login.cy.ts', 'passed'))).toBe('✓ login.cy.ts  passed')
+    })
+  })
+
+  describe('countsLine', () => {
+    it('renders each outcome, zero as `--`, and skipped only when non-zero', () => {
+      expect(plain(countsLine({ passed: 2, failed: 0, pending: 1, skipped: 0 }))).toBe(`${plain(stateBadge.passed.icon)} 2  ${plain(stateBadge.failed.icon)} --  ${plain(stateBadge.pending.icon)} 1`)
+      expect(plain(countsLine({ passed: 2, failed: 1, pending: 0, skipped: 3 }))).toContain('- 3')
+    })
+  })
+
+  describe('table', () => {
+    it('renders a counted heading and pads columns to their widest cell', () => {
+      const rendered = plain(layout([table('INSTANCES', ['PID', 'TYPE'], [['111', 'e2e'], ['2', 'component']])]))
+
+      expect(rendered).toBe([
+        'INSTANCES (2)',
+        '  PID  TYPE',
+        '  111  e2e',
+        '  2    component',
+      ].join('\n'))
+    })
+
+    it('applies the optional colorize to each padded row', () => {
+      const rows = table('T', ['A'], [['x']], (cells) => cells.map((cell) => `<${cell}>`))
+
+      expect(plain(rows[2])).toBe('  <x>')
+    })
+  })
+
+  describe('definitionList', () => {
+    it('aligns values past the widest label', () => {
+      expect(plainLines(definitionList([['pid', '4242'], ['testing type', 'e2e']]))).toEqual([
+        '  pid           4242',
+        '  testing type  e2e',
+      ])
+    })
+  })
+
+  describe('indent', () => {
+    it('nests by two spaces per level', () => {
+      expect(indent(0)).toBe('')
+      expect(indent(2)).toBe('    ')
+    })
+  })
+
+  describe('layout', () => {
+    it('separates blocks with a blank line and trims trailing whitespace', () => {
+      expect(plain(layout([['a  ', 'b'], [emptyState('c')]]))).toBe('a\nb\n\nc')
+    })
+  })
+})


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Extracts a shared `render/format` module that turns each tap command's structured result into human-readable CLI output (with a `--json` bypass), and adds `tap reporter`, mirroring the app's reporter panel in the terminal.

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap reporter
```

### How has the user experience changed?

`cypress tap reporter` now prints human-readable output:

```
cypress/e2e/2-advanced-examples/window.cy.js
✓ 3  ✖ --  ○ --  366ms

WINDOW
   r3  ✓ cy.window() - get the global window object  130ms
   r4  ✓ cy.document() - get the document object  105ms
   r5  ✓ cy.title() - get the title  89ms
```

Empty state — `cypress tap reporter --test <unknown-id>`:

```
TEST_NOT_FOUND: no test of this run matches the id "bogusid" — use the tests command to list this run’s tests
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and internal tap rendering only; structured JSON remains available via `--json`, with no auth or runtime test-runner behavior changes.
> 
> **Overview**
> Introduces **`cli/lib/tap/render/format.ts`** as the shared terminal vocabulary (reporter-aligned colors, `stateBadge`, `countsLine`, `heading`, `table`, `definitionList`, `layout`) and documents conventions in **`AGENTS.md`**. **`reporter.ts`** is refactored to compose those primitives instead of local duplicates.
> 
> Tap commands that previously called **`renderResult`** now go through **`renderOutcome(command, result, options.json)`**, which prints a registered human renderer when present and falls back to JSON (or forces JSON with **`--json`**). **`withResolvedAutFrame`** takes a command name so AUT-frame commands (`aria`, `dom`, `inspect`) use the same path. The render registry typing expands to **`TapNativeCommandName`**; **`reporter`** remains the command with a human renderer in this slice.
> 
> Adds **`render-format.spec.ts`** for the shared layout helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c93946a18754c22d8a45f02391b960d05ad5c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->