### PR TITLE
fix: bound every tap CDP call so an unresponsive renderer cannot hang the CLI

### DIFF
--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -128,6 +128,7 @@ const descriptions: any = {
   inspectBrk: 'enable the Node.js inspector and break before the Cypress development process starts. only available when used with --dev',
   instance: 'target a specific running Cypress instance by its server process id (pid)',
   json: 'print the raw JSON result instead of the human-readable rendering',
+  tapTimeout: 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)',
   key: 'your secret Record Key. you can omit this if you set a CYPRESS_RECORD_KEY environment variable.',
   parallel: 'enables concurrent runs and automatic load balancing of specs across multiple machines or processes',
   passWithNoTests: 'pass when no tests are found',
@@ -591,10 +592,11 @@ const cliModule = {
     .allowUnknownOption(true)
     .option('--instance <pid>', text('instance'), coerceAnyStringToInt)
     .option('--json', text('json'))
+    .option('--timeout <ms>', text('tapTimeout'), coerceAnyStringToInt)
     .action(async function (this: any, opts: any, args: string[]) {
       try {
         const { default: tapModule } = await import('./exec/tap')
-        const code = await tapModule.start(args || [], _.pick(opts, ['instance', 'json']))
+        const code = await tapModule.start(args || [], _.pick(opts, ['instance', 'json', 'timeout']))
 
         process.exit(code)
       } catch (e: any) {

--- a/cli/lib/cypress-instances/record.ts
+++ b/cli/lib/cypress-instances/record.ts
@@ -17,6 +17,7 @@ export type CypressInstanceErrorCode =
   | 'NO_INSTANCE'
   | 'STALE_INSTANCE'
   | 'NO_BROWSER_ATTACHED'
+  | 'RENDERER_UNRESPONSIVE'
 
 export class CypressInstanceError extends Error {
   code: CypressInstanceErrorCode

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -148,7 +148,7 @@ const tapModule = {
         }
 
         return dispatchCode
-      })
+      }, options.timeout)
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
         if (wantsHelp || !command) {

--- a/cli/lib/logger.ts
+++ b/cli/lib/logger.ts
@@ -8,26 +8,31 @@ const logLevel = (): string => {
 
 const error = (...messages: any[]): void => {
   logs.push(messages.join(' '))
-  console.log(chalk.red(...messages)) // eslint-disable-line no-console
+  console.log(chalk.red(...messages))
+}
+
+const errorToStderr = (...messages: any[]): void => {
+  logs.push(messages.join(' '))
+  console.error(chalk.red(...messages))
 }
 
 const warn = (...messages: any[]): void => {
   if (logLevel() === 'silent') return
 
   logs.push(messages.join(' '))
-  console.log(chalk.yellow(...messages)) // eslint-disable-line no-console
+  console.log(chalk.yellow(...messages))
 }
 
 const log = (...messages: any[]): void => {
   if (logLevel() === 'silent' || logLevel() === 'warn') return
 
   logs.push(messages.join(' '))
-  console.log(...messages) // eslint-disable-line no-console
+  console.log(...messages)
 }
 
 const always = (...messages: any[]): void => {
   logs.push(messages.join(' '))
-  console.log(...messages) // eslint-disable-line no-console
+  console.log(...messages)
 }
 
 // splits long text into lines and calls log()
@@ -52,6 +57,7 @@ const loggerModule = {
   log,
   warn,
   error,
+  errorToStderr,
   always,
   logLines,
   print,

--- a/cli/lib/tap/AGENTS.md
+++ b/cli/lib/tap/AGENTS.md
@@ -4,9 +4,9 @@ The experimental `cypress tap` subcommands and their AUT-frame/CDP plumbing — 
 
 ## User-facing help must not leak internals
 
-Help text describes WHAT a command does and its observable output/behavior — never how it gets there. Do not name the transport (CDP), the discovery/liveness mechanism, or in-browser binding internals.
+Help text describes WHAT a command does and its observable output/behavior — never how it gets there. Do not name the transport (CDP), the find-instance/liveness mechanism, or in-browser binding internals.
 
-Banned vocabulary (the class, not just these literals): "over CDP", "tap binding", "liveness probe", "isolated world", "backend node id", server PIDs / handshake internals — CDP protocol details, the discovery/liveness mechanism, and in-browser binding internals.
+Banned vocabulary (the class, not just these literals): "over CDP", "tap binding", "liveness probe", "isolated world", "backend node id", server PIDs / handshake internals — CDP protocol details, the find-instance/liveness mechanism, and in-browser binding internals.
 
 Before → after:
 

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -151,7 +151,7 @@ export const withResolvedAutFrame = async (
 
         throw err
       }
-    })
+    }, options.timeout)
   } catch (err: any) {
     if (err instanceof CypressInstanceError) {
       renderFailure(err)

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -44,11 +44,12 @@ const declareOptions = (command: commander.Command, options: readonly TapCommand
     }
   }
 
-  // Every tap command accepts `--instance` and `--json`; both are consumed by
-  // the top-level `cypress tap` command before a subprogram parses, so declaring
-  // them here is purely so they render in each command's generated help.
+  // Every tap command accepts `--instance`, `--json` and `--timeout`; all are
+  // consumed by the top-level `cypress tap` command before a subprogram parses,
+  // so declaring them here is purely so they render in each command's generated help.
   command.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
   command.option('--json', json?.description ?? JSON_DESCRIPTION)
+  command.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
 }
 
 const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly string[]): Record<string, string> => {
@@ -140,12 +141,13 @@ const newProgram = (): commander.Command => {
 export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): commander.Command => {
   const program = newProgram()
 
-  // The outer `tap` command owns --instance/--json and parses them before this
-  // program runs, so they never reach here — declared only so help lists them.
-  // The outer command disables its own help, making this the sole place they
-  // surface.
+  // The outer `tap` command owns --instance/--json/--timeout and parses them
+  // before this program runs, so they never reach here — declared only so help
+  // lists them. The outer command disables its own help, making this the sole
+  // place they surface.
   program.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
   program.option('--json', JSON_DESCRIPTION)
+  program.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
 
   for (const native of tapCliCommands) {
     declareCommand(program, native)

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -1,0 +1,133 @@
+import type CRI from 'chrome-remote-interface'
+
+import { CypressInstanceError } from '../cypress-instances'
+
+/** Per-call bound for CDP work that waits on the page under test. */
+export const DEFAULT_CDP_TIMEOUT_MS = 30_000
+
+/**
+ * Bound for the calls that locate the runner page. A healthy renderer answers
+ * these in milliseconds, so keeping them short is what lets the scan skip an
+ * unresponsive target rather than stop on it.
+ */
+export const DISCOVERY_TIMEOUT_MS = 2_000
+
+export interface CdpBounds {
+  /** Bound for a protocol call, including one awaiting app-side work. */
+  call: number
+  /** Bound for locating the runner page. */
+  discovery: number
+}
+
+/**
+ * The two default bounds differ by an order of magnitude because the waits do:
+ * finding the runner page is a round trip, while calling into it can legitimately
+ * wait on a spec. `--timeout` is the one knob for "this is slow, wait longer", so
+ * it raises both rather than leaving the shorter one to fail underneath it.
+ */
+export const cdpBounds = (timeoutMs?: number): CdpBounds => {
+  return {
+    call: timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS,
+    discovery: timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+  }
+}
+
+const unresponsive = (what: string, ms: number): CypressInstanceError => {
+  return new CypressInstanceError(
+    'RENDERER_UNRESPONSIVE',
+    `Cypress did not answer ${what} within ${ms}ms. The browser is reachable, but the page running Cypress is not responding — it may be paused in devtools, stuck in a loop, or starved of memory. Pass --timeout <ms> to wait longer.`,
+  )
+}
+
+const isThenable = (value: unknown): value is Promise<unknown> => {
+  return !!value && typeof (value as { then?: unknown }).then === 'function'
+}
+
+export const isRendererUnresponsive = (err: unknown): boolean => {
+  return err instanceof CypressInstanceError && err.code === 'RENDERER_UNRESPONSIVE'
+}
+
+/**
+ * A pending CDP reply has no timer of its own, and the only thing that settles
+ * one other than a matching reply is the browser-level socket closing — so a
+ * target that stops answering leaves the promise orphaned forever. Stop waiting
+ * on our side; the orphan settles when the session closes its client.
+ */
+export const withCdpDeadline = async <T> (work: Promise<T>, what: string, ms: number): Promise<T> => {
+  let timer: NodeJS.Timeout | undefined
+
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(unresponsive(what, ms)), ms)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const isProtocolName = (prop: string | symbol): prop is string => {
+  return typeof prop === 'string' && /^[A-Z]/.test(prop)
+}
+
+/**
+ * The CRI client with every protocol call bounded. Wrapping the client is what
+ * makes the bound structural: a CDP call added later is covered without having
+ * to remember to wrap it. Domain properties also expose event subscribers, which
+ * return an unsubscribe function rather than a promise, so only thenables are
+ * raced.
+ */
+export const boundCdpClient = (client: CRI.Client, ms: number): CRI.Client => {
+  const bind = (fn: (...args: unknown[]) => unknown, owner: object, what: string) => {
+    return (...args: unknown[]) => {
+      const result = fn.apply(owner, args)
+
+      return isThenable(result) ? withCdpDeadline(result, what, ms) : result
+    }
+  }
+
+  const domains = new Map<string, unknown>()
+
+  return new Proxy(client, {
+    get (target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver)
+
+      if (!isProtocolName(prop)) {
+        return value
+      }
+
+      // The client carries each command as a flat `Domain.method` key too.
+      if (typeof value === 'function') {
+        return bind(value as (...args: unknown[]) => unknown, target, prop)
+      }
+
+      if (typeof value !== 'object' || value === null) {
+        return value
+      }
+
+      const cached = domains.get(prop)
+
+      if (cached) {
+        return cached
+      }
+
+      const domain = new Proxy(value, {
+        get (domainTarget, method, domainReceiver) {
+          const fn = Reflect.get(domainTarget, method, domainReceiver)
+
+          if (typeof fn !== 'function' || typeof method !== 'string') {
+            return fn
+          }
+
+          return bind(fn as (...args: unknown[]) => unknown, domainTarget, `${prop}.${method}`)
+        },
+      })
+
+      domains.set(prop, domain)
+
+      return domain
+    },
+  }) as CRI.Client
+}

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -2,7 +2,7 @@ import type CRI from 'chrome-remote-interface'
 
 import { CypressInstanceError } from '../cypress-instances'
 
-/** Per-call bound for CDP work that waits on the page under test. */
+/** Bound for a protocol call, including one awaiting app-side work. */
 export const DEFAULT_CDP_TIMEOUT_MS = 30_000
 
 /**
@@ -12,35 +12,11 @@ export const DEFAULT_CDP_TIMEOUT_MS = 30_000
  */
 export const FIND_INSTANCE_TIMEOUT_MS = 2_000
 
-export interface CdpBounds {
-  /** Bound for a protocol call, including one awaiting app-side work. */
-  call: number
-  /** Bound for locating the runner page. */
-  findInstance: number
-}
-
-/**
- * The two default bounds differ by an order of magnitude because the waits do:
- * finding the runner page is a round trip, while calling into it can legitimately
- * wait on a spec. `--timeout` is the one knob for "this is slow, wait longer", so
- * it raises both rather than leaving the shorter one to fail underneath it.
- */
-export const cdpBounds = (timeoutMs?: number): CdpBounds => {
-  return {
-    call: timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS,
-    findInstance: timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS,
-  }
-}
-
 const unresponsive = (what: string, ms: number): CypressInstanceError => {
   return new CypressInstanceError(
     'RENDERER_UNRESPONSIVE',
     `Cypress did not answer ${what} within ${ms}ms. The browser is reachable, but the page running Cypress is not responding — it may be paused in devtools, stuck in a loop, or starved of memory. Pass --timeout <ms> to wait longer.`,
   )
-}
-
-const isThenable = (value: unknown): value is Promise<unknown> => {
-  return !!value && typeof (value as { then?: unknown }).then === 'function'
 }
 
 export const isRendererUnresponsive = (err: unknown): boolean => {
@@ -68,59 +44,16 @@ export const withCdpDeadline = async <T> (work: Promise<T>, what: string, ms: nu
   }
 }
 
-const isProtocolName = (prop: string | symbol): prop is string => {
-  return typeof prop === 'string' && /^[A-Z]/.test(prop)
-}
+/**
+ * Every domain shorthand (`client.Runtime.evaluate(...)`) is generated as a call
+ * to `client.send`, so replacing that one method bounds every protocol call the
+ * session makes, including the raw-client ones the frame extractors issue. Event
+ * subscriptions and `close` don't go through it and stay unbounded.
+ */
+export const boundCdpCalls = (client: CRI.Client, ms: number): void => {
+  const send = client.send.bind(client) as (...args: unknown[]) => Promise<unknown>
 
-export const boundCdpClient = (client: CRI.Client, ms: number): CRI.Client => {
-  const bind = (fn: (...args: unknown[]) => unknown, owner: object, what: string) => {
-    return (...args: unknown[]) => {
-      const result = fn.apply(owner, args)
-
-      return isThenable(result) ? withCdpDeadline(result, what, ms) : result
-    }
-  }
-
-  const domains = new Map<string, unknown>()
-
-  return new Proxy(client, {
-    get (target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver)
-
-      if (!isProtocolName(prop)) {
-        return value
-      }
-
-      // The client carries each command as a flat `Domain.method` key too.
-      if (typeof value === 'function') {
-        return bind(value as (...args: unknown[]) => unknown, target, prop)
-      }
-
-      if (typeof value !== 'object' || value === null) {
-        return value
-      }
-
-      const cached = domains.get(prop)
-
-      if (cached) {
-        return cached
-      }
-
-      const domain = new Proxy(value, {
-        get (domainTarget, method, domainReceiver) {
-          const fn = Reflect.get(domainTarget, method, domainReceiver)
-
-          if (typeof fn !== 'function' || typeof method !== 'string') {
-            return fn
-          }
-
-          return bind(fn as (...args: unknown[]) => unknown, domainTarget, `${prop}.${method}`)
-        },
-      })
-
-      domains.set(prop, domain)
-
-      return domain
-    },
-  }) as CRI.Client
+  client.send = ((method: string, ...rest: unknown[]) => {
+    return withCdpDeadline(send(method, ...rest), method, ms)
+  }) as CRI.Client['send']
 }

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -15,7 +15,7 @@ export const FIND_INSTANCE_TIMEOUT_MS = 2_000
 const unresponsive = (what: string, ms: number): CypressInstanceError => {
   return new CypressInstanceError(
     'RENDERER_UNRESPONSIVE',
-    `Cypress did not answer ${what} within ${ms}ms. The browser is reachable, but the page running Cypress is not responding — it may be paused in devtools, stuck in a loop, or starved of memory. Pass --timeout <ms> to wait longer.`,
+    `The targeted Cypress instance did not answer ${what} within ${ms}ms. The browser is reachable, but the page running Cypress is not responding — it may be paused in devtools, stuck in a loop, or starved of memory. Pass --timeout <ms> to wait longer.`,
   )
 }
 

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -10,13 +10,13 @@ export const DEFAULT_CDP_TIMEOUT_MS = 30_000
  * these in milliseconds, so keeping them short is what lets the scan skip an
  * unresponsive target rather than stop on it.
  */
-export const DISCOVERY_TIMEOUT_MS = 2_000
+export const FIND_INSTANCE_TIMEOUT_MS = 2_000
 
 export interface CdpBounds {
   /** Bound for a protocol call, including one awaiting app-side work. */
   call: number
   /** Bound for locating the runner page. */
-  discovery: number
+  findInstance: number
 }
 
 /**
@@ -28,7 +28,7 @@ export interface CdpBounds {
 export const cdpBounds = (timeoutMs?: number): CdpBounds => {
   return {
     call: timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS,
-    discovery: timeoutMs ?? DISCOVERY_TIMEOUT_MS,
+    findInstance: timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS,
   }
 }
 
@@ -72,13 +72,6 @@ const isProtocolName = (prop: string | symbol): prop is string => {
   return typeof prop === 'string' && /^[A-Z]/.test(prop)
 }
 
-/**
- * The CRI client with every protocol call bounded. Wrapping the client is what
- * makes the bound structural: a CDP call added later is covered without having
- * to remember to wrap it. Domain properties also expose event subscribers, which
- * return an unsubscribe function rather than a promise, so only thenables are
- * raced.
- */
 export const boundCdpClient = (client: CRI.Client, ms: number): CRI.Client => {
   const bind = (fn: (...args: unknown[]) => unknown, owner: object, what: string) => {
     return (...args: unknown[]) => {

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -3,6 +3,7 @@ import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXValue } from '../aut/cdp'
+import { isRendererUnresponsive } from '../cdp-timeout'
 import { readElementInfo } from '../aut/scripts'
 import type { ElementInfo } from '../aut/scripts'
 import { defineNativeCommand } from './definition'
@@ -78,7 +79,11 @@ const readAriaNode = async (session: TapSession, objectId: string): Promise<Fram
     const axNodes = nodes as AXNode[]
 
     return projectAria(axNodes.find((candidate) => candidate.backendDOMNodeId === node.backendNodeId) ?? axNodes[0])
-  } catch {
+  } catch (err) {
+    if (isRendererUnresponsive(err)) {
+      throw err
+    }
+
     return undefined
   }
 }

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -32,13 +32,13 @@ export interface TapInstanceSummary {
 // Bounded, and never throws: `instances` is what a caller reaches for when
 // everything else is failing, so an unanswered probe is a reported fact rather
 // than an error. Absent means there was nothing to ask, not that it went unasked.
-const probeRenderer = async (instance: LiveInstanceState): Promise<boolean | undefined> => {
+const probeRenderer = async (instance: LiveInstanceState, timeoutMs: number): Promise<boolean | undefined> => {
   if (instance.cdpBrowserWsUrl === null) {
     return undefined
   }
 
   try {
-    return await withTapSession(instance as ReadyInstanceState, async () => true, DISCOVERY_TIMEOUT_MS)
+    return await withTapSession(instance as ReadyInstanceState, async () => true, timeoutMs)
   } catch (err) {
     return isRendererUnresponsive(err) ? false : undefined
   }
@@ -53,7 +53,8 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  const responsive = await Promise.all(instances.map(probeRenderer))
+  const timeoutMs = options.timeout ?? DISCOVERY_TIMEOUT_MS
+  const responsive = await Promise.all(instances.map((instance) => probeRenderer(instance, timeoutMs)))
 
   const summaries: TapInstanceSummary[] = instances.map((instance, index) => ({
     pid: instance.pid,

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -2,7 +2,7 @@ import { listLiveInstances } from '../../cypress-instances'
 import type { LiveInstanceState, ReadyInstanceState } from '../../cypress-instances'
 import { renderOutcome, renderResult } from '../output'
 import { withTapSession } from '../tap-session'
-import { DISCOVERY_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
+import { FIND_INSTANCE_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 
@@ -53,7 +53,7 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  const timeoutMs = options.timeout ?? DISCOVERY_TIMEOUT_MS
+  const timeoutMs = options.timeout ?? FIND_INSTANCE_TIMEOUT_MS
   const responsive = await Promise.all(instances.map((instance) => probeRenderer(instance, timeoutMs)))
 
   const summaries: TapInstanceSummary[] = instances.map((instance, index) => ({

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,5 +1,8 @@
 import { listLiveInstances } from '../../cypress-instances'
+import type { LiveInstanceState, ReadyInstanceState } from '../../cypress-instances'
 import { renderOutcome, renderResult } from '../output'
+import { withTapSession } from '../tap-session'
+import { DISCOVERY_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 
@@ -17,6 +20,28 @@ export interface TapInstanceSummary {
   browserAttached: boolean
   /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
   browserName: string | null
+  /**
+   * Whether the runner page answered. `browserAttached` only says the browser
+   * process is reachable, so this is what separates a healthy instance from one
+   * whose page is wedged — the state in which every other command fails. Absent
+   * when there is no runner page to ask.
+   */
+  rendererResponsive?: boolean
+}
+
+// Bounded, and never throws: `instances` is what a caller reaches for when
+// everything else is failing, so an unanswered probe is a reported fact rather
+// than an error. Absent means there was nothing to ask, not that it went unasked.
+const probeRenderer = async (instance: LiveInstanceState): Promise<boolean | undefined> => {
+  if (instance.cdpBrowserWsUrl === null) {
+    return undefined
+  }
+
+  try {
+    return await withTapSession(instance as ReadyInstanceState, async () => true, DISCOVERY_TIMEOUT_MS)
+  } catch (err) {
+    return isRendererUnresponsive(err) ? false : undefined
+  }
 }
 
 const listInstances = async (options: TapCliOptions): Promise<number> => {
@@ -28,12 +53,15 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  const summaries: TapInstanceSummary[] = instances.map((instance) => ({
+  const responsive = await Promise.all(instances.map(probeRenderer))
+
+  const summaries: TapInstanceSummary[] = instances.map((instance, index) => ({
     pid: instance.pid,
     projectRoot: instance.projectRoot,
     testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
     browserName: instance.browserName,
+    ...(responsive[index] === undefined ? {} : { rendererResponsive: responsive[index] }),
   }))
 
   renderOutcome('instances', summaries, options.json)

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -63,7 +63,7 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   try {
     const outcome = await withTapSession(instance as ReadyInstanceState, async (session) => {
       return validateExecResult(await session.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
-    })
+    }, options.timeout)
 
     if ('error' in outcome) {
       renderFailure(outcome.error)
@@ -75,6 +75,14 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
 
     return 0
   } catch (err: any) {
+    // A degraded instance reached this far carries a code (e.g. an unresponsive
+    // renderer); the earlier catch only covers instances that never resolved.
+    if (err instanceof CypressInstanceError) {
+      renderFailure(err)
+
+      return 1
+    }
+
     if (err.known && err.details) {
       renderKnownFailure(err)
 

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -6,11 +6,11 @@ import type { InstanceSelection } from '../cypress-instances'
 import type { TapSchema } from '@packages/cypress-instances'
 
 export const renderFailure = (err: { code: string, message: string }): void => {
-  logger.error(`${err.code}: ${err.message}`)
+  logger.errorToStderr(`${err.code}: ${err.message}`)
 }
 
 export const renderKnownFailure = (err: { details: { description: string, solution: string } }): void => {
-  logger.error(`${err.details.description}\n\n${err.details.solution}`)
+  logger.errorToStderr(`${err.details.description}\n\n${err.details.solution}`)
 }
 
 export const renderResult = (result: unknown): void => {

--- a/cli/lib/tap/render/AGENTS.md
+++ b/cli/lib/tap/render/AGENTS.md
@@ -96,7 +96,7 @@ any instance version that has the command at all.
 - **Muted for secondary, `—` for absent.** Missing testing type, no attached
   browser, no timestamp — a muted em dash, never blank or "null".
 - **Guard/lifecycle messages are their own thing.** A "no instance / no browser"
-  guard is the discovery layer speaking, not the command's empty rendering;
+  guard is the find-instance layer speaking, not the command's empty rendering;
   don't dress it up as data.
 - **One thing, one rendering.** When two commands report the same thing, they
   share the block that renders it — the pinned command reads identically from

--- a/cli/lib/tap/render/instances.ts
+++ b/cli/lib/tap/render/instances.ts
@@ -9,6 +9,25 @@ export interface InstanceRow {
   projectRoot: string
   testingType: 'e2e' | 'component' | null
   browserName: string | null
+  rendererResponsive?: boolean
+}
+
+const browserCell = (instance: InstanceRow): string => {
+  if (instance.browserName === null) {
+    return '—'
+  }
+
+  // A browser that is attached but whose page will not answer is the state every
+  // other command fails in, so it reads differently from a healthy one.
+  return instance.rendererResponsive === false ? `${instance.browserName} (not responding)` : instance.browserName
+}
+
+const browserColor = (instance: InstanceRow) => {
+  if (instance.browserName === null) {
+    return color.muted
+  }
+
+  return instance.rendererResponsive === false ? color.aborted : color.pass
 }
 
 // One row per instance. PID is bold — it's the handle the other tap commands
@@ -19,14 +38,14 @@ export const instanceColumns = (instances: InstanceRow[]): string[] => {
     String(instance.pid),
     instance.projectRoot,
     instance.testingType ?? '—',
-    instance.browserName ?? '—',
+    browserCell(instance),
   ])
 
   return columns(['PID', 'PROJECT', 'TYPE', 'BROWSER'], rows, (cells, index) => [
     chalk.bold(cells[0]),
     cells[1],
     cells[2],
-    instances[index].browserName === null ? color.muted(cells[3]) : color.pass(cells[3]),
+    browserColor(instances[index])(cells[3]),
   ])
 }
 

--- a/cli/lib/tap/tap-session.ts
+++ b/cli/lib/tap/tap-session.ts
@@ -27,9 +27,6 @@ const matchesAnyMessage = (err: unknown, messages: string[]): boolean => {
 }
 
 export const throwTapError = (details: { description: string, solution: string }, message: string, cause?: unknown): never => {
-  // A bound that expired already names what went unanswered and how to wait
-  // longer, and only its own `message` carries that — wrapping it would print
-  // generic prose about the browser instead.
   if (isRendererUnresponsive(cause)) {
     throw cause
   }
@@ -117,9 +114,6 @@ const evaluateBinding = (client: CRI.Client, sessionId: string) => {
   return client.Runtime.evaluate({ expression: `window.${TAP_BINDING_GLOBAL}` }, sessionId)
 }
 
-// Bounded tighter than the rest of the session: this runs once per page target
-// while scanning for the runner, so a target that cannot answer has to fall out
-// of the scan quickly instead of stalling it.
 const probeForBinding = async (client: CRI.Client, sessionId: string, findInstanceMs: number): Promise<boolean> => {
   const { result, exceptionDetails } = await withCdpDeadline(
     evaluateBinding(client, sessionId),
@@ -251,10 +245,6 @@ export const withTapSession = async <T> (
   fn: (session: TapSession) => Promise<T>,
   timeoutMs?: number,
 ): Promise<T> => {
-  // The two defaults differ by an order of magnitude because the waits do: finding
-  // the runner page is a round trip, while calling into it can legitimately wait on
-  // a spec. `--timeout` is the one knob for "this is slow, wait longer", so it
-  // raises both rather than leaving the shorter one to fail underneath it.
   const callMs = timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS
   const findInstanceMs = timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS
 

--- a/cli/lib/tap/tap-session.ts
+++ b/cli/lib/tap/tap-session.ts
@@ -2,6 +2,7 @@ import Debug from 'debug'
 import CRI from 'chrome-remote-interface'
 
 import { errors } from '../errors'
+import { boundCdpClient, cdpBounds, isRendererUnresponsive, withCdpDeadline } from './cdp-timeout'
 import type { ReadyInstanceState } from '../cypress-instances'
 import { TAP_BINDING_GLOBAL, TAP_EXEC_METHOD } from '@packages/cypress-instances'
 import type { TapExecResult } from '@packages/cypress-instances'
@@ -109,13 +110,22 @@ const evaluateBinding = (client: CRI.Client, sessionId: string) => {
   return client.Runtime.evaluate({ expression: `window.${TAP_BINDING_GLOBAL}` }, sessionId)
 }
 
-const probeForBinding = async (client: CRI.Client, sessionId: string): Promise<boolean> => {
-  const { result, exceptionDetails } = await evaluateBinding(client, sessionId)
+// Bounded tighter than the rest of the session: this runs once per page target
+// while scanning for the runner, so a target that cannot answer has to fall out
+// of the scan quickly instead of stalling it.
+const probeForBinding = async (client: CRI.Client, sessionId: string, discoveryMs: number): Promise<boolean> => {
+  const { result, exceptionDetails } = await withCdpDeadline(
+    evaluateBinding(client, sessionId),
+    'the runner-page probe',
+    discoveryMs,
+  )
 
   return !exceptionDetails && result.type !== 'undefined' && !!result.objectId
 }
 
-const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[]): Promise<string> => {
+const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[], discoveryMs: number): Promise<string> => {
+  let unresponsive: unknown
+
   for (const target of targetInfos) {
     if (target.type !== 'page') {
       continue
@@ -126,18 +136,28 @@ const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTarget
     try {
       sessionId = await attachToPage(client, target.targetId)
 
-      if (await probeForBinding(client, sessionId)) {
+      if (await probeForBinding(client, sessionId, discoveryMs)) {
         debug('matched runner page target %o', { targetId: target.targetId, url: target.url })
 
         return sessionId
       }
     } catch (err: any) {
+      if (isRendererUnresponsive(err)) {
+        unresponsive = err
+      }
+
       debug('probing target %s failed: %s', target.targetId, err.message)
     }
 
     if (sessionId) {
       await client.Target.detachFromTarget({ sessionId }).catch(() => {})
     }
+  }
+
+  // A page that never answered the probe is a different failure from a browser
+  // holding no runner page at all, and only the former is worth waiting longer on.
+  if (unresponsive) {
+    throw unresponsive
   }
 
   return throwTapError(errors.tapBindingNotFound, `Failed to connect to the runner page.`)
@@ -222,16 +242,22 @@ const callBindingWithRetry = async (client: CRI.Client, sessionId: string, metho
 export const withTapSession = async <T> (
   instance: ReadyInstanceState,
   fn: (session: TapSession) => Promise<T>,
+  timeoutMs?: number,
 ): Promise<T> => {
-  debug('opening tap session for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl })
+  const bounds = cdpBounds(timeoutMs)
 
-  const client = await connectToBrowser(instance.cdpBrowserWsUrl)
+  debug('opening tap session for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, bounds })
+
+  const connection = await connectToBrowser(instance.cdpBrowserWsUrl)
+  // Every protocol call the session hands out is bounded; closing the connection
+  // is also what settles whatever a bound already gave up waiting on.
+  const client = boundCdpClient(connection, bounds.call)
 
   try {
     const attach = async (): Promise<string> => {
       const { targetInfos } = await listTargets(client)
 
-      return findRunnerPageSession(client, targetInfos)
+      return findRunnerPageSession(client, targetInfos, bounds.discovery)
     }
 
     let sessionId = await attach()
@@ -278,6 +304,6 @@ export const withTapSession = async <T> (
 
     return await fn(session)
   } finally {
-    await client.close().catch(() => {})
+    await connection.close().catch(() => {})
   }
 }

--- a/cli/lib/tap/tap-session.ts
+++ b/cli/lib/tap/tap-session.ts
@@ -2,7 +2,7 @@ import Debug from 'debug'
 import CRI from 'chrome-remote-interface'
 
 import { errors } from '../errors'
-import { boundCdpClient, cdpBounds, isRendererUnresponsive, withCdpDeadline } from './cdp-timeout'
+import { DEFAULT_CDP_TIMEOUT_MS, FIND_INSTANCE_TIMEOUT_MS, boundCdpCalls, isRendererUnresponsive, withCdpDeadline } from './cdp-timeout'
 import type { ReadyInstanceState } from '../cypress-instances'
 import { TAP_BINDING_GLOBAL, TAP_EXEC_METHOD } from '@packages/cypress-instances'
 import type { TapExecResult } from '@packages/cypress-instances'
@@ -251,20 +251,24 @@ export const withTapSession = async <T> (
   fn: (session: TapSession) => Promise<T>,
   timeoutMs?: number,
 ): Promise<T> => {
-  const bounds = cdpBounds(timeoutMs)
+  // The two defaults differ by an order of magnitude because the waits do: finding
+  // the runner page is a round trip, while calling into it can legitimately wait on
+  // a spec. `--timeout` is the one knob for "this is slow, wait longer", so it
+  // raises both rather than leaving the shorter one to fail underneath it.
+  const callMs = timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS
+  const findInstanceMs = timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS
 
-  debug('opening tap session for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, bounds })
+  debug('opening tap session for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, callMs, findInstanceMs })
 
-  const connection = await connectToBrowser(instance.cdpBrowserWsUrl)
-  // Every protocol call the session hands out is bounded; closing the connection
-  // is also what settles whatever a bound already gave up waiting on.
-  const client = boundCdpClient(connection, bounds.call)
+  const client = await connectToBrowser(instance.cdpBrowserWsUrl)
+
+  boundCdpCalls(client, callMs)
 
   try {
     const attach = async (): Promise<string> => {
       const { targetInfos } = await listTargets(client)
 
-      return findRunnerPageSession(client, targetInfos, bounds.findInstance)
+      return findRunnerPageSession(client, targetInfos, findInstanceMs)
     }
 
     let sessionId = await attach()
@@ -311,6 +315,6 @@ export const withTapSession = async <T> (
 
     return await fn(session)
   } finally {
-    await connection.close().catch(() => {})
+    await client.close().catch(() => {})
   }
 }

--- a/cli/lib/tap/tap-session.ts
+++ b/cli/lib/tap/tap-session.ts
@@ -27,6 +27,13 @@ const matchesAnyMessage = (err: unknown, messages: string[]): boolean => {
 }
 
 export const throwTapError = (details: { description: string, solution: string }, message: string, cause?: unknown): never => {
+  // A bound that expired already names what went unanswered and how to wait
+  // longer, and only its own `message` carries that — wrapping it would print
+  // generic prose about the browser instead.
+  if (isRendererUnresponsive(cause)) {
+    throw cause
+  }
+
   const err: any = new Error(message, cause === undefined ? undefined : { cause })
 
   err.details = details

--- a/cli/lib/tap/tap-session.ts
+++ b/cli/lib/tap/tap-session.ts
@@ -120,17 +120,17 @@ const evaluateBinding = (client: CRI.Client, sessionId: string) => {
 // Bounded tighter than the rest of the session: this runs once per page target
 // while scanning for the runner, so a target that cannot answer has to fall out
 // of the scan quickly instead of stalling it.
-const probeForBinding = async (client: CRI.Client, sessionId: string, discoveryMs: number): Promise<boolean> => {
+const probeForBinding = async (client: CRI.Client, sessionId: string, findInstanceMs: number): Promise<boolean> => {
   const { result, exceptionDetails } = await withCdpDeadline(
     evaluateBinding(client, sessionId),
     'the runner-page probe',
-    discoveryMs,
+    findInstanceMs,
   )
 
   return !exceptionDetails && result.type !== 'undefined' && !!result.objectId
 }
 
-const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[], discoveryMs: number): Promise<string> => {
+const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[], findInstanceMs: number): Promise<string> => {
   let unresponsive: unknown
 
   for (const target of targetInfos) {
@@ -143,7 +143,7 @@ const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTarget
     try {
       sessionId = await attachToPage(client, target.targetId)
 
-      if (await probeForBinding(client, sessionId, discoveryMs)) {
+      if (await probeForBinding(client, sessionId, findInstanceMs)) {
         debug('matched runner page target %o', { targetId: target.targetId, url: target.url })
 
         return sessionId
@@ -264,7 +264,7 @@ export const withTapSession = async <T> (
     const attach = async (): Promise<string> => {
       const { targetInfos } = await listTargets(client)
 
-      return findRunnerPageSession(client, targetInfos, bounds.discovery)
+      return findRunnerPageSession(client, targetInfos, bounds.findInstance)
     }
 
     let sessionId = await attach()

--- a/cli/lib/tap/types.ts
+++ b/cli/lib/tap/types.ts
@@ -5,6 +5,8 @@ export interface TapCliOptions {
   instance?: number
   /** Print the raw JSON result even when the command has a human-readable rendering. */
   json?: boolean
+  /** How long to wait on any single CDP call, in milliseconds. */
+  timeout?: number
 }
 
 /**

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -4,6 +4,7 @@ import logger from '../../../lib/logger'
 import { CypressInstanceError, listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
 import type { LiveInstanceSelection, LiveInstanceState, ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-instances'
 import { withTapSession } from '../../../lib/tap/tap-session'
+import { DISCOVERY_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
 import { tapCliCommands } from '../../../lib/tap/commands'
 import type { TapSession } from '../../../lib/tap/tap-session'
@@ -465,6 +466,22 @@ describe('lib/exec/tap', () => {
       expect(() => JSON.parse(output)).toThrow()
 
       expect(withTapSession).toHaveBeenCalledTimes(1)
+    })
+
+    it('bounds the renderer probe with --timeout', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111 })])
+
+      expect(await tap.start(['instances'], { timeout: 5000 })).toBe(0)
+
+      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), 5000)
+    })
+
+    it('bounds the renderer probe with the discovery default when --timeout is absent', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111 })])
+
+      expect(await tap.start(['instances'], {})).toBe(0)
+
+      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), DISCOVERY_TIMEOUT_MS)
     })
 
     it('prints the raw instance summaries with --json', async () => {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -446,7 +446,9 @@ describe('lib/exec/tap', () => {
       ...overrides,
     })
 
-    it('renders the live instances as a table and exits 0, without opening a session', async () => {
+    // Reporting whether the runner page answers takes a session, so this command
+    // opens one — bounded, and only where there is a browser to ask.
+    it('renders the live instances as a table and exits 0, probing only an instance with a browser attached', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([
         liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
         liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
@@ -462,7 +464,7 @@ describe('lib/exec/tap', () => {
       expect(output).toContain('Chrome')
       expect(() => JSON.parse(output)).toThrow()
 
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapSession).toHaveBeenCalledTimes(1)
     })
 
     it('prints the raw instance summaries with --json', async () => {
@@ -1210,6 +1212,8 @@ describe('lib/exec/tap', () => {
                                 server process id (pid)
           --json                print the raw JSON result instead of the human-readable
                                 rendering
+          --timeout <ms>        how long to wait on any single call into the running
+                                Cypress, in milliseconds (default 30000)
           -h, --help            display help for command
 
         Commands:
@@ -1279,6 +1283,8 @@ describe('lib/exec/tap', () => {
                                    human-readable rendering — every console property in
                                    full, however long, rather than the long ones named
                                    by their length
+          --timeout <ms>           how long to wait on any single call into the running
+                                   Cypress, in milliseconds (default 30000)
           -h, --help               display help for command
         "
       `)

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -4,7 +4,7 @@ import logger from '../../../lib/logger'
 import { CypressInstanceError, listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
 import type { LiveInstanceSelection, LiveInstanceState, ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-instances'
 import { withTapSession } from '../../../lib/tap/tap-session'
-import { DISCOVERY_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
+import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
 import { tapCliCommands } from '../../../lib/tap/commands'
 import type { TapSession } from '../../../lib/tap/tap-session'
@@ -476,12 +476,12 @@ describe('lib/exec/tap', () => {
       expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), 5000)
     })
 
-    it('bounds the renderer probe with the discovery default when --timeout is absent', async () => {
+    it('bounds the renderer probe with the find-instance default when --timeout is absent', async () => {
       vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111 })])
 
       expect(await tap.start(['instances'], {})).toBe(0)
 
-      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), DISCOVERY_TIMEOUT_MS)
+      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), FIND_INSTANCE_TIMEOUT_MS)
     })
 
     it('prints the raw instance summaries with --json', async () => {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -295,6 +295,31 @@ describe('lib/exec/tap', () => {
     })
   })
 
+  describe('coded failures go to stderr', () => {
+    const stderr = (): string => vi.mocked(console.error).mock.calls.flat().join(' ')
+
+    it('prints an app-side domain failure on stderr, leaving stdout clean under --json', async () => {
+      mockSession(schema, {
+        error: {
+          code: 'INVALID_ARGUMENTS',
+          message: '<spec> must be a string, but number was given.',
+        },
+      })
+
+      expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js'], { json: true })).toBe(1)
+      expect(stderr()).toContain('INVALID_ARGUMENTS: <spec> must be a string, but number was given.')
+      expect(console.log).not.toHaveBeenCalled()
+    })
+
+    it('prints a known tap error on stderr, leaving stdout clean under --json', async () => {
+      vi.mocked(withTapSession).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
+
+      expect(await tap.start(['health'], { json: true })).toBe(1)
+      expect(stderr()).toContain(errors.tapBindingNotFound.description)
+      expect(console.log).not.toHaveBeenCalled()
+    })
+  })
+
   describe('commander validates the command against the live schema', () => {
     it('rejects a command the instance does not advertise, without reaching exec', async () => {
       const call = mockSession()

--- a/cli/test/lib/tap/cdp-timeout.spec.ts
+++ b/cli/test/lib/tap/cdp-timeout.spec.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  DEFAULT_CDP_TIMEOUT_MS,
+  DISCOVERY_TIMEOUT_MS,
+  boundCdpClient,
+  cdpBounds,
+  isRendererUnresponsive,
+  withCdpDeadline,
+} from '../../../lib/tap/cdp-timeout'
+
+// A CDP reply carries no timer of its own, so a target that stops answering
+// leaves the promise pending forever. These cover the bound that replaces that
+// silence with a coded failure.
+const never = () => new Promise<never>(() => {})
+
+const BOUND = 20
+
+describe('lib/tap/cdp-timeout', () => {
+  describe('withCdpDeadline', () => {
+    it('rejects with RENDERER_UNRESPONSIVE when the call never answers', async () => {
+      const err = await withCdpDeadline(never(), 'the probe', BOUND).catch((e) => e)
+
+      expect(isRendererUnresponsive(err)).to.eq(true)
+      expect(err.code).to.eq('RENDERER_UNRESPONSIVE')
+      expect(err.message).to.contain('the probe')
+      expect(err.message).to.contain(`${BOUND}ms`)
+      expect(err.message).to.contain('--timeout')
+    })
+
+    it('resolves with the value when the call answers first', async () => {
+      await expect(withCdpDeadline(Promise.resolve('answered'), 'a call', BOUND)).resolves.to.eq('answered')
+    })
+
+    it('passes a rejection through untouched rather than reporting a timeout', async () => {
+      const failure = new Error('Session with given id not found')
+      const err = await withCdpDeadline(Promise.reject(failure), 'a call', BOUND).catch((e) => e)
+
+      expect(err).to.eq(failure)
+      expect(isRendererUnresponsive(err)).to.eq(false)
+    })
+
+    it('clears its timer once the call answers, so a pending timeout cannot outlive it', async () => {
+      const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+
+      await withCdpDeadline(Promise.resolve('answered'), 'a call', BOUND)
+
+      expect(clearTimeoutSpy).toHaveBeenCalled()
+      clearTimeoutSpy.mockRestore()
+    })
+  })
+
+  describe('cdpBounds', () => {
+    it('defaults the two waits apart: locating the runner page is a round trip, calling into it can wait on a spec', () => {
+      expect(cdpBounds()).to.deep.eq({ call: DEFAULT_CDP_TIMEOUT_MS, discovery: DISCOVERY_TIMEOUT_MS })
+      expect(DISCOVERY_TIMEOUT_MS).to.be.lessThan(DEFAULT_CDP_TIMEOUT_MS)
+    })
+
+    it('raises both waits together, so the shorter one cannot fail underneath an explicit --timeout', () => {
+      expect(cdpBounds(90_000)).to.deep.eq({ call: 90_000, discovery: 90_000 })
+    })
+  })
+
+  describe('isRendererUnresponsive', () => {
+    it('is false for anything that is not the timeout failure', () => {
+      expect(isRendererUnresponsive(new Error('boom'))).to.eq(false)
+      expect(isRendererUnresponsive(undefined)).to.eq(false)
+      expect(isRendererUnresponsive({ code: 'RENDERER_UNRESPONSIVE' })).to.eq(false)
+    })
+  })
+
+  describe('boundCdpClient', () => {
+    const fakeClient = (overrides: Record<string, unknown> = {}) => {
+      return {
+        Runtime: { evaluate: () => never() },
+        Target: { getTargets: () => Promise.resolve({ targetInfos: [] }) },
+        close: () => Promise.resolve(),
+        host: '127.0.0.1',
+        ...overrides,
+      } as any
+    }
+
+    it('bounds a domain call that never answers', async () => {
+      const client = boundCdpClient(fakeClient(), BOUND)
+
+      const err = await client.Runtime.evaluate({ expression: '1' }).catch((e: unknown) => e)
+
+      expect(isRendererUnresponsive(err)).to.eq(true)
+      expect((err as Error).message).to.contain('Runtime.evaluate')
+    })
+
+    it('passes a domain call that answers straight through', async () => {
+      const client = boundCdpClient(fakeClient(), BOUND)
+
+      await expect(client.Target.getTargets()).resolves.to.deep.eq({ targetInfos: [] })
+    })
+
+    it('forwards arguments and receiver to the underlying call', async () => {
+      const evaluate = vi.fn().mockResolvedValue({ result: {} })
+      const client = boundCdpClient(fakeClient({ Runtime: { evaluate } }), BOUND)
+
+      await client.Runtime.evaluate({ expression: 'window.x' }, 'session-1')
+
+      expect(evaluate).toHaveBeenCalledWith({ expression: 'window.x' }, 'session-1')
+    })
+
+    // Domain properties double as event subscribers, which hand back an
+    // unsubscribe function rather than a promise — racing one would swap it for a
+    // promise and break the caller.
+    it('leaves a non-promise return value alone', () => {
+      const unsubscribe = () => {}
+      const client = boundCdpClient(fakeClient({ Page: { loadEventFired: () => unsubscribe } }), BOUND)
+
+      expect((client as any).Page.loadEventFired(() => {})).to.eq(unsubscribe)
+    })
+
+    it('leaves the client’s own members alone, so closing the connection is never bounded', async () => {
+      const close = vi.fn().mockReturnValue(never())
+      const client = boundCdpClient(fakeClient({ close }), BOUND)
+
+      expect((client as any).host).to.eq('127.0.0.1')
+
+      const settled = await Promise.race([
+        client.close().then(() => 'closed'),
+        new Promise((resolve) => setTimeout(() => resolve('still pending'), BOUND * 3)),
+      ])
+
+      expect(settled).to.eq('still pending')
+    })
+
+    it('hands back the same proxy for a domain each time it is read', () => {
+      const client = boundCdpClient(fakeClient(), BOUND)
+
+      expect(client.Runtime).to.eq(client.Runtime)
+    })
+  })
+})

--- a/cli/test/lib/tap/cdp-timeout.spec.ts
+++ b/cli/test/lib/tap/cdp-timeout.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   DEFAULT_CDP_TIMEOUT_MS,
-  DISCOVERY_TIMEOUT_MS,
+  FIND_INSTANCE_TIMEOUT_MS,
   boundCdpClient,
   cdpBounds,
   isRendererUnresponsive,
@@ -52,12 +52,12 @@ describe('lib/tap/cdp-timeout', () => {
 
   describe('cdpBounds', () => {
     it('defaults the two waits apart: locating the runner page is a round trip, calling into it can wait on a spec', () => {
-      expect(cdpBounds()).to.deep.eq({ call: DEFAULT_CDP_TIMEOUT_MS, discovery: DISCOVERY_TIMEOUT_MS })
-      expect(DISCOVERY_TIMEOUT_MS).to.be.lessThan(DEFAULT_CDP_TIMEOUT_MS)
+      expect(cdpBounds()).to.deep.eq({ call: DEFAULT_CDP_TIMEOUT_MS, findInstance: FIND_INSTANCE_TIMEOUT_MS })
+      expect(FIND_INSTANCE_TIMEOUT_MS).to.be.lessThan(DEFAULT_CDP_TIMEOUT_MS)
     })
 
     it('raises both waits together, so the shorter one cannot fail underneath an explicit --timeout', () => {
-      expect(cdpBounds(90_000)).to.deep.eq({ call: 90_000, discovery: 90_000 })
+      expect(cdpBounds(90_000)).to.deep.eq({ call: 90_000, findInstance: 90_000 })
     })
   })
 

--- a/cli/test/lib/tap/cdp-timeout.spec.ts
+++ b/cli/test/lib/tap/cdp-timeout.spec.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import type CRI from 'chrome-remote-interface'
 
-import {
-  DEFAULT_CDP_TIMEOUT_MS,
-  FIND_INSTANCE_TIMEOUT_MS,
-  boundCdpClient,
-  cdpBounds,
-  isRendererUnresponsive,
-  withCdpDeadline,
-} from '../../../lib/tap/cdp-timeout'
+import { boundCdpCalls, isRendererUnresponsive, withCdpDeadline } from '../../../lib/tap/cdp-timeout'
 
 // A CDP reply carries no timer of its own, so a target that stops answering
 // leaves the promise pending forever. These cover the bound that replaces that
@@ -50,17 +44,6 @@ describe('lib/tap/cdp-timeout', () => {
     })
   })
 
-  describe('cdpBounds', () => {
-    it('defaults the two waits apart: locating the runner page is a round trip, calling into it can wait on a spec', () => {
-      expect(cdpBounds()).to.deep.eq({ call: DEFAULT_CDP_TIMEOUT_MS, findInstance: FIND_INSTANCE_TIMEOUT_MS })
-      expect(FIND_INSTANCE_TIMEOUT_MS).to.be.lessThan(DEFAULT_CDP_TIMEOUT_MS)
-    })
-
-    it('raises both waits together, so the shorter one cannot fail underneath an explicit --timeout', () => {
-      expect(cdpBounds(90_000)).to.deep.eq({ call: 90_000, findInstance: 90_000 })
-    })
-  })
-
   describe('isRendererUnresponsive', () => {
     it('is false for anything that is not the timeout failure', () => {
       expect(isRendererUnresponsive(new Error('boom'))).to.eq(false)
@@ -69,19 +52,38 @@ describe('lib/tap/cdp-timeout', () => {
     })
   })
 
-  describe('boundCdpClient', () => {
-    const fakeClient = (overrides: Record<string, unknown> = {}) => {
-      return {
-        Runtime: { evaluate: () => never() },
-        Target: { getTargets: () => Promise.resolve({ targetInfos: [] }) },
-        close: () => Promise.resolve(),
-        host: '127.0.0.1',
-        ...overrides,
-      } as any
+  describe('boundCdpCalls', () => {
+    const unsubscribe = () => {}
+
+    // Mirrors chrome-remote-interface: the domain shorthands are generated as
+    // `client.send` calls, while events and `close` are their own members.
+    const fakeClient = (commands: Record<string, (...args: any[]) => unknown> = {}) => {
+      const behaviors: Record<string, (...args: any[]) => unknown> = {
+        'Runtime.evaluate': () => never(),
+        'Target.getTargets': () => Promise.resolve({ targetInfos: [] }),
+        ...commands,
+      }
+
+      const client: any = {
+        send: (command: string, ...args: unknown[]) => behaviors[command](...args),
+        close: () => never(),
+        Page: { loadEventFired: () => unsubscribe },
+      }
+
+      Object.keys(behaviors).forEach((command) => {
+        const [domain, method] = command.split('.')
+
+        client[domain] = client[domain] ?? {}
+        client[domain][method] = (...args: unknown[]) => client.send(command, ...args)
+      })
+
+      return client as CRI.Client
     }
 
     it('bounds a domain call that never answers', async () => {
-      const client = boundCdpClient(fakeClient(), BOUND)
+      const client = fakeClient()
+
+      boundCdpCalls(client, BOUND)
 
       const err = await client.Runtime.evaluate({ expression: '1' }).catch((e: unknown) => e)
 
@@ -90,35 +92,38 @@ describe('lib/tap/cdp-timeout', () => {
     })
 
     it('passes a domain call that answers straight through', async () => {
-      const client = boundCdpClient(fakeClient(), BOUND)
+      const client = fakeClient()
+
+      boundCdpCalls(client, BOUND)
 
       await expect(client.Target.getTargets()).resolves.to.deep.eq({ targetInfos: [] })
     })
 
-    it('forwards arguments and receiver to the underlying call', async () => {
+    it('forwards the params and session id to the underlying call', async () => {
       const evaluate = vi.fn().mockResolvedValue({ result: {} })
-      const client = boundCdpClient(fakeClient({ Runtime: { evaluate } }), BOUND)
+      const client = fakeClient({ 'Runtime.evaluate': evaluate })
+
+      boundCdpCalls(client, BOUND)
 
       await client.Runtime.evaluate({ expression: 'window.x' }, 'session-1')
 
       expect(evaluate).toHaveBeenCalledWith({ expression: 'window.x' }, 'session-1')
     })
 
-    // Domain properties double as event subscribers, which hand back an
-    // unsubscribe function rather than a promise — racing one would swap it for a
-    // promise and break the caller.
-    it('leaves a non-promise return value alone', () => {
-      const unsubscribe = () => {}
-      const client = boundCdpClient(fakeClient({ Page: { loadEventFired: () => unsubscribe } }), BOUND)
+    // An event subscriber hands back an unsubscribe function rather than a promise,
+    // so racing one would swap it for a promise and break the caller.
+    it('leaves event subscriptions alone', () => {
+      const client = fakeClient()
+
+      boundCdpCalls(client, BOUND)
 
       expect((client as any).Page.loadEventFired(() => {})).to.eq(unsubscribe)
     })
 
-    it('leaves the client’s own members alone, so closing the connection is never bounded', async () => {
-      const close = vi.fn().mockReturnValue(never())
-      const client = boundCdpClient(fakeClient({ close }), BOUND)
+    it('leaves closing the connection unbounded, since that is what settles an abandoned call', async () => {
+      const client = fakeClient()
 
-      expect((client as any).host).to.eq('127.0.0.1')
+      boundCdpCalls(client, BOUND)
 
       const settled = await Promise.race([
         client.close().then(() => 'closed'),
@@ -126,12 +131,6 @@ describe('lib/tap/cdp-timeout', () => {
       ])
 
       expect(settled).to.eq('still pending')
-    })
-
-    it('hands back the same proxy for a domain each time it is read', () => {
-      const client = boundCdpClient(fakeClient(), BOUND)
-
-      expect(client.Runtime).to.eq(client.Runtime)
     })
   })
 })

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { CypressInstanceError } from '../../../lib/cypress-instances'
 import { extractInspect } from '../../../lib/tap/commands/inspect'
 import type { TapSession } from '../../../lib/tap/tap-session'
 
@@ -20,7 +21,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
     selectorSubtype?: string
     throwOnEval?: boolean
     elementInfo?: unknown
-    axThrows?: boolean
+    axError?: unknown
     axNodes?: unknown[]
   } = {}) => {
     // callFunctionOn is used twice: first to querySelector (returns the element
@@ -36,8 +37,8 @@ describe('lib/tap/commands/inspect extractInspect', () => {
     .mockImplementationOnce(async () => ({ result: { value: opts.elementInfo ?? ELEMENT_INFO } }))
 
     const getPartialAXTree = vi.fn().mockImplementation(async () => {
-      if (opts.axThrows) {
-        throw new Error('no ax')
+      if (opts.axError) {
+        throw opts.axError
       }
 
       return { nodes: opts.axNodes ?? [{ role: { value: 'textbox' }, name: { value: 'Username' }, backendDOMNodeId: 40, properties: [{ name: 'disabled', value: { value: true } }] }] }
@@ -87,12 +88,21 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   })
 
   it('still returns the element when the accessibility node is unavailable', async () => {
-    const { session } = makeInspectSession({ selectorObjectId: 'obj-1', axThrows: true })
+    const { session } = makeInspectSession({ selectorObjectId: 'obj-1', axError: new Error('no ax') })
 
     const result = await extractInspect(session, frame, '.plain')
 
     expect(result.found).to.eq(true)
     expect(result.aria).to.be.undefined
     expect(result.tag).to.eq('input')
+  })
+
+  it('fails instead of reporting a partial element when the renderer stops answering', async () => {
+    const { session } = makeInspectSession({
+      selectorObjectId: 'obj-1',
+      axError: new CypressInstanceError('RENDERER_UNRESPONSIVE', 'Cypress did not answer Accessibility.getPartialAXTree within 30000ms.'),
+    })
+
+    await expect(extractInspect(session, frame, '.wedged')).rejects.toMatchObject({ code: 'RENDERER_UNRESPONSIVE' })
   })
 })

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -100,7 +100,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   it('fails instead of reporting a partial element when the renderer stops answering', async () => {
     const { session } = makeInspectSession({
       selectorObjectId: 'obj-1',
-      axError: new CypressInstanceError('RENDERER_UNRESPONSIVE', 'Cypress did not answer Accessibility.getPartialAXTree within 30000ms.'),
+      axError: new CypressInstanceError('RENDERER_UNRESPONSIVE', 'The targeted Cypress instance did not answer Accessibility.getPartialAXTree within 30000ms.'),
     })
 
     await expect(extractInspect(session, frame, '.wedged')).rejects.toMatchObject({ code: 'RENDERER_UNRESPONSIVE' })

--- a/cli/test/lib/tap/render-instances.spec.ts
+++ b/cli/test/lib/tap/render-instances.spec.ts
@@ -20,4 +20,20 @@ describe('lib/tap/render/instances', () => {
       '  222  /projects/other  —     —',
     ].join('\n'))
   })
+
+  // An attached browser whose page will not answer is the state every other
+  // command fails in, so the row has to say so rather than read as healthy.
+  it('marks an attached browser whose renderer is not answering', () => {
+    const output = render([
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', rendererResponsive: false },
+      { pid: 222, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', rendererResponsive: true },
+    ])
+
+    expect(output).toBe([
+      'INSTANCES (2)',
+      '  PID  PROJECT        TYPE  BROWSER',
+      '  111  /projects/app  e2e   Chrome (not responding)',
+      '  222  /projects/app  e2e   Chrome',
+    ].join('\n'))
+  })
 })

--- a/cli/test/lib/tap/tap-session.spec.ts
+++ b/cli/test/lib/tap/tap-session.spec.ts
@@ -71,6 +71,23 @@ const callOnce = (method = 'health', args: unknown[] = []) => {
 
 const staleError = () => new Error(CdpErrorMessage.objectNotFound)
 
+const UNRESPONSIVE_MS = 25
+
+const never = () => vi.fn().mockReturnValue(new Promise(() => {}))
+
+const callWithBound = () => {
+  return withTapSession(instance, (session) => session.call('health'), UNRESPONSIVE_MS)
+}
+
+const expectUnresponsive = async (promise: Promise<any>) => {
+  const err = await promise.catch((e) => e)
+
+  expect(err.code).toBe('RENDERER_UNRESPONSIVE')
+  expect(err.details).toBeUndefined()
+
+  return err
+}
+
 const expectError = async (promise: Promise<any>, details: unknown) => {
   const err = await promise.catch((e) => e)
 
@@ -435,6 +452,37 @@ describe('lib/tap/tap-session', () => {
     await expectError(callOnce(), errors.tapCdpUnreachable)
 
     expect(client.Runtime.callFunctionOn).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces RENDERER_UNRESPONSIVE when the binding call never answers', async () => {
+    setup(makeClient({ callFunctionOn: never() }))
+
+    await expectUnresponsive(callWithBound())
+  })
+
+  it('surfaces RENDERER_UNRESPONSIVE when resolving the binding never answers', async () => {
+    const evaluate = vi.fn()
+    .mockResolvedValueOnce({ result: { type: 'object', objectId: 'OBJ_PROBE' } })
+    .mockReturnValue(new Promise(() => {}))
+
+    setup(makeClient({ evaluate }))
+
+    await expectUnresponsive(callWithBound())
+  })
+
+  it('surfaces RENDERER_UNRESPONSIVE rather than BINDING_NOT_FOUND when no page can be attached to', async () => {
+    setup(makeClient({
+      targetInfos: [pageTarget('T1'), pageTarget('T2')],
+      attachToTarget: never(),
+    }))
+
+    await expectUnresponsive(callWithBound())
+  })
+
+  it('surfaces RENDERER_UNRESPONSIVE when listing targets never answers', async () => {
+    setup(makeClient({ getTargets: never() }))
+
+    await expectUnresponsive(callWithBound())
   })
 
   it('attaches to the first page that probes positive when multiple pages have the binding', async () => {

--- a/cli/test/lib/tap/tap-session.spec.ts
+++ b/cli/test/lib/tap/tap-session.spec.ts
@@ -3,6 +3,7 @@ import CRI from 'chrome-remote-interface'
 
 import type { ReadyInstanceState } from '../../../lib/cypress-instances'
 import { CdpErrorMessage, withTapSession } from '../../../lib/tap/tap-session'
+import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { errors } from '../../../lib/errors'
 
 vi.mock('chrome-remote-interface', () => ({ default: vi.fn() }))
@@ -26,18 +27,27 @@ interface FakeClientOverrides {
 }
 
 const makeClient = (overrides: FakeClientOverrides = {}) => {
-  const client = {
-    Target: {
-      getTargets: overrides.getTargets ?? vi.fn().mockResolvedValue({ targetInfos: overrides.targetInfos ?? [pageTarget()] }),
-      attachToTarget: overrides.attachToTarget ?? vi.fn().mockResolvedValue({ sessionId: 'SID1' }),
-      detachFromTarget: vi.fn().mockResolvedValue({}),
-    },
-    Runtime: {
-      evaluate: overrides.evaluate ?? vi.fn().mockResolvedValue({ result: { type: 'object', objectId: 'OBJ1' } }),
-      callFunctionOn: overrides.callFunctionOn ?? vi.fn().mockResolvedValue({ result: { type: 'string', value: 'ok' } }),
-    },
+  const behaviors: Record<string, ReturnType<typeof vi.fn>> = {
+    'Target.getTargets': overrides.getTargets ?? vi.fn().mockResolvedValue({ targetInfos: overrides.targetInfos ?? [pageTarget()] }),
+    'Target.attachToTarget': overrides.attachToTarget ?? vi.fn().mockResolvedValue({ sessionId: 'SID1' }),
+    'Target.detachFromTarget': vi.fn().mockResolvedValue({}),
+    'Runtime.evaluate': overrides.evaluate ?? vi.fn().mockResolvedValue({ result: { type: 'object', objectId: 'OBJ1' } }),
+    'Runtime.callFunctionOn': overrides.callFunctionOn ?? vi.fn().mockResolvedValue({ result: { type: 'string', value: 'ok' } }),
+  }
+
+  // Mirrors chrome-remote-interface, where every domain shorthand is generated as
+  // a `client.send` call — the seam the session installs its bound on.
+  const client: any = {
+    send: (command: string, ...args: unknown[]) => behaviors[command](...args),
     close: vi.fn().mockResolvedValue(undefined),
   }
+
+  Object.keys(behaviors).forEach((command) => {
+    const [domain, method] = command.split('.')
+
+    client[domain] = client[domain] ?? {}
+    client[domain][method] = vi.fn((...args: unknown[]) => client.send(command, ...args))
+  })
 
   return client
 }
@@ -481,6 +491,27 @@ describe('lib/tap/tap-session', () => {
 
   it('surfaces RENDERER_UNRESPONSIVE when listing targets never answers', async () => {
     setup(makeClient({ getTargets: never() }))
+
+    await expectUnresponsive(callWithBound())
+  })
+
+  it('bounds the runner-page probe on its own shorter default, so a stuck page falls out of the scan fast', async () => {
+    setup(makeClient({ evaluate: never() }))
+    vi.useFakeTimers()
+
+    try {
+      const settled = callOnce().catch((e) => e)
+
+      await vi.advanceTimersByTimeAsync(FIND_INSTANCE_TIMEOUT_MS)
+
+      expect((await settled as Error & { code: string }).code).toBe('RENDERER_UNRESPONSIVE')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('raises the probe bound along with the call bound, so the shorter one cannot fail underneath --timeout', async () => {
+    setup(makeClient({ evaluate: never() }))
 
     await expectUnresponsive(callWithBound())
   })


### PR DESCRIPTION
- Closes [AW-56](https://cypress-io.atlassian.net/browse/AW-56)

### Additional details

A CDP reply callback carries no timer of its own (`chrome-remote-interface`'s `_enqueueCommand`), and the only thing that settles a pending one other than a matching reply is the **browser-level** socket closing. A page target that stops answering produces neither, so the promise is orphaned — and nothing under `cli/lib/tap/**` raced any of it.

The result: every tap command that talks to the page hung forever with **zero bytes on both streams**, while `instances` cheerfully answered `browserAttached: true` and pointed the caller straight back at the call that hangs.

**Bounding it.** Rather than wrapping thirteen call sites, the bound goes on the CRI client once, where `withTapSession` hands it out (`cli/lib/tap/cdp-timeout.ts`). `aut/frame.ts`, `aut/cdp.ts`, `aria.ts` and `inspect.ts` are covered without changing a line, and a protocol call added later is covered without anyone having to remember. The seam is the client's own `send`: `chrome-remote-interface` generates every domain shorthand as a call to it, so replacing that one method bounds commands, the flat `Domain.method` form, and the raw-client calls the frame extractors issue. Events and `close` don't route through `send`, so the two things that must stay unbounded are excluded structurally rather than by inspecting return values.

**Two default bounds, one knob.** Locating the runner page is a round trip that a healthy renderer answers in milliseconds (2s); calling *into* it can legitimately wait on a spec (30s) — the ticket's own numbers put `status` p95 at ~5s under contention, so a short bound there would break real calls. `--timeout <ms>` raises **both**, because the failure a caller actually wants to wait out shows up in the short one; leaving it pinned would make the flag useless for the case it exists for. `instances` honors it too, so its renderer probe can be waited out like every other call. The two bounds are `FIND_INSTANCE_TIMEOUT_MS` and the per-call one; the `find-instance` vocabulary replaces `discovery` across this slice, including the two tap agent guides that banned the term while still using it.

**The scan skips, but remembers.** A probe that hits its bound no longer stops the scan — but a page that never answered is a different failure from a browser holding no runner page at all, and only the former is worth waiting longer on, so the scan reports `RENDERER_UNRESPONSIVE` rather than "no runner page found".

**The code survives the wrap.** A bound that trips after the runner page is found used to be rewritten as `tapCdpUnreachable` on the way out, which renders as "the browser may have just closed" and drops the timeout text entirely. The session's error funnel now rethrows a `RENDERER_UNRESPONSIVE` untouched, so a hang caught mid-call reads the same as one caught during the probe. That is also what lets the runner-page scan, `instances` and `status` recognize the coded failure, and it stops `inspect` exiting 0 with an element whose accessibility node silently went missing.

**`instances` gains a field rather than changing one.** `browserAttached` means the browser process is reachable (an HTTP `/json/version` hit) and that is still all it claims. The new `rendererResponsive` is what separates a healthy instance from a wedged one. See the open question below.

### Steps to test

Validated live against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) through a real `cypress open` instance. `SIGSTOP` on the runner's renderer is the ticket's own repro, and a deterministic stand-in for a busy-looping page, a devtools-paused tab, or a renderer starved of memory:

```bash
kill -STOP <Cypress Helper (Renderer) pid>   # the one hosting the runner page
node cli/bin/cypress tap status
kill -CONT <pid>
```

**Before** — five commands, each killed by an external 12s bound, nothing on either stream:

```
--- tap status:        TIMED OUT after 12.01s | stdout=0B stderr=0B
--- tap reporter:      TIMED OUT after 12.01s | stdout=0B stderr=0B
--- tap dom:           TIMED OUT after 12.01s | stdout=0B stderr=0B
--- tap aria:          TIMED OUT after 12.01s | stdout=0B stderr=0B
--- tap inspect body:  TIMED OUT after 12.01s | stdout=0B stderr=0B
--- tap instances:     exit=0 after 0.37s → "browserAttached": true
```

**After** — each answers in ~2.4s with a coded failure at exit 1:

```
--- tap instances:    exit=0 after 2.40s → "browserAttached": true, "rendererResponsive": false
--- tap status:       exit=1 after 2.39s
    RENDERER_UNRESPONSIVE: The targeted Cypress instance did not answer the runner-page
    probe within 2000ms. The browser is reachable, but the page running Cypress is not
    responding — it may be paused in devtools, stuck in a loop, or starved of memory.
    Pass --timeout <ms> to wait longer.
--- tap reporter:     exit=1 after 2.39s   (same)
--- tap dom:          exit=1 after 2.40s   (same)
--- tap aria:         exit=1 after 2.39s   (same)
--- tap inspect body: exit=1 after 2.41s   (same)
--- tap specs:        exit=0 after 0.40s   (unaffected — goes over instance GraphQL, not CDP)
```

`--timeout` raises the bound, so a legitimately slow renderer can still be waited out:

```
--- tap status:                 exit=1 after 2.40s   (RENDERER_UNRESPONSIVE ... within 2000ms)
--- tap status --timeout 6000:  exit=1 after 6.40s   (RENDERER_UNRESPONSIVE ... within 6000ms)
```

The healthy path is unchanged — same instance, renderer running:

```
$ node cli/bin/cypress tap instances
INSTANCES (1)
  PID    PROJECT                                                      TYPE  BROWSER
  97732  /Users/davidr/Documents/Cypress/cypress-example-kitchensink  e2e   electron

$ node cli/bin/cypress tap status --json
{'status': 'passed', 'browserAttached': True, 'totalSpecs': 27}

$ node cli/bin/cypress tap reporter
cypress/e2e/2-advanced-examples/aliasing.cy.js
✓ 2  ✖ --  ○ --  617ms

ALIASING
   r3  ✓ .as() - alias a DOM element for later use  173ms
   r4  ✓ .as() - alias a route for later use  415ms
```

And wedged, in human form, `instances` says which state it is in instead of reading healthy:

```
INSTANCES (1)
  PID    PROJECT                                                      TYPE  BROWSER
  97732  /Users/davidr/Documents/Cypress/cypress-example-kitchensink  e2e   electron (not responding)
```

### Acceptance

| Ticket bullet | |
|---|---|
| Every CDP await in `cli/lib/tap/**` is bounded | ✅ structurally, by wrapping the client |
| Hitting the bound produces a coded error at non-zero exit, not silence | ✅ `RENDERER_UNRESPONSIVE` on stderr, exit 1 |
| The bound is overridable from the CLI | ✅ `--timeout <ms>`, raises both tiers |
| `instances` does not report a healthy renderer for one that cannot answer `Runtime.evaluate` | ✅ via a new `rendererResponsive` field — **see open question** |
| An unresponsive page target does not stop the runner-page scan | ✅ skipped, and the reason is kept |

**Two things I did not decide unilaterally:**

1. **Stream.** Settled: tap's coded failures now print on **stderr**. `logger.error` is `console.log` (`cli/lib/logger.ts:11`), and the rest of the CLI keeps printing errors on stdout — moving that is an output-contract change beyond this fix, so it is deliberately untouched. `logger` gains an `errorToStderr` that writes with `console.error` and records into the same `logs` buffer, and tap's two failure renderers (`cli/lib/tap/output.ts:8,12`) route through it. Nothing else moves: results and help stay on stdout, and a failure is never rendered as JSON, so `--json` now leaves stdout empty on failure instead of putting human error text on the machine-readable channel. This also closes the split with `cli/lib/tap/build-program.ts:76`, which already wrote to `console.error`.
2. **`instances` field vs redefinition.** The bullet literally asks for `browserAttached: false`. That would change what an existing field means and add a CDP round trip to the one command that always works. This PR adds `rendererResponsive` instead — purely additive, and it gives an agent triaging a hang *both* facts. One line to switch to the literal reading if preferred.

   Worth a reviewer's eye: `instances` had a test asserting it ran **"without opening a session"** (`tap.spec.ts:408`, `expect(withTapSession).not.toHaveBeenCalled()`). Reporting whether the runner page answers can't be done without one, so that assertion is now "probes only an instance with a browser attached" (`toHaveBeenCalledTimes(1)`) — a deliberate change to an invariant someone wrote down, not an incidental one. The invariant's *purpose* is intact: the probe is bounded and never throws, so `instances` still answers when everything else is wedged, which the before/after above demonstrates.

### How has the user experience changed?

A wedged renderer used to hang `cypress tap status|reporter|dom|aria|inspect` indefinitely with no output at all; they now fail in ~2.4s with `RENDERER_UNRESPONSIVE` on stderr and exit 1, and `--timeout <ms>` waits longer when the renderer is merely slow. `cypress tap instances` reports the new `rendererResponsive`, and its human table marks such a browser `(not responding)`. Nothing changes on a healthy instance. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- new cdp-timeout.spec.ts (10 cases: deadline, timer cleanup, bounded/pass-through commands, event subscribers, unbounded close); tap-session.spec.ts covers the two bound tiers behaviorally; render-instances.spec.ts covers the not-responding row; two cases in tap.spec.ts prove coded failures land on stderr and leave stdout clean. Also validated against real Chrome over real CDP (never-resolving promise and a busy-looped renderer both surface RENDERER_UNRESPONSIVE) and live against a running Electron instance -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-56]: https://cypress-io.atlassian.net/browse/AW-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experimental `cypress tap` CDP plumbing, instance discovery behavior, and failure output streams; bounded timeouts and new fields could affect agents/scripts that relied on indefinite waits or stdout-only errors.
> 
> **Overview**
> **`cypress tap` no longer hangs forever** when the Cypress runner page stops answering Chrome DevTools Protocol calls. Timeouts are enforced by wrapping the CDP client's `send` once per session (defaults: **2s** while locating the runner page, **30s** per protocol call). Overruns fail with **`RENDERER_UNRESPONSIVE`** on **stderr** at exit 1, with guidance to pass **`--timeout <ms>`**, which raises both tiers.
> 
> The runner-page scan **continues past** wedged tab targets instead of blocking the whole attach flow, and distinguishes "no runner page" from "page not responding." Session error handling **preserves** that code instead of remapping it to generic CDP unreachable errors.
> 
> **`tap instances`** now performs a bounded probe when a browser is attached and exposes optional **`rendererResponsive`** (human table: `Chrome (not responding)`). **`tap status`** surfaces the same coded failure when CDP fails after attach. **`inspect`** fails on renderer timeout during accessibility reads instead of returning a partial result without ARIA.
> 
> Tap coded failures use **`logger.errorToStderr`** so **`--json`** leaves stdout empty on error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32fc3cb0b65940554dc68387edc26ddd9b069003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






