### PR TITLE
feat: render the tap aria command as an indented role tree

### DIFF
--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -28,7 +28,9 @@ interface AXNode {
   backendDOMNodeId?: number
 }
 
-interface AriaNodeOut {
+/** One projected accessibility node in the tree `cypress tap aria` returns. */
+export interface AriaNodeOut {
+  /** Nesting depth within the projected tree (root is 0). */
   depth: number
   role: string
   name?: string
@@ -36,10 +38,14 @@ interface AriaNodeOut {
   states?: string[]
 }
 
-interface FrameAriaResult {
+/** What `cypress tap aria` returns: the projected accessibility tree. */
+export interface FrameAriaResult {
+  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
   url?: string
   nodes: AriaNodeOut[]
+  /** Number of nodes returned (`nodes.length`, before any client-side view). */
   nodeCount: number
+  /** Present (always `true`) when the node cap clipped the tree. */
   truncated?: true
 }
 

--- a/cli/lib/tap/render/aria.ts
+++ b/cli/lib/tap/render/aria.ts
@@ -1,0 +1,33 @@
+import chalk from 'chalk'
+
+import type { AriaNodeOut, FrameAriaResult } from '../commands/aria'
+import { color, emptyState, heading, indent, layout } from './format'
+
+// One node per line, indented by depth under the panel header: bold role, then
+// its accessible name, an `= value` for value-bearing controls, and any notable
+// states as a muted bracketed list — the compact role/name tree DevTools shows.
+const renderNode = (node: AriaNodeOut): string => {
+  const name = node.name ? `  ${node.name}` : ''
+  const value = node.value !== undefined ? ` = ${node.value}` : ''
+  const states = node.states?.length ? `  ${color.muted(`[${node.states.join(', ')}]`)}` : ''
+
+  return `${indent(node.depth + 1)}${chalk.bold(node.role)}${name}${value}${states}`
+}
+
+export const renderAriaHuman = (result: FrameAriaResult): string => {
+  if (!result.nodes.length) {
+    return emptyState('No accessibility nodes found.')
+  }
+
+  const urlSuffix = result.url ? `  ${color.muted(result.url)}` : ''
+
+  const blocks: string[][] = [
+    [`${heading('ARIA', result.nodeCount)}${urlSuffix}`, ...result.nodes.map(renderNode)],
+  ]
+
+  if (result.truncated) {
+    blocks.push([color.muted('(output truncated)')])
+  }
+
+  return layout(blocks)
+}

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -4,12 +4,14 @@ import type { TapInstanceSummary } from '../commands/instances'
 import type { TapSpecEntry } from '../commands/specs'
 import type { TapStatus } from '../types'
 import type { FrameDomResult } from '../commands/dom'
+import type { FrameAriaResult } from '../commands/aria'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
 import { renderInstancesHuman } from './instances'
 import { renderSpecsHuman } from './specs'
 import { renderStatusHuman } from './status'
 import { renderDomHuman } from './dom'
+import { renderAriaHuman } from './aria'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -36,6 +38,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
   specs: { renderHuman: (result) => renderSpecsHuman(result as TapSpecEntry[]) },
   status: { renderHuman: (result) => renderStatusHuman(result as TapStatus) },
   dom: { renderHuman: (result) => renderDomHuman(result as FrameDomResult) },
+  aria: { renderHuman: (result) => renderAriaHuman(result as FrameAriaResult) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/test/lib/tap/render-aria.spec.ts
+++ b/cli/test/lib/tap/render-aria.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderAriaHuman } from '../../../lib/tap/render/aria'
+import type { FrameAriaResult } from '../../../lib/tap/commands/aria'
+
+const render = (result: FrameAriaResult): string => stripAnsi(renderAriaHuman(result))
+
+describe('lib/tap/render/aria', () => {
+  it('renders an indented role tree with names, values, states, and a truncation note', () => {
+    const output = render({
+      url: 'http://localhost:3000',
+      nodeCount: 4,
+      nodes: [
+        { depth: 0, role: 'RootWebArea', name: 'Login' },
+        { depth: 1, role: 'heading', name: 'Sign in' },
+        { depth: 1, role: 'textbox', name: 'Username', value: 'ada', states: ['disabled'] },
+        { depth: 1, role: 'button', name: 'Submit' },
+      ],
+      truncated: true,
+    })
+
+    expect(output).toBe([
+      'ARIA (4)  http://localhost:3000',
+      '  RootWebArea  Login',
+      '    heading  Sign in',
+      '    textbox  Username = ada  [disabled]',
+      '    button  Submit',
+      '',
+      '(output truncated)',
+    ].join('\n'))
+  })
+
+  it('notes when the tree is empty', () => {
+    expect(render({ nodes: [], nodeCount: 0 })).toBe('No accessibility nodes found.')
+  })
+})


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap aria` as an indented accessibility role tree of the app-under-test.

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap aria
```

### How has the user experience changed?

`cypress tap aria` now prints human-readable output:

```
ARIA (34)  http://localhost:8080/commands/window
  RootWebArea  Cypress.io: Kitchen Sink
    navigation
      link  cypress.io
      list
        listitem
          button  Commands
        listitem
          link  Utilities
        listitem
          link  Cypress API
      list
        listitem
          link  GitHub
    main
      heading  Window
      link  docs.cypress.io
      heading  cy.window()
        link  cy.window()
      link  cy.window()
        code
      code
      separator
      heading  cy.document()
        link  cy.document()
      link  cy.document()
        code
      code
      separator
      heading  cy.title()
        link  cy.title()
      link  cy.title()
        code
      code
      separator
```

Empty state — `cypress tap aria   # with no Cypress running`:

```
NO_INSTANCE: No Cypress instance found. This command requires Cypress running in open mode. Start Cypress in open mode and try again.
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation only; no changes to accessibility extraction or CDP behavior.
> 
> **Overview**
> **`cypress tap aria`** now uses the same human-readable tap rendering path as commands like `dom` and `status`, so the default CLI output is an indented role/name tree instead of JSON (`--json` still returns the structured result).
> 
> The new renderer prints a counted **ARIA** header with the app-under-test URL, one line per node (bold role, accessible name, `= value` when present, muted `[states]`), and a muted **(output truncated)** line when the node cap clips the tree. Empty trees show **No accessibility nodes found.**
> 
> `AriaNodeOut` and `FrameAriaResult` are exported from the aria command module with JSDoc so the renderer and tests can type against the command result shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d7fa840787a590989f64a611819ac455f1cdc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->