### PR TITLE
feat(driver): support HTTP QUERY method in cy.request() and cy.intercept()

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
-## 15.19.1
+## 15.20.0
 
 **Performance:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Fixed an issue where visibility checks (such as [`.should('be.visible')`](https://on.cypress.io/should) and actionability) serialized an element's entire text subtree once per overflow-hidden ancestor, which on text-heavy pages could exhaust the renderer's memory and crash it (`We detected that the Chrome Renderer process just crashed`). Fixes [#34329](https://github.com/cypress-io/cypress/issues/34329).
 - Reduced the sampling overhead of [`experimentalMemoryManagement`](https://on.cypress.io/experiments) when Cypress runs inside a memory-limited container using cgroup v1. Memory readings no longer spawn helper subprocesses on every sampling interval, which lowers CPU usage that previously competed with the tests, most noticeably on constrained CI machines. Addresses [#34105](https://github.com/cypress-io/cypress/issues/34105). Fixed in [#34331](https://github.com/cypress-io/cypress/pull/34331).
 
+**Features:**
+
+- [`cy.request()`](https://on.cypress.io/request) and [`cy.intercept()`](https://on.cypress.io/intercept) now accept the HTTP `QUERY` method. Previously it was rejected as an invalid method in the browser. Fixes [#28282](https://github.com/cypress-io/cypress/issues/28282).
+
 **Bugfixes:**
 
 - Fixed an issue where a `cy.*` command error message that interpolated a value containing a `$` character could render incorrectly, with a leaked `{{...}}` placeholder or duplicated or dropped surrounding text. Such values are now inserted verbatim. Fixed in [#34221](https://github.com/cypress-io/cypress/pull/34221).

--- a/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
+++ b/packages/driver/cypress/e2e/commands/net_stubbing.cy.ts
@@ -315,6 +315,21 @@ describe('network stubbing', { retries: 15 }, function () {
       cy.wait('@create')
     })
 
+    // @see https://github.com/cypress-io/cypress/issues/28282
+    it('QUERY method shorthand is treated as a method, not a url', () => {
+      cy.intercept('QUERY', '/query-only', { statusCode: 200, body: 'ok' }).as('query')
+
+      cy.window().then((win) => {
+        win.eval(
+          `fetch("/query-only", {
+            method: 'QUERY',
+          });`,
+        )
+      })
+
+      cy.wait('@query').its('request.method').should('eq', 'QUERY')
+    })
+
     // @see https://github.com/cypress-io/cypress/issues/16117
     it('can statically stub a url response with headers', () => {
       cy.intercept('/url', { headers: { foo: 'bar' }, body: 'something' })

--- a/packages/driver/cypress/e2e/commands/request.cy.js
+++ b/packages/driver/cypress/e2e/commands/request.cy.js
@@ -560,6 +560,16 @@ describe('src/cy/commands/request', () => {
           expect(res.body).to.contain('M-SEARCH')
         })
       })
+
+      it('can use QUERY method', () => {
+        cy.request({
+          url: 'http://localhost:3500/dump-method',
+          method: 'QUERY',
+        })
+        .then((res) => {
+          expect(res.body).to.contain('QUERY')
+        })
+      })
     })
 
     describe('headers', () => {

--- a/packages/driver/cypress/e2e/cypress/utils.cy.js
+++ b/packages/driver/cypress/e2e/cypress/utils.cy.js
@@ -348,4 +348,23 @@ describe('driver/src/cypress/utils', () => {
       expect(encoded).to.equal('44K144Kk44OX44Oq44K544Gv5LiA55Wq')
     })
   })
+
+  context('.isValidHttpMethod', () => {
+    it('returns true for standard methods, case-insensitively', () => {
+      expect($utils.isValidHttpMethod('GET')).to.be.true
+      expect($utils.isValidHttpMethod('post')).to.be.true
+    })
+
+    it('returns true for the QUERY method', () => {
+      expect($utils.isValidHttpMethod('QUERY')).to.be.true
+      expect($utils.isValidHttpMethod('query')).to.be.true
+    })
+
+    it('returns false for unknown methods and non-strings', () => {
+      expect($utils.isValidHttpMethod('INVALID')).to.be.false
+      expect($utils.isValidHttpMethod('')).to.be.false
+      expect($utils.isValidHttpMethod(null)).to.be.false
+      expect($utils.isValidHttpMethod(undefined)).to.be.false
+    })
+  })
 })

--- a/packages/driver/src/cypress/utils.ts
+++ b/packages/driver/src/cypress/utils.ts
@@ -16,6 +16,13 @@ const webpackDevtoolNamespaceRegex = /webpack:\/{2}([^.]*)?\.\//
 const tagOpen = /\[([a-z\s='"-]+)\]/g
 const tagClosed = /\[\/([a-z]+)\]/g
 
+// `methods` derives its list from Node's `http.METHODS` when it is imported.
+// In the browser bundle there is no `http` module, so it falls back to a static
+// snapshot that predates newer standardized methods such as QUERY. Union those
+// in so validation matches regardless of the runtime doing the check.
+const additionalHttpMethods = ['query']
+const validHttpMethods = new Set([...methods, ...additionalHttpMethods].map((method) => method.toLowerCase()))
+
 const defaultOptions = {
   delay: 10,
   force: false,
@@ -341,7 +348,7 @@ export default {
   },
 
   isValidHttpMethod (str) {
-    return _.isString(str) && _.includes(methods, str.toLowerCase())
+    return _.isString(str) && validHttpMethods.has(str.toLowerCase())
   },
 
   addTwentyYears () {

--- a/packages/network-interception/lib/types/external-types.ts
+++ b/packages/network-interception/lib/types/external-types.ts
@@ -24,6 +24,8 @@ type Method =
   | 'PROPPATCH'
   | 'PURGE'
   | 'PUT'
+  // QUERY is not yet in the upstream DefinitelyTyped list; keep it when re-syncing.
+  | 'QUERY'
   | 'REBIND'
   | 'REPORT'
   | 'SEARCH'
@@ -58,6 +60,7 @@ type Method =
   | 'proppatch'
   | 'purge'
   | 'put'
+  | 'query'
   | 'rebind'
   | 'report'
   | 'search'


### PR DESCRIPTION
- Closes #28282

### Additional details

`cy.request()` and `cy.intercept()` rejected the HTTP `QUERY` method with an `invalid method` error, even though the underlying server (modern Node) can perform the request. This PR fixes that.

#### Before

cy.request

<img width="599" height="592" alt="Screenshot 2026-08-03 at 4 45 20 PM" src="https://github.com/user-attachments/assets/dbe20a81-23cd-4bf8-aeab-f3922bc4ee53" />

cy.intercept - treats 'QUERY' as a URL arg

<img width="573" height="490" alt="Screenshot 2026-08-03 at 4 47 20 PM" src="https://github.com/user-attachments/assets/139b0405-4ea7-4072-ae42-422374c8ec71" />

<img width="561" height="560" alt="Screenshot 2026-08-03 at 4 47 24 PM" src="https://github.com/user-attachments/assets/f7e3901a-f95e-4acd-a24d-19a19cc4bae8" />

#### After

cy.request

<img width="588" height="315" alt="Screenshot 2026-08-03 at 4 51 28 PM" src="https://github.com/user-attachments/assets/bb824527-ce77-431b-8b80-8cd0a29c2cd0" />

cy.intercept

<img width="592" height="841" alt="Screenshot 2026-08-03 at 4 51 22 PM" src="https://github.com/user-attachments/assets/31794aca-a7ed-4a8d-86f6-a0ff1b6ee22e" />


**Root cause:** method validation happens in the browser via `$utils.isValidHttpMethod()` (`packages/driver/src/cypress/utils.ts`), which checks membership in the `methods` package. `methods` builds its list from Node's `http.METHODS` **at import time**. In the browser bundle there is no `http` module and no webpack `http` fallback is configured (`packages/web-config/webpack.config.base.ts`), so `http` resolves to an empty module and `methods` silently falls back to a **static snapshot** that predates newer standardized methods like `QUERY`. The result: validation returns `true` for `QUERY` in Node (where unit tests run) but `false` in the browser (where the command is actually gated) — so a Node-only test would pass while the feature stayed broken.

**Fix:**
- Union an explicit allowlist of additional standardized methods (`query`) into the valid-methods set in `isValidHttpMethod`, so validation is correct regardless of the runtime doing the check.
- Add `QUERY`/`query` to the `Method` union type (`packages/network-interception/lib/types/external-types.ts`) — a copy of the DefinitelyTyped `methods` list that omitted it — so `cy.intercept('QUERY', ...)` type-checks against the `intercept(method, url, response)` overload.

No server-side change is needed — `@packages/network-interception` matches the method as a lowercased string (not via `isValidHttpMethod`), and the request executes on the bundled Electron Node (v22), which supports `QUERY`.

**Tests** are added in the **browser-run** driver specs — the environment that actually gates these commands, rather than only the Node-run unit specs where `QUERY` passes trivially:
- `cypress/e2e/cypress/utils.cy.js` — direct `isValidHttpMethod` coverage (standard methods case-insensitively, `QUERY`/`query`, and invalid/non-string inputs).
- `cypress/e2e/commands/request.cy.js` — end-to-end `cy.request('QUERY')` via the existing `/dump-method` endpoint.
- `cypress/e2e/commands/net_stubbing.cy.ts` — `cy.intercept('QUERY', ...)` matching, covering the method/url shorthand disambiguation that depends on `isValidHttpMethod`.

#### Out of scope (follow-ups for future PRs)

These are intentionally **not** addressed here to keep the change minimal and focused on the reported issue:

- **The broader method-drift class of bug.** The browser's static `methods` snapshot omits nine methods that modern Node knows: `acl, bind, link, mkcalendar, query, rebind, source, unbind, unlink`. This PR only adds the requested `query`. The durable fix is for the driver to stop depending on a runtime-derived list — e.g. own a canonical, frozen method list (removes the `methods` dependency for validation; deterministic across runtimes), or validate a method syntactically as an RFC 9110 `token` instead of by allowlist (never drifts, but is a validation-loosening behavior change that trades away the friendly typo guardrail). Both are worth a dedicated issue/PR and a maintainer decision.
- **`cypress-documentation` update** for the `cy.request()` / `cy.intercept()` method docs — tracked below.

### Steps to test

```shell
# Browser-run driver specs (the specs that gate these commands)
yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/cypress/utils.cy.js,cypress/e2e/commands/request.cy.js,cypress/e2e/commands/net_stubbing.cy.ts"
```

Expected: `isValidHttpMethod('QUERY')` is `true`, `cy.request({ method: 'QUERY' })` resolves, and `cy.intercept('QUERY', ...)` matches a `QUERY` request.

### How has the user experience changed?

`cy.request()` and `cy.intercept()` now accept the HTTP `QUERY` method instead of throwing an `invalid method` error. No other behavior changes.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #28282 -->
- [x] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- follow-up; noted as out of scope above -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- added QUERY/query to the `Method` union in packages/network-interception/lib/types/external-types.ts -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4uP5ZmLnGjk3HvTttkr4S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 028a154089a1cc8681294d653720d2805e61f045. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->