### PR TITLE
test: fix studio state-management spec for anonymous user workflow

### DIFF
--- a/packages/app/cypress/e2e/studio/studio-state-management.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-state-management.cy.ts
@@ -68,12 +68,6 @@ describe('Cypress Studio - State Management', () => {
   it('remains in studio mode when the test name is changed on the file system and file watching is disabled', () => {
     launchStudio({ cliArgs: ['--config', 'watchForFileChanges=false'] })
 
-    // since we aren't logged in, we need to close the connect to cloud panel
-    cy.get('[data-cy="studio-error"]').within(() => {
-      cy.contains('Login').should('be.visible')
-      cy.get('[aria-label="Close"]').click()
-    })
-
     cy.findByTestId('record-button-recording').should('be.visible')
 
     incrementCounter(0)
@@ -102,7 +96,7 @@ describe('studio functionality', () => {
     // the commands should still be there since the save failed
     cy.get('.cm-line').should('contain.text', `cy.get('#increment').click();`)
 
-    cy.findByTestId('studio-error').should('contain.text', 'Failed to save test code')
+    cy.contains('Failed to save test code').should('be.visible')
   })
 
   it('does not exit studio mode if the spec is changed on the file system', () => {


### PR DESCRIPTION
- Closes N/A

### Additional details

The `Cypress Studio - State Management` spec `remains in studio mode when the test name is changed on the file system and file watching is disabled` was failing in CI:

```
AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Login' within the element: <div.flex.z-50.AIStatus-module__aiStatusPopover___fBXip> but never did.
```

The spec is not a product bug — it drifted against the external Studio bundle for the anonymous user workflow. 

Two changes:

- Removed the login-panel close step entirely. It only existed because the later assertion used `cy.findByTestId('studio-error')`, which has `getByTestId` semantics and throws when multiple elements match — and both the AI popover and the save-failed banner default to `data-cy="studio-error"`. With `testIdAttribute` configured as `data-cy`, the popover had to be dismissed first to disambiguate.
- Switched the save-failure assertion from `cy.findByTestId('studio-error').should('contain.text', 'Failed to save test code')` to `cy.contains('Failed to save test code').should('be.visible')`. The text is unique to the save-failed banner, so it is unambiguous regardless of whether the AI popover is open, and the spec no longer couples to whichever banner the bundle shows for logged-out users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in a Cypress e2e spec; no product or runtime behavior is modified.
> 
> **Overview**
> Updates the **Cypress Studio – State Management** e2e test so it matches the current Studio bundle UI for logged-out users.
> 
> The setup that closed a **Login** cloud-connect panel inside `data-cy="studio-error"` is removed—that panel no longer appears first because the anonymous AI consent banner takes precedence, and multiple elements share that test id.
> 
> The save-failure check now uses **`cy.contains('Failed to save test code')`** instead of `findByTestId('studio-error')`, so the assertion stays stable whether the AI popover is open or not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd810ec2a4c14fe247ed1d8380a33a05ff03134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run the studio state-management e2e spec against the current Studio bundle:

```
yarn workspace @packages/app cypress:run:e2e -- --spec cypress/e2e/studio/studio-state-management.cy.ts
```

### How has the user experience changed?

No change. This is a test-only change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
