### PR TITLE
feat: take tap command arguments as flags, not positionals

### DIFF
--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -195,6 +195,6 @@ export const extractAria = async (
   }
 }
 
-export const ariaCommand = defineNativeCommand('aria', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractAria(session, frame, args.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
+export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
+  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'))
 }, 'aria'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -54,6 +54,6 @@ export const extractDom = async (
   }
 }
 
-export const domCommand = defineNativeCommand('dom', (options, args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractDom(session, frame, args.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
+export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
+  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'))
 }, 'dom'))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -125,6 +125,6 @@ export const extractInspect = async (
   }
 }
 
-export const inspectCommand = defineNativeCommand('inspect', (options, args) => withResolvedAutFrame(options, (session, frame) => {
-  return extractInspect(session, frame, args.selector)
+export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
+  return extractInspect(session, frame, commandOptions.selector)
 }, 'inspect'))

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -225,8 +225,8 @@ describe('lib/exec/tap', () => {
       const consoleProps = { name: 'request', type: 'command', props: { body: 'x'.repeat(2_000) } }
       const call = mockSession(buildTapSchema('15.0.0'), { result: { id: '1', consoleProps } })
 
-      expect(await tap.start(['command', '--test', 'r2', '--command', '1'], { json: true })).toBe(0)
-      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'test': 'r2', 'command': '1', 'json': 'true' }])
+      expect(await tap.start(['command', '--testId', 'r2', '--commandId', '1'], { json: true })).toBe(0)
+      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'testId': 'r2', 'commandId': '1', 'json': 'true' }])
       expect(JSON.parse(logger.print()).consoleProps).toEqual(consoleProps)
     })
 
@@ -241,8 +241,8 @@ describe('lib/exec/tap', () => {
       const commandView = { id: '1', name: 'visit', hook: { hookId: 'r2', hookName: 'test body' }, snapshots: [] }
       const call = mockSession(buildTapSchema('15.0.0'), { result: commandView })
 
-      expect(await tap.start(['command', '--test', 'r2', '--command', '1'], {})).toBe(0)
-      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { test: 'r2', command: '1' }])
+      expect(await tap.start(['command', '--testId', 'r2', '--commandId', '1'], {})).toBe(0)
+      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { testId: 'r2', commandId: '1' }])
     })
 
     it('resolves the target from --instance and the cwd, then opens a session against it', async () => {
@@ -1081,7 +1081,7 @@ describe('lib/exec/tap', () => {
     it('routes dom to the AUT-frame reader with the top-level options and returns its exit code', async () => {
       vi.mocked(withResolvedAutFrame).mockResolvedValue(0)
 
-      expect(await tap.start(['dom', '.foo'], { instance: 7 })).toBe(0)
+      expect(await tap.start(['dom', '--selector', '.foo'], { instance: 7 })).toBe(0)
 
       expect(withResolvedAutFrame).toHaveBeenCalledTimes(1)
       expect(vi.mocked(withResolvedAutFrame).mock.calls[0][0]).toEqual({ instance: 7 })
@@ -1109,7 +1109,7 @@ describe('lib/exec/tap', () => {
         return 0
       })
 
-      await tap.start(['dom', '.btn', '--max-chars', '50'], {})
+      await tap.start(['dom', '--selector', '.btn', '--max-chars', '50'], {})
 
       // selector and the coerced --max-chars reach the extractor as call arguments.
       expect(forwarded).toEqual([{ value: '.btn' }, { value: 50 }])
@@ -1117,7 +1117,7 @@ describe('lib/exec/tap', () => {
 
     it('rejects `inspect` with no selector, without reading the frame', async () => {
       expect(await tap.start(['inspect'], {})).toBe(1)
-      expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`missing required argument 'selector'`)
+      expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`required option '--selector <selector>' not specified`)
       expect(withResolvedAutFrame).not.toHaveBeenCalled()
     })
 
@@ -1206,40 +1206,35 @@ describe('lib/exec/tap', () => {
         Interacts with a running Cypress instance
 
         Options:
-          --instance <pid>                target a specific running Cypress instance by
-                                          its server process id (pid)
-          --json                          print the raw JSON result instead of the
-                                          human-readable rendering
-          -h, --help                      display help for command
+          --instance <pid>      target a specific running Cypress instance by its
+                                server process id (pid)
+          --json                print the raw JSON result instead of the human-readable
+                                rendering
+          -h, --help            display help for command
 
         Commands:
-          instances [options]             list the running Cypress instances this CLI
-                                          can reach
-          status [options]                report where a running Cypress instance is
-                                          in its lifecycle
-          specs [options]                 list the specs the running Cypress instance
-                                          can run, most recently modified first
-          run [options] <spec>            run (or rerun) a spec by its
-                                          project-relative path
-          dom [options] [selector]        read the app-under-test DOM as HTML: the
-                                          whole page, or each element matching a
-                                          selector (with its subtree)
-          aria [options] [selector]       read the accessibility (ARIA) tree of the
-                                          app-under-test frame, or the subtree at a
-                                          selector
-          inspect [options] <selector>    inspect the first element matching a
-                                          selector: its tag, attributes, computed
-                                          styles, box model, and accessibility node
-          command [options]               detail one command log entry of a test —
-                                          its reporter row, the DOM snapshots pinnable
-                                          on it, and its console properties
-          reporter [options]              render a test’s full reporter view — its
-                                          routes, hooks, and command log — or, without
-                                          --test, the spec-level overview: run stats
-                                          and every suite’s tests
-          pin [options] [test] [command]  pin a command’s DOM snapshot into the live
-                                          app-under-test frame so the dom/aria/inspect
-                                          commands can read it; pass --clear to release
+          instances [options]   list the running Cypress instances this CLI can reach
+          status [options]      report where a running Cypress instance is in its
+                                lifecycle
+          specs [options]       list the specs the running Cypress instance can run,
+                                most recently modified first
+          run [options] <spec>  run (or rerun) a spec by its project-relative path
+          dom [options]         read the app-under-test DOM as HTML: the whole page,
+                                or each element matching a selector (with its subtree)
+          aria [options]        read the accessibility (ARIA) tree of the
+                                app-under-test frame, or the subtree at a selector
+          inspect [options]     inspect the first element matching a selector: its
+                                tag, attributes, computed styles, box model, and
+                                accessibility node
+          command [options]     detail one command log entry of a test — its reporter
+                                row, the DOM snapshots pinnable on it, and its console
+                                properties
+          reporter [options]    render a test’s full reporter view — its routes,
+                                hooks, and command log — or, without --testId, the
+                                spec-level overview: run stats and every suite’s tests
+          pin [options]         pin a command’s DOM snapshot into the live
+                                app-under-test frame so the dom/aria/inspect commands
+                                can read it; pass --clear to release
         "
       `)
     })
@@ -1267,22 +1262,24 @@ describe('lib/exec/tap', () => {
         detail one command log entry of a test — its reporter row, the DOM snapshots pinnable on it, and its console properties
 
         Options:
-          --test <test>        test id, as listed by the reporter command
-          --command <command>  command id, as listed by the reporter command — a row
-                               number (test body first when duplicated), an e-prefixed
-                               event id, or hook-qualified like "h1:3"
-          --attempt <attempt>  1-based attempt (attempt 1 = first run); defaults to the
-                               latest
-          --depth <depth>      how many levels of nested console properties to expand
-                               before summarizing the rest as "{n keys}" / "[n items]":
-                               a number or "all" (default 3, and a section over 8 rows
-                               folds at any depth unless this is passed)
-          --instance <pid>     target a specific running Cypress instance by its server
-                               process id (pid)
-          --json               print the raw JSON result instead of the human-readable
-                               rendering — every console property in full, however
-                               long, rather than the long ones named by their length
-          -h, --help           display help for command
+          --testId <testId>        test id, as listed by the reporter command
+          --commandId <commandId>  command id, as listed by the reporter command — a
+                                   row number (test body first when duplicated), an
+                                   e-prefixed event id, or hook-qualified like "h1:3"
+          --attempt <attempt>      1-based attempt (attempt 1 = first run); defaults to
+                                   the latest
+          --depth <depth>          how many levels of nested console properties to
+                                   expand before summarizing the rest as "{n keys}" /
+                                   "[n items]": a number or "all" (default 3, and a
+                                   section over 8 rows folds at any depth unless this
+                                   is passed)
+          --instance <pid>         target a specific running Cypress instance by its
+                                   server process id (pid)
+          --json                   print the raw JSON result instead of the
+                                   human-readable rendering — every console property in
+                                   full, however long, rather than the long ones named
+                                   by their length
+          -h, --help               display help for command
         "
       `)
     })

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -198,26 +198,26 @@ describe('lib/tap/build-program', () => {
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
     const help = subcommand(program, 'reporter').helpInformation()
 
-    expect(help).toContain('--test <test>')
+    expect(help).toContain('--testId <testId>')
     expect(help).toContain('--attempt <attempt>')
 
-    program.parse(['reporter', '--test', 'r2', '--attempt', '1'], { from: 'user' })
+    program.parse(['reporter', '--testId', 'r2', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { test: 'r2', attempt: '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { testId: 'r2', attempt: '1' }, {})
   })
 
-  it('declares and forwards command --command from the shared contract', () => {
+  it('declares and forwards command --commandId from the shared contract', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
     const help = subcommand(program, 'command').helpInformation()
 
-    expect(help).toContain('--test <test>')
-    expect(help).toContain('--command <command>')
+    expect(help).toContain('--testId <testId>')
+    expect(help).toContain('--commandId <commandId>')
     expect(help).toContain('--attempt <attempt>')
 
-    program.parse(['command', '--test', 'r2', '--command', 'log-3', '--attempt', '1'], { from: 'user' })
+    program.parse(['command', '--testId', 'r2', '--commandId', 'log-3', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test': 'r2', 'command': 'log-3', 'attempt': '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'testId': 'r2', 'commandId': 'log-3', 'attempt': '1' }, {})
   })
 
   // `command` declares --json in its schema so the instance can be told, but the
@@ -228,7 +228,7 @@ describe('lib/tap/build-program', () => {
     const help = subcommand(program, 'command').helpInformation()
 
     expect(help.match(/--json/g)).toHaveLength(1)
-    expect(help).toContain('every console property in full')
+    expect(help.replace(/\s+/g, ' ')).toContain('every console property in full')
     expect(subcommand(program, 'reporter').helpInformation()).toContain('--json               print the raw JSON result')
   })
 
@@ -243,12 +243,12 @@ describe('lib/tap/build-program', () => {
     expect(help).toContain('--depth <depth>')
     expect(help).not.toContain('--path')
 
-    program.parse(['command', '--test', 'r2', '--command', '3', '--depth', '2'], { from: 'user' })
+    program.parse(['command', '--testId', 'r2', '--commandId', '3', '--depth', '2'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith(
       'command',
       {},
-      { test: 'r2', command: '3' },
+      { testId: 'r2', commandId: '3' },
       { depth: '2' },
     )
   })

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -100,7 +100,7 @@ describe('tap binding', () => {
       expect(names).to.include.members(['command', 'reporter', 'pin', 'run-state'])
       expect(names).not.to.include('console-props')
       // The two list subcommands folded into reporter: its spec overview lists
-      // the run's tests, and its --test view lists one test's command log.
+      // the run's tests, and its --testId view lists one test's command log.
       expect(names).not.to.include('tests')
       expect(names).not.to.include('commands')
 

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -39,7 +39,7 @@ const firstTestCommands = async (binding: TapBinding): Promise<{ testId: string,
   const tests = await specTests(binding)
   const testId = tests[0].id as string
 
-  return { testId, commands: await reporterCommands(binding, { test: testId }) }
+  return { testId, commands: await reporterCommands(binding, { testId }) }
 }
 
 const commandNamed = (commands: Array<Record<string, any>>, name: string): Record<string, any> => {
@@ -64,7 +64,7 @@ const leanEntries = async (binding: TapBinding, testId: string, rows: Array<Reco
   const entries: Array<Record<string, any>> = []
 
   for (const row of rows) {
-    const outcome = await binding.exec('command', {}, { test: testId, command: row.id as string })
+    const outcome = await binding.exec('command', {}, { testId, commandId: row.id as string })
 
     if (!('result' in outcome)) {
       throw new Error(`row ${row.id} is expected to resolve, got ${JSON.stringify(outcome)}`)
@@ -108,7 +108,7 @@ describe('tap binding', () => {
 
       expect((unknown as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')
 
-      const commandWithoutCommandId = await binding.exec('command', {}, { test: 'r1' })
+      const commandWithoutCommandId = await binding.exec('command', {}, { testId: 'r1' })
 
       expect((commandWithoutCommandId as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
 
@@ -117,11 +117,11 @@ describe('tap binding', () => {
 
       expect((specViewBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
-      const commandBeforeRun = await binding.exec('command', {}, { test: 'r1', command: '1' })
+      const commandBeforeRun = await binding.exec('command', {}, { testId: 'r1', commandId: '1' })
 
       expect((commandBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
-      const reporterBeforeRun = await binding.exec('reporter', {}, { test: 'r1' })
+      const reporterBeforeRun = await binding.exec('reporter', {}, { testId: 'r1' })
 
       expect((reporterBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
@@ -179,7 +179,7 @@ describe('tap binding', () => {
 
       const testId = tests[0].id as string
 
-      const view = await reporterResult(binding, { test: testId })
+      const view = await reporterResult(binding, { testId })
 
       expect(view.test).to.deep.eq({
         id: testId,
@@ -193,7 +193,7 @@ describe('tap binding', () => {
       expect(view.hooks).to.deep.eq([{ hookId: testId, hookName: 'test body' }])
       expect(view.error).to.be.undefined
 
-      const missingTest = await binding.exec('reporter', {}, { test: 'not-a-test' })
+      const missingTest = await binding.exec('reporter', {}, { testId: 'not-a-test' })
 
       expect((missingTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
@@ -210,11 +210,11 @@ describe('tap binding', () => {
         expect(Object.keys(entry), `command ${entry.id}`).to.satisfy(withinKeys(ENTRY_KEYS))
       }
 
-      const missingCommandTest = await binding.exec('command', {}, { test: 'not-a-test', command: commands[0].id as string })
+      const missingCommandTest = await binding.exec('command', {}, { testId: 'not-a-test', commandId: commands[0].id as string })
 
       expect((missingCommandTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
-      const missingSelectedCommand = await binding.exec('command', {}, { test: testId, command: 'not-a-command' })
+      const missingSelectedCommand = await binding.exec('command', {}, { testId, commandId: 'not-a-command' })
 
       expect((missingSelectedCommand as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
 
@@ -264,13 +264,13 @@ describe('tap binding with a retrying spec', () => {
       expect(tests[0].attempts).to.have.length(2)
       expect(tests[0].attempts.map((attempt: Record<string, unknown>) => attempt.state)).to.deep.eq(['failed', 'passed'])
 
-      const latest = await reporterResult(binding, { test: testId })
+      const latest = await reporterResult(binding, { testId })
 
       expect(latest.test.state).to.eq('passed')
       // The passing latest attempt has no error panel.
       expect(latest.error).to.be.undefined
 
-      const first = await reporterResult(binding, { test: testId, attempt: '1' })
+      const first = await reporterResult(binding, { testId, attempt: '1' })
 
       expect(first.test.id).to.eq(testId)
       expect(first.test.fullTitle).to.eq(latest.test.fullTitle)
@@ -278,11 +278,11 @@ describe('tap binding with a retrying spec', () => {
       expect(Object.keys(first.error)).to.satisfy(withinKeys(['name', 'message', 'stack', 'codeFrame']))
       expect(first.error.message).to.be.a('string')
 
-      const second = await reporterResult(binding, { test: testId, attempt: '2' })
+      const second = await reporterResult(binding, { testId, attempt: '2' })
 
       expect(second).to.deep.eq(latest)
 
-      const outOfRange = await binding.exec('reporter', {}, { test: testId, attempt: '3' })
+      const outOfRange = await binding.exec('reporter', {}, { testId, attempt: '3' })
 
       expect((outOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
 
@@ -301,8 +301,8 @@ describe('tap binding with a retrying spec', () => {
       expect(failedCommand, 'failed command from attempt 1').to.exist
 
       const firstAttemptCommand = await binding.exec('command', {}, {
-        test: testId,
-        command: failedCommand!.id as string,
+        testId,
+        commandId: failedCommand!.id as string,
         attempt: '1',
       })
 
@@ -315,7 +315,7 @@ describe('tap binding with a retrying spec', () => {
       // The console properties travel with the row, read from the same attempt.
       expect(entry.consoleProps).to.include({ name: failedCommand!.name, type: 'command' })
 
-      const attemptOutOfRange = await binding.exec('command', {}, { test: testId, command: failedCommand!.id as string, attempt: '3' })
+      const attemptOutOfRange = await binding.exec('command', {}, { testId, commandId: failedCommand!.id as string, attempt: '3' })
 
       expect((attemptOutOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
     })
@@ -344,7 +344,7 @@ describe('tap binding console properties', () => {
 
       expect(getToggle, 'the get #toggle command').to.exist
 
-      const selectedCommand = await binding.exec('command', {}, { test: testId, command: getToggle!.id as string })
+      const selectedCommand = await binding.exec('command', {}, { testId, commandId: getToggle!.id as string })
 
       const selected = (selectedCommand as { result: Record<string, unknown> }).result
 
@@ -372,7 +372,7 @@ describe('tap binding console properties', () => {
         expect(snapshot.timestamp).to.be.a('number')
       })
 
-      const missingCommand = await binding.exec('command', {}, { test: testId })
+      const missingCommand = await binding.exec('command', {}, { testId })
 
       expect((missingCommand as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
 
@@ -392,7 +392,7 @@ describe('tap binding console properties', () => {
 
       // A row the driver holds no details for still reports its row, with no
       // console properties on it.
-      const unavailable = await binding.exec('command', {}, { test: testId, command: emptyConsoleProps.id as string })
+      const unavailable = await binding.exec('command', {}, { testId, commandId: emptyConsoleProps.id as string })
       const withoutProps = (unavailable as { result: Record<string, unknown> }).result
 
       expect(withoutProps).to.have.property('id', emptyConsoleProps.id)
@@ -410,7 +410,7 @@ describe('tap binding console properties', () => {
       const { testId, commands } = await firstTestCommands(binding)
       const commandId = commandNamed(commands, 'deep-console-props').id as string
       const propsOf = async (options: Record<string, string> = {}) => {
-        const result = await binding.exec('command', {}, { test: testId, command: commandId, ...options })
+        const result = await binding.exec('command', {}, { testId, commandId, ...options })
 
         return (result as { result: Record<string, any> }).result.consoleProps
       }
@@ -470,7 +470,7 @@ describe('tap binding pin lifecycle', () => {
       const binding = getBinding(win)
 
       const { testId, commands } = await firstTestCommands(binding)
-      const outcome = await binding.exec('pin', { test: testId, command: commandNamed(commands, 'click').id as string }, { at: 'before' })
+      const outcome = await binding.exec('pin', {}, { testId, commandId: commandNamed(commands, 'click').id as string, at: 'before' })
 
       expect('result' in outcome).to.eq(true)
     })
@@ -492,7 +492,7 @@ describe('tap binding pin lifecycle', () => {
 
       expect(clearNoop).to.deep.eq({ result: { cleared: false } })
 
-      const beforeRun = await binding.exec('pin', { test: 'r2', command: '1' })
+      const beforeRun = await binding.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
       expect((beforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
     })
@@ -508,21 +508,21 @@ describe('tap binding pin lifecycle', () => {
       const { testId, commands } = await firstTestCommands(binding)
       const commandId = commandNamed(commands, 'click').id as string
 
-      const missingTest = await binding.exec('pin', { test: 'not-a-test', command: commandId })
+      const missingTest = await binding.exec('pin', {}, { testId: 'not-a-test', commandId })
 
       expect((missingTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
-      const missingCommand = await binding.exec('pin', { test: testId, command: 'not-a-command' })
+      const missingCommand = await binding.exec('pin', {}, { testId, commandId: 'not-a-command' })
 
       expect((missingCommand as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
 
-      const missingSnapshot = await binding.exec('pin', { test: testId, command: commandId }, { at: 'during' })
+      const missingSnapshot = await binding.exec('pin', {}, { testId, commandId, at: 'during' })
 
       expect((missingSnapshot as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
       expect((missingSnapshot as { error: { message: string } }).error.message).to.contain('"before" (1)')
 
       // The default pin lands on the click's final snapshot.
-      const pinOutcome = (await binding.exec('pin', { test: testId, command: commandId })) as { result: Record<string, any> }
+      const pinOutcome = (await binding.exec('pin', {}, { testId, commandId })) as { result: Record<string, any> }
 
       expect(Object.keys(pinOutcome.result)).to.satisfy((keys: string[]) => keys.every((key) => ['pinned', 'url'].includes(key)))
       expect(Object.keys(pinOutcome.result.pinned)).to.satisfy((keys: string[]) => keys.every((key) => ['test', 'command', 'hookName', 'at'].includes(key)))
@@ -535,7 +535,7 @@ describe('tap binding pin lifecycle', () => {
       expect(pinOutcome.result.pinned.at).to.deep.eq({ index: 2, total: 2, name: 'after' })
 
       // Re-running pin on the pinned command moves it in place.
-      const moved = (await binding.exec('pin', { test: testId, command: commandId }, { at: 'before' })) as { result: Record<string, any> }
+      const moved = (await binding.exec('pin', {}, { testId, commandId, at: 'before' })) as { result: Record<string, any> }
 
       expect(moved.result.pinned.at).to.deep.eq({ index: 1, total: 2, name: 'before' })
 
@@ -671,14 +671,14 @@ describe('tap binding with network activity', () => {
     cy.window().then(async (win) => {
       const binding = getBinding(win)
 
-      const missing = await binding.exec('reporter', {}, { test: 'not-a-test' })
+      const missing = await binding.exec('reporter', {}, { testId: 'not-a-test' })
 
       expect((missing as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
       const tests = await specTests(binding)
       const testId = tests[0].id as string
 
-      const view = await reporterResult(binding, { test: testId })
+      const view = await reporterResult(binding, { testId })
 
       expect(Object.keys(view)).to.deep.eq(['test', 'hooks', 'sessions', 'agents', 'routes', 'commands'])
       expect(view.test).to.deep.eq({
@@ -846,8 +846,8 @@ describe('tap binding run lifecycle', () => {
       const binding = getBinding(win)
       const refused = await Promise.all([
         binding.exec('reporter'),
-        binding.exec('command', {}, { test: 'r1', command: '1' }),
-        binding.exec('pin', { test: 'r1', command: '1' }),
+        binding.exec('command', {}, { testId: 'r1', commandId: '1' }),
+        binding.exec('pin', {}, { testId: 'r1', commandId: '1' }),
       ])
 
       for (const outcome of refused) {

--- a/packages/app/src/tap/commands/command.cy.ts
+++ b/packages/app/src/tap/commands/command.cy.ts
@@ -191,7 +191,7 @@ describe('tap/commands/command', () => {
     expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '9', attempt: '1' })).to.deep.eq({
       error: {
         code: 'COMMAND_NOT_FOUND',
-        message: 'no command of this test matches the id "9" — use the reporter command (with --test) to list this test’s commands',
+        message: 'no command of this test matches the id "9" — use the reporter command (with --testId) to list this test’s commands',
       },
     })
 

--- a/packages/app/src/tap/commands/command.cy.ts
+++ b/packages/app/src/tap/commands/command.cy.ts
@@ -69,7 +69,7 @@ describe('tap/commands/command', () => {
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       error: {
         code: 'NO_RUN',
         message: 'No spec has been started yet. Use the run command to start a spec.',
@@ -80,7 +80,7 @@ describe('tap/commands/command', () => {
   it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'nope', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'nope', commandId: '1' })).to.deep.eq({
       error: {
         code: 'TEST_NOT_FOUND',
         message: 'no test of this run matches the id "nope" — use the reporter command to list this run’s tests',
@@ -91,7 +91,7 @@ describe('tap/commands/command', () => {
   it('returns one command entry, keeping only the listed fields', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'h1:1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: 'h1:1' })).to.deep.eq({
       result: { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent', hook: { hookId: 'h1', hookName: 'before each' }, snapshots: [] },
     })
   })
@@ -101,7 +101,7 @@ describe('tap/commands/command', () => {
   it('names the hook a row ran in, falling back to its id alone', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: 'h1:1', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: 'h1:1', attempt: '1' })).to.deep.eq({
       result: { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent', hook: { hookId: 'h1' }, snapshots: [] },
     })
   })
@@ -112,7 +112,7 @@ describe('tap/commands/command', () => {
   it('resolves a duplicated row number to the test body, not the hook', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -120,7 +120,7 @@ describe('tap/commands/command', () => {
   it('returns the entry from the requested attempt', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'failed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -137,7 +137,7 @@ describe('tap/commands/command', () => {
 
     stubSnapshots(getSnapshotPropsForLog)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       result: {
         id: '1',
         name: 'get',
@@ -158,7 +158,7 @@ describe('tap/commands/command', () => {
     stubTests()
     stubSnapshots(() => ({ snapshots: [null, { timestamp: 1767276202481 }] }))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [{ index: 1, timestamp: 1767276202481 }] },
     })
   })
@@ -167,7 +167,7 @@ describe('tap/commands/command', () => {
     stubTests()
     stubSnapshots(() => ({ snapshots: null }))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -175,7 +175,7 @@ describe('tap/commands/command', () => {
   it('fails with ATTEMPT_NOT_FOUND when the attempt is out of range', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1', attempt: '3' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '3' })).to.deep.eq({
       error: {
         code: 'ATTEMPT_NOT_FOUND',
         message: 'test "r2" has 2 attempts; pass --attempt 1–2 (defaults to the latest)',
@@ -188,7 +188,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '9', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '9', attempt: '1' })).to.deep.eq({
       error: {
         code: 'COMMAND_NOT_FOUND',
         message: 'no command of this test matches the id "9" — use the reporter command (with --test) to list this test’s commands',
@@ -215,7 +215,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })
 
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-2', undefined)
     expect(outcome).to.deep.eq({
@@ -238,7 +238,7 @@ describe('tap/commands/command', () => {
       }
     })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { result: { consoleProps: unknown } }).result.consoleProps).to.deep.eq({
       name: 'get',
@@ -253,7 +253,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1', attempt: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '1' })
 
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-b', undefined)
     expect((outcome as { result: { consoleProps: unknown } }).result.consoleProps).to.deep.eq(consoleProps)
@@ -264,7 +264,7 @@ describe('tap/commands/command', () => {
 
     stubTests(() => cleanup)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r4', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r4', commandId: '1' })).to.deep.eq({
       result: {
         id: '1',
         name: 'visit',
@@ -283,7 +283,7 @@ describe('tap/commands/command', () => {
   it('omits console properties the driver has none of', async () => {
     stubTests(() => ({}))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { test: 'r2', command: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -295,8 +295,8 @@ describe('tap/commands/command', () => {
     stubTests(getSerializedConsolePropsForLog)
 
     const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, {
-      'test': 'r2',
-      'command': '1',
+      'testId': 'r2',
+      'commandId': '1',
       'json': 'true',
     })
 
@@ -309,8 +309,8 @@ describe('tap/commands/command', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    expect((await manager.exec('command', {}, { test: 'r2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
-    expect((await manager.exec('command', {}, { command: '1' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect((await manager.exec('command', {}, { testId: 'r2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect((await manager.exec('command', {}, { commandId: '1' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
     expect(getRunner).not.to.have.been.called
   })
 })

--- a/packages/app/src/tap/commands/command.ts
+++ b/packages/app/src/tap/commands/command.ts
@@ -41,7 +41,7 @@ export const commandCommand = defineCommand('command', async (_params, options):
   const resolved = resolveCommand(selection.attempt, command, test)
 
   if (!resolved) {
-    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --test) to list this test’s commands`)
+    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --testId) to list this test’s commands`)
   }
 
   const snapshotProps = tapManagerDataSource.getSnapshotRunner()?.getSnapshotPropsForLog(test, resolved.logId)

--- a/packages/app/src/tap/commands/command.ts
+++ b/packages/app/src/tap/commands/command.ts
@@ -21,7 +21,7 @@ const consolePropsOf = (props: ConsolePropsResult | undefined): ConsolePropsResu
 }
 
 export const commandCommand = defineCommand('command', async (_params, options): Promise<CommandResult> => {
-  const { test, attempt, command, json } = options
+  const { testId: test, attempt, commandId: command, json } = options
 
   const runner = tapManagerDataSource.getRunner()
 

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -51,7 +51,7 @@ describe('tap/commands/pin', () => {
   it('pins the last snapshot by default: captures the original, drives the app pin, listens for unpin', async () => {
     const { detachDom, pinSnapshot, onUnpinned, restoreDom } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect(detachDom).to.have.been.calledOnce
     // Default --at is the last snapshot (the command's final state), index 1.
@@ -79,7 +79,7 @@ describe('tap/commands/pin', () => {
   it('pins a named snapshot via --at', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' }, { at: 'before' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 0, 'r2', 'log-1')
     expect((outcome as { result: any }).result.pinned.at).to.deep.eq({ index: 1, total: 2, name: 'before' })
@@ -88,7 +88,7 @@ describe('tap/commands/pin', () => {
   it('fails with SNAPSHOT_NOT_FOUND when --at matches nothing, without touching the iframe', async () => {
     const { detachDom, pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' }, { at: 'during' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1', at: 'during' })
 
     expect(outcome).to.deep.eq({
       error: { code: 'SNAPSHOT_NOT_FOUND', message: 'no snapshot of this command matches "during" — available snapshots: "before" (1), "after" (2)' },
@@ -103,8 +103,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
-    const switched = await manager.exec('pin', { test: 'r2', command: '2' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const switched = await manager.exec('pin', {}, { testId: 'r2', commandId: '2' })
 
     expect((switched as { result: any }).result.pinned.command.id).to.eq('2')
     // No re-capture and no second listener: the original DOM and unpin listener
@@ -123,8 +123,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
-    const failed = await manager.exec('pin', { test: 'r2', command: '2' }, { at: 'during' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const failed = await manager.exec('pin', {}, { testId: 'r2', commandId: '2', at: 'during' })
 
     expect((failed as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
     // The failed switch touched nothing — the '1' pin is still live, proven by a
@@ -143,8 +143,8 @@ describe('tap/commands/pin', () => {
     const manager = new TapManager(CYPRESS_VERSION)
 
     // First pin lands on the last snapshot (index 1, "after").
-    await manager.exec('pin', { test: 'r2', command: '1' })
-    const moved = await manager.exec('pin', { test: 'r2', command: '1' }, { at: 'before' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const moved = await manager.exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
 
     // The move re-selects the snapshot in place: no second capture, no re-pin,
     // no new unpin listener — only a state switch to "before" (index 0).
@@ -165,8 +165,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
-    const outcome = await manager.exec('pin', { test: 'r2', command: '1' }, { at: 'during' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1', at: 'during' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
     // The pin never moved, so no state switch happened.
@@ -178,7 +178,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
 
     expect(restoreDom).to.have.been.calledOnceWith('ORIGINAL-DOM')
@@ -187,7 +187,7 @@ describe('tap/commands/pin', () => {
     expect(cleared).to.deep.eq({ result: { cleared: true } })
 
     // Pin state is released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
+    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
   })
@@ -197,7 +197,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     // Fire the handler the pin registered, as the runner's ✕ unpin would.
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -209,7 +209,7 @@ describe('tap/commands/pin', () => {
     expect(unpinSnapshot).not.to.have.been.called
 
     // The pin is released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
+    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
   })
@@ -219,7 +219,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     isRunning.returns(true)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -236,7 +236,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     getRunner.returns(undefined)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -252,7 +252,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     isRunning.returns(true)
 
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -267,7 +267,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     getRunner.returns(undefined)
 
     const onExternalUnpin = onUnpinned.firstCall.args[0] as () => void
@@ -290,7 +290,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     const outcome = await manager.exec('run-state')
 
@@ -307,7 +307,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect(await manager.exec('run-state')).to.deep.eq({ result: { spec: null, totalSpecs: 0 } })
   })
@@ -339,7 +339,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
     expect(pinSnapshot).to.have.been.calledOnce // the pin was rendered via the app pin
 
     // Simulate a re-run: the command id is reused, but its snapshots are fresh
@@ -370,7 +370,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r2', command: '1' })
+    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     // Simulate a re-run: the command id is reused, but its snapshots are fresh
     // objects — the captured DOM now belongs to the dead run.
@@ -385,7 +385,7 @@ describe('tap/commands/pin', () => {
     expect(restoreDom).not.to.have.been.called // never a stale restore over the live AUT
 
     // The stale pin was released, so a fresh pin lands cleanly.
-    const outcome = await manager.exec('pin', { test: 'r2', command: '1' })
+    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
   })
@@ -393,7 +393,7 @@ describe('tap/commands/pin', () => {
   it('requires a test and command (or --clear) before attempting a pin', async () => {
     const { detachDom, pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('PIN_TARGET_REQUIRED')
     // A malformed pin never touches the iframe or drives the app pin.
@@ -404,7 +404,7 @@ describe('tap/commands/pin', () => {
   it('fails with NO_RUN when no runner has mounted', async () => {
     stubSource({ runner: undefined })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('NO_RUN')
   })
@@ -412,7 +412,7 @@ describe('tap/commands/pin', () => {
   it('refuses to pin while a spec is running', async () => {
     stubSource({ running: true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { error: { code: string, message: string } }).error).to.deep.eq({
       code: 'RUN_IN_PROGRESS',
@@ -425,8 +425,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    expect((await manager.exec('pin', { test: 'nope', command: '1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
-    expect((await manager.exec('pin', { test: 'r2', command: '9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
+    expect((await manager.exec('pin', {}, { testId: 'nope', commandId: '1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+    expect((await manager.exec('pin', {}, { testId: 'r2', commandId: '9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
   })
 
   // Numbers restart per hook section, so a plain handle can be duplicated —
@@ -458,7 +458,7 @@ describe('tap/commands/pin', () => {
   it('resolves a duplicated plain number to the test body row', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-t1')
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
@@ -467,7 +467,7 @@ describe('tap/commands/pin', () => {
   it('resolves a hook-qualified handle to that section’s row', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: 'h2:1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: 'h2:1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-h2a')
   })
@@ -475,7 +475,7 @@ describe('tap/commands/pin', () => {
   it('refuses to guess between hooks: a number duplicated outside the test body is AMBIGUOUS_COMMAND', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: '2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: '2' })
 
     expect(outcome).to.deep.eq({
       error: {
@@ -490,7 +490,7 @@ describe('tap/commands/pin', () => {
   it('fails with COMMAND_NOT_FOUND for a qualifier that matches no section', async () => {
     stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r5', command: 'h9:1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: 'h9:1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
   })
@@ -501,7 +501,7 @@ describe('tap/commands/pin', () => {
       getSnapshotPropsForLog: () => ({ snapshots: null }),
     } })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r2', command: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_UNAVAILABLE')
   })
@@ -531,7 +531,7 @@ describe('tap/commands/pin', () => {
   it('resolves command ids against the latest attempt by default', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a2')
   })
@@ -539,7 +539,7 @@ describe('tap/commands/pin', () => {
   it('resolves command ids against the attempt named by --attempt', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' }, { attempt: '1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a1')
   })
@@ -547,7 +547,7 @@ describe('tap/commands/pin', () => {
   it('fails with ATTEMPT_NOT_FOUND when --attempt is out of range', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', { test: 'r6', command: '1' }, { attempt: '5' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '5' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
     expect(pinSnapshot).not.to.have.been.called
@@ -558,8 +558,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', { test: 'r6', command: '1' }, { attempt: '1' })
-    await manager.exec('pin', { test: 'r6', command: '1' }, { attempt: '2' })
+    await manager.exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '1' })
+    await manager.exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '2' })
 
     expect(detachDom).to.have.been.calledOnce
     expect(changeSnapshotState).not.to.have.been.called

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -157,7 +157,7 @@ const clearPin = (): ClearResult => {
   return { cleared: true }
 }
 
-export const pinCommand = defineCommand('pin', async ({ test, command }, { at, clear, attempt }): Promise<PinResult | ClearResult> => {
+export const pinCommand = defineCommand('pin', async (_params, { testId: test, commandId: command, at, clear, attempt }): Promise<PinResult | ClearResult> => {
   const runner = tapManagerDataSource.getSnapshotRunner()
 
   if (runner) {

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -199,7 +199,7 @@ export const pinCommand = defineCommand('pin', async (_params, { testId: test, c
   const logId = resolveCommandLogId(selection.attempt, command, test)
 
   if (logId === undefined) {
-    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --test) to list this test’s commands`)
+    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --testId) to list this test’s commands`)
   }
 
   const props = runner.getSnapshotPropsForLog(test, logId)

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -412,7 +412,7 @@ describe('tap/commands/reporter', () => {
       expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(10400)
     })
 
-    it('rejects --attempt without --test', async () => {
+    it('rejects --attempt without --testId', async () => {
       stubRunner(treeRunner())
 
       const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { attempt: '1' })
@@ -420,7 +420,7 @@ describe('tap/commands/reporter', () => {
       expect(outcome).to.deep.eq({
         error: {
           code: 'ATTEMPT_NOT_FOUND',
-          message: 'the --attempt option applies only when rendering a single test; pass --test <id>',
+          message: 'the --attempt option applies only when rendering a single test; pass --testId <id>',
         },
       })
     })

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -144,7 +144,7 @@ describe('tap/commands/reporter', () => {
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r2' })
 
     expect(outcome).to.deep.eq({
       error: {
@@ -157,7 +157,7 @@ describe('tap/commands/reporter', () => {
   it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
     stubRunner({ getTestState: () => undefined, isRunComplete: () => false })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'nope' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'nope' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
   })
@@ -165,7 +165,7 @@ describe('tap/commands/reporter', () => {
   it('returns the full reporter view: test header, hooks with a synthesized test body, routes, and enriched commands', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => false })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r2' })
 
     expect(outcome).to.deep.eq({
       result: {
@@ -215,7 +215,7 @@ describe('tap/commands/reporter', () => {
   it('carries a failed attempt’s error panel — messaging fields and code frame, extras trimmed', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r4' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r4' })
 
     expect((outcome as { result: Record<string, unknown> }).result.error).to.deep.eq({
       name: 'AssertionError',
@@ -233,7 +233,7 @@ describe('tap/commands/reporter', () => {
   it('drops non-string error fields from a non-Error throw', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r6' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r6' })
 
     expect((outcome as { result: { error: Record<string, unknown> } }).result.error).to.deep.eq({})
   })
@@ -241,7 +241,7 @@ describe('tap/commands/reporter', () => {
   it('carries alias names, not the badge text `.as()` writes onto the log', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r7' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r7' })
 
     expect((outcome as { result: { commands: Array<Record<string, unknown>> } }).result.commands).to.deep.eq([
       { id: '1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', aliases: ['firstBtn'], aliasType: 'dom' },
@@ -256,7 +256,7 @@ describe('tap/commands/reporter', () => {
   it('reports an unreached test with empty collections and just the test-body pseudo-hook', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r3' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r3' })
 
     expect(outcome).to.deep.eq({
       result: {
@@ -273,7 +273,7 @@ describe('tap/commands/reporter', () => {
   it('orders the synthesized test body between the before and after hooks', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { test: 'r5' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r5' })
 
     expect((outcome as { result: { hooks: unknown } }).result.hooks).to.deep.eq([
       { hookId: 'h-ba', hookName: 'before all' },

--- a/packages/app/src/tap/commands/reporter.ts
+++ b/packages/app/src/tap/commands/reporter.ts
@@ -12,7 +12,7 @@ export const reporterCommand = defineCommand('reporter', async (_params, { testI
 
   if (test === undefined) {
     if (attempt !== undefined) {
-      throw new TapCommandError('ATTEMPT_NOT_FOUND', 'the --attempt option applies only when rendering a single test; pass --test <id>')
+      throw new TapCommandError('ATTEMPT_NOT_FOUND', 'the --attempt option applies only when rendering a single test; pass --testId <id>')
     }
 
     return serializeReporterSpecView(runner, tapManagerDataSource.getActiveSpecRelative())

--- a/packages/app/src/tap/commands/reporter.ts
+++ b/packages/app/src/tap/commands/reporter.ts
@@ -3,7 +3,7 @@ import { defineCommand, noRunError, TapCommandError } from './definition'
 import { attemptSelectionError, selectTestAttempt, serializeReporterSpecView, serializeReporterView } from '../test-state'
 import type { TapReporterSpecView, TapReporterView } from '../contract'
 
-export const reporterCommand = defineCommand('reporter', async (_params, { test, attempt }): Promise<TapReporterView | TapReporterSpecView> => {
+export const reporterCommand = defineCommand('reporter', async (_params, { testId: test, attempt }): Promise<TapReporterView | TapReporterSpecView> => {
   const runner = tapManagerDataSource.getRunner()
 
   if (!runner) {

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -65,12 +65,12 @@ describe('cypress-instances contract', () => {
   })
 
   describe('tap command contract', () => {
-    it('lists reporter as a command taking --test and --attempt, advertised on the wire schema', () => {
+    it('lists reporter as a command taking --testId and --attempt, advertised on the wire schema', () => {
       const reporter = TAP_COMMANDS.find(({ name }) => name === 'reporter')!
 
       expect(reporter.params).toEqual([])
       expect(reporter.options.map(({ name, required }) => ({ name, required }))).toEqual([
-        { name: 'test', required: false },
+        { name: 'testId', required: false },
         { name: 'attempt', required: false },
       ])
 

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -80,12 +80,15 @@ export type TapRawParams<P extends readonly TapCommandParamSchema[]> =
 export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
   SchemaObject<O, { required: true, type: 'string' | 'number' }, RawScalars>
 
-// Params/options that recur across commands, defined once so their name, type,
-// and help text can't drift between the commands that expose them. `test` is
-// required in some commands and optional in others, so each use spreads it and
-// sets `required`; `attempt` is identical everywhere and used directly.
-const testIdField = { name: 'test', type: 'string', description: 'test id, as listed by the reporter command' } as const
+// Options that recur across commands, defined once so their name, type, and help
+// text can't drift between the commands that expose them. `testId` and
+// `commandId` are required in some commands and optional in others, so each use
+// spreads it and sets `required`; the rest are identical everywhere and used
+// directly.
+const testIdField = { name: 'testId', type: 'string', description: 'test id, as listed by the reporter command' } as const
+const commandIdField = { name: 'commandId', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
 const attemptField = { name: 'attempt', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
+const selectorField = { name: 'selector', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' } as const
 
 const commandMeta = {
   name: 'command',
@@ -93,7 +96,7 @@ const commandMeta = {
   params: [],
   options: [
     { ...testIdField, required: true },
-    { name: 'command', type: 'string', required: true, description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' },
+    { ...commandIdField, required: true },
     // `--json` is the CLI's own flag, but this command declares it because it
     // also changes what the command returns: nothing is withheld from a payload
     // that is not being rendered for reading room.
@@ -104,15 +107,15 @@ const commandMeta = {
 
 const reporterMeta = {
   name: 'reporter',
-  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test, the spec-level overview: run stats and every suite’s tests',
+  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --testId, the spec-level overview: run stats and every suite’s tests',
   details: `Shows test results the way the Cypress app's reporter panel does, right in
-your terminal. Pass --test <id> (test ids come from the spec overview this
-same command prints with no --test) to see one
+your terminal. Pass --testId <id> (test ids come from the spec overview this
+same command prints with no --testId) to see one
 test's full story: its network routes, the hooks that ran, the complete
 command log, and the failure output when something went wrong. Add --attempt
 to view an earlier retry.
 
-Leave --test off to get the spec-level overview instead: the run's pass/fail
+Leave --testId off to get the spec-level overview instead: the run's pass/fail
 stats and every suite's tests at a glance.`,
   params: [],
   options: [
@@ -124,11 +127,10 @@ stats and every suite's tests at a glance.`,
 const pinMeta = {
   name: 'pin',
   description: 'pin a command’s DOM snapshot into the live app-under-test frame so the dom/aria/inspect commands can read it; pass --clear to release',
-  params: [
-    { ...testIdField, required: false },
-    { name: 'command', type: 'string', required: false, description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' },
-  ],
+  params: [],
   options: [
+    { ...testIdField, required: false },
+    { ...commandIdField, required: false },
     attemptField,
     { name: 'at', type: 'string', required: false, description: 'which snapshot to pin: a name like "before"/"after" or a 1-based index; defaults to the last (the command’s final state). Re-run on the pinned command to switch snapshots without releasing the pin' },
     { name: 'clear', type: 'boolean', required: false, description: 'release the current pin and restore the app to its pre-pin state' },
@@ -162,7 +164,7 @@ export const buildTapSchema = (cypressVersion: string): TapSchema => {
       name: command.name,
       description: command.description,
       ...('details' in command ? { details: command.details } : {}),
-      params: command.params.map((param) => ({ ...param })),
+      params: (command.params as readonly TapCommandParamSchema[]).map((param) => ({ ...param })),
       options: command.options.map((option) => ({ ...option })),
       ...('hidden' in command && command.hidden ? { hidden: true } : {}),
     }
@@ -240,8 +242,11 @@ const domMeta = {
   details: `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of
 each element matching a CSS selector (each match includes its full subtree).
 Output is capped browser-side so a heavy page never ships megabytes at once.`,
-  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' }],
-  options: [{ name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' }],
+  params: [],
+  options: [
+    selectorField,
+    { name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
+  ],
 } as const satisfies TapNativeCommandSchema
 
 const ariaMeta = {
@@ -250,8 +255,11 @@ const ariaMeta = {
   details: `Reads the accessibility (ARIA) tree of the app-under-test frame, or the
 subtree rooted at a CSS selector. Structural and text-only roles are dropped,
 leaving the compact role/name/state tree DevTools shows.`,
-  params: [{ name: 'selector', type: 'string', required: false, description: 'a CSS selector to root the tree at; omit for the whole frame' }],
-  options: [{ name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' }],
+  params: [],
+  options: [
+    { ...selectorField, description: 'a CSS selector to root the tree at; omit for the whole frame' },
+    { name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
+  ],
 } as const satisfies TapNativeCommandSchema
 
 const inspectMeta = {
@@ -259,7 +267,8 @@ const inspectMeta = {
   description: 'inspect the first element matching a selector: its tag, attributes, computed styles, box model, and accessibility node',
   details: `Inspects the first element matching the selector: its tag, attributes,
 curated computed styles, box model, and accessibility node.`,
-  params: [{ name: 'selector', type: 'string', required: true, description: 'a CSS selector identifying the element to inspect' }],
+  params: [],
+  options: [{ ...selectorField, required: true, description: 'a CSS selector identifying the element to inspect' }],
 } as const satisfies TapNativeCommandSchema
 
 // CLI-native tap commands: implemented entirely in the CLI (instance discovery


### PR DESCRIPTION
- Closes [AW-36](https://cypress-io.atlassian.net/browse/AW-36)

> **Top of the tap stack**, based on [#34498](https://github.com/cypress-io/cypress/pull/34498) (AW-93) → [#34496](https://github.com/cypress-io/cypress/pull/34496) (AW-91) → [#34486](https://github.com/cypress-io/cypress/pull/34486) (AW-90). It rewrites the whole command surface, so it will need a restack as those merge. This diff is the 14 files below.

### Additional details

Arguments were split across two mechanisms with no rule behind the split:

| command | before | after |
|---|---|---|
| `pin` | `pin [test] [command]` | `pin --testId <id> --commandId <id>` |
| `dom` / `aria` | `dom [selector]` | `dom --selector <sel>` |
| `inspect` | `inspect <selector>` | `inspect --selector <sel>` |
| `command` | `--test` / `--command` | `--testId` / `--commandId` |
| `reporter` | `--test` | `--testId` |
| `run` | `run <spec>` | **unchanged** |

`pin r3 6` was the worst of it — two unlabelled ids whose order the caller had to remember, in the one command where getting them backwards silently pins the wrong thing.

`run <spec>` keeps its positional per the ticket: one unambiguous argument on the most-typed command.

**The renames close a gap with the result contract.** `--test` and `--command` named values the results already call `testId` and `commandId` (`TapReporterCommand.id` is what `--commandId` takes). An agent read `testId` out of one command's JSON and passed it as `--test` to the next.

**Recurring options are declared once.** `testIdField`, `commandIdField`, `attemptField` and `selectorField` live in `tap-contract.ts`, so name, type and help text can't drift between the commands that expose them — the "shared schema/constants module" from the ticket, extending a pattern that already existed for `testId` and `attempt`.

**Old forms fail loudly**, which matters more than usual for a surface agents call blind:

```
tap pin r3 6           -> exit 1  error: too many arguments for 'pin'. Expected 0 argument(s) but got 2.
tap reporter --test r3 -> exit 1  error: unknown option: --test
tap dom button         -> exit 1  error: too many arguments for 'dom'. Expected 0 argument(s) but got 1.
```

No aliases for the old names: tap isn't publicly documented or released, and keeping `--test` as a hidden alias preserves the thing the ticket removes. Easy to add if that's wrong.

### Steps to test

Validated live against [`cypress-example-kitchensink`](https://github.com/cypress-io/cypress-example-kitchensink) through a real `cypress open` instance — every command on the new surface, then every old form:

```
  exit=0  tap instances                                    INSTANCES (1)
  exit=0  tap status                                       PID    PROJECT
  exit=0  tap specs                                        SPECS (27)
  exit=0  tap reporter                                     cypress/e2e/2-advanced-examples/aliasing.cy.js
  exit=0  tap reporter --testId r3                         ✓ Aliasing > .as() - alias a DOM element for later
  exit=0  tap command --testId r3 --commandId 6            {
  exit=0  tap pin --testId r3 --commandId 6                ⚲ PINNED - (1/1)
  exit=0  tap pin --clear                                  ⚲ PIN CLEARED
  exit=0  tap dom --selector button --max-chars 60         MATCHES (6)  http://localhost:8080/commands/aliasi
  exit=0  tap aria --selector body --max-nodes 3           ARIA (3)  http://localhost:8080/commands/aliasing
  exit=0  tap inspect --selector body                      body  body  http://localhost:8080/commands/aliasin
  --- old forms (must fail) ---
  exit=1  tap pin r3 6                                     error: too many arguments for 'pin'. Expected 0 ar
  exit=1  tap reporter --test r3                           error: unknown option: --test
  exit=1  tap dom button                                   error: too many arguments for 'dom'. Expected 0 ar
```

Before, for contrast — the mixed surface:

```
$ node cli/bin/cypress tap pin --help
Usage: cypress tap pin [options] [test] [command]

$ node cli/bin/cypress tap dom --help
Usage: cypress tap dom [options] [selector]

$ node cli/bin/cypress tap command --help
    --test <test>        test id, as listed by the reporter command
    --command <command>  command id, as listed by the reporter command
```

The help listing now shows `[options]` for everything except `run`:

```
    dom [options]         read the app-under-test DOM as HTML: the whole page,
    aria [options]        read the accessibility (ARIA) tree of the
    inspect [options]     inspect the first element matching a selector: its
    command [options]     detail one command log entry of a test, or show its
    pin [options]         pin a command's DOM snapshot into the live
    run [options] <spec>  run (or rerun) a spec by its project-relative path
```

747 CLI unit tests pass; `check-ts` clean for `@packages/app` and `@packages/cypress-instances`; lint clean in all three packages.

### Not in this PR

**The `agent-remote-cypress` skill doc.** The ticket asks for it, but that skill lives only in a personal `~/.claude/skills/` directory — there's no copy in this repo, so it can't ship here. Every example in it (`tap pin r3 4`, `tap reporter --test r3`, `tap dom "[data-cy=task]"`) is now wrong, so it needs the same pass. Flagged rather than silently skipped.

### How has the user experience changed?

Every tap argument is a named flag except `run <spec>`. `pin --testId r3 --commandId 6` replaces `pin r3 6`; `dom --selector "button"` replaces `dom "button"`; `--test`/`--command` become `--testId`/`--commandId` to match the ids the results carry. This **breaks every existing invocation** — deliberately, and loudly: old positionals and `--test` both exit 1 with a specific message rather than being ignored. The messages that point a caller back at the reporter (`COMMAND_NOT_FOUND`, `ATTEMPT_NOT_FOUND`) name `--testId` too, so the guidance can't name a flag that no longer parses. Before/after above.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated? <!-- CLI unit + help snapshots updated for the new surface; ~105 exec() call sites across the app CT specs and the binding e2e migrated to the renamed options -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- the tap CLI is not yet publicly documented -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-36]: https://cypress-io.atlassian.net/browse/AW-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI/API surface for all tap consumers; behavior is intentionally strict with no aliases, but runtime pin/reporter logic is largely unchanged aside from option names.
> 
> **Overview**
> **Moves most `cypress tap` arguments from positionals to named flags** so agents and scripts don’t rely on argument order. **`run <spec>` stays positional** as the one high-traffic exception.
> 
> **Renames instance options** to match JSON: `--test` → `--testId`, `--command` → `--commandId` on `command`, `reporter`, and `pin`. Error text that pointed at the reporter now says `--testId`.
> 
> **`dom`, `aria`, and `inspect`** take **`--selector`** (required for `inspect`) instead of a trailing positional; **`pin`** uses **`--testId` / `--commandId`** instead of `[test] [command]`.
> 
> **`packages/cypress-instances/lib/tap-contract.ts`** centralizes shared option metadata (`testIdField`, `commandIdField`, `selectorField`, `attemptField`) and updates native command schemas so help shows **`[options]`** only (no `[selector]`). App tap handlers read the new option keys; CLI native handlers use `commandOptions` instead of `args`.
> 
> Tests and help snapshots are updated across CLI, app, binding e2e, and contract specs. **Old invocations fail at parse time** (unknown `--test`, excess positionals on `dom`/`pin`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2180d4e220ac4a9fb20853e508cf5edfc59058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

