### PR TITLE
test: skip Percy readiness gate when cy.clock() freezes the AUT timers

### DIFF
--- a/packages/frontend-shared/cypress/support/customPercyCommand.ts
+++ b/packages/frontend-shared/cypress/support/customPercyCommand.ts
@@ -287,12 +287,16 @@ export const installCustomPercyCommand = ({ before, elementOverrides }: {before?
         }
 
         // Percy's readiness gate (`@percy/dom`'s waitForReady) drives both its
-        // checks and its own timeout off real timers. When cy.clock() has
-        // installed fake timers the AUT clock is frozen, so waitForReady can
-        // never resolve and the snapshot command times out. The frozen DOM is
-        // already the deterministic state we want to capture, so skip readiness.
+        // checks and its own timeout off setTimeout. When cy.clock() has faked
+        // setTimeout the AUT clock is frozen, so waitForReady can never resolve
+        // and the snapshot command times out; the frozen DOM is already the
+        // deterministic state we want to capture, so skip readiness. Only key off
+        // setTimeout: a Date-only clock (cy.clock(date, ['Date'])) leaves timers
+        // real, so readiness still resolves and should run.
         // @ts-ignore - cy.state is not in the public types
-        if (cy.state('clock')) {
+        const clock = cy.state('clock')
+
+        if (clock?.details().methods.includes('setTimeout')) {
           snapshotOptions.readiness = { preset: 'disabled' }
         }
 

--- a/packages/frontend-shared/cypress/support/customPercyCommand.ts
+++ b/packages/frontend-shared/cypress/support/customPercyCommand.ts
@@ -281,10 +281,22 @@ export const installCustomPercyCommand = ({ before, elementOverrides }: {before?
       // enqueued appropriately.
       cy
       .then(() => {
-        return percySnapshot(screenshotName, {
+        const snapshotOptions: CustomSnapshotOptions & { readiness?: { preset: 'disabled' } } = {
           ...options,
           widths: [snapshotWidth],
-        })
+        }
+
+        // Percy's readiness gate (`@percy/dom`'s waitForReady) drives both its
+        // checks and its own timeout off real timers. When cy.clock() has
+        // installed fake timers the AUT clock is frozen, so waitForReady can
+        // never resolve and the snapshot command times out. The frozen DOM is
+        // already the deterministic state we want to capture, so skip readiness.
+        // @ts-ignore - cy.state is not in the public types
+        if (cy.state('clock')) {
+          snapshotOptions.readiness = { preset: 'disabled' }
+        }
+
+        return percySnapshot(screenshotName, snapshotOptions)
       })
       .then(() => {
         return reset()


### PR DESCRIPTION
- Closes <!-- no issue — internal CI fix for the release/16.0.0 branch; rationale below -->

### Additional details

The `run-app-component-tests-chrome`, `run-frontend-shared-component-tests-chrome`, and `run-launchpad-component-tests-chrome` jobs are failing on `release/16.0.0` ([example workflow](https://app.circleci.com/pipelines/github/cypress-io/cypress/84651/workflows/9f8814df-e49f-4e2c-b419-75c9f79870e2)). Five Percy snapshots fail identically with `` CypressError: `cy.then()` timed out after waiting `10000ms`. Your callback function returned a promise that never resolved. ``

**Root cause.** `@percy/cypress` floated from `3.1.7` → `3.1.9` on this branch (the `^3.1.7` → `^3.1.8` range bump landed only on `release/16.0.0`; `develop` is still on `3.1.7`). `3.1.9` introduced a DOM-readiness gate — `@percy/dom`'s `waitForReady()` — that waits for the page to go quiet (DOM-stable, network-idle, JS-idle, fonts, images) before serializing. That gate drives **both** its debounce checks **and** its own 10s master timeout off the browser's real timers. Every failing snapshot is taken while `cy.clock()` has installed fake timers, which freeze `setTimeout` / `requestAnimationFrame` / `requestIdleCallback` / `performance`. With those frozen, `waitForReady` can never resolve, and the snapshot's `cy.then()` hits the 10s command timeout. Snapshots taken with real timers reach readiness in ~350ms and pass — so the components are fine; the frozen clock is the sole cause.

**Fix.** In the custom `percySnapshot` command, detect an installed fake clock via `cy.state('clock')` and pass `readiness: { preset: 'disabled' }` for that snapshot only. `@percy/sdk-utils`'s `isReadinessDisabled` then short-circuits the gate, so the snapshot serializes immediately against the (intentionally) frozen DOM. Readiness continues to run normally for the ~98% of snapshots that use real timers, so the feature is preserved where it works.

I verified the mechanism and the fix against the real `@percy/dom`, `@percy/sdk-utils`, and `@sinonjs/fake-timers`: under a frozen clock `waitForReady({ preset: 'balanced' })` never resolves, while `isReadinessDisabled({ readiness: { preset: 'disabled' } })` returns `true` and `waitForReady({ preset: 'disabled' })` resolves synchronously. (The full component-test run couldn't be exercised in my environment because electron@41.7.0 wasn't downloadable there.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal Cypress test-support only; no published API or user-facing behavior change.
> 
> **Overview**
> Fixes **component-test Percy snapshots** that hang after `@percy/cypress` **3.1.9** added a DOM-readiness gate driven by `setTimeout`.
> 
> The custom `percySnapshot` wrapper now inspects **`cy.state('clock')`** and, when the fake clock includes **`setTimeout`**, passes **`readiness: { preset: 'disabled' }`** so `@percy/dom` does not wait on timers that `cy.clock()` has frozen. Snapshots without a faked `setTimeout` (including Date-only clocks) still use the normal readiness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e52ff7e856d9bfc7bba22a61b874afaeed69621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Re-run the `run-app-component-tests-chrome`, `run-frontend-shared-component-tests-chrome`, and `run-launchpad-component-tests-chrome` jobs on this branch. The previously failing specs — `debug/DebugRunNavigation`, `debug/DebugTestingProgress`, `gql-components/RecordRunModal`, `welcome/MajorVersionWelcome`, and `setup/InstallDependencies` (all of which call `cy.clock()` before `cy.percySnapshot()`) — should pass and upload their Percy snapshots.

### How has the user experience changed?

No change. This only affects the internal Percy snapshot command used by component tests; it is not part of the published Cypress binary or any `@cypress/` npm package.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI fix restoring green component-test jobs on release/16.0.0; no external issue. -->
- [na] Have tests been added/updated? <!-- This fixes the test-support command itself; it is exercised by the existing Percy component-test snapshots that were failing. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No public API change. -->
