### PR TITLE
chore: restore missing arch yarn.lock entry and add a lockfile drift check to CI

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1824,8 +1824,9 @@ jobs:
             node ./scripts/circle-env.js --check-canaries --is-contributor-pr $IS_CONTRIBUTOR_PR
       - build-and-persist
 
-  lint:
+  check-lockfile:
     <<: *defaults
+    executor: node-slim
     steps:
       - restore_cached_workspace
       - run:
@@ -1838,6 +1839,14 @@ jobs:
               echo "Run 'yarn-deduplicate --strategy=highest' and commit the resulting yarn.lock."
               exit 1
             fi
+      - run:
+          name: Check yarn.lock matches resolved dependencies 🔒
+          command: yarn check-lockfile-drift
+
+  lint:
+    <<: *defaults
+    steps:
+      - restore_cached_workspace
       - run:
           name: Linting 🧹
           command: |

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -19,6 +19,9 @@ linux-x64:
         context: test-runner:env-canary
         requires:
           - node_modules_install
+    - check-lockfile:
+        requires:
+          - build
     - check-ts:
         requires:
           - build
@@ -281,6 +284,7 @@ linux-x64:
           - npm-cypress-schematic
           - lint-types
           - linux-lint
+          - check-lockfile
           - percy-finalize
           - driver-integration-tests-firefox
           - driver-integration-tests-chrome

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -60,6 +60,10 @@ jobs:
         - internal-pr-build
         - external-pr-build
         - approve-contributor-pr
+  - check-lockfile:
+      requires:
+        - internal-pr-build
+        - external-pr-build
   - check-ts:
       requires:
         - internal-pr-build
@@ -459,6 +463,7 @@ jobs:
       requires:
         # Always-run jobs
         - linux-lint
+        - check-lockfile
         - check-ts
         - health-check
         - lint-types

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build-v8-snapshot-prod": "node --max-old-space-size=8192 tooling/v8-snapshot/scripts/setup-v8-snapshot-in-cypress.js",
     "check-binary-on-cdn": "node ./scripts/binary.js checkIfBinaryExistsOnCdn",
     "check-lockfile": "yarn-deduplicate --strategy=highest --list --fail",
+    "check-lockfile-drift": "./scripts/check-lockfile-drift.sh",
     "check-node-version": "node scripts/check-node-version.js",
     "check-terminal": "node scripts/check-terminal.js",
     "check-ts": "yarn lerna run check-ts",

--- a/scripts/check-lockfile-drift.sh
+++ b/scripts/check-lockfile-drift.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+# `yarn install --frozen-lockfile` only validates that top-level dependency
+# patterns are present, not the whole transitive closure. A yarn.lock missing a
+# nested entry therefore installs cleanly in CI while every unfrozen install
+# silently re-adds it, and until then that package is resolved live from the
+# registry with no locked version or integrity hash. Only a real resolution pass
+# detects it.
+
+before="$(mktemp)"
+trap 'rm -f "$before"' EXIT
+
+cp yarn.lock "$before"
+
+yarn install --ignore-scripts
+
+# yarn rewrites yarn.lock on every install and reports "Saved lockfile" even
+# when nothing changed, so compare contents rather than trusting the output.
+if diff -u "$before" yarn.lock; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+
+yarn.lock does not match what `yarn install` resolves (diff above).
+
+An entry is missing, stale, or was hand-edited — commonly from bumping a version
+in package.json and editing yarn.lock to match instead of installing. Affected
+packages resolve from the registry on every install with no locked integrity
+hash, and `--frozen-lockfile` does not catch it.
+
+Run `yarn install` and commit the resulting yarn.lock.
+EOF
+
+exit 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -11166,6 +11166,11 @@ aproba@^1.0.3:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
+arch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
+  integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
+
 arch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-3.0.0.tgz#a44e7077da4615fc5f1e3da21fbfc201d2c1817c"


### PR DESCRIPTION
- Closes N/A — no existing issue. Found while investigating why `yarn` produced an unexpected `yarn.lock` diff on a clean checkout of `develop`.

### Additional details

**The bug.** Running `yarn` on a clean `develop` checkout re-adds an `arch@^2.2.0` block to `yarn.lock`. [#34426](https://github.com/cypress-io/cypress/pull/34426) bumped `arch` for the CLI and its lockfile diff (`8 ++++----`) *renamed* the `arch@^2.2.0` entry into `arch@^3.0.0` instead of adding one beside it. Only `cli/package.json` moved to `^3.0.0`; `clipboardy@3.0.0` (via `cypress-example-kitchensink@6.0.2` → `serve@14.2.6`) still requires `^2.x`, so the entry satisfying it was lost. A real `yarn install` would have kept both — the lockfile was edited by hand to match the `package.json` change.

The consequence is not just a noisy diff: `arch` isn't skipped, it's resolved live from the registry on every install, with no locked version and no integrity hash. `node_modules/clipboardy/node_modules/arch` is currently 2.2.0 by luck of whatever the registry serves. This has been the case on every dev machine and in CI since Jul 31.

**Why nothing caught it.** Two independent gaps, both verified against the committed lockfile:

- `yarn install --check-files --frozen-lockfile` — the exact command CI runs — exits 0 and leaves the lockfile untouched. Yarn 1 only validates that top-level dependency patterns are present, not the transitive closure.
- The existing `yarn check-lockfile` (yarn-deduplicate) passes, correctly: a *missing* entry is not a duplicate. That check is healthy and I confirmed it still has teeth by injecting a synthetic duplicate.

`yarn check` is not a usable alternative — it reports 317 errors and 211 warnings on a healthy tree, because Yarn 1's tree validation doesn't understand workspace hoisting.

**The guard.** `yarn check-lockfile-drift` snapshots `yarn.lock`, runs a real resolution pass, and fails if the lockfile moved. Two details worth knowing: yarn rewrites the file and prints `success Saved lockfile` on *every* install even when nothing changed, so the check compares contents rather than trusting that output; and it uses a before/after snapshot rather than `git diff`, which would measure against `HEAD` and flag a locally-corrected lockfile as a failure.

**Why a separate job.** The drift check's install re-extracts packages, which reverts `patch-package` patches — I measured 4 of 5 sampled patched files reverting. Sharing a job with `yarn lint` would have required a patch re-apply step afterward, and putting it last would have let a lint failure mask lockfile failures. A dedicated `check-lockfile` job removes all of that; nothing else in it consumes `node_modules`. The deduplicate check moves there too, so one job owns both lockfile gates. It runs on `node-slim`, the executor already used for `check-ts` / `lint-types` / `health-check`.

This keeps both checks — they catch disjoint failures. `yarn install` does not deduplicate, so un-collapsed duplicate ranges still need the yarn-deduplicate pass.

**Scope note.** Two commits: the lockfile fix and the guard that would have caught it. Bundled deliberately, since the guard fails on `develop` today and is only meaningful alongside the fix.

Not user-facing, so no changelog entry: `arch@^2.2.0` reaches the tree only through a devDependency of `packages/example`, and the shipped `cli` dependency on `arch@^3.0.0` is correctly locked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile correction in a dev-only transitive path plus CI validation scripts; no runtime product or auth/data-path changes.
> 
> **Overview**
> Restores the missing **`arch@^2.2.0`** block in `yarn.lock` so transitive deps (e.g. `clipboardy` via kitchensink) are pinned again alongside **`arch@^3.0.0`** for the CLI.
> 
> Adds **`yarn check-lockfile-drift`**, implemented in `scripts/check-lockfile-drift.sh`, which snapshots `yarn.lock`, runs a real `yarn install --ignore-scripts`, and fails on content diff—catching hand-edited or incomplete lockfiles that **`--frozen-lockfile`** and **`yarn check-lockfile`** (dedupe only) miss.
> 
> CI moves dedupe + drift into a dedicated **`check-lockfile`** job on **`node-slim`** (separate from **`lint`** so install doesn’t disturb patched `node_modules`), and wires that job into main/PR workflows and the **`all-jobs-passed`** / **`ready-to-release`** gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d348d725475b8547b7749d2c37c674e47bd77fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Reviewers can verify both halves without CI.

The guard catches the bug it was written for:

```bash
git checkout develop -- yarn.lock   # restore the broken lockfile
yarn check-lockfile-drift            # exits 1, prints the missing arch@^2.2.0 block
```

And does not false-positive on the fix, including on a repeat run:

```bash
git checkout HEAD -- yarn.lock
yarn check-lockfile-drift   # exits 0
yarn check-lockfile-drift   # exits 0 — stable, not oscillating
yarn check-lockfile         # exits 0 — deduplicate check unaffected
```

CI config validation: `yarn pack-ci --validate` passes, and the `check-lockfile` job appears in `.circleci/packed/pipeline.yml` with four workflow references (job entry plus gate `requires`, in each of the PR and main workflows).

### How has the user experience changed?

No change. CI-only tooling plus a lockfile entry in a devDependency subtree.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical lockfile correction plus the CI guard that catches it; explanation above. -->
- [na] Have tests been added/updated? <!-- The change is a CI check. Verified by running it against both the broken and corrected lockfile, plus a synthetic duplicate to confirm the existing deduplicate check still fails as expected. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
