### PR TITLE
chore: quote mocha --fgrep for multi-word POSIX filters

### DIFF
--- a/packages/server/test/scripts/run.js
+++ b/packages/server/test/scripts/run.js
@@ -102,7 +102,11 @@ if (!isWindows()) {
 if (options.fgrep) {
   commandAndArguments.args.push(
     '--fgrep',
-    options.fgrep,
+    // Shell-joined below. On POSIX, quote so multi-word filters stay one mocha
+    // arg. On Windows (cmd.exe + shell:true), quotes pass through literally.
+    isWindows()
+      ? options.fgrep
+      : `'${String(options.fgrep).replace(/'/g, `'\\''`)}'`,
   )
 }
 

--- a/system-tests/scripts/run.js
+++ b/system-tests/scripts/run.js
@@ -108,7 +108,11 @@ if (!isWindows()) {
 if (options.fgrep) {
   commandAndArguments.args.push(
     '--fgrep',
-    options.fgrep,
+    // Shell-joined below. On POSIX, quote so multi-word filters stay one mocha
+    // arg. On Windows (cmd.exe + shell:true), quotes pass through literally.
+    isWindows()
+      ? options.fgrep
+      : `'${String(options.fgrep).replace(/'/g, `'\\''`)}'`,
   )
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Closes N/A (drive-by tooling fix pulled out of #34482 per review)

### Additional details
The server and system-tests mocha runners join argv into a shell string (`shell: true`). Multi-word `--fgrep` values were split across args on POSIX, so filters like `--fgrep "foo bar"` never matched.

This quotes the fgrep value for POSIX shells (with single-quote escaping), and leaves it unquoted on Windows where `cmd.exe` would pass the quotes through literally to mocha.

Pulled out of #34482 so that PR stays scoped to CDP `resourceType` propagation.

### Steps to test
```bash
# POSIX: multi-word fgrep should match
yarn workspace @packages/server test-unit -- --fgrep 'some multi word title'

# Confirm single-word still works
yarn workspace @packages/server test-unit -- --fgrep 'CalculateCredentialLevel'
```

### How has the user experience changed?
No change for end users. Local/dev `--fgrep` filtering with multi-word titles works on POSIX; Windows behavior unchanged from before.

### PR Tasks
- [na] Is there an associated issue with maintainer approval for PR submission? — mechanical test-runner quoting fix; requested in #34482 review
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71ff3831-38be-4c8d-b951-8a17e6f354fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71ff3831-38be-4c8d-b951-8a17e6f354fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

