### PR TITLE
fix: badge tap aliases the way the reporter does

### DIFF
--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -15,7 +15,13 @@ const INDICATORS: Record<NonNullable<TapNetworkInfo['indicator']>, string> = {
 // (route/agent/primitive) purple.
 const aliasColor = (aliasType: string | undefined) => (aliasType === 'dom' ? color.aliasDom : color.alias)
 
-const aliasBadge = (alias: string, aliasType?: string): string => aliasColor(aliasType)(`@${alias}`)
+// The reporter badges a `.as()` handle with the `@` you'd pass to `cy.get()`, and
+// leaves route and agent aliases bare.
+const aliasBadge = (alias: string, aliasType?: string): string => {
+  const handle = aliasType === 'route' || aliasType === 'agent' ? alias : `@${alias}`
+
+  return aliasColor(aliasType)(handle)
+}
 
 // Driver messages emphasize with markdown-style `**`; render the emphasis
 // instead of the markers, on one line.
@@ -112,7 +118,7 @@ const routesTable = (routes: TapReporterView['routes']): string[] => {
       route.method ?? '',
       route.url ?? '',
       route.stubbed ? 'yes' : 'no',
-      route.alias ? `@${route.alias}` : '',
+      route.alias ?? '',
       route.numResponses ? String(route.numResponses) : '-',
     ]
   })
@@ -158,9 +164,10 @@ const isEventRow = (command: TapReporterCommand): boolean => {
 // A row's alias badge(s): its own aliases (`.as()` definitions, spy/stub call
 // rows) or the alias its request matched.
 const aliasSuffix = (command: TapReporterCommand, network: TapNetworkInfo | undefined): string => {
-  const names = command.aliases ?? (network?.alias != null ? [network.alias] : [])
+  const badges = command.aliases?.map((name) => aliasBadge(name, command.aliasType))
+    ?? (network?.alias != null ? [aliasBadge(network.alias, 'route')] : [])
 
-  return names.length ? `  ${names.map((name) => aliasBadge(name, command.aliasType)).join(' ')}` : ''
+  return badges.length ? `  ${badges.join(' ')}` : ''
 }
 
 const networkSuffix = (network: TapNetworkInfo | undefined): string => {

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -81,9 +81,9 @@ describe('lib/tap/render/reporter', () => {
         stub-1  boop                 -
 
       ROUTES (2)
-        METHOD  MATCHER        STUBBED  ALIAS        #
-        GET     **/comments/*  no       @getComment  -
-        PUT     **/comments/*  yes      @putComment  1
+        METHOD  MATCHER        STUBBED  ALIAS       #
+        GET     **/comments/*  no       getComment  -
+        PUT     **/comments/*  yes      putComment  1
 
       BEFORE EACH · h1
          1  visit  http://localhost:8080/commands/network-requests
@@ -91,13 +91,13 @@ describe('lib/tap/render/reporter', () => {
       TEST BODY · r8
          1  get      .network-btn
          2  -click
-        e1    (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  @getComment
+        e1    (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  getComment
          3  wait     @getComment
          4  -assert  expected 200 to be one of [ 200, 304 ]
-        e2    (xhr) ● PUT 404 https://jsonplaceholder.cypress.io/comments/1  @putComment  (stubbed)
+        e2    (xhr) ● PUT 404 https://jsonplaceholder.cypress.io/comments/1  putComment  (stubbed)
          5  get      .network-put-comment ✖
          6    session  user
-        e3    (spy-1) beep()  @beep
+        e3    (spy-1) beep()  beep
          7  get      @beep
          8  wrap     { table: 1 }
          9  -as      table  @table

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -127,6 +127,12 @@ describe('tap/commands/reporter', () => {
         { id: 'log-a1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', alias: '@firstBtn', aliasType: 'dom' },
         { id: 'log-a2', name: 'wrap', message: '{ foo: bar }', state: 'passed', type: 'parent', hookId: 'r7', alias: '@myObject', aliasType: 'primitive' },
         { id: 'log-a3', name: 'get', message: '@firstBtn', state: 'passed', type: 'parent', hookId: 'r7', referencesAlias: { name: 'firstBtn' }, aliasType: 'dom' },
+        // A static alias carries the type in its badge text, and a name may
+        // contain `@` as long as it doesn't start with one.
+        { id: 'log-a4', name: 'wrap', message: '{ table: 1 }', state: 'passed', type: 'parent', hookId: 'r7', alias: '@table (static)', aliasType: 'primitive' },
+        { id: 'log-a5', name: 'wrap', message: '{ id: 1 }', state: 'passed', type: 'parent', hookId: 'r7', alias: '@user@example.com', aliasType: 'primitive' },
+        // An agent alias is stored bare, so it has no prefix to strip.
+        { id: 'log-a6', name: 'spy-1', displayName: 'spy-1', message: 'beep()', state: 'passed', type: 'parent', hookId: 'r7', event: true, alias: ['beep'], aliasType: 'agent' },
       ],
     },
   }
@@ -241,6 +247,9 @@ describe('tap/commands/reporter', () => {
       { id: '1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', aliases: ['firstBtn'], aliasType: 'dom' },
       { id: '2', name: 'wrap', message: '{ foo: bar }', state: 'passed', type: 'parent', hookId: 'r7', aliases: ['myObject'], aliasType: 'primitive' },
       { id: '3', name: 'get', message: '@firstBtn', state: 'passed', type: 'parent', hookId: 'r7', referencedAliases: ['firstBtn'], aliasType: 'dom' },
+      { id: '4', name: 'wrap', message: '{ table: 1 }', state: 'passed', type: 'parent', hookId: 'r7', aliases: ['table (static)'], aliasType: 'primitive' },
+      { id: '5', name: 'wrap', message: '{ id: 1 }', state: 'passed', type: 'parent', hookId: 'r7', aliases: ['user@example.com'], aliasType: 'primitive' },
+      { id: 'e1', name: 'spy-1', displayName: 'spy-1', message: 'beep()', state: 'passed', type: 'parent', hookId: 'r7', event: true, aliases: ['beep'], aliasType: 'agent' },
     ])
   })
 

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -117,6 +117,18 @@ describe('tap/commands/reporter', () => {
       state: 'failed',
       err: { name: 500, message: 42, stack: { frames: [] } },
     },
+    // `.as()` writes the reporter's badge text onto the log it aliases, so
+    // `@firstBtn` is the exact string the driver stores for `.as('firstBtn')`.
+    r7: {
+      id: 'r7',
+      title: 'aliases a subject',
+      state: 'passed',
+      commands: [
+        { id: 'log-a1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', alias: '@firstBtn', aliasType: 'dom' },
+        { id: 'log-a2', name: 'wrap', message: '{ foo: bar }', state: 'passed', type: 'parent', hookId: 'r7', alias: '@myObject', aliasType: 'primitive' },
+        { id: 'log-a3', name: 'get', message: '@firstBtn', state: 'passed', type: 'parent', hookId: 'r7', referencesAlias: { name: 'firstBtn' }, aliasType: 'dom' },
+      ],
+    },
   }
 
   // The spec's own window.Cypress is the instance running this test, so stub
@@ -218,6 +230,18 @@ describe('tap/commands/reporter', () => {
     const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r6' })
 
     expect((outcome as { result: { error: Record<string, unknown> } }).result.error).to.deep.eq({})
+  })
+
+  it('carries alias names, not the badge text `.as()` writes onto the log', async () => {
+    stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
+
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r7' })
+
+    expect((outcome as { result: { commands: Array<Record<string, unknown>> } }).result.commands).to.deep.eq([
+      { id: '1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', aliases: ['firstBtn'], aliasType: 'dom' },
+      { id: '2', name: 'wrap', message: '{ foo: bar }', state: 'passed', type: 'parent', hookId: 'r7', aliases: ['myObject'], aliasType: 'primitive' },
+      { id: '3', name: 'get', message: '@firstBtn', state: 'passed', type: 'parent', hookId: 'r7', referencedAliases: ['firstBtn'], aliasType: 'dom' },
+    ])
   })
 
   it('reports an unreached test with empty collections and just the test-body pseudo-hook', async () => {

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -295,7 +295,7 @@ interface ReporterLog {
 // carries the name. `.as()` rejects a name starting with `@`, so stripping the
 // prefix is unambiguous.
 const aliasName = (alias: string): string => {
-  return alias.replace(/^@+/, '')
+  return alias.startsWith('@') ? alias.slice(1) : alias
 }
 
 const asArray = <T>(value: T | T[] | undefined): T[] | undefined => {

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -291,6 +291,13 @@ interface ReporterLog {
   callCount?: number
 }
 
+// `.as()` stores the reporter's badge text on the log — `@name` — while the wire
+// carries the name. `.as()` rejects a name starting with `@`, so stripping the
+// prefix is unambiguous.
+const aliasName = (alias: string): string => {
+  return alias.replace(/^@+/, '')
+}
+
 const asArray = <T>(value: T | T[] | undefined): T[] | undefined => {
   if (value == null) {
     return undefined
@@ -321,7 +328,7 @@ const serializeReporterCommand = (command: SerializedCommandLog, ids: Map<string
     // into the same tap id space the rows use.
     group: group != null ? ids.get(group) : undefined,
     groupLevel,
-    aliases: asArray(alias),
+    aliases: asArray(alias)?.map(aliasName),
     aliasType,
     referencedAliases: asArray(referencesAlias)?.map((ref) => ref.name),
     network: serializeNetworkInfo(command),


### PR DESCRIPTION
- Closes [AW-90](https://cypress-io.atlassian.net/browse/AW-90)

### Additional details

`.as()` writes the reporter's **badge text** onto the log it aliases, not the alias name ([`aliasing.ts:61`](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/commands/aliasing.ts#L61)):

```js
alias: `@${alias}${options.type === 'static' ? ` (${options.type})` : ''}`
```

The app reporter UI renders that string directly, so it's load-bearing there. The tap serializer passed it straight to the wire and the CLI renderer prefixed another `@` — hence `@@firstBtn`. Only `.as()` rows doubled up; route and agent rows carry a bare name and rendered one `@`, so the wire was also inconsistent with itself:

```
{'id': '6', 'name': 'find',  'aliases': ['@firstBtn'], 'aliasType': 'dom'}   <-- prefixed
{'id': '7', 'name': 'get',   'referencedAliases': ['firstBtn']}              <-- bare
routes: [{'url': '**/comments/*', 'alias': 'getComment'}]                    <-- bare
```

Two changes:

**1. The wire carries alias names** (`packages/app/src/tap/test-state.ts`). `aliases` now matches [its documented shape](https://github.com/cypress-io/cypress/blob/feat/tap-cli-integration/packages/cypress-instances/lib/contracts/reporter.ts) (*"The route alias set via `.as()`, e.g. `getUsers`"*) and the bare `referencedAliases` beside it. Stripping the prefix is unambiguous because `.as()` rejects a name starting with `@` (`aliasDisplayRe`). Because that makes the prefix a single leading character rather than a pattern, the strip is a `startsWith`/`slice` rather than a regex.

**2. The renderer badges the way the reporter does.** Rather than picking a convention, this mirrors what the GUI already shows, which is not uniform:

| Surface | Reporter | Renders |
|---|---|---|
| Alias **reference** — `cy.get('@x')`, `cy.wait('@x')` | `command.tsx:157` — `content={`@${name}`}` | `@firstBtn` |
| Alias **definition** on a `.as()` row | `command.tsx:246` — raw `model.alias` | `@firstBtn` |
| **Agent** alias — spy/stub row and SPIES / STUBS panel | `agents.tsx:18` — raw (driver stores bare) | `foo` |
| **Route** alias — xhr row and ROUTES panel | `command.tsx:222`, `routes.tsx:26` | `getComment` |

So: `@` on a `.as()` handle, bare for route and agent aliases. Command **messages** are untouched and keep their literal `@` (`wait @getComment`) — that's the user's own source text, still colorized in place.

The driver and the app reporter UI are unchanged. A static alias (`.as(name, { type: 'static' })`) keeps the ` (static)` the driver appends to the badge text, so `aliases` carries `table (static)` and the CLI badges `@table (static)` — the same string the GUI shows, since the reporter renders `model.alias` raw.

### Steps to test

Validated end-to-end against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) driven through the tap CLI — a real `cypress open` instance, not a fixture.

```bash
node cli/bin/cypress tap run "cypress/e2e/2-advanced-examples/aliasing.cy.js"
node cli/bin/cypress tap reporter --test r3
```

**Before** — row `6` carries the double `@`:

```
✓ Aliasing > .as() - alias a DOM element for later use  passed

TEST BODY · r3
   1  get      .as-table
   ...
   6  find     button  @@firstBtn
   7  get      @firstBtn
   8  -click
```

**After** — one badge, matching the GUI:

```
✓ Aliasing > .as() - alias a DOM element for later use  passed

TEST BODY · r3
   1  get      .as-table
   ...
   6  find     button  @firstBtn
   7  get      @firstBtn
   8  -click
```

The wire now carries the name, so `aliases` agrees with `referencedAliases`:

```
$ node cli/bin/cypress tap reporter --test r3 --json
{'id': '6', 'name': 'find', 'aliases': ['firstBtn'], 'aliasType': 'dom'}
{'id': '7', 'name': 'get', 'referencedAliases': ['firstBtn'], 'aliasType': 'dom'}
```

Route aliases stay bare on both surfaces (`tap reporter --test r4`):

```
ROUTES (1)
  METHOD  MATCHER        STUBBED  ALIAS       #
  GET     **/comments/*  no       getComment  1

TEST BODY · r4
   1  get      .network-btn
   2  -click
  e1    (xhr) ● GET 200 https://jsonplaceholder.cypress.io/comments/1  getComment
   3  wait     @getComment
```

And agent aliases stay bare — `tap run "cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js"`, then `tap reporter --test r4`:

```
✓ Spies, Stubs, and Clock > cy.spy() retries until assertions pass  passed

SPIES / STUBS (1)
  TYPE   FUNCTION  ALIAS(ES)  CALLS
  spy-1  foo       foo        2

TEST BODY · r4
   1  visit    http://localhost:8080/commands/spies-stubs-clocks
   2  get      @foo
  e1    (spy-1) foo("first")  foo
  e2    (spy-1) foo("second")  foo
   3  -assert  expected foo to have been called exactly twice
```

### How has the user experience changed?

`cypress tap reporter --test <id>` no longer renders `@@name` on a `.as()` row — it renders `@name`, the same badge the GUI command log shows. Route and agent badges are unchanged visually. `--json` consumers get the alias name in `aliases[]` instead of display text. Before/after output above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- app-side serializer test for the `@` normalization; CLI renderer snapshot covers all four badge surfaces -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-90]: https://cypress-io.atlassian.net/browse/AW-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `--json` shape of `aliases[]` for tap reporter consumers; behavior is intentional alignment with docs and GUI, but any client expecting prefixed badge text must update.
> 
> **Overview**
> Fixes **double `@` badges** (e.g. `@@firstBtn`) on tap CLI reporter rows for `.as()` aliases by splitting **wire data** from **display**.
> 
> **Tap serialization** (`test-state.ts`) now puts **bare alias names** in `aliases[]` (strips the leading `@` the driver stores as badge text), matching `referencedAliases` and the documented contract. Static suffixes like ` (static)` and names containing `@` are preserved.
> 
> **CLI rendering** (`reporter.ts`) badges aliases the same way as the app reporter: **`@` for DOM/primitive `.as()` handles**, **bare names for route and agent** aliases (ROUTES table and xhr/spy rows). Command messages (e.g. `wait @getComment`) are unchanged.
> 
> Tests cover serializer normalization and updated reporter snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1aef3bc7cb7f43e8270057a5e0b69050b13098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

