### PR TITLE
feat: render the tap dom command in human-readable form

### DIFF
--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -8,10 +8,15 @@ import { defineNativeCommand } from './definition'
 
 const DEFAULT_MAX_CHARS = 30000
 
-interface FrameDomResult {
+/** What `cypress tap dom` returns: the whole document, or per-selector matches. */
+export interface FrameDomResult {
+  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
   url?: string
+  /** The document's outerHTML — present in whole-page mode. */
   html?: string
+  /** Per-match outerHTML — present in selector mode. */
   matches?: { count: number, html: string[] }
+  /** Present (always `true`) when the browser-side cap clipped the output. */
   truncated?: true
 }
 

--- a/cli/lib/tap/render/dom.ts
+++ b/cli/lib/tap/render/dom.ts
@@ -1,0 +1,31 @@
+import type { FrameDomResult } from '../commands/dom'
+import { color, emptyState, heading, layout } from './format'
+
+// The frame URL trails the panel title in muted text, the way the reporter dims
+// contextual detail.
+const urlSuffix = (url?: string): string => (url ? `  ${color.muted(url)}` : '')
+
+// Selector mode prints each match's outerHTML as its own block under a counted
+// title; whole-page mode prints the single document. A browser-side clip adds a
+// muted trailer either way.
+export const renderDomHuman = (result: FrameDomResult): string => {
+  const truncation = result.truncated ? [[color.muted('(output truncated)')]] : []
+
+  if (result.matches) {
+    if (result.matches.count === 0) {
+      return emptyState('No elements matched the selector.')
+    }
+
+    return layout([
+      [`${heading('MATCHES', result.matches.count)}${urlSuffix(result.url)}`],
+      ...result.matches.html.map((html) => [html]),
+      ...truncation,
+    ])
+  }
+
+  return layout([
+    [`${heading('DOM')}${urlSuffix(result.url)}`],
+    ...(result.html !== undefined ? [[result.html]] : []),
+    ...truncation,
+  ])
+}

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -3,11 +3,13 @@ import type { TapRunResult } from '../commands/run'
 import type { TapInstanceSummary } from '../commands/instances'
 import type { TapSpecEntry } from '../commands/specs'
 import type { TapStatus } from '../types'
+import type { FrameDomResult } from '../commands/dom'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
 import { renderInstancesHuman } from './instances'
 import { renderSpecsHuman } from './specs'
 import { renderStatusHuman } from './status'
+import { renderDomHuman } from './dom'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -33,6 +35,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
   instances: { renderHuman: (result) => renderInstancesHuman(result as TapInstanceSummary[]) },
   specs: { renderHuman: (result) => renderSpecsHuman(result as TapSpecEntry[]) },
   status: { renderHuman: (result) => renderStatusHuman(result as TapStatus) },
+  dom: { renderHuman: (result) => renderDomHuman(result as FrameDomResult) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/test/lib/tap/render-dom.spec.ts
+++ b/cli/test/lib/tap/render-dom.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderDomHuman } from '../../../lib/tap/render/dom'
+import type { FrameDomResult } from '../../../lib/tap/commands/dom'
+
+const render = (result: FrameDomResult): string => stripAnsi(renderDomHuman(result))
+
+describe('lib/tap/render/dom', () => {
+  it('renders the whole document under a DOM header with the url', () => {
+    expect(render({ url: 'http://localhost:5555/', html: '<html></html>' })).toBe([
+      'DOM  http://localhost:5555/',
+      '',
+      '<html></html>',
+    ].join('\n'))
+  })
+
+  it('renders each selector match as its own block under a counted header, and notes truncation', () => {
+    expect(render({ url: 'http://localhost:5555/', matches: { count: 2, html: ['<a></a>', '<b></b>'] }, truncated: true })).toBe([
+      'MATCHES (2)  http://localhost:5555/',
+      '',
+      '<a></a>',
+      '',
+      '<b></b>',
+      '',
+      '(output truncated)',
+    ].join('\n'))
+  })
+
+  it('notes when a selector matched nothing', () => {
+    expect(render({ url: 'http://x/', matches: { count: 0, html: [] } })).toBe('No elements matched the selector.')
+  })
+})


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap dom` in human-readable form — the app-under-test HTML, scoped to a CSS selector's matches (whole document when omitted).

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap dom h1
```

### How has the user experience changed?

`cypress tap dom h1` now prints human-readable output:

```
MATCHES (1)  http://localhost:8080/commands/window

<h1>Window</h1>
```

Empty state — `cypress tap dom <unmatched-selector>`:

```
No elements matched the selector.
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation only; no changes to DOM extraction or CDP behavior.
> 
> **Overview**
> **`cypress tap dom`** now uses the same human-readable tap rendering path as other commands (default output; **`--json`** unchanged).
> 
> A new **`renderDomHuman`** formatter prints whole-document HTML under a **DOM** header with a muted frame URL, selector hits under **MATCHES (n)** with each match’s outerHTML in separate blocks, an empty-state line when nothing matches, and **(output truncated)** when browser-side clipping applies. **`FrameDomResult`** is exported and documented on the command side so the renderer can type against the command result.
> 
> The tap render registry gains a **`dom`** entry; vitest coverage exercises whole-page, multi-match, empty, and truncated cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9868a51eaf235687cd52784eb7eff708f4c93622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->