### PR TITLE
test(launchpad): de-flake choose-a-browser browser-path warning test

### DIFF
--- a/packages/frontend-shared/cypress/support/e2e.ts
+++ b/packages/frontend-shared/cypress/support/e2e.ts
@@ -435,12 +435,12 @@ function specsPageIsVisible (specsSetup) {
   return cy.get('[data-cy=spec-list-container]').should('be.visible')
 }
 
-function visitLaunchpad (options: { showWelcome?: boolean } = { showWelcome: false }) {
+function visitLaunchpad (options: { showWelcome?: boolean, spinnerTimeout?: number } = { showWelcome: false }) {
   cy.task<{ e2e_launchpadPort: number }>('getCyInCyVariables', ['e2e_launchpadPort']).then(({ e2e_launchpadPort }) => {
     function launchpadVisit () {
       return cy.visit(`/__launchpad/index.html`, { log: false }).then((val) => {
         return cy.get('[data-e2e]', { timeout: 10000, log: false }).then(() => {
-          return cy.get('.spinner', { timeout: 10000, log: false }).should('not.exist').then(() => {
+          return cy.get('.spinner', { timeout: options.spinnerTimeout ?? 10000, log: false }).should('not.exist').then(() => {
             return val
           })
         })

--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -87,7 +87,10 @@ describe('Choose a browser page', () => {
 
       cy.openProject('launchpad', ['--e2e', '--browser', path])
 
-      cy.visitLaunchpad()
+      // Launchpad re-fetches its config on an increasing backoff while the project
+      // loads (see Main.vue), so the loading spinner can outlast visitLaunchpad's
+      // default settle timeout under CI load. Allow more time so it can clear.
+      cy.visitLaunchpad({ spinnerTimeout: 30000 })
 
       cy.get('h1').should('contain', 'Choose a browser')
 
@@ -115,7 +118,7 @@ describe('Choose a browser page', () => {
       cy.get('[data-cy="alert-suffix-icon"]').click()
       cy.get('[data-cy="alert-header"]').should('not.exist')
 
-      cy.visitLaunchpad()
+      cy.visitLaunchpad({ spinnerTimeout: 30000 })
       cy.get('h1').should('contain', 'Choose a browser')
       cy.get('[data-cy="alert-header"]').should('not.exist')
     })


### PR DESCRIPTION
- Closes N/A — no associated issue. Purely a test-reliability fix (no product code or behavior change).

### Additional details

The launchpad E2E test **"Choose a browser page > System Browsers Detected > shows warning when launched with --browser path option that cannot be matched to found browsers"** (`packages/launchpad/cypress/e2e/choose-a-browser.cy.ts`) intermittently failed on Chrome — ~9 of the last ~100 `develop` runs — with:

```
Timed out retrying after 10000ms: Expected <svg.spinner> not to exist in the DOM, but it was continuously found.
  at frontend-shared/cypress/support/e2e.ts:445   ← inside visitLaunchpad
```

**Root cause:** the flake is inside the shared `visitLaunchpad()` helper, which gates on the global loading spinner clearing via `cy.get('.spinner', { timeout: 10000 }).should('not.exist')`. `packages/launchpad/src/Main.vue` renders that spinner while the initial query/config is still loading and **re-fetches the config on an unbounded, increasing backoff** (`setTimeout(..., (refetchCount + 1) * 500)` → 1000, 1500, 2000, 2500, 3000…ms). The `choose-a-browser` "System Browsers Detected" specs are the heaviest settle path (`findBrowsers` stub + `openProject --e2e --browser <…>` requiring full config + active-browser resolution), so under CI load on Chrome the cumulative backoff occasionally pushes the spinner past the helper's fixed 10s cap. It always passed on the immediate retry — a timing race, not a real regression.

**Fix (test-only, minimal blast radius):**
- `packages/frontend-shared/cypress/support/e2e.ts` — `visitLaunchpad` gains an optional `spinnerTimeout` that **defaults to the current `10000`**, so the other ~143 call sites are unchanged.
- `packages/launchpad/cypress/e2e/choose-a-browser.cy.ts` — the target test's two `visitLaunchpad()` calls pass `{ spinnerTimeout: 30000 }`, giving the app's documented config-refetch backoff room to settle. The assertion is not weakened: the spinner must still fully clear before the test proceeds, and the existing `h1` "Choose a browser" check is untouched.

### Steps to test

```bash
yarn workspace @packages/launchpad cypress:run -- --spec cypress/e2e/choose-a-browser.cy.ts
```

The spec should pass; the targeted test no longer depends on the launchpad settling within a fixed 10s window.

### How has the user experience changed?

No change. This is a test-only reliability fix — no product code, no user-facing behavior change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-reliability fix; no product change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbKoJBBmQYzoa7XSGxXnGJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a Cypress helper default behavior; no product or runtime code paths affected.
> 
> **Overview**
> Addresses intermittent CI failures in the launchpad **choose-a-browser** spec where `visitLaunchpad()` timed out waiting for `.spinner` to disappear (10s cap) while launchpad config refetch backoff could keep the loader visible longer under load.
> 
> **`visitLaunchpad`** in shared Cypress support now accepts an optional **`spinnerTimeout`** (still defaults to **10s**), so existing call sites are unchanged. The flaky **invalid `--browser` path** test passes **`spinnerTimeout: 30000`** on its two `visitLaunchpad` calls so the helper can wait for the spinner to clear without relaxing assertions (the spinner must still be gone before the test continues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd2058f4777e625e6c22f0ad66653401c959944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->