### PR TITLE
test(launchpad): de-flake multiple config errors recovery test

### DIFF
--- a/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
+++ b/packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts
@@ -236,6 +236,12 @@ describe('setupNodeEvents', () => {
   })
 
   it('handles multiple config errors and then recovers', () => {
+    // Each 'Try again' fires this mutation to reset the error and reload the config. The
+    // old error stays mounted with identical markup until the mutation resolves, so waiting
+    // on it anchors the recovery assertions to the reloaded state instead of racing against
+    // the stale error DOM.
+    cy.intercept('mutation-Main_ResetErrorsAndLoadConfig').as('resetErrorsAndLoadConfig')
+
     cy.scaffoldProject('pristine')
     cy.openProject('pristine')
     cy.withCtx(async (ctx) => {
@@ -253,6 +259,7 @@ describe('setupNodeEvents', () => {
     })
 
     cy.findByRole('button', { name: 'Try again' }).click()
+    cy.wait('@resetErrorsAndLoadConfig')
     cy.get('[data-cy-testingType=e2e]').click()
     cy.contains('h1', cy.i18n.launchpadErrors.generic.configErrorTitle, { timeout: 10000 })
     cy.get('[data-cy="alert-body"]').should('contain', 'The baseUrl configuration option is invalid when set from the root of the config object')
@@ -262,6 +269,7 @@ describe('setupNodeEvents', () => {
     })
 
     cy.findByRole('button', { name: 'Try again' }).click()
+    cy.wait('@resetErrorsAndLoadConfig')
     cy.contains('h1', 'Choose a browser', { timeout: 10000 })
     cy.get('[data-cy="alert"]').should('contain', 'Warning: Cannot Connect Base Url Warning')
   })


### PR DESCRIPTION
- Closes N/A (flaky-test fix; no associated issue)

### Additional details

The launchpad E2E test `setupNodeEvents > handles multiple config errors and then recovers` (`packages/launchpad/cypress/e2e/config-files-error-handling.cy.ts`) has been intermittently flaky on `develop` (roughly 8 of the last ~100 runs, on Chrome).

**Why the change was necessary:** The test forces two successive config errors, then clicks **"Try again"** and immediately asserts the recovered launchpad state. That button fires the `Main_ResetErrorsAndLoadConfig` mutation, but while the mutation is in flight the existing error view stays fully mounted with **identical markup** (the same config-error `<h1>`) — there is no intermediate spinner during the reset. As a result the recovery assertions could evaluate against the **stale pre-reload DOM** before the config-reload cycle had settled.

**What the change does:** Intercept `mutation-Main_ResetErrorsAndLoadConfig` and `cy.wait` on it after each "Try again" click, anchoring the recovery assertions to the reloaded state instead of racing the stale error DOM. No assertion is weakened — every `should('contain', …)` / `h1` check is untouched; the waits only ensure the reset+reload round-trip has completed first.

This mirrors the existing, passing `clears the error correctly after first 'try again' attempt` test in the same file, which already uses this exact intercept + `cy.wait` idiom.

**Scope:** Test-only change to a single launchpad E2E spec. No production/runtime code changed, so no `cli/CHANGELOG.md` entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to one Cypress E2E spec; no production or runtime behavior is affected.
> 
> **Overview**
> Fixes intermittent flakiness in **`handles multiple config errors and then recovers`** by synchronizing recovery assertions with the config reset mutation instead of the stale error UI.
> 
> The test now **intercepts** `mutation-Main_ResetErrorsAndLoadConfig` and **`cy.wait`s** after each **Try again** click (twice in the flow), matching the existing **`clears the error correctly after first 'try again' attempt`** test in the same spec. A short comment explains why the wait is needed: the error view stays mounted with the same markup until the mutation finishes. **No assertions are relaxed**—only timing is tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e72c2d1eb075aca5d5b01cbaa146b923603124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Launchpad E2E cannot run in the automated sandbox, so this was verified by code inspection against the existing passing precedent. To confirm locally:

```
yarn workspace @packages/launchpad cypress:run:e2e -- --spec cypress/e2e/config-files-error-handling.cy.ts
```

The `setupNodeEvents > handles multiple config errors and then recovers` test should pass consistently across repeated runs.

### How has the user experience changed?

No change. This is a test-only stability fix with no user-facing or behavioral impact.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- test-only flake fix; no behavior change -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMAo8GubhocqJXmXnmSG6x)_