### PR TITLE
feat: render the tap run command's launch outcome

### DIFF
--- a/cli/lib/tap/commands/run.ts
+++ b/cli/lib/tap/commands/run.ts
@@ -6,6 +6,16 @@ import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 import { posixify } from '../../util'
 
+/** What `cypress tap run` returns once a spec is launched. */
+export interface TapRunResult {
+  /** Project-relative path of the launched spec. */
+  spec: string
+  /** Testing type the run launched under. */
+  testingType: string
+  /** Display name of the browser the run launched in. */
+  browser: string
+}
+
 const RUN_SPEC_TIMEOUT_MS = 60_000
 
 const findTargetSpec = async (instance: LiveInstanceState, relative: string) => {
@@ -30,11 +40,13 @@ const runSpec = async (options: TapCliOptions, args: { spec: string }): Promise<
     const { runSpec: result } = await queryInstanceGraphql(instance, tapRunSpecOperation(match.absolute), RUN_SPEC_TIMEOUT_MS)
 
     if (result?.__typename === 'RunSpecResponse') {
-      renderOutcome('run', {
+      const launched: TapRunResult = {
         spec: result.spec.relative.replace(/\\/g, '/'),
         testingType: result.testingType,
         browser: result.browser.displayName,
-      }, options.json)
+      }
+
+      renderOutcome('run', launched, options.json)
 
       return 0
     }

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,5 +1,7 @@
 import type { TapCommandName, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
+import type { TapRunResult } from '../commands/run'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
+import { renderRunHuman } from './run'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -21,6 +23,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
       return 'stats' in view ? renderReporterSpecHuman(view) : renderReporterHuman(view)
     },
   },
+  run: { renderHuman: (result) => renderRunHuman(result as TapRunResult) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/lib/tap/render/run.ts
+++ b/cli/lib/tap/render/run.ts
@@ -1,0 +1,14 @@
+import type { TapRunResult } from '../commands/run'
+import { color, definitionList, layout, titleLine } from './format'
+
+// The run command starts a spec and returns immediately (poll `status` for
+// progress), so this confirms what was launched rather than reporting an outcome.
+export const renderRunHuman = (result: TapRunResult): string => {
+  return layout([
+    [titleLine(color.pass('▶'), result.spec)],
+    definitionList([
+      ['testing type', result.testingType],
+      ['browser', result.browser],
+    ]),
+  ])
+}

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -795,15 +795,29 @@ describe('lib/exec/tap', () => {
       })
     }
 
-    it('triggers the run and renders the launch outcome as JSON, without opening a session', async () => {
+    it('triggers the run and renders the launch outcome, without opening a session', async () => {
       mockLiveResolved(liveInstance())
       mockInstanceGraphql()
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(0)
-      expect(JSON.parse(logger.print())).toEqual({ spec: 'cypress/e2e/login.cy.ts', testingType: 'e2e', browser: 'Chrome' })
+
+      const output = logger.print()
+
+      expect(output).toContain('cypress/e2e/login.cy.ts')
+      expect(output).toContain('e2e')
+      expect(output).toContain('Chrome')
+      expect(() => JSON.parse(output)).toThrow()
 
       // The run is driven from the instance's data layer, not over a CDP session.
       expect(withTapSession).not.toHaveBeenCalled()
+    })
+
+    it('prints the raw launch outcome with --json', async () => {
+      mockLiveResolved(liveInstance())
+      mockInstanceGraphql()
+
+      expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], { json: true })).toBe(0)
+      expect(JSON.parse(logger.print())).toEqual({ spec: 'cypress/e2e/login.cy.ts', testingType: 'e2e', browser: 'Chrome' })
     })
 
     it('sends the matched spec\'s instance-reported absolute path to the TapRunSpec operation', async () => {

--- a/cli/test/lib/tap/render-run.spec.ts
+++ b/cli/test/lib/tap/render-run.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderRunHuman } from '../../../lib/tap/render/run'
+import type { TapRunResult } from '../../../lib/tap/commands/run'
+
+const render = (result: TapRunResult): string => stripAnsi(renderRunHuman(result))
+
+describe('lib/tap/render/run', () => {
+  it('renders the launched spec as a title with its testing type and browser', () => {
+    const output = render({ spec: 'cypress/e2e/login.cy.ts', testingType: 'e2e', browser: 'Chrome' })
+
+    expect(output).toBe([
+      '▶ cypress/e2e/login.cy.ts',
+      '',
+      '  testing type  e2e',
+      '  browser       Chrome',
+    ].join('\n'))
+  })
+})

--- a/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
+++ b/packages/app/cypress/e2e/cypress-in-cypress.cy.ts
@@ -394,7 +394,7 @@ describe('Cypress in Cypress', { viewportWidth: 1500, defaultCommandTimeout: 100
 
       postRunSpecMutation()
 
-      cy.contains('Dom Content').should('be.visible')
+      cy.reporter().contains('Dom Content').should('be.visible')
       cy.waitForSpecToFinish({ passCount: 1 })
 
       let firstRunStartedAt: number | undefined

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -83,7 +83,7 @@ describe('tap binding', () => {
     cy.visitApp('/specs/runner?file=cypress/e2e/dom-content.spec.js')
 
     cy.waitForSpecToFinish({ passCount: 1 })
-    cy.contains('Dom Content').should('be.visible')
+    cy.reporter().contains('Dom Content').should('be.visible')
 
     cy.window().then(async (win) => {
       const outcome = await getBinding(win).exec('tests')
@@ -548,7 +548,7 @@ describe('tap binding pin lifecycle', () => {
     // Clicking the pinned command in the reporter unpins through a different
     // event path than the control above — it must restore the DOM all the same.
     pinClickAtBefore()
-    cy.contains('li.command-name-click', 'click').find('.command-pin-target').first().click()
+    cy.reporter().contains('li.command-name-click', 'click').find('.command-pin-target').first().click()
     expectReleased()
   })
 })

--- a/packages/app/src/tap/commands/command.cy.ts
+++ b/packages/app/src/tap/commands/command.cy.ts
@@ -6,14 +6,16 @@ const CYPRESS_VERSION = '15.0.0'
 describe('tap/commands/command', () => {
   // r2's failed first attempt has its own command log, distinct from the passing
   // latest attempt, so attempt selection is observable. r4 stands in for a test
-  // the driver evicted from memory (numTestsKeptInMemory).
+  // the driver evicted from memory (numTestsKeptInMemory). --command takes the id
+  // the reporter displays — a per-section row number — so these logs are
+  // addressed as "1" and "2" rather than by the driver log ids they carry here.
   const TESTS_STATE = {
     r2: {
       id: 'r2',
       title: 'logs in',
       state: 'passed',
       commands: [
-        { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent', displayName: 'visit', hookId: 'h1' },
+        { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent', displayName: 'visit' },
         { id: 'log-2', name: 'get', message: '#user', state: 'passed', type: 'parent' },
       ],
       prevAttempts: [
@@ -52,7 +54,7 @@ describe('tap/commands/command', () => {
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-2' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2' })).to.deep.eq({
       error: {
         code: 'NO_RUN',
         message: 'no spec has been run yet — use the run command to run a spec first',
@@ -63,7 +65,7 @@ describe('tap/commands/command', () => {
   it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'nope', command: 'log-2' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'nope', command: '2' })).to.deep.eq({
       error: {
         code: 'TEST_NOT_FOUND',
         message: 'no test of this run matches the id "nope" — use the tests command to list this run’s tests',
@@ -74,23 +76,23 @@ describe('tap/commands/command', () => {
   it('returns one lean command entry, keeping only the listed fields', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-1' })).to.deep.eq({
-      result: { id: 'log-1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+      result: { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent' },
     })
   })
 
   it('returns the entry from the requested attempt', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-b', attempt: '1' })).to.deep.eq({
-      result: { id: 'log-b', name: 'get', message: '#user', state: 'failed', type: 'parent' },
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2', attempt: '1' })).to.deep.eq({
+      result: { id: '2', name: 'get', message: '#user', state: 'failed', type: 'parent' },
     })
   })
 
   it('fails with ATTEMPT_NOT_FOUND when the attempt is out of range', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-2', attempt: '3' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2', attempt: '3' })).to.deep.eq({
       error: {
         code: 'ATTEMPT_NOT_FOUND',
         message: 'test "r2" has 2 attempts; pass --attempt 1–2 (defaults to the latest)',
@@ -103,10 +105,10 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-2', props: 'true', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '3', props: 'true', attempt: '1' })).to.deep.eq({
       error: {
         code: 'COMMAND_NOT_FOUND',
-        message: 'no command of this test matches the id "log-2" — use the commands command to list this test’s commands',
+        message: 'no command of this test matches the id "3" — use the commands command to list this test’s commands',
       },
     })
 
@@ -128,8 +130,9 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-2', props: 'true' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2', props: 'true' })
 
+    // The displayed id resolves to the driver log id the runner keys on.
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-2', undefined)
     expect(outcome).to.deep.eq({ result: consoleProps })
     expect(JSON.parse(JSON.stringify(outcome))).to.deep.eq(outcome)
@@ -141,7 +144,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-b', props: 'true', attempt: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2', props: 'true', attempt: '1' })
 
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-b', undefined)
     expect(outcome).to.deep.eq({ result: consoleProps })
@@ -152,13 +155,13 @@ describe('tap/commands/command', () => {
 
     stubTests(() => cleanup)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r4', command: 'log-c', props: 'true' })).to.deep.eq({ result: cleanup })
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r4', command: '1', props: 'true' })).to.deep.eq({ result: cleanup })
   })
 
   it('fails with CONSOLE_PROPS_UNAVAILABLE when the driver has no details for a listed command', async () => {
     stubTests(() => undefined)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'log-2', props: 'true' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '2', props: 'true' })).to.deep.eq({
       error: {
         code: 'CONSOLE_PROPS_UNAVAILABLE',
         message: 'this command has no console properties available — command details are captured in open mode and kept only for the most recent tests (numTestsKeptInMemory)',
@@ -174,7 +177,7 @@ describe('tap/commands/command', () => {
 
     const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, {
       'test': 'r2',
-      'command': 'log-2',
+      'command': '2',
       'props': 'true',
       'full-report': 'true',
     })
@@ -186,7 +189,7 @@ describe('tap/commands/command', () => {
   it('fails with PROPS_REQUIRED before reading the runner when --full-report has no --props', async () => {
     const getRunner = stubRunner({ getTestState: (id: string) => TESTS_STATE[id] })
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test': 'r2', 'command': 'log-2', 'full-report': 'true' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test': 'r2', 'command': '2', 'full-report': 'true' })).to.deep.eq({
       error: {
         code: 'PROPS_REQUIRED',
         message: 'pass --props with --full-report — only a command’s console properties are ever shortened',
@@ -202,7 +205,7 @@ describe('tap/commands/command', () => {
     const manager = new TapManager(CYPRESS_VERSION)
 
     expect((await manager.exec('command', {}, { test: 'r2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
-    expect((await manager.exec('command', {}, { command: 'log-2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect((await manager.exec('command', {}, { command: '2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
     expect(getRunner).not.to.have.been.called
   })
 })

--- a/packages/app/src/tap/commands/command.ts
+++ b/packages/app/src/tap/commands/command.ts
@@ -1,6 +1,6 @@
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
-import { attemptSelectionError, selectTestAttempt, serializeTestCommands } from '../test-state'
+import { attemptSelectionError, resolveCommand, selectTestAttempt } from '../test-state'
 import type { CommandEntry, ConsolePropsResult } from '../types'
 
 export const commandCommand = defineCommand('command', async (_params, options): Promise<CommandEntry | ConsolePropsResult> => {
@@ -23,17 +23,17 @@ export const commandCommand = defineCommand('command', async (_params, options):
     throw attemptSelectionError(selection, test)
   }
 
-  const selected = serializeTestCommands(selection.attempt).find((entry) => entry.id === command)
+  const resolved = resolveCommand(selection.attempt, command, test)
 
-  if (!selected) {
+  if (!resolved) {
     throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the commands command to list this test’s commands`)
   }
 
   if (!props) {
-    return selected
+    return resolved.entry
   }
 
-  const consoleProps = runner.getSerializedConsolePropsForLog(test, command, fullReport ? { fullReport } : undefined)
+  const consoleProps = runner.getSerializedConsolePropsForLog(test, resolved.logId, fullReport ? { fullReport } : undefined)
 
   if (!consoleProps || Object.keys(consoleProps).length === 0) {
     throw new TapCommandError('CONSOLE_PROPS_UNAVAILABLE', 'this command has no console properties available — command details are captured in open mode and kept only for the most recent tests (numTestsKeptInMemory)')

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -254,16 +254,17 @@ const tapCommandIds = (logs: SerializedCommandLog[]): Map<string, string> => {
 
 const hookIdOf = (log: SerializedCommandLog): string | undefined => (log as ReporterLog).hookId
 
-/**
- * Resolves a command handle to the driver's log id. A handle is the row's id
- * as displayed (`12` or `e3`), optionally qualified with its hook section
- * (`h1:12`) since the reporter's numbers restart per section. A plain number
- * prefers the test body, then a unique match anywhere; a remaining tie is
- * ambiguous rather than silently guessed.
- */
-export const resolveCommandLogId = (attempt: SerializedTest, tapId: string, testId: string): string | undefined => {
-  const logs = orderedAttemptLogs(attempt)
-  const ids = tapCommandIds(logs)
+export interface ResolvedCommand {
+  logId: string
+  entry: CommandEntry
+}
+
+// Matches a displayed command id to its underlying log. The id is a row's
+// number as the reporter shows it (`12` or the event rows' `e3`), optionally
+// qualified with its hook section (`h1:12`) since the numbers restart per
+// section. A plain number prefers the test body, then a unique match anywhere;
+// a remaining tie is ambiguous rather than silently guessed.
+const findCommandLog = (attempt: SerializedTest, logs: SerializedCommandLog[], ids: Map<string, string>, tapId: string, testId: string): SerializedCommandLog | undefined => {
   const colon = tapId.indexOf(':')
   const hookQualifier = colon === -1 ? undefined : tapId.slice(0, colon)
   const rowId = colon === -1 ? tapId : tapId.slice(colon + 1)
@@ -273,13 +274,13 @@ export const resolveCommandLogId = (attempt: SerializedTest, tapId: string, test
   })
 
   if (candidates.length <= 1) {
-    return candidates[0]?.id
+    return candidates[0]
   }
 
   const testBody = candidates.find((log) => hookIdOf(log) === testId)
 
   if (testBody) {
-    return testBody.id
+    return testBody
   }
 
   const hookNames = new Map(attemptHooks(attempt).map(({ hookId, hookName }) => [hookId, hookName]))
@@ -291,6 +292,25 @@ export const resolveCommandLogId = (attempt: SerializedTest, tapId: string, test
   })
 
   throw new TapCommandError('AMBIGUOUS_COMMAND', `"${tapId}" matches ${qualified.join(' and ')} — qualify the id with its section, e.g. "${qualified[0].split(' ')[0]}"`)
+}
+
+/**
+ * Resolves a command id the way the reporter shows it — a row number, an
+ * e-prefixed event id, or a hook-qualified `h1:3` — to the driver log id the
+ * runner keys on plus the serialized entry to display. The one command-id
+ * lookup the `command` and `pin` commands share, so both accept exactly the
+ * ids the reporter emits.
+ */
+export const resolveCommand = (attempt: SerializedTest, tapId: string, testId: string): ResolvedCommand | undefined => {
+  const logs = orderedAttemptLogs(attempt)
+  const ids = tapCommandIds(logs)
+  const log = findCommandLog(attempt, logs, ids, tapId, testId)
+
+  return log ? { logId: log.id, entry: serializeCommandEntry(log, ids.get(log.id)) } : undefined
+}
+
+export const resolveCommandLogId = (attempt: SerializedTest, tapId: string, testId: string): string | undefined => {
+  return resolveCommand(attempt, tapId, testId)?.logId
 }
 
 export const serializeTestCommands = (attempt: SerializedTest): CommandEntry[] => {

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -37,7 +37,7 @@ export interface PinSnapshotRunner {
   getSnapshotPropsForLog (testId: string, logId: string): PinSnapshotProps | undefined
 }
 
-export type TapJsonValue = null | boolean | number | string | TapJsonValue[] | { [key: string]: TapJsonValue }
+type TapJsonValue = null | boolean | number | string | TapJsonValue[] | { [key: string]: TapJsonValue }
 
 export type ConsolePropsResult = { [key: string]: TapJsonValue }
 


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap run`'s launch outcome (the spec it started, plus the testing type and browser) in human-readable form.

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

Also carries two fixes that CI was failing on. Both originate on the merged trunk rather than in this slice, but they block this PR, and this is the earliest open branch in the stack, so fixing here covers the 8 PRs above it:

- **`tap command` never resolved a command id to the driver's log id.** #34380 changed wire command ids to the reporter's displayed row numbers. `pin` was updated to resolve them; `command` was not. It matched `--command` against the row ids correctly, then passed that same row id to `getSerializedConsolePropsForLog`, which keys on the driver's `log-*` id, so `--props` could never resolve a command. Both commands now share a `resolveCommand` that returns the log id and the entry in one pass. The spec was also still addressing commands by driver log id, which had stopped being a valid handle.
- **`TapJsonValue` was exported but unused outside its own file**, which failed the knip health check. `ConsolePropsResult` is the exported surface, so the value type behind it is now local.
- **Three e2e assertions read reporter content from the top document.** The reporter renders into its own iframe, so `cy.contains` cannot reach it and those assertions could only time out. They now go through `cy.reporter()`, which exists for this and which the neighbouring assertions already used. Affects the `runSpec` restart test in `cypress-in-cypress.cy.ts` and two tests in `tap-binding.cy.ts`.

The first of these was the cause of the wider red on this PR: its 7 failing tests tripped Cypress Cloud auto-cancellation, which cancelled the whole run and made 13 unrelated CircleCI jobs and every `cypress:` group report a failure.

One app-e2e failure is left and is not addressed here: `studio/studio-state-management.cy.ts` is fixed on develop by #34410, which this branch is behind. It clears on the next develop sync.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap run <spec>
```

For the two fixes:

```
yarn workspace @packages/app cypress:run:ct -- --spec "src/tap/**/*.cy.ts"
yarn health-check
```

112 tap component tests pass across 9 specs, including `pin.cy.ts` (31 tests), which covers the shared id resolution. Reverting the fix reproduces exactly the 7 failures CI reported.

For the reporter-scope fix (needs chrome; cy-in-cy does not run under electron):

```
yarn workspace @packages/app cypress:run:e2e -- --spec "cypress/e2e/tap-binding.cy.ts,cypress/e2e/cypress-in-cypress.cy.ts" --browser chrome
```

27/27 pass across those two specs.

### How has the user experience changed?

`cypress tap run <spec>` now prints human-readable output:

```
▶ cypress/e2e/sanity.cy.js

  testing type  e2e
  browser       Electron
```

Empty state (`cypress tap run <unknown-spec>`):

```
SPEC_NOT_FOUND: No spec matches the path "cypress/e2e/does-not-exist.cy.js" — use the specs command to list runnable specs.
```

`cypress tap command --test <id> --command <id> --props` now returns console properties instead of always failing with `COMMAND_NOT_FOUND`.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and tap binding bugfixes with targeted tests; no auth, security, or public API surface changes.
> 
> **Overview**
> **`cypress tap run`** now prints a human-readable launch confirmation (spec path, testing type, browser) by default; **`--json`** still emits the structured payload.
> 
> The tap **`command`** binding is fixed so **`--command`** accepts reporter row ids (e.g. `1`, `2`) while **`--props`** resolves to the driver’s internal log id via shared **`resolveCommand`** (same path as **`pin`**). **`TapJsonValue`** is no longer exported (knip).
> 
> App e2e tests that assert reporter text now use **`cy.reporter()`** instead of top-document **`cy.contains`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a88e77d827191a2f799e012a5dfe97e38dab23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->