### PR TITLE
test: de-flake the webkit screenshot viewport capture system test

### DIFF
--- a/system-tests/__snapshots__/screenshot_viewport_capture_spec.js
+++ b/system-tests/__snapshots__/screenshot_viewport_capture_spec.js
@@ -31,7 +31,7 @@ exports['e2e screenshot viewport capture / passes'] = `
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
-  │ Screenshots:  27                                                                               │
+  │ Screenshots:  3                                                                                │
   │ Video:        false                                                                            │
   │ Duration:     X seconds                                                                        │
   │ Spec Ran:     screenshot_viewport_capture.cy.js                                                │
@@ -44,54 +44,6 @@ exports['e2e screenshot viewport capture / passes'] = `
      inal.png                                                                                       
   -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
      are.png                                                                                        
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (1).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (2).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (3).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (4).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (5).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (6).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (7).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (8).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (9).png                                                                                    
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (10).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (11).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (12).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (13).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (14).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (15).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (16).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (17).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (18).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (19).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (20).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (21).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (22).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (23).png                                                                                   
-  -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/viewport-comp     (1000x660)
-     are (24).png                                                                                   
   -  /XXX/XXX/XXX/cypress/screenshots/screenshot_viewport_capture.cy.js/properly blac      (400x400)
      ks out absolute elements within a relative container.png                                       
 

--- a/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/screenshot_viewport_capture.cy.js
@@ -10,10 +10,12 @@ it('takes consistent viewport captures', () => {
   cy.visit('http://localhost:3322/viewport')
   cy.screenshot('viewport-original', options)
   .then(() => {
-    // take 25 screenshots and check that they're all the same
+    // take 10 screenshots and check that they're all the same
     // to ensure the Cypress UI is consistently hidden
     const fn = function () {
-      cy.screenshot('viewport-compare', options)
+      // without `overwrite`, each capture lands at `viewport-compare (n).png`
+      // and the comparison below keeps re-reading the very first capture
+      cy.screenshot('viewport-compare', { ...options, overwrite: true })
 
       cy.task('compare:screenshots', {
         a: 'screenshot_viewport_capture.cy.js/viewport-original',
@@ -23,7 +25,7 @@ it('takes consistent viewport captures', () => {
       })
     }
 
-    Cypress._.times(25, fn)
+    Cypress._.times(10, fn)
   })
 })
 

--- a/system-tests/test/screenshot_viewport_capture_spec.js
+++ b/system-tests/test/screenshot_viewport_capture_spec.js
@@ -20,5 +20,9 @@ describe('e2e screenshot viewport capture', () => {
   systemTests.it('passes', {
     spec: 'screenshot_viewport_capture.cy.js',
     snapshot: true,
+    // viewport-sized captures are the most expensive of the screenshot specs,
+    // and WebKit is the slowest browser at producing them, so the default
+    // 2 minute system test timeout leaves too little room on a loaded CI box
+    timeout: 180000,
   })
 })


### PR DESCRIPTION
- Closes N/A — no tracked issue. This corrects an existing system test that has been failing intermittently on WebKit:

```
1) e2e screenshot viewport capture passes [webkit]:
   Error: Timeout of 120000ms exceeded.
   (/root/cypress/system-tests/test/screenshot_viewport_capture_spec.js)
```

### Additional details

**Nothing hangs.** I ran the unmodified spec against WebKit five times: 32.0s, 34.3s, 34.5s, 38.0s, 39.9s. The 120s ceiling is the generic system-test default, and this spec is simply the most expensive of the screenshot specs — it captures 1000x660 viewports (vs 600x500 for fullPage and 560x302 for element) and took 25 iterations where its siblings take 10. On a loaded CI box that leaves too little room.

Two things I ruled out along the way, so reviewers don't have to re-derive them:

- The `Jimp.diff` introduced in #34454 is *cheaper* than the `hash()` it replaced (29ms vs 75ms per 1280x720 pair).
- The whole server-side decode -> crop -> encode path costs ~3.6s across all 27 screenshots.

**Those 25 iterations were only ever performing one real comparison.** `cy.screenshot` does not overwrite by default, so the compare captures landed at `viewport-compare (1..24).png` while `compare:screenshots` kept re-reading `viewport-compare.png`. The committed snapshot shows this plainly. Passing `overwrite` makes every iteration compare a fresh capture, and dropping to 10 matches the sibling specs.

Net effect: **10 real comparisons instead of 1**, from 12 captures instead of 27.

This regressed a long time ago and is worth recording. The spec was written in #1504 (May 2018) with 50 iterations, and it worked then — `cy.screenshot` overwrote the same path, so all 50 comparisons were genuine. PR #1858 (June 2018) both dropped it to 25 and, as its headline feature, began appending `(1)`, `(2)`… to repeated screenshots. Issue #1766 asked for that only on *non-named* screenshots, but it was broadened to named ones during review ([comment](https://github.com/cypress-io/cypress/pull/1858#issuecomment-396121876)), which silently invalidated 24 of the 25 comparisons in the same PR that set the count. The `overwrite` option that fixes it did not exist until #7955 landed three years later.

I also raised this spec's timeout to 180000, matching `screenshots_spec.js`, for headroom against CI variance.

Measured on WebKit, 5 runs each: **32.0–39.9s before, 26.3–30.1s after** (in-browser spec duration 16s -> 10s). Combined with the higher timeout, headroom goes from ~3.5x to ~6.5x.

**Known gap:** I verified WebKit and Electron locally, both passing against the regenerated snapshot. Chrome and Firefox are not installed in my environment, so CI is the first real check for them. The residual risk is that making the comparison genuine exposes capture jitter on Firefox (which `screenshot_fullpage_capture_spec.js` already skips). I judge it low — the captured page is blank white with two blacked-out 10x10 squares, the tolerance is 1% (~6,600 pixels), and the pre-existing code already performed one genuine cross-capture comparison on every browser.

**Not addressed here:** `screenshot_element_capture.cy.js` and `screenshot_fullpage_capture.cy.js` have the identical `overwrite` defect, so 9 of their 10 comparisons are vacuous too. I left them out to keep this PR to one concern. Worth a follow-up, since it turns two currently-green specs into tests that actually assert something.

### Steps to test

```
cd system-tests
node ./scripts/run.js test/screenshot_viewport_capture_spec.js --browser webkit
node ./scripts/run.js test/screenshot_viewport_capture_spec.js --browser electron
```

Both should pass against the updated snapshot. To see the original defect on `develop`, run the spec and note that the reported screenshots are `viewport-compare (1).png` through `(24).png` while the `compare:screenshots` task only ever reads `viewport-compare.png`.

### How has the user experience changed?

No change. Test-only; no product code is touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-only correction to an existing flaky spec; no product behavior changes. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoZJVbzeJkzNDCoVdsTnjK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no product code; residual risk is genuine cross-capture comparison surfacing browser-specific screenshot jitter on Chrome/Firefox in CI.
> 
> **Overview**
> Fixes intermittent WebKit timeouts on the viewport screenshot system test by making each comparison use a fresh capture and reducing how much work the spec does.
> 
> The e2e spec now passes **`overwrite: true`** on repeated `viewport-compare` screenshots so `compare:screenshots` compares a new capture each time instead of re-reading the first `viewport-compare.png` while extras land as `(n).png`. Iterations drop from **25 to 10**, aligned with other screenshot specs. The system test **timeout rises to 180s** for CI headroom on slow WebKit viewport captures.
> 
> The snapshot updates from **27 to 3** screenshots listed (original, single compare file, blackout test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91e18f1fc42d9bef1b302cc0adc3dcd26c778c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->