### PR TITLE
chore: skip accessibility verification checkout for contributor PRs

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1933,6 +1933,14 @@ jobs:
             echo "skipping for contributor PRs since we don't record to the cloud"
             circleci-agent step halt
           fi
+
+          # Contributor PRs from forks run with $CIRCLE_BRANCH set to the PR ref
+          # (e.g. pull/34282/head), which is not a real branch and cannot be
+          # cloned below. There is no cloud run to verify for these anyway, so skip.
+          if [[ "$CIRCLE_BRANCH" =~ ^pull\/[0-9]+ ]]; then
+            echo "skipping for contributor PRs — $CIRCLE_BRANCH is an external PR ref that cannot be checked out"
+            circleci-agent step halt
+          fi
       - update_known_hosts
       - run:
           name: checkout


### PR DESCRIPTION
- Closes N/A

### Additional details

The `verify-accessibility-results` CircleCI job checks out the code with `git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" --depth 1`. On approved contributor PRs from forks, `$CIRCLE_BRANCH` is the PR ref (e.g. `pull/34282/head`), which is not a real branch, so the clone fails:

```
warning: Could not find remote branch pull/34282/head to clone.
fatal: Remote branch pull/34282/head not found in upstream origin
```

<img width="1125" height="554" alt="IMG_1685" src="https://github.com/user-attachments/assets/138655ea-5c1e-497f-b644-59b4275cb65a" />


The job already had a skip guard, but it only checks `MAIN_RECORD_KEY`. That secret comes from the `test-runner:cypress-record-key` context, which **is** available on approved contributor PRs, so the guard doesn't fire and the job proceeds to the failing checkout.

This adds a second guard in the same step that halts the job when `$CIRCLE_BRANCH` matches an external PR ref, reusing the existing `^pull/[0-9]+` pattern already used elsewhere in the pipeline. There is no cloud run to verify for forked PRs anyway, so skipping is the correct behavior.

Only the source config (`.circleci/src/pipeline/@pipeline.yml`) is edited; the packed pipeline is regenerated at CI runtime by the `pack-workflows` job.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to one job’s skip logic; no product runtime or release behavior affected.
> 
> **Overview**
> Fixes **false failures** on approved contributor PRs in the `verify-accessibility-results` CircleCI job.
> 
> That job clones with `git clone -b "$CIRCLE_BRANCH"`, but fork PRs set `$CIRCLE_BRANCH` to a GitHub PR ref like `pull/34282/head`, which is not a cloneable branch. The existing skip when `MAIN_RECORD_KEY` is unset does not apply on approved contributor runs because the record key context is still present.
> 
> A **second early halt** is added in the same step: when `$CIRCLE_BRANCH` matches `^pull/[0-9]+` (same pattern used elsewhere in the pipeline), the job exits successfully before checkout. There is no Cypress Cloud accessibility run to verify for those PRs anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8084ad20afa19f996bf9a7c9dcc10c1ed0d0b6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

This only affects CI behavior on contributor (forked) PRs:
1. On a contributor PR from a fork, observe that the `verify-accessibility-results` job halts early ("skipping for contributor PRs — ... is an external PR ref that cannot be checked out") instead of failing at the `checkout` step.
2. On an internal branch PR, the job continues to run as before (checks out and verifies accessibility results).

### How has the user experience changed?

No change — this is a CI-only change with no user-facing impact.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical CI fix. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrPGft84xojLDGcruaat4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPGft84xojLDGcruaat4t)_