### PR TITLE
fix: exit 0 when tap prints help for a bare invocation

### DIFF
--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -91,11 +91,11 @@ const execCommand = async (session: TapSession, command: string, commandArgs: Re
 // With no instance to query, fall back to the schema this CLI ships with so the
 // help listing still reflects every command the CLI knows — the query path stays
 // authoritative when an instance is attached (it may run a different version).
-const renderKnownSchema = (command: string | undefined, wantsHelp: boolean): number => {
+const renderKnownSchema = (command: string | undefined): number => {
   const schema = buildTapSchema(util.pkgVersion())
   const program = buildTapProgram(schema, () => {})
 
-  return renderStaticHelp(program, schema, command, wantsHelp)
+  return renderStaticHelp(program, schema, command)
 }
 
 const tapModule = {
@@ -122,7 +122,7 @@ const tapModule = {
         })
 
         if (wantsHelp || !command) {
-          return renderSchemaHelp(program, schema, selection, command, wantsHelp)
+          return renderSchemaHelp(program, schema, selection, command)
         }
 
         try {
@@ -140,7 +140,7 @@ const tapModule = {
     } catch (err: any) {
       if (err instanceof CypressInstanceError) {
         if (wantsHelp || !command) {
-          return renderKnownSchema(command, wantsHelp)
+          return renderKnownSchema(command)
         }
 
         debug('tap %s failed: %s %s', command || '(help)', err.code, err.message)

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -59,8 +59,6 @@ const instanceBanner = (schema: TapSchema, selection: InstanceSelection): string
   return target
 }
 
-// Printing help is a successful outcome however it was asked for, so a bare
-// `tap` exits 0 like `tap --help` does. An unknown command still fails below.
 const renderHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, banner?: string): number => {
   const prefix = banner ? `${banner}\n\n` : ''
 

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -59,7 +59,9 @@ const instanceBanner = (schema: TapSchema, selection: InstanceSelection): string
   return target
 }
 
-const renderHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, wantsHelp: boolean, banner?: string): number => {
+// Printing help is a successful outcome however it was asked for, so a bare
+// `tap` exits 0 like `tap --help` does. An unknown command still fails below.
+const renderHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, banner?: string): number => {
   const prefix = banner ? `${banner}\n\n` : ''
 
   if (command) {
@@ -87,13 +89,13 @@ const renderHelp = (program: commander.Command, schema: TapSchema, command: stri
 
   logger.always(`${prefix}${program.helpInformation()}`)
 
-  return wantsHelp ? 0 : 1
+  return 0
 }
 
-export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: InstanceSelection, command: string | undefined, wantsHelp: boolean): number => {
-  return renderHelp(program, schema, command, wantsHelp, instanceBanner(schema, selection))
+export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: InstanceSelection, command: string | undefined): number => {
+  return renderHelp(program, schema, command, instanceBanner(schema, selection))
 }
 
-export const renderStaticHelp = (program: commander.Command, schema: TapSchema, command: string | undefined, wantsHelp: boolean): number => {
-  return renderHelp(program, schema, command, wantsHelp)
+export const renderStaticHelp = (program: commander.Command, schema: TapSchema, command: string | undefined): number => {
+  return renderHelp(program, schema, command)
 }

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -285,13 +285,26 @@ describe('lib/exec/tap', () => {
   })
 
   describe('help', () => {
-    it('prints the schema-derived overview for a bare invocation and exits 1', async () => {
+    it('prints the schema-derived overview for a bare invocation and exits 0', async () => {
       mockSession()
 
-      expect(await tap.start([], {})).toBe(1)
+      expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
       expect(logger.print()).toContain('health')
       expect(logger.print()).toContain('fake-command-for-testing [options] <spec>')
+    })
+
+    // A bare invocation and --help print the same help, so they answer the same.
+    it('answers a bare invocation exactly as it answers --help', async () => {
+      mockSession()
+      const bareCode = await tap.start([], {})
+      const bareOutput = logger.print()
+
+      logger.reset()
+      mockSession()
+
+      expect(await tap.start(['--help'], {})).toBe(bareCode)
+      expect(logger.print()).toBe(bareOutput)
     })
 
     it('prints the overview and exits 0 for an explicit --help', async () => {
@@ -1157,10 +1170,10 @@ describe('lib/exec/tap', () => {
       `)
     })
 
-    it('falls back to generic help (exit 1) for a bare invocation with no instance found', async () => {
+    it('falls back to generic help (exit 0) for a bare invocation with no instance found', async () => {
       failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
 
-      expect(await tap.start([], {})).toBe(1)
+      expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
     })
 
@@ -1188,10 +1201,10 @@ describe('lib/exec/tap', () => {
       expect(logger.print()).not.toContain('STALE_INSTANCE')
     })
 
-    it('falls back to generic help (exit 1) for a bare invocation when an instance is up but has no browser', async () => {
+    it('falls back to generic help (exit 0) for a bare invocation when an instance is up but has no browser', async () => {
       failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
 
-      expect(await tap.start([], {})).toBe(1)
+      expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
       expect(logger.print()).not.toContain('NO_BROWSER_ATTACHED')
     })


### PR DESCRIPTION
- Closes [AW-94](https://cypress-io.atlassian.net/browse/AW-94)

### Additional details

`cypress tap` and `cypress tap --help` print **byte-identical** help — 2345 bytes, verified with `diff` — but the bare form exited 1. An agent or CI step that ran tap with no arguments read a failure where the CLI had done exactly what was asked.

One line produced it, at the general-help path in `cli/lib/tap/output.ts`:

```ts
return wantsHelp ? 0 : 1
```

That now returns `0`. Printing help is a successful outcome however it was reached.

**An unknown command still fails.** That's a different branch of the same function — it renders `UNKNOWN_COMMAND` and returns 1 before reaching the line above — so this change can't turn a usage error into a success. Verified both live (below) and by the existing tests.

With the two forms no longer distinguishable, `wantsHelp` carried no information for `renderHelp`/`renderSchemaHelp`/`renderStaticHelp` and is gone from them. The callers still use it, to decide whether help is the thing to render at all.

The ticket said the exit code "should be evaluated and potentially changed to 0". Evaluated: 0 is right, because the output is identical to the `--help` that already exits 0, and because the alternative (treating no-args as a usage error) would mean the same bytes on stdout mean two different things depending on argv — exactly what confuses a CI agent.

### Steps to test

Validated live against a real `cypress open` instance on [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink), covering both the instance-attached path (`renderSchemaHelp`) and the offline fallback (`renderStaticHelp`), since the discrepancy existed in both.

**Before:**

```
exit=1  | bare 'tap' (instance attached)          first line: Target:
exit=0  | 'tap --help' (instance attached)        first line: Target:
exit=1  | bare 'tap' (no instance)                first line: Usage: cypress tap [command] [args...] [options]
exit=0  | 'tap --help' (no instance)              first line: Usage: cypress tap [command] [args...] [options]
exit=0  | 'tap status --help'                     first line: Usage: cypress tap status [options]
```

**After** — every help path agrees:

```
exit=0  | bare 'tap' (instance attached)          first line: Target:
exit=0  | 'tap --help' (instance attached)        first line: Target:
exit=0  | bare 'tap' (no instance)                first line: Usage: cypress tap [command] [args...] [options]
exit=0  | 'tap --help' (no instance)              first line: Usage: cypress tap [command] [args...] [options]
exit=0  | 'tap status --help'                     first line: Usage: cypress tap status [options]
```

And the failure paths that must stay non-zero, confirmed unchanged:

```
exit=1  | unknown command (instance attached)   error: unknown command 'not-a-command'. See 'cypress tap --help'.
exit=1  | unknown command (offline)             NO_INSTANCE: No Cypress instance found with pid 999999. …
exit=0  | real command, no instance             ● not connected      ← unchanged; status reports lifecycle, never fails
```

The premise, checked rather than assumed:

```
$ node cli/bin/cypress tap      > /tmp/bare.txt; echo $?   # 0
$ node cli/bin/cypress tap --help > /tmp/help.txt; echo $?  # 0
$ diff /tmp/bare.txt /tmp/help.txt && echo identical
OUTPUT: byte-identical (2345 bytes)
```

### Tests

Three existing tests asserted the old exit 1 for a bare invocation (one on the schema path, two on the offline fallbacks) and now assert 0. Added one that pins the actual invariant rather than the constant — that a bare invocation answers with the same code *and* the same bytes as `--help` — so this can't drift apart again:

```ts
it('answers a bare invocation exactly as it answers --help', …)
```

748 unit tests pass; lint and type-check clean.

### How has the user experience changed?

`cypress tap` with no arguments prints the same help it always did, and now exits 0 instead of 1 — so a script or agent that probes tap without arguments no longer sees a spurious failure. `cypress tap <unknown>` still exits 1. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- three exit-code assertions updated; one added pinning bare == --help in both code and output -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI exit-code behavior only for help display paths; real commands and unknown-command failures are unchanged.
> 
> **Overview**
> **`cypress tap` with no arguments now exits 0** after printing the same overview help as `cypress tap --help`, instead of exiting 1 while showing identical output.
> 
> In `cli/lib/tap/output.ts`, the general-help path no longer uses `wantsHelp` to choose exit code (`return wantsHelp ? 0 : 1` → always `0`). **`wantsHelp` was removed** from `renderHelp`, `renderSchemaHelp`, and `renderStaticHelp`; callers still use it only to decide when to render help (`wantsHelp || !command`). **Unknown subcommands still exit 1** via the existing `UNKNOWN_COMMAND` branch.
> 
> Tests were updated for exit 0 on bare invocation (with and without a Cypress instance), and a new test asserts bare invocation matches `--help` in both exit code and printed output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa440e19b507b514ef361ed603fa95c3c92b9c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[AW-94]: https://cypress-io.atlassian.net/browse/AW-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ