### PR TITLE
fix: keep a suite's own case in the tap spec overview

### DIFF
--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -359,11 +359,13 @@ const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[]
 }
 
 // The app reporter renders each suite as its own section headed by the full
-// suite path — depth shows in the breadcrumb, not in indentation — styled here
-// like the single-test view's hook section titles. The wire shape is already
-// flattened that way: one entry per suite with direct tests, title pre-joined.
+// suite path — depth shows in the breadcrumb, not in indentation. The wire shape
+// is already flattened that way: one entry per suite with direct tests, title
+// pre-joined. Titles keep the case the spec wrote them in, so they can be pasted
+// into a case-sensitive search; only the hook sections are upper-cased, since
+// those names are ours rather than the author's.
 const specSuiteSections = (suites: TapReporterSuite[]): string[][] => {
-  return suites.map((suite) => [heading(suite.title.toUpperCase()), ...renderSpecTests(suite.tests, '  ')])
+  return suites.map((suite) => [heading(suite.title), ...renderSpecTests(suite.tests, '  ')])
 }
 
 export const renderReporterSpecHuman = (view: TapReporterSpecView): string => {

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -176,16 +176,18 @@ describe('lib/tap/render/reporter spec overview', () => {
       spec: 'cypress/e2e/actions.cy.js',
       stats: { passed: 2, failed: 1, pending: 1, skipped: 1, duration: 17400 },
       tests: [{ id: 't1', title: 'root test', state: 'passed', duration: 20 }],
+      // Mixed-case titles on purpose: a section head keeps the case the spec
+      // wrote, so it can be pasted into a case-sensitive search.
       suites: [
         {
-          title: 'A',
+          title: 'Actions',
           tests: [
             { id: 't2', title: 'a1', state: 'passed', duration: 10 },
             { id: 't4', title: 'a2', state: 'pending' },
           ],
         },
         {
-          title: 'A > B',
+          title: 'Actions > .type()',
           tests: [{
             id: 't3',
             title: 'b1',
@@ -199,7 +201,7 @@ describe('lib/tap/render/reporter spec overview', () => {
             ],
           }],
         },
-        { title: 'C', tests: [{ id: 't5', title: 'c1', state: 'skipped' }] },
+        { title: 'Cookies', tests: [{ id: 't5', title: 'c1', state: 'skipped' }] },
       ],
     }
 
@@ -209,17 +211,17 @@ describe('lib/tap/render/reporter spec overview', () => {
 
          t1  ✓ root test  20ms
 
-      A
+      Actions
          t2  ✓ a1  10ms
          t4  ○ a2
 
-      A > B
+      Actions > .type()
          t3  ✖ b1  30ms  (2 retries)
                ✖ attempt 1  4.5s
                ✖ attempt 2  4.4s
                ✖ attempt 3  30ms
 
-      C
+      Cookies
          t5  - c1"
     `)
   })


### PR DESCRIPTION
- Closes [AW-91](https://cypress-io.atlassian.net/browse/AW-91)

> **Stacked on [#34486](https://github.com/cypress-io/cypress/pull/34486)** (AW-90). Both touch `render/reporter.ts` and its inline snapshot, so this is based on that branch to keep the snapshot from conflicting. Review/merge that one first; this diff is the two files below.

### Additional details

`specSuiteSections` upper-cased each suite's title, so a `describe`/`context` name came back shouting and no longer matched what the spec wrote — you couldn't paste it into a case-sensitive search, or match it against how the Cloud shows it.

The tell was that the *same command* already printed the title in its original case on the single-test header line (`✓ Aliasing > .as() - …`) while shouting it as a section head (`ALIASING`).

Hook section heads keep their upper-casing, per the ticket: `BEFORE EACH` / `TEST BODY` are names **we** generate, not the author's text. After this change exactly one `toUpperCase()` remains in `cli/lib/tap/**`, and it's that one.

### Steps to test

Validated live against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) through a real `cypress open` instance.

```bash
node cli/bin/cypress tap run "cypress/e2e/2-advanced-examples/aliasing.cy.js"
node cli/bin/cypress tap reporter
```

**Before:**

```
cypress/e2e/2-advanced-examples/aliasing.cy.js
✓ 2  ✖ --  ○ --  670ms

ALIASING
   r3  ✓ .as() - alias a DOM element for later use  182ms
   r4  ✓ .as() - alias a route for later use  458ms
```

**After** — the section head now matches the `context('Aliasing', …)` the spec wrote:

```
cypress/e2e/2-advanced-examples/aliasing.cy.js
✓ 2  ✖ --  ○ --  670ms

Aliasing
   r3  ✓ .as() - alias a DOM element for later use  182ms
   r4  ✓ .as() - alias a route for later use  458ms
```

A title with richer casing and punctuation shows it better — `tap run "cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js"`, which was `SPIES, STUBS, AND CLOCK`:

```
cypress/e2e/2-advanced-examples/spies_stubs_clocks.cy.js
✓ 7  ✖ --  ○ --  00:03

Spies, Stubs, and Clock
   r3  ✓ cy.spy() - wrap a method in a spy  94ms
   r4  ✓ cy.spy() retries until assertions pass  2.5s
   r5  ✓ cy.stub() - create a stub and/or replace a function with stub  50ms
   r6  ✓ cy.clock() - control time in the browser  135ms
   r7  ✓ cy.tick() - move time in the browser  201ms
   r8  ✓ cy.stub() matches depending on arguments  11ms
   r9  ✓ matches call arguments using Sinon matchers  14ms
```

Hook sections are untouched — `tap reporter --test r3`:

```
✓ Aliasing > .as() - alias a DOM element for later use  passed

BEFORE EACH · h1
   1  visit  http://localhost:8080/commands/aliasing

TEST BODY · r3
   1  get      .as-table
   2  find     tbody>tr
```

### A coverage gap this exposed

The spec-view fixture used suite titles `'A'`, `'A > B'` and `'C'` — all single upper-case letters, so `.toUpperCase()` was a **no-op** and the whole test suite passed unchanged after removing it. Nothing covered the casing. The fixture titles are now mixed-case (`'Actions'`, `'Actions > .type()'`, `'Cookies'`), so the snapshot actually pins this behavior and a future re-introduction would fail.

### How has the user experience changed?

Suite section heads in `cypress tap reporter` (the spec overview) read in the case the spec wrote them — `Spies, Stubs, and Clock` rather than `SPIES, STUBS, AND CLOCK` — so they can be copied into a case-sensitive search or a chat message, and they match the Cloud. Hook heads (`BEFORE EACH`, `TEST BODY`) are unchanged. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- fixture titles made mixed-case so the snapshot actually covers the casing, which it previously could not -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-91]: https://cypress-io.atlassian.net/browse/AW-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI display-only change in tap reporter output with updated snapshots; no auth, data, or runtime test behavior impact.
> 
> **Overview**
> **Suite section headings** in `cypress tap reporter` spec overview no longer force titles to uppercase. They now match the case from the spec (`describe`/`context`), so names can be copied into case-sensitive searches and align with Cloud.
> 
> **Hook section headings** (`BEFORE EACH`, `TEST BODY`) still use upper-casing; only Cypress-generated labels are affected.
> 
> Tests now use mixed-case suite titles (`Actions`, `Actions > .type()`, `Cookies`) so the inline snapshot actually guards against re-adding `.toUpperCase()` on suite titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d234b80bd9c9cbd1550e5a7dc5dc95dbc0f3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->