### PR TITLE
test: de-flake 'e2e visit / low response timeout / passes'

### DIFF
--- a/system-tests/test/visit_spec.js
+++ b/system-tests/test/visit_spec.js
@@ -136,6 +136,13 @@ describe('e2e visit', () => {
       browser: '!webkit', // TODO(webkit): fix+unskip
       spec: 'visit.cy.js',
       snapshot: true,
+      // The context's low timeouts are for the failure-mode tests below. The
+      // TLSv1 visit's fail-then-retry handshake is racy under a 500ms
+      // responseTimeout, so restore normal timeouts for these passing visits.
+      config: {
+        responseTimeout: 30000,
+        pageLoadTimeout: 60000,
+      },
       onRun (exec) {
         return startTlsV1Server(6776)
         .then((serv) => {


### PR DESCRIPTION
- Closes N/A

### Additional details

The `e2e visit / low response timeout / passes` system test is flaky, intermittently exiting with code 1 (`AssertionError: Process errored: Exit code 1: expected 1 to equal +0`).

**Root cause:** The `low response timeout` context sets `responseTimeout: 500` and `pageLoadTimeout: 1000` so its failure-mode specs fail fast. The `passes` spec only piggybacks on that context to exercise successful visits — one of which loads a TLSv1 site (`cy.visit('https://localhost:6776')`).

Cypress connects to upstream servers with a modern TLS version first and only retries with `minVersion: 'TLSv1'` *after* the initial handshake fails with a TLS-version error (`packages/server/lib/request.ts`, done this way because forcing TLSv1 on every connection is slow). That fail-then-retry handshake plus the response must complete within the 500ms `responseTimeout`, which is racy under CI load.

The per-visit `{ timeout }` option can't cover this: it only raises `pageLoadTimeout` (`navigation.ts`), not the `responseTimeout` that bounds URL resolution.

**Fix:** Restore normal timeouts for the `passes` spec via a per-test `config` override, leaving the low timeouts in place for the failure-mode specs that rely on them. No stdout snapshot change (durations are normalized).

### Steps to test

Run the spec repeatedly against Chrome; it should pass consistently:

```
cd system-tests && node ./scripts/run.js --glob-in-dir="visit_spec" -- --browser chrome
```

### How has the user experience changed?

No change. Test-only change to the system test harness configuration.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical CI flake fix, test-only. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DecQg1vuzwnPzBM3DSWPg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DecQg1vuzwnPzBM3DSWPg2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness configuration only; no production runtime or user-facing behavior changes.
> 
> **Overview**
> The **`passes`** system test under the **`low response timeout`** context still shares the 500ms / 1s timeouts meant for failure-mode specs. That made **`cy.visit`** to the TLSv1 server intermittently fail, because Cypress retries with TLSv1 only after the first handshake fails and that work must fit within **`responseTimeout`**.
> 
> This PR adds a per-test **`config`** override on that spec (**`responseTimeout: 30000`**, **`pageLoadTimeout: 60000`**) so successful visit coverage uses normal limits while the sibling failure tests keep the aggressive timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8223ccc7de6fe3d5be6132ed1ac95e97e0624a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->