### PR TITLE
test: de-flake launchpad top-nav login modal workflow

### DIFF
--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -386,11 +386,12 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.findByRole('button', { name: 'Log in' }).click()
         })
 
-        cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal').within(() => {
-          // The login flow auto-starts when the modal opens; the CTA transitions through pending states
-          cy.findByRole('button', { name: 'Opening browser' }).should('be.visible').and('be.disabled')
-          cy.findByRole('button', { name: 'Waiting for browser...' }).should('be.visible').and('be.disabled')
-        })
+        // The login flow auto-starts when the modal opens and resolves through real-time timers
+        // (the stub fires `browserOpened` and resolves the user via `setTimeout`, and `cy.clock`
+        // here only fakes `Date`, not timers). Wait for the settled "Login successful" state rather
+        // than the transient "Opening browser" / "Waiting for browser..." CTA labels, which the
+        // command queue can miss once those timers have advanced under CI load.
+        cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal')
 
         cy.findByRole('dialog', { name: 'Login successful' }).within(() => {
           cy.findByText('You are now logged in as', { exact: false }).should('be.visible')

--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -387,9 +387,6 @@ describe('Launchpad Top Nav Workflows', () => {
         })
 
         cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal').within(() => {
-          // The login flow auto-starts when the modal opens and the disabled CTA transitions between
-          // pending labels on real-time timers. Match either label so we assert the pending state
-          // without racing the exact transition the command queue can't reliably catch.
           cy.findByRole('button', { name: /Opening browser|Waiting for browser/ }).should('be.visible').and('be.disabled')
         })
 

--- a/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
+++ b/packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts
@@ -386,12 +386,12 @@ describe('Launchpad Top Nav Workflows', () => {
           cy.findByRole('button', { name: 'Log in' }).click()
         })
 
-        // The login flow auto-starts when the modal opens and resolves through real-time timers
-        // (the stub fires `browserOpened` and resolves the user via `setTimeout`, and `cy.clock`
-        // here only fakes `Date`, not timers). Wait for the settled "Login successful" state rather
-        // than the transient "Opening browser" / "Waiting for browser..." CTA labels, which the
-        // command queue can miss once those timers have advanced under CI load.
-        cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal')
+        cy.findByRole('dialog', { name: 'Continue in your browser' }).as('logInModal').within(() => {
+          // The login flow auto-starts when the modal opens and the disabled CTA transitions between
+          // pending labels on real-time timers. Match either label so we assert the pending state
+          // without racing the exact transition the command queue can't reliably catch.
+          cy.findByRole('button', { name: /Opening browser|Waiting for browser/ }).should('be.visible').and('be.disabled')
+        })
 
         cy.findByRole('dialog', { name: 'Login successful' }).within(() => {
           cy.findByText('You are now logged in as', { exact: false }).should('be.visible')


### PR DESCRIPTION
- Closes <!-- no linked issue; purely a test-stability (flake) fix -->

### Additional details

The `Launchpad Top Nav Workflows > Login > user not logged in` modal-workflow tests flaked on `develop` (observed ~5/100 runs, Chrome) in `packages/launchpad/cypress/e2e/top-nav-launchpad.cy.ts`.

**Root cause:** the shared `logIn` helper drives login through the auth stub's real-time `setTimeout`s (`browserOpened` at ~2s, user resolved at ~3s), while the top-level `cy.clock(Date.UTC(2021, 9, 30), ['Date'])` fakes only `Date`, not timers. The helper asserted the two transient pending CTA labels as separate sequential snapshots:

```js
cy.findByRole('button', { name: 'Opening browser' }).should('be.visible').and('be.disabled')
cy.findByRole('button', { name: 'Waiting for browser...' }).should('be.visible').and('be.disabled')
```

The `Waiting for browser...` label only exists in the ~2s–3s window. Once the command queue reached that second assertion after the ~3s user-resolve had already advanced the modal to its settled `Login successful` state, the label was gone and `findByRole` retried to its timeout.

**Fix:** collapse the two pending-state assertions into a single regex match on either label, so the disabled pending CTA is still asserted without racing the exact transition:

```js
cy.findByRole('button', { name: /Opening browser|Waiting for browser/ }).should('be.visible').and('be.disabled')
```

A disabled pending button exists for the entire ~0–3s pending phase, so a single match lands reliably. This mirrors the same fix applied to the identical helper in `packages/app/cypress/e2e/top-nav.cy.ts` in #34448 — the two really should land together, since the Launchpad copy carries the same race.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `top-nav-launchpad.cy.ts`; no application, auth, or API code modified.
> 
> **Overview**
> Stabilizes Launchpad Cypress **Login** workflow tests by changing how the shared `logIn` helper asserts the login modal’s pending CTA.
> 
> Instead of two sequential `findByRole` checks for `Opening browser` and then `Waiting for browser...`, the helper now uses **one** assertion that matches either label via regex while still requiring the button to be visible and disabled. That avoids racing real `setTimeout`-driven auth stub transitions when only `Date` is faked by `cy.clock`, which could leave the modal on `Login successful` before the second label appeared.
> 
> **No product or runtime behavior changes**—E2E test helper only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837034d19821f75b81c9ec9292cc1d41c7569666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

- Run the Launchpad spec: `yarn workspace @packages/launchpad cypress:run -- --spec cypress/e2e/top-nav-launchpad.cy.ts`
- The `Login > user not logged in` workflow tests (including `shows log in modal workflow for user with only email`) should pass without depending on catching the transient `Waiting for browser...` label.

### How has the user experience changed?

No change — test-only change, no product code touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely a test-stability/flake fix; no product behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_018fpbPAb5JJRGuyu9aNjFyT)_