### PR TITLE
test(driver): fix flaky cy.wait() timeout error tests in waiting.cy.js

### DIFF
--- a/packages/driver/cypress/e2e/commands/waiting.cy.js
+++ b/packages/driver/cypress/e2e/commands/waiting.cy.js
@@ -242,7 +242,11 @@ describe('src/cy/commands/waiting', () => {
       })
 
       describe('errors', {
-        defaultCommandTimeout: 100,
+        // `defaultCommandTimeout` also bounds the async `done()` callback. These
+        // tests invoke `done()` only after `cy.wait()` fails on its per-test
+        // `requestTimeout`/`responseTimeout`, so this must stay well above those
+        // or a loaded machine times the test out before it can assert.
+        defaultCommandTimeout: 4000,
       }, () => {
         it('throws when alias does not match a route (DOM element)', (done) => {
           cy.on('fail', (err) => {


### PR DESCRIPTION
- Closes <!-- no associated issue; test-stability fix identified via Cypress Cloud flaky-test data -->

### Additional details

The two most flaky tests on `develop` over the last 100 runs both live in `packages/driver/cypress/e2e/commands/waiting.cy.js` and failed intermittently across Chrome, Chrome Beta, and Electron with:

```
CypressError: Timed out after `100ms`. The `done()` callback was never invoked!
```

**Root cause.** Every test under `describe('errors', { defaultCommandTimeout: 100 }, …)` inherits that `defaultCommandTimeout`, which in Cypress also caps the async `done()` callback budget (`mocha.ts` `resetTimeout` arms `setTimeout(…, this.timeout())`). Each of these tests drives its failure with a small per-test `requestTimeout`/`responseTimeout` (100–500ms) and calls `done()` from its `fail` handler only *after* `cy.wait()` times out. So the `done()` callback lands at/after the per-test timeout while the mocha budget was pinned to 100ms — a race the tests usually win (retries keep resetting the timer) but lose under CI load (a single >100ms stall fires the mocha timer first).

The tell: the error always reports `100ms` even for the test that sets `responseTimeout: 200`, proving the limiting value is the inherited `defaultCommandTimeout`, not the response timeout.

**Fix.** Raise the `done()` budget once at the block level (`100` → `4000`) instead of per test.

- `cy.wait()`'s request/response phases use `requestTimeout`/`responseTimeout`, **not** `defaultCommandTimeout`, so wait timing is unchanged.
- Every asserted timeout value in the block comes from an explicit per-test `requestTimeout`/`responseTimeout` override, so all error-message assertions are unchanged.
- Validation-error tests and force-fast tests (`_runnableTimeout = 0`) fail immediately regardless of the budget, so they are unaffected.

Net effect: the intentionally-small per-test timeouts still drive (and are asserted in) each failure; only the `done()` race is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration in the driver E2E suite; no Cypress runtime or product behavior changes.
> 
> **Overview**
> Stabilizes flaky driver E2E tests in `waiting.cy.js` under the `describe('errors')` block for `cy.wait()` alias failures.
> 
> That block previously set **`defaultCommandTimeout: 100`**, which also caps Mocha’s async **`done()`** budget. Several tests only call **`done()`** from a **`fail`** handler after **`cy.wait()`** hits an explicit per-test **`requestTimeout`** or **`responseTimeout`** (100–500ms). Under CI load, Mocha could fire **`Timed out after 100ms. The done() callback was never invoked!`** before **`cy.wait()`** finished failing, even though the asserted error text still comes from the route timeouts.
> 
> The fix raises the inherited timeout to **`4000`** and documents why it must stay above those per-test wait limits. **`cy.wait()`** timing and every error-message assertion are unchanged; this only removes the race on **`done()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377c0e92c0eb87fd8d1b76f744f648e206be66c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run the driver spec (ideally a few times, and/or under load) to confirm stability:

```bash
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/waiting.cy.js
```

The `describe('errors')` tests — notably `throws when waiting for response to route` and `throws when waiting for 2nd response to route` — should pass consistently.

### How has the user experience changed?

No change. This is a test-only change to the driver's own E2E suite; there is no change to Cypress runtime behavior.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-stability fix identified from Cypress Cloud flaky-test data; no runtime/behavior change. -->
- [x] Have tests been added/updated? <!-- Adjusts the flaky tests' timeout config; no assertions changed. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No user-facing change. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No API change. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_014M8B5wHCkcFX8GAAMupeug)_