### PR TITLE
test(driver): fix flaky service worker "supports caching" test in Firefox

### DIFF
--- a/packages/driver/cypress/e2e/e2e/service-worker.cy.js
+++ b/packages/driver/cypress/e2e/e2e/service-worker.cy.js
@@ -609,7 +609,10 @@ describe('service workers', { defaultCommandTimeout: 1000, pageLoadTimeout: 1000
       expect(response.ok).to.be.true
     })
 
-    cy.get('#output').should('have.text', 'done')
+    cy.get('#output', {
+      timeout: 8000,
+    }).should('have.text', 'done')
+
     validateFetchHandlers({ listenerCount: 1 })
   })
 


### PR DESCRIPTION
- Closes N/A <!-- No associated issue; purely a test-stability fix. -->

### Additional details

The `service workers > supports caching` test in `packages/driver/cypress/e2e/e2e/service-worker.cy.js` flakes on Firefox (~3% of `develop` runs), always with the same signature:

```
expected '<div#output>' to have text 'done', but the text was ''
```

**Why it happens:** The `describe` block caps every command at `defaultCommandTimeout: 1000`. The `service-worker.html` fixture only writes `'done'` into `#output` after the full service worker lifecycle completes: register → install → **activate** → `location.reload()` → post-reload fetch of `/fixtures/1mb` resolves. This particular test's `install` handler additionally caches the 1mb fixture via `event.waitUntil(caches.open('v1').then((cache) => cache.addAll(['/fixtures/1mb'])))`, forcing a 1mb download to finish and be cached **before** the worker can activate. Firefox's WebDriver BiDi timing is slower than Chromium's, so on occasion the activate → reload → fetch chain doesn't finish within the 1000ms retry window and `#output` is still empty.

**The fix:** Extend only the retry window on the final `cy.get('#output')` assertion to 8000ms, mirroring the existing precedent already used in this file for the `supports a redirected request` test. The assertion itself (`should('have.text', 'done')`) is unchanged, so this does not weaken the test — it only allows the slower-but-correct Firefox service worker lifecycle to complete.

```diff
-    cy.get('#output').should('have.text', 'done')
+    cy.get('#output', {
+      timeout: 8000,
+    }).should('have.text', 'done')
```

### Steps to test

Run the spec against Firefox, where the flake reproduces:

```
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/e2e/service-worker.cy.js --browser firefox
```

The `supports caching` test should pass reliably.

### How has the user experience changed?

No change. This is a test-only change with no impact on Cypress behavior or user-facing APIs.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical test-stability fix (flaky-test timeout adjustment). -->
- [x] Have tests been added/updated? <!-- Adjusts the affected test's retry window. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3LhtDmvtgBSUWBgJ5wU5e

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3LhtDmvtgBSUWBgJ5wU5e)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout tweak with no product or API impact.
> 
> **Overview**
> Stabilizes the **`supports caching`** service worker e2e test by giving the final `#output` assertion an **8000ms** command timeout instead of inheriting the suite’s **1000ms** `defaultCommandTimeout`.
> 
> That test waits for install-time caching of `/fixtures/1mb` and the full activate → reload → fetch path before the fixture writes `done`; Firefox/WebDriver BiDi often needs longer than 1s. The assertion is unchanged—only the retry window is widened, consistent with **`supports a redirected request`** in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e63126c101f39ec3a53a5da8de5f2836c2d72b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->