### PR TITLE
feat: read one element per tap dom/aria/inspect call, chosen with --at

### DIFF
--- a/cli/lib/tap/aut/cdp.ts
+++ b/cli/lib/tap/aut/cdp.ts
@@ -18,8 +18,9 @@ export const createFrameIsolatedWorld = async (session: TapSession, frame: AutFr
 }
 
 /**
- * Resolves a CSS selector to the matched element's CDP objectId, running
- * `querySelector` in an isolated world on the AUT frame. Throws
+ * Resolves a CSS selector to the matched element's CDP objectId, querying in an
+ * isolated world on the AUT frame. `index` picks one of several matches
+ * (`--at`), already checked against the match count by the caller. Throws
  * `INVALID_SELECTOR` when the selector is malformed; returns undefined when the
  * selector is valid but nothing matched.
  */
@@ -27,14 +28,15 @@ export const querySelectorObjectId = async (
   session: TapSession,
   frame: AutFrame,
   selector: string,
+  index: number,
 ): Promise<string | undefined> => {
   const { client, sessionId } = session
   const executionContextId = await createFrameIsolatedWorld(session, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
-    functionDeclaration: 'function (selector) { return document.querySelector(selector) }',
+    functionDeclaration: 'function (selector, index) { return document.querySelectorAll(selector)[index] }',
     executionContextId,
-    arguments: [{ value: selector }],
+    arguments: [{ value: selector }, { value: index }],
   }, sessionId)
 
   if (exceptionDetails) {

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -82,7 +82,15 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
 const WHOLE_NUMBER = /^\d+$/
 
 const parseWholeNumber = (raw: unknown): number | undefined => {
-  return typeof raw === 'string' && WHOLE_NUMBER.test(raw) ? Number(raw) : undefined
+  if (typeof raw !== 'string' || !WHOLE_NUMBER.test(raw)) {
+    return undefined
+  }
+
+  // A run of digits still overflows: past 2^53 `Number` silently rounds, and
+  // far enough past it returns Infinity, which would disable the caps entirely.
+  const value = Number(raw)
+
+  return Number.isSafeInteger(value) ? value : undefined
 }
 
 /** `--at`: which match to read, 0-based. Absent means "the only match". */

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -29,7 +29,6 @@ export class FrameCommandError extends Error {
 export interface AutFrame {
   /** CDP frameId — scopes `Accessibility.getFullAXTree` and `Page.createIsolatedWorld`. */
   frameId: string
-  url: string
 }
 
 interface FrameNode {
@@ -73,7 +72,22 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
 
   debug('resolved AUT frame %o', found)
 
-  return { frameId: found.id, url: found.url }
+  return { frameId: found.id }
+}
+
+/** `--at`: which match to read, 0-based. Absent means "the only match". */
+export const parseIndex = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) {
+    return undefined
+  }
+
+  const value = Number(raw)
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
+  }
+
+  return value
 }
 
 export const parsePositiveInt = (raw: string | undefined, fallback: number, label: string): number => {

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -76,9 +76,6 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
   return { frameId: found.id }
 }
 
-// A flag's value is whatever text the shell handed over, so it is matched
-// rather than coerced: `Number('')`, `Number('  7 ')`, `Number('0x10')` and
-// `Number(['5'])` all produce integers a range check happily accepts.
 const WHOLE_NUMBER = /^\d+$/
 
 const parseWholeNumber = (raw: unknown): number | undefined => {
@@ -86,14 +83,11 @@ const parseWholeNumber = (raw: unknown): number | undefined => {
     return undefined
   }
 
-  // A run of digits still overflows: past 2^53 `Number` silently rounds, and
-  // far enough past it returns Infinity, which would disable the caps entirely.
   const value = Number(raw)
 
   return Number.isSafeInteger(value) ? value : undefined
 }
 
-/** `--at`: which match to read, 0-based. Absent means "the only match". */
 export const parseIndex = (raw: string | undefined): number | undefined => {
   if (raw === undefined) {
     return undefined
@@ -102,7 +96,7 @@ export const parseIndex = (raw: string | undefined): number | undefined => {
   const value = parseWholeNumber(raw)
 
   if (value === undefined) {
-    throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
+    throw new FrameCommandError('INVALID_INDEX', '--at must be a 0-based index: a whole number, 0 or greater')
   }
 
   return value

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -6,6 +6,7 @@ import { withTapSession, validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
 import { renderOutcome, renderFailure, renderKnownFailure } from '../output'
 import type { TapCliOptions, TapRunState } from '../types'
+import type { FrameAmbiguousResult } from './single-match'
 import { TAP_EXEC_METHOD, TAP_RUN_IN_PROGRESS_MESSAGE } from '@packages/cypress-instances'
 
 const debug = Debug('cypress:cli:tap')
@@ -153,9 +154,14 @@ export const withResolvedAutFrame = async (
 
         const frame = await resolveAutFrame(session.client, session.sessionId)
 
-        renderOutcome(command, await read(session, frame), options.json)
+        const result = await read(session, frame)
 
-        return 0
+        renderOutcome(command, result, options.json)
+
+        // The ambiguity answer is still a result — it names the matches to
+        // choose between, so it prints on stdout like any other. But it is not
+        // the read that was asked for, and the exit code has to say so.
+        return (result as FrameAmbiguousResult).ambiguous ? 1 : 0
       } catch (err: any) {
         if (err instanceof FrameCommandError) {
           renderFailure({ code: err.code, message: err.message })

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -76,15 +76,24 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
   return { frameId: found.id }
 }
 
+// A flag's value is whatever text the shell handed over, so it is matched
+// rather than coerced: `Number('')`, `Number('  7 ')`, `Number('0x10')` and
+// `Number(['5'])` all produce integers a range check happily accepts.
+const WHOLE_NUMBER = /^\d+$/
+
+const parseWholeNumber = (raw: unknown): number | undefined => {
+  return typeof raw === 'string' && WHOLE_NUMBER.test(raw) ? Number(raw) : undefined
+}
+
 /** `--at`: which match to read, 0-based. Absent means "the only match". */
 export const parseIndex = (raw: string | undefined): number | undefined => {
   if (raw === undefined) {
     return undefined
   }
 
-  const value = Number(raw)
+  const value = parseWholeNumber(raw)
 
-  if (!Number.isInteger(value) || value < 0) {
+  if (value === undefined) {
     throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
   }
 
@@ -96,9 +105,9 @@ export const parsePositiveInt = (raw: string | undefined, fallback: number, labe
     return fallback
   }
 
-  const value = Number(raw)
+  const value = parseWholeNumber(raw)
 
-  if (!Number.isInteger(value) || value <= 0) {
+  if (value === undefined || value <= 0) {
     throw new FrameCommandError('INVALID_LIMIT', `${label} must be a positive integer`)
   }
 

--- a/cli/lib/tap/aut/scripts.ts
+++ b/cli/lib/tap/aut/scripts.ts
@@ -21,50 +21,53 @@
 
 export interface DomReadResult {
   html?: string
-  matches?: { count: number, html: string[] }
+  found?: boolean
   truncated?: boolean
   invalidSelector?: boolean
 }
 
-// Caps output while walking, so a heavy page never serializes megabytes across
-// CDP. Returns a tagged object rather than throwing, so a bad selector
-// round-trips as data instead of a CDP exception.
-export function readDom (selector: string | null, maxChars: number): DomReadResult {
+// Caps output, so a heavy page never serializes megabytes across CDP. Returns a
+// tagged object rather than throwing, so a bad selector round-trips as data
+// instead of a CDP exception. `index` picks one of several matches (`--at`); the
+// caller has already checked it against the match count.
+export function readDom (selector: string | null, maxChars: number, index: number): DomReadResult {
   if (selector === null) {
     const html = document.documentElement ? document.documentElement.outerHTML : ''
 
     return html.length > maxChars ? { html: html.slice(0, maxChars), truncated: true } : { html }
   }
 
-  let els: Element[]
+  let el: Element | undefined
 
   try {
-    els = Array.from(document.querySelectorAll(selector))
+    el = document.querySelectorAll(selector)[index]
   } catch (_e) {
     return { invalidSelector: true }
   }
 
-  const out: string[] = []
-  let remaining = maxChars
-  let truncated = false
-
-  for (const el of els) {
-    const html = el.outerHTML
-
-    if (html.length > remaining) {
-      if (remaining > 0) {
-        out.push(html.slice(0, remaining))
-      }
-
-      truncated = true
-      break
-    }
-
-    out.push(html)
-    remaining -= html.length
+  if (!el) {
+    return { found: false }
   }
 
-  return { matches: { count: els.length, html: out }, truncated }
+  const html = el.outerHTML
+
+  return html.length > maxChars ? { found: true, html: html.slice(0, maxChars), truncated: true } : { found: true, html }
+}
+
+export interface MatchCountResult {
+  count?: number
+  invalidSelector?: boolean
+}
+
+// Counts matches without serializing any of them, so the single-element guard
+// costs one number however heavy the page. Tags a bad selector as data, the way
+// `readDom` does.
+export function countMatches (selector: string): MatchCountResult {
+  try {
+    return { count: document.querySelectorAll(selector).length }
+  } catch (_e) {
+    return { invalidSelector: true }
+  }
 }
 
 export interface ElementInfo {

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -7,9 +7,9 @@ import type { MatchCountResult } from './scripts'
 
 /**
  * What a selector-taking AUT read returns in place of the read when the selector
- * matched more than one element: how many it matched. Not a failure — it is the
- * answer to "which one did you mean?", so it exits 0 and honors `--json` like
- * any other result.
+ * matched more than one element: how many it matched. It is the answer to "which
+ * one did you mean?", so it prints and honors `--json` like any other result —
+ * but the read never happened, so the command exits 1.
  */
 export interface FrameAmbiguousResult {
   /** Always `true` — marks this as the ambiguity answer rather than a read. */

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -1,0 +1,83 @@
+import type { TapSession } from '../tap-session'
+import { createFrameIsolatedWorld } from './cdp'
+import { FrameCommandError } from './frame'
+import type { AutFrame } from './frame'
+import { countMatches } from './scripts'
+import type { MatchCountResult } from './scripts'
+
+/**
+ * What a selector-taking AUT read returns in place of the read when the selector
+ * matched more than one element: how many it matched. Not a failure — it is the
+ * answer to "which one did you mean?", so it exits 0 and honors `--json` like
+ * any other result.
+ */
+export interface FrameAmbiguousResult {
+  /** Always `true` — marks this as the ambiguity answer rather than a read. */
+  ambiguous: true
+  /** The selector that matched more than one element. */
+  selector: string
+  /** How many elements it matched. */
+  count: number
+}
+
+/**
+ * Resolves what a selector-taking AUT read should do: `undefined` to go ahead —
+ * the selector matched one element, or none (which each command reports in its
+ * own shape), or `at` named which match to read — or the ambiguity answer to
+ * return in place of the read, so a reader is never silently shown one arbitrary
+ * match of several.
+ */
+export const resolveMatch = async (
+  session: TapSession,
+  frame: AutFrame,
+  selector: string | undefined,
+  at?: number,
+): Promise<FrameAmbiguousResult | undefined> => {
+  if (selector === undefined) {
+    if (at !== undefined) {
+      throw new FrameCommandError('INVALID_INDEX', 'at needs a selector to index into — without one there is only the one frame to read')
+    }
+
+    return undefined
+  }
+
+  const { client, sessionId } = session
+  const executionContextId = await createFrameIsolatedWorld(session, frame)
+
+  const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
+    functionDeclaration: countMatches.toString(),
+    executionContextId,
+    arguments: [{ value: selector }],
+    returnByValue: true,
+  }, sessionId)
+
+  if (exceptionDetails) {
+    throw new FrameCommandError('FRAME_READ_FAILED', `resolving "${selector}" in the app under test failed: ${exceptionDetails.exception?.description || exceptionDetails.text}`)
+  }
+
+  const { count, invalidSelector } = result.value as MatchCountResult
+
+  if (invalidSelector) {
+    throw new FrameCommandError('INVALID_SELECTOR', `"${selector}" is not a valid CSS selector`)
+  }
+
+  // Nothing matched: each command reports that in its own shape, and an `at`
+  // has no range to be out of.
+  if (count === undefined || count === 0) {
+    return undefined
+  }
+
+  if (at !== undefined) {
+    if (at >= count) {
+      throw new FrameCommandError('INVALID_INDEX', `at ${at} is out of range: "${selector}" matched ${count} element${count === 1 ? '' : 's'}, so the index must be 0-${count - 1}`)
+    }
+
+    return undefined
+  }
+
+  if (count === 1) {
+    return undefined
+  }
+
+  return { ambiguous: true, selector, count }
+}

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -20,7 +20,7 @@ export interface FrameAmbiguousResult {
   count: number
 }
 
-export const resolveMatch = async (
+export const resolveAmbiguity = async (
   session: TapSession,
   frame: AutFrame,
   selector: string | undefined,
@@ -28,7 +28,7 @@ export const resolveMatch = async (
 ): Promise<FrameAmbiguousResult | undefined> => {
   if (selector === undefined) {
     if (at !== undefined) {
-      throw new FrameCommandError('INVALID_INDEX', 'at needs a selector to index into — without one there is only the one frame to read')
+      throw new FrameCommandError('INVALID_INDEX', 'at needs a selector to index into')
     }
 
     return undefined
@@ -62,7 +62,7 @@ export const resolveMatch = async (
 
   if (at !== undefined) {
     if (at >= count) {
-      throw new FrameCommandError('INVALID_INDEX', `at ${at} is out of range: "${selector}" matched ${count} element${count === 1 ? '' : 's'}, so the index must be 0-${count - 1}`)
+      throw new FrameCommandError('INVALID_INDEX', `"${selector}" matched ${count} element${count === 1 ? '' : 's'}; pass at 0-${count - 1}`)
     }
 
     return undefined
@@ -82,7 +82,7 @@ export const withAmbiguous = async <T>(
   at: number | undefined,
   read: () => Promise<T>,
 ): Promise<T | FrameAmbiguousResult> => {
-  const ambiguous = await resolveMatch(session, frame, selector, at)
+  const ambiguous = await resolveAmbiguity(session, frame, selector, at)
 
   return ambiguous ?? read()
 }

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -20,13 +20,6 @@ export interface FrameAmbiguousResult {
   count: number
 }
 
-/**
- * Resolves what a selector-taking AUT read should do: `undefined` to go ahead —
- * the selector matched one element, or none (which each command reports in its
- * own shape), or `at` named which match to read — or the ambiguity answer to
- * return in place of the read, so a reader is never silently shown one arbitrary
- * match of several.
- */
 export const resolveMatch = async (
   session: TapSession,
   frame: AutFrame,
@@ -80,4 +73,16 @@ export const resolveMatch = async (
   }
 
   return { ambiguous: true, selector, count }
+}
+
+export const withAmbiguous = async <T>(
+  session: TapSession,
+  frame: AutFrame,
+  selector: string | undefined,
+  at: number | undefined,
+  read: () => Promise<T>,
+): Promise<T | FrameAmbiguousResult> => {
+  const ambiguous = await resolveMatch(session, frame, selector, at)
+
+  return ambiguous ?? read()
 }

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -28,7 +28,7 @@ export const resolveAmbiguity = async (
 ): Promise<FrameAmbiguousResult | undefined> => {
   if (selector === undefined) {
     if (at !== undefined) {
-      throw new FrameCommandError('INVALID_INDEX', 'at needs a selector to index into')
+      throw new FrameCommandError('INVALID_INDEX', '--at needs a selector to index into')
     }
 
     return undefined
@@ -54,7 +54,7 @@ export const resolveAmbiguity = async (
     throw new FrameCommandError('INVALID_SELECTOR', `"${selector}" is not a valid CSS selector`)
   }
 
-  // Nothing matched: each command reports that in its own shape, and an `at`
+  // Nothing matched: each command reports that in its own shape, and an `--at`
   // has no range to be out of.
   if (count === undefined || count === 0) {
     return undefined
@@ -62,7 +62,7 @@ export const resolveAmbiguity = async (
 
   if (at !== undefined) {
     if (at >= count) {
-      throw new FrameCommandError('INVALID_INDEX', `"${selector}" matched ${count} element${count === 1 ? '' : 's'}; pass at 0-${count - 1}`)
+      throw new FrameCommandError('INVALID_INDEX', `"${selector}" matched ${count} element${count === 1 ? '' : 's'}; pass --at 0-${count - 1}`)
     }
 
     return undefined

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -3,7 +3,7 @@ import type { AutFrame } from '../aut/frame'
 import { parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXProperty, AXValue } from '../aut/cdp'
-import { resolveMatch } from '../aut/single-match'
+import { withAmbiguous } from '../aut/single-match'
 import type { FrameAmbiguousResult } from '../aut/single-match'
 import { defineNativeCommand } from './definition'
 
@@ -141,67 +141,63 @@ const resolveSelectorBackendNodeId = async (
   return node.backendNodeId
 }
 
-export const extractAria = async (
+export const extractAria = (
   session: TapSession,
   frame: AutFrame,
   selector: string | undefined,
   maxNodes: number,
   at?: number,
 ): Promise<FrameAriaResult | FrameAmbiguousResult> => {
-  const { client, sessionId } = session
-
   // Ahead of the tree fetch: an ambiguous selector shouldn't cost a full AX tree.
-  const ambiguous = await resolveMatch(session, frame, selector, at)
+  return withAmbiguous(session, frame, selector, at, async (): Promise<FrameAriaResult> => {
+    const { client, sessionId } = session
 
-  if (ambiguous) {
-    return ambiguous
-  }
+    await client.DOM.enable({}, sessionId)
+    await client.Accessibility.enable(sessionId)
 
-  await client.DOM.enable({}, sessionId)
-  await client.Accessibility.enable(sessionId)
+    const { nodes: axNodes } = await client.Accessibility.getFullAXTree({ frameId: frame.frameId }, sessionId)
 
-  const { nodes: axNodes } = await client.Accessibility.getFullAXTree({ frameId: frame.frameId }, sessionId)
+    const byId = new Map<string, AXNode>()
 
-  const byId = new Map<string, AXNode>()
-
-  for (const node of axNodes as AXNode[]) {
-    byId.set(node.nodeId, node)
-  }
-
-  const base: FrameAriaResult = { nodes: [], nodeCount: 0 }
-
-  let rootId: string | undefined
-
-  if (selector !== undefined) {
-    const backendNodeId = await resolveSelectorBackendNodeId(session, frame, selector, at ?? 0)
-
-    if (backendNodeId === undefined) {
-      // Selector matched nothing, or the match is absent from the a11y tree.
-      return base
+    for (const node of axNodes as AXNode[]) {
+      byId.set(node.nodeId, node)
     }
 
-    rootId = (axNodes as AXNode[]).find((node) => node.backendDOMNodeId === backendNodeId)?.nodeId
+    const base: FrameAriaResult = { nodes: [], nodeCount: 0 }
+
+    let rootId: string | undefined
+
+    if (selector !== undefined) {
+      const backendNodeId = await resolveSelectorBackendNodeId(session, frame, selector, at ?? 0)
+
+      if (backendNodeId === undefined) {
+        // Selector matched nothing, or the match is absent from the a11y tree.
+        return base
+      }
+
+      rootId = (axNodes as AXNode[]).find((node) => node.backendDOMNodeId === backendNodeId)?.nodeId
+
+      if (rootId === undefined) {
+        return base
+      }
+    } else {
+      // The frame root is the sole node with no parent (the RootWebArea).
+      rootId = (axNodes as AXNode[]).find((node) => node.parentId === undefined)?.nodeId ?? (axNodes as AXNode[])[0]?.nodeId
+    }
 
     if (rootId === undefined) {
       return base
     }
-  } else {
-    // The frame root is the sole node with no parent (the RootWebArea).
-    rootId = (axNodes as AXNode[]).find((node) => node.parentId === undefined)?.nodeId ?? (axNodes as AXNode[])[0]?.nodeId
-  }
 
-  if (rootId === undefined) {
-    return base
-  }
+    const { nodes, truncated } = projectTree(byId, rootId, maxNodes)
 
-  const { nodes, truncated } = projectTree(byId, rootId, maxNodes)
-
-  return {
-    ...base,
-    nodes,
-    nodeCount: nodes.length,
-    ...(truncated ? { truncated: true } : {}),
-  }
+    return {
+      ...base,
+      nodes,
+      nodeCount: nodes.length,
+      ...(truncated ? { truncated: true } : {}),
+    }
+  })
 }
 
 export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -1,8 +1,10 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
+import { parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXProperty, AXValue } from '../aut/cdp'
+import { resolveMatch } from '../aut/single-match'
+import type { FrameAmbiguousResult } from '../aut/single-match'
 import { defineNativeCommand } from './definition'
 
 // The accessibility tree of a real app is deep; cap the projection so it stays
@@ -40,8 +42,6 @@ export interface AriaNodeOut {
 
 /** What `cypress tap aria` returns: the projected accessibility tree. */
 export interface FrameAriaResult {
-  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
-  url?: string
   nodes: AriaNodeOut[]
   /** Number of nodes returned (`nodes.length`, before any client-side view). */
   nodeCount: number
@@ -127,9 +127,10 @@ const resolveSelectorBackendNodeId = async (
   session: TapSession,
   frame: AutFrame,
   selector: string,
+  index: number,
 ): Promise<number | undefined> => {
   const { client, sessionId } = session
-  const objectId = await querySelectorObjectId(session, frame, selector)
+  const objectId = await querySelectorObjectId(session, frame, selector, index)
 
   if (objectId === undefined) {
     return undefined
@@ -145,8 +146,16 @@ export const extractAria = async (
   frame: AutFrame,
   selector: string | undefined,
   maxNodes: number,
-): Promise<FrameAriaResult> => {
+  at?: number,
+): Promise<FrameAriaResult | FrameAmbiguousResult> => {
   const { client, sessionId } = session
+
+  // Ahead of the tree fetch: an ambiguous selector shouldn't cost a full AX tree.
+  const ambiguous = await resolveMatch(session, frame, selector, at)
+
+  if (ambiguous) {
+    return ambiguous
+  }
 
   await client.DOM.enable({}, sessionId)
   await client.Accessibility.enable(sessionId)
@@ -159,12 +168,12 @@ export const extractAria = async (
     byId.set(node.nodeId, node)
   }
 
-  const base: FrameAriaResult = { ...(frame.url ? { url: frame.url } : {}), nodes: [], nodeCount: 0 }
+  const base: FrameAriaResult = { nodes: [], nodeCount: 0 }
 
   let rootId: string | undefined
 
   if (selector !== undefined) {
-    const backendNodeId = await resolveSelectorBackendNodeId(session, frame, selector)
+    const backendNodeId = await resolveSelectorBackendNodeId(session, frame, selector, at ?? 0)
 
     if (backendNodeId === undefined) {
       // Selector matched nothing, or the match is absent from the a11y tree.
@@ -196,5 +205,5 @@ export const extractAria = async (
 }
 
 export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
+  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'), parseIndex(commandOptions.at))
 }, 'aria'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -1,21 +1,21 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { FrameCommandError, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
+import { FrameCommandError, parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
 import { createFrameIsolatedWorld } from '../aut/cdp'
+import { resolveMatch } from '../aut/single-match'
+import type { FrameAmbiguousResult } from '../aut/single-match'
 import { readDom } from '../aut/scripts'
 import type { DomReadResult } from '../aut/scripts'
 import { defineNativeCommand } from './definition'
 
 const DEFAULT_MAX_CHARS = 30000
 
-/** What `cypress tap dom` returns: the whole document, or per-selector matches. */
+/** What `cypress tap dom` returns: the whole document, or the matched element. */
 export interface FrameDomResult {
-  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
-  url?: string
-  /** The document's outerHTML — present in whole-page mode. */
+  /** Whether the selector matched — present only in selector mode. */
+  found?: boolean
+  /** The matched element's outerHTML, or the whole document in whole-page mode. */
   html?: string
-  /** Per-match outerHTML — present in selector mode. */
-  matches?: { count: number, html: string[] }
   /** Present (always `true`) when the browser-side cap clipped the output. */
   truncated?: true
 }
@@ -25,14 +25,21 @@ export const extractDom = async (
   frame: AutFrame,
   selector: string | undefined,
   maxChars: number,
-): Promise<FrameDomResult> => {
+  at?: number,
+): Promise<FrameDomResult | FrameAmbiguousResult> => {
   const { client, sessionId } = session
+  const ambiguous = await resolveMatch(session, frame, selector, at)
+
+  if (ambiguous) {
+    return ambiguous
+  }
+
   const executionContextId = await createFrameIsolatedWorld(session, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
     functionDeclaration: readDom.toString(),
     executionContextId,
-    arguments: [{ value: selector ?? null }, { value: maxChars }],
+    arguments: [{ value: selector ?? null }, { value: maxChars }, { value: at ?? 0 }],
     returnByValue: true,
   }, sessionId)
 
@@ -47,13 +54,12 @@ export const extractDom = async (
   }
 
   return {
-    ...(frame.url ? { url: frame.url } : {}),
-    ...(value.matches ? { matches: value.matches } : {}),
+    ...(value.found !== undefined ? { found: value.found } : {}),
     ...(value.html !== undefined ? { html: value.html } : {}),
     ...(value.truncated ? { truncated: true } : {}),
   }
 }
 
 export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
+  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'), parseIndex(commandOptions.at))
 }, 'dom'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -2,7 +2,7 @@ import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
 import { createFrameIsolatedWorld } from '../aut/cdp'
-import { resolveMatch } from '../aut/single-match'
+import { withAmbiguous } from '../aut/single-match'
 import type { FrameAmbiguousResult } from '../aut/single-match'
 import { readDom } from '../aut/scripts'
 import type { DomReadResult } from '../aut/scripts'
@@ -20,20 +20,14 @@ export interface FrameDomResult {
   truncated?: true
 }
 
-export const extractDom = async (
+export const extractDom = (
   session: TapSession,
   frame: AutFrame,
   selector: string | undefined,
   maxChars: number,
   at?: number,
-): Promise<FrameDomResult | FrameAmbiguousResult> => {
+): Promise<FrameDomResult | FrameAmbiguousResult> => withAmbiguous(session, frame, selector, at, async (): Promise<FrameDomResult> => {
   const { client, sessionId } = session
-  const ambiguous = await resolveMatch(session, frame, selector, at)
-
-  if (ambiguous) {
-    return ambiguous
-  }
-
   const executionContextId = await createFrameIsolatedWorld(session, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
@@ -58,7 +52,7 @@ export const extractDom = async (
     ...(value.html !== undefined ? { html: value.html } : {}),
     ...(value.truncated ? { truncated: true } : {}),
   }
-}
+})
 
 export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
   return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'), parseIndex(commandOptions.at))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -1,9 +1,11 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
+import { FrameCommandError, parseIndex, withResolvedAutFrame } from '../aut/frame'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXValue } from '../aut/cdp'
 import { isRendererUnresponsive } from '../cdp-timeout'
+import { resolveMatch } from '../aut/single-match'
+import type { FrameAmbiguousResult } from '../aut/single-match'
 import { readElementInfo } from '../aut/scripts'
 import type { ElementInfo } from '../aut/scripts'
 import { defineNativeCommand } from './definition'
@@ -27,10 +29,8 @@ interface AXNode {
   backendDOMNodeId?: number
 }
 
-/** What `cypress tap inspect` returns for the first element matching a selector. */
+/** What `cypress tap inspect` returns for the element a selector matches. */
 export interface FrameInspectResult {
-  /** The app-under-test frame's URL; absent if it couldn't be resolved. */
-  url?: string
   /** The CSS selector that was inspected. */
   selector: string
   /** Whether an element matched. */
@@ -92,14 +92,21 @@ export const extractInspect = async (
   session: TapSession,
   frame: AutFrame,
   selector: string,
-): Promise<FrameInspectResult> => {
+  at?: number,
+): Promise<FrameInspectResult | FrameAmbiguousResult> => {
   const { client, sessionId } = session
+
+  const ambiguous = await resolveMatch(session, frame, selector, at)
+
+  if (ambiguous) {
+    return ambiguous
+  }
 
   await client.DOM.enable({}, sessionId)
   await client.Accessibility.enable(sessionId)
 
-  const base: FrameInspectResult = { ...(frame.url ? { url: frame.url } : {}), selector, found: false }
-  const objectId = await querySelectorObjectId(session, frame, selector)
+  const base: FrameInspectResult = { selector, found: false }
+  const objectId = await querySelectorObjectId(session, frame, selector, at ?? 0)
 
   if (!objectId) {
     return base
@@ -131,5 +138,5 @@ export const extractInspect = async (
 }
 
 export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractInspect(session, frame, commandOptions.selector)
+  return extractInspect(session, frame, commandOptions.selector, parseIndex(commandOptions.at))
 }, 'inspect'))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -4,7 +4,7 @@ import { FrameCommandError, parseIndex, withResolvedAutFrame } from '../aut/fram
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXValue } from '../aut/cdp'
 import { isRendererUnresponsive } from '../cdp-timeout'
-import { resolveMatch } from '../aut/single-match'
+import { withAmbiguous } from '../aut/single-match'
 import type { FrameAmbiguousResult } from '../aut/single-match'
 import { readElementInfo } from '../aut/scripts'
 import type { ElementInfo } from '../aut/scripts'
@@ -88,19 +88,13 @@ const readAriaNode = async (session: TapSession, objectId: string): Promise<Fram
   }
 }
 
-export const extractInspect = async (
+export const extractInspect = (
   session: TapSession,
   frame: AutFrame,
   selector: string,
   at?: number,
-): Promise<FrameInspectResult | FrameAmbiguousResult> => {
+): Promise<FrameInspectResult | FrameAmbiguousResult> => withAmbiguous(session, frame, selector, at, async (): Promise<FrameInspectResult> => {
   const { client, sessionId } = session
-
-  const ambiguous = await resolveMatch(session, frame, selector, at)
-
-  if (ambiguous) {
-    return ambiguous
-  }
 
   await client.DOM.enable({}, sessionId)
   await client.Accessibility.enable(sessionId)
@@ -135,7 +129,7 @@ export const extractInspect = async (
     box,
     styles,
   }
-}
+})
 
 export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
   return extractInspect(session, frame, commandOptions.selector, parseIndex(commandOptions.at))

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -1,0 +1,12 @@
+import chalk from 'chalk'
+
+import type { FrameAmbiguousResult } from '../aut/single-match'
+import { color, layout, quoted } from './format'
+
+// dom, aria, and inspect all answer an ambiguous selector the same way, so they
+// render it the same way: what went wrong, then the way through.
+export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
+  const headline = color.warn(`⚠ selector ${chalk.bold(quoted(result.selector))} matched ${chalk.bold(result.count)} elements but must be unique`)
+
+  return layout([[headline, color.muted(`pass --at <index> to read one of them (0-${result.count - 1})`)]])
+}

--- a/cli/lib/tap/render/aria.ts
+++ b/cli/lib/tap/render/aria.ts
@@ -1,17 +1,18 @@
 import chalk from 'chalk'
 
 import type { AriaNodeOut, FrameAriaResult } from '../commands/aria'
-import { color, emptyState, heading, indent, layout } from './format'
+import { color, emptyState, indent, layout } from './format'
 
-// One node per line, indented by depth under the panel header: bold role, then
-// its accessible name, an `= value` for value-bearing controls, and any notable
-// states as a muted bracketed list — the compact role/name tree DevTools shows.
+// One node per line, indented by its own depth so the root sits flush: bold
+// role, then its accessible name, an `= value` for value-bearing controls, and
+// any notable states as a muted bracketed list — the compact role/name tree
+// DevTools shows.
 const renderNode = (node: AriaNodeOut): string => {
   const name = node.name ? `  ${node.name}` : ''
   const value = node.value !== undefined ? ` = ${node.value}` : ''
   const states = node.states?.length ? `  ${color.muted(`[${node.states.join(', ')}]`)}` : ''
 
-  return `${indent(node.depth + 1)}${chalk.bold(node.role)}${name}${value}${states}`
+  return `${indent(node.depth)}${chalk.bold(node.role)}${name}${value}${states}`
 }
 
 export const renderAriaHuman = (result: FrameAriaResult): string => {
@@ -19,11 +20,7 @@ export const renderAriaHuman = (result: FrameAriaResult): string => {
     return emptyState('No accessibility nodes found.')
   }
 
-  const urlSuffix = result.url ? `  ${color.muted(result.url)}` : ''
-
-  const blocks: string[][] = [
-    [`${heading('ARIA', result.nodeCount)}${urlSuffix}`, ...result.nodes.map(renderNode)],
-  ]
+  const blocks: string[][] = [result.nodes.map(renderNode)]
 
   if (result.truncated) {
     blocks.push([color.muted('(output truncated)')])

--- a/cli/lib/tap/render/dom.ts
+++ b/cli/lib/tap/render/dom.ts
@@ -1,31 +1,36 @@
 import type { FrameDomResult } from '../commands/dom'
-import { color, emptyState, heading, layout } from './format'
+import { color, emptyState, layout } from './format'
 
-// The frame URL trails the panel title in muted text, the way the reporter dims
-// contextual detail.
-const urlSuffix = (url?: string): string => (url ? `  ${color.muted(url)}` : '')
+/**
+ * `outerHTML` starts at the element but its inner lines keep the indentation
+ * they had in the document, so a deeply nested element arrives ragged — first
+ * line at the margin, the rest pushed right. Removing the smallest indent they
+ * all share pulls the markup back to the margin without touching its internal
+ * shape. Rendering-only: `--json` keeps the document's own whitespace.
+ */
+const dedent = (html: string): string => {
+  const [first, ...rest] = html.split('\n')
+  const shared = rest
+  .filter((line) => line.trim().length)
+  .reduce((min, line) => Math.min(min, line.length - line.trimStart().length), Infinity)
 
-// Selector mode prints each match's outerHTML as its own block under a counted
-// title; whole-page mode prints the single document. A browser-side clip adds a
-// muted trailer either way.
+  if (!rest.length || shared === Infinity || shared === 0) {
+    return html
+  }
+
+  return [first, ...rest.map((line) => line.slice(shared))].join('\n')
+}
+
+// Nothing but the HTML — no title framing it, so the output reads (and pipes)
+// as the markup it is. A browser-side clip still adds a muted trailer, since
+// silently handing back half a document would be worse than a little furniture.
 export const renderDomHuman = (result: FrameDomResult): string => {
-  const truncation = result.truncated ? [[color.muted('(output truncated)')]] : []
-
-  if (result.matches) {
-    if (result.matches.count === 0) {
-      return emptyState('No elements matched the selector.')
-    }
-
-    return layout([
-      [`${heading('MATCHES', result.matches.count)}${urlSuffix(result.url)}`],
-      ...result.matches.html.map((html) => [html]),
-      ...truncation,
-    ])
+  if (result.found === false) {
+    return emptyState('No element matched the selector.')
   }
 
   return layout([
-    [`${heading('DOM')}${urlSuffix(result.url)}`],
-    ...(result.html !== undefined ? [[result.html]] : []),
-    ...truncation,
+    ...(result.html !== undefined ? [[dedent(result.html)]] : []),
+    ...(result.truncated ? [[color.muted('(output truncated)')]] : []),
   ])
 }

--- a/cli/lib/tap/render/format.ts
+++ b/cli/lib/tap/render/format.ts
@@ -19,6 +19,7 @@ export const color = {
   failStrong: chalk.hex('#f59aa9'), // $red-300
   errHeaderText: chalk.hex('#f59aa9'), // $err-header-text = $red-300
   aborted: chalk.hex('#db7903'), // $orange-400
+  warn: chalk.hex('#edbb4a'), // $warn-text = $orange-300
   bad: chalk.hex('#c62b49'), // $red-500
   pending: chalk.hex('#6470f3'), // $indigo-400
   alias: chalk.hex('#c8a7f5'), // $purple-300
@@ -76,6 +77,11 @@ export const startedAtLabel = (startedAt: string): string => {
 
 // A dim note standing in for an absent panel, e.g. `No specs to run.`
 export const emptyState = (message: string): string => chalk.dim(message)
+
+// A selector, quoted so it pastes straight back into a shell as one argument.
+// Single quotes throughout, since attribute selectors carry double ones
+// (`[data-test="x"]`); a single quote in the value becomes `'\''`.
+export const quoted = (selector: string): string => `'${selector.split('\'').join('\'\\\'\'')}'`
 
 export const indent = (depth: number): string => '  '.repeat(depth)
 

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -6,6 +6,8 @@ import type { TapStatus } from '../types'
 import type { FrameDomResult } from '../commands/dom'
 import type { FrameAriaResult } from '../commands/aria'
 import type { FrameInspectResult } from '../commands/inspect'
+import type { FrameAmbiguousResult } from '../aut/single-match'
+import { renderAmbiguousHuman } from './ambiguous'
 import { renderReporterHuman, renderReporterSpecHuman } from './reporter'
 import { renderRunHuman } from './run'
 import { renderInstancesHuman } from './instances'
@@ -37,6 +39,16 @@ export interface TapCommandRendering {
   options?: readonly TapCommandOptionSchema[]
 }
 
+// The selector-taking AUT reads answer an ambiguous selector in place of the
+// read they were asked for, so each one renders that answer instead of its own.
+const orAmbiguous = <T>(render: (result: T) => string) => {
+  return (result: unknown): string => {
+    const ambiguous = result as FrameAmbiguousResult
+
+    return ambiguous.ambiguous ? renderAmbiguousHuman(ambiguous) : render(result as T)
+  }
+}
+
 const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapCommandRendering>> = {
   reporter: {
     renderHuman: (result) => {
@@ -58,9 +70,9 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
   instances: { renderHuman: (result) => renderInstancesHuman(result as TapInstanceSummary[]) },
   specs: { renderHuman: (result) => renderSpecsHuman(result as TapSpecEntry[]) },
   status: { renderHuman: (result) => renderStatusHuman(result as TapStatus) },
-  dom: { renderHuman: (result) => renderDomHuman(result as FrameDomResult) },
-  aria: { renderHuman: (result) => renderAriaHuman(result as FrameAriaResult) },
-  inspect: { renderHuman: (result) => renderInspectHuman(result as FrameInspectResult) },
+  dom: { renderHuman: orAmbiguous<FrameDomResult>(renderDomHuman) },
+  aria: { renderHuman: orAmbiguous<FrameAriaResult>(renderAriaHuman) },
+  inspect: { renderHuman: orAmbiguous<FrameInspectResult>(renderInspectHuman) },
   pin: { renderHuman: (result) => renderPinHuman(result as PinResult | ClearResult) },
 }
 

--- a/cli/lib/tap/render/inspect.ts
+++ b/cli/lib/tap/render/inspect.ts
@@ -1,9 +1,7 @@
 import chalk from 'chalk'
 
 import type { FrameInspectResult } from '../commands/inspect'
-import { color, definitionList, heading, layout } from './format'
-
-const urlSuffix = (url?: string): string => (url ? `  ${color.muted(url)}` : '')
+import { color, definitionList, heading, layout, quoted } from './format'
 
 // A record renders as a counted heading over an aligned key/value list; an empty
 // or absent record contributes no block.
@@ -31,11 +29,10 @@ const boxBlock = (box: FrameInspectResult['box']): string[][] => {
 
 export const renderInspectHuman = (result: FrameInspectResult): string => {
   if (!result.found) {
-    return `${chalk.bold(result.selector)}  ${color.muted('not found')}${urlSuffix(result.url)}`
+    return `${chalk.bold(quoted(result.selector))}  ${color.muted('not found')}`
   }
 
   return layout([
-    [`${chalk.bold(result.tag ?? '?')}  ${result.selector}${urlSuffix(result.url)}`],
     ...recordBlock('ATTRIBUTES', result.attributes),
     ...ariaBlock(result.aria),
     ...boxBlock(result.box),

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1137,7 +1137,10 @@ describe('lib/exec/tap', () => {
       let forwarded: unknown
 
       vi.mocked(withResolvedAutFrame).mockImplementation(async (_options, read) => {
-        const callFunctionOn = vi.fn().mockResolvedValue({ result: { value: { html: '<html/>' } } })
+        // The single-element guard counts matches first; the read follows.
+        const callFunctionOn = vi.fn()
+        .mockResolvedValueOnce({ result: { value: { count: 1 } } })
+        .mockResolvedValue({ result: { value: { html: '<html/>' } } })
         const session = {
           call: vi.fn(),
           sessionId: 'S1',
@@ -1147,8 +1150,8 @@ describe('lib/exec/tap', () => {
           },
         } as unknown as TapSession
 
-        await read(session, { frameId: 'f', url: 'u' } as AutFrame)
-        forwarded = callFunctionOn.mock.calls[0][0].arguments
+        await read(session, { frameId: 'f' } as AutFrame)
+        forwarded = callFunctionOn.mock.calls[1][0].arguments
 
         return 0
       })
@@ -1156,7 +1159,7 @@ describe('lib/exec/tap', () => {
       await tap.start(['dom', '--selector', '.btn', '--max-chars', '50'], {})
 
       // selector and the coerced --max-chars reach the extractor as call arguments.
-      expect(forwarded).toEqual([{ value: '.btn' }, { value: 50 }])
+      expect(forwarded).toEqual([{ value: '.btn' }, { value: 50 }, { value: 0 }])
     })
 
     it('rejects `inspect` with no selector, without reading the frame', async () => {
@@ -1266,11 +1269,12 @@ describe('lib/exec/tap', () => {
                                 most recently modified first
           run [options] <spec>  run (or rerun) a spec by its project-relative path
           dom [options]         read the app-under-test DOM as HTML: the whole page,
-                                or each element matching a selector (with its subtree)
+                                or the one element a selector matches (with its
+                                subtree)
           aria [options]        read the accessibility (ARIA) tree of the
                                 app-under-test frame, or the subtree at a selector
-          inspect [options]     inspect the first element matching a selector: its
-                                tag, attributes, computed styles, box model, and
+          inspect [options]     inspect the element a selector matches: its tag,
+                                attributes, computed styles, box model, and
                                 accessibility node
           command [options]     detail one command log entry of a test — its reporter
                                 row, the DOM snapshots pinnable on it, and its console

--- a/cli/test/lib/tap/aria.spec.ts
+++ b/cli/test/lib/tap/aria.spec.ts
@@ -28,12 +28,14 @@ describe('lib/tap/commands/aria extractAria', () => {
     }),
   ]
 
-  const makeAxSession = (opts: { axNodes?: unknown[], selectorObjectId?: string | undefined, selectorSubtype?: string, backendNodeId?: number, throwOnEval?: boolean } = {}) => {
-    const callFunctionOn = vi.fn().mockImplementation(async () => {
-      if (opts.throwOnEval) {
-        return { exceptionDetails: { text: 'bad selector' } }
-      }
-
+  const makeAxSession = (opts: { axNodes?: unknown[], selectorObjectId?: string | undefined, selectorSubtype?: string, backendNodeId?: number, matchCount?: number, invalidSelector?: boolean } = {}) => {
+    // In selector mode the single-element guard counts matches first; the
+    // selector is only resolved to an element once it matched exactly one.
+    const callFunctionOn = vi.fn()
+    .mockImplementationOnce(async () => {
+      return { result: { value: opts.invalidSelector ? { invalidSelector: true } : { count: opts.matchCount ?? 1 } } }
+    })
+    .mockImplementation(async () => {
       return { result: { objectId: opts.selectorObjectId, subtype: opts.selectorSubtype } }
     })
 
@@ -53,14 +55,25 @@ describe('lib/tap/commands/aria extractAria', () => {
     return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapSession, client }
   }
 
-  const frame = { frameId: 'aut-frame-id', url: 'http://localhost:5555/index.html' }
+  const frame = { frameId: 'aut-frame-id' }
+
+  // A read returns the tree; an ambiguous selector returns the candidates
+  // instead, which only the dedicated test below expects.
+  const readAria = async (...args: Parameters<typeof extractAria>) => {
+    const result = await extractAria(...args)
+
+    if ('ambiguous' in result) {
+      throw new Error(`expected a tree, got the ambiguity answer: ${JSON.stringify(result)}`)
+    }
+
+    return result
+  }
 
   it('projects the whole tree, collapsing noise roles and reporting states/value', async () => {
     const { session } = makeAxSession()
 
-    const result = await extractAria(session, frame, undefined, 200)
+    const result = await readAria(session, frame, undefined, 200)
 
-    expect(result.url).to.eq('http://localhost:5555/index.html')
     expect(result.nodeCount).to.eq(3)
     // The generic node is dropped; the heading and textbox promote under the root.
     expect(result.nodes).to.deep.eq([
@@ -73,7 +86,7 @@ describe('lib/tap/commands/aria extractAria', () => {
   it('roots the tree at the selector match via its backend node id', async () => {
     const { session } = makeAxSession({ selectorObjectId: 'obj-1', backendNodeId: 99 })
 
-    const result = await extractAria(session, frame, '[data-testid=username]', 200)
+    const result = await readAria(session, frame, '[data-testid=username]', 200)
 
     expect(result.nodes).to.deep.eq([
       { depth: 0, role: 'textbox', name: 'Username', value: 'ada', states: ['disabled'] },
@@ -81,15 +94,22 @@ describe('lib/tap/commands/aria extractAria', () => {
   })
 
   it('returns an empty tree when the selector matches nothing', async () => {
-    const { session } = makeAxSession({ selectorObjectId: undefined, selectorSubtype: 'null' })
+    const { session } = makeAxSession({ matchCount: 0, selectorObjectId: undefined, selectorSubtype: 'null' })
 
-    const result = await extractAria(session, frame, '.missing', 200)
+    const result = await readAria(session, frame, '.missing', 200)
 
-    expect(result).to.deep.eq({ url: 'http://localhost:5555/index.html', nodes: [], nodeCount: 0 })
+    expect(result).to.deep.eq({ nodes: [], nodeCount: 0 })
+  })
+
+  it('answers a selector matching more than one element without fetching the tree', async () => {
+    const { session, client } = makeAxSession({ matchCount: 2 })
+
+    expect(await extractAria(session, frame, '.item', 200)).to.deep.include({ ambiguous: true, selector: '.item', count: 2 })
+    expect(client.Accessibility.getFullAXTree).not.toHaveBeenCalled()
   })
 
   it('maps a bad selector to INVALID_SELECTOR', async () => {
-    const { session } = makeAxSession({ throwOnEval: true })
+    const { session } = makeAxSession({ invalidSelector: true })
 
     await expect(extractAria(session, frame, '>>bad', 200)).rejects.toMatchObject({ code: 'INVALID_SELECTOR' })
   })
@@ -97,7 +117,7 @@ describe('lib/tap/commands/aria extractAria', () => {
   it('caps the tree at max-nodes and flags truncation', async () => {
     const { session } = makeAxSession()
 
-    const result = await extractAria(session, frame, undefined, 2)
+    const result = await readAria(session, frame, undefined, 2)
 
     expect(result.nodeCount).to.eq(2)
     expect(result.truncated).to.eq(true)

--- a/cli/test/lib/tap/dom.spec.ts
+++ b/cli/test/lib/tap/dom.spec.ts
@@ -6,10 +6,18 @@ import type { TapSession } from '../../../lib/tap/tap-session'
 
 const SESSION_ID = 'S1'
 
+// In selector mode the single-element guard counts matches first, so a session
+// serves its responses in order: the count, then the read.
+const MATCHED_ONE = { value: { count: 1 } }
+
 describe('lib/tap/commands/dom extractDom', () => {
-  const makeSession = (fnValue: unknown, exceptionDetails?: unknown) => {
+  const makeSession = (responses: Array<{ value?: unknown, exceptionDetails?: unknown }>) => {
     const createIsolatedWorld = vi.fn().mockResolvedValue({ executionContextId: 42 })
-    const callFunctionOn = vi.fn().mockResolvedValue({ result: { value: fnValue }, exceptionDetails })
+    const callFunctionOn = vi.fn()
+
+    for (const { value, exceptionDetails } of responses) {
+      callFunctionOn.mockResolvedValueOnce({ result: { value }, exceptionDetails })
+    }
 
     const session = {
       call: vi.fn(),
@@ -20,47 +28,83 @@ describe('lib/tap/commands/dom extractDom', () => {
     return { session, createIsolatedWorld, callFunctionOn }
   }
 
-  const frame = { frameId: 'aut-frame-id', url: 'http://localhost:5555/index.html' }
+  const frame = { frameId: 'aut-frame-id' }
 
-  it('returns the whole-document HTML with the frame url when no selector is given', async () => {
-    const { session, createIsolatedWorld, callFunctionOn } = makeSession({ html: '<html>hi</html>' })
+  // A read returns HTML; an ambiguous selector returns the candidates instead,
+  // which only the dedicated test below expects.
+  const readDom = async (...args: Parameters<typeof extractDom>) => {
+    const result = await extractDom(...args)
+
+    if ('ambiguous' in result) {
+      throw new Error(`expected a read, got the ambiguity answer: ${JSON.stringify(result)}`)
+    }
+
+    return result
+  }
+
+  it('returns the whole-document HTML when no selector is given', async () => {
+    const { session, createIsolatedWorld, callFunctionOn } = makeSession([{ value: { html: '<html>hi</html>' } }])
 
     const result = await extractDom(session, frame, undefined, 30000)
 
-    expect(result).to.deep.eq({ url: 'http://localhost:5555/index.html', html: '<html>hi</html>' })
+    expect(result).to.deep.eq({ html: '<html>hi</html>' })
     // Isolated world is created for the resolved AUT frame, on its session.
     expect(createIsolatedWorld).toHaveBeenCalledWith({ frameId: 'aut-frame-id', worldName: 'cypress-tap' }, SESSION_ID)
     // selector (null when absent) and maxChars are forwarded as call arguments.
     expect(callFunctionOn.mock.calls[0][0]).toMatchObject({
       executionContextId: 42,
-      arguments: [{ value: null }, { value: 30000 }],
+      arguments: [{ value: null }, { value: 30000 }, { value: 0 }],
       returnByValue: true,
     })
 
     expect(callFunctionOn.mock.calls[0][1]).to.eq(SESSION_ID)
   })
 
-  it('returns matches (and forwards the selector) in selector mode', async () => {
-    const { session, callFunctionOn } = makeSession({ matches: { count: 2, html: ['<a>', '<b>'] }, truncated: false })
+  it('returns the matched element (and forwards the selector) in selector mode', async () => {
+    const { session, callFunctionOn } = makeSession([MATCHED_ONE, { value: { found: true, html: '<a></a>' } }])
 
     const result = await extractDom(session, frame, '.x', 100)
 
-    expect(result.matches).to.deep.eq({ count: 2, html: ['<a>', '<b>'] })
-    expect(result.html).to.be.undefined
-    expect(callFunctionOn.mock.calls[0][0].arguments).to.deep.eq([{ value: '.x' }, { value: 100 }])
+    expect(result).to.deep.eq({ found: true, html: '<a></a>' })
+    expect(callFunctionOn.mock.calls[1][0].arguments).to.deep.eq([{ value: '.x' }, { value: 100 }, { value: 0 }])
+  })
+
+  it('returns found:false when the selector matches nothing', async () => {
+    const { session } = makeSession([{ value: { count: 0 } }, { value: { found: false } }])
+
+    const result = await extractDom(session, frame, '.missing', 100)
+
+    expect(result).to.deep.eq({ found: false })
+  })
+
+  it('answers a selector matching more than one element instead of reading', async () => {
+    const { session, callFunctionOn } = makeSession([{ value: { count: 3 } }])
+
+    expect(await extractDom(session, frame, '.x', 100)).to.deep.include({ ambiguous: true, selector: '.x', count: 3 })
+    // The read itself never runs — the count is the only call.
+    expect(callFunctionOn).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads the match --at names instead of answering with the list', async () => {
+    const { session, callFunctionOn } = makeSession([{ value: { count: 3 } }, { value: { found: true, html: '<c></c>' } }])
+
+    const result = await readDom(session, frame, '.x', 100, 2)
+
+    expect(result).to.deep.eq({ found: true, html: '<c></c>' })
+    expect(callFunctionOn.mock.calls[1][0].arguments).to.deep.eq([{ value: '.x' }, { value: 100 }, { value: 2 }])
   })
 
   it('reports truncation from the browser-side cap', async () => {
-    const { session } = makeSession({ html: '<htm', truncated: true })
+    const { session } = makeSession([{ value: { html: '<htm', truncated: true } }])
 
-    const result = await extractDom(session, frame, undefined, 4)
+    const result = await readDom(session, frame, undefined, 4)
 
     expect(result.truncated).to.eq(true)
     expect(result.html).to.eq('<htm')
   })
 
   it('maps a bad selector to INVALID_SELECTOR', async () => {
-    const { session } = makeSession({ invalidSelector: true })
+    const { session } = makeSession([{ value: { invalidSelector: true } }])
 
     await expect(extractDom(session, frame, '>>bad', 100)).rejects.toMatchObject({
       name: 'FrameCommandError',
@@ -69,9 +113,9 @@ describe('lib/tap/commands/dom extractDom', () => {
   })
 
   it('maps a CDP evaluation exception to FRAME_READ_FAILED', async () => {
-    const { session } = makeSession(undefined, { text: 'boom', exception: { description: 'boom' } })
+    const failing = () => makeSession([{ exceptionDetails: { text: 'boom', exception: { description: 'boom' } } }]).session
 
-    await expect(extractDom(session, frame, undefined, 100)).rejects.toBeInstanceOf(FrameCommandError)
-    await expect(extractDom(session, frame, undefined, 100)).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
+    await expect(extractDom(failing(), frame, undefined, 100)).rejects.toBeInstanceOf(FrameCommandError)
+    await expect(extractDom(failing(), frame, undefined, 100)).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
   })
 })

--- a/cli/test/lib/tap/frame-scripts.spec.ts
+++ b/cli/test/lib/tap/frame-scripts.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { readDom, readElementInfo } from '../../../lib/tap/aut/scripts'
+import { countMatches, readDom, readElementInfo } from '../../../lib/tap/aut/scripts'
 
 // These run in the AUT frame over CDP; here we call the real functions with the
 // handful of DOM globals they touch stubbed, so the logic is tested without a
@@ -15,34 +15,43 @@ describe('lib/tap/aut/scripts readDom', () => {
   it('returns the whole-document HTML when no selector is given', () => {
     stubDocument({ documentElement: { outerHTML: '<html>hi</html>' } })
 
-    expect(readDom(null, 30000)).to.deep.eq({ html: '<html>hi</html>' })
+    expect(readDom(null, 30000, 0)).to.deep.eq({ html: '<html>hi</html>' })
   })
 
   it('truncates and flags the whole-document HTML past the cap', () => {
     stubDocument({ documentElement: { outerHTML: '<html>too long</html>' } })
 
-    expect(readDom(null, 4)).to.deep.eq({ html: '<htm', truncated: true })
+    expect(readDom(null, 4, 0)).to.deep.eq({ html: '<htm', truncated: true })
   })
 
   it('returns an empty string when there is no documentElement', () => {
     stubDocument({ documentElement: null })
 
-    expect(readDom(null, 30000)).to.deep.eq({ html: '' })
+    expect(readDom(null, 30000, 0)).to.deep.eq({ html: '' })
   })
 
-  it('returns each match in selector mode', () => {
-    stubDocument({ querySelectorAll: () => [{ outerHTML: '<a>' }, { outerHTML: '<b>' }] })
+  it('returns the matched element in selector mode', () => {
+    stubDocument({ querySelectorAll: () => [{ outerHTML: '<a></a>' }] })
 
-    expect(readDom('.x', 100)).to.deep.eq({ matches: { count: 2, html: ['<a>', '<b>'] }, truncated: false })
+    expect(readDom('.x', 100, 0)).to.deep.eq({ found: true, html: '<a></a>' })
   })
 
-  it('caps across matches, keeping the partial element that overflows', () => {
-    stubDocument({ querySelectorAll: () => [{ outerHTML: '<a>' }, { outerHTML: '<bbbb>' }] })
+  it('reads the match the index names, not the first', () => {
+    stubDocument({ querySelectorAll: () => [{ outerHTML: '<a></a>' }, { outerHTML: '<b></b>' }, { outerHTML: '<c></c>' }] })
 
-    const result = readDom('.x', 5)
+    expect(readDom('.x', 100, 2)).to.deep.eq({ found: true, html: '<c></c>' })
+  })
 
-    expect(result.matches).to.deep.eq({ count: 2, html: ['<a>', '<b'] })
-    expect(result.truncated).to.eq(true)
+  it('truncates and flags the matched element past the cap', () => {
+    stubDocument({ querySelectorAll: () => [{ outerHTML: '<a>too long</a>' }] })
+
+    expect(readDom('.x', 3, 0)).to.deep.eq({ found: true, html: '<a>', truncated: true })
+  })
+
+  it('reports found:false when the selector matches nothing', () => {
+    stubDocument({ querySelectorAll: () => [] })
+
+    expect(readDom('.missing', 100, 0)).to.deep.eq({ found: false })
   })
 
   it('tags an invalid selector rather than throwing', () => {
@@ -50,7 +59,23 @@ describe('lib/tap/aut/scripts readDom', () => {
       throw new Error('bad selector')
     } })
 
-    expect(readDom('>>bad', 100)).to.deep.eq({ invalidSelector: true })
+    expect(readDom('>>bad', 100, 0)).to.deep.eq({ invalidSelector: true })
+  })
+})
+
+describe('lib/tap/aut/scripts countMatches', () => {
+  it('counts the matches without reading any of them', () => {
+    stubDocument({ querySelectorAll: () => ({ length: 3 }) })
+
+    expect(countMatches('.x')).to.deep.eq({ count: 3 })
+  })
+
+  it('tags an invalid selector rather than throwing', () => {
+    stubDocument({ querySelectorAll: () => {
+      throw new Error('bad selector')
+    } })
+
+    expect(countMatches('>>bad')).to.deep.eq({ invalidSelector: true })
   })
 })
 

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import stripAnsi from 'strip-ansi'
 
-import { resolveAutFrame, assertFrameReadable, parsePositiveInt, FrameCommandError } from '../../../lib/tap/aut/frame'
+import logger from '../../../lib/logger'
+import { resolveInstance } from '../../../lib/cypress-instances'
+import { withTapSession } from '../../../lib/tap/tap-session'
+import { resolveAutFrame, assertFrameReadable, parsePositiveInt, withResolvedAutFrame, FrameCommandError } from '../../../lib/tap/aut/frame'
 import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapCliOptions } from '../../../lib/tap/types'
+
+vi.mock('../../../lib/cypress-instances', async (importActual) => {
+  const actual = await importActual<typeof import('../../../lib/cypress-instances')>()
+
+  return { ...actual, resolveInstance: vi.fn() }
+})
+
+vi.mock('../../../lib/tap/tap-session', async (importActual) => {
+  const actual = await importActual<typeof import('../../../lib/tap/tap-session')>()
+
+  return { ...actual, withTapSession: vi.fn() }
+})
 
 const SESSION_ID = 'S1'
 
@@ -106,6 +123,53 @@ describe('lib/tap/aut/frame assertFrameReadable', () => {
       code: 'BOOM',
       message: 'run-state blew up',
     })
+  })
+})
+
+describe('lib/tap/aut/frame withResolvedAutFrame', () => {
+  const stdout = (): string => vi.mocked(console.log).mock.calls.flat().join(' ')
+  const stderr = (): string => vi.mocked(console.error).mock.calls.flat().join(' ')
+
+  beforeEach(() => {
+    const session = {
+      call: vi.fn().mockResolvedValue({ result: { spec: 'login.cy.js', totalSpecs: 1, state: 'passed' } }),
+      client: makePageClient(frameTree()),
+      sessionId: SESSION_ID,
+    } as unknown as TapSession
+
+    vi.mocked(resolveInstance).mockResolvedValue({ instance: {}, reason: 'only', candidateCount: 1 } as any)
+    vi.mocked(withTapSession).mockImplementation((_instance: any, use: any) => use(session))
+
+    logger.reset()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  const read = async (result: unknown, options: TapCliOptions = { json: true } as TapCliOptions): Promise<number> => {
+    return withResolvedAutFrame(options, async () => result, 'dom')
+  }
+
+  it('prints the read and exits 0', async () => {
+    expect(await read({ found: true, html: '<p>hi</p>' })).to.eq(0)
+    expect(stdout()).toContain('"html": "<p>hi</p>"')
+  })
+
+  it('exits 1 on an ambiguous selector — the read that was asked for did not happen', async () => {
+    expect(await read({ ambiguous: true, selector: '.item', count: 2 })).to.eq(1)
+  })
+
+  it('still prints the ambiguity answer as a result, so the matches to choose between survive the non-zero exit', async () => {
+    await read({ ambiguous: true, selector: '.item', count: 2 })
+
+    expect(JSON.parse(stdout())).to.deep.eq({ ambiguous: true, selector: '.item', count: 2 })
+    expect(stderr()).to.eq('')
+  })
+
+  it('renders the ambiguity for a human on stdout too, exiting 1 all the same', async () => {
+    expect(await read({ ambiguous: true, selector: '.item', count: 2 }, {} as TapCliOptions)).to.eq(1)
+
+    expect(stripAnsi(stdout())).toContain('matched 2 elements but must be unique')
+    expect(stderr()).to.eq('')
   })
 })
 

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -173,10 +173,10 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
   })
 })
 
-// Every input shape that is not a plain run of digits, shared by both parsers
-// so they reject the same class. `Number()` coerces most of these to a number
-// that passes an isInteger check, which is what makes the whole list necessary.
-const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', null, ['1', '2'], ['5'], 7, {}]
+// Every input shape both parsers must reject, shared so they reject the same
+// class: text `Number()` coerces to a number that passes an isInteger check,
+// and runs of digits long enough to leave the safe-integer range.
+const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', '9007199254740993', '9'.repeat(400), null, ['1', '2'], ['5'], 7, {}]
 
 describe('lib/tap/aut/frame parseIndex', () => {
   it('reads no index when the flag is absent', () => {
@@ -200,8 +200,9 @@ describe('lib/tap/aut/frame parsePositiveInt', () => {
     expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
   })
 
-  it('parses a positive integer', () => {
+  it('parses a positive integer, up to the largest one that survives the round trip', () => {
     expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
+    expect(parsePositiveInt('9007199254740991', 200, 'max-nodes')).to.eq(Number.MAX_SAFE_INTEGER)
   })
 
   it('rejects zero and every malformed value with INVALID_LIMIT', () => {

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -4,7 +4,7 @@ import stripAnsi from 'strip-ansi'
 import logger from '../../../lib/logger'
 import { resolveInstance } from '../../../lib/cypress-instances'
 import { withTapSession } from '../../../lib/tap/tap-session'
-import { resolveAutFrame, assertFrameReadable, parsePositiveInt, withResolvedAutFrame, FrameCommandError } from '../../../lib/tap/aut/frame'
+import { resolveAutFrame, assertFrameReadable, parseIndex, parsePositiveInt, withResolvedAutFrame, FrameCommandError } from '../../../lib/tap/aut/frame'
 import type { TapSession } from '../../../lib/tap/tap-session'
 import type { TapCliOptions } from '../../../lib/tap/types'
 
@@ -173,6 +173,28 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
   })
 })
 
+// Every input shape that is not a plain run of digits, shared by both parsers
+// so they reject the same class. `Number()` coerces most of these to a number
+// that passes an isInteger check, which is what makes the whole list necessary.
+const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', null, ['1', '2'], ['5'], 7, {}]
+
+describe('lib/tap/aut/frame parseIndex', () => {
+  it('reads no index when the flag is absent', () => {
+    expect(parseIndex(undefined)).to.eq(undefined)
+  })
+
+  it('parses a 0-based index', () => {
+    expect(parseIndex('0')).to.eq(0)
+    expect(parseIndex('3')).to.eq(3)
+  })
+
+  it('rejects every malformed value with INVALID_INDEX', () => {
+    for (const bad of MALFORMED) {
+      expect(() => parseIndex(bad as any), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_INDEX' })
+    }
+  })
+})
+
 describe('lib/tap/aut/frame parsePositiveInt', () => {
   it('falls back when the value is absent', () => {
     expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
@@ -182,9 +204,9 @@ describe('lib/tap/aut/frame parsePositiveInt', () => {
     expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
   })
 
-  it('rejects zero, negatives, and non-integers with INVALID_LIMIT', () => {
-    for (const bad of ['0', '-5', '1.5', 'abc']) {
-      expect(() => parsePositiveInt(bad, 200, 'max-nodes')).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
+  it('rejects zero and every malformed value with INVALID_LIMIT', () => {
+    for (const bad of ['0', ...MALFORMED]) {
+      expect(() => parsePositiveInt(bad as any, 200, 'max-nodes'), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
     }
   })
 })

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -33,7 +33,7 @@ describe('lib/tap/aut/frame resolveAutFrame', () => {
 
     const frame = await resolveAutFrame(client as any, SESSION_ID)
 
-    expect(frame).to.deep.eq({ frameId: 'aut-frame-id', url: 'http://localhost:5555/index.html' })
+    expect(frame).to.deep.eq({ frameId: 'aut-frame-id' })
     // getFrameTree takes no params — CRI routes the session id by type.
     expect(client.Page.getFrameTree).toHaveBeenCalledWith(SESSION_ID)
   })

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -7,7 +7,7 @@ import type { TapSession } from '../../../lib/tap/tap-session'
 const SESSION_ID = 'S1'
 
 describe('lib/tap/commands/inspect extractInspect', () => {
-  const frame = { frameId: 'aut-frame-id', url: 'http://localhost:5555/index.html' }
+  const frame = { frameId: 'aut-frame-id' }
 
   const ELEMENT_INFO = {
     tag: 'input',
@@ -19,21 +19,18 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   const makeInspectSession = (opts: {
     selectorObjectId?: string
     selectorSubtype?: string
-    throwOnEval?: boolean
+    matchCount?: number
+    invalidSelector?: boolean
     elementInfo?: unknown
     axError?: unknown
     axNodes?: unknown[]
   } = {}) => {
-    // callFunctionOn is used twice: first to querySelector (returns the element
-    // objectId), then to read the element's info by value.
+    // callFunctionOn is used three times: the single-element guard's match count,
+    // then querySelector (returns the element objectId), then the element's info
+    // by value.
     const callFunctionOn = vi.fn()
-    .mockImplementationOnce(async () => {
-      if (opts.throwOnEval) {
-        return { exceptionDetails: { text: 'bad selector' } }
-      }
-
-      return { result: { objectId: opts.selectorObjectId, subtype: opts.selectorSubtype } }
-    })
+    .mockImplementationOnce(async () => ({ result: { value: opts.invalidSelector ? { invalidSelector: true } : { count: opts.matchCount ?? 1 } } }))
+    .mockImplementationOnce(async () => ({ result: { objectId: opts.selectorObjectId, subtype: opts.selectorSubtype } }))
     .mockImplementationOnce(async () => ({ result: { value: opts.elementInfo ?? ELEMENT_INFO } }))
 
     const getPartialAXTree = vi.fn().mockImplementation(async () => {
@@ -60,10 +57,22 @@ describe('lib/tap/commands/inspect extractInspect', () => {
     return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapSession }
   }
 
+  // A read returns the element; an ambiguous selector returns the candidates
+  // instead, which only the dedicated test below expects.
+  const readInspect = async (...args: Parameters<typeof extractInspect>) => {
+    const result = await extractInspect(...args)
+
+    if ('ambiguous' in result) {
+      throw new Error(`expected a read, got the ambiguity answer: ${JSON.stringify(result)}`)
+    }
+
+    return result
+  }
+
   it('returns tag, attributes, curated styles, box, and the ax node for a match', async () => {
     const { session } = makeInspectSession({ selectorObjectId: 'obj-1' })
 
-    const result = await extractInspect(session, frame, '[data-testid=username-input]')
+    const result = await readInspect(session, frame, '[data-testid=username-input]')
 
     expect(result.found).to.eq(true)
     expect(result.tag).to.eq('input')
@@ -74,15 +83,25 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   })
 
   it('returns found:false when the selector matches nothing', async () => {
-    const { session } = makeInspectSession({ selectorObjectId: undefined, selectorSubtype: 'null' })
+    const { session } = makeInspectSession({ matchCount: 0, selectorObjectId: undefined, selectorSubtype: 'null' })
 
     const result = await extractInspect(session, frame, '.missing')
 
-    expect(result).to.deep.eq({ url: 'http://localhost:5555/index.html', selector: '.missing', found: false })
+    expect(result).to.deep.eq({ selector: '.missing', found: false })
+  })
+
+  it('answers a selector matching more than one element instead of reading', async () => {
+    const { session } = makeInspectSession({ matchCount: 4 })
+
+    expect(await extractInspect(session, frame, '.item')).to.deep.eq({
+      ambiguous: true,
+      selector: '.item',
+      count: 4,
+    })
   })
 
   it('maps a bad selector to INVALID_SELECTOR', async () => {
-    const { session } = makeInspectSession({ throwOnEval: true })
+    const { session } = makeInspectSession({ invalidSelector: true })
 
     await expect(extractInspect(session, frame, '>>bad')).rejects.toMatchObject({ code: 'INVALID_SELECTOR' })
   })
@@ -90,7 +109,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   it('still returns the element when the accessibility node is unavailable', async () => {
     const { session } = makeInspectSession({ selectorObjectId: 'obj-1', axError: new Error('no ax') })
 
-    const result = await extractInspect(session, frame, '.plain')
+    const result = await readInspect(session, frame, '.plain')
 
     expect(result.found).to.eq(true)
     expect(result.aria).to.be.undefined

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import stripAnsi from 'strip-ansi'
+
+import { renderAmbiguousHuman } from '../../../lib/tap/render/ambiguous'
+import type { FrameAmbiguousResult } from '../../../lib/tap/aut/single-match'
+
+const render = (result: FrameAmbiguousResult): string => stripAnsi(renderAmbiguousHuman(result))
+
+describe('lib/tap/render/ambiguous', () => {
+  it('states what went wrong, then the way through', () => {
+    expect(render({ ambiguous: true, selector: '.item', count: 2 })).toBe([
+      '⚠ selector \'.item\' matched 2 elements but must be unique',
+      'pass --at <index> to read one of them (0-1)',
+    ].join('\n'))
+  })
+
+  it('quotes a selector carrying a single quote so it pastes back into a shell', () => {
+    expect(render({ ambiguous: true, selector: '[data-x="it\'s"]', count: 3 })).toContain(
+      'selector \'[data-x="it\'\\\'\'s"]\' matched 3 elements',
+    )
+  })
+})

--- a/cli/test/lib/tap/render-aria.spec.ts
+++ b/cli/test/lib/tap/render-aria.spec.ts
@@ -7,9 +7,8 @@ import type { FrameAriaResult } from '../../../lib/tap/commands/aria'
 const render = (result: FrameAriaResult): string => stripAnsi(renderAriaHuman(result))
 
 describe('lib/tap/render/aria', () => {
-  it('renders an indented role tree with names, values, states, and a truncation note', () => {
+  it('renders a role tree rooted flush, with names, values, states, and a truncation note', () => {
     const output = render({
-      url: 'http://localhost:3000',
       nodeCount: 4,
       nodes: [
         { depth: 0, role: 'RootWebArea', name: 'Login' },
@@ -21,11 +20,10 @@ describe('lib/tap/render/aria', () => {
     })
 
     expect(output).toBe([
-      'ARIA (4)  http://localhost:3000',
-      '  RootWebArea  Login',
-      '    heading  Sign in',
-      '    textbox  Username = ada  [disabled]',
-      '    button  Submit',
+      'RootWebArea  Login',
+      '  heading  Sign in',
+      '  textbox  Username = ada  [disabled]',
+      '  button  Submit',
       '',
       '(output truncated)',
     ].join('\n'))

--- a/cli/test/lib/tap/render-dom.spec.ts
+++ b/cli/test/lib/tap/render-dom.spec.ts
@@ -7,27 +7,43 @@ import type { FrameDomResult } from '../../../lib/tap/commands/dom'
 const render = (result: FrameDomResult): string => stripAnsi(renderDomHuman(result))
 
 describe('lib/tap/render/dom', () => {
-  it('renders the whole document under a DOM header with the url', () => {
-    expect(render({ url: 'http://localhost:5555/', html: '<html></html>' })).toBe([
-      'DOM  http://localhost:5555/',
-      '',
-      '<html></html>',
-    ].join('\n'))
+  it('renders the whole document as bare HTML, with nothing framing it', () => {
+    expect(render({ html: '<html></html>' })).toBe('<html></html>')
   })
 
-  it('renders each selector match as its own block under a counted header, and notes truncation', () => {
-    expect(render({ url: 'http://localhost:5555/', matches: { count: 2, html: ['<a></a>', '<b></b>'] }, truncated: true })).toBe([
-      'MATCHES (2)  http://localhost:5555/',
-      '',
+  it('renders the matched element the same way, and notes truncation', () => {
+    expect(render({ found: true, html: '<a></a>', truncated: true })).toBe([
       '<a></a>',
-      '',
-      '<b></b>',
       '',
       '(output truncated)',
     ].join('\n'))
   })
 
+  it('pulls a nested element back to the margin, keeping its internal shape', () => {
+    // outerHTML as the document had it: the element starts at the margin, its
+    // body carries the depth it sat at.
+    const html = [
+      '<button type="button">',
+      '          <span class="icon-bar"></span>',
+      '            <em>x</em>',
+      '        </button>',
+    ].join('\n')
+
+    expect(render({ found: true, html })).toBe([
+      '<button type="button">',
+      '  <span class="icon-bar"></span>',
+      '    <em>x</em>',
+      '</button>',
+    ].join('\n'))
+  })
+
+  it('leaves markup that already sits at the margin alone', () => {
+    const html = '<ul>\n<li>a</li>\n</ul>'
+
+    expect(render({ found: true, html })).toBe(html)
+  })
+
   it('notes when a selector matched nothing', () => {
-    expect(render({ url: 'http://x/', matches: { count: 0, html: [] } })).toBe('No elements matched the selector.')
+    expect(render({ found: false })).toBe('No element matched the selector.')
   })
 })

--- a/cli/test/lib/tap/render-format.spec.ts
+++ b/cli/test/lib/tap/render-format.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import stripAnsi from 'strip-ansi'
 
-import { countsLine, definitionList, emptyState, heading, indent, layout, stateBadge, table, titleLine } from '../../../lib/tap/render/format'
+import { countsLine, definitionList, emptyState, heading, indent, layout, quoted, stateBadge, table, titleLine } from '../../../lib/tap/render/format'
 
 // chalk's color level depends on where the suite runs, so strip escape codes
 // before asserting — these target the shared layout, not the colors.
@@ -55,6 +55,17 @@ describe('lib/tap/render/format', () => {
         '  pid           4242',
         '  testing type  e2e',
       ])
+    })
+  })
+
+  describe('quoted', () => {
+    it('single-quotes a selector, leaving its double-quoted attribute values alone', () => {
+      expect(quoted(String.raw`[data-test="x"]`)).toBe(String.raw`'[data-test="x"]'`)
+    })
+
+    it('escapes a single quote so the whole selector stays one shell argument', () => {
+      expect(quoted(String.raw`[data-cy="Bob's item"]`)).toBe(String.raw`'[data-cy="Bob'\''s item"]'`)
+      expect(quoted(String.raw`[title='x']`)).toBe(String.raw`'[title='\''x'\'']'`)
     })
   })
 

--- a/cli/test/lib/tap/render-inspect.spec.ts
+++ b/cli/test/lib/tap/render-inspect.spec.ts
@@ -7,9 +7,8 @@ import type { FrameInspectResult } from '../../../lib/tap/commands/inspect'
 const render = (result: FrameInspectResult): string => stripAnsi(renderInspectHuman(result))
 
 describe('lib/tap/render/inspect', () => {
-  it('renders a found element as header + attribute/accessibility/box/style sections', () => {
+  it('renders a found element as attribute/accessibility/box/style sections', () => {
     const output = render({
-      url: 'http://localhost:3000',
       selector: '[data-testid=username]',
       found: true,
       tag: 'input',
@@ -20,8 +19,6 @@ describe('lib/tap/render/inspect', () => {
     })
 
     expect(output).toBe([
-      'input  [data-testid=username]  http://localhost:3000',
-      '',
       'ATTRIBUTES (2)',
       '  data-testid  username',
       '  name         username',
@@ -41,7 +38,7 @@ describe('lib/tap/render/inspect', () => {
   })
 
   it('renders a not-found result on a single line', () => {
-    expect(render({ url: 'http://x/', selector: '.missing', found: false })).toBe('.missing  not found  http://x/')
+    expect(render({ selector: '.missing', found: false })).toBe('\'.missing\'  not found')
   })
 
   it('omits the accessibility block when there is no aria node', () => {

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveMatch } from '../../../lib/tap/aut/single-match'
+import type { TapSession } from '../../../lib/tap/tap-session'
+
+const SESSION_ID = 'S1'
+
+describe('lib/tap/aut/single-match resolveMatch', () => {
+  const frame = { frameId: 'aut-frame-id' }
+
+  const makeSession = (count: unknown, exceptionDetails?: unknown) => {
+    const createIsolatedWorld = vi.fn().mockResolvedValue({ executionContextId: 42 })
+    const callFunctionOn = vi.fn().mockResolvedValue({ result: { value: count }, exceptionDetails })
+
+    const session = {
+      client: { Page: { createIsolatedWorld }, Runtime: { callFunctionOn } },
+      sessionId: SESSION_ID,
+    } as unknown as TapSession
+
+    return { session, callFunctionOn, createIsolatedWorld }
+  }
+
+  it('lets a selector matching exactly one element through, counting it in the AUT frame', async () => {
+    const { session, callFunctionOn, createIsolatedWorld } = makeSession({ count: 1 })
+
+    expect(await resolveMatch(session, frame, '.one')).to.be.undefined
+
+    expect(createIsolatedWorld).toHaveBeenCalledWith({ frameId: 'aut-frame-id', worldName: 'cypress-tap' }, SESSION_ID)
+    expect(callFunctionOn.mock.calls[0][0]).toMatchObject({
+      executionContextId: 42,
+      arguments: [{ value: '.one' }],
+      returnByValue: true,
+    })
+  })
+
+  it('lets a selector matching nothing through — each command reports that in its own shape', async () => {
+    const { session } = makeSession({ count: 0 })
+
+    expect(await resolveMatch(session, frame, '.missing')).to.be.undefined
+  })
+
+  it('answers a selector matching several with how many it matched', async () => {
+    const { session } = makeSession({ count: 3 })
+
+    expect(await resolveMatch(session, frame, '.item')).to.deep.eq({
+      ambiguous: true,
+      selector: '.item',
+      count: 3,
+    })
+  })
+
+  it('lets an in-range at through', async () => {
+    const { session } = makeSession({ count: 3 })
+
+    expect(await resolveMatch(session, frame, '.item', 2)).to.be.undefined
+  })
+
+  it('rejects an at past the last match, naming the valid range', async () => {
+    const { session } = makeSession({ count: 3 })
+
+    await expect(resolveMatch(session, frame, '.item', 3)).rejects.toMatchObject({
+      code: 'INVALID_INDEX',
+      message: 'at 3 is out of range: ".item" matched 3 elements, so the index must be 0-2',
+    })
+  })
+
+  it('rejects an at when nothing is there to index', async () => {
+    const { session, callFunctionOn } = makeSession({ count: 1 })
+
+    await expect(resolveMatch(session, frame, undefined, 0)).rejects.toMatchObject({ code: 'INVALID_INDEX' })
+    // No selector means no reason to reach into the frame at all.
+    expect(callFunctionOn).not.toHaveBeenCalled()
+  })
+
+  it('lets an at through when the selector matched nothing, leaving the read to report it', async () => {
+    const { session } = makeSession({ count: 0 })
+
+    expect(await resolveMatch(session, frame, '.missing', 4)).to.be.undefined
+  })
+
+  it('maps a bad selector to INVALID_SELECTOR', async () => {
+    const { session } = makeSession({ invalidSelector: true })
+
+    await expect(resolveMatch(session, frame, '>>bad')).rejects.toMatchObject({
+      name: 'FrameCommandError',
+      code: 'INVALID_SELECTOR',
+    })
+  })
+
+  it('maps a CDP evaluation exception to FRAME_READ_FAILED', async () => {
+    const { session } = makeSession(undefined, { text: 'boom', exception: { description: 'boom' } })
+
+    await expect(resolveMatch(session, frame, '.item')).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
+  })
+})

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -49,22 +49,22 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
     })
   })
 
-  it('lets an in-range at through', async () => {
+  it('lets an in-range --at through', async () => {
     const { session } = makeSession({ count: 3 })
 
     expect(await resolveAmbiguity(session, frame, '.item', 2)).to.be.undefined
   })
 
-  it('rejects an at past the last match, naming the valid range', async () => {
+  it('rejects an --at past the last match, naming the valid range', async () => {
     const { session } = makeSession({ count: 3 })
 
     await expect(resolveAmbiguity(session, frame, '.item', 3)).rejects.toMatchObject({
       code: 'INVALID_INDEX',
-      message: '".item" matched 3 elements; pass at 0-2',
+      message: '".item" matched 3 elements; pass --at 0-2',
     })
   })
 
-  it('rejects an at when nothing is there to index', async () => {
+  it('rejects an --at when nothing is there to index', async () => {
     const { session, callFunctionOn } = makeSession({ count: 1 })
 
     await expect(resolveAmbiguity(session, frame, undefined, 0)).rejects.toMatchObject({ code: 'INVALID_INDEX' })
@@ -72,7 +72,7 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
     expect(callFunctionOn).not.toHaveBeenCalled()
   })
 
-  it('lets an at through when the selector matched nothing, leaving the read to report it', async () => {
+  it('lets an --at through when the selector matched nothing, leaving the read to report it', async () => {
     const { session } = makeSession({ count: 0 })
 
     expect(await resolveAmbiguity(session, frame, '.missing', 4)).to.be.undefined

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { resolveMatch } from '../../../lib/tap/aut/single-match'
+import { resolveAmbiguity } from '../../../lib/tap/aut/single-match'
 import type { TapSession } from '../../../lib/tap/tap-session'
 
 const SESSION_ID = 'S1'
 
-describe('lib/tap/aut/single-match resolveMatch', () => {
+describe('lib/tap/aut/single-match resolveAmbiguity', () => {
   const frame = { frameId: 'aut-frame-id' }
 
   const makeSession = (count: unknown, exceptionDetails?: unknown) => {
@@ -23,7 +23,7 @@ describe('lib/tap/aut/single-match resolveMatch', () => {
   it('lets a selector matching exactly one element through, counting it in the AUT frame', async () => {
     const { session, callFunctionOn, createIsolatedWorld } = makeSession({ count: 1 })
 
-    expect(await resolveMatch(session, frame, '.one')).to.be.undefined
+    expect(await resolveAmbiguity(session, frame, '.one')).to.be.undefined
 
     expect(createIsolatedWorld).toHaveBeenCalledWith({ frameId: 'aut-frame-id', worldName: 'cypress-tap' }, SESSION_ID)
     expect(callFunctionOn.mock.calls[0][0]).toMatchObject({
@@ -36,13 +36,13 @@ describe('lib/tap/aut/single-match resolveMatch', () => {
   it('lets a selector matching nothing through — each command reports that in its own shape', async () => {
     const { session } = makeSession({ count: 0 })
 
-    expect(await resolveMatch(session, frame, '.missing')).to.be.undefined
+    expect(await resolveAmbiguity(session, frame, '.missing')).to.be.undefined
   })
 
   it('answers a selector matching several with how many it matched', async () => {
     const { session } = makeSession({ count: 3 })
 
-    expect(await resolveMatch(session, frame, '.item')).to.deep.eq({
+    expect(await resolveAmbiguity(session, frame, '.item')).to.deep.eq({
       ambiguous: true,
       selector: '.item',
       count: 3,
@@ -52,22 +52,22 @@ describe('lib/tap/aut/single-match resolveMatch', () => {
   it('lets an in-range at through', async () => {
     const { session } = makeSession({ count: 3 })
 
-    expect(await resolveMatch(session, frame, '.item', 2)).to.be.undefined
+    expect(await resolveAmbiguity(session, frame, '.item', 2)).to.be.undefined
   })
 
   it('rejects an at past the last match, naming the valid range', async () => {
     const { session } = makeSession({ count: 3 })
 
-    await expect(resolveMatch(session, frame, '.item', 3)).rejects.toMatchObject({
+    await expect(resolveAmbiguity(session, frame, '.item', 3)).rejects.toMatchObject({
       code: 'INVALID_INDEX',
-      message: 'at 3 is out of range: ".item" matched 3 elements, so the index must be 0-2',
+      message: '".item" matched 3 elements; pass at 0-2',
     })
   })
 
   it('rejects an at when nothing is there to index', async () => {
     const { session, callFunctionOn } = makeSession({ count: 1 })
 
-    await expect(resolveMatch(session, frame, undefined, 0)).rejects.toMatchObject({ code: 'INVALID_INDEX' })
+    await expect(resolveAmbiguity(session, frame, undefined, 0)).rejects.toMatchObject({ code: 'INVALID_INDEX' })
     // No selector means no reason to reach into the frame at all.
     expect(callFunctionOn).not.toHaveBeenCalled()
   })
@@ -75,13 +75,13 @@ describe('lib/tap/aut/single-match resolveMatch', () => {
   it('lets an at through when the selector matched nothing, leaving the read to report it', async () => {
     const { session } = makeSession({ count: 0 })
 
-    expect(await resolveMatch(session, frame, '.missing', 4)).to.be.undefined
+    expect(await resolveAmbiguity(session, frame, '.missing', 4)).to.be.undefined
   })
 
   it('maps a bad selector to INVALID_SELECTOR', async () => {
     const { session } = makeSession({ invalidSelector: true })
 
-    await expect(resolveMatch(session, frame, '>>bad')).rejects.toMatchObject({
+    await expect(resolveAmbiguity(session, frame, '>>bad')).rejects.toMatchObject({
       name: 'FrameCommandError',
       code: 'INVALID_SELECTOR',
     })
@@ -90,6 +90,6 @@ describe('lib/tap/aut/single-match resolveMatch', () => {
   it('maps a CDP evaluation exception to FRAME_READ_FAILED', async () => {
     const { session } = makeSession(undefined, { text: 'boom', exception: { description: 'boom' } })
 
-    await expect(resolveMatch(session, frame, '.item')).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
+    await expect(resolveAmbiguity(session, frame, '.item')).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
   })
 })

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -247,16 +247,38 @@ const specsMeta = {
 cypress instance with that testing type specified.`,
 } as const satisfies TapNativeCommandSchema
 
+// Every selector these three take must resolve to exactly one element, so a
+// reader is never silently shown one of several matches. Their help says so in
+// the same words, and names the remedy the ambiguity error offers.
+const SINGLE_ELEMENT_SELECTOR = 'a CSS selector matching exactly one element'
+
+const AMBIGUOUS_SELECTOR_HELP = `The selector must match exactly one element. When it matches more, nothing is
+read: the command answers with a numbered list of the matches, each with a
+unique selector. Re-run with --at <index> to read one of them, or with whichever
+selector you meant.`
+
+// Shared by the three selector-taking reads, so the way you pick one match out
+// of several is identical across them.
+const atField = {
+  name: 'at',
+  type: 'string',
+  required: false,
+  description: '0-based index of the match to read, as listed by the index column when a selector matches several',
+} as const satisfies TapCommandOptionSchema
+
 const domMeta = {
   name: 'dom',
-  description: 'read the app-under-test DOM as HTML: the whole page, or each element matching a selector (with its subtree)',
-  details: `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of
-each element matching a CSS selector (each match includes its full subtree).
-Output is capped browser-side so a heavy page never ships megabytes at once.`,
+  description: 'read the app-under-test DOM as HTML: the whole page, or the one element a selector matches (with its subtree)',
+  details: `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of the
+element a CSS selector matches (including its full subtree). Output is capped
+browser-side so a heavy page never ships megabytes at once.
+
+${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    selectorField,
+    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR}; omit to read the whole document` },
     { name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
+    atField,
   ],
 } as const satisfies TapNativeCommandSchema
 
@@ -265,21 +287,29 @@ const ariaMeta = {
   description: 'read the accessibility (ARIA) tree of the app-under-test frame, or the subtree at a selector',
   details: `Reads the accessibility (ARIA) tree of the app-under-test frame, or the
 subtree rooted at a CSS selector. Structural and text-only roles are dropped,
-leaving the compact role/name/state tree DevTools shows.`,
+leaving the compact role/name/state tree DevTools shows.
+
+${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    { ...selectorField, description: 'a CSS selector to root the tree at; omit for the whole frame' },
+    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at; omit for the whole frame` },
     { name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
+    atField,
   ],
 } as const satisfies TapNativeCommandSchema
 
 const inspectMeta = {
   name: 'inspect',
-  description: 'inspect the first element matching a selector: its tag, attributes, computed styles, box model, and accessibility node',
-  details: `Inspects the first element matching the selector: its tag, attributes,
-curated computed styles, box model, and accessibility node.`,
+  description: 'inspect the element a selector matches: its tag, attributes, computed styles, box model, and accessibility node',
+  details: `Inspects the element the selector matches: its tag, attributes, curated
+computed styles, box model, and accessibility node.
+
+${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
-  options: [{ ...selectorField, required: true, description: 'a CSS selector identifying the element to inspect' }],
+  options: [
+    { ...selectorField, required: true, description: `${SINGLE_ELEMENT_SELECTOR}, identifying the element to inspect` },
+    atField,
+  ],
 } as const satisfies TapNativeCommandSchema
 
 // CLI-native tap commands: implemented entirely in the CLI (instance discovery


### PR DESCRIPTION
- Closes N/A

### Additional details

Second of three slices. #34504 has merged, so this now sits directly on `feat/tap-cli-integration`; the unique-selector table that completes the ambiguity answer follows in #34505.

Rebased onto the trunk's #34500, which takes tap command arguments as flags rather than positionals — hence `--selector` below.

`dom`, `aria`, and `inspect` used to read whatever a selector matched: `dom` concatenated every match, `aria` and `inspect` silently took the first. On a real app most selectors match more than one element, so a reader could be handed one arbitrary element out of many with nothing in the output saying so.

The three reads now count the matches first. Exactly one match goes ahead. Several answer with the ambiguity in place of the read — the count, and the range `--at` accepts. That is a result and not a failure, so it exits 0 and honors `--json` like any other result.

The count comes from a browser-side `querySelectorAll().length`, so it costs one number however heavy the page.

`--at <index>` reads one match out of several. It is 0-based, and it skips the count check for ambiguity entirely, since the caller has already said which element it wants.

With the read now scoped to a single element, the output changes:

- `dom` selector mode returns one `html` rather than a `matches` array, which the guard makes vestigial.
- The frame URL is gone from all three results. `status` and `pin` already report it.
- `dom` prints bare HTML (no `DOM` heading), dedented so a deeply nested element reads at the left margin without losing its internal shape. `--json` keeps the document's own whitespace.
- `aria` drops its `ARIA (n)` header and one level of indent, so the root sits flush.
- `inspect` drops its tag/selector header.
- Selectors print quoted, so they paste back as a single shell argument. A single quote inside one becomes `'\''`.

Failure codes: `INVALID_INDEX` covers an `--at` that is not a whole number — the value is matched as digits rather than coerced, so blank, whitespace, `1.5`, `-1`, `0x10`, `1e3` and anything past `Number.MAX_SAFE_INTEGER` are all rejected — an index past the last match (the message names the valid range), and `--at` with no selector to index. `INVALID_SELECTOR` now also covers a selector the browser rejects at count time. `FRAME_READ_FAILED` is unchanged. Matching nothing stays a normal result: `found: false` for `dom` and `inspect`, an empty tree for `aria`.

### Steps to test

Against a running instance with a settled run:

```
npx cypress tap dom --selector 'div'                # ambiguity answer, exit 0
npx cypress tap dom --selector 'div' --json         # {ambiguous, selector, count}
npx cypress tap dom --selector 'div' --at 0         # reads that one match
npx cypress tap dom --selector 'div' --at 999       # INVALID_INDEX, names the valid range
npx cypress tap dom --at 0                          # INVALID_INDEX, no selector to index
npx cypress tap inspect --selector 'div' --at 2     # same answer shape from inspect
npx cypress tap aria --selector 'div' --at 2        # and from aria
```

Verified against a live kitchensink run: `inspect --selector '.well' --at 0|1|2` returned three different boxes. CLI unit tests run locally.

### How has the user experience changed?

`cypress tap dom --selector '.item'` with three matches, before: the first match's HTML, with nothing to indicate the other two existed.

After:

```
selector '.item' matched 3 elements but must be unique
pass --at <index> to read one of them (0-2)
```

Reads of an already-unique selector behave as before, apart from the framing removals listed above.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral breaking change for selector-based tap reads (multi-match and output shape), plus new exit-code semantics for ambiguity; scope is CLI/CDP tap tooling with broad test coverage.
> 
> **Overview**
> **`cypress tap dom`**, **`aria`**, and **`inspect`** no longer read “all matches” or silently use the first node. They **count** `querySelectorAll` matches first; **one** match proceeds, **several** without `--at` return a structured **`{ ambiguous, selector, count }`** answer (still printed to stdout / `--json`) and the command **exits 1** because the requested read did not run.
> 
> **`--at <index>`** picks a 0-based match when a selector matches multiple elements; **`parseIndex`** and stricter integer parsing gate invalid indices and limits. CDP **`querySelectorObjectId`** and in-frame **`readDom`** now take an **index** and return a **single** element’s HTML (`found` / one `html`), not a `matches` array.
> 
> Shared **`withAmbiguous` / `resolveAmbiguity`** and human **`renderAmbiguousHuman`** wire the same behavior across the three commands. **Frame URL** is dropped from their JSON results; human rendering is leaner (bare dedented DOM, flush ARIA tree, no inspect header) with **shell-safe quoted selectors**.
> 
> Tap contract help documents **exactly-one-element** selectors and the **`--at`** option for all three commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab8fe2103c1f9d8564ea0f22bf7241e24dae9235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



