### PR TITLE
test: de-flake system tests by disabling incidental failure screenshots

### DIFF
--- a/system-tests/__snapshots__/allow_cypress_env_spec.ts.js
+++ b/system-tests/__snapshots__/allow_cypress_env_spec.ts.js
@@ -42,17 +42,11 @@ https://on.cypress.io/cypress-env-migration
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     allow-cypress-env.cy.ts                                                          │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/allow-cypress-env.cy.ts/allowCypressEnv -- invo     (1280x720)
-     kes Cypress.env() (failed).png                                                                 
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/async_timeouts_spec.js
+++ b/system-tests/__snapshots__/async_timeouts_spec.js
@@ -46,19 +46,11 @@ exports['e2e async timeouts / failing1'] = `
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     async_timeouts.cy.js                                                             │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/async_timeouts.cy.js/async -- bar fails (failed     (1280x720)
-     ).png                                                                                          
-  -  /XXX/XXX/XXX/cypress/screenshots/async_timeouts.cy.js/async -- fails async after     (1280x720)
-      cypress command (failed).png                                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/before_all_after_all_throws_spec.ts.js
+++ b/system-tests/__snapshots__/before_all_after_all_throws_spec.ts.js
@@ -50,19 +50,11 @@ Because this error occurred during a \`after all\` hook we are skipping the rema
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      1                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     test.cy.js                                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/test.cy.js/before all and after all throw -- te     (1280x720)
-     st 1 -- before all hook (failed).png                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/test.cy.js/before all and after all throw -- te     (1280x720)
-     st 1 -- after all hook (failed).png                                                            
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/caught_uncaught_hook_errors_spec.js
+++ b/system-tests/__snapshots__/caught_uncaught_hook_errors_spec.js
@@ -71,21 +71,11 @@ Because this error occurred during a \`before all\` hook we are skipping the rem
   │ Failing:      3                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      3                                                                                │
-  │ Screenshots:  3                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     hook_caught_error_failing.cy.js                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_caught_error_failing.cy.js/s1a -- t2a -- b     (1280x720)
-     efore each hook (failed).png                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_caught_error_failing.cy.js/s3a -- t8a -- b     (1280x720)
-     efore all hook (failed).png                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_caught_error_failing.cy.js/s4a -- t10a --      (1280x720)
-     before all hook (failed).png                                                                   
 
 
 ====================================================================================================
@@ -160,17 +150,11 @@ Because this error occurred during a \`before each\` hook we are skipping the re
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      2                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     hook_uncaught_error_failing.cy.js                                                │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_uncaught_error_failing.cy.js/s1b -- t2b --     (1280x720)
-      before each hook (failed).png                                                                 
 
 
 ====================================================================================================
@@ -236,17 +220,11 @@ Because this error occurred during a \`before each\` hook we are skipping all of
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      3                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     hook_uncaught_root_error_failing.cy.js                                           │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_uncaught_root_error_failing.cy.js/t1c -- b     (1280x720)
-     efore each hook (failed).png                                                                   
 
 
 ====================================================================================================
@@ -321,18 +299,11 @@ Because this error occurred during a \`before each\` hook we are skipping the re
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     hook_uncaught_error_events_failing.cy.js                                         │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/hook_uncaught_error_events_failing.cy.js/uncaug     (1280x720)
-     ht hook error should continue to fire all mocha events -- s1 -- does not run --                
-     before each hook (failed).png                                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/commands_outside_of_test_spec.js
+++ b/system-tests/__snapshots__/commands_outside_of_test_spec.js
@@ -97,17 +97,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     assertions_failing_outside_of_test.cy.js                                         │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/assertions_failing_outside_of_test.cy.js/An unc     (1280x720)
-     aught error was detected outside of a test (failed).png                                        
 
 
 ====================================================================================================
@@ -180,17 +174,11 @@ https://on.cypress.io/cannot-execute-commands-outside-test
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     commands_outside_of_test.cy.js                                                   │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/commands_outside_of_test.cy.js/An uncaught erro     (1280x720)
-     r was detected outside of a test (failed).png                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/component_testing_spec.ts.js
+++ b/system-tests/__snapshots__/component_testing_spec.ts.js
@@ -326,19 +326,11 @@ exports['experimentalSingleTabRunMode / executes all specs in a single tab'] = `
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     1_fails.cy.js                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/1_fails.cy.js/simple failing spec -- fails (fai     (1280x633)
-     led).png                                                                                       
-  -  /XXX/XXX/XXX/cypress/screenshots/1_fails.cy.js/simple failing spec -- fails agai     (1280x633)
-     n (failed).png                                                                                 
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/system-tests/__snapshots__/experimental_csp_allow_list_spec.ts.js
+++ b/system-tests/__snapshots__/experimental_csp_allow_list_spec.ts.js
@@ -299,18 +299,11 @@ When this \`load\` event occurs, Cypress will continue running commands.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     form_action_with_allow_list_custom.cy.ts                                         │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/form_action_with_allow_list_custom.cy.ts/experi     (1280x720)
-     mentalCspAllowList=['script-src-elem', 'script-src', 'default-src'] -- fails on                
-     inline form action (failed).png                                                                
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/form_submissions_spec.js
+++ b/system-tests/__snapshots__/form_submissions_spec.js
@@ -164,18 +164,11 @@ exports['e2e forms / submissions with jquery XHR POST / failing'] = `
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     form_submission_failing.cy.js                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/form_submission_failing.cy.js/form submission f     (1280x720)
-     ails -- fails without an explicit wait when an element is immediately found (fai               
-     led).png                                                                                       
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/issue_149_spec.js
+++ b/system-tests/__snapshots__/issue_149_spec.js
@@ -38,16 +38,11 @@ exports['e2e issue 149 failing 1'] = `
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     issue_149.cy.js                                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/issue_149.cy.js/fails (failed).png                  (1280x720)
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/issue_1669_spec.js
+++ b/system-tests/__snapshots__/issue_1669_spec.js
@@ -42,18 +42,11 @@ Because this error occurred during a \`before each\` hook we are skipping the re
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     issue_1669.cy.js                                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/issue_1669.cy.js/issue-1669 undefined err.stack     (1280x720)
-      in beforeEach hook -- cy.setCookie should fail with correct error -- before eac               
-     h hook (failed).png                                                                            
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/issue_173_spec.ts.js
+++ b/system-tests/__snapshots__/issue_173_spec.ts.js
@@ -38,16 +38,11 @@ exports['e2e issue 173 / failing'] = `
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     issue_173.cy.js                                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/issue_173.cy.js/fails (failed).png                  (1280x720)
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/issue_674_spec.js
+++ b/system-tests/__snapshots__/issue_674_spec.js
@@ -46,19 +46,11 @@ exports['e2e issue 674 / fails'] = `
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     issue_674.cy.js                                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/issue_674.cy.js/issue 674 -- does not hang when     (1280x720)
-      both beforeEach and afterEach fail -- before each hook (failed).png                           
-  -  /XXX/XXX/XXX/cypress/screenshots/issue_674.cy.js/issue 674 -- does not hang when     (1280x720)
-      both beforeEach and afterEach fail -- after each hook (failed).png                            
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/js_error_handling_spec.js
+++ b/system-tests/__snapshots__/js_error_handling_spec.js
@@ -114,25 +114,11 @@ https://on.cypress.io/cross-origin-script-error
   │ Failing:      5                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  5                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     js_error_handling_failing.cy.js                                                  │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/js_error_handling_failing.cy.js/s1 -- without a     (1280x720)
-     n afterEach hook -- t1 (failed).png                                                            
-  -  /XXX/XXX/XXX/cypress/screenshots/js_error_handling_failing.cy.js/s1 -- without a     (1280x720)
-     n afterEach hook -- t2 (failed).png                                                            
-  -  /XXX/XXX/XXX/cypress/screenshots/js_error_handling_failing.cy.js/s1 -- with an a     (1280x720)
-     fterEach hook -- t4 (failed).png                                                               
-  -  /XXX/XXX/XXX/cypress/screenshots/js_error_handling_failing.cy.js/s1 -- with an a     (1280x720)
-     fterEach hook -- t5 (failed).png                                                               
-  -  /XXX/XXX/XXX/cypress/screenshots/js_error_handling_failing.cy.js/s1 -- cross ori     (1280x720)
-     gin script errors -- explains where script errored (failed).png                                
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/plugins_not_supported.ts.js
+++ b/system-tests/__snapshots__/plugins_not_supported.ts.js
@@ -73,19 +73,11 @@ Because this error occurred during a \`after all\` hook we are skipping all of t
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     foo.cy.js                                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/foo.cy.js/Blank Contents -- renders the visit f     (1280x720)
-     ailure page (failed).png                                                                       
-  -  /XXX/XXX/XXX/cypress/screenshots/foo.cy.js/renders the visit failure page -- aft     (1280x720)
-     er all hook mergeUnitTestCoverage (failed).png                                                 
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/promises_spec.js
+++ b/system-tests/__snapshots__/promises_spec.js
@@ -42,19 +42,11 @@ exports['e2e promises / failing1'] = `
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     promises.cy.js                                                                   │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/promises.cy.js/catches regular promise errors (     (1280x720)
-     failed).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/promises.cy.js/catches promise errors and calls     (1280x720)
-      done with err even when async (failed).png                                                    
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/request_spec.ts.js
+++ b/system-tests/__snapshots__/request_spec.ts.js
@@ -137,17 +137,11 @@ https://on.cypress.io/request
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     request_http_network_error_failing.cy.js                                         │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/request_http_network_error_failing.cy.js/when n     (1280x720)
-     etwork connection cannot be established -- fails (failed).png                                  
 
 
 ====================================================================================================
@@ -249,17 +243,11 @@ https://on.cypress.io/request
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     request_status_code_failing.cy.js                                                │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/request_status_code_failing.cy.js/when status c     (1280x720)
-     ode isnt 2xx or 3xx -- fails (failed).png                                                      
 
 
 ====================================================================================================
@@ -369,17 +357,11 @@ https://on.cypress.io/request
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     request_long_http_props_failing.cy.js                                            │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/request_long_http_props_failing.cy.js/when stat     (1280x720)
-     us code isnt 2xx or 3xx -- fails (failed).png                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/return_value_spec.js
+++ b/system-tests/__snapshots__/return_value_spec.js
@@ -79,21 +79,11 @@ Error: Resolution method is overspecified. Specify a callback *or* return a Prom
   │ Failing:      3                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  3                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     return_value.cy.js                                                               │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/return_value.cy.js/errors when invoking command     (1280x720)
-     s and return a different value (failed).png                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/return_value.cy.js/errors when invoking command     (1280x720)
-     s in custom command and returning different value (failed).png                                 
-  -  /XXX/XXX/XXX/cypress/screenshots/return_value.cy.js/errors when not invoking com     (1280x720)
-     mands, invoking done callback, and returning a promise (failed).png                            
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/runnable_execution_spec.ts.js
+++ b/system-tests/__snapshots__/runnable_execution_spec.ts.js
@@ -109,17 +109,11 @@ exports['e2e runnable execution / runs correctly after top navigation with alrea
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     runnables_already_run_suite.cy.js                                                │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/runnables_already_run_suite.cy.js/Top level des     (1280x720)
-     cribe -- suite 2 -- should fail (failed).png                                                   
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/stdout_spec.js
+++ b/system-tests/__snapshots__/stdout_spec.js
@@ -80,21 +80,11 @@ The internal Cypress web server responded with:
   │ Failing:      3                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  3                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     stdout_failing.cy.js                                                             │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_failing.cy.js/stdout_failing_spec -- fai     (1280x720)
-     ls (failed).png                                                                                
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_failing.cy.js/stdout_failing_spec -- fai     (1280x720)
-     ling hook -- is failing -- before each hook (failed).png                                       
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_failing.cy.js/stdout_failing_spec -- pas     (1280x720)
-     sing hook -- is failing (failed).png                                                           
 
 
 ====================================================================================================
@@ -472,23 +462,11 @@ exports['e2e stdout / displays assertion errors'] = `
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     stdout_assertion_errors.cy.js                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors.cy.js/assertion errors      (1280x720)
-     -- fails with assertion diff, no retries (failed).png                                          
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors.cy.js/assertion errors      (1280x720)
-     -- fails with assertion diff, with retries (failed).png                                        
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors.cy.js/assertion errors      (1280x720)
-     -- fails with dom assertion without diff, with retries (failed).png                            
-  -  /XXX/XXX/XXX/cypress/screenshots/stdout_assertion_errors.cy.js/assertion errors      (1280x720)
-     -- fails with dom assertion without diff, with retries (failed) (1).png                        
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/task_not_registered_spec.js
+++ b/system-tests/__snapshots__/task_not_registered_spec.js
@@ -44,17 +44,11 @@ https://on.cypress.io/api/task
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     task_not_registered.cy.js                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/task_not_registered.cy.js/fails because the tas          (YxX)
-     k event is not registered in setupNodeEvents method (failed).png                               
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/task_spec.js
+++ b/system-tests/__snapshots__/task_spec.js
@@ -119,19 +119,11 @@ https://on.cypress.io/api/task
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     task.cy.js                                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/task.cy.js/throws when task returns undefined (     (1280x720)
-     failed).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/task.cy.js/includes stack trace in error (faile     (1280x720)
-     d).png                                                                                         
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/testConfigOverrides_spec.ts.js
+++ b/system-tests/__snapshots__/testConfigOverrides_spec.ts.js
@@ -45,17 +45,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     invalid-browser.js                                                               │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid-browser.js/An uncaught error was detect     (1280x720)
-     ed outside of a test (failed).png                                                              
 
 
 ====================================================================================================
@@ -119,19 +113,11 @@ exports['testConfigOverrides / fails when setting invalid config opt with Cypres
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     invalid_before_test_event.js                                                     │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid_before_test_event.js/does not run (fail     (1280x720)
-     ed).png                                                                                        
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid_before_test_event.js/nested -- does not     (1280x720)
-      run 2 (failed).png                                                                            
 
 
 ====================================================================================================
@@ -195,19 +181,11 @@ exports['testConfigOverrides / fails when setting invalid config opt with Cypres
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     invalid_before_test_async_event.js                                               │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid_before_test_async_event.js/does not run     (1280x720)
-      (failed).png                                                                                  
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid_before_test_async_event.js/nested -- do     (1280x720)
-     es not run 2 (failed).png                                                                      
 
 
 ====================================================================================================
@@ -420,29 +398,11 @@ Because this error occurred during a \`after each\` hook we are skipping the rem
   │ Failing:      14                                                                               │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  7                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     invalid.js                                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/inline test config override throws e     (1280x720)
-     rror (failed).png                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/inline test config override throws e     (1280x720)
-     rror when executed within cy cmd (failed).png                                                  
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in test (failed).png                                                      
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in before hook -- 4 -- before all hook (failed).png                       
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in beforeEach hook -- 5 -- before each hook (failed).png                  
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in after hook -- 5 -- after all hook (failed).png                         
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in afterEach hook -- 5 -- after each hook (failed).png                    
 
 
 ====================================================================================================
@@ -605,19 +565,11 @@ https://on.cypress.io/config
   │ Failing:      8                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     before-invalid.js                                                                │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/before-invalid.js/runs all tests -- inline test     (1280x720)
-      config override throws error (failed).png                                                     
-  -  /XXX/XXX/XXX/cypress/screenshots/before-invalid.js/runs all tests -- inline test     (1280x720)
-      config override throws error when executed within cy cmd (failed).png                         
 
 
 ====================================================================================================
@@ -1076,29 +1028,11 @@ Because this error occurred during a \`after each\` hook we are skipping the rem
   │ Failing:      14                                                                               │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  7                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     invalid.js                                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/inline test config override throws e     (1280x720)
-     rror (failed).png                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/inline test config override throws e     (1280x720)
-     rror when executed within cy cmd (failed).png                                                  
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in test (failed).png                                                      
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in before hook -- 4 -- before all hook (failed).png                       
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in beforeEach hook -- 5 -- before each hook (failed).png                  
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in after hook -- 5 -- after all hook (failed).png                         
-  -  /XXX/XXX/XXX/cypress/screenshots/invalid.js/throws error when invalid config opt     (1280x720)
-      in Cypress.config() in afterEach hook -- 5 -- after each hook (failed).png                    
 
 
 ====================================================================================================
@@ -1255,19 +1189,11 @@ https://on.cypress.io/config
   │ Failing:      8                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     before-invalid.js                                                                │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/before-invalid.js/runs all tests -- inline test     (1280x720)
-      config override throws error (failed).png                                                     
-  -  /XXX/XXX/XXX/cypress/screenshots/before-invalid.js/runs all tests -- inline test     (1280x720)
-      config override throws error when executed within cy cmd (failed).png                         
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/uncaught_spec_errors_spec.js
+++ b/system-tests/__snapshots__/uncaught_spec_errors_spec.js
@@ -45,17 +45,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     uncaught_synchronous_before_tests_parsed.js                                      │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_synchronous_before_tests_parsed.js/An      (1280x720)
-     uncaught error was detected outside of a test (failed).png                                     
 
 
 ====================================================================================================
@@ -120,17 +114,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     uncaught_synchronous_during_hook.cy.js                                           │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_synchronous_during_hook.cy.js/An uncau     (1280x720)
-     ght error was detected outside of a test (failed).png                                          
 
 
 ====================================================================================================
@@ -222,21 +210,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      3                                                                                │
   │ Pending:      1                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  3                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     uncaught_during_test.cy.js                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_during_test.cy.js/foo -- fails with se     (1280x720)
-     tTimeout (failed).png                                                                          
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_during_test.cy.js/foo -- fails with se     (1280x720)
-     tTimeout and done (failed).png                                                                 
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_during_test.cy.js/foo -- fails with as     (1280x720)
-     ync app code error (failed).png                                                                
 
 
 ====================================================================================================
@@ -304,17 +282,11 @@ Because this error occurred during a \`before all\` hook we are skipping the rem
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     uncaught_during_hook.cy.js                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/uncaught_during_hook.cy.js/foo -- does not run      (1280x720)
-     -- before all hook (failed).png                                                                
 
 
 ====================================================================================================
@@ -395,23 +367,11 @@ exports['e2e uncaught errors / failing5'] = `
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     caught_async_sync_test.cy.js                                                     │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/caught_async_sync_test.cy.js/foo -- baz fails (     (1280x720)
-     failed).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/caught_async_sync_test.cy.js/foo -- bar fails (     (1280x720)
-     failed).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/caught_async_sync_test.cy.js/foo -- quux fails      (1280x720)
-     (failed).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/caught_async_sync_test.cy.js/foo -- quux2 fails     (1280x720)
-      (failed).png                                                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/uncaught_support_file_spec.js
+++ b/system-tests/__snapshots__/uncaught_support_file_spec.js
@@ -45,17 +45,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     spec.cy.js                                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/spec.cy.js/An uncaught error was detected outsi          (YxX)
-     de of a test (failed).png                                                                      
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/visit_spec.js
+++ b/system-tests/__snapshots__/visit_spec.js
@@ -127,17 +127,11 @@ If you do not want status codes to cause failures pass the option: \`failOnStatu
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     visit_http_500_response_failing.cy.js                                            │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_http_500_response_failing.cy.js/when serv     (1280x720)
-     er response is 500 -- fails (failed).png                                                       
 
 
 ====================================================================================================
@@ -295,19 +289,11 @@ When this \`load\` event occurs, Cypress will continue running commands.
   │ Failing:      2                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  2                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     visit_http_timeout_failing.cy.js                                                 │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_http_timeout_failing.cy.js/when visit tim     (1280x720)
-     es out -- fails timeout exceeds pageLoadTimeout (failed).png                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_http_timeout_failing.cy.js/when visit tim     (1280x720)
-     es out -- fails timeout exceeds timeout option (failed).png                                    
 
 
 ====================================================================================================
@@ -432,24 +418,11 @@ Common situations why this would fail:
   │ Failing:      3                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  3                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     visit_response_never_ends_failing.cy.js                                          │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_response_never_ends_failing.cy.js/respons     (1280x720)
-     e timeouts result in an error -- handles no response errors on the initial visit               
-      (failed).png                                                                                  
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_response_never_ends_failing.cy.js/respons     (1280x720)
-     e timeouts result in an error -- handles no response errors when not initially v               
-     isiting (failed).png                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/visit_response_never_ends_failing.cy.js/respons     (1280x720)
-     e timeouts result in an error -- fails after reducing the responseTimeout option               
-      (failed).png                                                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/vite_dev_server_fresh_spec.ts.js
+++ b/system-tests/__snapshots__/vite_dev_server_fresh_spec.ts.js
@@ -72,17 +72,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     AppCompilationError.cy.jsx                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/AppCompilationError.cy.jsx/An uncaught error wa     (1280x633)
-     s detected outside of a test (failed).png                                                      
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -155,22 +149,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     Errors.cy.jsx                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- error on mount (failed)     (1280x633)
-     .png                                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- sync error (failed).png     (1280x633)
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- async error (failed).pn     (1280x633)
-     g                                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- command failure (failed     (1280x633)
-     ).png                                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -206,17 +189,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReact.cy.jsx                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReact.cy.jsx/is missing React (failed).p     (1280x633)
-     ng                                                                                             
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -244,17 +221,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReactInSpec.cy.jsx                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReactInSpec.cy.jsx/is missing React in t     (1280x633)
-     his file (failed).png                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -498,17 +469,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     AppCompilationError.cy.jsx                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/AppCompilationError.cy.jsx/An uncaught error wa     (1280x633)
-     s detected outside of a test (failed).png                                                      
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -581,22 +546,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     Errors.cy.jsx                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- error on mount (failed)     (1280x633)
-     .png                                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- sync error (failed).png     (1280x633)
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- async error (failed).pn     (1280x633)
-     g                                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- command failure (failed     (1280x633)
-     ).png                                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -632,17 +586,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReact.cy.jsx                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReact.cy.jsx/is missing React (failed).p     (1280x633)
-     ng                                                                                             
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -670,17 +618,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReactInSpec.cy.jsx                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReactInSpec.cy.jsx/is missing React in t     (1280x633)
-     his file (failed).png                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -924,17 +866,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     AppCompilationError.cy.jsx                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/AppCompilationError.cy.jsx/An uncaught error wa     (1280x633)
-     s detected outside of a test (failed).png                                                      
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1007,22 +943,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     Errors.cy.jsx                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- error on mount (failed)     (1280x633)
-     .png                                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- sync error (failed).png     (1280x633)
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- async error (failed).pn     (1280x633)
-     g                                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- command failure (failed     (1280x633)
-     ).png                                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1058,17 +983,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReact.cy.jsx                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReact.cy.jsx/is missing React (failed).p     (1280x633)
-     ng                                                                                             
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1096,17 +1015,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReactInSpec.cy.jsx                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReactInSpec.cy.jsx/is missing React in t     (1280x633)
-     his file (failed).png                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1350,17 +1263,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     AppCompilationError.cy.jsx                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/AppCompilationError.cy.jsx/An uncaught error wa     (1280x633)
-     s detected outside of a test (failed).png                                                      
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1433,22 +1340,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     Errors.cy.jsx                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- error on mount (failed)     (1280x633)
-     .png                                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- sync error (failed).png     (1280x633)
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- async error (failed).pn     (1280x633)
-     g                                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- command failure (failed     (1280x633)
-     ).png                                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1484,17 +1380,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReact.cy.jsx                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReact.cy.jsx/is missing React (failed).p     (1280x633)
-     ng                                                                                             
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -1522,17 +1412,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReactInSpec.cy.jsx                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReactInSpec.cy.jsx/is missing React in t     (1280x633)
-     his file (failed).png                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/system-tests/__snapshots__/web_security_spec.js
+++ b/system-tests/__snapshots__/web_security_spec.js
@@ -89,23 +89,11 @@ https://on.cypress.io/cy-visit-succeeded-but-commands-fail
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     web_security.cy.js                                                               │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/web_security.cy.js/web security -- fails when c     (1280x720)
-     licking a to another origin (failed).png                                                       
-  -  /XXX/XXX/XXX/cypress/screenshots/web_security.cy.js/web security -- fails when s     (1280x720)
-     ubmitted a form and being redirected to another origin (failed).png                            
-  -  /XXX/XXX/XXX/cypress/screenshots/web_security.cy.js/web security -- fails when u     (1280x720)
-     sing a javascript redirect to another origin (failed).png                                      
-  -  /XXX/XXX/XXX/cypress/screenshots/web_security.cy.js/web security -- fails when d     (1280x720)
-     oing a CORS request cross-origin (failed).png                                                  
 
 
 ====================================================================================================

--- a/system-tests/__snapshots__/webpack_dev_server_fresh_spec.ts.js
+++ b/system-tests/__snapshots__/webpack_dev_server_fresh_spec.ts.js
@@ -110,17 +110,11 @@ We dynamically generated a new test to display this failure.
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     AppCompilationError.cy.jsx                                                       │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/AppCompilationError.cy.jsx/An uncaught error wa     (1280x633)
-     s detected outside of a test (failed).png                                                      
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -193,22 +187,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      4                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  4                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     Errors.cy.jsx                                                                    │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- error on mount (failed)     (1280x633)
-     .png                                                                                           
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- sync error (failed).png     (1280x633)
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- async error (failed).pn     (1280x633)
-     g                                                                                              
-  -  /XXX/XXX/XXX/cypress/screenshots/Errors.cy.jsx/Errors -- command failure (failed     (1280x633)
-     ).png                                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -244,17 +227,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReact.cy.jsx                                                              │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReact.cy.jsx/is missing React (failed).p     (1280x633)
-     ng                                                                                             
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────
@@ -282,17 +259,11 @@ https://on.cypress.io/uncaught-exception-from-application
   │ Failing:      1                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  1                                                                                │
+  │ Screenshots:  0                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     MissingReactInSpec.cy.jsx                                                        │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-
-
-  (Screenshots)
-
-  -  /XXX/XXX/XXX/cypress/screenshots/MissingReactInSpec.cy.jsx/is missing React in t     (1280x633)
-     his file (failed).png                                                                          
 
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/system-tests/test/allow_cypress_env_spec.ts
+++ b/system-tests/test/allow_cypress_env_spec.ts
@@ -9,6 +9,7 @@ describe('allowCypressEnv', () => {
     snapshot: true,
     expectedExitCode: 1,
     browser: 'electron',
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('correctly prints a warning when trying to use Cypress.env() with allowCypressEnv=true', {

--- a/system-tests/test/async_timeouts_spec.js
+++ b/system-tests/test/async_timeouts_spec.js
@@ -7,5 +7,6 @@ describe('e2e async timeouts', () => {
     spec: 'async_timeouts.cy.js',
     snapshot: true,
     expectedExitCode: 2,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/before_all_after_all_throws_spec.ts
+++ b/system-tests/test/before_all_after_all_throws_spec.ts
@@ -19,6 +19,7 @@ describe('before all and after all throw', () => {
     snapshot: true,
     expectedExitCode: 1,
     browser: 'electron',
+    config: { screenshotOnRunFailure: false },
     processEnv: {
       ELECTRON_ENABLE_LOGGING: 1,
     },

--- a/system-tests/test/caught_uncaught_hook_errors_spec.js
+++ b/system-tests/test/caught_uncaught_hook_errors_spec.js
@@ -12,23 +12,27 @@ describe('e2e caught and uncaught hooks errors', () => {
     spec: 'hook_caught_error_failing.cy.js',
     snapshot: true,
     expectedExitCode: 3,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing2', {
     spec: 'hook_uncaught_error_failing.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing3', {
     spec: 'hook_uncaught_root_error_failing.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing4', {
     spec: 'hook_uncaught_error_events_failing.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/commands_outside_of_test_spec.js
+++ b/system-tests/test/commands_outside_of_test_spec.js
@@ -7,12 +7,14 @@ describe('e2e commands outside of test', () => {
     spec: 'commands_outside_of_test.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('fails on failing assertions', {
     spec: 'assertions_failing_outside_of_test.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('passes on passing assertions', {

--- a/system-tests/test/component_testing_spec.ts
+++ b/system-tests/test/component_testing_spec.ts
@@ -174,6 +174,7 @@ describe('experimentalSingleTabRunMode', function () {
     browser: 'chrome',
     snapshot: true,
     expectedExitCode: 2,
+    config: { screenshotOnRunFailure: false },
   })
 
   // https://github.com/cypress-io/cypress/issues/23815

--- a/system-tests/test/experimental_csp_allow_list_spec.ts
+++ b/system-tests/test/experimental_csp_allow_list_spec.ts
@@ -110,6 +110,7 @@ describe('e2e experimentalCspAllowList', () => {
         videoCompression: false,
         retries: 0,
         experimentalCspAllowList: ['form-action'],
+        screenshotOnRunFailure: false,
       },
     })
   })

--- a/system-tests/test/form_submissions_spec.js
+++ b/system-tests/test/form_submissions_spec.js
@@ -103,6 +103,7 @@ describe('e2e forms', () => {
       spec: 'form_submission_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
       onStdout: (stdout) => {
         return stdout
         .replace(/((?: {6}-)+[^\n]+\n)/gm, '')

--- a/system-tests/test/issue_149_spec.js
+++ b/system-tests/test/issue_149_spec.js
@@ -11,6 +11,7 @@ describe('e2e issue 149', () => {
       spec: 'issue_149.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
     .then(() => {
       // the other test should have still run which should

--- a/system-tests/test/issue_1669_spec.js
+++ b/system-tests/test/issue_1669_spec.js
@@ -10,6 +10,7 @@ describe('e2e issue 1669', () => {
       snapshot: true,
       browser: 'chrome',
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
   })
 })

--- a/system-tests/test/issue_173_spec.ts
+++ b/system-tests/test/issue_173_spec.ts
@@ -8,5 +8,6 @@ describe('e2e issue 173', () => {
     spec: 'issue_173.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/issue_674_spec.js
+++ b/system-tests/test/issue_674_spec.js
@@ -8,5 +8,6 @@ describe('e2e issue 674', () => {
     spec: 'issue_674.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/js_error_handling_spec.js
+++ b/system-tests/test/js_error_handling_spec.js
@@ -49,6 +49,7 @@ describe('e2e js error handling', () => {
     spec: 'js_error_handling_failing.cy.js',
     snapshot: true,
     expectedExitCode: 5,
+    config: { screenshotOnRunFailure: false },
     onStdout (stdout) {
       // firefox has a stack line for the cross-origin error that other browsers don't
       return stdout

--- a/system-tests/test/plugins_not_supported.ts
+++ b/system-tests/test/plugins_not_supported.ts
@@ -9,5 +9,6 @@ describe('plugins not supported in v10', () => {
     spec: '*',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/promises_spec.js
+++ b/system-tests/test/promises_spec.js
@@ -7,5 +7,6 @@ describe('e2e promises', () => {
     spec: 'promises.cy.js',
     snapshot: true,
     expectedExitCode: 2,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/request_spec.ts
+++ b/system-tests/test/request_spec.ts
@@ -181,6 +181,7 @@ describe('e2e requests', () => {
       spec: 'request_http_network_error_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
   })
 
@@ -189,6 +190,7 @@ describe('e2e requests', () => {
       spec: 'request_status_code_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
       onStdout (stdout) {
         return stdout
         .replace(/"user-agent": ".+",/, '"user-agent": "foo",')
@@ -203,6 +205,7 @@ describe('e2e requests', () => {
       spec: 'request_long_http_props_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
       onStdout (stdout) {
         return stdout
         .replace(/"user-agent": ".+",/, '"user-agent": "foo",')

--- a/system-tests/test/return_value_spec.js
+++ b/system-tests/test/return_value_spec.js
@@ -8,6 +8,7 @@ describe('e2e return value', () => {
       spec: 'return_value.cy.js',
       snapshot: true,
       expectedExitCode: 3,
+      config: { screenshotOnRunFailure: false },
     })
   })
 })

--- a/system-tests/test/runnable_execution_spec.ts
+++ b/system-tests/test/runnable_execution_spec.ts
@@ -32,5 +32,6 @@ describe('e2e runnable execution', () => {
     spec: 'runnables_already_run_suite.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/stdout_spec.js
+++ b/system-tests/test/stdout_spec.js
@@ -29,6 +29,7 @@ describe('e2e stdout', () => {
       snapshot: true,
       spec: 'stdout_failing.cy.js',
       expectedExitCode: 3,
+      config: { screenshotOnRunFailure: false },
       onStdout: (stdout) => {
         // assert stack trace line numbers/columns mirror source map
         expect(stdout).to.include('Context.eval (webpack://e2e/./cypress/e2e/stdout_failing.cy.js:7:12)')
@@ -76,5 +77,6 @@ describe('e2e stdout', () => {
     spec: 'stdout_assertion_errors.cy.js',
     snapshot: true,
     expectedExitCode: 4,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/task_not_registered_spec.js
+++ b/system-tests/test/task_not_registered_spec.js
@@ -7,9 +7,9 @@ describe('e2e task', () => {
     return systemTests.exec(this, {
       project: 'task-not-registered',
       spec: 'task_not_registered.cy.js',
-      sanitizeScreenshotDimensions: true,
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
   })
 })

--- a/system-tests/test/task_spec.js
+++ b/system-tests/test/task_spec.js
@@ -8,6 +8,7 @@ describe('e2e task', () => {
       spec: 'task.cy.js',
       snapshot: true,
       expectedExitCode: 2,
+      config: { screenshotOnRunFailure: false },
     })
     .then(({ stdout }) => {
       // should include a stack trace from plugins file

--- a/system-tests/test/testConfigOverrides_spec.ts
+++ b/system-tests/test/testConfigOverrides_spec.ts
@@ -21,6 +21,7 @@ describe('testConfigOverrides', () => {
     spec: 'testConfigOverrides/invalid-browser.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('has originalTitle when skipped due to browser config', {
@@ -44,6 +45,7 @@ describe('testConfigOverrides', () => {
     outputPath,
     browser: 'electron',
     expectedExitCode: 2,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('fails when setting invalid config opt with Cypress.config() in before:test:run:async', {
@@ -52,6 +54,7 @@ describe('testConfigOverrides', () => {
     outputPath,
     browser: 'electron',
     expectedExitCode: 2,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it(`fails when trying to perform testConfigOverrides for Cypress.env() with allowCypressEnv=false`, {
@@ -75,6 +78,7 @@ describe('testConfigOverrides', () => {
       snapshot: true,
       browser: browserList,
       expectedExitCode: 14,
+      config: { screenshotOnRunFailure: false },
     })
 
     systemTests.it(`fails when passing invalid config values with beforeEach - [${browserList}]`, {
@@ -82,6 +86,7 @@ describe('testConfigOverrides', () => {
       snapshot: true,
       browser: browserList,
       expectedExitCode: 8,
+      config: { screenshotOnRunFailure: false },
     })
 
     systemTests.it(`correctly fails when invalid config values for it.only [${browserList}]`, {

--- a/system-tests/test/uncaught_spec_errors_spec.js
+++ b/system-tests/test/uncaught_spec_errors_spec.js
@@ -7,29 +7,34 @@ describe('e2e uncaught errors', () => {
     spec: 'uncaught_synchronous_before_tests_parsed.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing2', {
     spec: 'uncaught_synchronous_during_hook.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing3', {
     spec: 'uncaught_during_test.cy.js',
     snapshot: true,
     expectedExitCode: 3,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing4', {
     spec: 'uncaught_during_hook.cy.js',
     snapshot: true,
     expectedExitCode: 1,
+    config: { screenshotOnRunFailure: false },
   })
 
   systemTests.it('failing5', {
     spec: 'caught_async_sync_test.cy.js',
     snapshot: true,
     expectedExitCode: 4,
+    config: { screenshotOnRunFailure: false },
   })
 })

--- a/system-tests/test/uncaught_support_file_spec.js
+++ b/system-tests/test/uncaught_support_file_spec.js
@@ -6,9 +6,9 @@ describe('e2e uncaught support file errors', () => {
   it('failing', function () {
     return systemTests.exec(this, {
       project: 'uncaught-support-file',
-      sanitizeScreenshotDimensions: true,
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
   })
 })

--- a/system-tests/test/visit_spec.js
+++ b/system-tests/test/visit_spec.js
@@ -165,6 +165,7 @@ describe('e2e visit', () => {
       spec: 'visit_http_500_response_failing.cy.js',
       snapshot: true,
       expectedExitCode: 1,
+      config: { screenshotOnRunFailure: false },
     })
 
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23162
@@ -208,6 +209,7 @@ describe('e2e visit', () => {
       spec: 'visit_response_never_ends_failing.cy.js',
       snapshot: true,
       expectedExitCode: 3,
+      config: { screenshotOnRunFailure: false },
     })
   })
 
@@ -254,6 +256,7 @@ describe('e2e visit', () => {
       spec: 'visit_http_timeout_failing.cy.js',
       snapshot: true,
       expectedExitCode: 2,
+      config: { screenshotOnRunFailure: false },
     })
   })
 })

--- a/system-tests/test/vite_dev_server_fresh_spec.ts
+++ b/system-tests/test/vite_dev_server_fresh_spec.ts
@@ -22,6 +22,7 @@ describe('@cypress/vite-dev-server', function () {
           // @see https://github.com/cypress-io/cypress/issues/30881 and src/Rerendering.cy.jsx for details on skipping.
           spec: 'src/**/*.cy.jsx,!src/Rerendering.cy.jsx',
           expectedExitCode: 7,
+          config: { screenshotOnRunFailure: false },
         })
       })
 

--- a/system-tests/test/web_security_spec.js
+++ b/system-tests/test/web_security_spec.js
@@ -78,6 +78,7 @@ describe('e2e web security', () => {
       spec: 'web_security.cy.js',
       config: {
         pageLoadTimeout: 5000,
+        screenshotOnRunFailure: false,
       },
       snapshot: true,
       expectedExitCode: 4,

--- a/system-tests/test/webpack_dev_server_fresh_spec.ts
+++ b/system-tests/test/webpack_dev_server_fresh_spec.ts
@@ -18,6 +18,7 @@ describe('@cypress/webpack-dev-server', function () {
         browser: 'chrome',
         snapshot: true,
         expectedExitCode: 7,
+        config: { screenshotOnRunFailure: false },
         onStdout: (stdout) => {
           return systemTests.normalizeWebpackErrors(stdout)
         },


### PR DESCRIPTION
- Closes N/A

### Additional details

**Why:** The `testConfigOverrides` "fails when passing invalid config values with beforeEach" system test (`before-invalid.js`) expects 8 failing tests (exit code 8) but intermittently exits with code 1 — the flaky `expected exit code 8 but got 1` assertion.

**Root cause:** Its first two tests fail *inside the test body* via inline `Cypress.config('baseUrl', '')` / `Cypress.config('baseUrl', 'null')` calls. A body failure triggers Cypress's on-failure screenshot automation (a server round-trip bounded by `responseTimeout`), which overlaps with the between-test `about:blank` reset and spec-bridge teardown that runs under test isolation. Under CI load that overlap can abort the run after the first failing test, and because the e2e fixture disables retries (`retries: null`) there is no recovery.

**Fix:** Screenshots are incidental to what these specs verify, so disable them with `config: { screenshotOnRunFailure: false }` — matching the pattern already used in failure-reporting specs such as `experimental_retries.spec.ts` and `reporters_spec.ts`. Many other snapshot-based system tests capture on-failure screenshots the same way, purely as a side effect of the failure they assert on (config validation, uncaught/hook errors, task/plugin errors, visit failures, dev-server run failures, etc.), so the same fix is applied across the suite (44 entries across 28 specs).

Screenshots are **left enabled** where the on-failure behavior is relevant: the `screenshot_*`/`screenshots` specs, `issue_5016` (exercises `screenshotOnRunFailure`), `record_spec` (asserts screenshot artifact upload), `plugins_spec` (`after:screenshot` behavior), the retries specs (per-attempt screenshot naming), and `issue_5475` (takes a deliberate `cy.screenshot()`).

**What changes in the snapshots:** only the screenshot count (`Screenshots: N` → `0`) and removal of the `(Screenshots)` section. Test counts, error output, and exit codes are unchanged — verified with an independent invariant (stripping all screenshot sections and count lines from both the pre- and post-change snapshots yields identical output across all 28 regenerated files).

### Steps to test

Regenerating the affected snapshots should produce no diff:

```
cd system-tests && SNAPSHOT_UPDATE=1 yarn test <spec>
```

Highest-signal spot checks: `vite_dev_server_fresh_spec` / `webpack_dev_server_fresh_spec` (multi-spec runs) and `stdout_spec` (retry-deduplicated `(failed) (1).png` case).

### How has the user experience changed?

No change. This only affects the system-test suite's own configuration and snapshots — no product behavior changes.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- test-only change to the internal system-test suite -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdKNxbLLeeYr54YAP3jird)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal system-test configuration and snapshot updates only; no product or user-facing Cypress behavior changes.
> 
> **Overview**
> **De-flakes snapshot-based system tests** by turning off incidental failure screenshots where specs only assert on stdout, exit codes, and error text—not screenshot behavior.
> 
> Failing runs across ~28 specs now pass `config: { screenshotOnRunFailure: false }` (same approach as other failure-reporting system tests). That avoids screenshot automation overlapping test-isolation teardown and aborting multi-failure runs early (e.g. `before-invalid.js` expecting exit code 8 but sometimes exiting with 1). `sanitizeScreenshotDimensions` was dropped from a couple specs because screenshots are no longer taken.
> 
> **Snapshots** only change `Screenshots: N` → `0` and remove the `(Screenshots)` listing; test counts and error output stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c9f61a7a472ac23083e017c1eb229bbb348570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->