### PR TITLE
feat: render the tap inspect command in human-readable form

### DIFF
--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -26,10 +26,15 @@ interface AXNode {
   backendDOMNodeId?: number
 }
 
-interface FrameInspectResult {
+/** What `cypress tap inspect` returns for the first element matching a selector. */
+export interface FrameInspectResult {
+  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
   url?: string
+  /** The CSS selector that was inspected. */
   selector: string
+  /** Whether an element matched. */
   found: boolean
+  /** The matched element's tag name. */
   tag?: string
   attributes?: Record<string, string>
   aria?: { role?: string, name?: string, states?: string[] }

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -5,6 +5,7 @@ import type { TapSpecEntry } from '../commands/specs'
 import type { TapStatus } from '../types'
 import type { FrameDomResult } from '../commands/dom'
 import type { FrameAriaResult } from '../commands/aria'
+import type { FrameInspectResult } from '../commands/inspect'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
 import { renderInstancesHuman } from './instances'
@@ -12,6 +13,7 @@ import { renderSpecsHuman } from './specs'
 import { renderStatusHuman } from './status'
 import { renderDomHuman } from './dom'
 import { renderAriaHuman } from './aria'
+import { renderInspectHuman } from './inspect'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -39,6 +41,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
   status: { renderHuman: (result) => renderStatusHuman(result as TapStatus) },
   dom: { renderHuman: (result) => renderDomHuman(result as FrameDomResult) },
   aria: { renderHuman: (result) => renderAriaHuman(result as FrameAriaResult) },
+  inspect: { renderHuman: (result) => renderInspectHuman(result as FrameInspectResult) },
 }
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {

--- a/cli/lib/tap/render/inspect.ts
+++ b/cli/lib/tap/render/inspect.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk'
+
+import type { FrameInspectResult } from '../commands/inspect'
+import { color, definitionList, heading, layout } from './format'
+
+const urlSuffix = (url?: string): string => (url ? `  ${color.muted(url)}` : '')
+
+// A record renders as a counted heading over an aligned key/value list; an empty
+// or absent record contributes no block.
+const recordBlock = (title: string, record?: Record<string, string>): string[][] => {
+  const entries = Object.entries(record ?? {})
+
+  return entries.length ? [[heading(title, entries.length), ...definitionList(entries)]] : []
+}
+
+const ariaBlock = (aria: FrameInspectResult['aria']): string[][] => {
+  const rows: Array<[string, string | undefined]> = [
+    ['role', aria?.role],
+    ['name', aria?.name],
+    ['states', aria?.states?.length ? aria.states.join(', ') : undefined],
+  ]
+
+  const entries = rows.filter((row): row is [string, string] => row[1] !== undefined)
+
+  return entries.length ? [[heading('ACCESSIBILITY'), ...definitionList(entries)]] : []
+}
+
+const boxBlock = (box: FrameInspectResult['box']): string[][] => {
+  return box ? [[heading('BOX'), `  x ${box.x}   y ${box.y}   width ${box.width}   height ${box.height}`]] : []
+}
+
+export const renderInspectHuman = (result: FrameInspectResult): string => {
+  if (!result.found) {
+    return `${chalk.bold(result.selector)}  ${color.muted('not found')}${urlSuffix(result.url)}`
+  }
+
+  return layout([
+    [`${chalk.bold(result.tag ?? '?')}  ${result.selector}${urlSuffix(result.url)}`],
+    ...recordBlock('ATTRIBUTES', result.attributes),
+    ...ariaBlock(result.aria),
+    ...boxBlock(result.box),
+    ...recordBlock('STYLES', result.styles),
+  ])
+}

--- a/cli/test/lib/tap/render-inspect.spec.ts
+++ b/cli/test/lib/tap/render-inspect.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderInspectHuman } from '../../../lib/tap/render/inspect'
+import type { FrameInspectResult } from '../../../lib/tap/commands/inspect'
+
+const render = (result: FrameInspectResult): string => stripAnsi(renderInspectHuman(result))
+
+describe('lib/tap/render/inspect', () => {
+  it('renders a found element as header + attribute/accessibility/box/style sections', () => {
+    const output = render({
+      url: 'http://localhost:3000',
+      selector: '[data-testid=username]',
+      found: true,
+      tag: 'input',
+      attributes: { 'data-testid': 'username', name: 'username' },
+      aria: { role: 'textbox', name: 'Username', states: ['disabled'] },
+      box: { x: 8, y: 40, width: 200, height: 30 },
+      styles: { display: 'block', color: 'rgb(0, 0, 0)' },
+    })
+
+    expect(output).toBe([
+      'input  [data-testid=username]  http://localhost:3000',
+      '',
+      'ATTRIBUTES (2)',
+      '  data-testid  username',
+      '  name         username',
+      '',
+      'ACCESSIBILITY',
+      '  role    textbox',
+      '  name    Username',
+      '  states  disabled',
+      '',
+      'BOX',
+      '  x 8   y 40   width 200   height 30',
+      '',
+      'STYLES (2)',
+      '  display  block',
+      '  color    rgb(0, 0, 0)',
+    ].join('\n'))
+  })
+
+  it('renders a not-found result on a single line', () => {
+    expect(render({ url: 'http://x/', selector: '.missing', found: false })).toBe('.missing  not found  http://x/')
+  })
+
+  it('omits the accessibility block when there is no aria node', () => {
+    const output = render({ selector: 'div', found: true, tag: 'div', attributes: { id: 'x' } })
+
+    expect(output).not.toContain('ACCESSIBILITY')
+    expect(output).toContain('ATTRIBUTES (1)')
+  })
+})


### PR DESCRIPTION
- Closes N/A <!-- stacked PR in the `tap` human-readable CLI output series -->

### Additional details

Renders `tap inspect` in human-readable form — a single element's tag, attributes, accessibility node, box model, and curated computed styles.

Part of the stacked `tap` CLI series; this slice builds on the branch below it.

### Steps to test

With Cypress running in open mode (e2e) on a project, from the repo root run:

```
node cli/bin/cypress tap inspect h1
```

### How has the user experience changed?

`cypress tap inspect h1` now prints human-readable output:

```
h1  h1  http://localhost:8080/commands/window

ACCESSIBILITY
  role  heading
  name  Window

BOX
  x 24   y 97   width 940   height 40

STYLES (24)
  display           block
  visibility        visible
  opacity           1
  position          static
  top               auto
  right             auto
  bottom            auto
  left              auto
  width             940px
  height            39.5938px
  margin            20px 0px 10px
  padding           0px
  border            0px none rgb(255, 255, 255)
  box-sizing        border-box
  color             rgb(255, 255, 255)
  background-color  rgba(0, 0, 0, 0)
  font-size         36px
  font-weight       500
  line-height       39.6px
  text-align        start
  z-index           auto
  overflow          visible
  pointer-events    auto
  cursor            auto
```

Empty state — `cypress tap inspect <unmatched-selector>`:

```
.cy-nonexistent-xyz  not found  about:blank
```

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- [na] mechanical/stacked refactor of tap CLI output -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- [na] internal `tap` CLI, not yet documented -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- [na] no public type changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CLI changes with no impact on inspect data collection or CDP behavior.
> 
> **Overview**
> **`cypress tap inspect`** now uses the same default human-readable CLI path as other `tap` commands (`dom`, `aria`, etc.); **`--json`** still returns the raw `FrameInspectResult`.
> 
> Adds **`renderInspectHuman`**, which prints a one-line **not found** state or, when a match exists, a header (tag, selector, muted frame URL) plus optional **ATTRIBUTES**, **ACCESSIBILITY**, **BOX**, and **STYLES** sections via the shared `layout` / `definitionList` helpers. **`FrameInspectResult`** is exported from the inspect command module with field-level JSDoc so the renderer can type against it, and **`inspect`** is registered in the tap render registry.
> 
> Vitest coverage locks in full found output, the not-found line, and omission of the accessibility block when there is no aria data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1967e71771e5db34adec09b4604fbf4e7034d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->