### PR TITLE
chore: move windows CircleCI jobs to a daily schedule

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -29,7 +29,7 @@ If only unit/integration tests scoped to changed packages are sufficient, do **n
 
 Push your work to the branch name you add — do not repurpose an existing allowlisted branch (for example, do not change `update-v8-snapshot-cache-on-develop` to a different name).
 
-This gate turns on the main/multi-platform workflow graph — including `windows-v8-integration-tests` and `v8-integration-tests` on Linux/macOS. The existing `update-v8-snapshot-cache-on-develop` entry is reserved for automated v8 snapshot cache PRs.
+This gate turns on the main/multi-platform workflow graph — including `windows-v8-integration-tests` and `v8-integration-tests` on Linux/macOS. The existing `update-v8-snapshot-cache-on-develop` entry is reserved for automated v8 snapshot cache PRs. Note: `windows` specifically excludes plain `develop`/`release/*` pushes from this gate (it runs on those via a daily CircleCI Scheduled Pipeline instead — see the comment above the `windows` workflow in `@main.yml`); any other branch added here still turns Windows on immediately as before.
 
 **Optional — only if you need more than main workflows + path-filtered jobs:**
 

--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -29,7 +29,7 @@ If only unit/integration tests scoped to changed packages are sufficient, do **n
 
 Push your work to the branch name you add — do not repurpose an existing allowlisted branch (for example, do not change `update-v8-snapshot-cache-on-develop` to a different name).
 
-This gate turns on the main/multi-platform workflow graph — including `windows-v8-integration-tests` and `v8-integration-tests` on Linux/macOS. The existing `update-v8-snapshot-cache-on-develop` entry is reserved for automated v8 snapshot cache PRs. Note: `windows` specifically excludes plain `develop`/`release/*` pushes from this gate (it runs on those via a daily CircleCI Scheduled Pipeline instead — see the comment above the `windows` workflow in `@main.yml`); any other branch added here still turns Windows on immediately as before.
+This gate turns on the main/multi-platform workflow graph — including `windows-v8-integration-tests` and `v8-integration-tests` on Linux/macOS. The existing `update-v8-snapshot-cache-on-develop` entry is reserved for automated v8 snapshot cache PRs. Note: `windows` specifically excludes plain `develop`/`release/*` pushes from this gate (it runs on those on a CircleCI Scheduled Pipeline instead — see the comment above the `windows` workflow in `@main.yml`); any other branch added here still turns Windows on immediately as before.
 
 **Optional — only if you need more than main workflows + path-filtered jobs:**
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,13 @@ parameters:
   run-all-jobs:
     type: boolean
     default: false
+  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows`
+  # workflow once daily. Must be declared here (not just in
+  # .circleci/src/pipeline/@pipeline.yml) since this is the entry-point config
+  # CircleCI validates trigger parameters against.
+  run-windows-scheduled:
+    type: boolean
+    default: false
   # Opt-in proxy-disabled (CDP Fetch) coverage. Default false so known-red
   # suites do not fail or cancel the pull-request workflow; enable via
   # Trigger Pipeline when investigating that path.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,8 @@ parameters:
   run-all-jobs:
     type: boolean
     default: false
-  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows`
-  # workflow once daily. Must be declared here (not just in
-  # .circleci/src/pipeline/@pipeline.yml) since this is the entry-point config
-  # CircleCI validates trigger parameters against.
+  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows` workflow.
+  # (can also be set manually to run the Windows workflow)
   run-windows-scheduled:
     type: boolean
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ parameters:
     default: false
   # Set to true by the CircleCI Scheduled Pipeline that runs the `windows` workflow.
   # (can also be set manually to run the Windows workflow)
-  run-windows-scheduled:
+  run-windows-workflow:
     type: boolean
     default: false
   # Opt-in proxy-disabled (CDP Fetch) coverage. Default false so known-red

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -714,8 +714,8 @@ commands:
 
   # This code builds better-sqlite3 on Debian 11 (Bullseye). This is necessary because Debian 11 has the oldest glibc version (2.31) that we support.
   #
-  # Since this is running Docker remote (because the job running the command may not be using an executor with the appropriate glibc version), we need to
-  # copy the project into the container, and copy the built plugin out of the container because the host running docker does not have access to the
+  # Since this is running Docker remote (because the job running the command may not be using an executor with the appropriate glibc version), we need to 
+  # copy the project into the container, and copy the built plugin out of the container because the host running docker does not have access to the 
   # project directory so volume mounts are not possible. The built plugin is copied to the project directory so it can be injected into the final binary.
   build-better-sqlite3:
     description: Build better-sqlite3 for glibc 2.31

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -31,6 +31,11 @@ parameters:
   run-proxy-disabled-tests:
     type: boolean
     default: false
+  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows`
+  # workflow once daily.
+  run-windows-scheduled:
+    type: boolean
+    default: false
   # Path-filtering parameters — set by generate-pipeline-parameters.sh on PRs.
   # Default true so develop/release branches run everything without explicit params.
   run-driver-tests:
@@ -709,8 +714,8 @@ commands:
 
   # This code builds better-sqlite3 on Debian 11 (Bullseye). This is necessary because Debian 11 has the oldest glibc version (2.31) that we support.
   #
-  # Since this is running Docker remote (because the job running the command may not be using an executor with the appropriate glibc version), we need to 
-  # copy the project into the container, and copy the built plugin out of the container because the host running docker does not have access to the 
+  # Since this is running Docker remote (because the job running the command may not be using an executor with the appropriate glibc version), we need to
+  # copy the project into the container, and copy the built plugin out of the container because the host running docker does not have access to the
   # project directory so volume mounts are not possible. The built plugin is copied to the project directory so it can be injected into the final binary.
   build-better-sqlite3:
     description: Build better-sqlite3 for glibc 2.31

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1770,18 +1770,6 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
-  # TEMPORARY — used only to smoke-test the run-windows-scheduled CircleCI Scheduled Pipeline
-  # without paying for the full windows job graph. Remove this job, and restore the real job
-  # list under the `windows` workflow in @main.yml, before marking the PR ready for review.
-  windows-schedule-smoke-test:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small.gen2
-    steps:
-      - run:
-          name: Confirm scheduled trigger fired
-          command: echo "run-windows-scheduled fired correctly for branch << pipeline.git.branch >> at $(date)"
-
   ## Checks if we already have a valid cache for the node_modules_install and if it has,
   ## skips ahead to the build step, otherwise installs and caches the node_modules
   node_modules_install:

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1770,6 +1770,18 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
+  # TEMPORARY — used only to smoke-test the run-windows-scheduled CircleCI Scheduled Pipeline
+  # without paying for the full windows job graph. Remove this job, and restore the real job
+  # list under the `windows` workflow in @main.yml, before marking the PR ready for review.
+  windows-schedule-smoke-test:
+    docker:
+      - image: cimg/base:stable
+    resource_class: small.gen2
+    steps:
+      - run:
+          name: Confirm scheduled trigger fired
+          command: echo "run-windows-scheduled fired correctly for branch << pipeline.git.branch >> at $(date)"
+
   ## Checks if we already have a valid cache for the node_modules_install and if it has,
   ## skips ahead to the build step, otherwise installs and caches the node_modules
   node_modules_install:

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -33,7 +33,7 @@ parameters:
     default: false
   # Set to true by the CircleCI Scheduled Pipeline that runs the `windows` workflow.
   # (can also be set manually to run the Windows workflow)
-  run-windows-scheduled:
+  run-windows-workflow:
     type: boolean
     default: false
   # Path-filtering parameters — set by generate-pipeline-parameters.sh on PRs.

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -31,8 +31,8 @@ parameters:
   run-proxy-disabled-tests:
     type: boolean
     default: false
-  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows`
-  # workflow once daily.
+  # Set to true by the CircleCI Scheduled Pipeline that runs the `windows` workflow.
+  # (can also be set manually to run the Windows workflow)
   run-windows-scheduled:
     type: boolean
     default: false

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -611,77 +611,83 @@ windows:
                     pattern: /^release\/\d+\.\d+\.\d+$/
                     value: << pipeline.git.branch >>
   jobs:
-    - node_modules_install:
-        name: windows-node-modules-install
-        executor: windows
-        resource_class: windows.medium
-        only-cache-for-root-user: true
+    - windows-schedule-smoke-test
 
-    - build:
-        name: windows-build
-        context: test-runner:env-canary
-        executor: windows
-        resource_class: windows.large
-        requires:
-          - windows-node-modules-install
+  # TEMPORARY: real windows job list below is commented out to smoke-test the
+  # run-windows-scheduled CircleCI Scheduled Pipeline cheaply. Restore it (and delete
+  # the windows-schedule-smoke-test job here and in @pipeline.yml) before marking the
+  # PR ready for review.
+    # - node_modules_install:
+        # name: windows-node-modules-install
+        # executor: windows
+        # resource_class: windows.medium
+        # only-cache-for-root-user: true
 
-    - run-app-integration-tests-chrome:
-        name: windows-run-app-integration-tests-chrome
-        executor: windows
-        resource_class: windows.large
-        context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
-        requires:
-          - windows-build
+    # - build:
+        # name: windows-build
+        # context: test-runner:env-canary
+        # executor: windows
+        # resource_class: windows.large
+        # requires:
+          # - windows-node-modules-install
 
-    - run-launchpad-integration-tests-chrome:
-        name: windows-run-launchpad-integration-tests-chrome
-        executor: windows
-        resource_class: windows.large
-        context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
-        requires:
-          - windows-build
+    # - run-app-integration-tests-chrome:
+        # name: windows-run-app-integration-tests-chrome
+        # executor: windows
+        # resource_class: windows.large
+        # context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
+        # requires:
+          # - windows-build
 
-    - unit-tests:
-        name: windows-unit-tests
-        executor: windows
-        resource_class: windows.medium
-        requires:
-          - windows-build
+    # - run-launchpad-integration-tests-chrome:
+        # name: windows-run-launchpad-integration-tests-chrome
+        # executor: windows
+        # resource_class: windows.large
+        # context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
+        # requires:
+          # - windows-build
 
-    - server-unit-tests-cloud-environment:
-        name: windows-server-unit-tests-cloud-environment
-        executor: windows
-        resource_class: windows.medium
-        requires:
-          - windows-build
+    # - unit-tests:
+        # name: windows-unit-tests
+        # executor: windows
+        # resource_class: windows.medium
+        # requires:
+          # - windows-build
 
-    - create-build-artifacts:
-        name: windows-create-build-artifacts
-        executor: windows
-        resource_class: windows.large
-        context:
-          - test-runner:sign-windows-binary
-          - test-runner:upload
-          - test-runner:commit-status-checks
-          - test-runner:build-binary
-        requires:
-          - windows-build
+    # - server-unit-tests-cloud-environment:
+        # name: windows-server-unit-tests-cloud-environment
+        # executor: windows
+        # resource_class: windows.medium
+        # requires:
+          # - windows-build
 
-    - test-binary-against-kitchensink-chrome:
-        name: windows-test-binary-against-kitchensink-chrome
-        executor: windows
-        requires:
-          - windows-create-build-artifacts
+    # - create-build-artifacts:
+        # name: windows-create-build-artifacts
+        # executor: windows
+        # resource_class: windows.large
+        # context:
+          # - test-runner:sign-windows-binary
+          # - test-runner:upload
+          # - test-runner:commit-status-checks
+          # - test-runner:build-binary
+        # requires:
+          # - windows-build
 
-    - v8-integration-tests:
-        name: windows-v8-integration-tests
-        executor: windows
-        resource_class: windows.medium
-        requires:
-          - windows-build
-    - driver-integration-memory-tests:
-        name: windows-driver-integration-memory-tests
-        executor: windows
-        resource_class: windows.medium
-        requires:
-          - windows-build
+    # - test-binary-against-kitchensink-chrome:
+        # name: windows-test-binary-against-kitchensink-chrome
+        # executor: windows
+        # requires:
+          # - windows-create-build-artifacts
+
+    # - v8-integration-tests:
+        # name: windows-v8-integration-tests
+        # executor: windows
+        # resource_class: windows.medium
+        # requires:
+          # - windows-build
+    # - driver-integration-memory-tests:
+        # name: windows-driver-integration-memory-tests
+        # executor: windows
+        # resource_class: windows.medium
+        # requires:
+          # - windows-build

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -611,83 +611,77 @@ windows:
                     pattern: /^release\/\d+\.\d+\.\d+$/
                     value: << pipeline.git.branch >>
   jobs:
-    - windows-schedule-smoke-test
+    - node_modules_install:
+        name: windows-node-modules-install
+        executor: windows
+        resource_class: windows.medium
+        only-cache-for-root-user: true
 
-  # TEMPORARY: real windows job list below is commented out to smoke-test the
-  # run-windows-scheduled CircleCI Scheduled Pipeline cheaply. Restore it (and delete
-  # the windows-schedule-smoke-test job here and in @pipeline.yml) before marking the
-  # PR ready for review.
-    # - node_modules_install:
-        # name: windows-node-modules-install
-        # executor: windows
-        # resource_class: windows.medium
-        # only-cache-for-root-user: true
+    - build:
+        name: windows-build
+        context: test-runner:env-canary
+        executor: windows
+        resource_class: windows.large
+        requires:
+          - windows-node-modules-install
 
-    # - build:
-        # name: windows-build
-        # context: test-runner:env-canary
-        # executor: windows
-        # resource_class: windows.large
-        # requires:
-          # - windows-node-modules-install
+    - run-app-integration-tests-chrome:
+        name: windows-run-app-integration-tests-chrome
+        executor: windows
+        resource_class: windows.large
+        context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
+        requires:
+          - windows-build
 
-    # - run-app-integration-tests-chrome:
-        # name: windows-run-app-integration-tests-chrome
-        # executor: windows
-        # resource_class: windows.large
-        # context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
-        # requires:
-          # - windows-build
+    - run-launchpad-integration-tests-chrome:
+        name: windows-run-launchpad-integration-tests-chrome
+        executor: windows
+        resource_class: windows.large
+        context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
+        requires:
+          - windows-build
 
-    # - run-launchpad-integration-tests-chrome:
-        # name: windows-run-launchpad-integration-tests-chrome
-        # executor: windows
-        # resource_class: windows.large
-        # context: [ test-runner:cypress-record-key, test-runner:launchpad-tests ]
-        # requires:
-          # - windows-build
+    - unit-tests:
+        name: windows-unit-tests
+        executor: windows
+        resource_class: windows.medium
+        requires:
+          - windows-build
 
-    # - unit-tests:
-        # name: windows-unit-tests
-        # executor: windows
-        # resource_class: windows.medium
-        # requires:
-          # - windows-build
+    - server-unit-tests-cloud-environment:
+        name: windows-server-unit-tests-cloud-environment
+        executor: windows
+        resource_class: windows.medium
+        requires:
+          - windows-build
 
-    # - server-unit-tests-cloud-environment:
-        # name: windows-server-unit-tests-cloud-environment
-        # executor: windows
-        # resource_class: windows.medium
-        # requires:
-          # - windows-build
+    - create-build-artifacts:
+        name: windows-create-build-artifacts
+        executor: windows
+        resource_class: windows.large
+        context:
+          - test-runner:sign-windows-binary
+          - test-runner:upload
+          - test-runner:commit-status-checks
+          - test-runner:build-binary
+        requires:
+          - windows-build
 
-    # - create-build-artifacts:
-        # name: windows-create-build-artifacts
-        # executor: windows
-        # resource_class: windows.large
-        # context:
-          # - test-runner:sign-windows-binary
-          # - test-runner:upload
-          # - test-runner:commit-status-checks
-          # - test-runner:build-binary
-        # requires:
-          # - windows-build
+    - test-binary-against-kitchensink-chrome:
+        name: windows-test-binary-against-kitchensink-chrome
+        executor: windows
+        requires:
+          - windows-create-build-artifacts
 
-    # - test-binary-against-kitchensink-chrome:
-        # name: windows-test-binary-against-kitchensink-chrome
-        # executor: windows
-        # requires:
-          # - windows-create-build-artifacts
-
-    # - v8-integration-tests:
-        # name: windows-v8-integration-tests
-        # executor: windows
-        # resource_class: windows.medium
-        # requires:
-          # - windows-build
-    # - driver-integration-memory-tests:
-        # name: windows-driver-integration-memory-tests
-        # executor: windows
-        # resource_class: windows.medium
-        # requires:
-          # - windows-build
+    - v8-integration-tests:
+        name: windows-v8-integration-tests
+        executor: windows
+        resource_class: windows.medium
+        requires:
+          - windows-build
+    - driver-integration-memory-tests:
+        name: windows-driver-integration-memory-tests
+        executor: windows
+        resource_class: windows.medium
+        requires:
+          - windows-build

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -592,8 +592,24 @@ darwin-arm64:
         requires:
           - darwin-arm64-build
 
+# Windows CI is expensive (see cost analysis linked from the app team), so unlike the other
+# platform workflows above it does not run on every develop/release push. It runs once daily
+# via CircleCI Scheduled Pipelines (configured in the CircleCI UI, not here) that set
+# run-windows-scheduled=true, plus on everything else &full-workflow-filters covers . To revert
+# to running on every develop/release push again, delete this `when:` and restore
+# `when: *full-workflow-filters`.
 windows:
-  when: *full-workflow-filters
+  when:
+    or:
+      - equal: [ true, << pipeline.parameters.run-windows-scheduled >> ]
+      - and:
+          - *full-workflow-filters
+          - not:
+              or:
+                - equal: [ develop, << pipeline.git.branch >> ]
+                - matches:
+                    pattern: /^release\/\d+\.\d+\.\d+$/
+                    value: << pipeline.git.branch >>
   jobs:
     - node_modules_install:
         name: windows-node-modules-install

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -595,7 +595,7 @@ darwin-arm64:
 # Windows CI is expensive (see cost analysis linked from the app team), so unlike the other
 # platform workflows above it does not run on every develop/release push. It runs once daily
 # via CircleCI Scheduled Pipelines (configured in the CircleCI UI, not here) that set
-# run-windows-scheduled=true, plus on everything else &full-workflow-filters covers . To revert
+# run-windows-scheduled=true, plus on everything else &full-workflow-filters covers. To revert
 # to running on every develop/release push again, delete this `when:` and restore
 # `when: *full-workflow-filters`.
 windows:

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -594,11 +594,11 @@ darwin-arm64:
 
 # Windows CI is expensive, so unlike the other platform workflows above it does not run on every 
 # develop/release push. It runs via CircleCI Scheduled Pipelines (configured in the CircleCI UI, not here)
-# that set run-windows-scheduled=true, plus on the other filters listed below.
+# that set run-windows-workflow=true, plus on the other filters listed below.
 windows:
   when:
     or:
-      - equal: [ true, << pipeline.parameters.run-windows-scheduled >> ]
+      - equal: [ true, << pipeline.parameters.run-windows-workflow >> ]
       - and:
           - *full-workflow-filters
           - not:

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -592,12 +592,9 @@ darwin-arm64:
         requires:
           - darwin-arm64-build
 
-# Windows CI is expensive (see cost analysis linked from the app team), so unlike the other
-# platform workflows above it does not run on every develop/release push. It runs once daily
-# via CircleCI Scheduled Pipelines (configured in the CircleCI UI, not here) that set
-# run-windows-scheduled=true, plus on everything else &full-workflow-filters covers. To revert
-# to running on every develop/release push again, delete this `when:` and restore
-# `when: *full-workflow-filters`.
+# Windows CI is expensive, so unlike the other platform workflows above it does not run on every 
+# develop/release push. It runs via CircleCI Scheduled Pipelines (configured in the CircleCI UI, not here)
+# that set run-windows-scheduled=true, plus on the other filters listed below.
 windows:
   when:
     or:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
<!-- /CURSOR_SUMMARY -->

- Closes <!-- no GitHub issue for this — tracked internally in Jira: [CF-4375](https://cypress-io.atlassian.net/browse/CF-4375) -->

### Additional details

Windows CI (`windows.large`/`windows.medium`) is currently the org's single largest CircleCI resource class, because the `windows` workflow re-runs its full 10-job graph on every push to `develop` and every `release/*` branch. This change moves `windows` off that per-push trigger for `develop` and `release/*` specifically, replacing it with two CircleCI Scheduled Pipelines (configured separately in the CircleCI UI, not in this repo) that run once daily and pass a new `run-windows-scheduled` pipeline parameter.

What's unchanged:
- `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64` — completely untouched, still push-triggered exactly as today (`&full-workflow-filters` is unmodified).
- `windows` still runs immediately on push for `electron/*` branches, `force-persist-artifacts` runs, the `update-v8-snapshot-cache-on-develop` bot branch, and the existing ad-hoc branch opt-in (see `.circleci/AGENTS.md`) — only plain `develop`/`release/*` pushes are excluded.
- This is a stopgap; may be reverted if/when self-hosted Windows runners land (see comment above the `windows` workflow in `@main.yml` for the one-line revert).

This is a Draft PR — holding until the app team has been notified/aligned on this change before requesting review.

### Steps to test

- `yarn pack-ci --all --validate` compiles and validates cleanly.
- Trigger a manual pipeline run against this branch with `run-windows-scheduled=true` via the CircleCI API — confirms `windows` runs.
- Trigger a plain manual run against this branch (no param) — confirms `windows` is skipped.
- After merge, confirm the two Scheduled Pipelines (targeting `develop` and `release/16.0.0`) are created and firing as expected.

### How has the user experience changed?

No change — this only affects internal CI infrastructure, not the Cypress product or CLI.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- tracked in Jira internally, no public GitHub issue -->
- [na] Have tests been added/updated? <!-- CI config change; verified via yarn pack-ci --validate, see Steps to test -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- no user-facing change -->
- [na] Have API changes been updated in the type definitions? <!-- no API change -->


[CF-4375]: https://cypress-io.atlassian.net/browse/CF-4375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ