### PR TITLE
docs: update stale cypress-services paths in development guides

### DIFF
--- a/guides/cy-prompt-development.md
+++ b/guides/cy-prompt-development.md
@@ -39,7 +39,7 @@ yarn gulp downloadPromptTypes
 or to reference a local `cypress_services` repo:
 
 ```sh
-CYPRESS_LOCAL_CY_PROMPT_PATH=<path-to-cypress-services/app/cy-prompt/dist/development-directory> yarn gulp downloadPromptTypes
+CYPRESS_LOCAL_CY_PROMPT_PATH=<path-to-cypress-services/app/packages/cy-prompt/dist/development-directory> yarn gulp downloadPromptTypes
 ```
 
 ## Testing

--- a/guides/protocol-development.md
+++ b/guides/protocol-development.md
@@ -4,7 +4,7 @@ In production, the capture code used to capture and communicate test data will b
 
 * Clone the `cypress-services` repo (this requires that you be a member of the Cypress organization)
   * Run `yarn`
-  * Run `yarn watch` in `app/capture-protocol`
+  * Run `yarn watch` in `app/packages/capture-protocol`
 * Clone the `cypress` repo
   * Run `yarn`
-  * Execute `CYPRESS_LOCAL_PROTOCOL_PATH=path/to/cypress-services/app/capture-protocol/dist/index.js CYPRESS_INTERNAL_ENV=staging yarn cypress:run --record --key <record_key> --project <path/to/project>` on a project in record mode
+  * Execute `CYPRESS_LOCAL_PROTOCOL_PATH=path/to/cypress-services/app/packages/capture-protocol/dist/index.js CYPRESS_INTERNAL_ENV=staging yarn cypress:run --record --key <record_key> --project <path/to/project>` on a project in record mode

--- a/guides/studio-development.md
+++ b/guides/studio-development.md
@@ -30,7 +30,7 @@ yarn gulp downloadStudioTypes
 or to reference a local `cypress_services` repo:
 
 ```sh
-CYPRESS_LOCAL_STUDIO_PATH=<path-to-cypress-services/app/studio/dist/development-directory> yarn gulp downloadStudioTypes
+CYPRESS_LOCAL_STUDIO_PATH=<path-to-cypress-services/app/packages/studio/dist/development-directory> yarn gulp downloadStudioTypes
 ```
 
 ## Testing


### PR DESCRIPTION
- Closes N/A — purely mechanical documentation correction (no associated issue, per the PR checklist note)

### Additional details

cypress-services moved its `app/*` packages to `app/packages/*` (cypress-io/cypress-services#10531), and three of our development guides still reference the old layout in their local-development examples:

- `guides/protocol-development.md` — `CYPRESS_LOCAL_PROTOCOL_PATH` example and the `yarn watch` directory
- `guides/cy-prompt-development.md` — `CYPRESS_LOCAL_CY_PROMPT_PATH` example
- `guides/studio-development.md` — `CYPRESS_LOCAL_STUDIO_PATH` example

I swept the whole repo for other pre-move path references (`app/capture-protocol`, `app/studio`, `app/cy-prompt`, etc.); everything else is either a SHA-pinned permalink, an issue link, or changelog history, so these three guides are the complete set.

### Steps to test

N/A — documentation only.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path corrections with no runtime or product behavior changes.
> 
> **Overview**
> Updates local-development examples in three guides so they match the **cypress-services** layout after packages moved from `app/*` to **`app/packages/*`**.
> 
> **`guides/protocol-development.md`** — `yarn watch` and `CYPRESS_LOCAL_PROTOCOL_PATH` now point at `app/packages/capture-protocol`.
> 
> **`guides/cy-prompt-development.md`** and **`guides/studio-development.md`** — the `CYPRESS_LOCAL_CY_PROMPT_PATH` and `CYPRESS_LOCAL_STUDIO_PATH` gulp examples now use `app/packages/cy-prompt` and `app/packages/studio` respectively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dab7f0d6f9731c70e2aa730656097c05a54791b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->