### PR TITLE
chore: prevent duplicate PRs from the update-browser-versions workflow

### DIFF
--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -47,18 +47,24 @@ jobs:
             const { getVersions } = require('./scripts/github-actions/update-browser-versions.js')
 
             getVersions({ core })
-      - name: Determine name of new branch and if it already exists
+      - name: Check if an open PR already exists for the update branch
         id: check-branch
         env:
-          BRANCH_NAME: update-chrome-stable-from-${{ steps.get-versions.outputs.latest_stable_version }}-beta-from-${{ steps.get-versions.outputs.latest_beta_version }}-cft-from-${{ steps.get-versions.outputs.latest_chrome_for_testing_stable_version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH_NAME: update-browser-versions
         run: |
-          echo "branch_name=${{ env.BRANCH_NAME }}" >> $GITHUB_OUTPUT
-          echo "branch_exists=$(git show-ref --verify --quiet refs/remotes/origin/${{ env.BRANCH_NAME }} && echo 'true')" >> $GITHUB_OUTPUT
+          pr_exists=$(gh pr list --repo ${{ github.repository }} --head "$BRANCH_NAME" --base "$BASE_BRANCH" --state open --json number --jq 'length > 0')
+          # A leftover branch from a closed PR would base the new PR on a stale fork point
+          if [[ "$pr_exists" != "true" ]] && git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+            git push origin --delete "$BRANCH_NAME"
+          fi
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "pr_exists=$pr_exists" >> $GITHUB_OUTPUT
       - name: Check need for PR or branch update
         id: check-need-for-pr
         run: |
-          echo "needs_pr=${{ steps.get-versions.outputs.has_update == 'true' && steps.check-branch.outputs.branch_exists != 'true' }}" >> $GITHUB_OUTPUT
-          echo "needs_branch_update=${{ steps.get-versions.outputs.has_update == 'true' && steps.check-branch.outputs.branch_exists == 'true' }}" >> $GITHUB_OUTPUT
+          echo "needs_pr=${{ steps.get-versions.outputs.has_update == 'true' && steps.check-branch.outputs.pr_exists != 'true' }}" >> $GITHUB_OUTPUT
+          echo "needs_branch_update=${{ steps.get-versions.outputs.has_update == 'true' && steps.check-branch.outputs.pr_exists == 'true' }}" >> $GITHUB_OUTPUT
       ## Update available and a branch/PR already exists
       - name: Checkout existing branch
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}


### PR DESCRIPTION
- Closes N/A — internal CI automation fix, no user-facing issue

### Additional details

The daily Update Browser Versions workflow kept opening duplicate PRs instead of updating the existing one (e.g. #34404 was orphaned and #34423 was created the next day for the same stable/CfT bump). The root cause: the branch name was derived from the *latest available* versions (`update-chrome-stable-from-<latest>-beta-from-<latest>-cft-from-<latest>`), so whenever Google shipped a new version on any channel while an update PR was still open, the next run computed a different branch name, found no existing branch, and created a brand-new PR. The old PR was never closed, and its branch was left behind — there are currently ~24 stale `update-chrome-stable-from-*` branches on the remote from this pattern.

This PR fixes that by:

- Using a fixed branch name, `update-browser-versions`, so every run targets the same branch until its PR merges. The existing branch-update path (`checkNeedForBranchUpdate` + commit + `updatePRTitle`) then handles rolling newer versions onto the open PR, which is what it was designed for but never got to do. Merged PRs are cleaned up by the repo's delete-branch-on-merge setting, so each merge naturally starts the next cycle fresh.
- Keying the create-vs-update decision on whether an **open PR** exists for the branch (`gh pr list --head ... --state open`) rather than whether the branch exists. With a fixed name, the old branch-existence check would silently stall the automation forever if a PR was ever closed without merging but its branch left undeleted (exactly what happened with #34404): every run would take the "update existing branch" path with no PR to retitle, and no new PR would ever be created.
- Deleting a leftover branch (no open PR but the branch exists) before creating a fresh PR, so the new branch forks from current `develop` instead of a stale point.

No changes to the helper scripts were needed — `commitViaApi` already creates the branch when missing, and the branch-update/`updatePRTitle` machinery is unchanged.

The ~24 existing stale `update-chrome-stable-from-*` branches are not touched by this PR and can be deleted separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow YAML only; no application, auth, or release behavior changes.
> 
> **Overview**
> Fixes the **Update Browser Versions** workflow opening duplicate PRs when Chrome version strings changed between runs.
> 
> The automation now uses a **fixed branch** `update-browser-versions` instead of a name built from the latest stable/beta/CfT versions, so repeated runs target the same branch and can update the existing PR.
> 
> The create-vs-update gate switches from **remote branch exists** to **open PR exists** (`gh pr list` with the bot token). When there is no open PR but the fixed branch still exists (e.g. after closing without merge), the workflow **deletes that remote branch** so the next PR is based on current `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f0907c4bf633450d59f6ea15eb8253201bd944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Manually dispatch the Update Browser Versions workflow (or wait for the daily cron). If any Chrome channel has an update, it should create a single PR from the `update-browser-versions` branch.
2. Dispatch it again after a new Chrome version lands on any channel while that PR is still open: it should push the newer versions to the same branch and retitle the same PR instead of opening a new one.
3. Close the update PR without merging (leaving the branch), then dispatch again: the workflow should delete the leftover branch and open a fresh PR.

### How has the user experience changed?

No change — CI automation only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI automation fix identified from duplicate bot PRs #34404/#34423. -->
- [na] Have tests been added/updated? <!-- Workflow YAML only; the unit-tested helper scripts in scripts/github-actions are unchanged. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
