### PR TITLE
chore: own the browser-transfer encoding invariants in the synthetic proxy codec

### DIFF
--- a/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
@@ -1,3 +1,4 @@
+import zlib from 'zlib'
 import type { HttpRequest, HttpResponse, TransportCodecPort } from '@packages/network-interception'
 import type { HttpMiddlewareCtx } from '../http'
 import { createProxyHttpCodec } from './http-codec'
@@ -7,6 +8,87 @@ import {
   createSyntheticIncomingResponse,
 } from './synthetic-express-context'
 import type { SyntheticCypressResponse } from './synthetic-express-context'
+
+const WIRE_ENCODING_HEADERS = new Set(['content-encoding', 'content-length', 'transfer-encoding'])
+
+const CONTENT_DECODERS: Record<string, (body: Buffer) => Buffer> = {
+  gzip: (body) => zlib.gunzipSync(body),
+  'x-gzip': (body) => zlib.gunzipSync(body),
+  br: (body) => zlib.brotliDecompressSync(body),
+  deflate: (body) => zlib.inflateSync(body),
+}
+
+/**
+ * Normalizes a response the legacy middleware produced back to an identity
+ * body, dropping the wire encoding headers that described it.
+ *
+ * The legacy middleware is built for the MITM path, where Node performs the
+ * request/response transfer. This means `accept-encoding` is narrowed to what
+ * Node can decode (`getSupportedAcceptEncoding` — `br`, `gzip`, `identity`),
+ * so origin responses can arrive encoded.
+ *
+ * `makeResStreamPlainText` decodes them outermost-first — for
+ * `content-encoding: gzip, br` that is un-`br`, then un-`gzip` to get
+ * plaintext. These need to be decoded to plaintext because the following
+ * stages that read the body need plaintext:
+ *
+ * - injection
+ * - security rewriting
+ * - `cy.intercept()` response handlers
+ *
+ * On the way back out, `CompressBody` re-applies those same layers in their
+ * original order. That decode/re-encode round trip is highly sensitive, so
+ * we intentionally leave it alone.
+ *
+ * On this transport, the browser negotiated its own `accept-encoding` and has
+ * already decoded what the origin sent. Fulfillment runs no decoders, so the
+ * body has to go back as identity. Undo whatever encoding the legacy
+ * middleware left behind, which encompasses:
+ *
+ * - whatever `CompressBody` re-encoded
+ * - whatever a `cy.intercept()` stub may have declared
+ *
+ * These scenarios are decoded back to plaintext. An encoding we cannot undo —
+ * `zstd`, or bytes that fail to decode — is left exactly as it arrived, body
+ * and `content-encoding` header together. The page cannot render it either
+ * way, so we keep the response self-describing instead of stripping the header
+ * and claiming plaintext bytes that are not.
+ */
+function toIdentityResponse (response: HttpResponse): HttpResponse {
+  const headers = response.headers ?? {}
+  const contentEncoding = Object.entries(headers).find(([name]) => name.toLowerCase() === 'content-encoding')?.[1]
+  const encodings = String(contentEncoding ?? '')
+  .split(',')
+  .map((token) => token.trim().toLowerCase())
+  .filter((token) => token && token !== 'identity')
+
+  let body = response.body
+
+  if (body?.length && encodings.length) {
+    try {
+      // content-encoding lists tokens in the order applied — decode outermost first
+      body = encodings.reduceRight((decoded, encoding) => {
+        const decode = CONTENT_DECODERS[encoding]
+
+        if (!decode) {
+          throw new Error(`no decoder for content-encoding ${encoding}`)
+        }
+
+        return decode(decoded)
+      }, Buffer.from(body))
+    } catch {
+      return response
+    }
+  }
+
+  return {
+    ...response,
+    body,
+    headers: Object.fromEntries(
+      Object.entries(headers).filter(([name]) => !WIRE_ENCODING_HEADERS.has(name.toLowerCase())),
+    ),
+  }
+}
 
 type SyntheticProxyCodecOptions = {
   createMiddlewareContext: (
@@ -38,7 +120,26 @@ export function createSyntheticProxyCodec (
     },
 
     decodeRequest (ctx: HttpMiddlewareCtx<any>): HttpRequest {
-      return coreCodec.decodeRequest(ctx)
+      const request = coreCodec.decodeRequest(ctx)
+
+      // The browser owns accept-encoding on this transport.
+      //
+      // The legacy request middleware sets it in
+      // StripUnsupportedAcceptEncoding, which is undesired behavior when we
+      // continue the request in the browser: a value set in the Node context
+      // overrides what the browser would send, leaving us with encoded or
+      // garbled output (br origins fail outright with
+      // net::ERR_CONTENT_DECODING_FAILED).
+      //
+      // Get out of the browser's way — drop whatever the middleware set and
+      // Chrome re-attaches its own. Copy rather than mutate: the headers
+      // object belongs to the middleware.
+      const { 'accept-encoding': _acceptEncoding, ...headers } = request.headers ?? {}
+
+      return {
+        ...request,
+        headers,
+      }
     },
 
     encodeResponse (response: HttpResponse): HttpMiddlewareCtx<any> {
@@ -54,12 +155,12 @@ export function createSyntheticProxyCodec (
       const response = coreCodec.decodeResponse(ctx)
       const res = ctx.res as SyntheticCypressResponse
 
-      return {
+      return toIdentityResponse({
         ...response,
         body: res.getCapturedBody(),
-        headers: res.getCapturedHeaders(),
+        headers: res.getCapturedHeaders() ?? {},
         statusCode: res.getCapturedStatusCode(),
-      }
+      })
     },
 
     releaseRequest (id: string): void {

--- a/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'stream'
+import zlib from 'zlib'
 import type EventEmitter from 'events'
 import { describe, expect, it } from 'vitest'
 import { createSyntheticProxyCodec } from '../../../lib/adapters/synthetic-proxy-codec'
@@ -244,5 +245,266 @@ describe('createSyntheticProxyCodec', () => {
     expect(response.statusCode).to.equal(203)
     expect(response.headers).to.deep.equal({ 'x-result': 'synthetic' })
     expect(response.body?.toString()).to.equal('final')
+  })
+
+  it('decodes a pipeline re-encoded body back to identity and drops the encoding headers', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-3',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    // CompressBody re-encodes rewritten documents; the browser runs no
+    // decoders on bodies handed back over this codec's transports
+    ctx.res.status(200)
+    ctx.res.set('content-type', 'text/html')
+    ctx.res.set('content-encoding', 'gzip')
+    ctx.res.set('content-length', '9999')
+    ctx.res.end(zlib.gzipSync(Buffer.from('<html>compressed</html>')))
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('<html>compressed</html>')
+    expect(response.headers).to.deep.equal({ 'content-type': 'text/html' })
+  })
+
+  it('decodes layered encodings outermost first', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-4',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.status(200)
+    ctx.res.set('content-encoding', 'br, gzip')
+    ctx.res.end(zlib.gzipSync(zlib.brotliCompressSync(Buffer.from('layered'))))
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('layered')
+    expect(response.headers).to.deep.equal({})
+  })
+
+  it('decodes stub-declared x-gzip and deflate bodies', async () => {
+    for (const [encoding, bytes] of [
+      ['x-gzip', zlib.gzipSync(Buffer.from('aliased'))],
+      ['deflate', zlib.deflateSync(Buffer.from('aliased'))],
+    ] as const) {
+      const codec = createSyntheticProxyCodec({
+        createMiddlewareContext: (req, res) => {
+          return {
+            req,
+            res,
+          } as any
+        },
+      })
+
+      const ctx = codec.encodeRequest({
+        id: `network-${encoding}`,
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      const finished = onceFinish(ctx.res)
+
+      ctx.res.status(200)
+      ctx.res.set('content-encoding', encoding)
+      ctx.res.end(bytes)
+
+      await finished
+
+      const response = codec.decodeResponse(ctx)
+
+      expect(response.body?.toString(), encoding).to.equal('aliased')
+      expect(response.headers, encoding).to.deep.equal({})
+    }
+  })
+
+  it('drops a bare identity header without touching the body', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-identity',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.status(200)
+    ctx.res.set('content-encoding', 'identity')
+    ctx.res.end('plain')
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('plain')
+    expect(response.headers).to.deep.equal({})
+  })
+
+  it('strips wire length headers from unencoded bodies', async () => {
+    // the pipeline may have rewritten the body, so a captured content-length
+    // no longer describes it
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-length',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.status(200)
+    ctx.res.set('content-type', 'text/html')
+    ctx.res.set('content-length', '9999')
+    ctx.res.end('rewritten')
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('rewritten')
+    expect(response.headers).to.deep.equal({ 'content-type': 'text/html' })
+  })
+
+  it('keeps the pair when a known encoding fails to decode', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-corrupt',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.status(200)
+    ctx.res.set('content-encoding', 'gzip')
+    ctx.res.set('content-length', '12')
+    ctx.res.end(Buffer.from('not-gzip-at-all'))
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('not-gzip-at-all')
+    expect(response.headers).to.deep.equal({
+      'content-encoding': 'gzip',
+      'content-length': '12',
+    })
+  })
+
+  it('keeps the body and header pair when an encoding cannot be decoded', async () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-5',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    const finished = onceFinish(ctx.res)
+
+    ctx.res.status(200)
+    ctx.res.set('content-encoding', 'zstd')
+    ctx.res.end(Buffer.from('opaque-bytes'))
+
+    await finished
+
+    const response = codec.decodeResponse(ctx)
+
+    expect(response.body?.toString()).to.equal('opaque-bytes')
+    expect(response.headers).to.deep.equal({ 'content-encoding': 'zstd' })
+  })
+
+  it('strips accept-encoding from the outbound request so the browser keeps its own negotiation', () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-2',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    // StripUnsupportedAcceptEncoding synthesizes a narrowed header when the
+    // pause carries none; it must never ride out on Fetch.continueRequest
+    ctx.req.headers['accept-encoding'] = 'gzip,identity'
+
+    const outbound = codec.decodeRequest(ctx)
+
+    expect(outbound.headers).to.not.have.property('accept-encoding')
+    // the middleware's own view stays intact
+    expect(ctx.req.headers['accept-encoding']).to.equal('gzip,identity')
   })
 })

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -1,4 +1,3 @@
-import zlib from 'zlib'
 import debugModule from 'debug'
 import type {
   HttpHeaders,
@@ -74,13 +73,6 @@ function toResponseBody (body?: string | Buffer): string | undefined {
 const WIRE_LENGTH_HEADERS = new Set(['content-length', 'transfer-encoding'])
 const WIRE_ENCODING_HEADERS = new Set(['content-encoding', ...WIRE_LENGTH_HEADERS])
 
-const CONTENT_DECODERS: Record<string, (body: Buffer) => Buffer> = {
-  gzip: (body) => zlib.gunzipSync(body),
-  'x-gzip': (body) => zlib.gunzipSync(body),
-  br: (body) => zlib.brotliDecompressSync(body),
-  deflate: (body) => zlib.inflateSync(body),
-}
-
 function stripWireEncodingHeaders (headers?: HttpHeaders): HttpHeaders | undefined {
   if (!headers) {
     return undefined
@@ -97,59 +89,6 @@ function stripWireEncodingHeaders (headers?: HttpHeaders): HttpHeaders | undefin
 
 function stripHeaderEntries (headers: CdpFetchTransportResponse['responseHeaders'], names: ReadonlySet<string>): CdpFetchTransportResponse['responseHeaders'] {
   return headers?.filter(({ name }) => !names.has(name.toLowerCase()))
-}
-
-// Fetch.fulfillRequest hands the body to the renderer as-is — content
-// decoders do not run for fulfilled responses. The pipeline may emit encoded
-// bodies (CompressBody re-encodes rewritten documents), so decode fulfilled
-// bodies back to identity and drop the encoding headers. If an encoding
-// cannot be decoded, keep the body/header pair intact rather than shipping a
-// body that lies about its encoding.
-function toIdentityResponse (transportResponse: CdpFetchTransportResponse): CdpFetchTransportResponse {
-  const headers = transportResponse.responseHeaders
-  const contentEncoding = headers?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
-  const encodings = (contentEncoding ?? '')
-  .split(',')
-  .map((token) => token.trim().toLowerCase())
-  .filter((token) => token && token !== 'identity')
-
-  if (!transportResponse.body || !encodings.length) {
-    debugVerbose('toIdentityResponse passthrough %s (no body or encodings)', transportResponse.url)
-
-    return {
-      ...transportResponse,
-      responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
-    }
-  }
-
-  let body = Buffer.from(transportResponse.body, 'base64')
-
-  try {
-    debugVerbose('toIdentityResponse decoding %s encodings %o', transportResponse.url, encodings)
-
-    // encodings are listed in the order applied — decode outermost first
-    for (let i = encodings.length - 1; i >= 0; i--) {
-      const decode = CONTENT_DECODERS[encodings[i]]
-
-      if (!decode) {
-        throw new Error(`no decoder for content-encoding ${encodings[i]}`)
-      }
-
-      body = decode(body)
-    }
-  } catch (err) {
-    debugVerbose('toIdentityResponse decode failed for %s, keeping encoded body: %s', transportResponse.url, (err as Error).message)
-
-    return transportResponse
-  }
-
-  debugVerbose('toIdentityResponse decoded %s to %d byte(s)', transportResponse.url, body.length)
-
-  return {
-    ...transportResponse,
-    body: body.toString('base64'),
-    responseHeaders: stripHeaderEntries(headers, WIRE_ENCODING_HEADERS),
-  }
 }
 
 function toNetworkHeaders (headers?: HttpHeaders): Protocol.Network.Headers {
@@ -197,16 +136,6 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
     }
 
     return request as CdpFetchTransportRequest & { requestId: string }
-  }
-
-  const requireResponse = (id: string): CdpFetchTransportResponse => {
-    const response = inFlightResponses.get(id)
-
-    if (!response) {
-      throw new Error(`No CDP Fetch response pause found for ${id}. HttpIntercept middleware must call next() before returning a response.`)
-    }
-
-    return response
   }
 
   return {
@@ -314,20 +243,18 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
       transportResponse.url = httpResponse.url
       inFlightResponses.delete(httpResponse.id)
 
-      const encoded = transportResponse.fulfilled ? toIdentityResponse(transportResponse) : transportResponse
-
       if (debugVerbose.enabled) {
         debugVerbose('encodeResponse %s %o', httpResponse.url, {
           id: httpResponse.id,
           fulfilled,
-          statusCode: encoded.responseCode,
-          bodyBytes: encoded.body ? Buffer.from(encoded.body, 'base64').length : undefined,
-          headerNames: encoded.responseHeaders?.map(({ name }) => name),
+          statusCode: transportResponse.responseCode,
+          bodyBytes: transportResponse.body ? Buffer.from(transportResponse.body, 'base64').length : undefined,
+          headerNames: transportResponse.responseHeaders?.map(({ name }) => name),
           usedPausedResponse: !!pausedResponse,
         })
       }
 
-      return encoded
+      return transportResponse
     },
 
     releaseRequest (id: string): void {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -1,8 +1,6 @@
 import type { Protocol } from 'devtools-protocol'
 import debugModule from 'debug'
 import { Readable } from 'stream'
-import { promisify } from 'util'
-import zlib from 'zlib'
 import type { ForHttpIntercept } from '@packages/network-interception'
 import { HttpIntercept } from '@packages/network-interception'
 import type { ICriClient } from './cri-client'
@@ -17,7 +15,6 @@ type CdpFetchClient = Pick<ICriClient, 'send' | 'on' | 'off'>
 type CdpFetchRequest = Protocol.Fetch.RequestPausedEvent['request']
 const RESPONSE_PAUSE_TIMEOUT_MS = 30000
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308]
-const brotliDecompress = promisify(zlib.brotliDecompress)
 
 // CDP refuses Fetch.getResponseBody for a pause in the redirect-received state,
 // and documents a redirect status plus a location header as the way to tell that
@@ -466,46 +463,9 @@ export class CdpFetchTransport {
       requestId: event.requestId,
     }, sessionId) as Protocol.Fetch.GetResponseBodyResponse
 
-    const raw = Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8')
-    const body = await this.decodeUndeliveredEncodings(raw, event.responseHeaders)
+    const body = Buffer.from(response.body, response.base64Encoded ? 'base64' : 'utf8')
 
     return Readable.from(body.length ? [body] : [])
-  }
-
-  /**
-   * Fetch.getResponseBody delivers gzip/deflate content-decoded, but brotli
-   * arrives still encoded (and continueRequest cannot constrain
-   * accept-encoding — the network stack owns that header). Decode br here so
-   * the middleware's decoded-body premise holds. Falls back to the raw bytes
-   * if decompression fails, in case a newer CDP starts decoding br itself.
-   */
-  private decodeUndeliveredEncodings = async (body: Buffer, responseHeaders?: Protocol.Fetch.HeaderEntry[]): Promise<Buffer> => {
-    const contentEncoding = responseHeaders?.find(({ name }) => name.toLowerCase() === 'content-encoding')?.value
-
-    if (!contentEncoding || !body.length) {
-      return body
-    }
-
-    // encodings are listed in the order applied, so decode in reverse;
-    // gzip/deflate layers were already decoded by CDP
-    const encodings = contentEncoding.split(',').map((token) => token.trim().toLowerCase()).reverse()
-    let decoded = body
-
-    for (const encoding of encodings) {
-      if (encoding !== 'br') {
-        continue
-      }
-
-      try {
-        decoded = await brotliDecompress(decoded)
-      } catch (err) {
-        debug('brotli decompression failed, using body as delivered: %s', (err as Error).message)
-
-        return body
-      }
-    }
-
-    return decoded
   }
 
   private toContinueRequestHeaders (headers: Protocol.Network.Headers): Protocol.Fetch.HeaderEntry[] {

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -1,6 +1,5 @@
 const { expect, sinon } = require('../../spec_helper')
 
-import zlib from 'zlib'
 import type { Protocol } from 'devtools-protocol'
 import { HttpIntercept } from '@packages/network-interception'
 import { createCdpFetchCodec } from '../../../lib/browsers/cdp-protocol/cdp-fetch-codec'
@@ -483,16 +482,15 @@ describe('CdpFetchTransport', () => {
       })
     })
 
-    it('normalizes pipeline re-encoded fulfilled bodies to identity', async () => {
+    // Identity for fulfilled bodies is guaranteed upstream by the synthetic
+    // proxy codec's decodeResponse, so the transport fulfills verbatim.
+    it('fulfills pipeline bodies verbatim', async () => {
       const client = createClient()
       const httpIntercept = new HttpIntercept(createCdpFetchCodec())
       const { transport } = createTransport(client, { httpIntercept })
       const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
       const response = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 })
-      const gzippedBody = zlib.gzipSync(Buffer.from('<html>compressed</html>'))
 
-      // the legacy pipeline (CompressBody) may re-encode the outgoing body;
-      // fulfillRequest delivers bodies as-is, so it must go out as identity
       httpIntercept.use(async (req, next) => {
         const res = await next(req)
 
@@ -500,10 +498,9 @@ describe('CdpFetchTransport', () => {
           ...res,
           headers: {
             'content-type': 'text/html',
-            'content-encoding': 'gzip',
             'content-length': '9999',
           },
-          body: gzippedBody,
+          body: Buffer.from('<html>plain</html>'),
         }
       })
 
@@ -521,44 +518,7 @@ describe('CdpFetchTransport', () => {
           name: 'content-type',
           value: 'text/html',
         }],
-        body: Buffer.from('<html>compressed</html>').toString('base64'),
-      })
-    })
-
-    it('keeps the body and header pair when a fulfilled encoding cannot be decoded', async () => {
-      const client = createClient()
-      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
-      const { transport } = createTransport(client, { httpIntercept })
-      const request = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' })
-      const response = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 })
-
-      httpIntercept.use(async (req, next) => {
-        const res = await next(req)
-
-        return {
-          ...res,
-          headers: {
-            'content-encoding': 'zstd',
-          },
-          body: Buffer.from('opaque-bytes'),
-        }
-      })
-
-      const onRequestPaused = await startTransport(transport, client)
-      const handled = onRequestPaused(request)
-
-      await tick()
-      await onRequestPaused(response)
-      await handled
-
-      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
-        requestId: 'fetch-request',
-        responseCode: 200,
-        responseHeaders: [{
-          name: 'content-encoding',
-          value: 'zstd',
-        }],
-        body: Buffer.from('opaque-bytes').toString('base64'),
+        body: Buffer.from('<html>plain</html>').toString('base64'),
       })
     })
 
@@ -1261,113 +1221,6 @@ describe('CdpFetchTransport', () => {
       })
 
       expect(client.send).not.to.have.been.calledWith('Fetch.continueResponse')
-    })
-
-    it('decompresses brotli response bodies before middleware reads them', async () => {
-      const client = createClient()
-      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
-      const { transport } = createTransport(client, { httpIntercept })
-      const onRequestPaused = await startTransport(transport, client)
-
-      client.send.withArgs('Fetch.getResponseBody').resolves({
-        body: zlib.brotliCompressSync(Buffer.from('<html>origin</html>')).toString('base64'),
-        base64Encoded: true,
-      })
-
-      let seenBody
-
-      httpIntercept.use(async (req, next) => {
-        const response = await next(req)
-
-        seenBody = await readStream(response.bodyStream!)
-
-        return {
-          ...response,
-          body: `${seenBody}-rewritten`,
-        }
-      })
-
-      const handled = onRequestPaused(createPausedRequest({
-        requestId: 'fetch-request',
-        networkId: 'network-1',
-      }))
-
-      await tick()
-
-      const response = createPausedRequest({
-        requestId: 'fetch-request',
-        networkId: 'network-1',
-        responseStatusCode: 200,
-      })
-
-      response.responseHeaders = [
-        { name: 'Content-Encoding', value: 'br' },
-        { name: 'Content-Type', value: 'text/html' },
-      ]
-
-      await onRequestPaused(response)
-      await handled
-
-      expect(seenBody).to.equal('<html>origin</html>')
-
-      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
-        requestId: 'fetch-request',
-        responseCode: 200,
-        responseHeaders: [{
-          name: 'content-type',
-          value: 'text/html',
-        }],
-        body: Buffer.from('<html>origin</html>-rewritten').toString('base64'),
-      })
-    })
-
-    it('falls back to the delivered body when brotli decompression fails', async () => {
-      const client = createClient()
-      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
-      const { transport } = createTransport(client, { httpIntercept })
-      const onRequestPaused = await startTransport(transport, client)
-
-      // headers claim br but the body is already plaintext (e.g. a newer CDP
-      // that decodes br itself)
-      client.send.withArgs('Fetch.getResponseBody').resolves({
-        body: Buffer.from('<html>already decoded</html>').toString('base64'),
-        base64Encoded: true,
-      })
-
-      let seenBody
-
-      httpIntercept.use(async (req, next) => {
-        const response = await next(req)
-
-        seenBody = await readStream(response.bodyStream!)
-
-        return {
-          ...response,
-          body: seenBody,
-        }
-      })
-
-      const handled = onRequestPaused(createPausedRequest({
-        requestId: 'fetch-request',
-        networkId: 'network-1',
-      }))
-
-      await tick()
-
-      const response = createPausedRequest({
-        requestId: 'fetch-request',
-        networkId: 'network-1',
-        responseStatusCode: 200,
-      })
-
-      response.responseHeaders = [
-        { name: 'Content-Encoding', value: 'br' },
-      ]
-
-      await onRequestPaused(response)
-      await handled
-
-      expect(seenBody).to.equal('<html>already decoded</html>')
     })
 
     it('continues the response pause without running the intercept pipeline when the eager body fetch fails', async () => {


### PR DESCRIPTION
- Closes #34363

### Additional details

`StripUnsupportedAcceptEncoding` assumes Node performs the transfer. On the CDP path the Fetch pause carries no `accept-encoding` (Chrome appends it post-interception), so the stage *synthesizes* `gzip,identity`, which rides out as a `Fetch.continueRequest` headers override. Chrome honors the override by narrowing what its netstack will decode, so origins that ignore `Accept-Encoding` and serve br die with `net::ERR_CONTENT_DECODING_FAILED` before a response pause exists.

This PR puts both browser-transfer encoding invariants in the [synthetic proxy codec](https://github.com/cypress-io/cypress/blob/bill/34363/strip-accept-encoding-codec/packages/proxy/lib/adapters/synthetic-proxy-codec.ts) — the seam every CDP-bound exchange crosses, whose only consumer is `createCdpFetchRuntime`. The middleware onion is untouched on every pipeline.

1. `decodeRequest` **drops `accept-encoding`** from the outbound request. Probe-verified: Chrome re-attaches its own negotiation even when other header changes continue, and since the pause never carries the header, the transport usually sends no override at all.
2. `decodeResponse` **normalizes the captured response to identity** — `toIdentityResponse`/`CONTENT_DECODERS` (gzip/x-gzip/deflate/br) relocate here from the cdp-fetch codec, which now fulfills verbatim. An encoding that cannot be undone ships as the pair it arrived as.

Mechanism facts backing the design, verified via standalone CDP probes (details in #34363): `Fetch.getResponseBody` delivers bodies fully content-decoded including br/zstd, and `Fetch.fulfillRequest` runs no content decoders — so the only encoded bodies left to normalize are ones the pipeline itself emits (`CompressBody` re-encodes, stub-declared encodings).

This also lets the transport's inward br decode go. Chromium decodes intercepted bodies itself as of **M140** (`devtools_url_loader_interceptor.cc` routing them through `ContentDecodingInterceptor`), confirmed against real binaries — Chrome for Testing **136 returns br still encoded**, Chrome **149**/**150** return it decoded — so every Chrome in the last-three-majors support window is past the boundary and the decode was dead code. It is deleted here along with its two tests.

#### Trade-offs / invariants

- **The encode/decode dance stays**: `CompressBody` may re-encode a body the codec immediately decodes. Accepted — it completely obviates touching the legacy middleware and keeps the seam clean.
- **The middleware view keeps MITM parity**: stages downstream of `StripUnsupportedAcceptEncoding` see the synthesized value while the browser sends its own — the same view-vs-wire gap MITM already has. `InterceptRequest` snapshots before that stage on both pipelines, so `cy.intercept`'s view is identical across transports.
- Internal routes bypass the synthetic codec but self-guarantee identity (`accept-encoding` is hop-by-hop on the loopback leg, `gzip: false`).
- `getSupportedAcceptEncoding` is also called by `_onResolveUrl` — Node genuinely fetching; keeps the constraint.
- `x-gzip`/`deflate` stubs decode on this path; #34387 stays MITM-injection-only. Stub-declared `zstd` ships as the intact pair.

Supersedes #34388, which reached the identical test outcome with a per-pipeline driven-port design inside the onion; this approach was chosen to keep the onion transport-agnostic. Deferred tech debt from that review: extract `notifyResponseStreamReceived` from `CompressBody` into its own stage.

### Steps to test

Unit coverage: `packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts` (19 tests) and `packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts`.

`packages/driver/cypress/e2e/e2e/encoding.cy.ts` in dev mode, Chrome headless, once per transport:

```bash
# MITM (default): 17/17 — unchanged
yarn cypress:run --dev --project packages/driver --browser chrome --spec cypress/e2e/e2e/encoding.cy.ts

# proxy disabled: 4/13 on develop -> 10 passing / 7 failing
CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run --dev --project packages/driver --browser chrome --spec cypress/e2e/e2e/encoding.cy.ts
```

The 7 remaining proxy-disabled failures are pre-existing classes owned by #34379 (intercepted-visit 500s), #34384 (netstack-rejected observability), and #34386 (insecure-host br expectations).

### How has the user experience changed?

No change with the MITM proxy (the default and only released pipeline). With the proxy disabled, br/zstd survive end to end: pages served with brotli by origins that don't honor `Accept-Encoding` load instead of failing with `net::ERR_CONTENT_DECODING_FAILED`.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? #34363
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy-disabled CDP request/response fulfillment and content-encoding round-trips; MITM path is unchanged but encoding mistakes could break page loads or intercept rewrites.
> 
> **Overview**
> Moves **browser-owned encoding behavior** into `createSyntheticProxyCodec`, the adapter CDP Fetch traffic uses when the MITM proxy is off, so the legacy middleware stack stays unchanged.
> 
> On **outbound requests**, `decodeRequest` now **removes `accept-encoding`** before `Fetch.continueRequest`, so middleware’s narrowed value (from `StripUnsupportedAcceptEncoding`) no longer overrides Chrome’s negotiation and avoids `net::ERR_CONTENT_DECODING_FAILED` on br origins.
> 
> On **responses**, `decodeResponse` runs **`toIdentityResponse`**: decode gzip/x-gzip/br/deflate (outermost-first), strip `content-encoding`, `content-length`, and `transfer-encoding`, and leave undecodable pairs (e.g. zstd, corrupt gzip) unchanged. That logic lived in `cdp-fetch-codec` and is **removed** there—fulfillment is verbatim again.
> 
> **CDP Fetch transport** drops the extra **brotli** pass on `Fetch.getResponseBody` (Chromium now content-decodes intercepted bodies); related codec/transport tests move to the synthetic codec spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b8c8964b0ff922ccfe18bd57f04e59a6ae44daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->