### PR TITLE
chore: update actions/github-script to v9 to resolve Node 20 deprecation warning

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: scripts/github-actions/semantic-pull-request/
       - name: Lint PR Title and Cypress Changelog Entry
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const verifyPullRequest = require('./scripts/github-actions/semantic-pull-request')

--- a/.github/workflows/triage_add_to_project.yml
+++ b/.github/workflows/triage_add_to_project.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/triage_handle_new_comments.yml
+++ b/.github/workflows/triage_handle_new_comments.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 'lts/*'
       - name: Run comment_workflow.js Script
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.TRIAGE_BOARD_TOKEN }}
           script: |

--- a/.github/workflows/update-browser-versions.yml
+++ b/.github/workflows/update-browser-versions.yml
@@ -41,7 +41,7 @@ jobs:
         run: CI=true yarn
       - name: Check for new Chrome versions
         id: get-versions
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { getVersions } = require('./scripts/github-actions/update-browser-versions.js')
@@ -72,7 +72,7 @@ jobs:
       - name: Check need for update on existing branch
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
         id: check-need-for-branch-update
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { checkNeedForBranchUpdate } = require('./scripts/github-actions/update-browser-versions.js')
@@ -86,7 +86,7 @@ jobs:
       ## Both
       - name: Update Browser Versions File
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { updateBrowserVersionsFile } = require('./scripts/github-actions/update-browser-versions.js')
@@ -98,7 +98,7 @@ jobs:
             })
       - name: Commit and push via API
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' || steps.check-need-for-branch-update.outputs.has_newer_update == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -118,7 +118,7 @@ jobs:
       ## Update available and a branch/PR already exists
       - name: Update PR Title
         if: ${{ steps.check-need-for-pr.outputs.needs_branch_update == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -135,7 +135,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/update_v8_snapshot_cache.yml
+++ b/.github/workflows/update_v8_snapshot_cache.yml
@@ -205,7 +205,7 @@ jobs:
         shell: bash
       - name: Commit snapshot update via API
         if: ${{ steps.stage.outputs.has_changes == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           SNAPSHOT_FILES: ${{ steps.stage.outputs.files }}
           BASE_BRANCH: ${{ env.BASE_BRANCH }}
@@ -232,7 +232,7 @@ jobs:
             })
       - name: Create Pull Request
         if: ${{ steps.check-need-for-pr.outputs.needs_pr == 'true' }}
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |


### PR DESCRIPTION
- Closes N/A — mechanical CI maintenance change

### Additional details

GitHub Actions runners now deprecate the **Node 20** runtime in favor of **Node 24**. `actions/github-script@v7` runs on Node 20, so every workflow using it surfaced this deprecation warning (visible on the "Lint PR Title and Cypress Changelog Entry" check):

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

This bumps every `actions/github-script` reference from `v7` to `v9` (which runs on Node 24), using the SHA `3a2844b7e9c422d3c10d287c895573f7108da1b3` that was already vetted in `auto_approve_low_risk.yml`.

Affected workflows:
- `semantic-pull-request.yml` (the workflow showing the warning)
- `update-browser-versions.yml` (6 occurrences)
- `triage_handle_new_comments.yml`
- `triage_add_to_project.yml`
- `update_v8_snapshot_cache.yml` (2 occurrences)

The github-script exposed API (`github`, `context`, `core`, `glob`, `io`, `exec`) is stable across these majors — the only breaking change is the Node runtime — and v9 is already running successfully in this repo, so this is a low-risk pin bump.

### Steps to test

No behavioral change. The deprecation warning no longer appears when the workflows run on GitHub Actions, and the pinned SHA resolves to `actions/github-script` v9 running on Node 24.

### How has the user experience changed?

No change. This is a CI-only maintenance change with no impact on the Cypress application or its users.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical CI maintenance change: bumping a pinned GitHub Action to resolve the Node 20 runtime deprecation. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

---
_Generated by [Claude Code](https://claude.ai/code/session_019fuWMiWQXFB5FLpKYejbYp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin with no application code changes; v9 is already in use elsewhere in the repo with the same script API.
> 
> **Overview**
> Updates every remaining **`actions/github-script`** pin from **v7** (Node 20) to **v9** (Node 24), using SHA `3a2844b7e9c422d3c10d287c895573f7108da1b3` — the same pin already used in `auto_approve_low_risk.yml`.
> 
> **Workflows touched:** semantic PR linting, triage comment automation (two workflows), browser version automation (six steps), and V8 snapshot cache commit/PR steps (two steps). Inline `script` blocks and required modules are unchanged; only the action version/runtime moves forward to clear GitHub’s Node 20 deprecation warnings on runners defaulting to Node 24.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e944c0420e7baccfb062ceb438b5fa912edbfe45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->