### PR TITLE
test: de-flake launchpad manifest logged-in open-mode e2e test

### DIFF
--- a/packages/launchpad/cypress/e2e/open-mode.cy.ts
+++ b/packages/launchpad/cypress/e2e/open-mode.cy.ts
@@ -122,7 +122,9 @@ describe('Launchpad: Open Mode', () => {
         cy.loginUser()
         cy.visitLaunchpad()
         cy.get('h1').should('contain', 'Choose a browser')
-        cy.withCtx((ctx, o) => {
+        // The manifest request fires asynchronously from the version-data query and can
+        // resolve after the 'Choose a browser' page renders, so retry until it has fired.
+        cy.withRetryableCtx((ctx, o) => {
           expect(ctx.util.fetch).to.have.been.calledWithMatch('https://download.cypress.io/desktop.json', {
             headers: {
               'x-logged-in': 'true',


### PR DESCRIPTION
- Closes <!-- no associated issue -->

### Additional details

The e2e test `Launchpad: Open Mode > request for Cypress manifest > logged-in state > sends 'true' when logged in` (`packages/launchpad/cypress/e2e/open-mode.cy.ts`) has been flaking (~4 of the last ~100 `develop` runs, on Chrome).

**Root cause:** The manifest request (`https://download.cypress.io/desktop.json`) is fired asynchronously by the launchpad's version-data GraphQL query during app load — `VersionsDataSource.#getLatestVersion()`, which sets the `x-logged-in` header from `ctx.coreData.user`. The test spies on `ctx.util.fetch` and asserts it was `calledWithMatch(..., { headers: { 'x-logged-in': 'true' } })`.

That assertion ran via a **single-shot `cy.withCtx`** immediately after `cy.get('h1').should('contain', 'Choose a browser')`. Reaching the "Choose a browser" page and the version-data fetch completing are independent async operations, so the `h1` can render before the spy has recorded the manifest call. When that happened, the single-shot `withCtx` failed with no retry — the flake. Login state itself was never the issue: `cy.loginUser()` is awaited before `cy.visitLaunchpad()`, so the header value is reliably `'true'` once the request fires; the race was purely *asserting before the request occurred*.

**Fix:** Switch the assertion to **`cy.withRetryableCtx`**, which retries the spy assertion until the manifest request has fired. The `calledWithMatch` assertion is unchanged — it is not weakened, only awaited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Fixes intermittent failures in the Launchpad open-mode e2e that checks the Cypress desktop manifest is fetched with **`x-logged-in: true`** after login.
> 
> The assertion now runs through **`cy.withRetryableCtx`** instead of a one-shot **`cy.withCtx`**, so Cypress retries until **`ctx.util.fetch`** has recorded the **`desktop.json`** call. The **`calledWithMatch`** expectation is unchanged; only timing is handled. A short comment documents that the version-data/manifest request can finish after the “Choose a browser” UI is visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf78cf25233d5a3e1a804de1d4665ecf9b318be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Run the spec repeatedly and confirm it stays green:

```
yarn workspace @packages/launchpad cypress:run -- --spec cypress/e2e/open-mode.cy.ts
```

### How has the user experience changed?

No change — this is a test-only change with no impact on Cypress behavior.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely a test-flake fix; no product behavior change. -->
- [x] Have tests been added/updated? <!-- The flaky test's assertion is made retryable. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdThZdXB7TBe2wgWZK4NCU)_