### PR TITLE
test: de-flake top-nav "connect project" login workflow

### DIFF
--- a/packages/app/cypress/e2e/top-nav.cy.ts
+++ b/packages/app/cypress/e2e/top-nav.cy.ts
@@ -443,11 +443,6 @@ describe('App Top Nav Workflows', () => {
         })
 
         cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal').within(() => {
-          // Login auto-starts when the modal opens, so the CTA is disabled while
-          // pending. Its label flips "Opening browser" -> "Waiting for browser..."
-          // on an async GraphQL push, so asserting both labels in sequence races
-          // that push timing; assert the disabled pending state and let the settled
-          // "Login successful" dialog below confirm the flow completed.
           cy.findByRole('button', { name: /Opening browser|Waiting for browser/ })
           .should('be.visible')
           .and('be.disabled')

--- a/packages/app/cypress/e2e/top-nav.cy.ts
+++ b/packages/app/cypress/e2e/top-nav.cy.ts
@@ -443,9 +443,14 @@ describe('App Top Nav Workflows', () => {
         })
 
         cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal').within(() => {
-          // The login flow auto-starts when the modal opens; the CTA transitions through pending states
-          cy.findByRole('button', { name: 'Opening browser' }).should('be.visible').and('be.disabled')
-          cy.findByRole('button', { name: 'Waiting for browser...' }).should('be.visible').and('be.disabled')
+          // Login auto-starts when the modal opens, so the CTA is disabled while
+          // pending. Its label flips "Opening browser" -> "Waiting for browser..."
+          // on an async GraphQL push, so asserting both labels in sequence races
+          // that push timing; assert the disabled pending state and let the settled
+          // "Login successful" dialog below confirm the flow completed.
+          cy.findByRole('button', { name: /Opening browser|Waiting for browser/ })
+          .should('be.visible')
+          .and('be.disabled')
         })
 
         cy.findByRole('dialog', { name: 'Login successful' }).within(() => {


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `logIn()` helper in `packages/app/cypress/e2e/top-nav.cy.ts` asserted two **consecutive transient** CTA labels in strict order:

```js
cy.findByRole('button', { name: 'Opening browser' }).should('be.visible').and('be.disabled')
cy.findByRole('button', { name: 'Waiting for browser...' }).should('be.visible').and('be.disabled')
```

In `Auth.vue` the pending button's text is `browserOpened ? actionWaiting : actionOpening`. `browserOpened` only flips to `true` when the stubbed `authApi.logIn` fires `onMessage({ browserOpened: true })`, which propagates to the client via an **async GraphQL `authChange` push** over the socket (`AuthActions.#authenticate` → `ctx.update(authState)` → `ctx.emitter.authChange()`). Because that push races the subsequent login-resolution/reset flow, the intermediate `"Waiting for browser..."` label is not guaranteed to be rendered when Cypress polls. On a busy CI Chrome the push lags, the retry window expires while the button still reads `"Opening browser"`, and the second assertion times out — the test flaked ~3 of the last ~100 `develop` runs on Chrome (matching the sibling Launchpad signature in Cloud run 72602: `Unable to find … "Waiting for browser..."`, button stuck on "Opening browser").

The fix asserts the CTA is in its **disabled pending state** with a label matching either pending string, which is order- and push-timing-independent, and lets the existing `"Login successful"` dialog assertion wait on the settled post-login state. Both discrete pending labels remain covered by the `LoginModal.cy.tsx` component tests (`actionOpening` / `actionWaiting`), so no coverage is lost.

### Steps to test

Run the affected spec (it should pass consistently across repeated runs):

```
yarn workspace @packages/app cypress:run -- --spec cypress/e2e/top-nav.cy.ts
```

### How has the user experience changed?

No change. This is a test-only change to remove a timing-dependent flake.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely a test-flake fix; no production code changed. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1kqkV1tovkKbyV5T1LNkP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in Cypress e2e; no production or auth logic modified.
> 
> **Overview**
> The `logIn()` helper in `top-nav.cy.ts` no longer requires the login modal CTA to show **"Opening browser"** and then **"Waiting for browser..."** in strict sequence.
> 
> It now asserts a single disabled pending button whose accessible name matches either label via `/Opening browser|Waiting for browser/`, avoiding flakes when async auth state updates lag on CI. The flow still waits on the **Login successful** dialog afterward; no app behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e919931c597ec372ac103dacb8c0a66b02674ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->