### PR TITLE
test(net-stubbing): fix flaky body-parsing intercept tests

### DIFF
--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -2213,6 +2213,7 @@ describe('network stubbing', { retries: 15 }, function () {
     })
 
     context('body parsing', function () {
+      // `/post-only` is shared by other tests here, including one that fires a `GET /post-only`
       [
         ['application/json', '{"foo":"bar"}'],
         ['application/vnd.api+json', '{}'],
@@ -2220,7 +2221,7 @@ describe('network stubbing', { retries: 15 }, function () {
         it(`automatically parses ${contentType} request bodies`, function () {
           const p = Promise.defer()
 
-          cy.intercept('/post-only', (req) => {
+          cy.intercept({ method: 'POST', url: '/post-only' }, (req) => {
             expect(req.headers['content-type']).to.eq(contentType)
             expect(req.body).to.deep.eq({ foo: 'bar' })
 
@@ -2245,7 +2246,7 @@ describe('network stubbing', { retries: 15 }, function () {
       it('doesn\'t automatically parse JSON request bodies if content-type is wrong', function () {
         const p = Promise.defer()
 
-        cy.intercept('/post-only', (req) => {
+        cy.intercept({ method: 'POST', url: '/post-only' }, (req) => {
           expect(req.body).to.deep.eq(JSON.stringify({ foo: 'bar' }))
 
           p.resolve()
@@ -2264,7 +2265,7 @@ describe('network stubbing', { retries: 15 }, function () {
       it('sets body to string if JSON is malformed', function () {
         const p = Promise.defer()
 
-        cy.intercept('/post-only*', (req) => {
+        cy.intercept({ method: 'POST', url: '/post-only*' }, (req) => {
           expect(req.body).to.deep.eq('{ foo::: }')
 
           p.resolve()


### PR DESCRIPTION
- Addresses flakiness tracked in #23434 (see also #20397, requests leaking between tests)

### Additional details

**Why was this change necessary?**

The `body parsing` tests in `packages/driver/cypress/e2e/commands/net_stubbing.cy.ts` — including `automatically parses application/json request bodies` — flaked in ~15% of recent `develop` runs across Chrome, Chrome Beta, and Electron, always with the same signature:

```
AssertionError: expected undefined to equal 'application/json'
  at net_stubbing.cy.ts:2224
  at before-request.ts:321 (onBeforeRequest)
```

**Root cause**

These tests intercept the **shared, non-unique** `/post-only` route *without a method matcher*, so the route matches any HTTP method:

```js
cy.intercept('/post-only', (req) => {
  expect(req.headers['content-type']).to.eq(contentType) // fails: undefined
  ...
})
```

A sibling test in the same file (`can add a body to a request that does not have one`, itself `retries: 15`, #23422) fires `$.get('/post-only')` — a **GET with no `content-type` header**. Per #20397, a request initiated late in one test can arrive at the proxy after the test boundary and be matched against the *next* test's routes: on the server, an incoming request is matched purely by URL/method against whatever routes are currently registered (`packages/net-stubbing/lib/server/middleware/request.ts` → `matchRoutes`), with no test-origin marker. When that leaked GET is caught by a body-parsing route, `req.headers['content-type']` is `undefined`, producing the assertion above. Run 72925 shows this failing 5 attempts in a row before passing — consistent with pending GETs arriving repeatedly across retries.

**Fix**

Scope the three body-parsing intercepts to `POST` (their ajax is already `POST` and `/post-only` is POST-only server-side) so a leaked `GET` can no longer match. This removes the race without changing any assertion. It mirrors the existing `{ method: 'POST', url: ... }` matcher usage already present in this file and the `uniqueRoute` convention documented at the top of the spec.

### Steps to test

- CI: the `net_stubbing.cy.ts` driver E2E spec should pass without flaking on this test.
- Locally: `yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/net_stubbing.cy.ts`

### How has the user experience changed?

No change. This is a test-only change with no impact on shipped code or user-facing behavior.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- purely mechanical test-stability fix; relates to #23434 / #20397 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJAE9B4HQmrYPvBdMNGDBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJAE9B4HQmrYPvBdMNGDBu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Driver E2E test matcher changes only; no runtime or user-facing Cypress behavior is modified.
> 
> **Overview**
> Stabilizes flaky **body parsing** E2E cases in `net_stubbing.cy.ts` by tightening how routes are registered, not by changing net-stubbing behavior.
> 
> Those intercepts previously matched **any method** on the shared `/post-only` URL. A nearby test issues `$.get('/post-only')`, and leaked cross-test requests (#20397) could hit the body-parsing handler without a `content-type` header, failing assertions on `req.headers['content-type']`. The three affected `cy.intercept` calls now use **`{ method: 'POST', url: ... }`**, aligned with the POST ajax each test already sends. A short comment notes that `/post-only` is shared with tests that fire GET.
> 
> Assertions and product code are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb83a66ef6e683473816d59f5b8d0d50078adc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->