### PR TITLE
test(driver): fix flaky "sets initial=true and then removes" navigation test

### DIFF
--- a/packages/driver/cypress/e2e/commands/navigation.cy.js
+++ b/packages/driver/cypress/e2e/commands/navigation.cy.js
@@ -1916,23 +1916,27 @@ describe('src/cy/commands/navigation', () => {
 
       let expected = false
 
-      cy.on('window:before:unload', () => {
-        expected = true
-
-        expect(Cookie.get('__cypress.initial')).to.eq('true')
-      })
-
-      // this navigates us to a new page so
-      // we should be setting the initial cookie
       cy
       .visit('/fixtures/form.html')
       .then(() => {
+        // bind after the visit so the assertion only runs for the anchor
+        // click below. `__cypress.initial` can't be set or read on an
+        // opaque origin like `about:blank`, which a prior test may leave in
+        // the AUT, so asserting on the visit's own unload flakes as `undefined`.
+        cy.once('window:before:unload', () => {
+          expected = true
+
+          expect(Cookie.get('__cypress.initial')).to.eq('true')
+        })
+
         cy.once('window:unload', () => {
           expect(cy.state('onPageLoadErr')).to.be.a('function')
         })
 
         return null
       })
+      // clicking this anchor navigates us to a new page so
+      // we should be setting the initial cookie
       .get('a:first').click().then(() => {
         const listeners = cy.listeners('window:load')
 


### PR DESCRIPTION
- Closes <!-- no associated issue; flaky-test fix surfaced via Cypress Cloud (project ypt4pf, e.g. run 72631) -->

### Additional details

The `src/cy/commands/navigation > #page load > sets initial=true and then removes` test in `packages/driver/cypress/e2e/commands/navigation.cy.js` flaked intermittently on Chrome and Chrome Beta (~7 of the last ~100 `develop` runs).

**Root cause.** The test bound its `window:before:unload` assertion *before* `cy.visit('/fixtures/form.html')`. Because the handler was a persistent `cy.on`, it also fired for the visit's own navigation, which unloads whatever page the previous test left in the AUT. The `#page load` context has no `beforeEach` visit and follows a block of intentionally-failing `#visit` tests, so the AUT is frequently sitting on `about:blank` when this test starts.

On unload, the driver's `onBeforeUnload` (`cy.ts`) calls `cy.Cookies.setInitial()`, which writes `__cypress.initial` for the AUT superdomain via `js-cookie` → `document.cookie`. On `about:blank` (an opaque origin) that write is silently dropped, so the in-handler assertion `expect(Cookie.get('__cypress.initial')).to.eq('true')` reads back `undefined` and throws as an unhandled rejection — failing the test. The observed signature was `expected undefined to equal 'true'` at `navigation.cy.js:1922`.

**Fix.** Bind the `before:unload` (and `unload`) assertions inside the `.then()` after the visit resolves, so they run only for the `a:first` click that unloads the fully-loaded `form.html` on a real origin — where `__cypress.initial` is reliably set. This synchronizes the assertion with the actual page-load lifecycle without weakening it: it still asserts `initial === 'true'` on unload and `undefined` after the next load. `cy.once` scopes each assertion to exactly that one navigation.

This is a test-only change; there is no product code change and no changelog entry.

### Steps to test

Run the driver E2E spec; the target test should pass consistently:

```bash
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/navigation.cy.js
```

### How has the user experience changed?

No change. Test-only fix.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical flaky-test stabilization; no product behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5S5q8KgdoMrGGLC5E4mey)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in driver E2E; no production code or runtime behavior is modified.
> 
> **Overview**
> Stabilizes the driver E2E **"sets initial=true and then removes"** test in `navigation.cy.js` by scoping unload assertions to the anchor-click navigation instead of `cy.visit`.
> 
> The test previously registered a persistent `cy.on('window:before:unload')` **before** `cy.visit`, so the handler also ran when the visit unloaded whatever page the prior test left in the AUT (often `about:blank`). On that opaque origin, `__cypress.initial` cannot be set or read reliably, so the assertion `Cookie.get('__cypress.initial') === 'true'` intermittently failed with `undefined`.
> 
> The fix registers **`cy.once('window:before:unload')`** and **`cy.once('window:unload')`** inside the `.then()` after the visit completes, so assertions run only when **`a:first`** navigates away from loaded `form.html` on a real origin. Product behavior is unchanged; this is test-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da157823ae4847f11eca661ac3b285d8c0557520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->