### PR TITLE
feat: render the tap specs command as a human-readable list

### DIFF
--- a/cli/lib/tap/commands/specs.ts
+++ b/cli/lib/tap/commands/specs.ts
@@ -6,9 +6,13 @@ import { defineNativeCommand } from './definition'
 import type { TapSpecsQuery } from '@packages/cypress-instances'
 import type { TapCliOptions } from '../types'
 
-interface TapSpecEntry {
+/** One row of `cypress tap specs`: a runnable spec of the active project. */
+export interface TapSpecEntry {
+  /** POSIX project-relative spec path. */
   relativePath: string
+  /** Git's human-readable last-modified time (e.g. `2 hours ago`); absent without git info. */
   lastModified?: string
+  /** Machine-facing last-modified epoch; JSON-only, omitted from the human view. */
   lastModifiedTimestamp?: string
 }
 

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,9 +1,11 @@
 import type { TapCommandName, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
 import type { TapRunResult } from '../commands/run'
 import type { TapInstanceSummary } from '../commands/instances'
+import type { TapSpecEntry } from '../commands/specs'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
 import { renderInstancesHuman } from './instances'
+import { renderSpecsHuman } from './specs'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -27,6 +29,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
   },
   run: { renderHuman: (result) => renderRunHuman(result as TapRunResult) },
   instances: { renderHuman: (result) => renderInstancesHuman(result as TapInstanceSummary[]) },
+  specs: { renderHuman: (result) => renderSpecsHuman(result as TapSpecEntry[]) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/lib/tap/render/specs.ts
+++ b/cli/lib/tap/render/specs.ts
@@ -1,0 +1,22 @@
+import type { TapSpecEntry } from '../commands/specs'
+import { color, emptyState, heading, layout } from './format'
+
+// A flat, headed list of runnable specs. The git last-modified time trails each
+// path, aligned into a muted column; the machine-facing timestamp stays in --json.
+// An empty project keeps the same `SPECS (n)` frame so the shape reads the same
+// whether or not any specs exist.
+export const renderSpecsHuman = (specs: TapSpecEntry[]): string => {
+  if (!specs.length) {
+    return layout([[heading('SPECS', 0), `  ${emptyState('[EMPTY PROJECT]')}`]])
+  }
+
+  const width = Math.max(...specs.map((spec) => spec.relativePath.length))
+
+  const rows = specs.map((spec) => {
+    const modified = spec.lastModified ? `  ${color.muted(spec.lastModified)}` : ''
+
+    return `  ${spec.relativePath.padEnd(width)}${modified}`
+  })
+
+  return layout([[heading('SPECS', specs.length), ...rows]])
+}

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -656,7 +656,7 @@ describe('lib/exec/tap', () => {
       return selection
     }
 
-    it('renders the live spec list as JSON and exits 0, without opening a session', async () => {
+    it('renders the live spec list as a headed list and exits 0, without opening a session', async () => {
       mockLiveResolved(liveInstance())
       vi.mocked(queryInstanceGraphql).mockResolvedValue({
         currentProject: { specs: [
@@ -666,15 +666,34 @@ describe('lib/exec/tap', () => {
       })
 
       expect(await tap.start(['specs'], {})).toBe(0)
+
+      const output = logger.print()
+
+      expect(output).toContain('SPECS (2)')
+      expect(output).toContain('cypress/e2e/a.cy.ts')
+      expect(output).toContain('2 hours ago')
+      expect(() => JSON.parse(output)).toThrow()
+
+      // The spec list comes from the instance's data layer, not the browser.
+      expect(withTapSession).not.toHaveBeenCalled()
+    })
+
+    it('prints the raw spec entries (with git timestamps) via --json', async () => {
+      mockLiveResolved(liveInstance())
+      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+        currentProject: { specs: [
+          { relative: 'cypress/e2e/a.cy.ts', gitInfo: { lastModifiedHumanReadable: '2 hours ago', lastModifiedTimestamp: '2026-07-24 09:00:00 -0500' } },
+          { relative: 'cypress/e2e/b.cy.ts', gitInfo: null },
+        ] },
+      })
+
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
       // git's last-modified (human-readable + raw timestamp) rides along when
       // present, omitted when the spec has none.
       expect(JSON.parse(logger.print())).toEqual([
         { relativePath: 'cypress/e2e/a.cy.ts', lastModified: '2 hours ago', lastModifiedTimestamp: '2026-07-24 09:00:00 -0500' },
         { relativePath: 'cypress/e2e/b.cy.ts' },
       ])
-
-      // The spec list comes from the instance's data layer, not the browser.
-      expect(withTapSession).not.toHaveBeenCalled()
     })
 
     it('lists specs even when the instance has no browser attached', async () => {
@@ -683,7 +702,7 @@ describe('lib/exec/tap', () => {
         currentProject: { specs: [{ relative: 'cypress/e2e/a.cy.ts' }] },
       })
 
-      expect(await tap.start(['specs'], {})).toBe(0)
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([{ relativePath: 'cypress/e2e/a.cy.ts' }])
     })
 
@@ -693,7 +712,7 @@ describe('lib/exec/tap', () => {
         currentProject: { specs: [{ relative: 'cypress\\e2e\\win.cy.ts', gitInfo: null }] },
       })
 
-      expect(await tap.start(['specs'], {})).toBe(0)
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([{ relativePath: 'cypress/e2e/win.cy.ts' }])
     })
 
@@ -720,7 +739,7 @@ describe('lib/exec/tap', () => {
       mockLiveResolved(liveInstance())
       vi.mocked(queryInstanceGraphql).mockResolvedValue({ currentProject: null })
 
-      expect(await tap.start(['specs'], {})).toBe(0)
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([])
     })
 
@@ -736,7 +755,7 @@ describe('lib/exec/tap', () => {
         ] },
       })
 
-      expect(await tap.start(['specs'], {})).toBe(0)
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
       // Non-string git fields are dropped, not rendered as junk.
       expect(JSON.parse(logger.print())).toEqual([
         { relativePath: 'cypress/e2e/no-git.cy.ts' },

--- a/cli/test/lib/tap/render-specs.spec.ts
+++ b/cli/test/lib/tap/render-specs.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderSpecsHuman } from '../../../lib/tap/render/specs'
+import type { TapSpecEntry } from '../../../lib/tap/commands/specs'
+
+const render = (specs: TapSpecEntry[]): string => stripAnsi(renderSpecsHuman(specs))
+
+describe('lib/tap/render/specs', () => {
+  it('lists specs with git times aligned into a column, and no time when absent', () => {
+    const output = render([
+      { relativePath: 'cypress/e2e/a.cy.ts', lastModified: '2 hours ago', lastModifiedTimestamp: '2026-07-24 09:00:00 -0500' },
+      { relativePath: 'cypress/e2e/longer-name.cy.ts' },
+    ])
+
+    expect(output).toBe([
+      'SPECS (2)',
+      '  cypress/e2e/a.cy.ts            2 hours ago',
+      '  cypress/e2e/longer-name.cy.ts',
+    ].join('\n'))
+  })
+
+  it('keeps the SPECS frame with an empty-project placeholder when there are no specs', () => {
+    expect(render([])).toBe([
+      'SPECS (0)',
+      '  [EMPTY PROJECT]',
+    ].join('\n'))
+  })
+})


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap specs` as a human-readable list of the project's specs with their last-modified times.

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap specs
```

### How has the user experience changed?

`cypress tap specs` now prints human-readable output:

```
SPECS (26)
  cypress/e2e/actions-solved.cy.js                          8 days ago
  cypress/e2e/all-commands.cy.js                            a day ago
  cypress/e2e/iframe.cy.js                                  8 days ago
  cypress/e2e/large-string.cy.js                            8 days ago
  cypress/e2e/live-specs-demo.cy.js                         5 days ago
  cypress/e2e/sanity.cy.js                                  8 days ago
  cypress/e2e/1-getting-started/todo.cy.js                  2 months ago
  cypress/e2e/2-advanced-examples/actions.cy.js             13 hours ago
  cypress/e2e/2-advanced-examples/aliasing.cy.js            4 years, 2 months ago
  cypress/e2e/2-advanced-examples/assertions.cy.js          4 years, 2 months ago
  cypress/e2e/2-advanced-examples/connectors.cy.js          2 years, 3 months ago
  cypress/e2e/2-advanced-examples/cookies.cy.js             2 years, 4 months ago
  cypress/e2e/2-advanced-examples/cypress_api.cy.js         2 years, 3 months ago
  cypress/e2e/2-advanced-examples/files.cy.js               3 years, 3 months ago
  cypress/e2e/2-advanced-examples/location.cy.js            4 years, 2 months ago
  cypress/e2e/2-advanced-examples/misc.cy.js                2 years, 4 months ago
  cypress/e2e/2-advanced-examples/navigation.cy.js          3 months ago
  cypress/e2e/2-advanced-examples/network_requests.cy.js    4 years, 2 months ago
  cypress/e2e/2-advanced-examples/querying.cy.js            4 years, 2 months ago
  cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js  2 years, 3 months ago
  cypress/e2e/2-advanced-examples/storage.cy.js             2 years, 5 months ago
  cypress/e2e/2-advanced-examples/traversal.cy.js           4 years, 2 months ago
  cypress/e2e/2-advanced-examples/utilities.cy.js           4 months ago
  cypress/e2e/2-advanced-examples/viewport.cy.js            3 years, 3 months ago
  cypress/e2e/2-advanced-examples/waiting.cy.js             a month ago
  cypress/e2e/2-advanced-examples/window.cy.js              4 years, 2 months ago
```

Empty state — `cypress tap specs` (project with no specs) keeps the same `SPECS (n)` frame:

```
SPECS (0)
  [EMPTY PROJECT]
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation-only change with no auth, data, or instance protocol changes; behavior is covered by updated integration and unit tests.
> 
> **Overview**
> **`cypress tap specs`** now prints a formatted list by default instead of JSON, matching other tap commands that expose `renderHuman` (e.g. `instances`, `run`).
> 
> The view is a **`SPECS (n)`** header with padded spec paths and optional muted git **last-modified** text; empty projects show **`[EMPTY PROJECT]`**. **`--json`** still returns the same structured entries, including **`lastModifiedTimestamp`**, which stays out of the human view.
> 
> Wiring is a new **`renderSpecsHuman`** renderer registered on the shared tap render map; **`TapSpecEntry`** is exported and documented for that contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb52a257eadeef7281a23e5e71ebf82f4891f5fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->