### PR TITLE
fix: read tap test state without serializing the run

### DIFF
--- a/packages/app/src/tap/AGENTS.md
+++ b/packages/app/src/tap/AGENTS.md
@@ -28,9 +28,14 @@ Rules:
   failure code — MUST be asserted in `tap-binding.cy.ts` against the real binding,
   with no stubbing or mocking of the runner seam.** This is the only layer that
   proves the coupling to Cypress internals (`getEventManager`, `getCypress().runner`,
-  `getAllTestsState`, `eventManager.runComplete`, and the
+  `getAllTestStates`, `getAllTestsSummary`, `eventManager.runComplete`, and the
   runtime `SerializedTest` shape) still holds. Those internals are not ours; only an
   unmocked end-to-end run catches them drifting.
+- The runner seam deliberately withholds the driver's `getAllTestsState`: it
+  serializes every command log of every test, which costs tens of seconds on a real
+  spec and blocks the renderer for all of it. Read states through
+  `getAllTestStates` and per-test properties through `getAllTestsSummary`; only a
+  single-test view (`getTestState`) may pay for logs, because it renders them.
 - Adding or changing a subcommand is not done until its happy path **and** its
   domain-failure codes are covered by real `exec(...)` calls in that spec.
 - Assert the **exact** key set of every result (e.g. `expect(Object.keys(entry)).to.deep.eq([...])`),

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -301,7 +301,8 @@ describe('tap/commands/pin', () => {
   describe('a pin made in the reporter UI', () => {
     const stubStatusRunner = () => {
       cy.stub(tapManagerDataSource, 'getRunner').returns({
-        getAllTestsState: () => TESTS_STATE,
+        getAllTestStates: () => Object.fromEntries(Object.entries(TESTS_STATE).map(([id, test]) => [id, test.state])),
+        getAllTestsSummary: () => TESTS_STATE,
         getTestState: (id: string) => TESTS_STATE[id as keyof typeof TESTS_STATE],
         isRunComplete: () => true,
         getStartTime: () => '2026-07-29T10:15:00.000Z',
@@ -368,7 +369,8 @@ describe('tap/commands/pin', () => {
       const { unpinSnapshot, pinInApp } = stubSource({ runner: { getTestState, getSnapshotPropsForLog: () => SNAPSHOT_PROPS } })
 
       cy.stub(tapManagerDataSource, 'getRunner').returns({
-        getAllTestsState: () => testsState,
+        getAllTestStates: () => Object.fromEntries(Object.entries(testsState).map(([id, test]) => [id, test.state])),
+        getAllTestsSummary: () => testsState,
         getTestState,
         isRunComplete: () => true,
         getStartTime: () => '2026-07-29T10:15:00.000Z',

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -263,7 +263,6 @@ describe('tap/commands/pin', () => {
   it('run-state reports the pin — with its reporter row — once verified against a live runner', async () => {
     stubSource()
     cy.stub(tapManagerDataSource, 'getRunner').returns({
-      getAllTestsState: () => ({}),
       getAllTestStates: () => ({}),
       getAllTestsSummary: () => ({}),
       getTestState: (id: string) => TESTS_STATE[id as keyof typeof TESTS_STATE],

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -264,6 +264,8 @@ describe('tap/commands/pin', () => {
     stubSource()
     cy.stub(tapManagerDataSource, 'getRunner').returns({
       getAllTestsState: () => ({}),
+      getAllTestStates: () => ({}),
+      getAllTestsSummary: () => ({}),
       getTestState: (id: string) => TESTS_STATE[id as keyof typeof TESTS_STATE],
       isRunComplete: () => true,
       getStartTime: () => '2026-07-29T10:15:00.000Z',

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -303,11 +303,8 @@ describe('tap/commands/reporter', () => {
 
     const stubSpec = (relative: string | undefined) => cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
 
-    // The spec view takes the summary; the serializing accessor is stubbed so a
-    // test can assert the view never reaches for it.
     const treeRunner = (overrides: Record<string, unknown> = {}) => {
       return {
-        getAllTestsState: cy.stub().returns(TREE_STATE),
         getAllTestsSummary: () => TREE_STATE,
         isRunComplete: () => false,
         getStartTime: () => null,
@@ -413,20 +410,6 @@ describe('tap/commands/reporter', () => {
       const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
 
       expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(10400)
-    })
-
-    // Serializing every command log to render a list of test titles and states is
-    // tens of seconds of blocked renderer on a real spec.
-    it('builds the overview without serializing the command logs', async () => {
-      const runner = treeRunner()
-
-      stubRunner(runner)
-      stubSpec('cypress/e2e/actions.cy.js')
-
-      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
-
-      expect((outcome as { result: { stats: Record<string, number> } }).result.stats).to.deep.eq({ passed: 2, failed: 1, pending: 2, skipped: 0 })
-      expect(runner.getAllTestsState).not.to.have.been.called
     })
 
     it('rejects --attempt without --testId', async () => {

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -303,9 +303,12 @@ describe('tap/commands/reporter', () => {
 
     const stubSpec = (relative: string | undefined) => cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
 
+    // The spec view takes the summary; the serializing accessor is stubbed so a
+    // test can assert the view never reaches for it.
     const treeRunner = (overrides: Record<string, unknown> = {}) => {
       return {
-        getAllTestsState: () => TREE_STATE,
+        getAllTestsState: cy.stub().returns(TREE_STATE),
+        getAllTestsSummary: () => TREE_STATE,
         isRunComplete: () => false,
         getStartTime: () => null,
         ...overrides,
@@ -397,7 +400,7 @@ describe('tap/commands/reporter', () => {
       stubRunner(treeRunner({
         isRunComplete: () => true,
         getStartTime: () => '2026-01-01T00:00:00.000Z',
-        getAllTestsState: () => {
+        getAllTestsSummary: () => {
           return {
             t1: { ...TREE_STATE.t1, wallClockStartedAt: '2026-01-01T00:00:05.000Z', wallClockDuration: 1000 },
             t2: { ...TREE_STATE.t2, wallClockStartedAt: '2026-01-01T00:00:10.000Z', wallClockDuration: 400 },
@@ -410,6 +413,20 @@ describe('tap/commands/reporter', () => {
       const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
 
       expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(10400)
+    })
+
+    // Serializing every command log to render a list of test titles and states is
+    // tens of seconds of blocked renderer on a real spec.
+    it('builds the overview without serializing the command logs', async () => {
+      const runner = treeRunner()
+
+      stubRunner(runner)
+      stubSpec('cypress/e2e/actions.cy.js')
+
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter')
+
+      expect((outcome as { result: { stats: Record<string, number> } }).result.stats).to.deep.eq({ passed: 2, failed: 1, pending: 2, skipped: 0 })
+      expect(runner.getAllTestsState).not.to.have.been.called
     })
 
     it('rejects --attempt without --testId', async () => {

--- a/packages/app/src/tap/commands/run-state.cy.ts
+++ b/packages/app/src/tap/commands/run-state.cy.ts
@@ -40,13 +40,26 @@ describe('tap/commands/run-state', () => {
     r5: { id: 'r5', title: 'has not run yet' },
   }
 
+  const ONE_PASSING = { r1: { id: 'r1', title: 'passes', state: 'passed' } }
+
   const STARTED_AT = '2026-07-29T10:15:00.000Z'
+
+  // Both accessors come off the same fixture so a test can assert run-state never
+  // reaches the serializing one.
+  const runnerFacade = (tests: Record<string, { id: string, title: string, state?: string }>, isRunComplete: () => boolean, startedAt = STARTED_AT) => {
+    return {
+      getAllTestsState: cy.stub().returns(tests),
+      getAllTestStates: () => Object.fromEntries(Object.entries(tests).map(([id, test]) => [id, test.state])),
+      isRunComplete,
+      getStartTime: () => startedAt,
+    }
+  }
 
   // The spec's own window.Cypress is the instance running this test, so stub
   // the seams rather than replace live state. `getRunner` only ever serves a
   // run that has started, so a stub always carries its start time.
-  const stubRunner = (runner: { getAllTestsState: () => unknown, isRunComplete: () => boolean }, startedAt = STARTED_AT) => {
-    return cy.stub(tapManagerDataSource, 'getRunner').returns({ ...runner, getStartTime: () => startedAt })
+  const stubRunner = (runner: ReturnType<typeof runnerFacade>) => {
+    return cy.stub(tapManagerDataSource, 'getRunner').returns(runner)
   }
   const stubNoRunner = () => cy.stub(tapManagerDataSource, 'getRunner').returns(undefined)
   const stubActiveSpec = (relative: string | undefined) => cy.stub(tapManagerDataSource, 'getActiveSpecRelative').returns(relative)
@@ -101,7 +114,7 @@ describe('tap/commands/run-state', () => {
 
   it('reports a spec that failed to build as failed, carrying the failure instead of counts', async () => {
     // The runner is settled and empty — the shape a passing run of nothing has.
-    stubRunner({ getAllTestsState: cy.stub().returns({}), isRunComplete: () => true })
+    stubRunner(runnerFacade({}, () => true))
     stubActiveSpec('cypress/e2e/login.cy.ts')
     stubScriptError('Error: Webpack Compilation Error\nSyntaxError: Unexpected token (4:2)\n    at Watching.handle (/x/webpack.js:1:1)')
 
@@ -134,7 +147,7 @@ describe('tap/commands/run-state', () => {
   })
 
   it('reports a run in progress as running, with the active spec and partial results', async () => {
-    stubRunner({ getAllTestsState: cy.stub().returns(TESTS_STATE), isRunComplete: () => false })
+    stubRunner(runnerFacade(TESTS_STATE, () => false))
     stubActiveSpec('cypress/e2e/login.cy.ts')
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -153,7 +166,7 @@ describe('tap/commands/run-state', () => {
   })
 
   it('reports an unsettled run with no failures as running, never a premature passed', async () => {
-    stubRunner({ getAllTestsState: cy.stub().returns({ r1: { id: 'r1', title: 'passes', state: 'passed' } }), isRunComplete: () => false })
+    stubRunner(runnerFacade(ONE_PASSING, () => false))
     stubActiveSpec('cypress/e2e/login.cy.ts')
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -171,7 +184,7 @@ describe('tap/commands/run-state', () => {
   })
 
   it('reports a settled run with a failure as failed, counting never-run tests as skipped', async () => {
-    stubRunner({ getAllTestsState: cy.stub().returns(TESTS_STATE), isRunComplete: () => true })
+    stubRunner(runnerFacade(TESTS_STATE, () => true))
     stubActiveSpec('cypress/e2e/login.cy.ts')
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -190,7 +203,7 @@ describe('tap/commands/run-state', () => {
   })
 
   it('reports a settled run with no failures as passed', async () => {
-    stubRunner({ getAllTestsState: cy.stub().returns({ r1: { id: 'r1', title: 'passes', state: 'passed' } }), isRunComplete: () => true })
+    stubRunner(runnerFacade(ONE_PASSING, () => true))
     stubActiveSpec('cypress/e2e/login.cy.ts')
 
     const manager = new TapManager(CYPRESS_VERSION)
@@ -208,7 +221,7 @@ describe('tap/commands/run-state', () => {
   })
 
   it('names a verdict with the start time of the run it describes, so a superseded one is recognizable', async () => {
-    const settled = { getAllTestsState: cy.stub().returns({ r1: { id: 'r1', title: 'passes', state: 'passed' } }), isRunComplete: () => true }
+    const settled = runnerFacade(ONE_PASSING, () => true)
     const rerunStartedAt = '2026-07-29T10:16:30.000Z'
 
     stubRunner(settled).onSecondCall().returns({ ...settled, getStartTime: () => rerunStartedAt })
@@ -225,8 +238,27 @@ describe('tap/commands/run-state', () => {
     expect(second.result.startedAt).to.eq(rerunStartedAt)
   })
 
+  // Serializing the run to read one field per test walks every command log,
+  // stringifying DOM references and invoking consoleProps builders — tens of
+  // seconds on a real spec, all of it blocking the renderer. Status is a polling
+  // payload, so it must never do that.
+  it('counts test states without serializing the run', async () => {
+    const runner = runnerFacade(TESTS_STATE, () => true)
+
+    stubRunner(runner)
+    stubActiveSpec('cypress/e2e/login.cy.ts')
+
+    const manager = new TapManager(CYPRESS_VERSION)
+
+    const outcome = await manager.exec('run-state') as { result: { totalTests: number, results: Record<string, number> } }
+
+    expect(outcome.result.totalTests).to.eq(5)
+    expect(outcome.result.results).to.deep.eq({ passed: 1, failed: 1, pending: 1, skipped: 2 })
+    expect(runner.getAllTestsState).not.to.have.been.called
+  })
+
   it('reports a null spec when a run is readable but its path is not', async () => {
-    stubRunner({ getAllTestsState: cy.stub().returns({}), isRunComplete: () => false })
+    stubRunner(runnerFacade({}, () => false))
     stubActiveSpec(undefined)
 
     const manager = new TapManager(CYPRESS_VERSION)

--- a/packages/app/src/tap/commands/run-state.cy.ts
+++ b/packages/app/src/tap/commands/run-state.cy.ts
@@ -44,11 +44,8 @@ describe('tap/commands/run-state', () => {
 
   const STARTED_AT = '2026-07-29T10:15:00.000Z'
 
-  // Both accessors come off the same fixture so a test can assert run-state never
-  // reaches the serializing one.
   const runnerFacade = (tests: Record<string, { id: string, title: string, state?: string }>, isRunComplete: () => boolean, startedAt = STARTED_AT) => {
     return {
-      getAllTestsState: cy.stub().returns(tests),
       getAllTestStates: () => Object.fromEntries(Object.entries(tests).map(([id, test]) => [id, test.state])),
       isRunComplete,
       getStartTime: () => startedAt,
@@ -236,25 +233,6 @@ describe('tap/commands/run-state', () => {
     // the whole of what tells them apart.
     expect(first.result.startedAt).to.eq(STARTED_AT)
     expect(second.result.startedAt).to.eq(rerunStartedAt)
-  })
-
-  // Serializing the run to read one field per test walks every command log,
-  // stringifying DOM references and invoking consoleProps builders — tens of
-  // seconds on a real spec, all of it blocking the renderer. Status is a polling
-  // payload, so it must never do that.
-  it('counts test states without serializing the run', async () => {
-    const runner = runnerFacade(TESTS_STATE, () => true)
-
-    stubRunner(runner)
-    stubActiveSpec('cypress/e2e/login.cy.ts')
-
-    const manager = new TapManager(CYPRESS_VERSION)
-
-    const outcome = await manager.exec('run-state') as { result: { totalTests: number, results: Record<string, number> } }
-
-    expect(outcome.result.totalTests).to.eq(5)
-    expect(outcome.result.results).to.deep.eq({ passed: 1, failed: 1, pending: 1, skipped: 2 })
-    expect(runner.getAllTestsState).not.to.have.been.called
   })
 
   it('reports a null spec when a run is readable but its path is not', async () => {

--- a/packages/app/src/tap/tap-manager-data-source.cy.ts
+++ b/packages/app/src/tap/tap-manager-data-source.cy.ts
@@ -35,6 +35,16 @@ describe('tap/tap-manager-data-source', () => {
       expect(tapManagerDataSource.getRunner()?.getStartTime()).to.eq('2026-07-29T10:15:00.000Z')
     })
 
+    // The driver carries it, but no tap command may reach it: it serializes every
+    // command log of every test, which costs tens of seconds on a real spec and
+    // blocks the renderer for all of it. Withholding it here is the guarantee.
+    it('withholds the whole-run serializing accessor', () => {
+      installRunner(startedRunner, false)
+
+      expect(startedRunner).to.have.property('getAllTestsState')
+      expect(tapManagerDataSource.getRunner()).not.to.have.property('getAllTestsState')
+    })
+
     it('withholds a runner whose spec is installed but whose run has not started, however the event manager reports completion', () => {
       // The state every rerun passes through: this runner holds no test state
       // yet, while `runComplete` still belongs to the run being replaced —

--- a/packages/app/src/tap/tap-manager-data-source.cy.ts
+++ b/packages/app/src/tap/tap-manager-data-source.cy.ts
@@ -35,9 +35,6 @@ describe('tap/tap-manager-data-source', () => {
       expect(tapManagerDataSource.getRunner()?.getStartTime()).to.eq('2026-07-29T10:15:00.000Z')
     })
 
-    // The driver carries it, but no tap command may reach it: it serializes every
-    // command log of every test, which costs tens of seconds on a real spec and
-    // blocks the renderer for all of it. Withholding it here is the guarantee.
     it('withholds the whole-run serializing accessor', () => {
       installRunner(startedRunner, false)
 

--- a/packages/app/src/tap/tap-manager-data-source.cy.ts
+++ b/packages/app/src/tap/tap-manager-data-source.cy.ts
@@ -23,6 +23,8 @@ describe('tap/tap-manager-data-source', () => {
 
     const startedRunner = {
       getAllTestsState: () => ({}),
+      getAllTestStates: () => ({}),
+      getAllTestsSummary: () => ({}),
       getTestState: () => undefined,
       getStartTime: () => '2026-07-29T10:15:00.000Z',
     }

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -37,7 +37,6 @@ export const tapManagerDataSource = {
       }
 
       return {
-        getAllTestsState: runner.getAllTestsState,
         getAllTestStates: runner.getAllTestStates,
         getAllTestsSummary: runner.getAllTestsSummary,
         getTestState: runner.getTestState,

--- a/packages/app/src/tap/tap-manager-data-source.ts
+++ b/packages/app/src/tap/tap-manager-data-source.ts
@@ -38,6 +38,8 @@ export const tapManagerDataSource = {
 
       return {
         getAllTestsState: runner.getAllTestsState,
+        getAllTestStates: runner.getAllTestStates,
+        getAllTestsSummary: runner.getAllTestsSummary,
         getTestState: runner.getTestState,
         getSerializedConsolePropsForLog: runner.getSerializedConsolePropsForLog,
         isRunComplete: () => em.runComplete,

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -548,26 +548,23 @@ export interface RunResults {
   skipped: number
 }
 
-export const aggregateResults = (runner: TapTestsRunner): { results: RunResults, totalTests: number } => {
-  const tests = Object.values(runner.getAllTestsState())
-  const runComplete = runner.isRunComplete()
+const countStates = (states: (TestStateValue | undefined)[], runComplete: boolean): RunResults => {
   const results: RunResults = { passed: 0, failed: 0, pending: 0, skipped: 0 }
 
-  for (const test of tests) {
-    const state = test.state ?? unreachedState(runComplete)
-
-    if (state === 'passed') {
-      results.passed++
-    } else if (state === 'failed') {
-      results.failed++
-    } else if (state === 'pending') {
-      results.pending++
-    } else {
-      results.skipped++
-    }
+  for (const state of states) {
+    results[state ?? unreachedState(runComplete)]++
   }
 
-  return { results, totalTests: tests.length }
+  return results
+}
+
+// Counts come off the states-only accessor: serializing the run to read one field
+// per test costs tens of seconds on a spec with a large command log, and blocks the
+// renderer for all of it.
+export const aggregateResults = (runner: TapTestsRunner): { results: RunResults, totalTests: number } => {
+  const states = Object.values(runner.getAllTestStates())
+
+  return { results: countStates(states, runner.isRunComplete()), totalTests: states.length }
 }
 
 const suitePathOf = (test: SerializedTest): string[] => {
@@ -635,7 +632,10 @@ const serializeSpecTest = (test: SerializedTest, runComplete: boolean): TapRepor
  * appearance reproduces the reporter's section order.
  */
 export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string | undefined): TapReporterSpecView => {
-  const tests = Object.values(runner.getAllTestsState())
+  // The view reads only each test's own properties — id, title, state, duration,
+  // title path, wall clock — and never its logs, so it takes the summary. The logs
+  // are what make a whole-run serialization cost tens of seconds.
+  const tests = Object.values(runner.getAllTestsSummary())
   const runComplete = runner.isRunComplete()
   const rootTests: TapReporterSpecTest[] = []
   const suites = new Map<string, TapReporterSuite>()
@@ -655,7 +655,9 @@ export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string |
     suite.tests.push(serializeSpecTest(test, runComplete))
   }
 
-  const { results } = aggregateResults(runner)
+  // Counted off the tests already serialized above, so the view serializes the run
+  // once rather than paying for it again through aggregateResults.
+  const results = countStates(tests.map((test) => test.state), runComplete)
 
   return omitNullish({
     spec,

--- a/packages/app/src/tap/test-state.ts
+++ b/packages/app/src/tap/test-state.ts
@@ -558,9 +558,6 @@ const countStates = (states: (TestStateValue | undefined)[], runComplete: boolea
   return results
 }
 
-// Counts come off the states-only accessor: serializing the run to read one field
-// per test costs tens of seconds on a spec with a large command log, and blocks the
-// renderer for all of it.
 export const aggregateResults = (runner: TapTestsRunner): { results: RunResults, totalTests: number } => {
   const states = Object.values(runner.getAllTestStates())
 
@@ -632,9 +629,6 @@ const serializeSpecTest = (test: SerializedTest, runComplete: boolean): TapRepor
  * appearance reproduces the reporter's section order.
  */
 export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string | undefined): TapReporterSpecView => {
-  // The view reads only each test's own properties — id, title, state, duration,
-  // title path, wall clock — and never its logs, so it takes the summary. The logs
-  // are what make a whole-run serialization cost tens of seconds.
   const tests = Object.values(runner.getAllTestsSummary())
   const runComplete = runner.isRunComplete()
   const rootTests: TapReporterSpecTest[] = []
@@ -655,8 +649,6 @@ export const serializeReporterSpecView = (runner: TapTestsRunner, spec: string |
     suite.tests.push(serializeSpecTest(test, runComplete))
   }
 
-  // Counted off the tests already serialized above, so the view serializes the run
-  // once rather than paying for it again through aggregateResults.
   const results = countStates(tests.map((test) => test.state), runComplete)
 
   return omitNullish({

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -15,6 +15,10 @@ export type ConsolePropsResult = TapConsoleProps
 export interface TapTestsRunner {
   /** Serializes every test of the run, keyed by id. */
   getAllTestsState (): Record<string, SerializedTest>
+  /** Every test's state, keyed by id, without the whole-run serialization cost. */
+  getAllTestStates (): Record<string, SerializedTest['state']>
+  /** Every test's own properties, keyed by id, without its command logs. */
+  getAllTestsSummary (): Record<string, SerializedTest>
   /** Serializes one test by id lookup, skipping the whole-run serialization cost. */
   getTestState (testId: string): SerializedTest | undefined
   /**

--- a/packages/app/src/tap/types.ts
+++ b/packages/app/src/tap/types.ts
@@ -13,9 +13,7 @@ export type CommandHook = TapCommandHook
 export type ConsolePropsResult = TapConsoleProps
 
 export interface TapTestsRunner {
-  /** Serializes every test of the run, keyed by id. */
-  getAllTestsState (): Record<string, SerializedTest>
-  /** Every test's state, keyed by id, without the whole-run serialization cost. */
+  /** Every test's state, keyed by id. */
   getAllTestStates (): Record<string, SerializedTest['state']>
   /** Every test's own properties, keyed by id, without its command logs. */
   getAllTestsSummary (): Record<string, SerializedTest>

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1950,6 +1950,42 @@ export default {
         return tests
       },
 
+      // Counting test states must not pay for whole-run serialization:
+      // `serializeTest` stringifies DOM references and invokes the consoleProps
+      // builders of every command log, which runs into tens of seconds on a spec
+      // with a large log. Read the state off the raw runnable instead — it is the
+      // same value `getAllTestsState` would surface, since `state` is a
+      // RUNNABLE_PROPS passthrough.
+      getAllTestStates (): Record<string, SerializedTest['state']> {
+        const states: Record<string, SerializedTest['state']> = {}
+
+        for (let testRunnable of _tests) {
+          states[testRunnable.id] = testRunnable.state
+        }
+
+        return states
+      },
+
+      // A spec-level view needs each test's own properties but none of its logs,
+      // and the logs are the entire cost — `wrap` is the props-only reduction.
+      getAllTestsSummary (): Record<string, SerializedTest> {
+        const tests: Record<string, SerializedTest> = {}
+
+        for (let testRunnable of _tests) {
+          const test = wrap(testRunnable) as SerializedTest
+
+          // `_titlePath` is only stamped on the normalized runnable copy;
+          // `_tests` holds the raw runnables, so read it off the live runnable.
+          test._titlePath = testRunnable.titlePath()
+
+          test.prevAttempts = _.map(testRunnable.prevAttempts, wrap) as SerializedTest[]
+
+          tests[test.id] = test
+        }
+
+        return tests
+      },
+
       getTestState (testId: string): SerializedTest | undefined {
         const testRunnable = getTestById(testId)
 

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -1950,12 +1950,6 @@ export default {
         return tests
       },
 
-      // Counting test states must not pay for whole-run serialization:
-      // `serializeTest` stringifies DOM references and invokes the consoleProps
-      // builders of every command log, which runs into tens of seconds on a spec
-      // with a large log. Read the state off the raw runnable instead — it is the
-      // same value `getAllTestsState` would surface, since `state` is a
-      // RUNNABLE_PROPS passthrough.
       getAllTestStates (): Record<string, SerializedTest['state']> {
         const states: Record<string, SerializedTest['state']> = {}
 
@@ -1966,16 +1960,12 @@ export default {
         return states
       },
 
-      // A spec-level view needs each test's own properties but none of its logs,
-      // and the logs are the entire cost — `wrap` is the props-only reduction.
       getAllTestsSummary (): Record<string, SerializedTest> {
         const tests: Record<string, SerializedTest> = {}
 
         for (let testRunnable of _tests) {
           const test = wrap(testRunnable) as SerializedTest
 
-          // `_titlePath` is only stamped on the normalized runnable copy;
-          // `_tests` holds the raw runnables, so read it off the live runnable.
           test._titlePath = testRunnable.titlePath()
 
           test.prevAttempts = _.map(testRunnable.prevAttempts, wrap) as SerializedTest[]


### PR DESCRIPTION
### Additional details

`tap status` and `tap reporter` built their payloads from `runner.getAllTestsState()`, which serializes **every test and every retry attempt** — and `serializeTest` runs `LogUtils.toSerializedJSON` over every `commands`/`hooks`/`routes`/`agents` entry, DOM-stringifying element references, invoking the `consoleProps`/table builders, and deep-cloning objects to strip circular refs.

Measured on `cypress-realworld-app`'s `transaction-feeds.spec.ts` (20 tests, 982 log entries), that one call takes **~155s**, synchronously, on the renderer main thread. Because it blocks that thread, every later CDP call queues behind it — so the whole tap surface stalls and the app UI and AUT freeze with it. `tap reporter` paid it **twice**: once directly, once again via `aggregateResults`.

Neither payload reads the logs:

- `run-state` needs test states and a count.
- The spec overview needs each test's own properties — `id`, `title`, `state`, `duration`, `_titlePath`, `wallClockStartedAt`, `wallClockDuration`, and `prevAttempts[].state/.duration`. All `RUNNABLE_PROPS`.

Two driver accessors serve exactly that, and `aggregateResults` and the spec view now share a `countStates` helper so the view counts off tests it already has:

| accessor | what it does | used by |
| --- | --- | --- |
| `getAllTestStates()` | states keyed by id, read off the raw runnables | `run-state` |
| `getAllTestsSummary()` | props-only serialization via the existing `wrap` helper (no `RUNNABLE_LOGS`) | `serializeReporterSpecView` |

`reporter --testId <id>` is deliberately unchanged: it goes through `getTestState(testId)`, serializes the single test it renders, and that test's logs are the thing being displayed.

The second commit removes `getAllTestsState` from the tap runner seam (`TapTestsRunner` + `tapManagerDataSource`) now that nothing in tap reads it, so a command reaching for it fails to compile rather than quietly costing a spec's worth of log serialization. **The driver keeps the method** — it is public API, has its own e2e coverage in `packages/driver/cypress/e2e/cypress/runner.cy.js`, and is read directly by the cypress-in-cypress rerun spec.

Worth noting this pairs with #34487 (already on this base): with CDP calls now bounded, a 155s block would surface as `RENDERER_UNRESPONSIVE` at exit 1 rather than an unbounded hang — so status would hard-fail on a large spec without this fix.

### Steps to test

1. Open Cypress against a project with a command-log-heavy spec (this was measured against `cypress-realworld-app`'s `cypress/tests/ui/transaction-feeds.spec.ts`, 20 tests).
2. Run the spec and let it finish.
3. `cypress tap status` and `cypress tap reporter` — both return promptly, and the reported counts match the reporter panel.
4. `cypress tap reporter --testId <id>` still renders the full command log for that test.
5. While either is in flight, other tap commands (`tap instances`, `tap dom`) stay responsive.

Timed inside the runner page after rebuilding the runner and app bundles:

```
getAllTestStates()    (status)            0ms
getAllTestsSummary()  (spec view)         0ms
getAllTestsState()    (old, unused)  155537ms

tests 20   log entries in the run 982   log entries carried by the summary 0
counts  states {"passed":20}  summary {"passed":20}  full {"passed":20}
counts agree: true
```

Binding calls, i.e. what the CLI invokes, and then the real CLI (dominated by node startup + the CDP connect):

```
exec('run-state')          12ms        tap status   #1 592ms  #2 400ms
exec('reporter')           12ms        tap reporter #1 428ms  #2 416ms
exec('reporter' --testId)  76ms
```

Before the fix the same `tap status` call blocked past a 20s bound on three consecutive attempts, and one earlier call took over 120s before returning `passed, 20/20`.

### How has the user experience changed?

`cypress tap status` and `cypress tap reporter` return in well under a second on a spec where they previously blocked for minutes — and while they were blocked the app UI and the app under test were frozen, so the whole session appeared hung. Output is unchanged; only the cost is. No visual change to the GUI.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- AW-97 -->
- [x] Have tests been added/updated? <!-- run-state.cy.ts, reporter.cy.ts, pin.cy.ts, tap-manager-data-source.cy.ts — 63 passing -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- tap is not yet documented publicly; base branch is the tap feature branch -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- internal driver/app accessors, not public types -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runner/tap read paths and changes the tap seam contract, but behavior is intended to be wire-compatible while fixing a severe performance regression; single-test reporter paths still use full serialization.
> 
> **Overview**
> **`cypress tap status` and spec-level `tap reporter`** no longer call `getAllTestsState()`, which serialized every test’s command logs and could block the renderer for minutes on large specs. They now use **`getAllTestStates()`** for pass/fail counts and **`getAllTestsSummary()`** for the spec overview (props only, no logs). Per-test **`getTestState(testId)`** is unchanged for full command-log views.
> 
> The **driver** adds those two accessors; **`aggregateResults`** and **`serializeReporterSpecView`** share a **`countStates`** helper so the reporter view doesn’t pay for full serialization twice. The **tap runner seam** exposes only the new methods and **drops `getAllTestsState`** so tap code can’t accidentally trigger expensive serialization (the driver still keeps the public API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90627f02ea8cfa3ea3aea3ac831aad7988bf9712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->