### PR TITLE
chore: split Test Replay stream capture out of CompressBody

### DIFF
--- a/packages/proxy/lib/adapters/network-capture.ts
+++ b/packages/proxy/lib/adapters/network-capture.ts
@@ -9,7 +9,7 @@ import type { ResponseInterceptionMiddlewareCtx } from './types'
  */
 export async function notifyResponseStreamReceived (mw: ResponseInterceptionMiddlewareCtx): Promise<void> {
   if (!mw.protocolManager || !mw.req.browserPreRequest?.requestId) {
-    return
+    return mw.next()
   }
 
   const preRequest = mw.req.browserPreRequest
@@ -42,6 +42,8 @@ export async function notifyResponseStreamReceived (mw: ResponseInterceptionMidd
   } else {
     span?.end()
   }
+
+  mw.next()
 }
 
 /**

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -202,6 +202,7 @@ const FilterNonProxiedResponse: ResponseMiddleware = function () {
       'MaybeSendRedirectToClient',
       'CopyResponseStatusCode',
       'MaybeEndWithEmptyBody',
+      'NotifyResponseStreamReceived',
       'CompressBody',
       'SendResponseBodyToClient',
     ])
@@ -619,9 +620,11 @@ const MaybeInjectServiceWorker: ResponseMiddleware = function () {
   })
 }
 
-const CompressBody: ResponseMiddleware = async function () {
-  await this.networkInterceptionCore.notifyResponseStreamReceived(this)
+const NotifyResponseStreamReceived: ResponseMiddleware = function () {
+  return this.networkInterceptionCore.notifyResponseStreamReceived(this)
+}
 
+const CompressBody: ResponseMiddleware = function () {
   // Re-compress in the same order as the original content-encoding (innermost first).
   const order = this.contentEncodingOrder ?? []
 
@@ -687,6 +690,7 @@ export default {
   MaybeInjectHtml,
   MaybeRemoveSecurity,
   MaybeInjectServiceWorker,
+  NotifyResponseStreamReceived,
   CompressBody,
   SendResponseBodyToClient,
 }

--- a/packages/proxy/test/unit/http/response-middleware.spec.ts
+++ b/packages/proxy/test/unit/http/response-middleware.spec.ts
@@ -51,6 +51,7 @@ describe('http/response-middleware', function () {
       'MaybeInjectHtml',
       'MaybeRemoveSecurity',
       'MaybeInjectServiceWorker',
+      'NotifyResponseStreamReceived',
       'CompressBody',
       'SendResponseBodyToClient',
     ])
@@ -2727,8 +2728,8 @@ describe('http/response-middleware', function () {
     }
   })
 
-  describe('CompressBody', function () {
-    const { CompressBody } = ResponseMiddleware
+  describe('NotifyResponseStreamReceived and CompressBody', function () {
+    const { CompressBody, NotifyResponseStreamReceived } = ResponseMiddleware
     let ctx
     let responseStreamReceivedStub: Mock
 
@@ -2766,7 +2767,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',
@@ -2810,7 +2811,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',
@@ -2843,7 +2844,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).not.toHaveBeenCalled()
     })
 
@@ -2868,7 +2869,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).not.toHaveBeenCalled()
     })
 
@@ -2903,7 +2904,7 @@ describe('http/response-middleware', function () {
         incomingResStream: stream,
       })
 
-      await testMiddleware([CompressBody], ctx)
+      await testMiddleware([NotifyResponseStreamReceived], ctx)
       expect(responseStreamReceivedStub).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: '123',


### PR DESCRIPTION
- Related: #34363 (deferred tech debt surfaced in the #34388 review)

### Additional details

`CompressBody` did two unrelated things: notify Test Replay that the response stream is available and re-encode the body for the wire. The capture call moves to its own stage, `NotifyResponseStreamReceived`, immediately before `CompressBody`. Capture must observe the stream before re-encoding (it may replace `incomingResStream` with a tee), so the ordering is now expressed by stage order.

Behavior-neutral: identical call sequence in the same stack position. The `FilterNonProxiedResponse` allowlist and the stage-order test gain the new stage name.

### Steps to test

`packages/proxy/test/unit/http/response-middleware.spec.ts` — capture tests target the new stage; re-compression tests stay on `CompressBody`.

### How has the user experience changed?

No change — behavior-preserving refactor.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? #34363 (deferred tech-debt item)
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves pipeline order and behavior; risk is limited to middleware continuation, covered by updated unit tests.
> 
> **Overview**
> **Test Replay stream capture** is no longer bundled inside `CompressBody`. A dedicated response middleware stage, `NotifyResponseStreamReceived`, runs **immediately before** `CompressBody` so the protocol manager sees the body stream before any gzip/Brotli re-encoding (and can tee/replace `incomingResStream`).
> 
> `CompressBody` now only re-compresses the stream. The extra-target minimal middleware allowlist and the exported stage-order test include the new stage name.
> 
> In `notifyResponseStreamReceived`, early exits and the success path now call `mw.next()` so the chain always advances (previously some paths could return without continuing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507dd3b37d09f0d4403906e41772eff5744ccb3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->