### PR TITLE
feat: order tap specs most recently modified first

### DIFF
--- a/cli/lib/tap/commands/specs.ts
+++ b/cli/lib/tap/commands/specs.ts
@@ -16,6 +16,24 @@ export interface TapSpecEntry {
   lastModifiedTimestamp?: string
 }
 
+// The timestamp arrives as git's `%ci` (`-0500`) or, for a file git has no commit
+// for, as a dayjs-formatted ctime (`-05:00`); Date.parse reads both.
+const modifiedAt = (spec: TapSpecEntry): number => {
+  const parsed = spec.lastModifiedTimestamp === undefined ? NaN : Date.parse(spec.lastModifiedTimestamp)
+
+  return Number.isNaN(parsed) ? -Infinity : parsed
+}
+
+// Most recently modified first, so the spec just edited is the first one read.
+// Specs git knows nothing about sort last, keeping their original order — sort is
+// stable, and an unknown time should not outrank a known recent one.
+const byMostRecentlyModified = (a: TapSpecEntry, b: TapSpecEntry): number => {
+  const left = modifiedAt(a)
+  const right = modifiedAt(b)
+
+  return left === right ? 0 : right - left
+}
+
 // `TapSpecsQuery` is the schema shape, but the value crosses the wire unvalidated,
 // so entries are guarded against nulls and non-string fields before rendering.
 const toSpecList = (data: TapSpecsQuery): TapSpecEntry[] => {
@@ -33,6 +51,7 @@ const toSpecList = (data: TapSpecsQuery): TapSpecEntry[] => {
         ...(typeof lastModifiedTimestamp === 'string' ? { lastModifiedTimestamp } : {}),
       }
     })
+    .sort(byMostRecentlyModified)
 }
 
 const listSpecs = async (options: TapCliOptions): Promise<number> => {

--- a/cli/lib/tap/commands/specs.ts
+++ b/cli/lib/tap/commands/specs.ts
@@ -16,17 +16,12 @@ export interface TapSpecEntry {
   lastModifiedTimestamp?: string
 }
 
-// The timestamp arrives as git's `%ci` (`-0500`) or, for a file git has no commit
-// for, as a dayjs-formatted ctime (`-05:00`); Date.parse reads both.
 const modifiedAt = (spec: TapSpecEntry): number => {
   const parsed = spec.lastModifiedTimestamp === undefined ? NaN : Date.parse(spec.lastModifiedTimestamp)
 
   return Number.isNaN(parsed) ? -Infinity : parsed
 }
 
-// Most recently modified first, so the spec just edited is the first one read.
-// Specs git knows nothing about sort last, keeping their original order — sort is
-// stable, and an unknown time should not outrank a known recent one.
 const byMostRecentlyModified = (a: TapSpecEntry, b: TapSpecEntry): number => {
   const left = modifiedAt(a)
   const right = modifiedAt(b)

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -710,6 +710,35 @@ describe('lib/exec/tap', () => {
       ])
     })
 
+    // The data layer returns specs in path order; an agent wants the one it just
+    // edited first. The two timestamp shapes both appear in practice — git's `%ci`
+    // (`-0500`) and, for a file git has no commit for, a dayjs ctime (`-05:00`) —
+    // and offsets differ, so they are compared as instants rather than as text.
+    it('orders specs most recently modified first, listing specs git knows nothing about last', async () => {
+      mockLiveResolved(liveInstance())
+      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+        currentProject: { specs: [
+          { relative: 'cypress/e2e/older.cy.ts', gitInfo: { lastModifiedTimestamp: '2026-07-20 09:00:00 -0500' } },
+          { relative: 'cypress/e2e/untracked-first.cy.ts', gitInfo: null },
+          // 09:30 -0500 is 14:30Z — later than the 15:00 +0200 (13:00Z) below,
+          // which text ordering would get backwards.
+          { relative: 'cypress/e2e/newest.cy.ts', gitInfo: { lastModifiedTimestamp: '2026-07-24 09:30:00 -05:00' } },
+          { relative: 'cypress/e2e/untracked-second.cy.ts', gitInfo: null },
+          { relative: 'cypress/e2e/middle.cy.ts', gitInfo: { lastModifiedTimestamp: '2026-07-24 15:00:00 +0200' } },
+        ] },
+      })
+
+      expect(await tap.start(['specs'], { json: true })).toBe(0)
+
+      expect(JSON.parse(logger.print()).map((spec: { relativePath: string }) => spec.relativePath)).toEqual([
+        'cypress/e2e/newest.cy.ts',
+        'cypress/e2e/middle.cy.ts',
+        'cypress/e2e/older.cy.ts',
+        'cypress/e2e/untracked-first.cy.ts',
+        'cypress/e2e/untracked-second.cy.ts',
+      ])
+    })
+
     it('lists specs even when the instance has no browser attached', async () => {
       mockLiveResolved(liveInstance({ cdpBrowserWsUrl: null }))
       vi.mocked(queryInstanceGraphql).mockResolvedValue({
@@ -770,10 +799,11 @@ describe('lib/exec/tap', () => {
       })
 
       expect(await tap.start(['specs'], { json: true })).toBe(0)
-      // Non-string git fields are dropped, not rendered as junk.
+      // Non-string git fields are dropped, not rendered as junk — which leaves the
+      // entry with no usable time, so it orders after the one that has one.
       expect(JSON.parse(logger.print())).toEqual([
-        { relativePath: 'cypress/e2e/no-git.cy.ts' },
         { relativePath: 'cypress/e2e/ok.cy.ts', lastModified: 'yesterday', lastModifiedTimestamp: '2026-07-23 10:00:00 -0500' },
+        { relativePath: 'cypress/e2e/no-git.cy.ts' },
       ])
     })
 
@@ -1088,7 +1118,7 @@ describe('lib/exec/tap', () => {
           status [options]                report where a running Cypress instance is
                                           in its lifecycle
           specs [options]                 list the specs the running Cypress instance
-                                          can run
+                                          can run, most recently modified first
           run [options] <spec>            run (or rerun) a spec by its
                                           project-relative path
           dom [options] [selector]        read the app-under-test DOM as HTML: the

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -214,9 +214,7 @@ passed, failed.`,
 const specsMeta = {
   name: 'specs',
   description: 'list the specs the running Cypress instance can run, most recently modified first',
-  details: `Lists the specs the running Cypress instance can run, ordered by last modified
-with the most recent first, so a spec you just edited is at the top. Specs with no
-git information are listed last. To find other testing types you must open a new
+  details: `Lists the specs the connected Cypress instance can run, in descending order by last modified. To find other testing types you must open a new
 cypress instance with that testing type specified.`,
 } as const satisfies TapNativeCommandSchema
 

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -213,8 +213,11 @@ passed, failed.`,
 
 const specsMeta = {
   name: 'specs',
-  description: 'list the specs the running Cypress instance can run',
-  details: `Lists the specs the running Cypress instance can run. To find other testing types you must open a new cypress instance with that testing type specified.`,
+  description: 'list the specs the running Cypress instance can run, most recently modified first',
+  details: `Lists the specs the running Cypress instance can run, ordered by last modified
+with the most recent first, so a spec you just edited is at the top. Specs with no
+git information are listed last. To find other testing types you must open a new
+cypress instance with that testing type specified.`,
 } as const satisfies TapNativeCommandSchema
 
 const domMeta = {


### PR DESCRIPTION
- Closes [AW-38](https://cypress-io.atlassian.net/browse/AW-38)

### Additional details

`cypress tap specs` rendered whatever order the data layer returned, which is path order — the `TapSpecs` GraphQL query asks for no ordering and nothing sorted the result. So the spec an agent just edited landed wherever its path happened to fall.

The git timestamp was already travelling with every entry (`lastModifiedTimestamp`), so this sorts on it rather than adding a query or a round trip.

One wrinkle worth knowing about: that field arrives in **two** shapes, from two different code paths in `GitDataSource`:

| source | shape | example |
|---|---|---|
| git `%ci`, for a tracked file (`GitDataSource.ts:351`) | no colon in the offset | `2026-07-24 09:00:00 -0500` |
| dayjs-formatted ctime, for a file git has no commit for (`:329`, `:338`) | colon in the offset | `2026-07-24 09:00:00 -05:00` |

Offsets differ between entries too, so ordering these as **text** gets instants backwards — `09:30 -05:00` (14:30Z) sorts before `15:00 +0200` (13:00Z) as strings but is actually later. They're parsed and compared as instants; `Date.parse` reads both shapes identically (verified). A unit test pins exactly that pair.

Specs with no usable time sort **last**, keeping their original order (the sort is stable) — an unknown time shouldn't outrank a known recent one. That covers both a `noGitInfo` spec and one whose git fields arrived non-string and got dropped by the existing guard.

No new flag: the ticket asks only for the default ordering, and [AW-36](https://cypress-io.atlassian.net/browse/AW-36) is reworking the tap flag surface, so an escape hatch now would likely be renamed a week later. Easy to add if wanted — see the open question below.

### Steps to test

Validated live against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) through a real `cypress open` instance (27 specs).

```bash
node cli/bin/cypress tap specs
```

**Before** — path order; the file I'd touched 13 hours earlier is sixth, behind four two-week-old specs:

```
SPECS (27)
  cypress/e2e/actions-solved.cy.js                          14 days ago
  cypress/e2e/all-commands.cy.js                            7 days ago
  cypress/e2e/iframe.cy.js                                  14 days ago
  cypress/e2e/large-string.cy.js                            14 days ago
  cypress/e2e/live-specs-demo.cy.js                         11 days ago
  cypress/e2e/load-error.cy.js                              13 hours ago
  cypress/e2e/sanity.cy.js                                  14 days ago
  cypress/e2e/1-getting-started/todo.cy.js                  2 months ago
  cypress/e2e/2-advanced-examples/actions.cy.js             7 days ago
  cypress/e2e/2-advanced-examples/aliasing.cy.js            4 years, 2 months ago
```

**After** — most recently modified first:

```
SPECS (27)
  cypress/e2e/load-error.cy.js                              13 hours ago
  cypress/e2e/2-advanced-examples/actions.cy.js             7 days ago
  cypress/e2e/all-commands.cy.js                            7 days ago
  cypress/e2e/live-specs-demo.cy.js                         11 days ago
  cypress/e2e/actions-solved.cy.js                          14 days ago
  cypress/e2e/sanity.cy.js                                  14 days ago
  cypress/e2e/large-string.cy.js                            14 days ago
  cypress/e2e/iframe.cy.js                                  14 days ago
  cypress/e2e/2-advanced-examples/waiting.cy.js             2 months ago
  cypress/e2e/1-getting-started/todo.cy.js                  2 months ago
  cypress/e2e/2-advanced-examples/navigation.cy.js          3 months ago
  cypress/e2e/2-advanced-examples/utilities.cy.js           5 months ago
  cypress/e2e/2-advanced-examples/connectors.cy.js          2 years, 3 months ago
  ...
```

Checked mechanically rather than by eye — parsed every `lastModifiedTimestamp` from `--json` and asserted the sequence:

```
$ node cli/bin/cypress tap specs --json | <parse and check>
total=27 with-timestamp=27 without=0
descending: True
all no-git-info entries at the end: True
```

Ordering is documented in the command help, per the acceptance:

```
$ node cli/bin/cypress tap specs --help
Usage: cypress tap specs [options]

Lists the specs the running Cypress instance can run, ordered by last modified
with the most recent first, so a spec you just edited is at the top. Specs with no
git information are listed last. To find other testing types you must open a new
cypress instance with that testing type specified.
```

### Acceptance

| Ticket bullet | |
|---|---|
| Default ordering is most-recently-modified first | ✅ verified live across 27 specs, strictly descending |
| Ordering is documented in the command help | ✅ `description` + `details` (help output above) |

**One open question:** this changes the default output order, so anything already scripted against `tap specs` was implicitly getting path order. The ticket says "*default* ordering", which hints at alternatives but only requires the default — so there's no `--sort` flag here. Happy to add one if you'd rather have the escape hatch now; it's additive either way.

### How has the user experience changed?

`cypress tap specs` now lists most-recently-modified first instead of by path, so the spec you just edited is the first line rather than buried — the point of the ticket. Entry fields are unchanged; only the order differs, plus the help text now states it. `--json` gets the same order. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- new ordering case (mixed offsets + no-git-info-last); an existing case's expected order updated where a dropped-git-fields entry now sorts last; help snapshot updated -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-38]: https://cypress-io.atlassian.net/browse/AW-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AW-36]: https://cypress-io.atlassian.net/browse/AW-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only ordering change on existing fields; no auth, GraphQL, or runtime behavior changes beyond output order.
> 
> **Overview**
> **`cypress tap specs`** now returns specs **most recently modified first** (human and `--json` output), using the existing `lastModifiedTimestamp` field instead of the data layer’s path order.
> 
> Sorting parses timestamps as **instants** via `Date.parse` so mixed git `%ci` and dayjs offset formats compare correctly. Entries with no usable timestamp sort **last**, with stable ordering among ties.
> 
> Help text in **`tap-contract.ts`** and the CLI help snapshot state the new default order. Tests cover mixed offsets, untracked specs, and entries that drop invalid git fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c5ee058d2a8991cdea66bd76665cb4158c9e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->