### PR TITLE
chore: notify Slack when a release SBOM upload fails

### DIFF
--- a/.github/workflows/upload_release_asset.yml
+++ b/.github/workflows/upload_release_asset.yml
@@ -72,3 +72,21 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: SBOM.rpt
+
+  notify_failure:
+    # Alert the team only when a real release fails to produce or attach its
+    # SBOM. Manual workflow_dispatch runs are excluded so ad-hoc generation
+    # never pages anyone.
+    if: failure() && github.event_name == 'release'
+    needs:
+      - generate_sbom
+      - attach_to_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack of the failed release SBOM upload
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "<!subteam^${{ vars.APP_FOUNDATIONS_ONCALL_SUBTEAM_ID }}|app-foundations-oncall> :rotating_light: SBOM release upload failed for *${{ github.event.release.tag_name }}* — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"


### PR DESCRIPTION
- Closes N/A

### Additional details

The [Upload SBOM as Release Asset](.github/workflows/upload_release_asset.yml) workflow generates an SPDX SBOM and attaches it to every published GitHub release. If either step fails on a real release, nobody currently finds out until someone notices the missing `SBOM.rpt` asset.

This adds a `notify_failure` job that posts to Slack via an incoming webhook and mentions the `@app-foundations-oncall` group when a release fails to generate or attach its SBOM.

Details:
- Runs only when `failure() && github.event_name == 'release'`, so manual `workflow_dispatch` runs never page anyone.
- `needs` both `generate_sbom` and `attach_to_release` so it waits for the release path to settle before deciding.
- Keeps least-privilege intact — the job needs no `contents: write`, so it inherits the top-level `contents: read`. The webhook secret and oncall group id are the only inputs.
- The Slack action is SHA-pinned (`slackapi/slack-github-action` v2.1.1), matching the pinning convention used elsewhere in this workflow.

Two repo settings must exist for this to fire (not committed, since they are environment config):
- `SLACK_WEBHOOK_URL` secret — a Slack incoming webhook bound to the target channel (already verified working via a manual `curl`).
- `APP_FOUNDATIONS_ONCALL_SUBTEAM_ID` variable — the Slack user-group id for `@app-foundations-oncall` (`S06HNNTJV1P`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change: a conditional failure-notification job with no product code or elevated repo permissions beyond an existing webhook secret.
> 
> **Overview**
> Adds a **`notify_failure`** job to the **Upload SBOM as Release Asset** workflow so failed release SBOM generation or attachment is surfaced in Slack instead of going unnoticed.
> 
> The job runs only when **`failure() && github.event_name == 'release'`**, depends on **`generate_sbom`** and **`attach_to_release`**, and posts an incoming-webhook message that mentions **`@app-foundations-oncall`** with the release tag and a link to the Actions run. Manual **`workflow_dispatch`** runs are excluded, and the job keeps default **`contents: read`** (no new write permissions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f2c07b3c33097985490e464346d604b2df9fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This only runs on a real `release: published` event, so it can't be exercised from a feature branch. The Slack side (webhook + `@app-foundations-oncall` mention) was verified independently by POSTing the same payload to the webhook with `curl`. Once merged, a failing release SBOM upload will post the alert; the failure path itself is standard `if: failure()` job wiring.

### How has the user experience changed?

No change for Cypress end users. This is CI/release tooling only — it adds a Slack alert to the internal App Foundations oncall group when a release SBOM upload fails.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- internal CI/release tooling change -->
- [na] Have tests been added/updated? <!-- GitHub Actions workflow; not unit-testable, validated by YAML parse -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)