### PR TITLE
fix: count attempts instead of retries in the tap spec overview

### DIFF
--- a/cli/lib/tap/render/reporter.ts
+++ b/cli/lib/tap/render/reporter.ts
@@ -345,10 +345,11 @@ const testDuration = (duration: number | undefined): string => {
 
 const renderSpecTests = (tests: TapReporterSpecTest[], indent: string): string[] => {
   return tests.flatMap((test) => {
-    const retries = test.retries ? `  ${color.aborted(`(${test.retries} ${test.retries === 1 ? 'retry' : 'retries'})`)}` : ''
+    // Only a retried test carries attempts, so the count is always 2 or more.
+    const attempts = test.attempts?.length ? `  ${color.aborted(`(${test.attempts.length} attempts)`)}` : ''
 
     return [
-      `${indent}${chalk.dim(test.id.padStart(3))}  ${stateBadge[test.state].icon} ${test.title}${testDuration(test.duration)}${retries}`,
+      `${indent}${chalk.dim(test.id.padStart(3))}  ${stateBadge[test.state].icon} ${test.title}${testDuration(test.duration)}${attempts}`,
       // Nested under the title, the way the app reporter lists a retried
       // test's attempts; the id column stays empty so the rows read as one test.
       ...(test.attempts ?? []).map((attempt) => {

--- a/cli/test/lib/tap/render-reporter.spec.ts
+++ b/cli/test/lib/tap/render-reporter.spec.ts
@@ -193,7 +193,6 @@ describe('lib/tap/render/reporter spec overview', () => {
             title: 'b1',
             state: 'failed',
             duration: 30,
-            retries: 2,
             attempts: [
               { attempt: 1, state: 'failed', duration: 4476 },
               { attempt: 2, state: 'failed', duration: 4400 },
@@ -216,7 +215,7 @@ describe('lib/tap/render/reporter spec overview', () => {
          t4  ○ a2
 
       Actions > .type()
-         t3  ✖ b1  30ms  (2 retries)
+         t3  ✖ b1  30ms  (3 attempts)
                ✖ attempt 1  4.5s
                ✖ attempt 2  4.4s
                ✖ attempt 3  30ms

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -171,10 +171,9 @@ describe('tap binding', () => {
       expect(tests).to.have.length.greaterThan(0)
 
       for (const test of tests) {
-        expect(Object.keys(test), `entry ${test.id}`).to.deep.eq(['id', 'title', 'state', 'duration', 'retries'])
+        expect(Object.keys(test), `entry ${test.id}`).to.deep.eq(['id', 'title', 'state', 'duration'])
         expect(test.state).to.eq('passed')
         expect(test.duration).to.be.a('number')
-        expect(test.retries).to.eq(0)
       }
 
       const testId = tests[0].id as string
@@ -265,7 +264,7 @@ describe('tap binding with a retrying spec', () => {
 
       // One retry was taken, so two attempts exist — the overview reports both.
       expect(tests[0].state).to.eq('passed')
-      expect(tests[0].retries).to.eq(1)
+      expect(tests[0].attempts).to.have.length(2)
       expect(tests[0].attempts.map((attempt: Record<string, unknown>) => attempt.state)).to.deep.eq(['failed', 'passed'])
 
       const latest = await reporterResult(binding, { test: testId })

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -340,7 +340,6 @@ describe('tap/commands/reporter', () => {
                 title: 'b1',
                 state: 'failed',
                 duration: 30,
-                retries: 2,
                 attempts: [
                   { attempt: 1, state: 'failed', duration: 12 },
                   { attempt: 2, state: 'failed', duration: 18 },

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -549,7 +549,6 @@ const serializeSpecTest = (test: SerializedTest, runComplete: boolean): TapRepor
     title: test.title,
     state: test.state ?? unreachedState(runComplete),
     duration: test.duration,
-    retries: test.currentRetry,
     attempts: serializeSpecAttempts(test, runComplete),
   })
 }

--- a/packages/cypress-instances/lib/contracts/reporter.ts
+++ b/packages/cypress-instances/lib/contracts/reporter.ts
@@ -178,9 +178,10 @@ export interface TapReporterSpecTest {
   state: 'passed' | 'failed' | 'pending' | 'skipped'
   /** Wall-clock run time in ms; absent until the test has run. */
   duration?: number
-  /** Retries actually taken this run, not the configured maximum. */
-  retries?: number
-  /** Every attempt in run order, last one final; present only when the test was retried. */
+  /**
+   * Every attempt in run order, last one final; present only when the test was
+   * retried, so its length is the attempt count and is never 1.
+   */
   attempts?: TapReporterSpecAttempt[]
 }
 


### PR DESCRIPTION
- Closes [AW-93](https://cypress-io.atlassian.net/browse/AW-93)

> **Stacked on [#34496](https://github.com/cypress-io/cypress/pull/34496)** (AW-91) → [#34486](https://github.com/cypress-io/cypress/pull/34486) (AW-90). All three touch `render/reporter.ts` and its inline snapshot. Merge down the stack; this diff is the six files below.

### Additional details

A retried test was labelled `(2 retries)` while the rows immediately beneath it counted **three** attempts, so the reader had to add one to reconcile the label with the list right under it — the cognitive load the ticket describes.

The interesting part: a literal rename wasn't possible, and wasn't needed. The contract already carried **both** fields:

```ts
retries?: number
attempts?: TapReporterSpecAttempt[]
```

`attempts` is emitted only for a test that was actually retried (`serializeSpecAttempts` returns `undefined` below 2), so **its length already is the attempt count**. Confirmed against the live wire:

| test | `retries` | `attempts.length` |
|---|---|---|
| always fails, retried twice | 2 | 3 |
| retried once then passes | 1 | 2 |
| passes on the first attempt | 0 | *absent* |

`attempts.length === retries + 1`, always. So `retries` was redundant with a field that already had the better name, and it's **removed** rather than renamed — one reader (`render/reporter.ts`), one writer (`test-state.ts`), one contract line, two fixtures.

Two smaller consequences:

- The label only ever renders for 2+ attempts, so the `retry`/`retries` singular branch is gone — it's always "attempts".
- A test that ran once still gets no annotation, exactly as before (`attempts` absent → falsy length).

### Steps to test

Validated live against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) through a real `cypress open` instance. Kitchensink configures no retries, so I ran a throwaway spec with test-level `{ retries: 2 }` covering all three cases — retried-and-failed, retried-then-passed, and passed-first-time:

```js
context('Attempt labelling', () => {
  it('always fails, retried twice', { retries: 2 }, () => {
    expect(1).to.eq(2)
  })

  it('retried once then passes', { retries: 2 }, function () {
    if (this.test.currentRetry() < 1) {
      expect('first attempt').to.eq('fails')
    }
  })

  it('passes on the first attempt', () => {
    expect(1).to.eq(1)
  })
})
```

```bash
node cli/bin/cypress tap run "cypress/e2e/2-advanced-examples/tmp-attempts.cy.js"
node cli/bin/cypress tap reporter
```

**Before** — labels disagree with the rows they head:

```
cypress/e2e/2-advanced-examples/tmp-attempts.cy.js
✓ 2  ✖ 1  ○ --  150ms

Attempt labelling
   r3  ✖ always fails, retried twice  20ms  (2 retries)
         ✖ attempt 1  12ms
         ✖ attempt 2  16ms
         ✖ attempt 3  20ms
   r4  ✓ retried once then passes  6ms  (1 retry)
         ✖ attempt 1  7ms
         ✓ attempt 2  6ms
   r5  ✓ passes on the first attempt  5ms
```

**After** — the label is the count of the rows under it:

```
cypress/e2e/2-advanced-examples/tmp-attempts.cy.js
✓ 2  ✖ 1  ○ --  174ms

Attempt labelling
   r3  ✖ always fails, retried twice  14ms  (3 attempts)
         ✖ attempt 1  29ms
         ✖ attempt 2  16ms
         ✖ attempt 3  14ms
   r4  ✓ retried once then passes  7ms  (2 attempts)
         ✖ attempt 1  7ms
         ✓ attempt 2  7ms
   r5  ✓ passes on the first attempt  6ms
```

The wire drops the redundant field, and the count still comes through:

```
$ node cli/bin/cypress tap reporter --json
{'id': 'r3', 'state': 'failed', "'retries' still on wire": False, 'attempts_len': 3}
{'id': 'r4', 'state': 'passed', "'retries' still on wire": False, 'attempts_len': 2}
{'id': 'r5', 'state': 'passed', "'retries' still on wire": False, 'attempts_len': 0}
```

The word is gone from the tap surface entirely — this now returns nothing:

```bash
$ grep -rn "retries" cli/lib/tap packages/app/src/tap packages/cypress-instances/lib/contracts
(no matches)
```

### Review follow-up

Bugbot caught a real miss: `packages/app/cypress/e2e/tap-binding.cy.ts` still asserted the removed field — an exact-key list (`['id', 'title', 'state', 'duration', 'retries']`) on a non-retried test, plus `retries === 1` on the retried one. My sweep had covered `cli/lib/tap`, `packages/app/src/tap` and the contracts but not `packages/app/cypress/e2e`, and app-e2e hadn't run yet, so it would have gone red later.

Fixed in `9d9919f0` by pointing both at the replacement rather than deleting them — the key list drops `retries`, and the retried case asserts `attempts` has length 2, which is the number the label renders. So the e2e now covers the contract change instead of merely tolerating it.

### How has the user experience changed?

`cypress tap reporter` labels a retried test `(3 attempts)` rather than `(2 retries)`, so the number matches the attempt rows listed beneath it and the total failure count. A test that ran once is still unannotated. `--json` consumers lose the redundant `retries` field and read the count from `attempts.length`, which was already there. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- render snapshot now asserts (3 attempts); retries dropped from the CLI render fixture and the app CT expectation; the binding e2e now asserts attempts length -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-93]: https://cypress-io.atlassian.net/browse/AW-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tap reporter contract and CLI labeling change; breaking for JSON consumers that read `retries`, but `attempts` was already on the wire.
> 
> **Overview**
> Fixes a mismatch where the tap spec overview showed **(N retries)** while listing **N+1** attempt rows underneath.
> 
> The **`retries`** field is **removed** from `TapReporterSpecTest` serialization and the shared contract; retried tests already expose **`attempts`**, so the human label now uses **`attempts.length`** (e.g. **(3 attempts)**). Tests and binding e2e assert **`attempts`** instead of **`retries`**; **`--json`** consumers should use **`attempts.length`** when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fd9faad3527e6cc4e61dcba12f17d4b1247d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->