### PR TITLE
feat: render the tap instances table (with attached browser name)

### DIFF
--- a/cli/lib/cypress-instances/liveness.ts
+++ b/cli/lib/cypress-instances/liveness.ts
@@ -57,17 +57,19 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       return null
     }
 
-    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown }
+    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown }
 
     if (live.instanceId !== record.instanceId) {
       return null
     }
 
     const cdpBrowserWsUrl = typeof live.cdpBrowserWsUrl === 'string' ? live.cdpBrowserWsUrl : null
+    const attached = cdpBrowserWsUrl !== null && await cdpEndpointReachable(cdpBrowserWsUrl, timeoutMs)
 
     return {
       ...record,
-      cdpBrowserWsUrl: cdpBrowserWsUrl && await cdpEndpointReachable(cdpBrowserWsUrl, timeoutMs) ? cdpBrowserWsUrl : null,
+      cdpBrowserWsUrl: attached ? cdpBrowserWsUrl : null,
+      browserName: attached && typeof live.browserName === 'string' ? live.browserName : null,
     }
   } catch (err) {
     debug('liveness probe failed for pid %d on port %d: %o', record.pid, record.serverPort, err)

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -5,6 +5,18 @@ import type { TapCliOptions } from '../types'
 
 const NO_INSTANCES_GUIDANCE = 'No running Cypress instance found. Start Cypress in open mode (e.g. `cypress open`) and select a testing type to get started.'
 
+/** One row of `cypress tap instances`: a reachable open-mode Cypress instance. */
+export interface TapInstanceSummary {
+  /** Process id — the handle other tap commands accept via `--instance`. */
+  pid: number
+  /** Absolute path of the project the instance has open. */
+  projectRoot: string
+  /** Testing type the instance has open, or `null` before one is chosen. */
+  testingType: 'e2e' | 'component' | null
+  /** Whether the instance has a browser attached over CDP. */
+  browserAttached: boolean
+}
+
 const listInstances = async (options: TapCliOptions): Promise<number> => {
   const instances = await listLiveInstances({ instance: options.instance })
 
@@ -14,12 +26,14 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  renderOutcome('instances', instances.map((instance) => ({
+  const summaries: TapInstanceSummary[] = instances.map((instance) => ({
     pid: instance.pid,
     projectRoot: instance.projectRoot,
     testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
-  })), options.json)
+  }))
+
+  renderOutcome('instances', summaries, options.json)
 
   return 0
 }

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -15,6 +15,8 @@ export interface TapInstanceSummary {
   testingType: 'e2e' | 'component' | null
   /** Whether the instance has a browser attached over CDP. */
   browserAttached: boolean
+  /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
+  browserName: string | null
 }
 
 const listInstances = async (options: TapCliOptions): Promise<number> => {
@@ -31,6 +33,7 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     projectRoot: instance.projectRoot,
     testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
+    browserName: instance.browserName,
   }))
 
   renderOutcome('instances', summaries, options.json)

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,7 +1,9 @@
 import type { TapCommandName, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
 import type { TapRunResult } from '../commands/run'
+import type { TapInstanceSummary } from '../commands/instances'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
+import { renderInstancesHuman } from './instances'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -24,6 +26,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
     },
   },
   run: { renderHuman: (result) => renderRunHuman(result as TapRunResult) },
+  instances: { renderHuman: (result) => renderInstancesHuman(result as TapInstanceSummary[]) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/lib/tap/render/instances.ts
+++ b/cli/lib/tap/render/instances.ts
@@ -1,0 +1,25 @@
+import chalk from 'chalk'
+
+import type { TapInstanceSummary } from '../commands/instances'
+import { color, layout, table } from './format'
+
+// The reachable open-mode instances, one row each. PID is bold — it's the handle
+// the other tap commands accept via `--instance` — and an attached browser reads
+// green, an absent one (or testing type) as a muted dash.
+export const renderInstancesHuman = (instances: TapInstanceSummary[]): string => {
+  const rows = instances.map((instance) => [
+    String(instance.pid),
+    instance.projectRoot,
+    instance.testingType ?? '—',
+    instance.browserAttached ? 'attached' : '—',
+  ])
+
+  return layout([
+    table('INSTANCES', ['PID', 'PROJECT', 'TYPE', 'BROWSER'], rows, (cells) => [
+      chalk.bold(cells[0]),
+      cells[1],
+      cells[2],
+      cells[3].startsWith('attached') ? color.pass(cells[3]) : color.muted(cells[3]),
+    ]),
+  ])
+}

--- a/cli/lib/tap/render/instances.ts
+++ b/cli/lib/tap/render/instances.ts
@@ -5,13 +5,13 @@ import { color, layout, table } from './format'
 
 // The reachable open-mode instances, one row each. PID is bold — it's the handle
 // the other tap commands accept via `--instance` — and an attached browser reads
-// green, an absent one (or testing type) as a muted dash.
+// green by its name, an absent one (or testing type) as a muted dash.
 export const renderInstancesHuman = (instances: TapInstanceSummary[]): string => {
   const rows = instances.map((instance) => [
     String(instance.pid),
     instance.projectRoot,
     instance.testingType ?? '—',
-    instance.browserAttached ? 'attached' : '—',
+    instance.browserName ?? '—',
   ])
 
   return layout([
@@ -19,7 +19,7 @@ export const renderInstancesHuman = (instances: TapInstanceSummary[]): string =>
       chalk.bold(cells[0]),
       cells[1],
       cells[2],
-      cells[3].startsWith('attached') ? color.pass(cells[3]) : color.muted(cells[3]),
+      cells[3] === '—' ? color.muted(cells[3]) : color.pass(cells[3]),
     ]),
   ])
 }

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -165,14 +165,22 @@ describe('lib/cypress-instances', () => {
       return JSON.parse(makeRecord({ serverPort, instanceId }))
     }
 
-    it('resolves the record with the live CDP state when the instance echoes the instanceId', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL } })
+    it('resolves the record with the live CDP state and browser name when the instance echoes the instanceId', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome' } })
       const record = recordFor(port)
 
       expect(await verifyInstanceRecord(record)).toEqual({
         ...record,
         cdpBrowserWsUrl: CDP_WS_URL,
+        browserName: 'Chrome',
       })
+    })
+
+    it('nulls the browser name when the CDP endpoint is unreachable', async () => {
+      const deadCdpPort = await getClosedPort()
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc`, browserName: 'Chrome' } })
+
+      expect((await verifyInstanceRecord(recordFor(port)))!.browserName).toBeNull()
     })
 
     it('normalizes a missing or junk cdpBrowserWsUrl in the probe response to null', async () => {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -99,6 +99,7 @@ const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstan
   instanceId: 'inst-1',
   testingType: 'e2e',
   cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+  browserName: 'Chrome',
   ...overrides,
 })
 
@@ -400,13 +401,14 @@ describe('lib/exec/tap', () => {
       instanceId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+      browserName: 'Chrome',
       ...overrides,
     })
 
     it('renders the live instances as a table and exits 0, without opening a session', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x' }),
-        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null }),
+        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
+        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
       ])
 
       expect(await tap.start(['instances'], {})).toBe(0)
@@ -416,7 +418,7 @@ describe('lib/exec/tap', () => {
       expect(output).toContain('INSTANCES (2)')
       expect(output).toContain('111')
       expect(output).toContain('/projects/app')
-      expect(output).toContain('attached')
+      expect(output).toContain('Chrome')
       expect(() => JSON.parse(output)).toThrow()
 
       expect(withTapSession).not.toHaveBeenCalled()
@@ -424,14 +426,14 @@ describe('lib/exec/tap', () => {
 
     it('prints the raw instance summaries with --json', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x' }),
-        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null }),
+        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
+        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
       ])
 
       expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([
-        { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true },
-        { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false },
+        { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome' },
+        { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false, browserName: null },
       ])
     })
 
@@ -500,6 +502,7 @@ describe('lib/exec/tap', () => {
       instanceId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+      browserName: 'Chrome',
       ...overrides,
     })
 
@@ -641,6 +644,7 @@ describe('lib/exec/tap', () => {
       instanceId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+      browserName: 'Chrome',
       ...overrides,
     })
 
@@ -789,6 +793,7 @@ describe('lib/exec/tap', () => {
       instanceId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+      browserName: 'Chrome',
       ...overrides,
     })
 

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -403,32 +403,49 @@ describe('lib/exec/tap', () => {
       ...overrides,
     })
 
-    it('renders the live instances as a JSON summary and exits 0, without opening a session', async () => {
+    it('renders the live instances as a table and exits 0, without opening a session', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([
         liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x' }),
         liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null }),
       ])
 
       expect(await tap.start(['instances'], {})).toBe(0)
+
+      const output = logger.print()
+
+      expect(output).toContain('INSTANCES (2)')
+      expect(output).toContain('111')
+      expect(output).toContain('/projects/app')
+      expect(output).toContain('attached')
+      expect(() => JSON.parse(output)).toThrow()
+
+      expect(withTapSession).not.toHaveBeenCalled()
+    })
+
+    it('prints the raw instance summaries with --json', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([
+        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x' }),
+        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null }),
+      ])
+
+      expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([
         { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true },
         { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false },
       ])
-
-      expect(withTapSession).not.toHaveBeenCalled()
     })
 
     it('reports the testing type as null for an instance that has not chosen one', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, testingType: null })])
 
-      expect(await tap.start(['instances'], {})).toBe(0)
+      expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())[0].testingType).toBeNull()
     })
 
     it('never exposes the internal serverPort', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, serverPort: 49200 })])
 
-      expect(await tap.start(['instances'], {})).toBe(0)
+      expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())[0]).not.toHaveProperty('serverPort')
     })
 

--- a/cli/test/lib/tap/instance-gql.spec.ts
+++ b/cli/test/lib/tap/instance-gql.spec.ts
@@ -12,6 +12,7 @@ const instance: LiveInstanceState = {
   instanceId: 'inst-1',
   testingType: 'e2e',
   cdpBrowserWsUrl: null,
+  browserName: null,
 }
 
 const request = {

--- a/cli/test/lib/tap/render-instances.spec.ts
+++ b/cli/test/lib/tap/render-instances.spec.ts
@@ -9,14 +9,14 @@ const render = (instances: TapInstanceSummary[]): string => stripAnsi(renderInst
 describe('lib/tap/render/instances', () => {
   it('renders a padded table; missing testing type and detached browser show a dash', () => {
     const output = render([
-      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true },
-      { pid: 222, projectRoot: '/projects/other', testingType: null, browserAttached: false },
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome' },
+      { pid: 222, projectRoot: '/projects/other', testingType: null, browserAttached: false, browserName: null },
     ])
 
     expect(output).toBe([
       'INSTANCES (2)',
       '  PID  PROJECT          TYPE  BROWSER',
-      '  111  /projects/app    e2e   attached',
+      '  111  /projects/app    e2e   Chrome',
       '  222  /projects/other  —     —',
     ].join('\n'))
   })

--- a/cli/test/lib/tap/render-instances.spec.ts
+++ b/cli/test/lib/tap/render-instances.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderInstancesHuman } from '../../../lib/tap/render/instances'
+import type { TapInstanceSummary } from '../../../lib/tap/commands/instances'
+
+const render = (instances: TapInstanceSummary[]): string => stripAnsi(renderInstancesHuman(instances))
+
+describe('lib/tap/render/instances', () => {
+  it('renders a padded table; missing testing type and detached browser show a dash', () => {
+    const output = render([
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true },
+      { pid: 222, projectRoot: '/projects/other', testingType: null, browserAttached: false },
+    ])
+
+    expect(output).toBe([
+      'INSTANCES (2)',
+      '  PID  PROJECT          TYPE  BROWSER',
+      '  111  /projects/app    e2e   attached',
+      '  222  /projects/other  —     —',
+    ].join('\n'))
+  })
+})

--- a/cli/test/lib/tap/tap-session.spec.ts
+++ b/cli/test/lib/tap/tap-session.spec.ts
@@ -51,6 +51,7 @@ const makeRecord = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceS
     instanceId: 'instance-abc',
     testingType: 'e2e',
     cdpBrowserWsUrl: BROWSER_WS_URL,
+    browserName: 'Chrome',
     ...overrides,
   }
 }

--- a/packages/cypress-instances/lib/index.ts
+++ b/packages/cypress-instances/lib/index.ts
@@ -31,6 +31,8 @@ export interface CypressInstance {
 
 export interface LiveInstanceState extends CypressInstance {
   cdpBrowserWsUrl: string | null
+  /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
+  browserName: string | null
 }
 
 export interface ReadyInstanceState extends LiveInstanceState {

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -259,7 +259,7 @@ export class BrowserCriClient {
         onServiceWorkerClientEvent,
       })
 
-      cypressInstances.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl)
+      cypressInstances.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl, browserName)
 
       if (fullyManageTabs) {
         await this._manageTabs({ browserClient, browserCriClient, browserName, host, onAsynchronousError, port, protocolManager })

--- a/packages/server/lib/cypress-instances.ts
+++ b/packages/server/lib/cypress-instances.ts
@@ -53,7 +53,7 @@ export const cypressInstances = {
       testingType,
     }
 
-    currentState = { ...record, cdpBrowserWsUrl: null }
+    currentState = { ...record, cdpBrowserWsUrl: null, browserName: null }
 
     try {
       await persist(record)
@@ -63,13 +63,15 @@ export const cypressInstances = {
     }
   },
 
-  setCdpBrowserWsUrl (cdpBrowserWsUrl: string | null): void {
+  setCdpBrowserWsUrl (cdpBrowserWsUrl: string | null, browserName: string | null = null): void {
     if (!currentState) {
       return
     }
 
-    currentState = { ...currentState, cdpBrowserWsUrl }
-    debug('cypress instances cdpBrowserWsUrl is now %o', cdpBrowserWsUrl)
+    // browserName is only meaningful while a browser is attached; clearing the
+    // url clears the name so the two never disagree.
+    currentState = { ...currentState, cdpBrowserWsUrl, browserName: cdpBrowserWsUrl ? browserName : null }
+    debug('cypress instances cdpBrowserWsUrl is now %o (browser %o)', cdpBrowserWsUrl, currentState.browserName)
   },
 
   getCurrent (): LiveInstanceState | null {

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -135,12 +135,12 @@ describe('lib/browsers/browser-cri-client', function () {
       expect(criImport.Version).to.be.calledTwice
     })
 
-    it('advertises the browser websocket url to cypress instances once connected', async function () {
+    it('advertises the browser websocket url and name to cypress instances once connected', async function () {
       const setCdpBrowserWsUrl = sinon.stub(cypressInstances, 'setCdpBrowserWsUrl')
 
       await getClient()
 
-      expect(setCdpBrowserWsUrl).to.be.calledWith('http://web/socket/url')
+      expect(setCdpBrowserWsUrl).to.be.calledWith('http://web/socket/url', 'Chrome')
     })
 
     it('clears the cypress instances cdp url when the browser connection is lost', async function () {

--- a/packages/server/test/unit/cypress-instances_spec.ts
+++ b/packages/server/test/unit/cypress-instances_spec.ts
@@ -116,23 +116,25 @@ describe('lib/cypress-instances', () => {
 
       const onDiskBefore = await fs.readJson(recordPath)
 
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
+      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc', 'Chrome')
 
       expect(cypressInstances.getCurrent()).to.deep.include({
         serverPort: 4455,
         cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+        browserName: 'Chrome',
       })
 
       expect(await fs.readJson(recordPath)).to.deep.eq(onDiskBefore)
     })
 
-    it('clears the endpoint when the browser goes away', async () => {
+    it('clears the endpoint and browser name when the browser goes away', async () => {
       await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
 
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
+      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc', 'Chrome')
       cypressInstances.setCdpBrowserWsUrl(null)
 
       expect(cypressInstances.getCurrent()!.cdpBrowserWsUrl).to.be.null
+      expect(cypressInstances.getCurrent()!.browserName).to.be.null
     })
 
     it('is a no-op when no record has been written yet', () => {
@@ -158,6 +160,7 @@ describe('lib/cypress-instances', () => {
       expect(cypressInstances.getCurrent()).to.deep.eq({
         ...await fs.readJson(recordPath),
         cdpBrowserWsUrl: null,
+        browserName: null,
       })
     })
   })


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap instances` as a table of reachable open-mode Cypress instances, and reports the **attached browser's name** (e.g. `electron`) in the BROWSER column instead of a generic "attached".

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap instances
```

### How has the user experience changed?

`cypress tap instances` now prints human-readable output:

```
INSTANCES (1)
  PID    PROJECT                                                      TYPE  BROWSER
  65699  /Users/davidr/Documents/Cypress/cypress-example-kitchensink  e2e   electron
```

Empty state — `cypress tap instances   # with no Cypress running`:

```
No running Cypress instance found. Start Cypress in open mode (e.g. `cypress open`) and select a testing type to get started.
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal `tap` CLI output and in-memory instance discovery; no auth, data, or public API surface beyond optional JSON fields.
> 
> **Overview**
> **`cypress tap instances`** now defaults to a human-readable **INSTANCES** table (PID, project, type, **BROWSER**) instead of JSON; **`--json`** still returns structured rows and adds **`browserName`** alongside **`browserAttached`**.
> 
> The running Cypress server tracks **`browserName`** in live instance state (set when CDP connects via **`setCdpBrowserWsUrl(url, browserName)`**, cleared when the browser disconnects). The CLI liveness probe exposes the name only when CDP is actually reachable, so stale probe data does not show a misleading browser label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc22b0baf537c2bf0a889ddd12b3ea921d43f3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->