### PR TITLE
test: de-flake cookies redirect-cascade system test

### DIFF
--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
@@ -303,7 +303,7 @@ describe('cookies', () => {
 
               cy[cmd](`/setCascadingCookies?n=${n}&a=${altUrl}&b=${baseUrl}`)
 
-              cy.getAllCookies().then((cookies) => {
+              cy.getAllCookies().should((cookies) => {
                 // reverse them so they'll be in the order they were set
                 cookies = _.reverse(_.sortBy(cookies, _.property('name')))
 


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

The `system-tests/test/cookies_spec.ts` case **"with forced SameSite strictness [chrome]"** intermittently failed with `AssertionError: Process errored: Exit code 2: expected 2 to equal +0`.

**Why the change was necessary:**

- The e2e project fixture disables retries (`retries: null`), so a single racy assertion is a hard test failure.
- The spec (`cookies_spec_baseurl.cy.js`) runs every test twice — once in a `cy.visit` context and once in a `cy.request` context — so one racy logical test fails in *both*, producing exactly 2 inner failures → exit code 2, the signature in the failure.
- The culprit is **"can set cookies on lots of redirects"**: it fires 7–8 sequential cross-domain redirects that each `Set-Cookie`, then reads the entire cookie jar with a one-shot `cy.getAllCookies().then()` and a hard `expect(...).to.deep.eq()`. If the final redirect's cookie hadn't yet propagated into the browser jar when `getAllCookies` ran, the assertion failed with no retry.

**What is affected:**

Only the assertion in the redirect-cascade test. Switched the terminal `.then()` to `.should()` so Cypress retries the `getAllCookies` query until the full cascade has propagated — matching the retrying `.should('have.length', 0)` sanity check already used a few lines above. The assertion logic is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to assertion timing; no production or runtime Cypress behavior is modified.
> 
> **Overview**
> **De-flakes** the *"can set cookies on lots of redirects"* case in `cookies_spec_baseurl.cy.js` by changing the post-cascade cookie jar check from `cy.getAllCookies().then(...)` to `cy.getAllCookies().should(...)`.
> 
> The deep-equality assertion is unchanged; Cypress now **retries** `getAllCookies` until the full set of cookies from the multi-redirect cascade is visible, instead of failing once if the last `Set-Cookie` had not landed yet. This aligns with the retrying `should('have.length', 0)` sanity check above it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a522dcbed2989fa093e206ef9e036e164630bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```bash
cd system-tests
node ./scripts/run.js --glob-in-dir="cookies_spec" -- --browser chrome
```

To exercise the previously-flaky path, run it repeatedly and confirm no `exit code 2` failures appear in the "with forced SameSite strictness" case.

### How has the user experience changed?

No change. This is a test-only change with no impact on shipped behavior.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical test-flake fix. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6u1S8gikmpyTFjhv1CQ9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6u1S8gikmpyTFjhv1CQ9G)_