### PR TITLE
fix: report a spec that failed to build as failed, not passed (14062)

### DIFF
--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -21,6 +21,7 @@ const mergeRunState = (base: TapStatus, runState: TapRunState): TapStatus => {
     startedAt: runState.startedAt ?? null,
     totalTests: runState.totalTests,
     results: runState.results,
+    ...(runState.error ? { error: runState.error } : {}),
     ...pinned,
   }
 }

--- a/cli/lib/tap/render/status.ts
+++ b/cli/lib/tap/render/status.ts
@@ -49,6 +49,12 @@ export const renderStatusHuman = (status: TapStatus): string => {
 
   const blocks = [instanceColumns([instance]), progress]
 
+  // A spec that failed to build has no results to show, so the failure is the
+  // only thing the run has to say.
+  if (status.error) {
+    blocks.push([color.fail(status.error)])
+  }
+
   if (status.pinned) {
     blocks.push(pinnedBlock(status.pinned))
   }

--- a/cli/lib/tap/types.ts
+++ b/cli/lib/tap/types.ts
@@ -38,6 +38,8 @@ export interface TapRunState {
   totalTests?: number
   /** Per-outcome test counts for the selected spec. */
   results?: { passed: number, failed: number, pending: number, skipped: number }
+  /** Why the spec could not run, when it failed to build. */
+  error?: string
   /** The currently pinned command, if any. */
   pinned?: PinnedView
 }
@@ -73,6 +75,8 @@ export interface TapStatus {
   totalTests?: number
   /** Per-outcome test counts for the selected spec. */
   results?: { passed: number, failed: number, pending: number, skipped: number }
+  /** Why the spec could not run, when it failed to build. */
+  error?: string
   /** The currently pinned command, if any. */
   pinned?: PinnedView
 }

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -636,6 +636,27 @@ describe('lib/exec/tap', () => {
       })
     })
 
+    it('reports a spec that failed to build as failed, carrying the reason', async () => {
+      mockLiveResolved(liveInstance())
+      mockSession(schema, {
+        result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'failed', startedAt: '2026-07-29T10:15:00.000Z', error: 'Error: Webpack Compilation Error' },
+      } satisfies TapExecResult)
+
+      expect(await tap.start(['status'], { json: true })).toBe(0)
+      expect(JSON.parse(logger.print())).toEqual({
+        status: 'failed',
+        pid: 4242,
+        projectRoot: '/projects/app',
+        testingType: 'e2e',
+        browserAttached: true,
+        browserName: 'Chrome',
+        totalSpecs: 3,
+        spec: 'cypress/e2e/login.cy.ts',
+        startedAt: '2026-07-29T10:15:00.000Z',
+        error: 'Error: Webpack Compilation Error',
+      })
+    })
+
     it('reports a null startedAt for an instance whose binding does not name the run', async () => {
       mockLiveResolved(liveInstance())
       mockSession(schema, {

--- a/cli/test/lib/tap/render-status.spec.ts
+++ b/cli/test/lib/tap/render-status.spec.ts
@@ -66,6 +66,31 @@ describe('lib/tap/render/status', () => {
     ].join('\n'))
   })
 
+  it('renders a build failure as the reason under the spec, with no counts to read', () => {
+    const output = render({
+      status: 'failed',
+      pid: 4242,
+      projectRoot: '/projects/app',
+      testingType: 'e2e',
+      browserAttached: true,
+      browserName: 'Chrome',
+      totalSpecs: 3,
+      spec: 'cypress/e2e/login.cy.ts',
+      startedAt: '2026-07-29T10:15:00.000Z',
+      error: 'Error: Webpack Compilation Error\nSyntaxError: Unexpected token (4:2)',
+    })
+
+    expect(output).toBe([
+      'PID   PROJECT        TYPE  BROWSER',
+      '4242  /projects/app  e2e   Chrome',
+      '',
+      '✖ cypress/e2e/login.cy.ts  (started at 10:15:00 AM)',
+      '',
+      'Error: Webpack Compilation Error',
+      'SyntaxError: Unexpected token (4:2)',
+    ].join('\n'))
+  })
+
   it('renders a pre-spec phase as the instance row plus the phase on its own', () => {
     const output = render({
       status: 'browser not selected',

--- a/packages/app/src/tap/commands/run-state.cy.ts
+++ b/packages/app/src/tap/commands/run-state.cy.ts
@@ -50,6 +50,7 @@ describe('tap/commands/run-state', () => {
   }
   const stubNoRunner = () => cy.stub(tapManagerDataSource, 'getRunner').returns(undefined)
   const stubActiveSpec = (relative: string | undefined) => cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
+  const stubScriptError = (error: string) => cy.stub(tapManagerDataSource, 'getScriptError').returns(error)
 
   beforeEach(() => {
     window.__RUN_MODE_SPECS__ = RUN_MODE_SPECS
@@ -95,6 +96,40 @@ describe('tap/commands/run-state', () => {
         state: 'loading',
         startedAt: null,
       },
+    })
+  })
+
+  it('reports a spec that failed to build as failed, carrying the failure instead of counts', async () => {
+    // The runner is settled and empty — the shape a passing run of nothing has.
+    stubRunner({ getAllTestsState: cy.stub().returns({}), isRunComplete: () => true })
+    stubActiveSpec('cypress/e2e/login.cy.ts')
+    stubScriptError('Error: Webpack Compilation Error\nSyntaxError: Unexpected token (4:2)\n    at Watching.handle (/x/webpack.js:1:1)')
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    expect(await manager.exec('run-state')).to.deep.eq({
+      result: {
+        spec: 'cypress/e2e/login.cy.ts',
+        totalSpecs: 2,
+        state: 'failed',
+        startedAt: STARTED_AT,
+        // No results to read as a clean sweep, and the compiler's own stack is
+        // dropped — what identifies the failure is kept.
+        error: 'Error: Webpack Compilation Error\nSyntaxError: Unexpected token (4:2)',
+      },
+    })
+  })
+
+  it('reports a build failure that kept the driver from booting at all', async () => {
+    stubNoRunner()
+    stubActiveSpec('cypress/e2e/login.cy.ts')
+    stubScriptError('Error: Webpack Compilation Error')
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    // Terminal, not loading: this spec is never going to start.
+    expect(await manager.exec('run-state')).to.deep.eq({
+      result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 2, state: 'failed', startedAt: null, error: 'Error: Webpack Compilation Error' },
     })
   })
 

--- a/packages/app/src/tap/commands/run-state.ts
+++ b/packages/app/src/tap/commands/run-state.ts
@@ -9,9 +9,9 @@ export interface RunStateResult {
   spec: string | null
   totalSpecs: number
   /**
-   * Where the selected spec is in its run. `loading` is a spec waiting on its
-   * own build — one still compiling, or one that never will — and is never a
-   * verdict; only `passed`/`failed` are.
+   * Where the selected spec is in its run. `loading` is a spec still building
+   * and is never a verdict; only `passed`/`failed` are. A build that fails is
+   * `failed`, reported with `error` and no counts.
    */
   state?: 'loading' | 'running' | 'passed' | 'failed'
   /**
@@ -23,8 +23,21 @@ export interface RunStateResult {
   startedAt?: string | null
   totalTests?: number
   results?: RunResults
+  /** Why the spec could not run, when it failed to build. */
+  error?: string
   /** The currently pinned command, if any — only reported once verified against a live runner (see the pin command). */
   pinned?: PinnedView
+}
+
+// The app shows the whole build failure over the AUT — compiler stack and the
+// terminal colors webpack writes into its code frame. Status is a polling
+// payload read by a machine, so keep the part that identifies the failure and
+// drop the compiler's own stack.
+// eslint-disable-next-line no-control-regex
+const ANSI = /\u001b\[[0-9;]*m/g
+
+const buildFailure = (error: string): string => {
+  return error.split('\n    at ')[0].replace(ANSI, '').trim()
 }
 
 export const runStateCommand = defineCommand('run-state', async (): Promise<RunStateResult> => {
@@ -36,6 +49,15 @@ export const runStateCommand = defineCommand('run-state', async (): Promise<RunS
   }
 
   const runner = tapManagerDataSource.getRunner()
+  const error = tapManagerDataSource.getScriptError()
+
+  // A spec that failed to build never ran, however settled its runner looks: it
+  // reaches mocha with no tests, so it aggregates to the same all-zero sweep a
+  // wholly passing run does. The build failure is the only thing that tells
+  // them apart, and it is terminal — a poller has to stop on it, not wait.
+  if (error) {
+    return { spec, totalSpecs, state: 'failed', startedAt: runner?.getStartTime() ?? null, error: buildFailure(error) }
+  }
 
   if (!runner) {
     return { spec, totalSpecs, state: 'loading', startedAt: null }

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -88,6 +88,16 @@ export const tapManagerDataSource = {
     }
   },
 
+  // The spec's own build failure, as the app shows it over the AUT. Cleared at
+  // the start of every run, so it always belongs to the spec now selected.
+  getScriptError (): string | undefined {
+    try {
+      return useAutStore().scriptError?.error
+    } catch {
+      return undefined
+    }
+  },
+
   pinSnapshot (props: PinSnapshotProps, index: number, testId: string, logId: string): void {
     eventManager()?.localBus.emit('pin:snapshot', props)
 

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -214,9 +214,10 @@ polling and "where am I?" checks. Always exits 0 for a determinable stage
 Stages: not connected, browser not selected, spec not selected, loading,
 running, passed, failed.
 
-Only passed and failed are verdicts. Loading is a selected spec waiting on its
-own build — one still compiling, or one that will never compile — and stays
-loading for as long as that takes, so a poller needs its own timeout.
+Only passed and failed are verdicts. Loading is a selected spec still building,
+and stays loading for as long as the build takes, so a poller needs its own
+timeout. A spec whose build fails reports failed and carries the reason as
+error — it ran no tests, so it reports no counts either.
 
 From loading onwards the output carries startedAt, the run every other field
 describes (null while loading). A rerun leaves the previous run's verdict


### PR DESCRIPTION
- Refs cypress-io/cypress-services#14062

Stacked on #34406, which introduced the start-time gate this builds on.

### Additional details

#34406 stops `status` reporting `passed` for a run that has **not started**. A spec that **fails to build** slips past that gate, because its run genuinely starts: the bundle error does not stop the driver booting, mocha runs a suite with no tests, `run()` sets a start time, and the run completes. The empty test set aggregates to all zeros, `results.failed > 0` is false, and the verdict is `passed`.

So the exact failure mode #14062 is about survives in the one case where the spec never ran at all — and it is terminal, so a poller stops on it and believes it.

Measured against a live instance before this change, with a spec containing a syntax error:

```
run  -> {"relativePath": "cypress/e2e/_probe.cy.js", "testingType": "e2e", "browser": "Electron"}
t+1  -> passed  startedAt 16:52:37.175Z  {passed: 0, failed: 0, pending: 0, skipped: 0}
t+2  -> passed  ...  (stable through t+6 — 12 seconds)
```

The app already knows what went wrong: `autStore.scriptError` holds the failure it renders over the AUT, set from the `script:error` the preprocessor emits and cleared at the start of every run, so it always describes the spec now selected. `tapManagerDataSource` already reaches that store for `isRunning`, so this is one method on the existing seam.

`run-state` reports it as `failed`, carrying the reason:

- **No counts.** A spec that ran no tests offers nothing that reads as a clean sweep — the same reason `loading` carries none.
- **No compiler stack.** The message and webpack's code frame identify the failure; the 4KB of `at Watching.handle …` does not. Terminal colors are stripped, since this is a payload a machine reads.

This also corrects the contract text. `status --help` claimed `loading` covered "one still compiling, or one that will never compile" — the second half was never true, as the measurement above shows. Loading is now described as what it is: a spec still building.

### Steps to test

1. `cypress open` any project.
2. Write a spec that cannot compile, e.g.

   ```js
   describe('probe', () => {
     it('never compiles', () => {
       const oops = (
     })
   })
   ```

3. `cypress tap run <that spec>`, then `cypress tap status`.

Before: `{"status": "passed", "totalTests": 0, "results": {...all zero}}`.

After, verified live:

```
PID    PROJECT                                                      TYPE  BROWSER
57232  /Users/davidr/Documents/Cypress/cypress-example-kitchensink  e2e   electron

✖ cypress/e2e/_probe.cy.js  (started at 12:08:22 PM)

Error: Webpack Compilation Error
Module build failed (from ../../node_modules/babel-loader/lib/index.js):
SyntaxError: /Users/.../cypress/e2e/_probe.cy.js: Unexpected token (4:2)

  2 |   it('never compiles', () => {
  3 |     const oops = (
> 4 |   })
    |   ^
  5 | })
```

```
yarn workspace @packages/app cypress:run:ct --spec 'src/tap/commands/run-state.cy.ts'
cd cli && yarn test-unit -- test/lib/tap/ test/lib/exec/tap.spec.ts
```

The CLI unit suite (229 tests) is green, as are `check-ts` and `lint` for `cypress`, `@packages/app` and `@packages/cypress-instances`. The app CT suite is unrunnable on my machine (the browser never connects, including on an untouched control spec), so the two new `run-state` component tests have been verified by review and by the live run above, not executed.

### How has the user experience changed?

`cypress tap status` on a spec that failed to build changes from `passed` to `failed`, and gains an `error` field:

```json
{ "status": "failed", "spec": "cypress/e2e/_probe.cy.js",
  "startedAt": "2026-08-04T17:08:22.000Z",
  "error": "Error: Webpack Compilation Error\nSyntaxError: … Unexpected token (4:2)\n\n  3 |     const oops = (\n> 4 |   })" }
```

`totalTests` and `results` are absent for that case rather than reported as zero.

No GUI change — the app already showed this failure over the AUT; it is only the tap payload that was lying about it.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tap polling verdicts and JSON shape for compile failures, which automation may depend on, but the behavior is a targeted bugfix with tests and no auth or data-path changes.
> 
> **Overview**
> **Fixes `cypress tap status` / `run-state` wrongly reporting `passed` when a spec fails to compile** — empty Mocha runs looked like a clean sweep.
> 
> When the app has a **script/build error** (`autStore.scriptError`), **`run-state` now short-circuits to `state: failed`** with an optional **`error`** string (ANSI stripped, compiler stack trimmed). It **omits test counts** for that case. **`tap status`** forwards **`error`** in JSON and **prints the message** in human output instead of pass/fail tallies.
> 
> **`status --help` contract text** now says **`loading`** is only “still building,” and **build failures** are terminal **`failed`** with **`error`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 560e5f051a225858bf6fc1b1df3acc403248ab8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->