### PR TITLE
test: de-flake Git-data runs list e2e assertions

### DIFF
--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -778,9 +778,6 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         cy.visitApp()
         cy.specsPageIsVisible()
         moveToRunsPage()
-        // The Git-data runs list is populated from the relevantRuns subscription,
-        // which resolves local Git and cloud run data asynchronously. Wait for a
-        // resolved run to render so we don't assert against the still-empty list.
         cy.findByText('fix: using Git data CANCELLED').should('be.visible')
         cy.get('[data-cy="runs"]')
       })
@@ -791,21 +788,15 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         cy.specsPageIsVisible()
         moveToRunsPage()
 
-        // The Git-data runs list is populated from the relevantRuns subscription,
-        // which resolves local Git and cloud run data asynchronously and re-renders
-        // the list as it settles. Re-query the card for each assertion (rather than
-        // scoping a `within` block to a captured element) so a mid-assertion
-        // re-render can't leave us asserting against a card detached from the DOM.
         cy.findByText('fix: using Git data CANCELLED').should('be.visible')
 
         cy.get('[href^="http://dummy.cypress.io/runs/0"]').first()
         .find('[data-cy="runNumber-status-CANCELLED"]')
-        .should('exist')
 
         cy.get('[data-cy="runCard-status-CANCELLED"]').first().as('firstRun')
 
         cy.get('@firstRun').find('[data-cy="runCard-author"]').should('contain', 'John Appleseed')
-        cy.get('@firstRun').find('[data-cy="runCard-avatar"]').should('exist')
+        cy.get('@firstRun').find('[data-cy="runCard-avatar"]')
         cy.get('@firstRun').find('[data-cy="runCard-branchName"]').should('contain', 'main')
         cy.get('@firstRun').find('[data-cy="runCard-createdAt"]').should('contain', '01m 00s (an hour ago)')
 

--- a/packages/app/cypress/e2e/runs.cy.ts
+++ b/packages/app/cypress/e2e/runs.cy.ts
@@ -778,6 +778,10 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         cy.visitApp()
         cy.specsPageIsVisible()
         moveToRunsPage()
+        // The Git-data runs list is populated from the relevantRuns subscription,
+        // which resolves local Git and cloud run data asynchronously. Wait for a
+        // resolved run to render so we don't assert against the still-empty list.
+        cy.findByText('fix: using Git data CANCELLED').should('be.visible')
         cy.get('[data-cy="runs"]')
       })
 
@@ -787,24 +791,28 @@ describe('App: Runs', { viewportWidth: 1200 }, () => {
         cy.specsPageIsVisible()
         moveToRunsPage()
 
-        cy.findByText('fix: using Git data CANCELLED')
-        cy.get('[href^="http://dummy.cypress.io/runs/0"]').first().within(() => {
-          cy.get('[data-cy="runNumber-status-CANCELLED"]')
-        })
+        // The Git-data runs list is populated from the relevantRuns subscription,
+        // which resolves local Git and cloud run data asynchronously and re-renders
+        // the list as it settles. Re-query the card for each assertion (rather than
+        // scoping a `within` block to a captured element) so a mid-assertion
+        // re-render can't leave us asserting against a card detached from the DOM.
+        cy.findByText('fix: using Git data CANCELLED').should('be.visible')
+
+        cy.get('[href^="http://dummy.cypress.io/runs/0"]').first()
+        .find('[data-cy="runNumber-status-CANCELLED"]')
+        .should('exist')
 
         cy.get('[data-cy="runCard-status-CANCELLED"]').first().as('firstRun')
 
-        cy.get('@firstRun').within(() => {
-          cy.get('[data-cy="runCard-author"]').contains('John Appleseed')
-          cy.get('[data-cy="runCard-avatar"]')
-          cy.get('[data-cy="runCard-branchName"]').contains('main')
-          cy.get('[data-cy="runCard-createdAt"]').contains('01m 00s (an hour ago)')
+        cy.get('@firstRun').find('[data-cy="runCard-author"]').should('contain', 'John Appleseed')
+        cy.get('@firstRun').find('[data-cy="runCard-avatar"]').should('exist')
+        cy.get('@firstRun').find('[data-cy="runCard-branchName"]').should('contain', 'main')
+        cy.get('@firstRun').find('[data-cy="runCard-createdAt"]').should('contain', '01m 00s (an hour ago)')
 
-          cy.contains('span', 'skipped')
-          cy.get('span').contains('pending')
-          cy.get('span').contains('passed')
-          cy.get('span').contains('failed')
-        })
+        cy.get('@firstRun').contains('span', 'skipped')
+        cy.get('@firstRun').find('span').contains('pending')
+        cy.get('@firstRun').find('span').contains('passed')
+        cy.get('@firstRun').find('span').contains('failed')
       })
 
       it('opens the run page if a run is clicked', () => {


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `App: Runs > Runs - Runs List > has Git data` e2e tests in `packages/app/cypress/e2e/runs.cy.ts` (`displays each run with correct information` and `displays a list of recorded runs if a run has been recorded`) were intermittently failing on `develop` (~3/100 recent runs, Chrome — single failed attempt, passing retry).

**Root cause:** Unlike the stable "no Git data" path (`useProjectRuns`, a single `network-only` query that resolves once), the "has Git data" path uses `useGitTreeRuns`, which derives the runs list from `useRelevantRun('RUNS')` — a GraphQL **subscription** (`relevantRuns`) fed asynchronously by the local `GitDataSource` + `RelevantRunsDataSource` polling the cloud (`runsByCommitShas`). That data resolves in stages (empty → populated) and re-executes the `RunsGitTree` (`cloudNodesByIds`) query as it settles, re-rendering the list. This spec does not stub `RelevantRunsDataSource_RunsByCommitShas`, so it depends on real, timing-variable Git resolution.

The test captured a run card via `.first().as('firstRun')` and asserted inside a `cy.get('@firstRun').within(...)` block. A re-render during that block **detached** the captured card from the DOM, so the nested assertions ran against a stale element — a classic detached-DOM flake. The sibling test asserted `[data-cy="runs"]` before the list had resolved (transient empty state).

**Fix (test-only, assertions unchanged):**
- Wait for a resolved run to render (`cy.findByText('fix: using Git data CANCELLED').should('be.visible')`) before asserting.
- Re-query the card for each assertion (`cy.get('@firstRun').find(...)`) instead of holding a captured subject inside a `within` block, so Cypress retries re-run the query against the live DOM and can't get stuck on a detached element.

No production code changed; the same elements, text, and link are verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Cypress e2e assertion patterns in runs.cy.ts change; no production behavior.
> 
> **Overview**
> Stabilizes the **has Git data** runs-list Cypress specs in `runs.cy.ts` against async Git-driven re-renders, without changing what the tests assert.
> 
> Both affected tests now wait for **`fix: using Git data CANCELLED`** to be visible before touching the list or run card. In **displays each run with correct information**, nested checks no longer use a single **`within`** on a captured card; each assertion uses **`cy.get('@firstRun').find(...)`** (or equivalent) so Cypress retries against the live DOM when the card is replaced. The run-link/status check uses **`.find`** on the href instead of **`within`**.
> 
> **Test-only** — no app or production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit effd9ab1d4358894b9e331d3a4f8a9288cfd1e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Run `yarn workspace @packages/app cypress:run:e2e -- --spec cypress/e2e/runs.cy.ts` on Chrome.
2. Confirm the `has Git data` runs-list tests pass, and re-run repeatedly to confirm stability.

### How has the user experience changed?

No change — this is a test-only change to remove flake; no product behavior is affected.

### PR Tasks

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. --> This is a purely mechanical test-stability change (no product behavior change).
- [x] Have tests been added/updated? Existing e2e assertions were made resilient to the async Git-data render.
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bf22QqHdoX5wFMUDMSjtME)_