### PR TITLE
chore: replace p-defer with native Promise.withResolvers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,17 @@ Good examples:
 // Domain and let the cookie default to host-only.
 ```
 
+## Runtime targets
+
+Code in this monorepo runs in several runtimes, each with its own JavaScript / runtime-API floor. Before using a modern JS or Node/DOM API, identify which runtime a file executes in and confirm the API is supported there — do **not** assume the development Node version. Where each floor is defined:
+
+- **Dev tooling, gulp, build/dev scripts** — the Node version in [`.node-version`](./.node-version).
+- **The bundled app (main/Electron process)** — the Node embedded in the `electron` version pinned in the root [`package.json`](./package.json) (look up that Electron release's Node/V8).
+- **The config/plugins child process** (`@packages/server` `lib/plugins/child/require_async_child.ts`, forked by `@packages/data-context` `ProjectConfigIpc`) and the **`cypress` CLI** (`cli/`) — the *user's* Node, whose supported range is `engines.node` in [`cli/package.json`](./cli/package.json). This floor is lower than the dev/bundled Node, so it is the binding constraint for that code.
+- **Browser-shipped bundles** (`@packages/app`, `@packages/frontend-shared`, `@packages/driver`) — the last 3 major versions of the supported browsers. Since Safari releases majors roughly annually, the last 3 major versions reach back years, making this the most conservative floor. `@packages/driver` runs in the user's AUT browser. For WebKit, Cypress runs the WebKit bundled with the installed `playwright-webkit` version — not the user's system Safari — so the WebKit floor tracks that dependency.
+
+Verify an API against the relevant floor (node.green for Node, caniuse/MDN for browsers) before relying on it.
+
 ## Pull Requests
 
 [`CONTRIBUTING.md`](./CONTRIBUTING.md) is the source of truth for PR conventions, including the semantic-release title prefix that determines the next version. The other essentials:

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "mocha-multi-reporters": "1.1.7",
     "mock-fs": "5.4.0",
     "npm-packlist": "9.0.0",
-    "p-defer": "^3.0.0",
     "patch-package": "8.0.1",
     "playwright-webkit": "1.61.0",
     "pluralize": "8.0.0",
@@ -197,7 +196,7 @@
     "through2": "^4.0.2",
     "tree-kill": "1.2.2",
     "ts-node": "^10.9.2",
-    "typescript": "5.3.3",
+    "typescript": "~5.4.5",
     "vitest": "^3.2.4",
     "yaml": "2.8.0",
     "yarn-deduplicate": "3.1.0"

--- a/packages/app/cypress/e2e/studio/studio-ui.cy.ts
+++ b/packages/app/cypress/e2e/studio/studio-ui.cy.ts
@@ -1,5 +1,4 @@
 import { launchStudio, loadProjectAndRunSpec } from './helper'
-import pDefer from 'p-defer'
 
 describe('Cypress Studio - UI and Panel Management', () => {
   it('shows Run test button label in single-test mode', () => {
@@ -75,7 +74,7 @@ describe('studio functionality', () => {
   })
 
   it('immediately loads the studio panel from existing test', () => {
-    const deferred = pDefer()
+    const deferred = Promise.withResolvers<void>()
 
     loadProjectAndRunSpec()
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -67,7 +67,6 @@
     "lodash": "4.17.23",
     "mobx": "6.13.6",
     "nanoid": "^5.1.3",
-    "p-defer": "^3.0.0",
     "pinia": "2.0.0-rc.14",
     "rollup-plugin-copy": "3.4.0",
     "simple-git": "^3.32.3",

--- a/packages/app/src/runner/injectBundle.ts
+++ b/packages/app/src/runner/injectBundle.ts
@@ -1,6 +1,4 @@
-import pDefer from 'p-defer'
-
-export const dfd = pDefer()
+export const dfd = Promise.withResolvers<void>()
 
 export function injectBundle (namespace: string) {
   const script = document.createElement('script')

--- a/packages/app/vite.config.mjs
+++ b/packages/app/vite.config.mjs
@@ -13,7 +13,6 @@ const config = makeConfig({
       '@cypress-design/**',
       '@cypress-design/vue-button',
       'debug',
-      'p-defer',
       'bluebird',
       'events',
       '@popperjs/core',

--- a/packages/data-context/AGENTS.md
+++ b/packages/data-context/AGENTS.md
@@ -48,6 +48,7 @@ schemas/               JSON schema definitions
 - The `browser` field in `package.json` points to `src/index.ts` (source), which allows Vite-based consumers (`app`, `launchpad`, `frontend-shared`) to import TypeScript directly without a pre-build step.
 - The GraphQL schema is built in two phases: (1) `build:schema` emits a JSON SDL, (2) `build:graphql` runs graphql-codegen against it for downstream consumers.
 - **CI coverage for schema / codegen**: The CircleCI `build` job runs `yarn build`, which invokes `lerna run build` and therefore this package’s `build` script (`build:schema`, `build:graphql`, `nexus-build`). Changes to `PACKAGE_MANAGERS` in `@packages/types`, Nexus `PackageManagerEnum`, or hand-edited `schemas/schema.graphql` must leave `yarn workspace @packages/data-context build` (and committed generated artifacts where applicable) passing so PRs stay green.
+- `ProjectConfigIpc` forks the config/plugins child (`@packages/server` `lib/plugins/child/require_async_child.ts`) using the user's resolved Node (`coreData.app.nodePath`), not the bundled/dev Node. Code reachable from that child must stay within the user-Node floor (`engines.node` in `cli/package.json`). See root `AGENTS.md` → Runtime targets.
 
 ## Integration Points
 

--- a/packages/data-context/graphql/makeGraphQLServer.ts
+++ b/packages/data-context/graphql/makeGraphQLServer.ts
@@ -1,7 +1,6 @@
 import express, { Request } from 'express'
 import type { AddressInfo, Socket } from 'net'
 import { DataContext, getCtx, globalPubSub, GraphQLRequestInfo } from '../src'
-import pDefer from 'p-defer'
 import cors from 'cors'
 import { corsOriginDelegate, isOriginAllowed } from './corsOriginDelegate'
 import { SocketIONamespace, SocketIOServer } from '@packages/socket'
@@ -34,7 +33,7 @@ globalPubSub.on('reset:data-context', (ctx) => {
 })
 
 export async function makeGraphQLServer () {
-  const dfd = pDefer<number>()
+  const dfd = Promise.withResolvers<number>()
   const app = express()
 
   app.use(cors(corsOriginDelegate))

--- a/packages/data-context/graphql/utils/nexusTypegenUtils.ts
+++ b/packages/data-context/graphql/utils/nexusTypegenUtils.ts
@@ -2,7 +2,6 @@
 /* eslint-disable no-restricted-syntax */
 import { spawn, execSync } from 'child_process'
 import chalk from 'chalk'
-import pDefer from 'p-defer'
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -32,7 +31,7 @@ async function windowsTouch (filename: string, time: Date) {
 }
 
 async function nexusTypegen (cfg: NexusTypegenCfg) {
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
 
   if (cfg.outputPath) {
     await fs.ensureDir(path.join(dataContextPackageRoot, 'src/gen'))

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -61,7 +61,6 @@
     "minimatch": "3.1.3",
     "nexus": "^1.2.0-next.15",
     "node-machine-id": "1.1.12",
-    "p-defer": "^3.0.0",
     "parse-glob": "3.0.4",
     "prettier": "2.8.8",
     "randexp": "0.5.3",

--- a/packages/data-context/src/actions/DataEmitterActions.ts
+++ b/packages/data-context/src/actions/DataEmitterActions.ts
@@ -1,4 +1,3 @@
-import pDefer from 'p-defer'
 import { EventEmitter } from 'stream'
 import { DataContext } from '../DataContext'
 import type { CloudRun, RelevantRun } from '../gen/graphcache-config.gen'
@@ -236,7 +235,7 @@ export class DataEmitterActions extends DataEmitterEvents {
   subscribeTo <T> (evt: keyof DataEmitterEvents, opts?: {sendInitial: boolean, initialValue?: T, filter?: (val: any) => boolean, onUnsubscribe?: (listenerCount: number) => void }): AsyncGenerator<T> {
     const { sendInitial = true } = opts ?? {}
     let hasSentInitial = false
-    let dfd: pDefer.DeferredPromise<any> | undefined
+    let dfd: PromiseWithResolvers<any> | undefined
     let pending: any[] = []
     let done = false
 
@@ -276,7 +275,7 @@ export class DataEmitterActions extends DataEmitterEvents {
         }
 
         if (pending.length === 0) {
-          dfd = pDefer()
+          dfd = Promise.withResolvers()
 
           return await dfd.promise
         }

--- a/packages/data-context/src/actions/LocalSettingsActions.ts
+++ b/packages/data-context/src/actions/LocalSettingsActions.ts
@@ -1,5 +1,4 @@
 import { AllowedState, defaultPreferences, Editor, NotifyCompletionStatuses } from '@packages/types'
-import pDefer from 'p-defer'
 import _ from 'lodash'
 import Debug from 'debug'
 
@@ -52,7 +51,7 @@ export class LocalSettingsActions {
 
     debug('refresh local settings')
 
-    const dfd = pDefer<Editor[]>()
+    const dfd = Promise.withResolvers<Editor[]>()
 
     this.ctx.coreData.localSettings.refreshing = dfd.promise
 
@@ -78,6 +77,6 @@ export class LocalSettingsActions {
       await this.ctx._apis.localSettingsApi.setPreferences(preferences)
     }
 
-    dfd.resolve()
+    dfd.resolve(availableEditors)
   }
 }

--- a/packages/data-context/src/data/ProjectLifecycleManager.ts
+++ b/packages/data-context/src/data/ProjectLifecycleManager.ts
@@ -17,7 +17,6 @@ import type { AllModeOptions, FoundBrowser, FullConfig, TestingType } from '@pac
 import { autoBindDebug } from '../util/autoBindDebug'
 import { EventCollectorSource, GitDataSource } from '../sources'
 import { OnFinalConfigLoadedOptions, ProjectConfigManager } from './ProjectConfigManager'
-import pDefer from 'p-defer'
 import { EventRegistrar } from './EventRegistrar'
 import { getServerPluginHandlers, resetPluginHandlers } from '../util/pluginHandlers'
 import { detectLanguage } from '@packages/scaffold-config'
@@ -56,7 +55,7 @@ export class ProjectLifecycleManager {
   private _projectRoot: string | undefined
   private _configManager: ProjectConfigManager | undefined
   private _projectMetaState: ProjectMetaState = { ...PROJECT_META_STATE }
-  private _pendingInitialize?: pDefer.DeferredPromise<FullConfig>
+  private _pendingInitialize?: PromiseWithResolvers<FullConfig>
   private _cachedInitialConfig: Cypress.ConfigOptions | undefined
   private _cachedFullConfig: FullConfig | undefined
   private _initializedProject: unknown | undefined
@@ -825,7 +824,7 @@ export class ProjectLifecycleManager {
   }
 
   async initializeRunMode (testingType: TestingType | null) {
-    this._pendingInitialize = pDefer()
+    this._pendingInitialize = Promise.withResolvers()
 
     if (await this.waitForInitializeSuccess()) {
       if (!this.metaState.hasValidConfigFile) {

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import os from 'os'
 import simpleGit from 'simple-git'
 import fs from 'fs-extra'
-import pDefer from 'p-defer'
 import chokidar from 'chokidar'
 
 import { scaffoldMigrationProject } from '../helper'
@@ -45,7 +44,7 @@ describe('GitDataSource', () => {
 
   it(`gets correct status for files on ${os.platform()}`, async function () {
     const onBranchChange = jest.fn()
-    const dfd = pDefer()
+    const dfd = Promise.withResolvers()
 
     // create a file and modify a file to express all
     // git states we are interested in (created, unmodified, modified)
@@ -120,7 +119,7 @@ describe('GitDataSource', () => {
     .map((filename) => path.join(e2eFolder, filename))
     .map((filepath) => toPosix(filepath))
 
-    const dfd = pDefer()
+    const dfd = Promise.withResolvers()
 
     gitInfo = new GitDataSource({
       isRunMode: false,
@@ -154,7 +153,7 @@ describe('GitDataSource', () => {
 
   it(`watches switching branches on ${os.platform()}`, async () => {
     const stub = jest.fn()
-    const dfd = pDefer()
+    const dfd = Promise.withResolvers()
 
     stub.mockImplementationOnce(dfd.resolve)
 
@@ -170,7 +169,7 @@ describe('GitDataSource', () => {
 
     expect(result).toEqual((await git.branch()).current)
 
-    const switchBranch = pDefer()
+    const switchBranch = Promise.withResolvers()
 
     stub.mockImplementationOnce(switchBranch.resolve)
 
@@ -194,7 +193,7 @@ describe('GitDataSource', () => {
 
     const errorStub = jest.fn()
     const stub = jest.fn()
-    const dfd = pDefer()
+    const dfd = Promise.withResolvers()
 
     stub.mockImplementationOnce(dfd.resolve)
 
@@ -215,7 +214,7 @@ describe('GitDataSource', () => {
 
   describe('Git Hashes - no fake timers', () => {
     it('does not include commits that are part of the Git tree from a merge', async () => {
-      const dfd = pDefer()
+      const dfd = Promise.withResolvers()
 
       const logCallback = jest.fn()
 

--- a/packages/data-context/test/unit/sources/GitDataSource_unit.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource_unit.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, jest } from '@jest/globals'
-import pDefer, { DeferredPromise } from 'p-defer'
 import EventEmitter from 'events'
 
 import type { SimpleGit } from 'simple-git'
@@ -52,7 +51,7 @@ describe('GitDataSource', () => {
   describe('Unit', () => {
     describe('in run mode', () => {
       it('does not load git info when setSpecs is called', async () => {
-        const revparseP = pDefer<void>()
+        const revparseP = Promise.withResolvers<void>()
 
         stubbedSimpleGit.revparse.mockImplementationOnce((opts: string) => {
           revparseP.resolve()
@@ -97,12 +96,12 @@ describe('GitDataSource', () => {
       const firstHashesReturnValue = ['abc']
       const secondHashes = [...firstHashes, { hash: 'efg' }]
       const secondHashesReturnValue = [...firstHashesReturnValue, 'efg']
-      let firstGitLogCall: DeferredPromise<void>
-      let secondGitLogCall: DeferredPromise<void>
+      let firstGitLogCall: PromiseWithResolvers<void>
+      let secondGitLogCall: PromiseWithResolvers<void>
 
       beforeEach(async () => {
-        firstGitLogCall = pDefer()
-        secondGitLogCall = pDefer()
+        firstGitLogCall = Promise.withResolvers()
+        secondGitLogCall = Promise.withResolvers()
         branchName = 'main'
         onBranchChange = jest.fn()
         onGitInfoChange = jest.fn()
@@ -124,7 +123,7 @@ describe('GitDataSource', () => {
         // #verifyGitRepo
 
         // constructor verifies the repo in open mode via #refreshAllGitData, but does not wait for it :womp:
-        const revparseP = pDefer<void>()
+        const revparseP = Promise.withResolvers<void>()
 
         stubbedSimpleGit.revparse.mockImplementationOnce((opts: string) => {
           revparseP.resolve()
@@ -138,7 +137,7 @@ describe('GitDataSource', () => {
         // #loadAndWatchCurrentBranch
 
         // next in initialization, it loads the current branch
-        const branchP = pDefer<void>()
+        const branchP = Promise.withResolvers<void>()
 
         // again, ignoring type warning re: chaining
         stubbedSimpleGit.branch.mockImplementationOnce((opts: P<'branch'>) => {
@@ -147,7 +146,7 @@ describe('GitDataSource', () => {
           return Promise.resolve({ current: branchName }) as unknown as R<'branch'>
         })
 
-        const onBranchChangeP = pDefer<void>()
+        const onBranchChangeP = Promise.withResolvers<void>()
 
         onBranchChange.mockImplementationOnce(() => onBranchChangeP.resolve())
 

--- a/packages/driver/tsconfig.json
+++ b/packages/driver/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../ts/tsconfig.json",
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable", "ESNext.Promise"],
     "noImplicitThis": false,
     "preserveWatchOutput": true,
     "sourceMap": true,

--- a/packages/electron/src/open.ts
+++ b/packages/electron/src/open.ts
@@ -7,7 +7,6 @@ import inspector from 'inspector'
 import { ChildProcess, spawn } from 'child_process'
 import Debug from 'debug'
 import os from 'os'
-import pDefer from 'p-defer'
 
 function getInspectFromUrl (url: string): string {
   const flag = process.execArgv.some((f) => f === '--inspect' || f.startsWith('--inspect=')) ? '--inspect' : '--inspect-brk'
@@ -80,7 +79,7 @@ export async function open (
       { stdio: 'pipe' },
     )
 
-    const childClosed = pDefer<number>()
+    const childClosed = Promise.withResolvers<number>()
 
     spawned.on('error', (err) => {
       console.error(err)

--- a/packages/electron/tsconfig.base.json
+++ b/packages/electron/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "ESNext.Promise"],
     "module": "ESNext",
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
+++ b/packages/frontend-shared/cypress/e2e/e2ePluginSetup.ts
@@ -35,7 +35,6 @@ import nock from 'nock'
 import { CYPRESS_REMOTE_MANIFEST_URL, NPM_CYPRESS_REGISTRY_URL } from '@packages/types'
 
 import { CloudQuery } from '@packages/data-context/test/graphql/stubCloudTypes'
-import pDefer from 'p-defer'
 import { Readable } from 'stream'
 
 const pkg = require('@packages/root')
@@ -548,7 +547,6 @@ async function makeE2ETasks () {
         require,
         process,
         sinon,
-        pDefer,
         projectDir (projectName) {
           if (!fixtureDirs.includes(projectName)) {
             throw new Error(`${projectName} is not a fixture project`)

--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -9,7 +9,6 @@ import { GET_MAJOR_VERSION_FOR_CONTENT, type Browser, type FoundBrowser, type Op
 
 import type { SinonStub } from 'sinon'
 import type sinon from 'sinon'
-import type pDefer from 'p-defer'
 import 'cypress-plugin-tab'
 import type { Response } from 'cross-fetch'
 import type nock from 'nock'
@@ -40,7 +39,6 @@ export interface WithCtxInjected extends WithCtxOptions {
   require: typeof require
   process: typeof process
   sinon: typeof sinon
-  pDefer: typeof pDefer
   testState: Record<string, any>
   projectDir(projectName: ProjectFixtureDir): string
 }
@@ -320,7 +318,7 @@ function startAppServer (mode: 'component' | 'e2e' = 'e2e', options: { skipMocki
       return cy.withCtx(async (ctx, o) => {
         await ctx.lifecycleManager.waitForInitializeSuccess()
         ctx.actions.project.setAndLoadCurrentTestingType(o.mode)
-        const isInitialized = o.pDefer()
+        const isInitialized = Promise.withResolvers()
         const initializeActive = ctx.actions.project.initializeActiveProject
         const onErrorStub = o.sinon.stub(ctx, 'onError')
         const onLoadErrorStub = o.sinon.stub(ctx.lifecycleManager, 'onLoadError')

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -84,7 +84,6 @@
     "lodash": "4.17.23",
     "markdown-it": "13.0.1",
     "nock": "13.2.9",
-    "p-defer": "^3.0.0",
     "patch-package": "8.0.1",
     "postcss": "^8.4.22",
     "shiki": "^0.9.12",

--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -82,7 +82,7 @@ describe('Launchpad: Open Mode', () => {
             'x-framework': 'react',
             'x-dev-server': 'webpack',
             'x-notifications': 'failed',
-            'x-dependencies': 'typescript@5.3.3',
+            'x-dependencies': o.sinon.match(/^typescript@\d+\.\d+\.\d+/),
           },
         })
       })

--- a/packages/launchpad/cypress/e2e/slow-network.cy.ts
+++ b/packages/launchpad/cypress/e2e/slow-network.cy.ts
@@ -10,7 +10,7 @@ describe('slow network: launchpad', () => {
       (ctx.util.fetch as Sinon.SinonStub).restore()
       o.testState.pendingFetches = []
       o.sinon.stub(ctx.util, 'fetch').callsFake(async (input, init) => {
-        const dfd = o.pDefer()
+        const dfd = Promise.withResolvers()
 
         o.testState.pendingFetches.push(dfd)
 

--- a/packages/proxy/lib/http/util/service-worker-manager.ts
+++ b/packages/proxy/lib/http/util/service-worker-manager.ts
@@ -1,5 +1,4 @@
 import Debug from 'debug'
-import pDefer from 'p-defer'
 import type { BrowserPreRequest } from '../../types'
 import type Protocol from 'devtools-protocol'
 
@@ -93,7 +92,7 @@ export class ServiceWorkerManager {
   private serviceWorkerRegistrations: Map<string, ServiceWorkerRegistration> = new Map<string, ServiceWorkerRegistration>()
   private pendingInitiators: Map<string, string> = new Map<string, string>()
   private pendingControlledUrls: Map<string, string[]> = new Map<string, string[]>()
-  private pendingPotentiallyControlledRequests: Map<string, pDefer.DeferredPromise<boolean>[]> = new Map<string, pDefer.DeferredPromise<boolean>[]>()
+  private pendingPotentiallyControlledRequests: Map<string, PromiseWithResolvers<boolean>[]> = new Map<string, PromiseWithResolvers<boolean>[]>()
   private pendingServiceWorkerFetches: Map<string, boolean[]> = new Map<string, boolean[]>()
 
   /**
@@ -381,7 +380,7 @@ export class ServiceWorkerManager {
       this.pendingPotentiallyControlledRequests.set(url, promises)
     }
 
-    const deferred = pDefer<boolean>()
+    const deferred = Promise.withResolvers<boolean>()
 
     promises.push(deferred)
     debug('adding pending controlled request promise: %o', { url, requestId: browserPreRequest.requestId })

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -25,7 +25,6 @@
     "grapheme-splitter": "1.0.4",
     "iconv-lite": "0.6.2",
     "lodash": "^4.17.19",
-    "p-defer": "3.0.0",
     "pumpify": "1.5.1",
     "through": "2.3.8",
     "utf8-stream": "0.0.0"

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -49,6 +49,7 @@ yarn workspace @packages/server build-prod
 - E2E/system tests have moved to `system-tests/`; only unit and integration tests live in `test/unit` and `test/integration`.
 - `better-sqlite3` requires native compilation; run `yarn workspace @packages/server rebuild-better-sqlite3` after an Electron version upgrade.
 - Several dependencies (e.g., `axios`, `devtools-protocol`, `geckodriver`) are nohoisted to avoid version conflicts.
+- **The config/plugins child runs under the user's Node, not the bundled/dev Node.** `lib/plugins/child/require_async_child.ts` (and everything reachable from it) is forked with the user's resolved Node; its supported range is `engines.node` in `cli/package.json`, which is lower than the dev floor (`.node-version`) or the bundled Electron. Do not use runtime APIs newer than that floor in this path — the rest of the server runs in the bundled Electron main process. See root `AGENTS.md` → Runtime targets.
 
 **Integration Points**
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-command-queue.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-command-queue.ts
@@ -1,5 +1,4 @@
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
-import pDefer, { DeferredPromise } from 'p-defer'
 import type { CdpCommand } from './cdp_automation'
 import Debug from 'debug'
 
@@ -11,7 +10,7 @@ type CommandReturn<T extends CdpCommand> = ProtocolMapping.Commands[T]['returnTy
 export type Command<T extends CdpCommand> = {
   command: T
   params?: object
-  deferred: DeferredPromise<CommandReturn<T>>
+  deferred: PromiseWithResolvers<CommandReturn<T>>
   sessionId?: string
 }
 
@@ -30,7 +29,7 @@ export class CDPCommandQueue {
     debug('enqueing command %s', command)
     debugVerbose('enqueing command %s with params %o', command, params)
 
-    const deferred = pDefer<CommandReturn<TCmd>>()
+    const deferred = Promise.withResolvers<CommandReturn<TCmd>>()
 
     const commandPackage: Command<TCmd> = {
       command,

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -1,6 +1,5 @@
 import type { Protocol } from 'devtools-protocol'
 import debugModule from 'debug'
-import pDefer from 'p-defer'
 import { Readable } from 'stream'
 import { promisify } from 'util'
 import zlib from 'zlib'
@@ -46,7 +45,7 @@ export interface CdpFetchTransportResponse extends CdpFetchTransportRequest {
 }
 
 export class CdpFetchTransport {
-  private readonly inFlightRequests = new Map<string, pDefer.DeferredPromise<CdpFetchTransportResponse>>()
+  private readonly inFlightRequests = new Map<string, PromiseWithResolvers<CdpFetchTransportResponse>>()
 
   private isStarted = false
 
@@ -152,7 +151,7 @@ export class CdpFetchTransport {
     let response: CdpFetchTransportResponse | undefined
     let responseRequestId: string | undefined
     let responseSessionId: string | undefined
-    let deferred: pDefer.DeferredPromise<CdpFetchTransportResponse> | undefined
+    let deferred: PromiseWithResolvers<CdpFetchTransportResponse> | undefined
 
     try {
       debug('intercepting request pause %s %s (fetchRequestId=%s, networkRequestId=%s, resourceType=%s)',
@@ -192,7 +191,7 @@ export class CdpFetchTransport {
         request.headers[AUT_FRAME_HEADER.toLowerCase()] = 'true'
       }
 
-      const responseDeferred = pDefer<CdpFetchTransportResponse>()
+      const responseDeferred = Promise.withResolvers<CdpFetchTransportResponse>()
 
       // reset()/stop() may reject this before the continue callback races on
       // it (e.g. a between-tests reset while request middleware is still
@@ -564,7 +563,7 @@ export class CdpFetchTransport {
   // Must NOT clear extraInfo tracking on success — the next response under a
   // reused network id may already be tracked, and CDPNetworkExtraInfo manages
   // its own lifecycle. Errored and unmatched flows clear at their own sites.
-  private cleanup (fetchRequestId: string, deferred?: pDefer.DeferredPromise<CdpFetchTransportResponse>): void {
+  private cleanup (fetchRequestId: string, deferred?: PromiseWithResolvers<CdpFetchTransportResponse>): void {
     if (deferred && this.inFlightRequests.get(fetchRequestId) !== deferred) {
       return
     }

--- a/packages/server/lib/browsers/cdp-protocol/cdp-network-extra-info.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-network-extra-info.ts
@@ -1,6 +1,5 @@
 import type { Protocol } from 'devtools-protocol'
 import debugModule from 'debug'
-import pDefer from 'p-defer'
 import type { ICriClient } from './cri-client'
 
 const debug = debugModule('cypress:server:browsers:cdp-network-extra-info')
@@ -8,7 +7,7 @@ const debug = debugModule('cypress:server:browsers:cdp-network-extra-info')
 type CDPNetworkExtraInfoClient = Pick<ICriClient, 'on' | 'off'>
 
 type ExtraInfoDeferred = {
-  deferred: pDefer.DeferredPromise<Protocol.Network.ResponseReceivedExtraInfoEvent | undefined>
+  deferred: PromiseWithResolvers<Protocol.Network.ResponseReceivedExtraInfoEvent | undefined>
   // requestWillBeSentExtraInfo arrived: this transaction is on the
   // instrumented wire path, so a response extraInfo will follow — hold for it
   expectsExtraInfo: boolean
@@ -216,7 +215,7 @@ export class CDPNetworkExtraInfo {
     // chain (same request id), so replace it
     if (!entry || entry.consumed) {
       entry = {
-        deferred: pDefer<Protocol.Network.ResponseReceivedExtraInfoEvent | undefined>(),
+        deferred: Promise.withResolvers<Protocol.Network.ResponseReceivedExtraInfoEvent | undefined>(),
         expectsExtraInfo: false,
         settled: false,
         consumed: false,

--- a/packages/server/lib/plugins/child/require_async_child.ts
+++ b/packages/server/lib/plugins/child/require_async_child.ts
@@ -1,7 +1,6 @@
 process.title = 'Cypress: Config Manager'
 
 import os from 'os'
-import pDefer from 'p-defer'
 import Debug from 'debug'
 import { telemetry, OTLPTraceExporterIpc, decodeTelemetryContext } from '@packages/telemetry'
 import minimist from 'minimist'
@@ -52,12 +51,15 @@ const ipc = util.wrapIpc(process as unknown as util.WrappedIpcProcess)
 exporter.attachIPC(ipc)
 
 let disconnection: Promise<void> | null = null
-const willDisconnect = pDefer<void>()
+let resolveWillDisconnect!: () => void
+const willDisconnect = new Promise<void>((resolve) => {
+  resolveWillDisconnect = resolve
+})
 
 process.on('disconnect', async () => {
   try {
     debug('received disconnect event')
-    willDisconnect.resolve()
+    resolveWillDisconnect()
     await Promise.resolve() // allow for diconnect teardown to complete, if in process
   } finally {
     process.exit()
@@ -81,14 +83,14 @@ ipc.on('main:process:will:disconnect', async () => {
 
   debug('sending main:process:will:disconnect:ack')
   ipc.send('main:process:will:disconnect:ack')
-  willDisconnect.resolve()
+  resolveWillDisconnect()
 })
 
 ;['SIGINT', 'SIGTERM'].forEach((signal) => {
   process.on(signal, async () => {
     debug('received signal', signal)
     await Promise.race([
-      willDisconnect.promise,
+      willDisconnect,
       new Promise<void>((resolve) => {
         setTimeout(() => {
           debug('timeout waiting for main:process:will:disconnect signal')

--- a/packages/server/lib/socket-ct.ts
+++ b/packages/server/lib/socket-ct.ts
@@ -1,7 +1,6 @@
 import Debug from 'debug'
 import devServer from './plugins/dev-server'
 import { SocketBase } from './socket-base'
-import dfd from 'p-defer'
 import type { Socket } from '@packages/socket'
 import type { DestroyableHttpServer } from './util/server_destroy'
 import assert from 'assert'
@@ -9,7 +8,7 @@ import type { Automation } from './automation'
 const debug = Debug('cypress:server:socket-ct')
 
 export class SocketCt extends SocketBase {
-  #destroyAutPromise?: dfd.DeferredPromise<void>
+  #destroyAutPromise?: PromiseWithResolvers<void>
 
   constructor (config: Record<string, any>) {
     super(config)
@@ -57,7 +56,7 @@ export class SocketCt extends SocketBase {
   }
 
   destroyAut () {
-    this.#destroyAutPromise = dfd()
+    this.#destroyAutPromise = Promise.withResolvers<void>()
 
     this.toRunner('aut:destroy:init')
 

--- a/packages/server/lib/util/graceful_crash_handling.ts
+++ b/packages/server/lib/util/graceful_crash_handling.ts
@@ -2,7 +2,6 @@ import type { ProjectBase } from '../project-base'
 import type { BaseReporterResults, ReporterResults, ReporterTestError } from '../types/reporter'
 import { log, stackUtils, stripAnsi } from '@packages/errors'
 import Debug from 'debug'
-import pDefer, { DeferredPromise } from 'p-defer'
 
 const debug = Debug('cypress:util:crash_handling')
 
@@ -104,13 +103,13 @@ const defaultStats = (error: Error): BaseReporterResults => {
 }
 
 export class EarlyExitTerminator {
-  private terminator: DeferredPromise<BaseReporterResults>
+  private terminator: PromiseWithResolvers<BaseReporterResults>
 
   private pendingRunnable: any
   private intermediateStats: ReporterResults | undefined
 
   constructor () {
-    this.terminator = pDefer<BaseReporterResults>()
+    this.terminator = Promise.withResolvers<BaseReporterResults>()
   }
 
   waitForEarlyExit (project: ProjectBase) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -99,7 +99,6 @@
     "morgan": "1.9.1",
     "node-machine-id": "1.1.12",
     "ospath": "1.2.2",
-    "p-defer": "^3.0.0",
     "p-queue": "6.1.0",
     "pidusage": "3.0.2",
     "pluralize": "8.0.0",

--- a/packages/server/test/integration/cdp_spec.ts
+++ b/packages/server/test/integration/cdp_spec.ts
@@ -6,7 +6,6 @@ import WebSocket from 'ws'
 import { CdpCommand, CdpEvent } from '../../lib/browsers/cdp-protocol/cdp_automation'
 import { CriClient } from '../../lib/browsers/cdp-protocol/cri-client'
 import { expect, nock } from '../spec_helper'
-import pDefer from 'p-defer'
 import sinon from 'sinon'
 
 const debug = Debug('cypress:server:tests')
@@ -28,7 +27,7 @@ describe('CDP Clients', () => {
   let wsClient: WebSocket
   let messages: object[]
   let onMessage: sinon.SinonStub
-  let messageResponse: ReturnType<typeof pDefer> | undefined
+  let messageResponse: ReturnType<typeof Promise.withResolvers> | undefined
   let neverAck: boolean
 
   const startWsServer = async (onConnection?: OnWSConnection): Promise<WebSocket.Server> => {
@@ -122,11 +121,11 @@ describe('CDP Clients', () => {
   it('properly handles various ways to add event listeners', async () => {
     const sessionId = 'abc123'
     const method = `Network.responseReceived`
-    const sessionDeferred = pDefer<void>()
+    const sessionDeferred = Promise.withResolvers<void>()
     const sessionCb = sinon.stub().callsFake(sessionDeferred.resolve)
-    const eventDeferred = pDefer<void>()
+    const eventDeferred = Promise.withResolvers<void>()
     const eventCb = sinon.stub().callsFake(eventDeferred.resolve)
-    const globalDeferred = pDefer<void>()
+    const globalDeferred = Promise.withResolvers<void>()
     const globalCb = sinon.stub().callsFake(globalDeferred.resolve)
     const params = { foo: 'bar' }
 
@@ -268,8 +267,8 @@ describe('CDP Clients', () => {
         command: 'DOM.getDocument',
         params: { depth: -1 },
       }
-      let reconnectPromise = pDefer()
-      let commandSent = pDefer()
+      let reconnectPromise = Promise.withResolvers()
+      let commandSent = Promise.withResolvers()
       const reconnectOnThirdTry = sinon.stub().onThirdCall().callsFake(async () => {
         wsSrv = await startWsServer((ws) => {
         })
@@ -295,7 +294,7 @@ describe('CDP Clients', () => {
       await commandSent.promise
       await Promise.all([clientDisconnected(), closeWsServer()])
 
-      commandSent = pDefer()
+      commandSent = Promise.withResolvers()
       onMessage.resetHistory()
 
       reconnectOnThirdTry.resetHistory()
@@ -306,10 +305,10 @@ describe('CDP Clients', () => {
 
       reconnectOnThirdTry.resetHistory()
 
-      reconnectPromise = pDefer()
+      reconnectPromise = Promise.withResolvers()
 
       // set up response value
-      messageResponse = pDefer()
+      messageResponse = Promise.withResolvers()
 
       neverAck = false
 
@@ -323,8 +322,8 @@ describe('CDP Clients', () => {
     })
 
     it('reattaches subscriptions, reenables enablements, and sends pending commands on reconnect', async () => {
-      let reconnectPromise = pDefer()
-      let commandSent = pDefer()
+      let reconnectPromise = Promise.withResolvers()
+      let commandSent = Promise.withResolvers()
       let wsClient
       const reconnectOnThirdTry = sinon.stub().onThirdCall().callsFake(async () => {
         wsSrv = await startWsServer((ws) => {
@@ -388,7 +387,7 @@ describe('CDP Clients', () => {
       neverAck = true
       // send each command, and wait for them to be sent (but not responded to)
       for (let i = 0; i < commandsToEnqueue.length; i++) {
-        commandSent = pDefer()
+        commandSent = Promise.withResolvers()
         const command = commandsToEnqueue[i]
 
         commandsToEnqueue[i].promise = criClient.send(command.command, command.params)
@@ -434,7 +433,7 @@ describe('CDP Clients', () => {
       // for full integration, send events that should be subscribed to, and expect that subscription
       // callback to be called
       for (const { eventName, cb, mockEvent } of subscriptions) {
-        const deferred = pDefer()
+        const deferred = Promise.withResolvers()
 
         cb.onFirstCall().callsFake(deferred.resolve)
         wsClient.send(JSON.stringify({

--- a/packages/server/test/unit/browsers/cdp-command-queue_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-command-queue_spec.ts
@@ -1,6 +1,5 @@
 import { CDPCommandQueue, Command } from '../../../lib/browsers/cdp-protocol/cdp-command-queue'
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
-import pDeferred from 'p-defer'
 import _ from 'lodash'
 
 const { expect } = require('../../spec_helper')
@@ -152,7 +151,7 @@ describe('CDPCommandQueue', () => {
       const queue = new CDPCommandQueue()
 
       queue.add(enableAnimation.command, enableAnimation.params)
-      const deferred = pDeferred()
+      const deferred = Promise.withResolvers()
 
       queue.unshift({
         command: enableAnimation.command,

--- a/packages/server/test/unit/browsers/cdp-connection_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-connection_spec.ts
@@ -5,7 +5,6 @@ import type { CdpEvent, CdpCommand } from '../../../lib/browsers/cdp-protocol/cd
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
 import { CDPTerminatedError, CDPAlreadyConnectedError, CDPDisconnectedError } from '../../../lib/browsers/cdp-protocol/cri-errors'
 import WebSocket from 'ws'
-import pDefer, { DeferredPromise } from 'p-defer'
 const { expect, proxyquire, sinon } = require('../../spec_helper')
 
 const DEBUGGER_URL = 'http://foo'
@@ -303,7 +302,7 @@ describe('CDPConnection', () => {
   })
 
   describe('when created with auto reconnect behavior enabled and disconnected', () => {
-    let deferredReconnection: DeferredPromise<any>
+    let deferredReconnection: PromiseWithResolvers<any>
 
     beforeEach(async () => {
       cdpConnection = new CDPConnection({
@@ -315,7 +314,7 @@ describe('CDPConnection', () => {
       cdpConnection.addConnectionEventListener('cdp-connection-reconnect-attempt', onReconnectAttemptCb)
       cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', onReconnectErrCb)
 
-      deferredReconnection = pDefer()
+      deferredReconnection = Promise.withResolvers()
       onReconnectCb.callsFake(() => deferredReconnection.resolve())
       onReconnectErrCb.callsFake(() => deferredReconnection.reject())
       CDPImport.withArgs({ target: DEBUGGER_URL, local: true }).resolves(stubbedCDPClient)

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -2,7 +2,6 @@ import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
 import EventEmitter from 'events'
 import { ProtocolManagerShape } from '@packages/types'
 import type { CriClient } from '../../../lib/browsers/cdp-protocol/cri-client'
-import pDefer from 'p-defer'
 import type Protocol from 'devtools-protocol'
 const { expect, proxyquire, sinon } = require('../../spec_helper')
 
@@ -345,7 +344,7 @@ describe('lib/browsers/cri-client', function () {
       // @ts-ignore
       await criStub.on.withArgs('disconnect').args[0][1]()
 
-      const reconnection = pDefer()
+      const reconnection = Promise.withResolvers()
 
       onReconnect.callsFake(() => reconnection.resolve())
       await reconnection.promise
@@ -371,7 +370,7 @@ describe('lib/browsers/cri-client', function () {
       // @ts-ignore
       await criStub.on.withArgs('disconnect').args[0][1]()
 
-      const reconnection = pDefer()
+      const reconnection = Promise.withResolvers()
 
       onReconnect.callsFake(() => reconnection.resolve())
       await reconnection.promise
@@ -396,7 +395,7 @@ describe('lib/browsers/cri-client', function () {
       // @ts-ignore
       await criStub.on.withArgs('disconnect').args[0][1]()
 
-      const reconnection = pDefer()
+      const reconnection = Promise.withResolvers()
 
       onReconnect.callsFake(() => reconnection.resolve())
       await reconnection.promise

--- a/packages/ts/tsconfig.json
+++ b/packages/ts/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "ES2018",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2021"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2021", "esnext.promise"],                 /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     "jsx": "react",                                      /* Specify what JSX code is generated. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */

--- a/packages/ts/tslint.json
+++ b/packages/ts/tslint.json
@@ -1,10 +1,6 @@
 {
   "rules": {
-    "no-floating-promises": true,
-    "no-implicit-dependencies": [
-      true,
-      "dev"
-    ]
+    "no-floating-promises": true
   },
   "jsRules": {
     "no-empty": true

--- a/scripts/gulp/tasks/gulpCypress.ts
+++ b/scripts/gulp/tasks/gulpCypress.ts
@@ -6,7 +6,6 @@
  */
 import chokidar from 'chokidar'
 import path from 'path'
-import pDefer from 'p-defer'
 import fs from 'fs-extra'
 import { DevActions } from '@packages/data-context/src/actions/DevActions'
 
@@ -26,7 +25,7 @@ const pathToCli = path.resolve(monorepoPaths.root, 'cli', 'bin', 'cypress')
  *------------------------------------------------------------------------**/
 
 export async function killExistingCypress () {
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
   const child = exec('killall Cypress')
 
   child.on('error', dfd.resolve)
@@ -150,7 +149,7 @@ export async function startCypressWatch () {
       return
     }
 
-    const dfd = pDefer()
+    const dfd = Promise.withResolvers()
 
     if (child) {
       isRestarting = true

--- a/scripts/gulp/tasks/gulpGraphql.ts
+++ b/scripts/gulp/tasks/gulpGraphql.ts
@@ -1,7 +1,6 @@
 // @ts-expect-error - no types
 import rp from '@cypress/request-promise'
 import path from 'path'
-import pDefer from 'p-defer'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import { buildSchema, extendSchema, GraphQLSchema, introspectionFromSchema, isObjectType, parse } from 'graphql'
@@ -45,7 +44,7 @@ export async function graphqlCodegenWatch () {
   const spawned = universalSpawn('graphql-codegen', ['--watch', '--config', 'graphql/graphql-codegen.yml'], {
     cwd: monorepoPaths.pkgDataContext,
   })
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
   let hasResolved = false
 
   spawned.stdout.on('data', (chunk) => {

--- a/scripts/gulp/tasks/gulpRegistry.ts
+++ b/scripts/gulp/tasks/gulpRegistry.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from 'child_process'
-import pDefer from 'p-defer'
 import treeKill from 'tree-kill'
 import gulp from 'gulp'
 import os from 'os'
@@ -41,7 +40,7 @@ export async function exitAndRemoveProcess (child: ChildProcess) {
 
   childProcesses.delete(child)
 
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
 
   exitedPids.add(child.pid)
   treeKill(child.pid, (err) => {

--- a/scripts/gulp/tasks/gulpWebpack.ts
+++ b/scripts/gulp/tasks/gulpWebpack.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk'
-import pDefer from 'p-defer'
 import { monorepoPaths } from '../monorepoPaths'
 import { universalSpawn } from '../utils/childProcessUtils'
 import { addChildProcess } from './gulpRegistry'
@@ -34,7 +33,7 @@ type RunWebpackCfg = {
 
 export async function runWebpack (cfg: RunWebpackCfg) {
   const { cwd, args = [], env = process.env, prefix, enableLiveReload = false } = cfg
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
   const spawned = universalSpawn('webpack',
     args,
     {

--- a/scripts/gulp/utils/childProcessUtils.ts
+++ b/scripts/gulp/utils/childProcessUtils.ts
@@ -5,7 +5,6 @@ import { ChildProcess,
   spawn, SpawnOptions,
 } from 'child_process'
 import through2 from 'through2'
-import pDefer from 'p-defer'
 import util from 'util'
 
 import { prefixLog, prefixStream } from './prefixStream'
@@ -39,7 +38,7 @@ export async function spawnUntilMatch (
   prefix: AllSpawnableApps,
   config: SpawnUntilMatchConfig,
 ) {
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
   let ready = false
 
   spawned(prefix, config.command, {
@@ -68,7 +67,7 @@ export async function forkUntilMatch (
   prefix: AllSpawnableApps,
   config: ForkUntilMatchConfig,
 ) {
-  const dfd = pDefer<ChildProcess>()
+  const dfd = Promise.withResolvers<ChildProcess>()
   let ready = false
 
   const cp = await forked(prefix, config.modulePath, config.args, {
@@ -196,7 +195,7 @@ export interface StreamHandlerConfig extends TapThroughConfig {
 }
 
 function streamHandler (cp: ChildProcess, config: StreamHandlerConfig) {
-  const dfd = pDefer<ChildProcess>()
+  const dfd = Promise.withResolvers<ChildProcess>()
   const { command, tapErr = null, tapOut = null, prefix, waitForExit, waitForData = true } = config
   const prefixedStdout = cp.stdout?.pipe(
     through2(function (chunk, enc, cb) {

--- a/scripts/gulp/utils/nexusTypegenUtil.ts
+++ b/scripts/gulp/utils/nexusTypegenUtil.ts
@@ -1,6 +1,5 @@
 import { spawn, execSync } from 'child_process'
 import chalk from 'chalk'
-import pDefer from 'p-defer'
 import chokidar from 'chokidar'
 import _ from 'lodash'
 import path from 'path'
@@ -33,7 +32,7 @@ async function windowsTouch (filename: string, time: Date) {
 }
 
 export async function nexusTypegen (cfg: NexusTypegenCfg) {
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
 
   if (cfg.outputPath) {
     await fs.ensureDir(path.join(monorepoPaths.pkgDataContext, 'src/gen'))
@@ -100,7 +99,7 @@ interface NexusTypegenWatchCfg extends NexusTypegenCfg {
 }
 
 export async function watchNexusTypegen (cfg: NexusTypegenWatchCfg) {
-  const dfd = pDefer()
+  const dfd = Promise.withResolvers()
 
   const watcher = chokidar.watch(cfg.watchPaths, {
     cwd: cfg.cwd,

--- a/yarn.lock
+++ b/yarn.lock
@@ -25216,11 +25216,6 @@ p-cancelable@^4.0.1:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-4.0.1.tgz#2d1edf1ab8616b72c73db41c4bc9ecdd10af640e"
   integrity sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==
 
-p-defer@3.0.0, p-defer@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
-  integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
-
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
@@ -31346,11 +31341,6 @@ typescript-eslint@^8.37.0:
     "@typescript/typescript-sunos-x64" "7.0.2"
     "@typescript/typescript-win32-arm64" "7.0.2"
     "@typescript/typescript-win32-x64" "7.0.2"
-
-typescript@5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 typescript@5.4.5, typescript@~5.4.5:
   version "5.4.5"


### PR DESCRIPTION
- Closes N/A — no associated issue. This is a purely mechanical, internal refactor with no user-facing behavior change, which the [contributing guide](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests) exempts from the issue requirement.

### Additional details

Replaces the `p-defer` dependency with the native `Promise.withResolvers()` across all first-party packages, removing `p-defer` from the repository (and lockfile) entirely.

**Why:** `Promise.withResolvers()` is the ECMAScript-standard (ES2024) equivalent of `p-defer` — identical `{ promise, resolve, reject }` shape — and is available on every runtime the converted code targets, so the dependency is redundant.

**Scope & the runtime-floor nuance:**
- **Node-side main process** (`proxy`, `server`, `data-context`, `electron`, gulp build scripts): converted; `p-defer` dropped from each `package.json`. These run in the bundled Electron (or dev Node), which supports `Promise.withResolvers`.
- **`frontend-shared` / `launchpad`**: the only `p-defer` usage was the `withCtx` e2e test harness, whose callbacks execute in the **Node** plugins process — converted, and the injected `pDefer` helper removed from `WithCtxInjected`.
- **`app`**: the runner-bundle injector (`injectBundle.ts`) and the Studio e2e spec. The app UI renders only in Electron, evergreen Chrome/Edge/Firefox, and Playwright's bundled WebKit — all of which support `Promise.withResolvers` natively.
- **Config/plugins child (`require_async_child.ts`) — special case:** this process is forked with the **user's** resolved Node, and Cypress supports **Node ≥ 20.1** (`cli/package.json` engines), which predates `Promise.withResolvers`. It therefore uses a plain-`Promise` deferred (not the native API, and not a dependency), keeping it compatible with all supported user Node versions.
- **`driver`** (runs in the user's AUT browser) never used `p-defer` and is untouched.

**Behavior-preserving type nuance:** native `resolve` requires its argument where `p-defer`'s was optional. One production site (`LocalSettingsActions`) resolved a typed deferred with no value; it now resolves with the value already in scope (used only as a truthiness guard, so no behavior change). Valueless deferreds use `Promise.withResolvers<void>()`.

**Toolchain changes required by this:**
- `withResolvers` typings ship in TypeScript ≥ 5.4, so root `typescript` is bumped `5.3.3 → ~5.4.5`, and `esnext.promise` is added to the shared base `lib` (`packages/ts/tsconfig.json`) and the `electron` lib. Packages that type-check imported source under their own tsconfig (e.g. `launcher`, `driver`) inherit/pick this up.
- The deprecated tslint `no-implicit-dependencies` rule relies on `tsutils@2.29.0`, which cannot parse the TS 5.4 AST and throws on every file (non-blocking; already the case for `proxy`, which was pinned to 5.4.5) — it is removed from the shared config. `no-floating-promises` is retained.

**Docs:** added a "Runtime targets" section to `AGENTS.md` (and cross-references in `server`/`data-context` AGENTS) documenting where each runtime's Node/browser floor is defined, so future changes don't assume the dev Node version.

### Steps to test

No behavior change. `yarn check-ts` passes for all packages; the unit specs covering the converted deferreds pass locally:

```
yarn workspace @packages/data-context test -- test/unit/sources/GitDataSource.spec.ts test/unit/sources/GitDataSource_unit.spec.ts
yarn workspace @packages/server test-unit -- browsers/cdp-command-queue_spec   # + cri-client_spec, cdp-connection_spec
yarn workspace @packages/proxy test -- test/unit/http/util/service-worker-manager.spec.ts
```

### How has the user experience changed?

No change. Internal refactor with no user-facing behavior difference; the config/plugins child remains compatible with all supported Node versions.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — Purely mechanical/internal change (dependency removal); no user-facing impact.
- [na] Have tests been added/updated? — No new behavior; existing specs exercise the converted code and pass (a launchpad manifest assertion was also made version-agnostic so it no longer pins the TypeScript version).
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — No user-facing change.
- [na] Have API changes been updated in the type definitions? — No public API change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uxy2t9s6efKxB8h48NFa53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency swap and doc/tsconfig updates; disconnect handling in the config child was adjusted for older user Node but remains equivalent.
> 
> **Overview**
> This PR **drops `p-defer` everywhere** it was used and replaces the same `{ promise, resolve, reject }` pattern with native **`Promise.withResolvers()`** across server, proxy, data-context, electron, app, gulp scripts, and related tests. The dependency is removed from package manifests and the lockfile.
> 
> **Tooling:** Root **TypeScript** moves from 5.3.3 to **~5.4.5** (needed for `withResolvers` types). Shared and package tsconfigs add **`esnext.promise`** to `lib` where needed. Tslint **`no-implicit-dependencies`** is removed from the shared config because it breaks under TS 5.4.
> 
> **Docs:** Root **`AGENTS.md`** gains a **Runtime targets** section (dev Node, bundled Electron, user Node for CLI/config child, browser bundles); **`packages/server`** and **`packages/data-context`** AGENTS files cross-link the user-Node constraint for the config/plugins child.
> 
> **Small behavior-preserving fixes:** `LocalSettingsActions.refreshLocalSettings` now resolves its refresh deferred with the editors list (typed `resolve` requirement). E2E harnesses no longer inject `pDefer`; launchpad asserts **`x-dependencies`** with a semver regex instead of pinning `typescript@5.3.3`. The config child **`require_async_child.ts`** uses a manual `new Promise` + external `resolve` for disconnect signaling so it stays compatible with supported user Node versions that predate `Promise.withResolvers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1955203f796857b3f4f75f4fd3258db5594bd7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->