### PR TITLE
feat: offer a unique selector for each match of an ambiguous tap selector

### DIFF
--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -76,46 +76,6 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
   return { frameId: found.id }
 }
 
-const WHOLE_NUMBER = /^\d+$/
-
-const parseWholeNumber = (raw: unknown): number | undefined => {
-  if (typeof raw !== 'string' || !WHOLE_NUMBER.test(raw)) {
-    return undefined
-  }
-
-  const value = Number(raw)
-
-  return Number.isSafeInteger(value) ? value : undefined
-}
-
-export const parseIndex = (raw: string | undefined): number | undefined => {
-  if (raw === undefined) {
-    return undefined
-  }
-
-  const value = parseWholeNumber(raw)
-
-  if (value === undefined) {
-    throw new FrameCommandError('INVALID_INDEX', '--at must be a 0-based index: a whole number, 0 or greater')
-  }
-
-  return value
-}
-
-export const parsePositiveInt = (raw: string | undefined, fallback: number, label: string): number => {
-  if (raw === undefined) {
-    return fallback
-  }
-
-  const value = parseWholeNumber(raw)
-
-  if (value === undefined || value <= 0) {
-    throw new FrameCommandError('INVALID_LIMIT', `${label} must be a positive integer`)
-  }
-
-  return value
-}
-
 /**
  * Gates the AUT-frame reads on the same run lifecycle `status` reports. The
  * frame is only worth reading once a spec has settled: while a spec is running

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -1,3 +1,7 @@
+import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
+import type { ElementSelectorMatch, ElementSelectorsResult } from '@packages/cypress-instances'
+
+import { validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
 import { createFrameIsolatedWorld } from './cdp'
 import { FrameCommandError } from './frame'
@@ -7,9 +11,10 @@ import type { MatchCountResult } from './scripts'
 
 /**
  * What a selector-taking AUT read returns in place of the read when the selector
- * matched more than one element: how many it matched. It is the answer to "which
- * one did you mean?", so it prints and honors `--json` like any other result —
- * but the read never happened, so the command exits 1.
+ * matched more than one element: how many it matched, and a selector unique to
+ * each, to re-run with. It is the answer to "which one did you mean?", so it
+ * prints and honors `--json` like any other result — but the read never
+ * happened, so the command exits 1.
  */
 export interface FrameAmbiguousResult {
   /** Always `true` — marks this as the ambiguity answer rather than a read. */
@@ -18,6 +23,30 @@ export interface FrameAmbiguousResult {
   selector: string
   /** How many elements it matched. */
   count: number
+  /**
+   * A selector unique to each match, in document order, each carrying the index
+   * of the match it names. May be shorter than `count`: a match no unique
+   * selector could be derived for is omitted.
+   */
+  selectors: ElementSelectorMatch[]
+}
+
+/**
+ * A unique selector for each match, to offer in place of the ambiguous one.
+ * Best effort: these come from the instance itself, which derives them the way
+ * its Selector Playground does — so they honor any selectorPriority the project
+ * configured, and are selectors the user's own tests would use. An instance that
+ * can't reach its app under test (a secondary origin inside `cy.origin`) just
+ * leaves the match count to speak for itself.
+ */
+const disambiguatingSelectors = async (session: TapSession, selector: string): Promise<ElementSelectorMatch[]> => {
+  try {
+    const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['element-selectors', { selector }, {}]))
+
+    return 'error' in outcome ? [] : (outcome.result as ElementSelectorsResult).selectors
+  } catch {
+    return []
+  }
 }
 
 export const resolveAmbiguity = async (
@@ -72,7 +101,12 @@ export const resolveAmbiguity = async (
     return undefined
   }
 
-  return { ambiguous: true, selector, count }
+  return {
+    ambiguous: true,
+    selector,
+    count,
+    selectors: await disambiguatingSelectors(session, selector),
+  }
 }
 
 export const withAmbiguous = async <T>(

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -1,5 +1,5 @@
 import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
-import type { ElementSelectorMatch, ElementSelectorsResult } from '@packages/cypress-instances'
+import type { ResolveSelectorMatch, ResolveSelectorResult } from '@packages/cypress-instances'
 
 import { validateExecResult } from '../tap-session'
 import type { TapSession } from '../tap-session'
@@ -24,11 +24,11 @@ export interface FrameAmbiguousResult {
   /** How many elements it matched. */
   count: number
   /**
-   * A selector unique to each match, in document order, each carrying the index
-   * of the match it names. May be shorter than `count`: a match no unique
-   * selector could be derived for is omitted.
+   * One entry per match, in document order, each carrying the index of the match
+   * it names and a selector unique to it — `null` where none could be derived.
+   * May be shorter than `count`: the instance only derives so many.
    */
-  selectors: ElementSelectorMatch[]
+  selectors: ResolveSelectorMatch[]
 }
 
 /**
@@ -39,11 +39,11 @@ export interface FrameAmbiguousResult {
  * can't reach its app under test (a secondary origin inside `cy.origin`) just
  * leaves the match count to speak for itself.
  */
-const disambiguatingSelectors = async (session: TapSession, selector: string): Promise<ElementSelectorMatch[]> => {
+const disambiguatingSelectors = async (session: TapSession, selector: string): Promise<ResolveSelectorMatch[]> => {
   try {
-    const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['element-selectors', { selector }, {}]))
+    const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['resolve-selector', { selector }, {}]))
 
-    return 'error' in outcome ? [] : (outcome.result as ElementSelectorsResult).selectors
+    return 'error' in outcome ? [] : (outcome.result as ResolveSelectorResult).selectors
   } catch {
     return []
   }

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -1,6 +1,7 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
+import { withResolvedAutFrame } from '../aut/frame'
+import { parseIndex, parsePositiveInt } from '../utils'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXProperty, AXValue } from '../aut/cdp'
 import { withAmbiguous } from '../aut/single-match'

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -1,6 +1,7 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { FrameCommandError, parseIndex, parsePositiveInt, withResolvedAutFrame } from '../aut/frame'
+import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
+import { parseIndex, parsePositiveInt } from '../utils'
 import { createFrameIsolatedWorld } from '../aut/cdp'
 import { withAmbiguous } from '../aut/single-match'
 import type { FrameAmbiguousResult } from '../aut/single-match'

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -1,6 +1,7 @@
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
-import { FrameCommandError, parseIndex, withResolvedAutFrame } from '../aut/frame'
+import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
+import { parseIndex } from '../utils'
 import { collectTrueStates, querySelectorObjectId } from '../aut/cdp'
 import type { AXValue } from '../aut/cdp'
 import { isRendererUnresponsive } from '../cdp-timeout'

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -1,12 +1,21 @@
 import chalk from 'chalk'
 
 import type { FrameAmbiguousResult } from '../aut/single-match'
-import { color, layout, quoted } from './format'
+import { color, columns, layout, quoted } from './format'
 
 // dom, aria, and inspect all answer an ambiguous selector the same way, so they
-// render it the same way: what went wrong, then the way through.
+// render it the same way: what went wrong, then the matches. Either column
+// re-runs the read — `--at <index>`, or the unique selector.
 export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
   const headline = color.warn(`⚠ selector ${chalk.bold(quoted(result.selector))} matched ${chalk.bold(result.count)} elements but must be unique`)
 
-  return layout([[headline, color.muted(`pass --at <index> to read one of them (0-${result.count - 1})`)]])
+  // With no selector derived for any match, --at is the only way through.
+  if (!result.selectors.length) {
+    return layout([[headline, color.muted(`pass --at <index> to read one of them (0-${result.count - 1})`)]])
+  }
+
+  const rows = result.selectors.map(({ index, selector }) => [String(index), quoted(selector)])
+  const note = color.warn(`provide ${chalk.bold('--at')} with an index to select an element from the list or update the selector.`)
+
+  return layout([[headline, note, ...columns(['index', 'selector'], rows)]])
 }

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -24,9 +24,15 @@ export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
 
   const table = [headline, note, ...columns(['index', 'selector'], rows, colorize)]
 
+  // Only a null the instance reported says a match has no derivable selector. A
+  // list that stops short — the lookup failed, or never reached the app under
+  // test — leaves its rows as dashes with nothing known about why, so there is
+  // nothing to send the reader back to their selector config over.
+  const underivable = result.selectors.some(({ selector }) => !selector)
+
   const notes = [
     ...(numbered === result.count ? [] : [`showing the first ${numbered} of ${result.count} matches — --at takes any index up to ${result.count - 1}.`]),
-    ...(derived.size === numbered ? [] : ['- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.']),
+    ...(underivable ? ['- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.'] : []),
   ].map((line) => color.muted(line))
 
   return layout(notes.length ? [table, notes] : [table])

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -8,14 +8,13 @@ import { color, columns, layout, quoted } from './format'
 // re-runs the read — `--at <index>`, or the unique selector.
 export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
   const headline = color.warn(`⚠ selector ${chalk.bold(quoted(result.selector))} matched ${chalk.bold(result.count)} elements but must be unique`)
-
-  // With no selector derived for any match, --at is the only way through.
-  if (!result.selectors.length) {
-    return layout([[headline, color.muted(`pass --at <index> to read one of them (0-${result.count - 1})`)]])
-  }
-
-  const rows = result.selectors.map(({ index, selector }) => [String(index), quoted(selector)])
   const note = color.warn(`provide ${chalk.bold('--at')} with an index to select an element from the list or update the selector.`)
 
-  return layout([[headline, note, ...columns(['index', 'selector'], rows)]])
+  // A match no unique selector could be derived for still keeps its row, since
+  // --at reads it either way.
+  const derived = new Map(result.selectors.map(({ index, selector }) => [index, quoted(selector)]))
+  const rows = Array.from({ length: result.count }, (_, index) => [String(index), derived.get(index) ?? '-'])
+  const colorize = (cells: string[], index: number) => (derived.has(index) ? cells : [cells[0], color.muted(cells[1])])
+
+  return layout([[headline, note, ...columns(['index', 'selector'], rows, colorize)]])
 }

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { MAX_DERIVED_SELECTORS } from '@packages/cypress-instances'
 
 import type { FrameAmbiguousResult } from '../aut/single-match'
 import { color, columns, layout, quoted } from './format'
@@ -10,11 +11,22 @@ export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
   const headline = color.warn(`⚠ selector ${chalk.bold(quoted(result.selector))} matched ${chalk.bold(result.count)} elements but must be unique`)
   const note = color.warn(`provide ${chalk.bold('--at')} with an index to select an element from the list or update the selector.`)
 
+  // Number no further than the instance derives selectors for: `*` on a real
+  // page matches thousands, and every row past the cap could only ever be a
+  // bare index. --at still reads any of them, so say what the list leaves out.
+  const numbered = Math.min(result.count, MAX_DERIVED_SELECTORS)
+
   // A match no unique selector could be derived for still keeps its row, since
   // --at reads it either way.
   const derived = new Map(result.selectors.flatMap(({ index, selector }) => (selector ? [[index, quoted(selector)] as const] : [])))
-  const rows = Array.from({ length: result.count }, (_, index) => [String(index), derived.get(index) ?? '-'])
+  const rows = Array.from({ length: numbered }, (_, index) => [String(index), derived.get(index) ?? '-'])
   const colorize = (cells: string[], index: number) => (derived.has(index) ? cells : [cells[0], color.muted(cells[1])])
 
-  return layout([[headline, note, ...columns(['index', 'selector'], rows, colorize)]])
+  const table = [headline, note, ...columns(['index', 'selector'], rows, colorize)]
+
+  if (numbered === result.count) {
+    return layout([table])
+  }
+
+  return layout([table, [color.muted(`showing the first ${numbered} of ${result.count} matches — --at takes any index up to ${result.count - 1}.`)]])
 }

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -12,7 +12,7 @@ export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
 
   // A match no unique selector could be derived for still keeps its row, since
   // --at reads it either way.
-  const derived = new Map(result.selectors.map(({ index, selector }) => [index, quoted(selector)]))
+  const derived = new Map(result.selectors.flatMap(({ index, selector }) => (selector ? [[index, quoted(selector)] as const] : [])))
   const rows = Array.from({ length: result.count }, (_, index) => [String(index), derived.get(index) ?? '-'])
   const colorize = (cells: string[], index: number) => (derived.has(index) ? cells : [cells[0], color.muted(cells[1])])
 

--- a/cli/lib/tap/render/ambiguous.ts
+++ b/cli/lib/tap/render/ambiguous.ts
@@ -24,9 +24,10 @@ export const renderAmbiguousHuman = (result: FrameAmbiguousResult): string => {
 
   const table = [headline, note, ...columns(['index', 'selector'], rows, colorize)]
 
-  if (numbered === result.count) {
-    return layout([table])
-  }
+  const notes = [
+    ...(numbered === result.count ? [] : [`showing the first ${numbered} of ${result.count} matches — --at takes any index up to ${result.count - 1}.`]),
+    ...(derived.size === numbered ? [] : ['- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.']),
+  ].map((line) => color.muted(line))
 
-  return layout([table, [color.muted(`showing the first ${numbered} of ${result.count} matches — --at takes any index up to ${result.count - 1}.`)]])
+  return layout(notes.length ? [table, notes] : [table])
 }

--- a/cli/lib/tap/utils.ts
+++ b/cli/lib/tap/utils.ts
@@ -6,7 +6,15 @@ import { FrameCommandError } from './aut/frame'
 const WHOLE_NUMBER = /^\d+$/
 
 const parseWholeNumber = (raw: unknown): number | undefined => {
-  return typeof raw === 'string' && WHOLE_NUMBER.test(raw) ? Number(raw) : undefined
+  if (typeof raw !== 'string' || !WHOLE_NUMBER.test(raw)) {
+    return undefined
+  }
+
+  // A run of digits still overflows: past 2^53 `Number` silently rounds, and
+  // far enough past it returns Infinity, which would disable the caps entirely.
+  const value = Number(raw)
+
+  return Number.isSafeInteger(value) ? value : undefined
 }
 
 /** `--at`: which match to read, 0-based. Absent means "the only match". */

--- a/cli/lib/tap/utils.ts
+++ b/cli/lib/tap/utils.ts
@@ -1,8 +1,5 @@
 import { FrameCommandError } from './aut/frame'
 
-// A flag's value is whatever text the shell handed over, so it is matched
-// rather than coerced: `Number('')`, `Number('  7 ')`, `Number('0x10')` and
-// `Number(['5'])` all produce integers a range check happily accepts.
 const WHOLE_NUMBER = /^\d+$/
 
 const parseWholeNumber = (raw: unknown): number | undefined => {
@@ -10,14 +7,11 @@ const parseWholeNumber = (raw: unknown): number | undefined => {
     return undefined
   }
 
-  // A run of digits still overflows: past 2^53 `Number` silently rounds, and
-  // far enough past it returns Infinity, which would disable the caps entirely.
   const value = Number(raw)
 
   return Number.isSafeInteger(value) ? value : undefined
 }
 
-/** `--at`: which match to read, 0-based. Absent means "the only match". */
 export const parseIndex = (raw: string | undefined): number | undefined => {
   if (raw === undefined) {
     return undefined
@@ -26,7 +20,7 @@ export const parseIndex = (raw: string | undefined): number | undefined => {
   const value = parseWholeNumber(raw)
 
   if (value === undefined) {
-    throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
+    throw new FrameCommandError('INVALID_INDEX', '--at must be a 0-based index: a whole number, 0 or greater')
   }
 
   return value

--- a/cli/lib/tap/utils.ts
+++ b/cli/lib/tap/utils.ts
@@ -1,14 +1,23 @@
 import { FrameCommandError } from './aut/frame'
 
+// A flag's value is whatever text the shell handed over, so it is matched
+// rather than coerced: `Number('')`, `Number('  7 ')`, `Number('0x10')` and
+// `Number(['5'])` all produce integers a range check happily accepts.
+const WHOLE_NUMBER = /^\d+$/
+
+const parseWholeNumber = (raw: unknown): number | undefined => {
+  return typeof raw === 'string' && WHOLE_NUMBER.test(raw) ? Number(raw) : undefined
+}
+
 /** `--at`: which match to read, 0-based. Absent means "the only match". */
 export const parseIndex = (raw: string | undefined): number | undefined => {
   if (raw === undefined) {
     return undefined
   }
 
-  const value = Number(raw)
+  const value = parseWholeNumber(raw)
 
-  if (!Number.isInteger(value) || value < 0) {
+  if (value === undefined) {
     throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
   }
 
@@ -20,9 +29,9 @@ export const parsePositiveInt = (raw: string | undefined, fallback: number, labe
     return fallback
   }
 
-  const value = Number(raw)
+  const value = parseWholeNumber(raw)
 
-  if (!Number.isInteger(value) || value <= 0) {
+  if (value === undefined || value <= 0) {
     throw new FrameCommandError('INVALID_LIMIT', `${label} must be a positive integer`)
   }
 

--- a/cli/lib/tap/utils.ts
+++ b/cli/lib/tap/utils.ts
@@ -1,0 +1,30 @@
+import { FrameCommandError } from './aut/frame'
+
+/** `--at`: which match to read, 0-based. Absent means "the only match". */
+export const parseIndex = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) {
+    return undefined
+  }
+
+  const value = Number(raw)
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new FrameCommandError('INVALID_INDEX', 'at must be a 0-based index: a whole number, 0 or greater')
+  }
+
+  return value
+}
+
+export const parsePositiveInt = (raw: string | undefined, fallback: number, label: string): number => {
+  if (raw === undefined) {
+    return fallback
+  }
+
+  const value = Number(raw)
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new FrameCommandError('INVALID_LIMIT', `${label} must be a positive integer`)
+  }
+
+  return value
+}

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -4,7 +4,7 @@ import stripAnsi from 'strip-ansi'
 import logger from '../../../lib/logger'
 import { resolveInstance } from '../../../lib/cypress-instances'
 import { withTapSession } from '../../../lib/tap/tap-session'
-import { resolveAutFrame, assertFrameReadable, parseIndex, parsePositiveInt, withResolvedAutFrame, FrameCommandError } from '../../../lib/tap/aut/frame'
+import { resolveAutFrame, assertFrameReadable, withResolvedAutFrame } from '../../../lib/tap/aut/frame'
 import type { TapSession } from '../../../lib/tap/tap-session'
 import type { TapCliOptions } from '../../../lib/tap/types'
 
@@ -170,44 +170,5 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
 
     expect(stripAnsi(stdout())).toContain('matched 2 elements but must be unique')
     expect(stderr()).to.eq('')
-  })
-})
-
-// Every input shape both parsers must reject, shared so they reject the same
-// class: text `Number()` coerces to a number that passes an isInteger check,
-// and runs of digits long enough to leave the safe-integer range.
-const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', '9007199254740993', '9'.repeat(400), null, ['1', '2'], ['5'], 7, {}]
-
-describe('lib/tap/aut/frame parseIndex', () => {
-  it('reads no index when the flag is absent', () => {
-    expect(parseIndex(undefined)).to.eq(undefined)
-  })
-
-  it('parses a 0-based index', () => {
-    expect(parseIndex('0')).to.eq(0)
-    expect(parseIndex('3')).to.eq(3)
-  })
-
-  it('rejects every malformed value with INVALID_INDEX', () => {
-    for (const bad of MALFORMED) {
-      expect(() => parseIndex(bad as any), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_INDEX' })
-    }
-  })
-})
-
-describe('lib/tap/aut/frame parsePositiveInt', () => {
-  it('falls back when the value is absent', () => {
-    expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
-  })
-
-  it('parses a positive integer, up to the largest one that survives the round trip', () => {
-    expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
-    expect(parsePositiveInt('9007199254740991', 200, 'max-nodes')).to.eq(Number.MAX_SAFE_INTEGER)
-  })
-
-  it('rejects zero and every malformed value with INVALID_LIMIT', () => {
-    for (const bad of ['0', ...MALFORMED]) {
-      expect(() => parsePositiveInt(bad as any, 200, 'max-nodes'), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
-    }
   })
 })

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -149,24 +149,31 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
     return withResolvedAutFrame(options, async () => result, 'dom')
   }
 
+  const ambiguous = {
+    ambiguous: true,
+    selector: '.item',
+    count: 2,
+    selectors: [{ index: 0, selector: '#first' }, { index: 1, selector: '#second' }],
+  }
+
   it('prints the read and exits 0', async () => {
     expect(await read({ found: true, html: '<p>hi</p>' })).to.eq(0)
     expect(stdout()).toContain('"html": "<p>hi</p>"')
   })
 
   it('exits 1 on an ambiguous selector — the read that was asked for did not happen', async () => {
-    expect(await read({ ambiguous: true, selector: '.item', count: 2 })).to.eq(1)
+    expect(await read(ambiguous)).to.eq(1)
   })
 
   it('still prints the ambiguity answer as a result, so the matches to choose between survive the non-zero exit', async () => {
-    await read({ ambiguous: true, selector: '.item', count: 2 })
+    await read(ambiguous)
 
-    expect(JSON.parse(stdout())).to.deep.eq({ ambiguous: true, selector: '.item', count: 2 })
+    expect(JSON.parse(stdout())).to.deep.eq(ambiguous)
     expect(stderr()).to.eq('')
   })
 
   it('renders the ambiguity for a human on stdout too, exiting 1 all the same', async () => {
-    expect(await read({ ambiguous: true, selector: '.item', count: 2 }, {} as TapCliOptions)).to.eq(1)
+    expect(await read(ambiguous, {} as TapCliOptions)).to.eq(1)
 
     expect(stripAnsi(stdout())).toContain('matched 2 elements but must be unique')
     expect(stderr()).to.eq('')

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -97,6 +97,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
       ambiguous: true,
       selector: '.item',
       count: 4,
+      selectors: [],
     })
   })
 

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -8,6 +8,8 @@ const render = (result: FrameAmbiguousResult): string => stripAnsi(renderAmbiguo
 
 const numbered = (...selectors: string[]) => selectors.map((selector, index) => ({ index, selector }))
 
+const undeliverable = '- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.'
+
 describe('lib/tap/render/ambiguous', () => {
   it('states what went wrong, then numbers a selector per match', () => {
     expect(render({
@@ -27,7 +29,7 @@ describe('lib/tap/render/ambiguous', () => {
     ].join('\n'))
   })
 
-  it('keeps a row for a match no selector could be derived for', () => {
+  it('keeps a row for a match no selector could be derived for, saying what the dash means', () => {
     // The second of four matches had no unique selector, but --at still reads it,
     // so it keeps its index and the dash stands in for the selector it lacks.
     expect(render({
@@ -43,6 +45,8 @@ describe('lib/tap/render/ambiguous', () => {
       '1      -',
       '2      \'#third\'',
       '3      \'#fourth\'',
+      '',
+      undeliverable,
     ].join('\n'))
   })
 
@@ -53,6 +57,8 @@ describe('lib/tap/render/ambiguous', () => {
       'index  selector',
       '0      -',
       '1      -',
+      '',
+      undeliverable,
     ].join('\n'))
   })
 
@@ -73,13 +79,14 @@ describe('lib/tap/render/ambiguous', () => {
       '9      -',
       '',
       'showing the first 10 of 5000 matches — --at takes any index up to 4999.',
+      undeliverable,
     ].join('\n'))
   })
 
   it('stays bounded for a selector matching a whole document, rather than building a row per match', () => {
     const rendered = render({ ambiguous: true, selector: '*', count: 1_000_000, selectors: [] })
 
-    expect(rendered.split('\n')).to.have.length(15)
+    expect(rendered.split('\n')).to.have.length(16)
     expect(rendered).toContain('showing the first 10 of 1000000 matches')
   })
 })

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -27,9 +27,9 @@ describe('lib/tap/render/ambiguous', () => {
     ].join('\n'))
   })
 
-  it('numbers each row by the match it names, not its position in the table', () => {
-    // The second of four matches had no unique selector, so the rows skip 1 —
-    // printing 0-2 here would have --at read a different element than shown.
+  it('keeps a row for a match no selector could be derived for', () => {
+    // The second of four matches had no unique selector, but --at still reads it,
+    // so it keeps its index and the dash stands in for the selector it lacks.
     expect(render({
       ambiguous: true,
       selector: 'li',
@@ -40,15 +40,19 @@ describe('lib/tap/render/ambiguous', () => {
       'provide --at with an index to select an element from the list or update the selector.',
       'index  selector',
       '0      \'#first\'',
+      '1      -',
       '2      \'#third\'',
       '3      \'#fourth\'',
     ].join('\n'))
   })
 
-  it('points at --at when no selector could be derived for any match', () => {
+  it('numbers every match when no selector could be derived for any of them', () => {
     expect(render({ ambiguous: true, selector: '.item', count: 2, selectors: [] })).toBe([
       '⚠ selector \'.item\' matched 2 elements but must be unique',
-      'pass --at <index> to read one of them (0-1)',
+      'provide --at with an index to select an element from the list or update the selector.',
+      'index  selector',
+      '0      -',
+      '1      -',
     ].join('\n'))
   })
 })

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -55,4 +55,31 @@ describe('lib/tap/render/ambiguous', () => {
       '1      -',
     ].join('\n'))
   })
+
+  it('stops numbering at the cap the instance derives to, saying how much of the match list is shown', () => {
+    expect(render({ ambiguous: true, selector: '*', count: 5000, selectors: numbered('.a', '.b') })).toBe([
+      '⚠ selector \'*\' matched 5000 elements but must be unique',
+      'provide --at with an index to select an element from the list or update the selector.',
+      'index  selector',
+      '0      \'.a\'',
+      '1      \'.b\'',
+      '2      -',
+      '3      -',
+      '4      -',
+      '5      -',
+      '6      -',
+      '7      -',
+      '8      -',
+      '9      -',
+      '',
+      'showing the first 10 of 5000 matches — --at takes any index up to 4999.',
+    ].join('\n'))
+  })
+
+  it('stays bounded for a selector matching a whole document, rather than building a row per match', () => {
+    const rendered = render({ ambiguous: true, selector: '*', count: 1_000_000, selectors: [] })
+
+    expect(rendered.split('\n')).to.have.length(15)
+    expect(rendered).toContain('showing the first 10 of 1000000 matches')
+  })
 })

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -34,7 +34,7 @@ describe('lib/tap/render/ambiguous', () => {
       ambiguous: true,
       selector: 'li',
       count: 4,
-      selectors: [{ index: 0, selector: '#first' }, { index: 2, selector: '#third' }, { index: 3, selector: '#fourth' }],
+      selectors: [{ index: 0, selector: '#first' }, { index: 1, selector: null }, { index: 2, selector: '#third' }, { index: 3, selector: '#fourth' }],
     })).toBe([
       '⚠ selector \'li\' matched 4 elements but must be unique',
       'provide --at with an index to select an element from the list or update the selector.',

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -8,7 +8,7 @@ const render = (result: FrameAmbiguousResult): string => stripAnsi(renderAmbiguo
 
 const numbered = (...selectors: string[]) => selectors.map((selector, index) => ({ index, selector }))
 
-const undeliverable = '- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.'
+const underivable = '- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.'
 
 describe('lib/tap/render/ambiguous', () => {
   it('states what went wrong, then numbers a selector per match', () => {
@@ -46,24 +46,27 @@ describe('lib/tap/render/ambiguous', () => {
       '2      \'#third\'',
       '3      \'#fourth\'',
       '',
-      undeliverable,
+      underivable,
     ].join('\n'))
   })
 
-  it('numbers every match when no selector could be derived for any of them', () => {
+  it('numbers every match when the instance named none of them, without blaming the selector config', () => {
+    // An empty list means the lookup never answered — the instance could not be
+    // reached, or could not reach its app under test. It says nothing about why
+    // any one match has no selector, so the dashes go unexplained.
     expect(render({ ambiguous: true, selector: '.item', count: 2, selectors: [] })).toBe([
       '⚠ selector \'.item\' matched 2 elements but must be unique',
       'provide --at with an index to select an element from the list or update the selector.',
       'index  selector',
       '0      -',
       '1      -',
-      '',
-      undeliverable,
     ].join('\n'))
   })
 
   it('stops numbering at the cap the instance derives to, saying how much of the match list is shown', () => {
-    expect(render({ ambiguous: true, selector: '*', count: 5000, selectors: numbered('.a', '.b') })).toBe([
+    const derived = [...numbered('.a', '.b'), ...Array.from({ length: 8 }, (_, offset) => ({ index: offset + 2, selector: null }))]
+
+    expect(render({ ambiguous: true, selector: '*', count: 5000, selectors: derived })).toBe([
       '⚠ selector \'*\' matched 5000 elements but must be unique',
       'provide --at with an index to select an element from the list or update the selector.',
       'index  selector',
@@ -79,14 +82,21 @@ describe('lib/tap/render/ambiguous', () => {
       '9      -',
       '',
       'showing the first 10 of 5000 matches — --at takes any index up to 4999.',
-      undeliverable,
+      underivable,
     ].join('\n'))
+  })
+
+  it('leaves a list the instance answered short of the cap unexplained', () => {
+    // Two entries for ten rows is not the instance reporting eight underivable
+    // matches, so the rows it never spoke for get no explanation either.
+    expect(render({ ambiguous: true, selector: '*', count: 5000, selectors: numbered('.a', '.b') })).not.toContain(underivable)
   })
 
   it('stays bounded for a selector matching a whole document, rather than building a row per match', () => {
     const rendered = render({ ambiguous: true, selector: '*', count: 1_000_000, selectors: [] })
 
-    expect(rendered.split('\n')).to.have.length(16)
+    expect(rendered.split('\n')).to.have.length(15)
     expect(rendered).toContain('showing the first 10 of 1000000 matches')
+    expect(rendered).not.toContain(underivable)
   })
 })

--- a/cli/test/lib/tap/render-ambiguous.spec.ts
+++ b/cli/test/lib/tap/render-ambiguous.spec.ts
@@ -6,17 +6,49 @@ import type { FrameAmbiguousResult } from '../../../lib/tap/aut/single-match'
 
 const render = (result: FrameAmbiguousResult): string => stripAnsi(renderAmbiguousHuman(result))
 
+const numbered = (...selectors: string[]) => selectors.map((selector, index) => ({ index, selector }))
+
 describe('lib/tap/render/ambiguous', () => {
-  it('states what went wrong, then the way through', () => {
-    expect(render({ ambiguous: true, selector: '.item', count: 2 })).toBe([
-      '⚠ selector \'.item\' matched 2 elements but must be unique',
-      'pass --at <index> to read one of them (0-1)',
+  it('states what went wrong, then numbers a selector per match', () => {
+    expect(render({
+      ambiguous: true,
+      selector: 'div',
+      count: 5,
+      selectors: numbered('.container', '.navbar-header', '#navbar', '.todoapp', '.view'),
+    })).toBe([
+      '⚠ selector \'div\' matched 5 elements but must be unique',
+      'provide --at with an index to select an element from the list or update the selector.',
+      'index  selector',
+      '0      \'.container\'',
+      '1      \'.navbar-header\'',
+      '2      \'#navbar\'',
+      '3      \'.todoapp\'',
+      '4      \'.view\'',
     ].join('\n'))
   })
 
-  it('quotes a selector carrying a single quote so it pastes back into a shell', () => {
-    expect(render({ ambiguous: true, selector: '[data-x="it\'s"]', count: 3 })).toContain(
-      'selector \'[data-x="it\'\\\'\'s"]\' matched 3 elements',
-    )
+  it('numbers each row by the match it names, not its position in the table', () => {
+    // The second of four matches had no unique selector, so the rows skip 1 —
+    // printing 0-2 here would have --at read a different element than shown.
+    expect(render({
+      ambiguous: true,
+      selector: 'li',
+      count: 4,
+      selectors: [{ index: 0, selector: '#first' }, { index: 2, selector: '#third' }, { index: 3, selector: '#fourth' }],
+    })).toBe([
+      '⚠ selector \'li\' matched 4 elements but must be unique',
+      'provide --at with an index to select an element from the list or update the selector.',
+      'index  selector',
+      '0      \'#first\'',
+      '2      \'#third\'',
+      '3      \'#fourth\'',
+    ].join('\n'))
+  })
+
+  it('points at --at when no selector could be derived for any match', () => {
+    expect(render({ ambiguous: true, selector: '.item', count: 2, selectors: [] })).toBe([
+      '⚠ selector \'.item\' matched 2 elements but must be unique',
+      'pass --at <index> to read one of them (0-1)',
+    ].join('\n'))
   })
 })

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -8,20 +8,28 @@ const SESSION_ID = 'S1'
 describe('lib/tap/aut/single-match resolveAmbiguity', () => {
   const frame = { frameId: 'aut-frame-id' }
 
-  const makeSession = (count: unknown, exceptionDetails?: unknown) => {
+  const makeSession = (count: unknown, execResult?: unknown, exceptionDetails?: unknown) => {
     const createIsolatedWorld = vi.fn().mockResolvedValue({ executionContextId: 42 })
     const callFunctionOn = vi.fn().mockResolvedValue({ result: { value: count }, exceptionDetails })
+    const call = vi.fn().mockImplementation(async () => {
+      if (execResult instanceof Error) {
+        throw execResult
+      }
+
+      return execResult
+    })
 
     const session = {
+      call,
       client: { Page: { createIsolatedWorld }, Runtime: { callFunctionOn } },
       sessionId: SESSION_ID,
     } as unknown as TapSession
 
-    return { session, callFunctionOn, createIsolatedWorld }
+    return { session, call, callFunctionOn, createIsolatedWorld }
   }
 
   it('lets a selector matching exactly one element through, counting it in the AUT frame', async () => {
-    const { session, callFunctionOn, createIsolatedWorld } = makeSession({ count: 1 })
+    const { session, callFunctionOn, createIsolatedWorld, call } = makeSession({ count: 1 })
 
     expect(await resolveAmbiguity(session, frame, '.one')).to.be.undefined
 
@@ -31,6 +39,9 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
       arguments: [{ value: '.one' }],
       returnByValue: true,
     })
+
+    // Nothing to disambiguate, so the instance is never asked for selectors.
+    expect(call).not.toHaveBeenCalled()
   })
 
   it('lets a selector matching nothing through — each command reports that in its own shape', async () => {
@@ -39,20 +50,49 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
     expect(await resolveAmbiguity(session, frame, '.missing')).to.be.undefined
   })
 
-  it('answers a selector matching several with how many it matched', async () => {
-    const { session } = makeSession({ count: 3 })
+  it('answers a selector matching several with a unique selector for each', async () => {
+    const selectors = [{ index: 0, selector: 'li[data-i="1"]' }, { index: 1, selector: 'li[data-i="2"]' }, { index: 2, selector: 'li[data-i="3"]' }]
+    const { session, call } = makeSession({ count: 3 }, { result: { selectors } })
 
     expect(await resolveAmbiguity(session, frame, '.item')).to.deep.eq({
       ambiguous: true,
       selector: '.item',
       count: 3,
+      selectors,
+    })
+
+    expect(call).toHaveBeenCalledWith('exec', ['element-selectors', { selector: '.item' }, {}])
+  })
+
+  it('still answers with the count when the instance could derive no selectors', async () => {
+    const { session } = makeSession({ count: 2 }, { result: { selectors: [] } })
+
+    expect(await resolveAmbiguity(session, frame, '.item')).to.deep.eq({
+      ambiguous: true,
+      selector: '.item',
+      count: 2,
+      selectors: [],
     })
   })
 
-  it('lets an in-range --at through', async () => {
-    const { session } = makeSession({ count: 3 })
+  it('still answers when the instance reports a failure for the selectors', async () => {
+    const { session } = makeSession({ count: 2 }, { error: { code: 'NO_AUT', message: 'no app under test is loaded' } })
+
+    expect(await resolveAmbiguity(session, frame, '.item')).to.deep.include({ ambiguous: true, count: 2 })
+  })
+
+  it('still answers when asking the instance for selectors throws', async () => {
+    const { session } = makeSession({ count: 2 }, new Error('binding gone'))
+
+    expect(await resolveAmbiguity(session, frame, '.item')).to.deep.include({ ambiguous: true, count: 2, selectors: [] })
+  })
+
+  it('lets an in-range --at through without asking for selectors', async () => {
+    const { session, call } = makeSession({ count: 3 })
 
     expect(await resolveAmbiguity(session, frame, '.item', 2)).to.be.undefined
+    // The caller named which match it wants, so there is nothing to disambiguate.
+    expect(call).not.toHaveBeenCalled()
   })
 
   it('rejects an --at past the last match, naming the valid range', async () => {
@@ -88,7 +128,7 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
   })
 
   it('maps a CDP evaluation exception to FRAME_READ_FAILED', async () => {
-    const { session } = makeSession(undefined, { text: 'boom', exception: { description: 'boom' } })
+    const { session } = makeSession(undefined, undefined, { text: 'boom', exception: { description: 'boom' } })
 
     await expect(resolveAmbiguity(session, frame, '.item')).rejects.toMatchObject({ code: 'FRAME_READ_FAILED' })
   })

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -61,7 +61,7 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
       selectors,
     })
 
-    expect(call).toHaveBeenCalledWith('exec', ['element-selectors', { selector: '.item' }, {}])
+    expect(call).toHaveBeenCalledWith('exec', ['resolve-selector', { selector: '.item' }, {}])
   })
 
   it('still answers with the count when the instance could derive no selectors', async () => {

--- a/cli/test/lib/tap/utils.spec.ts
+++ b/cli/test/lib/tap/utils.spec.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { parsePositiveInt } from '../../../lib/tap/utils'
+import { parseIndex, parsePositiveInt } from '../../../lib/tap/utils'
 import { FrameCommandError } from '../../../lib/tap/aut/frame'
+
+// Every input shape that is not a plain run of digits, shared by both parsers
+// so they reject the same class. `Number()` coerces most of these to a number
+// that passes an isInteger check, which is what makes the whole list necessary.
+const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', null, ['1', '2'], ['5'], 7, {}]
+
+describe('lib/tap/utils parseIndex', () => {
+  it('reads no index when the flag is absent', () => {
+    expect(parseIndex(undefined)).to.eq(undefined)
+  })
+
+  it('parses a 0-based index', () => {
+    expect(parseIndex('0')).to.eq(0)
+    expect(parseIndex('3')).to.eq(3)
+  })
+
+  it('rejects every malformed value with INVALID_INDEX', () => {
+    for (const bad of MALFORMED) {
+      expect(() => parseIndex(bad as any), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_INDEX' })
+    }
+  })
+})
 
 describe('lib/tap/utils parsePositiveInt', () => {
   it('falls back when the value is absent', () => {
@@ -12,9 +34,9 @@ describe('lib/tap/utils parsePositiveInt', () => {
     expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
   })
 
-  it('rejects zero, negatives, and non-integers with INVALID_LIMIT', () => {
-    for (const bad of ['0', '-5', '1.5', 'abc']) {
-      expect(() => parsePositiveInt(bad, 200, 'max-nodes')).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
+  it('rejects zero and every malformed value with INVALID_LIMIT', () => {
+    for (const bad of ['0', ...MALFORMED]) {
+      expect(() => parsePositiveInt(bad as any, 200, 'max-nodes'), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
     }
   })
 })

--- a/cli/test/lib/tap/utils.spec.ts
+++ b/cli/test/lib/tap/utils.spec.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from 'vitest'
 import { parseIndex, parsePositiveInt } from '../../../lib/tap/utils'
 import { FrameCommandError } from '../../../lib/tap/aut/frame'
 
-// Every input shape that is not a plain run of digits, shared by both parsers
-// so they reject the same class. `Number()` coerces most of these to a number
-// that passes an isInteger check, which is what makes the whole list necessary.
-const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', null, ['1', '2'], ['5'], 7, {}]
+// Every input shape both parsers must reject, shared so they reject the same
+// class: text `Number()` coerces to a number that passes an isInteger check,
+// and runs of digits long enough to leave the safe-integer range.
+const MALFORMED = ['', ' ', '   ', '\t', '\n', 'abc', '1.5', '-1', '-5', '0x10', '1e3', '  7  ', '+3', 'Infinity', 'NaN', '9007199254740993', '9'.repeat(400), null, ['1', '2'], ['5'], 7, {}]
 
 describe('lib/tap/utils parseIndex', () => {
   it('reads no index when the flag is absent', () => {
@@ -30,8 +30,9 @@ describe('lib/tap/utils parsePositiveInt', () => {
     expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
   })
 
-  it('parses a positive integer', () => {
+  it('parses a positive integer, up to the largest one that survives the round trip', () => {
     expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
+    expect(parsePositiveInt('9007199254740991', 200, 'max-nodes')).to.eq(Number.MAX_SAFE_INTEGER)
   })
 
   it('rejects zero and every malformed value with INVALID_LIMIT', () => {

--- a/cli/test/lib/tap/utils.spec.ts
+++ b/cli/test/lib/tap/utils.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { parsePositiveInt } from '../../../lib/tap/utils'
+import { FrameCommandError } from '../../../lib/tap/aut/frame'
+
+describe('lib/tap/utils parsePositiveInt', () => {
+  it('falls back when the value is absent', () => {
+    expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
+  })
+
+  it('parses a positive integer', () => {
+    expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
+  })
+
+  it('rejects zero, negatives, and non-integers with INVALID_LIMIT', () => {
+    for (const bad of ['0', '-5', '1.5', 'abc']) {
+      expect(() => parsePositiveInt(bad, 200, 'max-nodes')).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
+    }
+  })
+})

--- a/packages/app/src/tap/commands/resolve-selector.cy.ts
+++ b/packages/app/src/tap/commands/resolve-selector.cy.ts
@@ -1,4 +1,4 @@
-import { MAX_DERIVED_SELECTORS } from './resolve-selector'
+import { MAX_DERIVED_SELECTORS } from '../contract'
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import { TapManager } from '../tap-manager'
 import type { TapElementSelectorSource } from '../types'

--- a/packages/app/src/tap/commands/resolve-selector.ts
+++ b/packages/app/src/tap/commands/resolve-selector.ts
@@ -1,5 +1,6 @@
 import { tapManagerDataSource } from '../tap-manager-data-source'
 import { defineCommand, TapCommandError } from './definition'
+import { MAX_DERIVED_SELECTORS } from '../contract'
 import type { ResolveSelectorMatch, ResolveSelectorResult } from '../contract'
 
 // A shadow-scoped selector is unique only within its own shadow root, so it can't
@@ -7,12 +8,6 @@ import type { ResolveSelectorMatch, ResolveSelectorResult } from '../contract'
 // report the match as having none rather than suggest one that would resolve to
 // nothing.
 const isDocumentScoped = (selector: string): boolean => !selector.startsWith(':host')
-
-// Deriving a unique selector walks up from the element testing each candidate
-// against the whole document, so deriving one per match for a selector as broad
-// as `*` would hold the app's main thread for the size of the page. Past this
-// many matches the list is no longer one a caller picks out of anyway.
-export const MAX_DERIVED_SELECTORS = 10
 
 export const resolveSelectorCommand = defineCommand('resolve-selector', async ({ selector }): Promise<ResolveSelectorResult> => {
   const source = tapManagerDataSource.getElementSelectorSource()

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -11,6 +11,7 @@ export {
   TAP_SCHEMA_VERSION,
   TAP_COMMANDS,
   TAP_RUN_IN_PROGRESS_MESSAGE,
+  MAX_DERIVED_SELECTORS,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 export type {

--- a/packages/cypress-instances/lib/contracts/resolve-selector.ts
+++ b/packages/cypress-instances/lib/contracts/resolve-selector.ts
@@ -2,6 +2,13 @@
 // lives here in `contracts/`, next to the command metadata in `../tap-contract`,
 // so the app-side command and the CLI-side rendering type against the same shape.
 
+// Deriving a unique selector walks up from the element testing each candidate
+// against the whole document, so deriving one per match for a selector as broad
+// as `*` would hold the app's main thread for the size of the page. Past this
+// many matches the list is no longer one a caller picks out of anyway — so the
+// app derives up to here, and the CLI numbers up to here.
+export const MAX_DERIVED_SELECTORS = 10
+
 /** A unique CSS selector for one of the elements a selector matched. */
 export interface ResolveSelectorMatch {
   /**


### PR DESCRIPTION
- Closes N/A

### Additional details

Last of three slices. Stacked on #34485, which made `dom`, `aria`, and `inspect` answer an ambiguous selector with the match count instead of reading one arbitrary element.

The count alone leaves the reader to work out how to name the element they meant. The answer now carries a unique selector for each match as well, so the numbered table it prints re-runs the read either way: `--at <index>`, or the selector itself.

The selectors come from the instance's own `resolve-selector` binding command (#34504) rather than a generator ported into the CLI, so they honor whatever `selectorPriority` the project configured and read as selectors the project's own tests would use.

Best effort, by design. An instance that cannot reach its app under test — a secondary origin inside `cy.origin` — or that fails outright leaves the table with indexes and nothing else, and the answer still comes back. The lookup is skipped entirely when `--at` was passed, since the caller has already named the match.

Each entry carries its own index rather than relying on its position in the table. A match no unique selector could be derived for comes back with a `null` selector, and the instance only derives so many, so a position in `selectors` would otherwise number a different element than `--at` would read. Either way the match keeps its row in the table, with a faded `-` in place of the selector, since `--at` reads it. A note beneath the table says what the dash means and what to do about it — a selector priority the project's `Cypress.ElementSelector` config can change, or an element no document-scoped CSS selector reaches. It appears only where the instance reported a match it could not name. A list that stops short instead means the lookup never answered, which says nothing about why any one match has no selector, so those dashes go unexplained rather than send the reader to a config that is probably fine.

The table stops at the same cap the instance derives to, `MAX_DERIVED_SELECTORS`, which moves to the shared contract so the two sides count to one number rather than two copies of it. `tap dom '*'` on a real page matches thousands, and every row past the cap could only ever be a bare index — so the table numbers up to the cap and a line beneath it reports the total and that `--at` still reaches the rest. `--json` is untouched: it carries the true `count` and never builds a row per match.

### Steps to test

Against a running instance with a settled run:

```
npx cypress tap dom 'div'                # ambiguity answer, now with a selector per match
npx cypress tap dom 'div' --json         # {ambiguous, selector, count, selectors}
npx cypress tap inspect 'div'            # same table from inspect
npx cypress tap aria 'div'               # and from aria
npx cypress tap dom '*'                  # thousands of matches, ten rows
```

Then re-run with either column — `--at <index>` or the printed selector — and confirm both read the same element.

Verified against a live kitchensink run. `dom 'input'` came back with `[data-test="new-todo"]`, `#toggle-all`, `.toggle`, which is the driver's data-\* then id then class priority order.

### How has the user experience changed?

`cypress tap dom '.item'` with three matches, on the previous slice:

```
selector '.item' matched 3 elements but must be unique
pass --at <index> to read one of them (0-2)
```

Now:

```
selector '.item' matched 3 elements but must be unique
provide --at with an index to select an element from the list or update the selector.
index  selector
0      'li[data-i="1"]'
1      'li[data-i="2"]'
2      'li[data-i="3"]'
```

A match no unique selector could be derived for keeps its row, with a faded `-` in place of the selector:

```
selector '.item' matched 3 elements but must be unique
provide --at with an index to select an element from the list or update the selector.
index  selector
0      'li[data-i="1"]'
1      -
2      'li[data-i="3"]'

- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.
```

A selector broad enough to match a whole document stops at ten rows rather than printing one per match:

```
selector '*' matched 4821 elements but must be unique
provide --at with an index to select an element from the list or update the selector.
index  selector
0      '.container'
1      '#navbar'
2      -
3      -
4      -
5      -
6      -
7      -
8      -
9      -

showing the first 10 of 4821 matches — --at takes any index up to 4820.
- means no unique selector could be derived for that match — you may need to adjust your Cypress.ElementSelector config, or the element may be one no standard CSS selector can identify.
```

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds instance RPC on ambiguity paths and changes CLI output/JSON fields for dom/aria/inspect, but behavior degrades safely when resolve-selector fails and does not touch auth or data persistence.
> 
> **Overview**
> When `dom`, `aria`, or `inspect` hit a non-unique selector, the ambiguity payload now includes a **`selectors`** list (index + best-effort unique CSS selector per match) by calling the running instance’s **`resolve-selector`** exec. That lookup is skipped when **`--at`** is already set, and failures or missing AUT context still return the count with an empty or partial list.
> 
> Human output replaces the old “pass `--at`” hint with an **index / selector** table (copy-paste either column to re-run). Rows are capped at **`MAX_DERIVED_SELECTORS`** (moved into the shared tap contract so CLI rendering and the app command share one limit), with muted notes for truncated match lists, underivable selectors (`-`), and large `*` matches.
> 
> **`parseIndex`** / **`parsePositiveInt`** move from `aut/frame` to **`cli/lib/tap/utils`** with tests relocated; JSON shape gains **`selectors`** unchanged otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b5cbc68552be30de80b1f13dc779ae951409a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





