### PR TITLE
chore: reference issue #30052 in ws changelog entry to fix release-readiness validation

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 **Dependency Updates:**
 
 - Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).
-- Upgraded `ws` from `8.18.3` to `8.21.1`. Addressed in [#34392](https://github.com/cypress-io/cypress/pull/34392).
+- Upgraded `ws` from `8.18.3` to `8.21.1`. Addresses [#30052](https://github.com/cypress-io/cypress/issues/30052). Addressed in [#34392](https://github.com/cypress-io/cypress/pull/34392).
 
 ## 15.19.0
 


### PR DESCRIPTION
- Closes N/A — fixes a CI validation failure on `develop`, not a user-facing issue.

### Additional details

The `verify-release-readiness` CircleCI job was failing on `develop` at the `validate-binary-changelog.js` step ([failing job](https://app.circleci.com/pipelines/github/cypress-io/cypress/84649/workflows/611b1fa9-0fc6-400f-8d2b-f6eb5b0284be/jobs/3834212)).

That script computes the next release (15.19.1), collects the PRs merged since the last release along with the issues they close, and requires each user-facing `cli/CHANGELOG.md` entry to reference the issues its PR resolves. PR #34392 closes #30052, but its changelog entry (the `ws` upgrade) only linked the PR, so validation failed with:

> The changelog entry does not include the linked issues that this pull request resolves. Please update your entry for 'dependency: commit the deduplicated yarn.lock and fix v8 snapshot generation (#34392)' to include: Addresses [#30052](https://github.com/cypress-io/cypress/issues/30052).

This adds the `#30052` reference to that entry, following the existing `Addresses … Addressed in …` convention already used by the neighboring `tar` entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no product code or dependency changes.
> 
> **Overview**
> Updates the **15.19.1** `ws` dependency changelog line so it cites issue **#30052** (PR **#34392**), using the same **Addresses … / Addressed in …** wording as the adjacent `tar` entry.
> 
> This is metadata only: it satisfies `validate-binary-changelog.js` / release-readiness checks that require user-facing changelog bullets to reference issues closed by the merging PR. No runtime or dependency changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacb62157caabccfc57d8b9d8f72f9e5b54a5149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run the changelog validation with the same inputs CI uses:

```
node -e '
const fs = require("fs");
const { _validateEntry } = require("./scripts/semantic-commits/validate-changelog.js");
const { parseChangelog } = require("./scripts/semantic-commits/parse-changelog.js");
(async () => {
  const changelog = await parseChangelog({ changelogContent: fs.readFileSync("./cli/CHANGELOG.md", "utf8") });
  const err = _validateEntry(changelog, { commitMessage: "(#34392)", prNumber: 34392, semanticType: "dependency", associatedIssues: [30052] });
  console.log(err ? "ERROR: " + err : "PASS");
})();
'
```

Prints `PASS`.

### How has the user experience changed?

No change — documentation/changelog metadata only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical changelog metadata fix to unblock the release-readiness CI job. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
