### PR TITLE
test: use .should() for retryable cookie query commands

### DIFF
--- a/packages/driver/cypress/e2e/commands/cookies.cy.js
+++ b/packages/driver/cypress/e2e/commands/cookies.cy.js
@@ -28,7 +28,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.getCookie('foo').its('hostOnly').should('eq', true)
     }
 
-    cy.getCookies().then((cookies) => {
+    cy.getCookies().should((cookies) => {
       expect(cookies).to.have.lengthOf(1)
 
       const cookie = cookies[0]
@@ -39,7 +39,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       }
     })
 
-    cy.getAllCookies().then((cookies) => {
+    cy.getAllCookies().should((cookies) => {
       expect(cookies).to.have.lengthOf(1)
 
       const cookie = cookies[0]
@@ -56,7 +56,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://barbaz.com:3500/fixtures/generic.html')
       setCookies()
 
-      cy.getCookies().then((cookies) => {
+      cy.getCookies().should((cookies) => {
         expect(cookies).to.have.length(2)
 
         const sortedCookies = Cypress._.sortBy(cookies, 'name')
@@ -73,7 +73,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://foobar.com:3500', () => {
         cy.visit('http://foobar.com:3500/fixtures/generic.html')
 
-        cy.getCookies().then((cookies) => {
+        cy.getCookies().should((cookies) => {
           expect(cookies).to.have.length(1)
           expect(cookies[0].name).to.equal('key2')
           expect(cookies[0].domain).to.match(/\.?foobar\.com/)
@@ -84,7 +84,7 @@ describe('src/cy/commands/cookies - no stub', () => {
     it('returns cookies from the subdomain and bare domain matching the AUT by default when AUT is a subdomain', () => {
       cy.visit('http://www.barbaz.com:3500/fixtures/generic.html')
       setCookies()
-      cy.getCookies().then((cookies) => {
+      cy.getCookies().should((cookies) => {
         expect(cookies).to.have.length(4)
 
         const sortedCookies = Cypress._.sortBy(cookies, 'name')
@@ -105,7 +105,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://www.foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/generic.html')
 
-        cy.getCookies().then((cookies) => {
+        cy.getCookies().should((cookies) => {
           const sortedCookies = Cypress._.sortBy(cookies, 'name')
 
           expect(sortedCookies).to.have.length(2)
@@ -121,7 +121,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://barbaz.com:3500/fixtures/generic.html')
       setCookies()
 
-      cy.getCookies({ domain: 'www.foobar.com' }).then((cookies) => {
+      cy.getCookies({ domain: 'www.foobar.com' }).should((cookies) => {
         expect(cookies).to.have.length(2)
 
         const sortedCookies = Cypress._.sortBy(cookies, 'name')
@@ -132,7 +132,7 @@ describe('src/cy/commands/cookies - no stub', () => {
         expect(sortedCookies[1].domain).to.match(/\.?foobar\.com/)
       })
 
-      cy.getCookies({ domain: 'barbaz.com' }).then((cookies) => {
+      cy.getCookies({ domain: 'barbaz.com' }).should((cookies) => {
         expect(cookies).to.have.length(2)
 
         const sortedCookies = Cypress._.sortBy(cookies, 'name')
@@ -149,7 +149,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://www.foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/generic.html')
 
-        cy.getCookies({ domain: 'www.barbaz.com' }).then((cookies) => {
+        cy.getCookies({ domain: 'www.barbaz.com' }).should((cookies) => {
           expect(cookies).to.have.length(4)
 
           const sortedCookies = Cypress._.sortBy(cookies, 'name')
@@ -172,7 +172,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://barbaz.com:3500/fixtures/generic.html')
       setCookies()
 
-      cy.getAllCookies().then((cookies) => {
+      cy.getAllCookies().should((cookies) => {
         expect(cookies).to.have.length(8)
 
         const sortedCookies = Cypress._.sortBy(cookies, 'name').map((cookie) => `${cookie.name}=${cookie.value}`)
@@ -195,7 +195,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://foobar.com:3500', () => {
         cy.visit('http://foobar.com:3500/fixtures/generic.html')
 
-        cy.getAllCookies().then((cookies) => {
+        cy.getAllCookies().should((cookies) => {
           expect(cookies).to.have.length(8)
 
           const sortedCookies = Cypress._.sortBy(cookies, 'name').map((cookie) => `${cookie.name}=${cookie.value}`)
@@ -228,7 +228,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://barbaz.com:3500/fixtures/generic.html')
       setCookies()
 
-      cy.getCookie('key').then((cookie) => {
+      cy.getCookie('key').should((cookie) => {
         expect(cookie.value).to.equal('barbaz.com value')
         expect(cookie.domain).to.match(/\.?barbaz\.com/)
       })
@@ -239,7 +239,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://foobar.com:3500', () => {
         cy.visit('http://foobar.com:3500/fixtures/generic.html')
 
-        cy.getCookie('key').then((cookie) => {
+        cy.getCookie('key').should((cookie) => {
           expect(cookie.value).to.equal('foobar.com value')
           expect(cookie.domain).to.match(/\.?foobar\.com/)
         })
@@ -250,7 +250,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://www.barbaz.com:3500/fixtures/generic.html')
       cy.setCookie('key', 'www.barbaz.com value', { domain: 'www.barbaz.com', log: false })
 
-      cy.getCookie('key').then((cookie) => {
+      cy.getCookie('key').should((cookie) => {
         expect(cookie.value).to.equal('www.barbaz.com value')
         expect(cookie.domain).to.match(/\.?www\.barbaz\.com/)
       })
@@ -262,7 +262,7 @@ describe('src/cy/commands/cookies - no stub', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/generic.html')
         cy.setCookie('key', 'www.foobar.com value', { domain: 'www.foobar.com', log: false })
 
-        cy.getCookie('key').then((cookie) => {
+        cy.getCookie('key').should((cookie) => {
           expect(cookie.value).to.equal('www.foobar.com value')
           expect(cookie.domain).to.match(/\.?www\.foobar\.com/)
         })
@@ -273,7 +273,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://www.barbaz.com:3500/fixtures/generic.html')
       cy.setCookie('key', 'barbaz.com value', { domain: 'barbaz.com', log: false })
 
-      cy.getCookie('key').then((cookie) => {
+      cy.getCookie('key').should((cookie) => {
         expect(cookie.value).to.equal('barbaz.com value')
         expect(cookie.domain).to.match(/\.?barbaz\.com/)
       })
@@ -285,7 +285,7 @@ describe('src/cy/commands/cookies - no stub', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/generic.html')
         cy.setCookie('key', 'foobar.com value', { domain: 'foobar.com', log: false })
 
-        cy.getCookie('key').then((cookie) => {
+        cy.getCookie('key').should((cookie) => {
           expect(cookie.value).to.equal('foobar.com value')
           expect(cookie.domain).to.match(/\.?foobar\.com/)
         })
@@ -296,7 +296,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.visit('http://www.barbaz.com:3500/fixtures/generic.html')
       setCookies()
 
-      cy.getCookie('key', { domain: 'www.foobar.com' }).then((cookie) => {
+      cy.getCookie('key', { domain: 'www.foobar.com' }).should((cookie) => {
         expect(cookie.value).to.equal('www.foobar.com value')
         expect(cookie.domain).to.match(/\.?www\.foobar\.com/)
       })
@@ -307,7 +307,7 @@ describe('src/cy/commands/cookies - no stub', () => {
       cy.origin('http://www.foobar.com:3500', () => {
         cy.visit('http://www.foobar.com:3500/fixtures/generic.html')
 
-        cy.getCookie('key', { domain: 'www.barbaz.com' }).then((cookie) => {
+        cy.getCookie('key', { domain: 'www.barbaz.com' }).should((cookie) => {
           expect(cookie.value).to.equal('www.barbaz.com value')
           expect(cookie.domain).to.match(/\.?www\.barbaz\.com/)
         })

--- a/packages/driver/cypress/e2e/e2e/e2e_cookies.cy.js
+++ b/packages/driver/cypress/e2e/e2e/e2e_cookies.cy.js
@@ -13,8 +13,7 @@ const firefoxDefaultSameSite = Cypress.isBrowser({ family: 'firefox' }) ? { same
 describe('e2e cookies spec', () => {
   it('simple cookie', () => {
     cy.setCookie('foo', 'bar')
-    cy.getCookie('foo', 'bar')
-    .then((cookie) => expect(cookie).exist)
+    cy.getCookie('foo', 'bar').should('exist')
   })
 
   context('__Host- prefix', () => {
@@ -28,12 +27,12 @@ describe('e2e cookies spec', () => {
         secure: true,
       })
 
-      cy.getCookie('__Host-foobar').then(((cookie) => {
+      cy.getCookie('__Host-foobar').should((cookie) => {
         expect(cookie).exist
         expect(cookie.domain).match(/^\.?example\.com$/)
         expect(cookie.path).eq('/')
         expect(cookie.secure).is.true
-      }))
+      })
     })
 
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23444
@@ -75,12 +74,12 @@ describe('e2e cookies spec', () => {
         secure: true,
       })
 
-      cy.getCookie('__Secure-foobar').then(((cookie) => {
+      cy.getCookie('__Secure-foobar').should((cookie) => {
         expect(cookie).exist
         expect(cookie.domain).match(/^\.?example\.com$/)
         expect(cookie.path).eq('/foo')
         expect(cookie.secure).is.true
-      }))
+      })
     })
 
     // TODO: fix flaky test https://github.com/cypress-io/cypress/issues/23444

--- a/packages/driver/cypress/e2e/e2e/origin/cookie_login.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/cookie_login.cy.ts
@@ -720,7 +720,7 @@ describe('cy.origin - cookie login', { browser: '!webkit' }, () => {
           doc.cookie = 'key=value; SameSite=Strict; Secure; Path=/fixtures'
         })
 
-        cy.getCookie('key').then((cookie) => {
+        cy.getCookie('key').should((cookie) => {
           expect(Cypress._.omit(cookie, 'expiry')).to.deep.equal({
             domain: 'www.foobar.com',
             httpOnly: false,
@@ -849,7 +849,7 @@ describe('cy.origin - cookie login', { browser: '!webkit' }, () => {
       cy.origin('http://www.foobar.com:3500', () => {
         cy.document().its('cookie').should('include', 'name=value')
         cy.get('[data-cy="doc-cookie"]').invoke('text').should('equal', 'name=value')
-        cy.getCookie('name').then((cookie) => {
+        cy.getCookie('name').should((cookie) => {
           expect(Cypress._.omit(cookie, 'expiry')).to.deep.equal({
             domain: 'www.foobar.com',
             httpOnly: false,

--- a/packages/driver/cypress/e2e/e2e/origin/cookie_misc.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/cookie_misc.cy.ts
@@ -10,7 +10,7 @@ describe('misc cookie tests', { browser: '!webkit' }, () => {
     // does a 302 redirect back to www.foobar.com primary-origin page, but sets a sameSite=None cookie
     cy.get('[data-cy="cookie-cross-origin-redirects-host-only"]').click()
 
-    cy.getCookies({ domain: 'www.foobar.com' }).then((cookies) => {
+    cy.getCookies({ domain: 'www.foobar.com' }).should((cookies) => {
       expect(cookies).to.have.length(1)
 
       const singleCookie = cookies[0]
@@ -27,7 +27,7 @@ describe('misc cookie tests', { browser: '!webkit' }, () => {
     // does a 302 redirect back to www.foobar.com primary-origin page, but sets a sameSite=None cookie
     cy.get('[data-cy="cookie-cross-origin-redirects"]').click()
 
-    cy.getCookies({ domain: 'www.foobar.com' }).then((cookies) => {
+    cy.getCookies({ domain: 'www.foobar.com' }).should((cookies) => {
       expect(cookies).to.have.length(1)
 
       const singleCookie = cookies[0]

--- a/system-tests/projects/cookies/cypress/e2e/app.cy.js
+++ b/system-tests/projects/cookies/cypress/e2e/app.cy.js
@@ -20,7 +20,7 @@ describe('Cookies', () => {
 
     cy.getCookies()
     .should('have.length', 1)
-    .then((cookies) => {
+    .should((cookies) => {
       const c = cookies[0]
 
       expect(c.domain).to.eq('localhost')
@@ -38,7 +38,7 @@ describe('Cookies', () => {
 
     cy.clearCookies().should('be.null')
     cy.setCookie('wtf', 'bob', { httpOnly: true, path: '/foo', secure: true })
-    cy.getCookie('wtf').then((c) => {
+    cy.getCookie('wtf').should((c) => {
       expect(c.domain).to.eq('localhost')
       expect(c.httpOnly).to.eq(true)
       expect(c.name).to.eq('wtf')

--- a/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/cookies_spec_baseurl.cy.js
@@ -174,7 +174,7 @@ describe('cookies', () => {
           })
 
           cy.getCookies()
-          .then((cookies) => {
+          .should((cookies) => {
             expect(cookies).to.have.length(1)
             expect(cookies[0]).to.include({
               name: 'domaincookie',
@@ -192,7 +192,7 @@ describe('cookies', () => {
           })
 
           cy.getCookies()
-          .then((cookies) => {
+          .should((cookies) => {
             expect(cookies).to.have.length(1)
             expect(cookies[0]).to.include({
               name: 'domaincookie',

--- a/system-tests/projects/e2e/cypress/e2e/request.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/request.cy.js
@@ -11,9 +11,7 @@ describe('redirects + requests', () => {
       '2293': 'true',
       '2293-session': 'true',
     })
-    .getCookies().then((cookies) => {
-      console.log(cookies)
-
+    .getCookies().should((cookies) => {
       expect(cookies[0].domain).to.eq('localhost')
       expect(cookies[0].name).to.eq('2293')
       expect(cookies[0].value).to.eq('true')

--- a/system-tests/projects/e2e/cypress/e2e/subdomain.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/subdomain.cy.js
@@ -24,9 +24,7 @@ describe('subdomains', () => {
       document.cookie = 'foo=bar'
     })
 
-    cy.getCookies().then((cookies) => {
-      expect(cookies.length).to.eq(3)
-    })
+    cy.getCookies().should('have.length', 3)
   })
 
   it('issue: #207: does not duplicate or hostOnly cookies as a domain cookie', () => {

--- a/system-tests/projects/e2e/cypress/e2e/subdomain_origin.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/subdomain_origin.cy.js
@@ -30,9 +30,7 @@ describe('subdomains', () => {
         document.cookie = 'foo=bar'
       })
 
-      cy.getCookies().then((cookies) => {
-        expect(cookies.length).to.eq(3)
-      })
+      cy.getCookies().should('have.length', 3)
     })
   })
 

--- a/system-tests/projects/session-and-origin-e2e-specs/cypress/e2e/session/session_persist_1.cy.js
+++ b/system-tests/projects/session-and-origin-e2e-specs/cypress/e2e/session/session_persist_1.cy.js
@@ -27,9 +27,7 @@ describe('creates global session', () => {
       }
     })
 
-    cy.getCookie('token').then((cookie) => {
-      expect(cookie.value).to.eq('1')
-    })
+    cy.getCookie('token').its('value').should('eq', '1')
   })
 
   it('restores global session', () => {
@@ -46,9 +44,7 @@ describe('creates global session', () => {
       }
     })
 
-    cy.getCookie('token').then((cookie) => {
-      expect(cookie.value).to.eq('1')
-    })
+    cy.getCookie('token').its('value').should('eq', '1')
   })
 
   it('creates spec session', () => {
@@ -65,9 +61,7 @@ describe('creates global session', () => {
       }
     })
 
-    cy.getCookie('token').then((cookie) => {
-      expect(cookie.value).to.eq('2')
-    })
+    cy.getCookie('token').its('value').should('eq', '2')
   })
 
   it('restores spec session', () => {
@@ -84,8 +78,6 @@ describe('creates global session', () => {
       }
     })
 
-    cy.getCookie('token').then((cookie) => {
-      expect(cookie.value).to.eq('2')
-    })
+    cy.getCookie('token').its('value').should('eq', '2')
   })
 })

--- a/system-tests/projects/session-and-origin-e2e-specs/cypress/e2e/session/session_persist_2.cy.js
+++ b/system-tests/projects/session-and-origin-e2e-specs/cypress/e2e/session/session_persist_2.cy.js
@@ -26,9 +26,7 @@ it('restores global session from last spec', () => {
     }
   })
 
-  cy.getCookie('token').then((cookie) => {
-    expect(cookie.value).to.eq('1')
-  })
+  cy.getCookie('token').its('value').should('eq', '1')
 })
 
 it('creates spec session since it is a new spec', () => {
@@ -46,7 +44,5 @@ it('creates spec session since it is a new spec', () => {
     }
   })
 
-  cy.getCookie('token').then((cookie) => {
-    expect(cookie.value).to.eq('2')
-  })
+  cy.getCookie('token').its('value').should('eq', '2')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3078,13 +3078,6 @@
     "@emnapi/wasi-threads" "1.2.2"
     tslib "^2.4.0"
 
-"@emnapi/core@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
-  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
-  dependencies:
-    tslib "^2.4.0"
-
 "@emnapi/runtime@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.1.tgz#58f1f3d5d81a9b12f793ab688c96371901027c24"
@@ -3096,20 +3089,6 @@
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.2.tgz#eb22f04d76febfdf4f87fdaff54c8a53f6bf0dbd"
   integrity sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/runtime@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
-  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
-  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
   dependencies:
     tslib "^2.4.0"
 
@@ -5365,7 +5344,7 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
-"@napi-rs/wasm-runtime@^1.1.2", "@napi-rs/wasm-runtime@^1.1.6":
+"@napi-rs/wasm-runtime@^1.1.6":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz#d7aa398845e3ab1c9c8f81ea50f527ed37d16715"
   integrity sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==
@@ -25834,7 +25813,7 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-path-to-regexp@^6.2.0, path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
+path-to-regexp@^6.2.1, path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
   integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
@@ -30568,7 +30547,7 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.12, tinyglobby@^0.2.13, tinyglobby@^0.2.14, tinyglobby@^0.2.15, tinyglobby@^0.2.17:
+tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
@@ -30958,11 +30937,6 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
-  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
-
 tslib@2.3.1, tslib@~2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -30973,7 +30947,7 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.8.1:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -32887,7 +32861,7 @@ ws@8.2.2:
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
-ws@^8.0.0, ws@^8.17.1, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0:
+ws@^8.17.1, ws@^8.18.0, ws@^8.5.0, ws@^8.8.0:
   version "8.21.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
   integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==


### PR DESCRIPTION
- Closes <!-- link to the issue here, if there is one -->

### Additional details

`cy.getCookie()`, `cy.getCookies()`, `cy.getAllCookies()`, `cy.getAllLocalStorage()` and `cy.getAllSessionStorage()` are query commands, so assertions chained through `.should()` re-read the underlying state on every retry. Assertion-only `.then()` callbacks chained off them do not — they read once and fail immediately.

That's a race wherever the cookie is set asynchronously relative to the read: 302 redirects, `document.cookie` writes from the AUT, and the server-side cookie jar syncing back to the browser. Several of the specs touched here are already marked flaky for exactly this reason (the `__Host-`/`__Secure-` prefix tests carry `{ retries: 15 }` and reference [#23444](https://github.com/cypress-io/cypress/issues/23444)).

This converts assertion-only `.then()` callbacks off these commands to `.should()` so the read is retried along with the assertion. Tests only — no production code changes.

**`packages/driver`**
- `cypress/e2e/commands/cookies.cy.js` — 19 conversions in the real-browser (`- no stub`) suite, covering `getCookies`/`getAllCookies`/`getCookie`, including the blocks inside `cy.origin()`.
- `cypress/e2e/e2e/e2e_cookies.cy.js` — the `__Host-`/`__Secure-` prefix assertions, plus the simple-cookie case which collapses to `.should('exist')`.
- `cypress/e2e/e2e/origin/cookie_login.cy.ts` — two blocks asserting cookie shape immediately after a `document.cookie` write.
- `cypress/e2e/e2e/origin/cookie_misc.cy.ts` — two blocks asserting on cookies set by a 302 redirect.

**`system-tests`**
- `projects/e2e/`: `request.cy.js` (also drops a leftover `console.log`, which would otherwise fire once per retry), `subdomain.cy.js` and `subdomain_origin.cy.js` (→ `.should('have.length', 3)`), `cookies_spec_baseurl.cy.js` (2 domain-cookie blocks).
- `projects/cookies/cypress/e2e/app.cy.js` — 2 blocks.
- `projects/session-and-origin-e2e-specs/.../session_persist_{1,2}.cy.js` — 6 token assertions → `.its('value').should('eq', …)`.

Deliberately left as `.then()`:

- The stubbed-automation halves of `cookies.cy.js` and `storage.cy.ts` — `.log`, `consoleProps`, `ends immediately`, `snapshots immediately`, and `Promise.prototype.timeout` spy assertions. These assert single-invocation behavior; `.should()` would re-invoke the automation stub and change what is under test. `logs once` in particular can't be helped by a retry — if the command logged the wrong number of times, retrying only delays the failure.
- `cli/types/tests/cypress-tests.ts` — type-assertion fixtures where `.then` is the overload being type-checked.
- `e2e_cookies.cy.js` `.then(cleanse)` — a transform, not an assertion, in an already-skipped test.
- `Cypress.session.getCookies()` in `multi_cookies.cy.js` — a different internal API, not the `cy.*` command.

`cy.getAllLocalStorage()` and `cy.getAllSessionStorage()` call sites were already `.should()`-based from #34318, which is where those two became queries; no changes were needed for them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors plus lockfile housekeeping; no production or API changes.
> 
> **Overview**
> Cookie e2e and system-test specs now assert on **`cy.getCookie`**, **`cy.getCookies`**, and **`cy.getAllCookies`** via **`.should()`** instead of assertion-only **`.then()`**, so reads participate in query-command retries when cookies appear asynchronously (redirects, `document.cookie`, jar sync).
> 
> Coverage spans driver command/e2e/origin specs and several system-test projects; simple cases use chained assertions like **`.its('value').should('eq', …)`** or **`.should('have.length', n)`**. **`request.cy.js`** drops a stray **`console.log`**. **`yarn.lock`** only deduplicates/consolidates dependency resolution entries—no intentional dependency bumps.
> 
> Stubbed automation tests that must assert single-invocation behavior are unchanged, per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe93fee5613f244adf0b0935e20059cf064bf10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```bash
yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/commands/cookies.cy.js,cypress/e2e/e2e/e2e_cookies.cy.js,cypress/e2e/e2e/origin/cookie_misc.cy.ts,cypress/e2e/e2e/origin/cookie_login.cy.ts"

cd system-tests && node ./scripts/run.js --glob-in-dir="cookies"
```

These specs exercise real browser cookie state, so the conversions should be validated across the browser matrix rather than Electron alone.

### How has the user experience changed?

No change. Test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-only change: converts assertion-only `.then()` callbacks to `.should()` so retries re-read cookie state. No production code is touched. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrHbUte3m9aUnXwJENW9hY)_