### PR TITLE
chore: merge develop into release/16.0.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -45,6 +45,10 @@
 - Fixed an issue where the configuration validation error shown when `passesRequired` is omitted from the experimental `detect-flake-and-pass-on-threshold` retry strategy reported the value of an unrelated option instead of the `passesRequired` value. Fixed in [#34202](https://github.com/cypress-io/cypress/pull/34202).
 - Fixed an issue where the configuration validation error for an absolute `ca` filepath in `clientCertificates` referenced the wrong certificate. Fixed in [#34201](https://github.com/cypress-io/cypress/pull/34201).
 
+**Misc:**
+
+- Fixed an issue where passing the `options` argument to [`cy.env()`](https://on.cypress.io/env), such as `cy.env(['FOO'], { log: false })`, raised a TypeScript error (`Expected 1 arguments, but got 2`). Fixes [#34284](https://github.com/cypress-io/cypress/issues/34284).
+
 **Dependency Updates:**
 
 - Upgraded `tar` from `6.2.1` to `7.5.21` to address [CVE-2026-59873](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) reported in security scans. Addresses [#34333](https://github.com/cypress-io/cypress/issues/34333). Addressed in [#34335](https://github.com/cypress-io/cypress/pull/34335).

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -2195,7 +2195,7 @@ declare namespace Cypress {
      * @example
      *    cy.env(['KEY_1', 'KEY_2']).then(({ KEY_1, KEY_2 }) => { ... })
      */
-    env(keys: string[]): Chainable<Record<string, any>>
+    env(keys: string[], options?: Partial<Loggable & Timeoutable>): Chainable<Record<string, any>>
 
     /**
      * Gets multiple environment variables with a specific type.
@@ -2206,7 +2206,7 @@ declare namespace Cypress {
      *      expect(KEY_2).to.be.a('number')
      *    })
      */
-    env<T extends object>(keys: string[]): Chainable<T>
+    env<T extends object>(keys: string[], options?: Partial<Loggable & Timeoutable>): Chainable<T>
 
     /**
      * Enables you to work with the subject yielded from the previous command.

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -46,6 +46,14 @@ namespace CypressConfigTests {
   Cypress.config('includeShadowDom') // $ExpectType boolean
 }
 
+namespace CypressEnvTests {
+  // Just making sure these are valid - no real type safety
+  cy.env(['KEY_1', 'KEY_2']) // $ExpectType Chainable<Record<string, any>>
+  cy.env(['KEY_1', 'KEY_2'], { log: false }) // $ExpectType Chainable<Record<string, any>>
+  cy.env(['KEY_1', 'KEY_2'], { timeout: 1000 }) // $ExpectType Chainable<Record<string, any>>
+  cy.env<{ KEY_1: string }>(['KEY_1'], { log: false, timeout: 1000 }) // $ExpectType Chainable<{ KEY_1: string; }>
+}
+
 namespace CypressExposeTests {
   // Just making sure these are valid - no real type safety
   Cypress.expose('foo')


### PR DESCRIPTION
- Closes N/A — routine branch sync, no associated issue

### Additional details

Routine merge of `develop` into `release/16.0.0` to keep the release branch up to date, as scheduled.

`develop` had diverged by a single commit since the last sync: #34285 ("misc: add options argument to `cy.env()` TypeScript definitions"), which added an `options` parameter to `cy.env(keys, options)` and appended new dtslint test assertions.

**Conflicting file:** `cli/types/tests/cypress-tests.ts`

The conflict occurred because `release/16.0.0` had already removed the deprecated static `Cypress.env()` API as part of a breaking change in 16.0.0 (see the `## 16.0.0` section of `cli/CHANGELOG.md`: *"Removed `Cypress.env()`. Use `Cypress.expose()` ... and `cy.env()` ..."*), including deleting the `Cypress.env(...)` assertions from the `CypressEnvTests` namespace in this test file. Meanwhile `develop` still has the old deprecated `Cypress.env()` static method and, in #34285, appended new `cy.env(['KEY_1', 'KEY_2'], options)` assertions to the same (still-present-on-develop) `CypressEnvTests` namespace block. Git's 3-way merge flagged this as a conflict since both sides touched the same region.

**Resolution:** kept only the new `cy.env(keys, options)` command assertions from develop (still valid — `cy.env()` was not removed, only `Cypress.env()` was), and dropped the `Cypress.env(...)` static-method assertions carried over from develop, since that API no longer exists in `release/16.0.0`'s type definitions. Verified this is correct by confirming:
- `Cypress.env(` has no remaining declaration in the merged `cli/types/cypress.d.ts` (only `cy.env(keys, options)` on `Chainable` remains).
- `CypressExposeTests` (the intended replacement) is already present in the file.
- `yarn types` (dtslint) passes cleanly for `cli/types` after the fix.

`cli/CHANGELOG.md` and `cli/types/cypress.d.ts` merged automatically with no conflicts.

I opened this as a PR rather than pushing directly to `release/16.0.0` because resolving the conflict required understanding an intentional breaking-change removal rather than a purely mechanical resolution.

### Steps to test

- Review the resolved conflict block in `cli/types/tests/cypress-tests.ts` (around the `CypressEnvTests` namespace).
- Run `cd cli && yarn types` to confirm the dtslint type tests pass.

### How has the user experience changed?

No change — this is a branch sync merge, not a feature change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxjGNJeyjB8aZZYXe2GCsE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-definition and changelog/test-only changes; no runtime behavior change in this diff.
> 
> **Overview**
> Syncs `develop` into `release/16.0.0`, bringing in the **optional second argument** on the multi-key `cy.env()` overloads in `cypress.d.ts` (`options?: Partial<Loggable & Timeoutable>`), so calls like `cy.env(['FOO'], { log: false })` type-check.
> 
> Documents the fix under **15.19.1 → Misc** in `CHANGELOG.md`. Adds **dtslint** coverage in `cypress-tests.ts` for `cy.env` with `log` / `timeout` options only (no `Cypress.env()` assertions, consistent with the 16.0.0 removal of that static API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7a281604047bd315d75d1b4a2ba22a1779d7e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->