### PR TITLE
fix: prevent the AUT pane from going blank after pinning a command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Bugfixes:**
 
-- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the application preview pane permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the preview pane. Addressed in [#PR_NUMBER](https://github.com/cypress-io/cypress/pull/PR_NUMBER).
+- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the application preview pane permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the preview pane. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
 
 ## 15.20.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Bugfixes:**
 
-- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the application preview pane permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the preview pane. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
+- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the AUT snapshot permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the AUT. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
 
 ## 15.20.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.20.1
+
+**Bugfixes:**
+
+- Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the application preview pane permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the preview pane. Addressed in [#PR_NUMBER](https://github.com/cypress-io/cypress/pull/PR_NUMBER).
+
 ## 15.20.0
 
 **Performance:**

--- a/packages/app/cypress/e2e/runner/runner.ui.cy.ts
+++ b/packages/app/cypress/e2e/runner/runner.ui.cy.ts
@@ -308,5 +308,43 @@ describe('src/cypress/runner', () => {
       .should('not.contain', 'ran afterEach even though specs were stopped')
       .and('contain', 'Cypress test was stopped while running this command.')
     })
+
+    it('leaves the aut in place after stopping mid-run, and can still pin a snapshot', () => {
+      // set up by hand rather than with loadSpec/runSpec: both settle on the run's final
+      // state, and this spec deliberately hangs until it is stopped
+      cy.scaffoldProject('runner-e2e-specs')
+      cy.openProject('runner-e2e-specs')
+      cy.startAppServer()
+      cy.visitApp('specs/runner?file=cypress/e2e/runner/stop-preserves-aut.runner.cy.js')
+
+      cy.reporter({ timeout: 30000 }).find('[data-cy="runnable-header"]', { timeout: 30000 }).should('contain', 'stop-preserves-aut.runner.cy.js')
+
+      // the spec stops itself. The reset-page decision is made while the stopped test runs its
+      // after-run hooks, so wait for that error before asserting on the page — otherwise this
+      // passes on a page that simply has not been reset yet
+      cy.reporter().find('.runnable-err-message', { timeout: 30000 })
+      .should('contain', 'Cypress test was stopped while running this command.')
+
+      cy.reporter().find('.restart', { timeout: 30000 }).should('be.visible')
+
+      // the stopped test is not the last one in the suite, but nothing runs after a stop, so
+      // the page is kept rather than reset to about:blank for test isolation
+      cy.get('iframe.aut-iframe').its('0.contentDocument.body').then(cy.wrap).within(() => {
+        cy.get('input').should('exist')
+      })
+
+      // only the running test is expanded, so open the completed one to reach its commands
+      cy.reporter().find('.runnable-title:contains(completed test)').click()
+      cy.reporter().find('.command-name-type .command-number-column').first().click()
+      cy.reporter().find('.command-pin').should('exist')
+
+      // the pin lands on the command's "before" snapshot; the typed value is what distinguishes
+      // the restored "after" snapshot from the live page, which is also on the fixture
+      cy.contains('[data-testid="snapshot-controls"] button', 'after').click()
+
+      cy.get('iframe.aut-iframe').its('0.contentDocument.body').then(cy.wrap).within(() => {
+        cy.get('input').should('have.value', 'pinned')
+      })
+    })
   })
 })

--- a/packages/app/src/runner/aut-iframe.cy.tsx
+++ b/packages/app/src/runner/aut-iframe.cy.tsx
@@ -1,6 +1,7 @@
 import { AutIframe } from './aut-iframe'
 import { createEventManager } from '../../cypress/component/support/ctSupport'
 import { getElementDimensions } from './dimensions'
+import { logger } from './logger'
 
 describe('AutIframe', () => {
   let autIframe: AutIframe
@@ -197,6 +198,65 @@ describe('AutIframe', () => {
 
     it('should throw error when destroy is called without create', () => {
       expect(() => autIframe.destroy()).to.throw('Cannot call #remove without first calling #create')
+    })
+  })
+
+  context('.doesAUTMatchTopSuperDomainOrigin', () => {
+    let iframe: HTMLIFrameElement
+
+    const attachIframe = (src?: string) => {
+      iframe = document.createElement('iframe')
+
+      if (src) {
+        iframe.src = src
+      }
+
+      document.body.appendChild(iframe)
+      autIframe.$iframe = Cypress.$(iframe) as JQuery<HTMLIFrameElement>
+    }
+
+    beforeEach(() => {
+      const eventManager = createEventManager()
+
+      eventManager._testingOnlySetCypress({ Location: Cypress.Location })
+      autIframe = new AutIframe('Test Project', eventManager, Cypress.$)
+    })
+
+    afterEach(() => {
+      iframe?.remove()
+    })
+
+    it('is true when the AUT is on about:blank', () => {
+      attachIframe()
+
+      expect(autIframe.doesAUTMatchTopSuperDomainOrigin()).to.be.true
+    })
+
+    it('is true when the AUT shares a super domain origin with top', () => {
+      attachIframe(window.location.href)
+
+      expect(autIframe.doesAUTMatchTopSuperDomainOrigin()).to.be.true
+    })
+  })
+
+  context('.restoreDom', () => {
+    it('does not wait on a load event that cannot fire when the AUT has no src to remove', () => {
+      const iframe = document.createElement('iframe')
+
+      document.body.appendChild(iframe)
+
+      autIframe.$iframe = Cypress.$(iframe) as JQuery<HTMLIFrameElement>
+      autIframe.doesAUTMatchTopSuperDomainOrigin = () => false
+
+      const logError = cy.stub(logger, 'logError')
+      const one = cy.spy(autIframe.$iframe, 'one')
+
+      autIframe.restoreDom({ body: { get: () => document.createElement('body') }, htmlAttrs: {} })
+
+      expect(one).not.to.be.called
+      expect(logError).to.be.calledOnce
+
+      iframe.remove()
     })
   })
 })

--- a/packages/app/src/runner/aut-iframe.cy.tsx
+++ b/packages/app/src/runner/aut-iframe.cy.tsx
@@ -218,7 +218,8 @@ describe('AutIframe', () => {
     beforeEach(() => {
       const eventManager = createEventManager()
 
-      eventManager._testingOnlySetCypress({ Location: Cypress.Location })
+      // Location is a driver internal, so it is absent from the public Cypress types
+      eventManager._testingOnlySetCypress({ Location: (Cypress as any).Location })
       autIframe = new AutIframe('Test Project', eventManager, Cypress.$)
     })
 

--- a/packages/app/src/runner/aut-iframe.ts
+++ b/packages/app/src/runner/aut-iframe.ts
@@ -126,7 +126,7 @@ export class AutIframe {
    * If the AUT is cross super domain origin relative to top, a security error is thrown and the method returns false
    * If the AUT is cross super domain origin relative to top and chromeWebSecurity is false, origins of the AUT and top need to be compared and returns false
    * Otherwise, if top and the AUT match super domain origins, the method returns true.
-   * If the AUT origin is "about://blank", that means the src attribute has been stripped off the iframe and is adhering to same origin policy
+   * If the AUT is on about:blank, the src attribute has been stripped off the iframe and it is adhering to same origin policy
    */
   doesAUTMatchTopSuperDomainOrigin = () => {
     const Cypress = this.eventManager.getCypress()
@@ -138,7 +138,11 @@ export class AutIframe {
       const locationTop = Cypress.Location.create(window.location.href)
       const locationAUT = Cypress.Location.create(currentHref)
 
-      return locationTop.superDomainOrigin === locationAUT.superDomainOrigin || locationAUT.superDomainOrigin === 'about://blank'
+      if (locationAUT.protocol === 'about:') {
+        return true
+      }
+
+      return locationTop.superDomainOrigin === locationAUT.superDomainOrigin
     } catch (err) {
       if (err.name === 'SecurityError') {
         return false
@@ -180,13 +184,19 @@ export class AutIframe {
 
   restoreDom = (snapshot) => {
     if (!this.doesAUTMatchTopSuperDomainOrigin()) {
+      if (!this.$iframe?.attr('src')) {
+        logger.logError('Cannot restore the snapshot: the AUT is cross origin and has no src attribute to remove.')
+
+        return
+      }
+
       /**
        * A load event fires here when the src is removed (as does an unload event).
        * This is equivalent to loading about:blank (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-src).
        * This doesn't resort in a log message being generated for a new page.
        * In the event-manager code, we stop adding logs from other domains once the spec is finished.
        */
-      this.$iframe?.one('load', () => {
+      this.$iframe.one('load', () => {
         this.restoreDom(snapshot)
       })
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -527,9 +527,12 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
         const shouldAlwaysResetPage = isRunMode && !isHeadedNoExit
         const isLastTestThatWillRunInSuite = test.final && lastTestThatWillRunInSuite(test, getAllSiblingTests(topSuite, getTestById))
 
-        // If we're not in open mode or we're in open mode and not the last test we reset state.
-        // The last test will needs to stay so that the user can see what the end result of the AUT was.
-        if (shouldAlwaysResetPage || !isLastTestThatWillRunInSuite) {
+        // In open mode the page is left alone once nothing else will run, so the user can see what
+        // the end result of the AUT was. That is true after the last test and equally true after
+        // the user stops the run — stopping is how they ask to look at the application.
+        const shouldResetPage = shouldAlwaysResetPage || (!isLastTestThatWillRunInSuite && !_runner.stopped)
+
+        if (shouldResetPage) {
           let nextTestHasTestIsolationOn
 
           if (!isLastTestThatWillRunInSuite) {

--- a/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/stop-preserves-aut.runner.cy.js
+++ b/system-tests/project-fixtures/runner-specs/cypress/e2e/runner/stop-preserves-aut.runner.cy.js
@@ -1,0 +1,27 @@
+// Stops itself so that runner.ui.cy.ts can pin a command afterwards. The stop takes effect once
+// the command in flight finishes, hence the short wait. The third test keeps the stopped one from
+// being the last in the suite — only a non-final test resets the page.
+describe('stop preserves the aut', {
+  // the project sets this to 0; the first test's snapshots have to survive into the second to be pinnable
+  numTestsKeptInMemory: 2,
+}, () => {
+  it('completed test', () => {
+    cy.visit('cypress/fixtures/example.html')
+    cy.get('input').type('pinned')
+  })
+
+  it('test stops while running', () => {
+    cy.visit('cypress/fixtures/example.html')
+    cy.then(() => {
+      const appDoc = window.parent.document
+
+      appDoc.getElementById('reporter-frame').contentDocument.querySelector('button.stop').click()
+    })
+
+    cy.wait(500)
+  })
+
+  it('never runs', () => {
+    cy.visit('cypress/fixtures/example.html')
+  })
+})


### PR DESCRIPTION
- Closes n/a

https://discord.com/channels/755913899261296641/1532889426127093831/1532889426127093831 

### Additional details

Reported on 15.19.0: stop a spec mid-run, pin a command in the Command Log, and the application preview pane goes white and never comes back, with the pin stuck on. Bisected to **15.18.0**.

`AutIframe#doesAUTMatchTopSuperDomainOrigin` treated the AUT as reachable when its `superDomainOrigin` was the literal `'about://blank'`. [#34050](https://github.com/cypress-io/cypress/pull/34050) (15.18.0) moved the URL parsing behind that value from Node's legacy `url.parse` to the WHATWG `URL` parser. The legacy parser read `about:blank` as host `blank`; the WHATWG parser reads no host at all:

| | `Cypress.Location.create('about:blank').superDomainOrigin` |
| --- | --- |
| 15.17.0 | `about://blank` |
| 15.18.0 – 15.20.0 | `about://` |

So once test isolation navigated the AUT to `about:blank`, the check returned false and `restoreDom` took its cross-origin path: register a one-shot `load` listener, call `removeSrcAttribute()`, return. The first pass genuinely removed `src="about:blank"`, which fired a load and retried — but the retry hit the same false check, and `removeAttr('src')` was by then a no-op, so no further load event ever fired and the snapshot was never restored. Meanwhile `isSnapshotPinned` stayed true, which makes `setSnapshots` and `_clearSnapshots` early-return, so nothing else could repaint the pane either. Blank forever, pin stuck on.

This PR makes three changes:

1. **`doesAUTMatchTopSuperDomainOrigin` matches on the AUT's protocol** rather than the `'about://blank'` literal. That literal was only ever an artifact of legacy URL parsing, and this was its only consumer in the codebase.
2. **`restoreDom` no longer waits on a load event that cannot fire.** When there is no `src` attribute to remove, it logs and returns instead of registering a listener that will never be called. The genuine cross-origin case always has a `src`, so that path is unchanged. This is what turned a wrong origin check into a *permanent* blank pane rather than a one-frame glitch.
3. **Stopping a run in open mode no longer resets the page.** `isLastTestThatWillRunInSuite` is computed purely from suite structure, so a test stopped mid-suite was still treated as "not last" and took the test-isolation path — defeating the intent of the very branch it sits in ("The last test will needs to stay so that the user can see what the end result of the AUT was"). Stopping is precisely how a user asks to look at the application. A stopped run now takes the same terminal path a finished run already takes; run mode is unaffected, since `shouldAlwaysResetPage` still short-circuits, and `nextTestHasTestIsolationOn` is computed exactly as before. This also removes the `about:blank` navigation that triggered the original report.

Verified by A/B: reverting change 3 alone makes the new e2e test fail with `Expected to find element: input` inside the AUT, because the page was reset to `about:blank`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches runner test-isolation reset logic and AUT iframe DOM restore paths used when pinning snapshots; behavior change in open mode when stopping mid-suite, but run mode reset behavior is unchanged.
> 
> **Overview**
> Fixes a **15.18.0 regression** where pinning a command in open mode could leave the AUT preview blank with the pin stuck on, after test isolation had navigated the iframe to `about:blank`.
> 
> **`AutIframe`** now treats an AUT on `about:` as same-origin (instead of matching the legacy `about://blank` `superDomainOrigin` string that WHATWG URL parsing no longer produces). **`restoreDom`** bails out with a logged error when the cross-origin recovery path has no `src` to remove, instead of registering a `load` listener that never fires.
> 
> In **open mode**, stopping a run no longer triggers the test-isolation page reset for a non-final test—the stopped run is treated like a terminal state so the AUT stays on screen and snapshots can be restored.
> 
> Changelog **15.20.1**, unit tests for the iframe helpers, and a runner e2e spec that stops mid-run and pins a snapshot are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1586d0c78b1e18237c1086abbac573dd189c9c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Automated coverage is included. To reproduce by hand against a released binary, in a project with at least two tests where the second is long-running:

1. `npx cypress open --e2e` on 15.18.0 or later and run the spec.
2. Click **stop** while the second test is running.
3. Pin a command from the first test in the Command Log.

Before: the preview pane goes white and never recovers; the pin cannot be cleared and hovering other commands does nothing. After: the application stays visible when the run is stopped, and pinning shows the command's snapshot.

A two-second headless check of the underlying value, which passes on 15.17.0 and fails from 15.18.0 on:

```js
it('about:blank resolves to the superDomainOrigin the AUT origin check looks for', () => {
  expect(Cypress.Location.create('about:blank').superDomainOrigin).to.eq('about://blank')
})
```

### How has the user experience changed?

In open mode, stopping a run now leaves the application under test on screen instead of clearing it to the "Default blank page" placeholder, and pinning a command afterwards shows that command's snapshot instead of a white pane.

Before:

https://github.com/user-attachments/assets/214211b3-d045-42db-a7d9-7b270ecfd946

After:

https://github.com/user-attachments/assets/320a8fdf-5a26-4d37-8436-6c9fa781703b

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- customer report via Slack; no public issue -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
