### PR TITLE
test: fix flaky git-repo setup to address flake when run on Windows CI

### DIFF
--- a/packages/app/cypress/tasks/git.ts
+++ b/packages/app/cypress/tasks/git.ts
@@ -6,11 +6,12 @@ export async function initGitRepoForTestProject (projectPath: string) {
   const git = simpleGit({ baseDir: projectPath })
 
   if (process.env.CI) {
-    // need to set a user on CI
-    await Promise.all([
-      git.addConfig('user.name', 'Test User', true, 'global'),
-      git.addConfig('user.email', 'test-user@example.com', true, 'global'),
-    ])
+    // Set a user on CI. `git config --global` takes a lock on the global
+    // .gitconfig (a .gitconfig.lock file), and on Windows concurrent writes
+    // fail to acquire it with "could not lock config file ...: File exists",
+    // so these must not overlap.
+    await git.addConfig('user.name', 'Test User', true, 'global')
+    await git.addConfig('user.email', 'test-user@example.com', true, 'global')
   }
 
   const e2eFolder = path.join(projectPath, 'cypress', 'e2e')


### PR DESCRIPTION
- Closes N/A — internal test-flake fix, no associated issue.

### Additional details

`initGitRepoForTestProject` (`packages/app/cypress/tasks/git.ts`) set `user.name` and `user.email` on CI with a `Promise.all`, which spawns two concurrent `git config --global` processes. On Windows, git guards the global `.gitconfig` with a `.gitconfig.lock` file, so the two writes race for that lock and one fails with:

```
error: could not lock config file C:/Users/circleci/.gitconfig: File exists
```

This surfaced as a first-attempt failure of `cy.task('initGitRepoForTestProject')` (the assertions never ran), which then passed on retry — a classic flake. Cypress Cloud (project `ypt4pf`) showed the target test `specs_list_actual_git_repo.cy.ts` › "shows correct git icons" flaking with this exact signature in 3 of the last ~57 develop runs, all on Chrome/Windows. The same lock error also flaked git-dependent tests in `runs.cy.ts`, which use the same task.

The fix writes the two global-config values sequentially so they can't contend for the lock. Behavior is unchanged (both values are still set); it only removes the concurrency. This is Windows-specific because of git's lockfile semantics there.

### Steps to test

This reproduces only on Windows CI (the affected code path is gated behind `if (process.env.CI)`). To exercise the surrounding flow:

```
yarn workspace @packages/app cypress:run -- --spec cypress/e2e/specs_list_actual_git_repo.cy.ts
```

### How has the user experience changed?

No change. This is test-only infrastructure and is not bundled into or reachable from the published `cypress` package.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal test-flake fix; no user-facing behavior change. -->
- [x] Have tests been added/updated? <!-- Fixes the git-repo setup task used by the flaky specs. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No user-facing change. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No API change. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_013KA3Ef97YZHU9YUDELgqFB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Cypress task change with no product or published-package behavior impact.
> 
> **Overview**
> Fixes intermittent failures of the Cypress task **`initGitRepoForTestProject`** on Windows CI when setting global git `user.name` and `user.email`.
> 
> On CI, those two **`git config --global`** calls used to run in parallel via **`Promise.all`**. On Windows, concurrent updates contend for **`.gitconfig.lock`**, so one write can fail before tests that depend on the repo (e.g. **`specs_list_actual_git_repo.cy.ts`**, **`runs.cy.ts`**) run. The change runs the two **`addConfig`** calls **sequentially** and documents why; the values set are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5531c07cc7bb9170889ff7d5ed05e19b5db7364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->