### PR TITLE
chore: de-flake screenshot capture consistency checks

### DIFF
--- a/system-tests/projects/e2e/cypress/plugins/index.js
+++ b/system-tests/projects/e2e/cypress/plugins/index.js
@@ -112,8 +112,15 @@ module.exports = (on, config) => {
           throw new Error('Blackout not present!')
         }
 
-        if (originalImage.hash() !== compareImage.hash()) {
-          throw new Error('Screenshot mismatch!')
+        // Captures can differ by a few anti-aliased edge pixels between runs,
+        // so allow a small pixel-diff tolerance (pixelmatch, anti-aliasing
+        // excluded). The regressions this guards against — the runner UI
+        // leaking into the capture or the page failing to scroll — change far
+        // more than 1% of the pixels.
+        const { percent } = Jimp.diff(originalImage, compareImage)
+
+        if (percent > 0.01) {
+          throw new Error(`Screenshot mismatch! ${(percent * 100).toFixed(2)}% of pixels differ`)
         }
 
         return null


### PR DESCRIPTION
- Closes N/A

### Additional details

The `e2e screenshot element capture` system test (and its `viewport`/`fullPage` siblings) has been flaky, failing intermittently with `AssertionError: Process errored: Exit code 1: expected 1 to equal +0`.

**Root cause:** These specs capture the same element/page repeatedly and assert each capture matches the original via the `compare:screenshots` task in `system-tests/projects/e2e/cypress/plugins/index.js`. That task compared images with `originalImage.hash() !== compareImage.hash()`. Jimp's `hash()` is a 64-bit perceptual hash (an 8×8 DCT of a 32×32 downsample), and the check required exact string equality — so flipping a **single** of those 64 bits failed the test. A few anti-aliased edge pixels or sub-pixel rendering jitter between captures is enough to push a low-frequency DCT coefficient across its median and flip a bit, throwing `Screenshot mismatch!`, exiting Cypress with code `1`, and surfacing as the flaky error above.

**Fix:** Compare with a pixel diff via `Jimp.diff` (backed by `pixelmatch`, bundled in `@jimp/core`), which excludes anti-aliased pixels and returns the fraction of differing pixels, failing only above a small (1%) tolerance. This absorbs sub-pixel noise while still catching the regressions these tests exist to guard against — the runner UI leaking into a capture, or the page not scrolling — which change far more than 1% of the pixels. All three specs share this one task, so they are all de-flaked by the single change.

Validated in isolation with `jimp@0.22.12`:

| Scenario | Old `hash()` equality | New `Jimp.diff` % |
|---|---|---|
| Identical capture | PASS | 0.000% → PASS |
| A few anti-aliased edge pixels (flake) | fragile | 0.141% → PASS |
| Large region changed (real regression) | FAIL | 33.775% → FAIL |

The 1% threshold sits roughly two orders of magnitude away from both the noise floor and a real regression.

### Steps to test

Run the affected system tests against Chrome; they should pass consistently:

```bash
cd system-tests && node ./scripts/run.js --glob-in-dir="screenshot_element_capture" -- --browser chrome
```

### How has the user experience changed?

No change. This only affects the internal system-test suite; there is no change to Cypress behavior or public API.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-suite maintenance only; no product change. -->
- [x] Have tests been added/updated? <!-- Updates the shared screenshot comparison used by the element, viewport, and fullPage capture specs. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

---
_Generated by [Claude Code](https://claude.ai/code/session_0154u83QdbAqZpZmFXAPhitt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the e2e plugin; no product or public API impact.
> 
> **Overview**
> The shared Cypress `compare:screenshots` task no longer requires **exact** perceptual-hash equality between captures. It now uses **`Jimp.diff`** (pixelmatch, anti-aliasing excluded) and fails only when more than **1%** of pixels differ, with the error message reporting the actual diff percentage.
> 
> This de-flakes element, viewport, and fullPage screenshot consistency system tests that were intermittently failing on minor anti-aliased edge noise, while still catching large visual regressions (runner UI leakage, scroll failures) that change far more than 1% of pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151f1d4d3fe843257545b48ef2afe896bc4dd4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->