### PR TITLE
feat: report tap CLI invocations to the Cloud event collector

### DIFF
--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -27,6 +27,14 @@ function unknownOption (this: any, flag: string, type: string = 'option'): void 
   logger.error(`  error: unknown ${type}:`, flag)
   logger.error()
   this.outputHelp()
+
+  // A command that took exitOverride() means to handle its own failure — exiting
+  // here would skip the rest of its run, including anything it does on the way
+  // out. `cypress tap` relies on this to report the invocation before leaving.
+  if (this._exitCallback) {
+    this._exitCallback(new commander.CommanderError(1, 'commander.unknownOption', `unknown ${type}: ${flag}`))
+  }
+
   process.exit(1)
 }
 commander.Command.prototype.unknownOption = unknownOption

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -68,6 +68,12 @@ export interface ResolveInstanceOptions {
   probeTimeoutMs?: number
 }
 
+let lastResolvedInstanceId: string | null = null
+
+// Read rather than threaded through every caller: each tap command resolves its
+// own instance, several of them below this module.
+export const resolvedInstanceId = (): string | null => lastResolvedInstanceId
+
 const describeFilter = (instance: number | undefined): string => {
   if (instance !== undefined) {
     return ` with pid ${instance}`
@@ -130,6 +136,8 @@ export const resolveLiveInstance = async (options: ResolveInstanceOptions): Prom
 
   const { instance, reason } = selectInstance(live, options)
 
+  lastResolvedInstanceId = instance.instanceId
+
   return { instance, reason, candidateCount: live.length }
 }
 
@@ -154,6 +162,8 @@ export const resolveInstance = async (options: ResolveInstanceOptions): Promise<
   }
 
   const { instance: selected, reason } = selectInstance(ready, options)
+
+  lastResolvedInstanceId = selected.instanceId
 
   return { instance: selected, reason, candidateCount: ready.length }
 }

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -66,8 +66,8 @@ const withJson = (schema: TapSchema, name: string, options: Record<string, strin
 
 const runNativeCommand = async (native: TapCliCommand, positionals: string[], options: TapCliOptions, wantsHelp: boolean): Promise<number> => {
   let dispatchCode: number | undefined
-  const program = buildNativeProgram(native, async (name, args, commandOptions, renderOptions) => {
-    noteTapCommand(name, args, commandOptions, renderOptions)
+  const program = buildNativeProgram(native, async (name, args, commandOptions) => {
+    noteTapCommand(name, args, commandOptions)
     dispatchCode = await native.handler(options, args, commandOptions)
   })
 
@@ -92,7 +92,7 @@ const runNativeCommand = async (native: TapCliCommand, positionals: string[], op
   return dispatchCode ?? 1
 }
 
-const execCommand = async (session: TapSession, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>, json: boolean | undefined, renderOptions: Record<string, string>): Promise<number> => {
+const execCommand = async (session: TapSession, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>, json: boolean | undefined): Promise<number> => {
   const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, [command, commandArgs, commandOptions]))
 
   if ('error' in outcome) {
@@ -101,9 +101,7 @@ const execCommand = async (session: TapSession, command: string, commandArgs: Re
     return 1
   }
 
-  // The rendering reads both: the options that shaped the result and the ones
-  // that only shape its view.
-  renderOutcome(command, outcome.result, json, { ...commandOptions, ...renderOptions })
+  renderOutcome(command, outcome.result, json, commandOptions)
 
   return 0
 }
@@ -132,9 +130,9 @@ const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options:
       const schema = validateSchema(await session.call(TAP_SCHEMA_METHOD))
 
       let dispatchCode = 0
-      const program = buildTapProgram(schema, async (name, args, commandOptions, renderOptions) => {
-        noteTapCommand(name, args, commandOptions, renderOptions)
-        dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json, renderOptions)
+      const program = buildTapProgram(schema, async (name, args, commandOptions) => {
+        noteTapCommand(name, args, commandOptions)
+        dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json)
       })
 
       if (wantsHelp || !command) {

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -66,7 +66,8 @@ const withJson = (schema: TapSchema, name: string, options: Record<string, strin
 
 const runNativeCommand = async (native: TapCliCommand, positionals: string[], options: TapCliOptions, wantsHelp: boolean): Promise<number> => {
   let dispatchCode: number | undefined
-  const program = buildNativeProgram(native, async (_name, args, commandOptions) => {
+  const program = buildNativeProgram(native, async (name, args, commandOptions, renderOptions) => {
+    noteTapCommand(name, args, commandOptions, renderOptions)
     dispatchCode = await native.handler(options, args, commandOptions)
   })
 
@@ -132,7 +133,7 @@ const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options:
 
       let dispatchCode = 0
       const program = buildTapProgram(schema, async (name, args, commandOptions, renderOptions) => {
-        noteTapCommand(name)
+        noteTapCommand(name, args, commandOptions, renderOptions)
         dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json, renderOptions)
       })
 
@@ -184,7 +185,7 @@ const tapModule = {
     const info = buildCommandInfo(operands)
     let exitCode = 1
 
-    beginTapTrace(reportedInvocation(info.command, operands, options))
+    beginTapTrace(reportedInvocation(info.command, info.wantsHelp, options))
 
     // The CLI exits the moment this returns, so the trace is reported before it
     // does rather than left in flight.

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -7,13 +7,59 @@ import type { TapSession } from '../tap/tap-session'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
 import { renderFailure, renderKnownFailure, renderOutcome, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
+import { beginTapTrace, noteTapCommand, noteTapFailure, recordTapEvent } from '../tap/events'
+import { renderOptionsFor } from '../tap/render'
 import type { TapCliCommand, TapCliOptions } from '../tap/types'
-import { TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
-import type { TapSchema } from '@packages/cypress-instances'
+import { TAP_COMMANDS, TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
+import type { TapCommandOptionSchema, TapSchema } from '@packages/cypress-instances'
 import util from '../util'
 import { errors } from '../errors'
 
 const debug = Debug('cypress:cli:tap')
+
+const INVALID_USAGE = 'INVALID_USAGE'
+const UNHANDLED = 'UNHANDLED'
+
+const knownCommands = new Set<string>([
+  ...tapCliCommands.map(({ name }) => name),
+  ...TAP_COMMANDS.map(({ name }) => name),
+])
+
+// A name this CLI does not know is whatever the user typed, so it is reported
+// as unknown rather than sent verbatim.
+const reportedCommand = (command: string | undefined): string => {
+  if (!command) {
+    return 'none'
+  }
+
+  return knownCommands.has(command) ? command : 'unknown'
+}
+
+const declaredOptions: readonly TapCommandOptionSchema[] = [...tapCliCommands, ...TAP_COMMANDS].flatMap(({ name, options = [] }) => {
+  return [...options, ...renderOptionsFor(name)]
+})
+
+// Both spellings of every option resolve to the canonical name, so `-b` and
+// `--browser` report as one flag.
+const knownFlags = new Map<string, string>([
+  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
+  ['h', 'help'],
+  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
+])
+
+// Names only: an option's value carries selectors, spec paths and test titles.
+// An undeclared flag is whatever the user typed, so it reports as unknown.
+// --instance/--json/--timeout are parsed off by the outer `cypress tap` command
+// and never reach the operands, so they are read from the options it passes on.
+const reportedFlags = (operands: string[], options: TapCliOptions): string[] => {
+  const named = operands
+  .filter((operand) => operand.startsWith('-'))
+  .map((operand) => knownFlags.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
+
+  const topLevel = Object.entries(options).filter(([, value]) => value !== undefined).map(([name]) => name)
+
+  return [...new Set([...named, ...topLevel])]
+}
 
 const validateSchema = (value: unknown): TapSchema => {
   const schema = value as TapSchema | null | undefined
@@ -75,6 +121,8 @@ const runNativeCommand = async (native: TapCliCommand, positionals: string[], op
     await program.parseAsync(positionals, { from: 'user' })
   } catch (err: any) {
     if (err instanceof commander.CommanderError) {
+      noteTapFailure(INVALID_USAGE)
+
       return 1
     }
 
@@ -110,65 +158,88 @@ const renderKnownSchema = (command: string | undefined): number => {
   return renderStaticHelp(program, schema, command)
 }
 
+const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options: TapCliOptions): Promise<number> => {
+  const native = tapCliCommands.find(({ name }) => name === command)
+
+  if (native) {
+    return runNativeCommand(native, positionals, options, wantsHelp)
+  }
+
+  try {
+    const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
+
+    return await withTapSession(selection.instance, async (session) => {
+      const schema = validateSchema(await session.call(TAP_SCHEMA_METHOD))
+
+      let dispatchCode = 0
+      const program = buildTapProgram(schema, async (name, args, commandOptions, renderOptions) => {
+        noteTapCommand(name)
+        dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json, renderOptions)
+      })
+
+      if (wantsHelp || !command) {
+        return renderSchemaHelp(program, schema, selection, command)
+      }
+
+      try {
+        await program.parseAsync(positionals, { from: 'user' })
+      } catch (err: any) {
+        if (err instanceof commander.CommanderError) {
+          noteTapFailure(INVALID_USAGE)
+
+          return 1
+        }
+
+        throw err
+      }
+
+      return dispatchCode
+    }, options.timeout)
+  } catch (err: any) {
+    if (err instanceof CypressInstanceError) {
+      if (wantsHelp || !command) {
+        return renderKnownSchema(command)
+      }
+
+      debug('tap %s failed: %s %s', command || '(help)', err.code, err.message)
+      renderFailure(err)
+
+      return 1
+    }
+
+    if (err.known && err.details) {
+      debug('tap %s failed: %s', command || '(help)', err.message)
+      renderKnownFailure(err)
+
+      return 1
+    }
+
+    throw err
+  }
+}
+
 const tapModule = {
   async start (operands: string[] = [], options: TapCliOptions = {}): Promise<number> {
     debug('tap invocation %o with options %o', operands, options)
 
-    const { wantsHelp, positionals, command } = buildCommandInfo(operands)
+    const info = buildCommandInfo(operands)
+    const startedAt = Date.now()
+    let exitCode = 1
 
-    const native = tapCliCommands.find(({ name }) => name === command)
+    beginTapTrace(reportedCommand(info.command), reportedFlags(operands, options))
 
-    if (native) {
-      return runNativeCommand(native, positionals, options, wantsHelp)
-    }
-
+    // The CLI exits the moment this returns, so the event is reported before it
+    // does rather than left in flight.
     try {
-      const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
+      exitCode = await runTap(info, options)
 
-      return await withTapSession(selection.instance, async (session) => {
-        const schema = validateSchema(await session.call(TAP_SCHEMA_METHOD))
-
-        let dispatchCode = 0
-        const program = buildTapProgram(schema, async (name, args, commandOptions, renderOptions) => {
-          dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json, renderOptions)
-        })
-
-        if (wantsHelp || !command) {
-          return renderSchemaHelp(program, schema, selection, command)
-        }
-
-        try {
-          await program.parseAsync(positionals, { from: 'user' })
-        } catch (err: any) {
-          if (err instanceof commander.CommanderError) {
-            return 1
-          }
-
-          throw err
-        }
-
-        return dispatchCode
-      }, options.timeout)
+      return exitCode
     } catch (err: any) {
-      if (err instanceof CypressInstanceError) {
-        if (wantsHelp || !command) {
-          return renderKnownSchema(command)
-        }
-
-        debug('tap %s failed: %s %s', command || '(help)', err.code, err.message)
-        renderFailure(err)
-
-        return 1
-      }
-
-      if (err.known && err.details) {
-        debug('tap %s failed: %s', command || '(help)', err.message)
-        renderKnownFailure(err)
-
-        return 1
-      }
+      noteTapFailure(UNHANDLED)
 
       throw err
+    } finally {
+      await recordTapEvent(exitCode, Date.now() - startedAt)
     }
   },
 }

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -7,7 +7,7 @@ import type { TapSession } from '../tap/tap-session'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
 import { renderFailure, renderKnownFailure, renderOutcome, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
-import { beginTapTrace, noteTapCommand, noteTapFailure, recordTapEvent } from '../tap/events'
+import { beginTapTrace, noteTapCommand, noteTapFailure, reportTapTrace } from '../tap/events'
 import { renderOptionsFor } from '../tap/render'
 import type { TapCliCommand, TapCliOptions } from '../tap/types'
 import { TAP_COMMANDS, TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
@@ -20,27 +20,27 @@ const debug = Debug('cypress:cli:tap')
 const INVALID_USAGE = 'INVALID_USAGE'
 const UNHANDLED = 'UNHANDLED'
 
-const knownCommands = new Set<string>([
-  ...tapCliCommands.map(({ name }) => name),
-  ...TAP_COMMANDS.map(({ name }) => name),
-])
+const allTapCommands = [...tapCliCommands, ...TAP_COMMANDS]
+
+const knownCommands = new Set<string>(allTapCommands.map(({ name }) => name))
 
 // A name this CLI does not know is whatever the user typed, so it is reported
 // as unknown rather than sent verbatim.
-const reportedCommand = (command: string | undefined): string => {
+const reportedCommand = (command: string | undefined): string | undefined => {
   if (!command) {
-    return 'none'
+    return undefined
   }
 
   return knownCommands.has(command) ? command : 'unknown'
 }
 
-const declaredOptions: readonly TapCommandOptionSchema[] = [...tapCliCommands, ...TAP_COMMANDS].flatMap(({ name, options = [] }) => {
+const declaredOptions: readonly TapCommandOptionSchema[] = allTapCommands.flatMap(({ name, options = [] }) => {
   return [...options, ...renderOptionsFor(name)]
 })
 
 // Both spellings of every option resolve to the canonical name, so `-b` and
-// `--browser` report as one flag.
+// `--browser` report as one flag. The names seeded here belong to `cypress tap`
+// itself rather than to any command, so `declaredOptions` does not carry them.
 const knownFlags = new Map<string, string>([
   ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
   ['h', 'help'],
@@ -56,7 +56,9 @@ const reportedFlags = (operands: string[], options: TapCliOptions): string[] => 
   .filter((operand) => operand.startsWith('-'))
   .map((operand) => knownFlags.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
 
-  const topLevel = Object.entries(options).filter(([, value]) => value !== undefined).map(([name]) => name)
+  const topLevel = Object.entries(options)
+  .filter(([name, value]) => value !== undefined && knownFlags.has(name))
+  .map(([name]) => name)
 
   return [...new Set([...named, ...topLevel])]
 }
@@ -223,12 +225,11 @@ const tapModule = {
     debug('tap invocation %o with options %o', operands, options)
 
     const info = buildCommandInfo(operands)
-    const startedAt = Date.now()
     let exitCode = 1
 
     beginTapTrace(reportedCommand(info.command), reportedFlags(operands, options))
 
-    // The CLI exits the moment this returns, so the event is reported before it
+    // The CLI exits the moment this returns, so the trace is reported before it
     // does rather than left in flight.
     try {
       exitCode = await runTap(info, options)
@@ -239,7 +240,7 @@ const tapModule = {
 
       throw err
     } finally {
-      await recordTapEvent(exitCode, Date.now() - startedAt)
+      await reportTapTrace(exitCode)
     }
   },
 }

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -8,10 +8,10 @@ import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
 import { renderFailure, renderKnownFailure, renderOutcome, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
 import { beginTapTrace, noteTapCommand, noteTapFailure, reportTapTrace } from '../tap/events'
-import { renderOptionsFor } from '../tap/render'
+import { reportedInvocation } from '../tap/reported-invocation'
 import type { TapCliCommand, TapCliOptions } from '../tap/types'
-import { TAP_COMMANDS, TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
-import type { TapCommandOptionSchema, TapSchema } from '@packages/cypress-instances'
+import { TAP_EXEC_METHOD, TAP_SCHEMA_VERSION, TAP_SCHEMA_METHOD, buildTapSchema } from '@packages/cypress-instances'
+import type { TapSchema } from '@packages/cypress-instances'
 import util from '../util'
 import { errors } from '../errors'
 
@@ -19,49 +19,6 @@ const debug = Debug('cypress:cli:tap')
 
 const INVALID_USAGE = 'INVALID_USAGE'
 const UNHANDLED = 'UNHANDLED'
-
-const allTapCommands = [...tapCliCommands, ...TAP_COMMANDS]
-
-const knownCommands = new Set<string>(allTapCommands.map(({ name }) => name))
-
-// A name this CLI does not know is whatever the user typed, so it is reported
-// as unknown rather than sent verbatim.
-const reportedCommand = (command: string | undefined): string | undefined => {
-  if (!command) {
-    return undefined
-  }
-
-  return knownCommands.has(command) ? command : 'unknown'
-}
-
-const declaredOptions: readonly TapCommandOptionSchema[] = allTapCommands.flatMap(({ name, options = [] }) => {
-  return [...options, ...renderOptionsFor(name)]
-})
-
-// Both spellings of every option resolve to the canonical name, so `-b` and
-// `--browser` report as one flag. The names seeded here belong to `cypress tap`
-// itself rather than to any command, so `declaredOptions` does not carry them.
-const knownFlags = new Map<string, string>([
-  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
-  ['h', 'help'],
-  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
-])
-
-// Names only: an option's value carries selectors, spec paths and test titles.
-// An undeclared flag is whatever the user typed, so it reports as unknown.
-// --instance/--json/--timeout are parsed off by the outer `cypress tap` command
-// and never reach the operands, so they are read from the options it passes on.
-const reportedFlags = (operands: string[], options: TapCliOptions): string[] => {
-  const named = operands
-  .filter((operand) => operand.startsWith('-'))
-  .map((operand) => knownFlags.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
-
-  const topLevel = Object.entries(options)
-  .filter(([name, value]) => value !== undefined && knownFlags.has(name))
-  .map(([name]) => name)
-
-  return [...new Set([...named, ...topLevel])]
-}
 
 const validateSchema = (value: unknown): TapSchema => {
   const schema = value as TapSchema | null | undefined
@@ -227,7 +184,7 @@ const tapModule = {
     const info = buildCommandInfo(operands)
     let exitCode = 1
 
-    beginTapTrace(reportedCommand(info.command), reportedFlags(operands, options))
+    beginTapTrace(reportedInvocation(info.command, operands, options))
 
     // The CLI exits the moment this returns, so the trace is reported before it
     // does rather than left in flight.

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -3,9 +3,8 @@ import commander from 'commander'
 import { tapCliCommands } from './commands'
 import type { TapCliCommand } from './types'
 import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from '@packages/cypress-instances'
-import { viewOptionsFor, withoutViewOptions } from '@packages/cypress-instances'
 
-type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>, renderOptions: Record<string, string>) => Promise<void> | void
+type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>) => Promise<void> | void
 
 interface CommandSpec {
   name: string
@@ -117,20 +116,13 @@ const declareCommand = (program: commander.Command, spec: CommandSpec, dispatch?
     command.description(description)
   }
 
-  // A command's view-only options are declared alongside the ones it forwards so
-  // they render in the same help, but they are collected apart from them: only
-  // the forwarded ones reach the instance. They are taken from the CLI's own copy
-  // of the contract, since the schema an attached instance advertises omits them.
-  const execOptions = withoutViewOptions(options)
-  const renderOptions = viewOptionsFor(name)
-
-  declareOptions(command, [...execOptions, ...renderOptions])
+  declareOptions(command, options)
 
   if (dispatch) {
     command.action(() => {
       rejectExcessArguments(name, params, command.args)
 
-      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(command, execOptions), forwardedOptions(command, renderOptions))
+      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(command, options))
     })
   }
 }

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -1,9 +1,9 @@
 import commander from 'commander'
 
 import { tapCliCommands } from './commands'
-import { renderOptionsFor } from './render'
 import type { TapCliCommand } from './types'
 import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from '@packages/cypress-instances'
+import { viewOptionsFor, withoutViewOptions } from '@packages/cypress-instances'
 
 type TapDispatch = (command: string, args: Record<string, string>, options: Record<string, string>, renderOptions: Record<string, string>) => Promise<void> | void
 
@@ -117,18 +117,20 @@ const declareCommand = (program: commander.Command, spec: CommandSpec, dispatch?
     command.description(description)
   }
 
-  // A command's view-only options are declared alongside the schema's so they
-  // render in the same help, but they are collected apart from them: only the
-  // schema's reach the instance.
-  const renderOptions = renderOptionsFor(name)
+  // A command's view-only options are declared alongside the ones it forwards so
+  // they render in the same help, but they are collected apart from them: only
+  // the forwarded ones reach the instance. They are taken from the CLI's own copy
+  // of the contract, since the schema an attached instance advertises omits them.
+  const execOptions = withoutViewOptions(options)
+  const renderOptions = viewOptionsFor(name)
 
-  declareOptions(command, [...options, ...renderOptions])
+  declareOptions(command, [...execOptions, ...renderOptions])
 
   if (dispatch) {
     command.action(() => {
       rejectExcessArguments(name, params, command.args)
 
-      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(command, options), forwardedOptions(command, renderOptions))
+      return dispatch(name, forwardedArgs(params, command.args), forwardedOptions(command, execOptions), forwardedOptions(command, renderOptions))
     })
   }
 }

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -9,7 +9,7 @@ import type { ReportedInvocation } from './reported-invocation'
 const debug = Debug('cypress:cli:tap')
 
 const CAMPAIGN = 'Tap Command'
-const MEDIUM = 'cli'
+const MEDIUM = 'tap-cli'
 const POST_TIMEOUT_MS = 2000
 
 // The same map the app reads through @packages/data-context; the CLI cannot reach
@@ -90,7 +90,6 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
     exitCode,
     errorCode: trace.errorCode,
     durationMs: Date.now() - trace.startedAt,
-    cypressVersion,
   }
 
   const url = eventCollectorUrl()

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto'
 
 import util from '../util'
 import { resolvedInstanceId } from '../cypress-instances'
+import { detectAgent } from '@packages/agent-info'
 
 const debug = Debug('cypress:cli:tap')
 
@@ -56,6 +57,7 @@ export const recordTapEvent = async (exitCode: number, durationMs: number): Prom
   const payload = {
     command,
     flags,
+    agent: detectAgent(),
     instanceId: resolvedInstanceId() ?? undefined,
     exitCode,
     errorCode,

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -12,6 +12,11 @@ const CAMPAIGN = 'Tap Command'
 const MEDIUM = 'cli'
 const POST_TIMEOUT_MS = 2000
 
+// The version a source checkout reports, which publishing replaces with the
+// released one. Nothing else tells the CLI it is running from the repo: gulp
+// hands the app a collector environment, but nothing launches the CLI.
+const DEVELOPMENT_VERSION = '0.0.0-development'
+
 // The same map the app reads through @packages/data-context; the CLI cannot reach
 // that package, so the three URLs are duplicated here.
 const CLOUD_URLS = {
@@ -70,6 +75,15 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
   }
 
   const cypressVersion = util.pkgVersion()
+
+  // Local development reports nothing unless it names the collector to use, so
+  // working on tap cannot put its own traffic in the production analytics.
+  if (cypressVersion === DEVELOPMENT_VERSION && !process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV) {
+    debug('skipped tap event: development build')
+
+    return
+  }
+
   const payload = {
     command: trace.command,
     flags: trace.flags,
@@ -81,8 +95,10 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
     cypressVersion,
   }
 
+  const url = eventCollectorUrl()
+
   try {
-    await fetch(eventCollectorUrl(), {
+    await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -92,8 +108,8 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
       signal: AbortSignal.timeout(POST_TIMEOUT_MS),
     })
 
-    debug('recorded tap event %o', payload)
+    debug('recorded tap event to %s %o', url, payload)
   } catch (err) {
-    debug('failed to record tap event %o due to error %o', payload, err)
+    debug('failed to record tap event to %s %o due to error %o', url, payload, err)
   }
 }

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -70,7 +70,7 @@ export const noteTapFailure = (code: string): void => {
 // spelled out here rather than spread from the trace, so a new trace field
 // cannot silently become a new wire field.
 export const reportTapTrace = async (exitCode: number): Promise<void> => {
-  if (process.env.CYPRESS_CRASH_REPORTS === '0') {
+  if (process.env.CYPRESS_DISABLE_TELEMETRY) {
     return
   }
 

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -52,8 +52,11 @@ export const beginTapTrace = ({ command, flags }: ReportedInvocation): void => {
   trace = newTrace(command, flags)
 }
 
-export const noteTapCommand = (dispatched: string): void => {
+// Names only: an option's value carries selectors, spec paths and test titles,
+// so the trace takes the keys of what commander parsed, never the values.
+export const noteTapCommand = (dispatched: string, ...parsed: Record<string, string>[]): void => {
   trace.command = dispatched
+  trace.flags = [...new Set([...trace.flags, ...parsed.flatMap((values) => Object.keys(values))])]
 }
 
 export const noteTapFailure = (code: string): void => {

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 import { randomUUID } from 'crypto'
 
-import util from '../util'
+import util, { DEVELOPMENT_VERSION } from '../util'
 import { resolvedInstanceId } from '../cypress-instances'
 import { detectAgent } from '@packages/agent-info'
 import type { ReportedInvocation } from './reported-invocation'
@@ -11,11 +11,6 @@ const debug = Debug('cypress:cli:tap')
 const CAMPAIGN = 'Tap Command'
 const MEDIUM = 'cli'
 const POST_TIMEOUT_MS = 2000
-
-// The version a source checkout reports, which publishing replaces with the
-// released one. Nothing else tells the CLI it is running from the repo: gulp
-// hands the app a collector environment, but nothing launches the CLI.
-const DEVELOPMENT_VERSION = '0.0.0-development'
 
 // The same map the app reads through @packages/data-context; the CLI cannot reach
 // that package, so the three URLs are duplicated here.

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -20,11 +20,17 @@ const CLOUD_URLS = {
   production: 'https://cloud.cypress.io',
 } as const
 
-const eventCollectorUrl = (includeMachineId = false): string => {
-  const collectorEnv = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV as keyof typeof CLOUD_URLS
-  const cloudUrl = CLOUD_URLS[Object.prototype.hasOwnProperty.call(CLOUD_URLS, collectorEnv) ? collectorEnv : 'production']
+// Which collector the environment names, if it names one this CLI has a URL for.
+// An unrecognized value is no collector at all, so a typo cannot pass for naming
+// one and land a source checkout's traffic in the production analytics.
+const namedCollectorEnv = (): keyof typeof CLOUD_URLS | undefined => {
+  const named = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV as keyof typeof CLOUD_URLS
 
-  return `${cloudUrl}/${includeMachineId ? 'machine-collect' : 'anon-collect'}`
+  return Object.prototype.hasOwnProperty.call(CLOUD_URLS, named) ? named : undefined
+}
+
+const eventCollectorUrl = (includeMachineId = false): string => {
+  return `${CLOUD_URLS[namedCollectorEnv() ?? 'production']}/${includeMachineId ? 'machine-collect' : 'anon-collect'}`
 }
 
 // What the invocation turned out to be, accumulated as it runs. `beginTapTrace`
@@ -72,29 +78,31 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
     return
   }
 
-  const cypressVersion = util.pkgVersion()
-
-  // Local development reports nothing unless it names the collector to use, so
-  // working on tap cannot put its own traffic in the production analytics.
-  if (cypressVersion === DEVELOPMENT_VERSION && !process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV) {
-    debug('skipped tap event: development build')
-
-    return
-  }
-
-  const payload = {
-    command: trace.command,
-    flags: trace.flags,
-    agent: detectAgent(),
-    instanceId: resolvedInstanceId() ?? undefined,
-    exitCode,
-    errorCode: trace.errorCode,
-    durationMs: Date.now() - trace.startedAt,
-  }
-
-  const url = eventCollectorUrl()
-
+  // This runs from the `finally` the CLI exits on, so nothing here may throw: a
+  // failure while assembling the event would replace the command's own outcome.
   try {
+    const cypressVersion = util.pkgVersion()
+
+    // Local development reports nothing unless it names the collector to use, so
+    // working on tap cannot put its own traffic in the production analytics.
+    if (cypressVersion === DEVELOPMENT_VERSION && !namedCollectorEnv()) {
+      debug('skipped tap event: development build')
+
+      return
+    }
+
+    const payload = {
+      command: trace.command,
+      flags: trace.flags,
+      agent: detectAgent(),
+      instanceId: resolvedInstanceId() ?? undefined,
+      exitCode,
+      errorCode: trace.errorCode,
+      durationMs: Date.now() - trace.startedAt,
+    }
+
+    const url = eventCollectorUrl()
+
     await fetch(url, {
       method: 'POST',
       headers: {
@@ -107,6 +115,6 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
 
     debug('recorded tap event to %s %o', url, payload)
   } catch (err) {
-    debug('failed to record tap event to %s %o due to error %o', url, payload, err)
+    debug('failed to record tap event for %o due to error %o', trace, err)
   }
 }

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -12,8 +12,8 @@ const CAMPAIGN = 'Tap Command'
 const MEDIUM = 'tap-cli'
 const POST_TIMEOUT_MS = 2000
 
-// The same map the app reads through @packages/data-context; the CLI cannot reach
-// that package, so the three URLs are duplicated here.
+// Duplicated from packages/data-context/src/util/cloudUrls.ts, which the CLI
+// cannot import.
 const CLOUD_URLS = {
   development: 'http://localhost:3000',
   staging: 'https://cloud-staging.cypress.io',
@@ -33,10 +33,6 @@ const eventCollectorUrl = (includeMachineId = false): string => {
   return `${CLOUD_URLS[namedCollectorEnv() ?? 'production']}/${includeMachineId ? 'machine-collect' : 'anon-collect'}`
 }
 
-// What the invocation turned out to be, accumulated as it runs. `beginTapTrace`
-// opens one the moment the CLI knows what was typed, the `note` calls refine it
-// as the command resolves and fails, and `reportTapTrace` posts it once, just
-// before the process exits.
 interface TapTrace {
   messageId: string
   startedAt: number

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto'
 import util from '../util'
 import { resolvedInstanceId } from '../cypress-instances'
 import { detectAgent } from '@packages/agent-info'
+import type { ReportedInvocation } from './reported-invocation'
 
 const debug = Debug('cypress:cli:tap')
 
@@ -47,7 +48,7 @@ const newTrace = (command = 'none', flags: string[] = []): TapTrace => ({
 
 let trace = newTrace()
 
-export const beginTapTrace = (command: string | undefined, flags: string[]): void => {
+export const beginTapTrace = ({ command, flags }: ReportedInvocation): void => {
   trace = newTrace(command, flags)
 }
 

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -26,42 +26,57 @@ const eventCollectorUrl = (includeMachineId = false): string => {
   return `${cloudUrl}/${includeMachineId ? 'machine-collect' : 'anon-collect'}`
 }
 
-const messageId = randomUUID()
+// What the invocation turned out to be, accumulated as it runs. `beginTapTrace`
+// opens one the moment the CLI knows what was typed, the `note` calls refine it
+// as the command resolves and fails, and `reportTapTrace` posts it once, just
+// before the process exits.
+interface TapTrace {
+  messageId: string
+  startedAt: number
+  command: string
+  flags: string[]
+  errorCode?: string
+}
 
-let command = 'none'
-let flags: string[] = []
-let errorCode: string | undefined
+const newTrace = (command = 'none', flags: string[] = []): TapTrace => ({
+  messageId: randomUUID(),
+  startedAt: Date.now(),
+  command,
+  flags,
+})
 
-export const beginTapTrace = (invoked: string, invokedFlags: string[]): void => {
-  command = invoked
-  flags = invokedFlags
-  errorCode = undefined
+let trace = newTrace()
+
+export const beginTapTrace = (command: string | undefined, flags: string[]): void => {
+  trace = newTrace(command, flags)
 }
 
 export const noteTapCommand = (dispatched: string): void => {
-  command = dispatched
+  trace.command = dispatched
 }
 
 export const noteTapFailure = (code: string): void => {
-  errorCode = code
+  trace.errorCode = code
 }
 
 // Tap error messages interpolate selectors, spec paths and project roots, and so
-// do option values, so the payload is a fixed field list of names and codes.
-export const recordTapEvent = async (exitCode: number, durationMs: number): Promise<void> => {
+// do option values, so the payload is a fixed field list of names and codes —
+// spelled out here rather than spread from the trace, so a new trace field
+// cannot silently become a new wire field.
+export const reportTapTrace = async (exitCode: number): Promise<void> => {
   if (process.env.CYPRESS_CRASH_REPORTS === '0') {
     return
   }
 
   const cypressVersion = util.pkgVersion()
   const payload = {
-    command,
-    flags,
+    command: trace.command,
+    flags: trace.flags,
     agent: detectAgent(),
     instanceId: resolvedInstanceId() ?? undefined,
     exitCode,
-    errorCode,
-    durationMs,
+    errorCode: trace.errorCode,
+    durationMs: Date.now() - trace.startedAt,
     cypressVersion,
   }
 
@@ -72,7 +87,7 @@ export const recordTapEvent = async (exitCode: number, durationMs: number): Prom
         'Content-Type': 'application/json',
         'x-cypress-version': cypressVersion,
       },
-      body: JSON.stringify({ campaign: CAMPAIGN, medium: MEDIUM, messageId, payload }),
+      body: JSON.stringify({ campaign: CAMPAIGN, medium: MEDIUM, messageId: trace.messageId, payload }),
       signal: AbortSignal.timeout(POST_TIMEOUT_MS),
     })
 

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -12,6 +12,10 @@ const CAMPAIGN = 'Tap Command'
 const MEDIUM = 'tap-cli'
 const POST_TIMEOUT_MS = 2000
 
+// Only flags a command declares reach a trace, and no command declares close to
+// this many, so the cap is a backstop rather than the real bound.
+const MAX_REPORTED_FLAGS = 25
+
 // Duplicated from packages/data-context/src/util/cloudUrls.ts, which the CLI
 // cannot import.
 const CLOUD_URLS = {
@@ -20,11 +24,13 @@ const CLOUD_URLS = {
   production: 'https://cloud.cypress.io',
 } as const
 
-// Which collector the environment names, if it names one this CLI has a URL for.
-// An unrecognized value is no collector at all, so a typo cannot pass for naming
-// one and land a source checkout's traffic in the production analytics.
+// Which collector the environment names, if it names one this CLI has a URL for:
+// the collector variable the app reads (see EventCollectorActions), then the
+// internal environment it is normally derived from. An unrecognized value is no
+// collector at all, so a typo cannot pass for naming one and land a source
+// checkout's traffic in the production analytics.
 const namedCollectorEnv = (): keyof typeof CLOUD_URLS | undefined => {
-  const named = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV as keyof typeof CLOUD_URLS
+  const named = (process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV ?? process.env.CYPRESS_INTERNAL_ENV) as keyof typeof CLOUD_URLS
 
   return Object.prototype.hasOwnProperty.call(CLOUD_URLS, named) ? named : undefined
 }
@@ -70,10 +76,6 @@ export const noteTapFailure = (code: string): void => {
 // spelled out here rather than spread from the trace, so a new trace field
 // cannot silently become a new wire field.
 export const reportTapTrace = async (exitCode: number): Promise<void> => {
-  if (process.env.CYPRESS_DISABLE_TELEMETRY) {
-    return
-  }
-
   // This runs from the `finally` the CLI exits on, so nothing here may throw: a
   // failure while assembling the event would replace the command's own outcome.
   try {
@@ -89,7 +91,7 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
 
     const payload = {
       command: trace.command,
-      flags: trace.flags,
+      flags: trace.flags.slice(0, MAX_REPORTED_FLAGS),
       agent: detectAgent(),
       instanceId: resolvedInstanceId() ?? undefined,
       exitCode,

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -1,0 +1,81 @@
+import Debug from 'debug'
+import { randomUUID } from 'crypto'
+
+import util from '../util'
+import { resolvedInstanceId } from '../cypress-instances'
+
+const debug = Debug('cypress:cli:tap')
+
+const CAMPAIGN = 'Tap Command'
+const MEDIUM = 'cli'
+const POST_TIMEOUT_MS = 2000
+
+// The same map the app reads through @packages/data-context; the CLI cannot reach
+// that package, so the three URLs are duplicated here.
+const CLOUD_URLS = {
+  development: 'http://localhost:3000',
+  staging: 'https://cloud-staging.cypress.io',
+  production: 'https://cloud.cypress.io',
+} as const
+
+const eventCollectorUrl = (includeMachineId = false): string => {
+  const collectorEnv = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV as keyof typeof CLOUD_URLS
+  const cloudUrl = CLOUD_URLS[Object.prototype.hasOwnProperty.call(CLOUD_URLS, collectorEnv) ? collectorEnv : 'production']
+
+  return `${cloudUrl}/${includeMachineId ? 'machine-collect' : 'anon-collect'}`
+}
+
+const messageId = randomUUID()
+
+let command = 'none'
+let flags: string[] = []
+let errorCode: string | undefined
+
+export const beginTapTrace = (invoked: string, invokedFlags: string[]): void => {
+  command = invoked
+  flags = invokedFlags
+  errorCode = undefined
+}
+
+export const noteTapCommand = (dispatched: string): void => {
+  command = dispatched
+}
+
+export const noteTapFailure = (code: string): void => {
+  errorCode = code
+}
+
+// Tap error messages interpolate selectors, spec paths and project roots, and so
+// do option values, so the payload is a fixed field list of names and codes.
+export const recordTapEvent = async (exitCode: number, durationMs: number): Promise<void> => {
+  if (process.env.CYPRESS_CRASH_REPORTS === '0') {
+    return
+  }
+
+  const cypressVersion = util.pkgVersion()
+  const payload = {
+    command,
+    flags,
+    instanceId: resolvedInstanceId() ?? undefined,
+    exitCode,
+    errorCode,
+    durationMs,
+    cypressVersion,
+  }
+
+  try {
+    await fetch(eventCollectorUrl(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-cypress-version': cypressVersion,
+      },
+      body: JSON.stringify({ campaign: CAMPAIGN, medium: MEDIUM, messageId, payload }),
+      signal: AbortSignal.timeout(POST_TIMEOUT_MS),
+    })
+
+    debug('recorded tap event %o', payload)
+  } catch (err) {
+    debug('failed to record tap event %o due to error %o', payload, err)
+  }
+}

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -2,10 +2,12 @@ import commander from 'commander'
 
 import logger from '../logger'
 import { renderingFor } from './render'
+import { noteTapFailure } from './events'
 import type { InstanceSelection } from '../cypress-instances'
 import type { TapSchema } from '@packages/cypress-instances'
 
 export const renderFailure = (err: { code: string, message: string }): void => {
+  noteTapFailure(err.code)
   logger.errorToStderr(`${err.code}: ${err.message}`)
 }
 

--- a/cli/lib/tap/render/AGENTS.md
+++ b/cli/lib/tap/render/AGENTS.md
@@ -79,11 +79,6 @@ soft-wrapped line breaks the column it was padded into. Reach for the same
 three moves — summarize, offer the drill-down, clamp to width — for any future
 result whose depth the CLI does not control.
 
-`--depth` is an ordinary option on the `command` command, declared in the shared
-contract like any other. The instance advertises it, the CLI forwards it with the
-rest, and the renderer reads it from that same options bag. A flag that only
-changes how a result reads needs no special plumbing: the handler ignores it.
-
 ## Conventions worth keeping
 
 - **Empty states keep the frame.** Prefer the command's normal shape with a

--- a/cli/lib/tap/render/AGENTS.md
+++ b/cli/lib/tap/render/AGENTS.md
@@ -79,11 +79,10 @@ soft-wrapped line breaks the column it was padded into. Reach for the same
 three moves — summarize, offer the drill-down, clamp to width — for any future
 result whose depth the CLI does not control.
 
-`--depth` is a **view option**: declared by the rendering
-(`TapCommandRendering.options`), rendered into the command's help like any other
-flag, but collected apart from the schema's and never sent to the instance. A
-flag that only changes how a result reads belongs there — it then works against
-any instance version that has the command at all.
+`--depth` is an ordinary option on the `command` command, declared in the shared
+contract like any other. The instance advertises it, the CLI forwards it with the
+rest, and the renderer reads it from that same options bag. A flag that only
+changes how a result reads needs no special plumbing: the handler ignores it.
 
 ## Conventions worth keeping
 

--- a/cli/lib/tap/render/console-props.ts
+++ b/cli/lib/tap/render/console-props.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import type { TapCommandOptionSchema, TapConsoleProps, TapJsonValue } from '@packages/cypress-instances'
+import type { TapConsoleProps, TapJsonValue } from '@packages/cypress-instances'
 import { clamp, color, emptyState, heading, layout, tableRows, terminalWidth } from './format'
 
 // A command's console properties are the deepest payload the tap returns — a
@@ -28,10 +28,6 @@ const MIN_VALUE_WIDTH = 24
 // Console prop labels are short prose (`Request Headers`); anything past this is
 // a key carrying data, and it does not get to own the level's whole row.
 const MAX_KEY_WIDTH = 32
-
-export const consolePropsOptions: readonly TapCommandOptionSchema[] = [
-  { name: 'depth', alias: 'd', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
-]
 
 export interface ConsolePropsOptions {
   depth?: string

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,4 +1,5 @@
 import type { ClearResult, PinResult, TapCommandName, TapCommandOptionSchema, TapCommandResult, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
+import { TAP_VIEW_OPTIONS } from '@packages/cypress-instances'
 import type { TapRunResult } from '../commands/run'
 import type { TapInstanceSummary } from '../commands/instances'
 import type { TapSpecEntry } from '../commands/specs'
@@ -18,7 +19,6 @@ import { renderAriaHuman } from './aria'
 import { renderInspectHuman } from './inspect'
 import { renderPinHuman } from './pin'
 import { renderCommandHuman } from './command'
-import { consolePropsOptions } from './console-props'
 
 /**
  * The CLI-side rendering half of a tap command's definition. A command that
@@ -29,14 +29,9 @@ import { consolePropsOptions } from './console-props'
  * options, for a command whose result shape depends on them. Returning
  * undefined declines the rendering for the invoked options, printing the raw
  * JSON as if `--json` had been passed.
- *
- * `options` here are the view's own: flags the CLI declares on top of the
- * command's schema, parsed and rendered into its help like any other but never
- * forwarded to the instance, since they only shape how the result reads.
  */
 export interface TapCommandRendering {
   renderHuman: (result: unknown, options: Record<string, string>) => string | undefined
-  options?: readonly TapCommandOptionSchema[]
 }
 
 // The selector-taking AUT reads answer an ambiguous selector in place of the
@@ -59,7 +54,6 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
     },
   },
   command: {
-    options: consolePropsOptions,
     renderHuman: (result, options) => {
       return renderCommandHuman(result as TapCommandResult, {
         depth: options.depth,
@@ -86,5 +80,5 @@ export const renderingFor = (command: string): TapCommandRendering | undefined =
  * them, so they work against any version that has the command at all.
  */
 export const renderOptionsFor = (command: string): readonly TapCommandOptionSchema[] => {
-  return renderingFor(command)?.options ?? []
+  return TAP_VIEW_OPTIONS[command as TapCommandName | TapNativeCommandName] ?? []
 }

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,5 +1,4 @@
-import type { ClearResult, PinResult, TapCommandName, TapCommandOptionSchema, TapCommandResult, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
-import { TAP_VIEW_OPTIONS } from '@packages/cypress-instances'
+import type { ClearResult, PinResult, TapCommandName, TapCommandResult, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-instances'
 import type { TapRunResult } from '../commands/run'
 import type { TapInstanceSummary } from '../commands/instances'
 import type { TapSpecEntry } from '../commands/specs'
@@ -72,13 +71,4 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
 
 export const renderingFor = (command: string): TapCommandRendering | undefined => {
   return renderings[command as TapCommandName | TapNativeCommandName]
-}
-
-/**
- * The view-only options to declare on a command on top of the ones its schema
- * advertises. They stay in the CLI: the instance neither needs nor is told about
- * them, so they work against any version that has the command at all.
- */
-export const renderOptionsFor = (command: string): readonly TapCommandOptionSchema[] => {
-  return TAP_VIEW_OPTIONS[command as TapCommandName | TapNativeCommandName] ?? []
 }

--- a/cli/lib/tap/reported-invocation.ts
+++ b/cli/lib/tap/reported-invocation.ts
@@ -1,0 +1,63 @@
+import { tapCliCommands } from './commands'
+import { renderOptionsFor } from './render'
+import type { TapCliOptions } from './types'
+import { TAP_COMMANDS } from '@packages/cypress-instances'
+import type { TapCommandOptionSchema } from '@packages/cypress-instances'
+
+const allTapCommands = [...tapCliCommands, ...TAP_COMMANDS]
+
+const knownCommands = new Set<string>(allTapCommands.map(({ name }) => name))
+
+// A name this CLI does not know is whatever the user typed, so it is reported
+// as unknown rather than sent verbatim.
+const reportedCommand = (command: string | undefined): string | undefined => {
+  if (!command) {
+    return undefined
+  }
+
+  return knownCommands.has(command) ? command : 'unknown'
+}
+
+const declaredOptions: readonly TapCommandOptionSchema[] = allTapCommands.flatMap(({ name, options = [] }) => {
+  return [...options, ...renderOptionsFor(name)]
+})
+
+// Both spellings of every option resolve to the canonical name, so `-b` and
+// `--browser` report as one flag. The names seeded here belong to `cypress tap`
+// itself rather than to any command, so `declaredOptions` does not carry them.
+const knownFlags = new Map<string, string>([
+  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
+  ['h', 'help'],
+  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
+])
+
+// Names only: an option's value carries selectors, spec paths and test titles.
+// An undeclared flag is whatever the user typed, so it reports as unknown.
+// --instance/--json/--timeout are parsed off by the outer `cypress tap` command
+// and never reach the operands, so they are read from the options it passes on.
+const reportedFlags = (operands: string[], options: TapCliOptions): string[] => {
+  const named = operands
+  .filter((operand) => operand.startsWith('-'))
+  .map((operand) => knownFlags.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
+
+  const topLevel = Object.entries(options)
+  .filter(([name, value]) => value !== undefined && knownFlags.has(name))
+  .map(([name]) => name)
+
+  return [...new Set([...named, ...topLevel])]
+}
+
+export interface ReportedInvocation {
+  command: string | undefined
+  flags: string[]
+}
+
+/**
+ * The fixed names a trace may carry, reduced from what the user actually typed.
+ * Everything the tap CLI reports about an invocation passes through here, so no
+ * selector, spec path, project root or option value can reach the wire.
+ */
+export const reportedInvocation = (command: string | undefined, operands: string[], options: TapCliOptions): ReportedInvocation => ({
+  command: reportedCommand(command),
+  flags: reportedFlags(operands, options),
+})

--- a/cli/lib/tap/reported-invocation.ts
+++ b/cli/lib/tap/reported-invocation.ts
@@ -1,18 +1,15 @@
 import type { TapCliOptions } from './types'
+import type { TapCommandName, TapNativeCommandName } from '@packages/cypress-instances'
 import { KNOWN_COMMANDS } from '@packages/cypress-instances'
+
+type ReportedCommand = TapNativeCommandName | TapCommandName | 'unknown'
 
 // A name this CLI does not know is whatever the user typed, so it is reported
 // as unknown rather than sent verbatim.
-const reportedCommand = (command: string | undefined): string | undefined => {
-  if (!command) {
-    return undefined
-  }
-
-  return KNOWN_COMMANDS.has(command) ? command : 'unknown'
-}
+const getKnownCommand = (command: string): ReportedCommand => KNOWN_COMMANDS.has(command) ? command as ReportedCommand : 'unknown'
 
 export interface ReportedInvocation {
-  command: string | undefined
+  command: ReportedCommand | undefined
   flags: string[]
 }
 
@@ -22,9 +19,9 @@ export interface ReportedInvocation {
  * command declares are reported once commander has parsed them, by noteTapCommand.
  */
 export const reportedInvocation = (command: string | undefined, wantsHelp: boolean, options: TapCliOptions): ReportedInvocation => ({
-  command: reportedCommand(command),
+  command: command ? getKnownCommand(command) : undefined,
   flags: [
     ...wantsHelp ? ['help'] : [],
-    ...Object.entries(options).filter(([, value]) => value !== undefined).map(([name]) => name),
+    ...Object.keys(options),
   ],
 })

--- a/cli/lib/tap/reported-invocation.ts
+++ b/cli/lib/tap/reported-invocation.ts
@@ -1,5 +1,5 @@
 import type { TapCliOptions } from './types'
-import { KNOWN_COMMANDS, KNOWN_FLAGS } from '@packages/cypress-instances'
+import { KNOWN_COMMANDS } from '@packages/cypress-instances'
 
 // A name this CLI does not know is whatever the user typed, so it is reported
 // as unknown rather than sent verbatim.
@@ -11,33 +11,20 @@ const reportedCommand = (command: string | undefined): string | undefined => {
   return KNOWN_COMMANDS.has(command) ? command : 'unknown'
 }
 
-// Names only: an option's value carries selectors, spec paths and test titles.
-// An undeclared flag is whatever the user typed, so it reports as unknown.
-// --instance/--json/--timeout are parsed off by the outer `cypress tap` command
-// and never reach the operands, so they are read from the options it passes on.
-const reportedFlags = (operands: string[], options: TapCliOptions): string[] => {
-  const named = operands
-  .filter((operand) => operand.startsWith('-'))
-  .map((operand) => KNOWN_FLAGS.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
-
-  const topLevel = Object.entries(options)
-  .filter(([name, value]) => value !== undefined && KNOWN_FLAGS.has(name))
-  .map(([name]) => name)
-
-  return [...new Set([...named, ...topLevel])]
-}
-
 export interface ReportedInvocation {
   command: string | undefined
   flags: string[]
 }
 
 /**
- * The fixed names a trace may carry, reduced from what the user actually typed.
- * Everything the tap CLI reports about an invocation passes through here, so no
- * selector, spec path, project root or option value can reach the wire.
+ * What an invocation reports before it runs: the command it named, and the flags
+ * `cypress tap` handles itself rather than passing to a command. The flags a
+ * command declares are reported once commander has parsed them, by noteTapCommand.
  */
-export const reportedInvocation = (command: string | undefined, operands: string[], options: TapCliOptions): ReportedInvocation => ({
+export const reportedInvocation = (command: string | undefined, wantsHelp: boolean, options: TapCliOptions): ReportedInvocation => ({
   command: reportedCommand(command),
-  flags: reportedFlags(operands, options),
+  flags: [
+    ...wantsHelp ? ['help'] : [],
+    ...Object.entries(options).filter(([, value]) => value !== undefined).map(([name]) => name),
+  ],
 })

--- a/cli/lib/tap/reported-invocation.ts
+++ b/cli/lib/tap/reported-invocation.ts
@@ -1,12 +1,5 @@
-import { tapCliCommands } from './commands'
-import { renderOptionsFor } from './render'
 import type { TapCliOptions } from './types'
-import { TAP_COMMANDS } from '@packages/cypress-instances'
-import type { TapCommandOptionSchema } from '@packages/cypress-instances'
-
-const allTapCommands = [...tapCliCommands, ...TAP_COMMANDS]
-
-const knownCommands = new Set<string>(allTapCommands.map(({ name }) => name))
+import { KNOWN_COMMANDS, KNOWN_FLAGS } from '@packages/cypress-instances'
 
 // A name this CLI does not know is whatever the user typed, so it is reported
 // as unknown rather than sent verbatim.
@@ -15,21 +8,8 @@ const reportedCommand = (command: string | undefined): string | undefined => {
     return undefined
   }
 
-  return knownCommands.has(command) ? command : 'unknown'
+  return KNOWN_COMMANDS.has(command) ? command : 'unknown'
 }
-
-const declaredOptions: readonly TapCommandOptionSchema[] = allTapCommands.flatMap(({ name, options = [] }) => {
-  return [...options, ...renderOptionsFor(name)]
-})
-
-// Both spellings of every option resolve to the canonical name, so `-b` and
-// `--browser` report as one flag. The names seeded here belong to `cypress tap`
-// itself rather than to any command, so `declaredOptions` does not carry them.
-const knownFlags = new Map<string, string>([
-  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
-  ['h', 'help'],
-  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
-])
 
 // Names only: an option's value carries selectors, spec paths and test titles.
 // An undeclared flag is whatever the user typed, so it reports as unknown.
@@ -38,10 +18,10 @@ const knownFlags = new Map<string, string>([
 const reportedFlags = (operands: string[], options: TapCliOptions): string[] => {
   const named = operands
   .filter((operand) => operand.startsWith('-'))
-  .map((operand) => knownFlags.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
+  .map((operand) => KNOWN_FLAGS.get(operand.replace(/^-+/, '').split('=')[0]) ?? 'unknown')
 
   const topLevel = Object.entries(options)
-  .filter(([name, value]) => value !== undefined && knownFlags.has(name))
+  .filter(([name, value]) => value !== undefined && KNOWN_FLAGS.has(name))
   .map(([name]) => name)
 
   return [...new Set([...named, ...topLevel])]

--- a/cli/lib/util.ts
+++ b/cli/lib/util.ts
@@ -132,6 +132,14 @@ function isNonProductionCypressInternalEnvValue (value: string | undefined): boo
 }
 
 /**
+ * The version every package carries in a source checkout, which the release
+ * replaces with the computed one (see scripts/get-next-version.js). Comparing
+ * `pkgVersion()` against it is how the CLI knows it is running from the repo
+ * rather than from an install.
+ */
+export const DEVELOPMENT_VERSION = '0.0.0-development'
+
+/**
  * Prints NODE_OPTIONS using debug() module, but only
  * if DEBUG=cypress... is set
  */

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@cypress/request": "^4.0.0",
     "@cypress/xvfb": "^1.2.4",
+    "@packages/agent-info": "0.0.0-development",
     "@packages/cypress-instances": "0.0.0-development",
     "@packages/stderr-filtering": "0.0.0-development",
     "@types/sinonjs__fake-timers": "8.1.1",

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -220,8 +220,8 @@ describe('cli', () => {
         // the reporting prints — or whether it prints one at all.
         env: {
           DEBUG: 'cypress:cli:tap',
-          CYPRESS_DISABLE_TELEMETRY: undefined,
           CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV: undefined,
+          CYPRESS_INTERNAL_ENV: undefined,
         },
         filter: ['code', 'stdout', 'stderr'],
       }

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -907,6 +907,16 @@ describe('cli', () => {
       expect(tap.start).toBeCalledWith(['health'], { instance: 123 })
     })
 
+    // The invocation reports the keys of what commander parsed, so an option left
+    // unset has to arrive as no key rather than as an undefined value.
+    it('forwards a key only for the options the invocation set', async () => {
+      await exec('tap health --json')
+
+      await flushPromises()
+
+      expect(Object.keys(vi.mocked(tap.start).mock.calls[0][1]!)).toEqual(['json'])
+    })
+
     it('catches rejection and exits', async () => {
       const err = new Error('tap health failed badly')
 

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -216,7 +216,13 @@ describe('cli', () => {
     // tests import lib/exec/tap directly and never see it.
     it('leaves a command that took exitOverride to finish its own failure', async () => {
       const options = {
-        env: { DEBUG: 'cypress:cli:tap' },
+        // The child inherits this environment, and both of these decide which line
+        // the reporting prints — or whether it prints one at all.
+        env: {
+          DEBUG: 'cypress:cli:tap',
+          CYPRESS_CRASH_REPORTS: undefined,
+          CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV: undefined,
+        },
         filter: ['code', 'stdout', 'stderr'],
       }
 

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -209,6 +209,24 @@ describe('cli', () => {
 
       expect(result).toMatchSnapshot()
     })
+
+    // The patch above exits the process, which skips whatever the command still
+    // had to do. `tap` takes exitOverride() so it can report the invocation on
+    // its way out, and only a spawned binary loads the patch at all — the unit
+    // tests import lib/exec/tap directly and never see it.
+    it('leaves a command that took exitOverride to finish its own failure', async () => {
+      const options = {
+        env: { DEBUG: 'cypress:cli:tap' },
+        filter: ['code', 'stdout', 'stderr'],
+      }
+
+      const result = await execa('bin/cypress', ['tap', 'status', '--fake'], options)
+
+      expect(result).toContain('unknown option: --fake')
+      expect(result).toContain('code: 1')
+      // Only printed from the reporting that the exit would have skipped.
+      expect(result).toContain('skipped tap event')
+    })
   })
 
   describe('help command', () => {

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -220,7 +220,7 @@ describe('cli', () => {
         // the reporting prints — or whether it prints one at all.
         env: {
           DEBUG: 'cypress:cli:tap',
-          CYPRESS_CRASH_REPORTS: undefined,
+          CYPRESS_DISABLE_TELEMETRY: undefined,
           CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV: undefined,
         },
         filter: ['code', 'stdout', 'stderr'],

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -14,6 +14,7 @@ import {
   listLiveInstances,
   getInstancesDir,
   pruneDeadInstanceRecords,
+  resolvedInstanceId,
   CypressInstanceError,
 } from '../../lib/cypress-instances'
 
@@ -304,6 +305,17 @@ describe('lib/cypress-instances', () => {
       stubKill({ alive: [111] })
 
       await expect(resolveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+    })
+
+    it('remembers the id of the instance it selected', async () => {
+      const port = await startReadyInstance(INSTANCE_ID)
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      await resolveInstance({ cwd: PROJECT })
+
+      expect(resolvedInstanceId()).toBe(INSTANCE_ID)
     })
 
     it('reaps the leftover record and throws NO_INSTANCE when the only match’s process is dead', async () => {

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -1,0 +1,94 @@
+import { vi } from 'vitest'
+
+import logger from '../../../lib/logger'
+import { listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
+import type { ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-instances'
+import { withTapSession } from '../../../lib/tap/tap-session'
+import type { TapSession } from '../../../lib/tap/tap-session'
+import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
+import { withResolvedAutFrame } from '../../../lib/tap/aut/frame'
+import type { TapExecResult, TapSchema } from '@packages/cypress-instances'
+
+export const tapError = (details: { description: string, solution: string }, message: string): Error => {
+  return Object.assign(new Error(message), { details, known: true })
+}
+
+export const schema: TapSchema = {
+  schemaVersion: 1,
+  cypressVersion: '15.0.0',
+  commands: [
+    {
+      name: 'health',
+      description: 'check that a running Cypress instance is reachable and its tap binding responds',
+      params: [],
+      options: [],
+    },
+    {
+      name: 'fake-command-for-testing',
+      description: 'a fake command, advertised only by this test\'s schema, exercising schema-forwarded dispatch',
+      params: [
+        { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the spec command' },
+      ],
+      options: [
+        { name: 'browser', alias: 'b', type: 'string', required: false, description: 'which browser to run in' },
+        { name: 'headed', type: 'boolean', required: false, description: 'show the browser' },
+      ],
+    },
+  ],
+}
+
+export const mockSession = (sessionSchema: unknown = schema, execOutcome: unknown = { result: 'ok' } satisfies TapExecResult) => {
+  const call = vi.fn(async (method: string) => {
+    return method === 'getSchema' ? sessionSchema : execOutcome
+  })
+
+  // These tests drive the binding exec/status paths, which use only `call`;
+  // the frame extractors (dom/aria/inspect, which use client/sessionId) are
+  // covered separately, so the session's CDP members are stubbed away here.
+  vi.mocked(withTapSession).mockImplementation(async (_runner, fn) => fn({ call } as unknown as TapSession))
+
+  return call
+}
+
+export const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceState => ({
+  schemaVersion: 1,
+  pid: 4242,
+  projectRoot: '/projects/app',
+  serverPort: 49200,
+  instanceId: 'inst-1',
+  testingType: 'e2e',
+  cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+  browserName: 'Chrome',
+  ...overrides,
+})
+
+export const mockResolved = (overrides: Partial<InstanceSelection> = {}): InstanceSelection => {
+  const selection: InstanceSelection = { instance: readyInstance(), reason: 'only', candidateCount: 1, ...overrides }
+
+  vi.mocked(resolveInstance).mockResolvedValue(selection)
+
+  return selection
+}
+
+// Every invocation reports itself to the Cloud event collector, so nothing in
+// these specs is allowed to reach the network.
+export const fetchMock = vi.fn()
+
+export const reportedEvent = () => JSON.parse(fetchMock.mock.calls.at(-1)![1].body).payload
+
+export const resetTapMocks = (): void => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue({ status: 200 })
+  vi.stubGlobal('fetch', fetchMock)
+  vi.mocked(withTapSession).mockReset()
+  vi.mocked(queryInstanceGraphql).mockReset()
+  vi.mocked(listLiveInstances).mockReset()
+  vi.mocked(resolveLiveInstance).mockReset()
+  vi.mocked(resolveInstance).mockReset()
+  vi.mocked(withResolvedAutFrame).mockReset()
+  vi.mocked(withResolvedAutFrame).mockResolvedValue(0)
+  mockResolved()
+  logger.reset()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+}

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -14,31 +14,21 @@ import { buildTapSchema } from '@packages/cypress-instances'
 import type { TapExecResult, TapSchema } from '@packages/cypress-instances'
 import { errors } from '../../../lib/errors'
 import tap from '../../../lib/exec/tap'
+import { mockResolved, mockSession, readyInstance, resetTapMocks, schema, tapError } from './tap-fixtures'
 
-const tapError = (details: { description: string, solution: string }, message: string): Error => {
-  return Object.assign(new Error(message), { details, known: true })
-}
-
+// vi.mock is hoisted above these imports, so the factories cannot come from
+// ./tap-fixtures — everything they don't cover does.
 vi.mock('../../../lib/tap/tap-session', async (importActual) => {
-  const actual = await importActual<typeof import('../../../lib/tap/tap-session')>()
-
-  return {
-    ...actual,
-    withTapSession: vi.fn(),
-  }
+  return { ...await importActual<typeof import('../../../lib/tap/tap-session')>(), withTapSession: vi.fn() }
 })
 
 vi.mock('../../../lib/tap/instance-gql', () => {
-  return {
-    queryInstanceGraphql: vi.fn(),
-  }
+  return { queryInstanceGraphql: vi.fn() }
 })
 
 vi.mock('../../../lib/cypress-instances', async (importActual) => {
-  const actual = await importActual<typeof import('../../../lib/cypress-instances')>()
-
   return {
-    ...actual,
+    ...await importActual<typeof import('../../../lib/cypress-instances')>(),
     listLiveInstances: vi.fn(),
     resolveLiveInstance: vi.fn(),
     resolveInstance: vi.fn(),
@@ -48,85 +38,11 @@ vi.mock('../../../lib/cypress-instances', async (importActual) => {
 // The AUT-frame reader drives CDP, covered in frame.spec.ts; here we assert only
 // that dom/aria/inspect route to it with their parsed args, so stub it out.
 vi.mock('../../../lib/tap/aut/frame', async (importActual) => {
-  const actual = await importActual<typeof import('../../../lib/tap/aut/frame')>()
-
-  return {
-    ...actual,
-    withResolvedAutFrame: vi.fn(),
-  }
+  return { ...await importActual<typeof import('../../../lib/tap/aut/frame')>(), withResolvedAutFrame: vi.fn() }
 })
-
-const schema: TapSchema = {
-  schemaVersion: 1,
-  cypressVersion: '15.0.0',
-  commands: [
-    {
-      name: 'health',
-      description: 'check that a running Cypress instance is reachable and its tap binding responds',
-      params: [],
-      options: [],
-    },
-    {
-      name: 'fake-command-for-testing',
-      description: 'a fake command, advertised only by this test\'s schema, exercising schema-forwarded dispatch',
-      params: [
-        { name: 'spec', type: 'string', required: true, description: 'project-relative spec path, as listed by the spec command' },
-      ],
-      options: [
-        { name: 'browser', alias: 'b', type: 'string', required: false, description: 'which browser to run in' },
-        { name: 'headed', type: 'boolean', required: false, description: 'show the browser' },
-      ],
-    },
-  ],
-}
-
-const mockSession = (sessionSchema: unknown = schema, execOutcome: unknown = { result: 'ok' } satisfies TapExecResult) => {
-  const call = vi.fn(async (method: string) => {
-    return method === 'getSchema' ? sessionSchema : execOutcome
-  })
-
-  // These tests drive the binding exec/status paths, which use only `call`;
-  // the frame extractors (dom/aria/inspect, which use client/sessionId) are
-  // covered separately, so the session's CDP members are stubbed away here.
-  vi.mocked(withTapSession).mockImplementation(async (_runner, fn) => fn({ call } as unknown as TapSession))
-
-  return call
-}
-
-const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceState => ({
-  schemaVersion: 1,
-  pid: 4242,
-  projectRoot: '/projects/app',
-  serverPort: 49200,
-  instanceId: 'inst-1',
-  testingType: 'e2e',
-  cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-  browserName: 'Chrome',
-  ...overrides,
-})
-
-const mockResolved = (overrides: Partial<InstanceSelection> = {}): InstanceSelection => {
-  const selection: InstanceSelection = { instance: readyInstance(), reason: 'only', candidateCount: 1, ...overrides }
-
-  vi.mocked(resolveInstance).mockResolvedValue(selection)
-
-  return selection
-}
 
 describe('lib/exec/tap', () => {
-  beforeEach(() => {
-    vi.mocked(withTapSession).mockReset()
-    vi.mocked(queryInstanceGraphql).mockReset()
-    vi.mocked(listLiveInstances).mockReset()
-    vi.mocked(resolveLiveInstance).mockReset()
-    vi.mocked(resolveInstance).mockReset()
-    vi.mocked(withResolvedAutFrame).mockReset()
-    vi.mocked(withResolvedAutFrame).mockResolvedValue(0)
-    mockResolved()
-    logger.reset()
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
+  beforeEach(resetTapMocks)
 
   afterEach(() => {
     vi.useRealTimers()

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -60,18 +60,24 @@ describe('lib/exec/tap reporting the invocation', () => {
     expect(reportedEvent()).not.toHaveProperty('errorCode')
   })
 
+  // A schema command's flags are named by the schema, which a discovery failure
+  // never fetched, so the code is all such an invocation has to report.
   it('reports a discovery failure by its code', async () => {
     vi.mocked(resolveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
 
-    expect(await tap.start(['reporter', '--testId', 'r2'], {})).toBe(1)
+    expect(await tap.start(['reporter', '--test-id', 'r2'], {})).toBe(1)
     expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'NO_INSTANCE' })
+    expect(reportedEvent().flags).toEqual([])
   })
 
+  // A CLI-native command is dispatched before it looks for an instance, so it
+  // reports what was typed as well as the code it failed with.
   it('reports a discovery failure a CLI-native command handled itself', async () => {
     vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
 
-    expect(await tap.start(['specs'], {})).toBe(1)
-    expect(reportedEvent()).toMatchObject({ command: 'specs', exitCode: 1, errorCode: 'NO_INSTANCE' })
+    expect(await tap.start(['run', 'cypress/e2e/a.cy.js'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ command: 'run', exitCode: 1, errorCode: 'NO_INSTANCE', flags: ['spec'] })
+    expect(JSON.stringify(reportedEvent())).not.toContain('a.cy.js')
   })
 
   it('reports an instance-side failure by the code the instance gave', async () => {
@@ -124,9 +130,9 @@ describe('lib/exec/tap reporting the invocation', () => {
     it('reports the flag names an invocation used, never their values', async () => {
       mockSession(buildTapSchema('15.0.0'))
 
-      expect(await tap.start(['reporter', '--testId', 'r2'], { json: true, instance: 4242 })).toBe(0)
+      expect(await tap.start(['reporter', '--test-id', 'r2'], { json: true, instance: 4242 })).toBe(0)
 
-      expect(reportedEvent().flags).toEqual(['testId', 'json', 'instance'])
+      expect(reportedEvent().flags).toEqual(['json', 'instance', 'test-id'])
       expect(JSON.stringify(reportedEvent())).not.toContain('r2')
       expect(JSON.stringify(reportedEvent())).not.toContain('4242')
     })
@@ -138,11 +144,14 @@ describe('lib/exec/tap reporting the invocation', () => {
       expect(reportedEvent().flags).toEqual(['help'])
     })
 
-    it('reports a flag this CLI does not declare as unknown', async () => {
-      mockSession()
+    // An undeclared flag is rejected before dispatch, so it reports as the usage
+    // error it is, under no flag at all — and the value it carried stays home.
+    it('reports no flag for one this CLI does not declare, and never its value', async () => {
+      mockSession(buildTapSchema('15.0.0'))
 
-      expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js', '--secret-token=abc123'], {})).toBe(1)
-      expect(reportedEvent().flags).toEqual(['unknown'])
+      expect(await tap.start(['reporter', '--secret-token=abc123'], {})).toBe(1)
+      expect(reportedEvent()).toMatchObject({ command: 'reporter', errorCode: 'INVALID_USAGE' })
+      expect(reportedEvent().flags).toEqual([])
       expect(JSON.stringify(reportedEvent())).not.toContain('abc123')
     })
 

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -33,9 +33,10 @@ vi.mock('../../../lib/tap/aut/frame', async (importActual) => {
 // These specs assert what an invocation reports, which a source checkout's
 // version would otherwise stop it from sending at all.
 vi.mock('../../../lib/util', async (importActual) => {
-  const actual = await importActual<{ default: typeof import('../../../lib/util').default }>()
+  const actual = await importActual<typeof import('../../../lib/util')>()
 
   return {
+    ...actual,
     default: { ...actual.default, pkgVersion: vi.fn().mockReturnValue('15.0.0') },
   }
 })

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -30,6 +30,16 @@ vi.mock('../../../lib/tap/aut/frame', async (importActual) => {
   return { ...await importActual<typeof import('../../../lib/tap/aut/frame')>(), withResolvedAutFrame: vi.fn() }
 })
 
+// These specs assert what an invocation reports, which a source checkout's
+// version would otherwise stop it from sending at all.
+vi.mock('../../../lib/util', async (importActual) => {
+  const actual = await importActual<{ default: typeof import('../../../lib/util').default }>()
+
+  return {
+    default: { ...actual.default, pkgVersion: vi.fn().mockReturnValue('15.0.0') },
+  }
+})
+
 describe('lib/exec/tap reporting the invocation', () => {
   beforeEach(resetTapMocks)
 

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -177,17 +177,15 @@ describe('lib/exec/tap reporting the invocation', () => {
     expect(await tap.start(['health'], {})).toBe(0)
   })
 
-  it('sends nothing when crash reports are turned off', async () => {
-    const original = process.env.CYPRESS_CRASH_REPORTS
-
-    process.env.CYPRESS_CRASH_REPORTS = '0'
+  it('sends nothing when telemetry is turned off', async () => {
+    vi.stubEnv('CYPRESS_DISABLE_TELEMETRY', '1')
     mockSession()
 
     try {
       expect(await tap.start(['health'], {})).toBe(0)
       expect(fetchMock).not.toHaveBeenCalled()
     } finally {
-      process.env.CYPRESS_CRASH_REPORTS = original
+      vi.unstubAllEnvs()
     }
   })
 })

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -176,16 +176,4 @@ describe('lib/exec/tap reporting the invocation', () => {
 
     expect(await tap.start(['health'], {})).toBe(0)
   })
-
-  it('sends nothing when telemetry is turned off', async () => {
-    vi.stubEnv('CYPRESS_DISABLE_TELEMETRY', '1')
-    mockSession()
-
-    try {
-      expect(await tap.start(['health'], {})).toBe(0)
-      expect(fetchMock).not.toHaveBeenCalled()
-    } finally {
-      vi.unstubAllEnvs()
-    }
-  })
 })

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CypressInstanceError, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
+import { withTapSession } from '../../../lib/tap/tap-session'
+import { buildTapSchema } from '@packages/cypress-instances'
+import { errors } from '../../../lib/errors'
+import tap from '../../../lib/exec/tap'
+import { fetchMock, mockSession, reportedEvent, resetTapMocks, schema, tapError } from './tap-fixtures'
+
+// vi.mock is hoisted above these imports, so the factories cannot come from
+// ./tap-fixtures — everything they don't cover does.
+vi.mock('../../../lib/tap/tap-session', async (importActual) => {
+  return { ...await importActual<typeof import('../../../lib/tap/tap-session')>(), withTapSession: vi.fn() }
+})
+
+vi.mock('../../../lib/tap/instance-gql', () => {
+  return { queryInstanceGraphql: vi.fn() }
+})
+
+vi.mock('../../../lib/cypress-instances', async (importActual) => {
+  return {
+    ...await importActual<typeof import('../../../lib/cypress-instances')>(),
+    listLiveInstances: vi.fn(),
+    resolveLiveInstance: vi.fn(),
+    resolveInstance: vi.fn(),
+  }
+})
+
+vi.mock('../../../lib/tap/aut/frame', async (importActual) => {
+  return { ...await importActual<typeof import('../../../lib/tap/aut/frame')>(), withResolvedAutFrame: vi.fn() }
+})
+
+describe('lib/exec/tap reporting the invocation', () => {
+  beforeEach(resetTapMocks)
+
+  // `health` is advertised by this test's schema but is not a command this CLI
+  // ships, standing in for a newer instance.
+  it('reports a dispatched command that succeeded', async () => {
+    mockSession()
+
+    expect(await tap.start(['health'], {})).toBe(0)
+
+    expect(reportedEvent()).toMatchObject({
+      command: 'health',
+      exitCode: 0,
+      durationMs: expect.any(Number),
+    })
+
+    expect(reportedEvent()).not.toHaveProperty('errorCode')
+  })
+
+  it('reports a discovery failure by its code', async () => {
+    vi.mocked(resolveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+
+    expect(await tap.start(['reporter', '--testId', 'r2'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'NO_INSTANCE' })
+  })
+
+  it('reports a discovery failure a CLI-native command handled itself', async () => {
+    vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+
+    expect(await tap.start(['specs'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ command: 'specs', exitCode: 1, errorCode: 'NO_INSTANCE' })
+  })
+
+  it('reports an instance-side failure by the code the instance gave', async () => {
+    mockSession(schema, { error: { code: 'INVALID_ARGUMENTS', message: '<spec> must be a string.' } })
+
+    expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ exitCode: 1, errorCode: 'INVALID_ARGUMENTS' })
+  })
+
+  // A known transport failure has no code of its own to report, only the
+  // description and solution the user was shown.
+  it('reports a known transport failure without a code', async () => {
+    mockSession()
+    vi.mocked(withTapSession).mockRejectedValue(tapError(errors.tapCdpUnreachable, 'socket hang up'))
+
+    expect(await tap.start(['health'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ exitCode: 1 })
+    expect(reportedEvent()).not.toHaveProperty('errorCode')
+  })
+
+  it('reports a mistyped flag as invalid usage', async () => {
+    mockSession(buildTapSchema('15.0.0'))
+
+    expect(await tap.start(['reporter', '--nope'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'INVALID_USAGE' })
+  })
+
+  it('reports a command this CLI does not know as unknown', async () => {
+    mockSession()
+
+    expect(await tap.start(['../../etc/passwd'], {})).toBe(1)
+    expect(reportedEvent()).toMatchObject({ command: 'unknown', exitCode: 1 })
+  })
+
+  it('reports a bare invocation under no command', async () => {
+    mockSession()
+
+    expect(await tap.start(['--help'], {})).toBe(0)
+    expect(reportedEvent()).toMatchObject({ command: 'none', exitCode: 0, flags: ['help'] })
+
+    expect(await tap.start(['status', '--help'], {})).toBe(0)
+    expect(reportedEvent()).toMatchObject({ command: 'status', exitCode: 0, flags: ['help'] })
+  })
+
+  describe('flags', () => {
+    // The names say which options agents reach for; the values are selectors,
+    // spec paths and test titles, so they never leave the machine.
+    // The outer `cypress tap` command parses --instance/--json/--timeout off
+    // before start() sees the operands, so they arrive as options instead.
+    it('reports the flag names an invocation used, never their values', async () => {
+      mockSession(buildTapSchema('15.0.0'))
+
+      expect(await tap.start(['reporter', '--testId', 'r2'], { json: true, instance: 4242 })).toBe(0)
+
+      expect(reportedEvent().flags).toEqual(['testId', 'json', 'instance'])
+      expect(JSON.stringify(reportedEvent())).not.toContain('r2')
+      expect(JSON.stringify(reportedEvent())).not.toContain('4242')
+    })
+
+    it('reports an option by its canonical name whichever spelling was used', async () => {
+      mockSession()
+
+      expect(await tap.start(['status', '-h'], {})).toBe(0)
+      expect(reportedEvent().flags).toEqual(['help'])
+    })
+
+    it('reports a flag this CLI does not declare as unknown', async () => {
+      mockSession()
+
+      expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js', '--secret-token=abc123'], {})).toBe(1)
+      expect(reportedEvent().flags).toEqual(['unknown'])
+      expect(JSON.stringify(reportedEvent())).not.toContain('abc123')
+    })
+
+    it('reports no flags for an invocation that passed none', async () => {
+      mockSession()
+
+      expect(await tap.start(['health'], {})).toBe(0)
+      expect(reportedEvent().flags).toEqual([])
+    })
+  })
+
+  it('reports an unexpected error before rethrowing it', async () => {
+    vi.mocked(resolveInstance).mockRejectedValue(new Error('boom'))
+
+    await expect(tap.start(['health'], {})).rejects.toThrow('boom')
+    expect(reportedEvent()).toMatchObject({ exitCode: 1, errorCode: 'UNHANDLED' })
+  })
+
+  it('leaves the exit code alone when the collector cannot be reached', async () => {
+    mockSession()
+    fetchMock.mockRejectedValue(new Error('socket hang up'))
+
+    expect(await tap.start(['health'], {})).toBe(0)
+  })
+
+  it('sends nothing when crash reports are turned off', async () => {
+    const original = process.env.CYPRESS_CRASH_REPORTS
+
+    process.env.CYPRESS_CRASH_REPORTS = '0'
+    mockSession()
+
+    try {
+      expect(await tap.start(['health'], {})).toBe(0)
+      expect(fetchMock).not.toHaveBeenCalled()
+    } finally {
+      process.env.CYPRESS_CRASH_REPORTS = original
+    }
+  })
+})

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -121,7 +121,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['open', 'cypress/e2e/a.cy.js', '42'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js', line: '42' }, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js', line: '42' }, {})
   })
 
   it('keys only the supplied positionals, omitting an absent trailing optional', () => {
@@ -130,7 +130,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['open', 'cypress/e2e/a.cy.js'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js' }, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('open', { spec: 'cypress/e2e/a.cy.js' }, {})
   })
 
   it('dispatches a no-param command with an empty arg map and no options', () => {
@@ -139,7 +139,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['health'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('health', {}, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('health', {}, {})
   })
 
   it('throws a catchable missingArgument error when a required positional is absent', () => {
@@ -190,7 +190,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['launch', 'a.cy.js', '--browser', 'chrome', '--port', '8080', '--headed'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, { browser: 'chrome', port: '8080', headed: 'true' }, {})
+    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, { browser: 'chrome', port: '8080', headed: 'true' })
   })
 
   it('declares and forwards the reporter listing options from the shared contract', () => {
@@ -203,7 +203,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['reporter', '--test-id', 'r2', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { 'test-id': 'r2', attempt: '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { 'test-id': 'r2', attempt: '1' })
   })
 
   it('declares and forwards command --command-id from the shared contract', () => {
@@ -217,7 +217,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['command', '--test-id', 'r2', '--command-id', 'log-3', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': 'log-3', 'attempt': '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': 'log-3', 'attempt': '1' })
   })
 
   // `command` declares --json in its schema so the instance can be told, but the
@@ -232,10 +232,7 @@ describe('lib/tap/build-program', () => {
     expect(subcommand(program, 'reporter').helpInformation().replace(/\s+/g, ' ')).toContain('--json print the raw JSON result')
   })
 
-  // The CLI's own view options ride in the schema commands' help, but they shape
-  // only how the result reads, so they are collected apart from the options the
-  // instance is told about.
-  it('declares the rendering’s view options separately from the schema’s', () => {
+  it('forwards an option the renderer reads alongside the rest', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
     const help = subcommand(program, 'command').helpInformation()
@@ -248,8 +245,7 @@ describe('lib/tap/build-program', () => {
     expect(dispatch).toHaveBeenCalledWith(
       'command',
       {},
-      { 'test-id': 'r2', 'command-id': '3' },
-      { depth: '2' },
+      { 'test-id': 'r2', 'command-id': '3', depth: '2' },
     )
   })
 
@@ -259,16 +255,16 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['launch', 'a.cy.js', '-b', 'firefox'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, { browser: 'firefox' }, {})
+    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, { browser: 'firefox' })
   })
 
-  it('resolves the shared contract’s aliases, schema and view options alike', () => {
+  it('resolves every alias the shared contract declares', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
 
     program.parse(['command', '-t', 'r2', '-c', '3', '-a', '1', '-d', '2'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': '3', attempt: '1' }, { depth: '2' })
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': '3', attempt: '1', depth: '2' })
   })
 
   it('renders each alias alongside its long spelling in the generated help', () => {
@@ -281,7 +277,7 @@ describe('lib/tap/build-program', () => {
 
   // Commander accepts a short flag claimed twice within one command and silently
   // lets the last declaration win, so nothing but this catches an alias that
-  // collides with another option, with a view-only one, or with -h.
+  // collides with another option or with -h.
   it('claims each short flag at most once per command', () => {
     const program = buildTapProgram(buildTapSchema('15.0.0'), vi.fn())
 
@@ -298,7 +294,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['launch', 'a.cy.js'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, {})
   })
 
   it('throws a catchable unknownOption error for a flag not in the schema', () => {
@@ -322,7 +318,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['health'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('health', {}, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('health', {}, {})
 
     expect(() => program.parse(['health', 'extra'], { from: 'user' })).toThrowError(
       expect.objectContaining({ code: 'commander.excessArguments' }),
@@ -349,7 +345,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['export', '--dry-run'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'dry-run': 'true' }, {})
+    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'dry-run': 'true' })
   })
 
   it('forwards a dashed value option keyed by its raw schema name despite commander camelCasing it', () => {
@@ -358,7 +354,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['export', '--output-file', 'out.json'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'output-file': 'out.json' }, {})
+    expect(dispatch).toHaveBeenCalledWith('export', {}, { 'output-file': 'out.json' })
   })
 
   it('omits dashed options the user did not supply', () => {
@@ -367,7 +363,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['export'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('export', {}, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('export', {}, {})
   })
 
   it('forwards a dashed param name keyed by its raw schema name (positionals bypass camelCasing)', () => {
@@ -385,7 +381,7 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['show', 'a.cy.js'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('show', { 'spec-path': 'a.cy.js' }, {}, {})
+    expect(dispatch).toHaveBeenCalledWith('show', { 'spec-path': 'a.cy.js' }, {})
   })
 
   it('declares a required value option with requiredOption so commander enforces it', () => {

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { beginTapTrace, noteTapFailure, recordTapEvent } from '../../../lib/tap/events'
+import { beginTapTrace, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
 import { resolvedInstanceId } from '../../../lib/cypress-instances'
 import { detectAgent } from '@packages/agent-info'
 
@@ -30,6 +30,7 @@ const posted = (fetchMock: ReturnType<typeof vi.fn>) => {
 
 describe('lib/tap/events', () => {
   const fetchMock = vi.fn()
+  const dateNow = vi.spyOn(Date, 'now')
   const originalEnv = { ...process.env }
 
   beforeEach(() => {
@@ -40,6 +41,7 @@ describe('lib/tap/events', () => {
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
+    dateNow.mockReturnValue(1_000)
     beginTapTrace('status', ['json'])
   })
 
@@ -48,7 +50,9 @@ describe('lib/tap/events', () => {
   })
 
   it('posts an anonymous event describing the invocation', async () => {
-    await recordTapEvent(0, 42)
+    dateNow.mockReturnValue(1_042)
+
+    await reportTapTrace(0)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
@@ -76,13 +80,13 @@ describe('lib/tap/events', () => {
   it('carries the id of the instance the command resolved', async () => {
     vi.mocked(resolvedInstanceId).mockReturnValue('a1b2c3d4-0000-4000-8000-000000000000')
 
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(posted(fetchMock).payload).toMatchObject({ instanceId: 'a1b2c3d4-0000-4000-8000-000000000000' })
   })
 
   it('omits the instance id when the command never resolved one', async () => {
-    await recordTapEvent(1, 1)
+    await reportTapTrace(1)
 
     expect(posted(fetchMock).payload).not.toHaveProperty('instanceId')
   })
@@ -90,13 +94,13 @@ describe('lib/tap/events', () => {
   it('carries the agent that invoked the command', async () => {
     vi.mocked(detectAgent).mockReturnValue('claude')
 
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(posted(fetchMock).payload).toMatchObject({ agent: 'claude' })
   })
 
   it('omits the agent when the environment names none', async () => {
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(posted(fetchMock).payload).not.toHaveProperty('agent')
   })
@@ -104,14 +108,14 @@ describe('lib/tap/events', () => {
   it('carries the noted failure code', async () => {
     noteTapFailure('NO_INSTANCE')
 
-    await recordTapEvent(1, 7)
+    await reportTapTrace(1)
 
     expect(posted(fetchMock).payload).toMatchObject({ exitCode: 1, errorCode: 'NO_INSTANCE' })
   })
 
   it('reuses one message id across the events of an invocation', async () => {
-    await recordTapEvent(0, 1)
-    await recordTapEvent(0, 2)
+    await reportTapTrace(0)
+    await reportTapTrace(0)
 
     const [first, second] = fetchMock.mock.calls.map(([, request]: any) => JSON.parse(request.body))
 
@@ -122,16 +126,34 @@ describe('lib/tap/events', () => {
     noteTapFailure('NO_INSTANCE')
     beginTapTrace('specs', [])
 
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(posted(fetchMock).payload).toMatchObject({ command: 'specs' })
     expect(posted(fetchMock).payload).not.toHaveProperty('errorCode')
   })
 
+  it('mints a message id per trace', async () => {
+    await reportTapTrace(0)
+    beginTapTrace('specs', [])
+    await reportTapTrace(0)
+
+    const [first, second] = fetchMock.mock.calls.map(([, request]: any) => JSON.parse(request.body))
+
+    expect(first.messageId).not.toBe(second.messageId)
+  })
+
+  it('reports the command as none until a trace names one', async () => {
+    beginTapTrace(undefined, ['help'])
+
+    await reportTapTrace(0)
+
+    expect(posted(fetchMock).payload).toMatchObject({ command: 'none', flags: ['help'] })
+  })
+
   it('reports to the collector environment the app uses', async () => {
     process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'development'
 
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3000/anon-collect')
   })
@@ -139,7 +161,7 @@ describe('lib/tap/events', () => {
   it('falls back to production for an unrecognized collector environment', async () => {
     process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'nonsense'
 
-    await recordTapEvent(0, 1)
+    await reportTapTrace(0)
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/anon-collect')
   })
@@ -147,7 +169,7 @@ describe('lib/tap/events', () => {
   it('sends nothing when crash reports are turned off', async () => {
     process.env.CYPRESS_CRASH_REPORTS = '0'
 
-    await recordTapEvent(1, 1)
+    await reportTapTrace(1)
 
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -155,6 +177,6 @@ describe('lib/tap/events', () => {
   it('stays silent when the collector cannot be reached', async () => {
     fetchMock.mockRejectedValue(new Error('socket hang up'))
 
-    await expect(recordTapEvent(0, 1)).resolves.toBeUndefined()
+    await expect(reportTapTrace(0)).resolves.toBeUndefined()
   })
 })

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { beginTapTrace, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
+import { beginTapTrace, noteTapCommand, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
 import { resolvedInstanceId } from '../../../lib/cypress-instances'
 import { detectAgent } from '@packages/agent-info'
 import util, { DEVELOPMENT_VERSION } from '../../../lib/util'
@@ -49,8 +49,8 @@ describe('lib/tap/events', () => {
     fetchMock.mockReset()
     fetchMock.mockResolvedValue({ status: 200 })
     vi.stubGlobal('fetch', fetchMock)
-    delete process.env.CYPRESS_DISABLE_TELEMETRY
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
+    delete process.env.CYPRESS_INTERNAL_ENV
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
     vi.mocked(util.pkgVersion).mockReturnValue('15.0.0')
@@ -170,8 +170,33 @@ describe('lib/tap/events', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3000/anon-collect')
   })
 
+  it('reports to the collector the internal environment names', async () => {
+    process.env.CYPRESS_INTERNAL_ENV = 'staging'
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud-staging.cypress.io/anon-collect')
+  })
+
+  it('prefers the collector environment over the internal one', async () => {
+    process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'staging'
+    process.env.CYPRESS_INTERNAL_ENV = 'development'
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud-staging.cypress.io/anon-collect')
+  })
+
   it('falls back to production for an unrecognized collector environment', async () => {
     process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'nonsense'
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/anon-collect')
+  })
+
+  it('falls back to production for an internal environment naming no collector', async () => {
+    process.env.CYPRESS_INTERNAL_ENV = 'test'
 
     await reportTapTrace(0)
 
@@ -204,12 +229,14 @@ describe('lib/tap/events', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://cloud-staging.cypress.io/anon-collect')
   })
 
-  it('sends nothing when telemetry is turned off', async () => {
-    process.env.CYPRESS_DISABLE_TELEMETRY = '1'
+  it('reports no more flags than the payload holds', async () => {
+    const declared = Object.fromEntries(Array.from({ length: 40 }, (_value, index) => [`flag-${index}`, 'set']))
 
-    await reportTapTrace(1)
+    noteTapCommand('status', declared)
 
-    expect(fetchMock).not.toHaveBeenCalled()
+    await reportTapTrace(0)
+
+    expect(posted(fetchMock).payload.flags).toHaveLength(25)
   })
 
   it('stays silent when the collector cannot be reached', async () => {

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -3,6 +3,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { beginTapTrace, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
 import { resolvedInstanceId } from '../../../lib/cypress-instances'
 import { detectAgent } from '@packages/agent-info'
+import util from '../../../lib/util'
+
+// The suite runs from a source checkout, whose version tells the reporter to stay
+// off the collector entirely, so every test states the version it is reporting as.
+vi.mock('../../../lib/util', async (importActual) => {
+  const actual = await importActual<{ default: typeof import('../../../lib/util').default }>()
+
+  return {
+    default: { ...actual.default, pkgVersion: vi.fn().mockReturnValue('15.0.0') },
+  }
+})
 
 vi.mock('../../../lib/cypress-instances', async (importActual) => {
   const actual = await importActual<typeof import('../../../lib/cypress-instances')>()
@@ -41,6 +52,7 @@ describe('lib/tap/events', () => {
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
+    vi.mocked(util.pkgVersion).mockReturnValue('15.0.0')
     dateNow.mockReturnValue(1_000)
     beginTapTrace({ command: 'status', flags: ['json'] })
   })
@@ -164,6 +176,23 @@ describe('lib/tap/events', () => {
     await reportTapTrace(0)
 
     expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/anon-collect')
+  })
+
+  it('sends nothing from a development build', async () => {
+    vi.mocked(util.pkgVersion).mockReturnValue('0.0.0-development')
+
+    await reportTapTrace(0)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reports from a development build that names a collector environment', async () => {
+    vi.mocked(util.pkgVersion).mockReturnValue('0.0.0-development')
+    process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'staging'
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud-staging.cypress.io/anon-collect')
   })
 
   it('sends nothing when crash reports are turned off', async () => {

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -3,14 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { beginTapTrace, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
 import { resolvedInstanceId } from '../../../lib/cypress-instances'
 import { detectAgent } from '@packages/agent-info'
-import util from '../../../lib/util'
+import util, { DEVELOPMENT_VERSION } from '../../../lib/util'
 
 // The suite runs from a source checkout, whose version tells the reporter to stay
 // off the collector entirely, so every test states the version it is reporting as.
 vi.mock('../../../lib/util', async (importActual) => {
-  const actual = await importActual<{ default: typeof import('../../../lib/util').default }>()
+  const actual = await importActual<typeof import('../../../lib/util')>()
 
   return {
+    ...actual,
     default: { ...actual.default, pkgVersion: vi.fn().mockReturnValue('15.0.0') },
   }
 })
@@ -179,7 +180,7 @@ describe('lib/tap/events', () => {
   })
 
   it('sends nothing from a development build', async () => {
-    vi.mocked(util.pkgVersion).mockReturnValue('0.0.0-development')
+    vi.mocked(util.pkgVersion).mockReturnValue(DEVELOPMENT_VERSION)
 
     await reportTapTrace(0)
 
@@ -187,7 +188,7 @@ describe('lib/tap/events', () => {
   })
 
   it('reports from a development build that names a collector environment', async () => {
-    vi.mocked(util.pkgVersion).mockReturnValue('0.0.0-development')
+    vi.mocked(util.pkgVersion).mockReturnValue(DEVELOPMENT_VERSION)
     process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'staging'
 
     await reportTapTrace(0)

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -42,7 +42,7 @@ describe('lib/tap/events', () => {
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
     dateNow.mockReturnValue(1_000)
-    beginTapTrace('status', ['json'])
+    beginTapTrace({ command: 'status', flags: ['json'] })
   })
 
   afterEach(() => {
@@ -124,7 +124,7 @@ describe('lib/tap/events', () => {
 
   it('starts a trace with no failure carried over from the previous command', async () => {
     noteTapFailure('NO_INSTANCE')
-    beginTapTrace('specs', [])
+    beginTapTrace({ command: 'specs', flags: [] })
 
     await reportTapTrace(0)
 
@@ -134,7 +134,7 @@ describe('lib/tap/events', () => {
 
   it('mints a message id per trace', async () => {
     await reportTapTrace(0)
-    beginTapTrace('specs', [])
+    beginTapTrace({ command: 'specs', flags: [] })
     await reportTapTrace(0)
 
     const [first, second] = fetchMock.mock.calls.map(([, request]: any) => JSON.parse(request.body))
@@ -143,7 +143,7 @@ describe('lib/tap/events', () => {
   })
 
   it('reports the command as none until a trace names one', async () => {
-    beginTapTrace(undefined, ['help'])
+    beginTapTrace({ command: undefined, flags: ['help'] })
 
     await reportTapTrace(0)
 

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { beginTapTrace, noteTapFailure, recordTapEvent } from '../../../lib/tap/events'
+import { resolvedInstanceId } from '../../../lib/cypress-instances'
+
+vi.mock('../../../lib/cypress-instances', async (importActual) => {
+  const actual = await importActual<typeof import('../../../lib/cypress-instances')>()
+
+  return {
+    ...actual,
+    resolvedInstanceId: vi.fn().mockReturnValue(null),
+  }
+})
+
+const posted = (fetchMock: ReturnType<typeof vi.fn>) => {
+  return JSON.parse(fetchMock.mock.calls[0][1].body)
+}
+
+describe('lib/tap/events', () => {
+  const fetchMock = vi.fn()
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue({ status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+    delete process.env.CYPRESS_CRASH_REPORTS
+    delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
+    vi.mocked(resolvedInstanceId).mockReturnValue(null)
+    beginTapTrace('status', ['json'])
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('posts an anonymous event describing the invocation', async () => {
+    await recordTapEvent(0, 42)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, request] = fetchMock.mock.calls[0]
+
+    expect(url).toBe('https://cloud.cypress.io/anon-collect')
+    expect(request.method).toBe('POST')
+    expect(request.headers['Content-Type']).toBe('application/json')
+    expect(request.headers['x-cypress-version']).toEqual(expect.any(String))
+
+    expect(posted(fetchMock)).toEqual({
+      campaign: 'Tap Command',
+      medium: 'cli',
+      messageId: expect.any(String),
+      payload: {
+        command: 'status',
+        flags: ['json'],
+        exitCode: 0,
+        durationMs: 42,
+        cypressVersion: expect.any(String),
+      },
+    })
+  })
+
+  it('carries the id of the instance the command resolved', async () => {
+    vi.mocked(resolvedInstanceId).mockReturnValue('a1b2c3d4-0000-4000-8000-000000000000')
+
+    await recordTapEvent(0, 1)
+
+    expect(posted(fetchMock).payload).toMatchObject({ instanceId: 'a1b2c3d4-0000-4000-8000-000000000000' })
+  })
+
+  it('omits the instance id when the command never resolved one', async () => {
+    await recordTapEvent(1, 1)
+
+    expect(posted(fetchMock).payload).not.toHaveProperty('instanceId')
+  })
+
+  it('carries the noted failure code', async () => {
+    noteTapFailure('NO_INSTANCE')
+
+    await recordTapEvent(1, 7)
+
+    expect(posted(fetchMock).payload).toMatchObject({ exitCode: 1, errorCode: 'NO_INSTANCE' })
+  })
+
+  it('reuses one message id across the events of an invocation', async () => {
+    await recordTapEvent(0, 1)
+    await recordTapEvent(0, 2)
+
+    const [first, second] = fetchMock.mock.calls.map(([, request]: any) => JSON.parse(request.body))
+
+    expect(first.messageId).toBe(second.messageId)
+  })
+
+  it('starts a trace with no failure carried over from the previous command', async () => {
+    noteTapFailure('NO_INSTANCE')
+    beginTapTrace('specs', [])
+
+    await recordTapEvent(0, 1)
+
+    expect(posted(fetchMock).payload).toMatchObject({ command: 'specs' })
+    expect(posted(fetchMock).payload).not.toHaveProperty('errorCode')
+  })
+
+  it('reports to the collector environment the app uses', async () => {
+    process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'development'
+
+    await recordTapEvent(0, 1)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:3000/anon-collect')
+  })
+
+  it('falls back to production for an unrecognized collector environment', async () => {
+    process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'nonsense'
+
+    await recordTapEvent(0, 1)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/anon-collect')
+  })
+
+  it('sends nothing when crash reports are turned off', async () => {
+    process.env.CYPRESS_CRASH_REPORTS = '0'
+
+    await recordTapEvent(1, 1)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when the collector cannot be reached', async () => {
+    fetchMock.mockRejectedValue(new Error('socket hang up'))
+
+    await expect(recordTapEvent(0, 1)).resolves.toBeUndefined()
+  })
+})

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -49,7 +49,7 @@ describe('lib/tap/events', () => {
     fetchMock.mockReset()
     fetchMock.mockResolvedValue({ status: 200 })
     vi.stubGlobal('fetch', fetchMock)
-    delete process.env.CYPRESS_CRASH_REPORTS
+    delete process.env.CYPRESS_DISABLE_TELEMETRY
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
@@ -204,8 +204,8 @@ describe('lib/tap/events', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('https://cloud-staging.cypress.io/anon-collect')
   })
 
-  it('sends nothing when crash reports are turned off', async () => {
-    process.env.CYPRESS_CRASH_REPORTS = '0'
+  it('sends nothing when telemetry is turned off', async () => {
+    process.env.CYPRESS_DISABLE_TELEMETRY = '1'
 
     await reportTapTrace(1)
 

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { beginTapTrace, noteTapFailure, recordTapEvent } from '../../../lib/tap/events'
 import { resolvedInstanceId } from '../../../lib/cypress-instances'
+import { detectAgent } from '@packages/agent-info'
 
 vi.mock('../../../lib/cypress-instances', async (importActual) => {
   const actual = await importActual<typeof import('../../../lib/cypress-instances')>()
@@ -9,6 +10,17 @@ vi.mock('../../../lib/cypress-instances', async (importActual) => {
   return {
     ...actual,
     resolvedInstanceId: vi.fn().mockReturnValue(null),
+  }
+})
+
+// These tests are themselves usually run by an agent, so detection is stubbed rather
+// than driven through process.env — the payload must not depend on who ran the suite.
+vi.mock('@packages/agent-info', async (importActual) => {
+  const actual = await importActual<typeof import('@packages/agent-info')>()
+
+  return {
+    ...actual,
+    detectAgent: vi.fn().mockReturnValue(undefined),
   }
 })
 
@@ -27,6 +39,7 @@ describe('lib/tap/events', () => {
     delete process.env.CYPRESS_CRASH_REPORTS
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     vi.mocked(resolvedInstanceId).mockReturnValue(null)
+    vi.mocked(detectAgent).mockReturnValue(undefined)
     beginTapTrace('status', ['json'])
   })
 
@@ -72,6 +85,20 @@ describe('lib/tap/events', () => {
     await recordTapEvent(1, 1)
 
     expect(posted(fetchMock).payload).not.toHaveProperty('instanceId')
+  })
+
+  it('carries the agent that invoked the command', async () => {
+    vi.mocked(detectAgent).mockReturnValue('claude')
+
+    await recordTapEvent(0, 1)
+
+    expect(posted(fetchMock).payload).toMatchObject({ agent: 'claude' })
+  })
+
+  it('omits the agent when the environment names none', async () => {
+    await recordTapEvent(0, 1)
+
+    expect(posted(fetchMock).payload).not.toHaveProperty('agent')
   })
 
   it('carries the noted failure code', async () => {

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -78,14 +78,13 @@ describe('lib/tap/events', () => {
 
     expect(posted(fetchMock)).toEqual({
       campaign: 'Tap Command',
-      medium: 'cli',
+      medium: 'tap-cli',
       messageId: expect.any(String),
       payload: {
         command: 'status',
         flags: ['json'],
         exitCode: 0,
         durationMs: 42,
-        cypressVersion: expect.any(String),
       },
     })
   })

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -186,6 +186,15 @@ describe('lib/tap/events', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('sends nothing from a development build whose collector environment is unrecognized', async () => {
+    vi.mocked(util.pkgVersion).mockReturnValue(DEVELOPMENT_VERSION)
+    process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'dev'
+
+    await reportTapTrace(0)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('reports from a development build that names a collector environment', async () => {
     vi.mocked(util.pkgVersion).mockReturnValue(DEVELOPMENT_VERSION)
     process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'staging'
@@ -207,5 +216,17 @@ describe('lib/tap/events', () => {
     fetchMock.mockRejectedValue(new Error('socket hang up'))
 
     await expect(reportTapTrace(0)).resolves.toBeUndefined()
+  })
+
+  // The command's own outcome is already decided by the time this runs, so a throw
+  // from anywhere in here would replace it.
+  it('stays silent when assembling the event throws', async () => {
+    vi.mocked(detectAgent).mockImplementation(() => {
+      throw new Error('cannot read the environment')
+    })
+
+    await expect(reportTapTrace(0)).resolves.toBeUndefined()
+
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/agent-info/lib/__spec__/index.spec.ts
+++ b/packages/agent-info/lib/__spec__/index.spec.ts
@@ -108,6 +108,10 @@ describe('lib/agent-info', () => {
       expect(detectAgent({ AI_AGENT: 'some-internal-tool-v3' })).toBe('other')
     })
 
+    it('reports a value that only begins with a known name as other', () => {
+      expect(detectAgent({ AI_AGENT: 'pipecat' })).toBe('other')
+    })
+
     it('loses to an env var the detection table recognizes', () => {
       expect(detectAgent({ AI_AGENT: 'cursor', CLAUDECODE: '1' })).toBe('claude')
     })

--- a/packages/agent-info/lib/index.ts
+++ b/packages/agent-info/lib/index.ts
@@ -55,7 +55,9 @@ const KNOWN_NAMES = AGENTS.map(([name]) => name)
 const fromAiAgent = (value: string): AgentName => {
   const normalized = value.toLowerCase()
 
-  return KNOWN_NAMES.find((name) => normalized.startsWith(name)) ?? 'other'
+  // The name has to end where it ends, so a short one like `pi` cannot claim an
+  // unrelated `pipecat`.
+  return KNOWN_NAMES.find((name) => new RegExp(`^${name}($|[^a-z0-9])`).test(normalized)) ?? 'other'
 }
 
 export const detectAgent = (env: NodeJS.ProcessEnv = process.env): AgentName | undefined => {

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -12,6 +12,7 @@ export {
   TAP_COMMANDS,
   TAP_RUN_IN_PROGRESS_MESSAGE,
   MAX_DERIVED_SELECTORS,
+  withoutViewOptions,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 export type {

--- a/packages/app/src/tap/contract.ts
+++ b/packages/app/src/tap/contract.ts
@@ -12,7 +12,6 @@ export {
   TAP_COMMANDS,
   TAP_RUN_IN_PROGRESS_MESSAGE,
   MAX_DERIVED_SELECTORS,
-  withoutViewOptions,
 } from '@packages/cypress-instances/lib/tap-contract'
 
 export type {

--- a/packages/app/src/tap/tap-manager.ts
+++ b/packages/app/src/tap/tap-manager.ts
@@ -2,7 +2,7 @@ import { tapCommands } from './commands'
 import { TapCommandError } from './commands/definition'
 import type { TapCommandDefinition } from './commands/definition'
 import { coerceCommandArgs, coerceCommandOptions } from './exec-args'
-import { TAP_SCHEMA_VERSION } from './contract'
+import { TAP_SCHEMA_VERSION, withoutViewOptions } from './contract'
 import type { TapBindingContract, TapExecResult, TapSchema } from './contract'
 
 // Normalize a wire payload to a plain object, or null if malformed. `null` maps
@@ -38,7 +38,7 @@ export class TapManager implements TapBindingContract {
           description,
           ...(details ? { details } : {}),
           params: params.map((param) => ({ ...param })),
-          options: (options ?? []).map((option) => ({ ...option })),
+          options: withoutViewOptions(options).map((option) => ({ ...option })),
           ...(hidden ? { hidden: true } : {}),
         }
       }),
@@ -78,7 +78,9 @@ export class TapManager implements TapBindingContract {
       }
     }
 
-    const optionSchema = definition.options ?? []
+    // View-only options are the CLI's own; a caller naming one is naming an
+    // option this command does not have, and is told so.
+    const optionSchema = withoutViewOptions(definition.options)
 
     const coercedArgs = coerceCommandArgs(command, definition.params, normalizedArgs, optionSchema)
 

--- a/packages/app/src/tap/tap-manager.ts
+++ b/packages/app/src/tap/tap-manager.ts
@@ -2,7 +2,7 @@ import { tapCommands } from './commands'
 import { TapCommandError } from './commands/definition'
 import type { TapCommandDefinition } from './commands/definition'
 import { coerceCommandArgs, coerceCommandOptions } from './exec-args'
-import { TAP_SCHEMA_VERSION, withoutViewOptions } from './contract'
+import { TAP_SCHEMA_VERSION } from './contract'
 import type { TapBindingContract, TapExecResult, TapSchema } from './contract'
 
 // Normalize a wire payload to a plain object, or null if malformed. `null` maps
@@ -38,7 +38,7 @@ export class TapManager implements TapBindingContract {
           description,
           ...(details ? { details } : {}),
           params: params.map((param) => ({ ...param })),
-          options: withoutViewOptions(options).map((option) => ({ ...option })),
+          options: (options ?? []).map((option) => ({ ...option })),
           ...(hidden ? { hidden: true } : {}),
         }
       }),
@@ -78,9 +78,7 @@ export class TapManager implements TapBindingContract {
       }
     }
 
-    // View-only options are the CLI's own; a caller naming one is naming an
-    // option this command does not have, and is told so.
-    const optionSchema = withoutViewOptions(definition.options)
+    const optionSchema = definition.options ?? []
 
     const coercedArgs = coerceCommandArgs(command, definition.params, normalizedArgs, optionSchema)
 

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -9,7 +9,6 @@ import {
   INSTANCES_DIRNAME,
   SCHEMA_VERSION,
   TAP_COMMANDS,
-  withoutViewOptions,
 } from '../index'
 
 const validRecord = {
@@ -81,16 +80,12 @@ describe('cypress-instances contract', () => {
       expect(advertised!.details).toBe(reporter.details)
     })
 
-    it('keeps a view-only option on its command but off the wire schema', () => {
+    it('advertises every option a command declares', () => {
       const command = TAP_COMMANDS.find(({ name }) => name === 'command')!
-      const depth = command.options.find(({ name }) => name === 'depth')
-
-      expect(depth).toMatchObject({ viewOnly: true })
-
       const advertised = buildTapSchema('15.0.0').commands.find(({ name }) => name === 'command')!
 
-      expect(advertised.options.map(({ name }) => name)).not.toContain('depth')
-      expect(withoutViewOptions(command.options).map(({ name }) => name)).toEqual(advertised.options.map(({ name }) => name))
+      expect(advertised.options.map(({ name }) => name)).toContain('depth')
+      expect(advertised.options.map(({ name }) => name)).toEqual(command.options.map(({ name }) => name))
     })
   })
 })

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -9,6 +9,7 @@ import {
   INSTANCES_DIRNAME,
   SCHEMA_VERSION,
   TAP_COMMANDS,
+  withoutViewOptions,
 } from '../index'
 
 const validRecord = {
@@ -78,6 +79,18 @@ describe('cypress-instances contract', () => {
 
       expect(advertised).toBeDefined()
       expect(advertised!.details).toBe(reporter.details)
+    })
+
+    it('keeps a view-only option on its command but off the wire schema', () => {
+      const command = TAP_COMMANDS.find(({ name }) => name === 'command')!
+      const depth = command.options.find(({ name }) => name === 'depth')
+
+      expect(depth).toMatchObject({ viewOnly: true })
+
+      const advertised = buildTapSchema('15.0.0').commands.find(({ name }) => name === 'command')!
+
+      expect(advertised.options.map(({ name }) => name)).not.toContain('depth')
+      expect(withoutViewOptions(command.options).map(({ name }) => name)).toEqual(advertised.options.map(({ name }) => name))
     })
   })
 })

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -332,6 +332,40 @@ export const TAP_NATIVE_COMMANDS = [
 
 export type TapNativeCommandName = typeof TAP_NATIVE_COMMANDS[number]['name']
 
+/**
+ * View-only options: flags the CLI declares on a command on top of the ones its
+ * schema advertises, parsed and rendered into its help like any other but never
+ * forwarded to the instance, since they only shape how the result reads. They
+ * live here so one place holds every name a tap invocation can carry.
+ */
+export const TAP_VIEW_OPTIONS: Partial<Record<TapCommandName | TapNativeCommandName, readonly TapCommandOptionSchema[]>> = {
+  command: [
+    { name: 'depth', alias: 'd', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
+  ],
+}
+
+const allTapCommands: readonly (TapCommandSchema | TapNativeCommandSchema)[] = [...TAP_NATIVE_COMMANDS, ...TAP_COMMANDS]
+
+/** Every command name this CLI ships, whether it dispatches to the instance or handles it itself. */
+export const KNOWN_COMMANDS: ReadonlySet<string> = new Set(allTapCommands.map(({ name }) => name))
+
+const declaredOptions: readonly TapCommandOptionSchema[] = [
+  ...allTapCommands.flatMap(({ options = [] }) => [...options]),
+  ...Object.values(TAP_VIEW_OPTIONS).flatMap((options) => options ?? []),
+]
+
+/**
+ * Every option name this CLI declares, mapped to its canonical spelling so `-h`
+ * and `--help` report as the one flag `help`. The seeded names belong to
+ * `cypress tap` itself rather than to any command, so no command's options
+ * carry them.
+ */
+export const KNOWN_FLAGS: ReadonlyMap<string, string> = new Map<string, string>([
+  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
+  ['h', 'help'],
+  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
+])
+
 // Per-command result contracts live in `./contracts/`; re-exported here so the
 // app's deep import of this module and the package barrel both reach them.
 export * from './contracts/reporter'

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -19,20 +19,12 @@ export interface TapCommandOptionSchema {
   name: string
   // A single letter, rendered by the CLI as `-t, --test-id <test-id>`. Commander
   // accepts a letter claimed twice within one command and silently lets the last
-  // declaration win, so an alias must be unique across the command's own options,
-  // the CLI's view-only ones, and the `--instance` every command shares.
+  // declaration win, so an alias must be unique across the command's own options
+  // and the `--instance` every command shares.
   alias?: string
   type: 'string' | 'number' | 'boolean'
   required: boolean
   description: string
-  // Absent ⇒ forwarded to the instance. A view-only option shapes how the CLI
-  // renders a result rather than what the instance returns, so it is declared in
-  // the command's help like any other but never sent, never reaches a handler,
-  // and is left out of the advertised schema. The CLI reads it from its own
-  // bundled copy of this contract, which is what lets `--depth` work against any
-  // instance that has the command at all rather than only one new enough to
-  // advertise the flag.
-  viewOnly?: true
 }
 
 export interface TapCommandSchema {
@@ -70,10 +62,6 @@ type SchemaObject<
   { [E in Entry as E extends Present ? E['name'] : never]: Scalars[E['type']] } &
   { [E in Entry as E extends Present ? never : E['name']]?: Scalars[E['type']] }
 
-// A view-only option is consumed by the CLI's renderer and never handed to a
-// handler on either side, so it is dropped before the option types are built.
-type ForwardedOption<O extends TapCommandOptionSchema> = O extends { viewOnly: true } ? never : O
-
 // App-side handlers see coerced values (the binding's exec coerces each wire
 // string to its declared scalar before dispatch): required params are present,
 // and boolean options default to false when the flag is absent.
@@ -83,7 +71,7 @@ export type TapCoercedParams<P extends readonly TapCommandParamSchema[]> =
   SchemaObject<P[number], { required: true }, CoercedScalars>
 
 export type TapCoercedOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<ForwardedOption<O[number]>, { required: true } | { type: 'boolean' }, CoercedScalars>
+  SchemaObject<O[number], { required: true } | { type: 'boolean' }, CoercedScalars>
 
 // CLI-side handlers see commander's values forwarded as raw strings (a set
 // boolean flag arrives as the string 'true'). Only required value options are
@@ -94,7 +82,7 @@ export type TapRawParams<P extends readonly TapCommandParamSchema[]> =
   SchemaObject<P[number], { required: true }, RawScalars>
 
 export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<ForwardedOption<O[number]>, { required: true, type: 'string' | 'number' }, RawScalars>
+  SchemaObject<O[number], { required: true, type: 'string' | 'number' }, RawScalars>
 
 // Options that recur across commands, defined once so their name, type, and help
 // text can't drift between the commands that expose them. `test-id` and
@@ -118,7 +106,7 @@ const commandMeta = {
     // that is not being rendered for reading room.
     { name: 'json', type: 'boolean', required: false, description: 'print the raw JSON result instead of the human-readable rendering — every console property in full, however long, rather than the long ones named by their length' },
     attemptField,
-    { name: 'depth', alias: 'd', type: 'string', required: false, viewOnly: true, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
+    { name: 'depth', alias: 'd', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
   ],
 } as const satisfies TapCommandSchema
 
@@ -193,7 +181,7 @@ export const buildTapSchema = (cypressVersion: string): TapSchema => {
       description: command.description,
       ...('details' in command ? { details: command.details } : {}),
       params: (command.params as readonly TapCommandParamSchema[]).map((param) => ({ ...param })),
-      options: withoutViewOptions(command.options).map((option) => ({ ...option })),
+      options: (command.options as readonly TapCommandOptionSchema[]).map((option) => ({ ...option })),
       ...('hidden' in command && command.hidden ? { hidden: true } : {}),
     }
   })
@@ -346,21 +334,6 @@ export const TAP_NATIVE_COMMANDS = [
 export type TapNativeCommandName = typeof TAP_NATIVE_COMMANDS[number]['name']
 
 const allTapCommands: readonly (TapCommandSchema | TapNativeCommandSchema)[] = [...TAP_NATIVE_COMMANDS, ...TAP_COMMANDS]
-
-/**
- * A command's view-only options, taken from this bundled contract rather than
- * from the schema an attached instance advertises — which never carries them.
- */
-export const viewOptionsFor = (command: string): readonly TapCommandOptionSchema[] => {
-  const options = allTapCommands.find(({ name }) => name === command)?.options ?? []
-
-  return options.filter(({ viewOnly }) => viewOnly)
-}
-
-/** The options a command actually accepts: what an instance advertises and the CLI forwards. */
-export const withoutViewOptions = (options: readonly TapCommandOptionSchema[] = []): readonly TapCommandOptionSchema[] => {
-  return options.filter(({ viewOnly }) => !viewOnly)
-}
 
 /** Every command name this CLI ships, whether it dispatches to the instance or handles it itself. */
 export const KNOWN_COMMANDS: ReadonlySet<string> = new Set(allTapCommands.map(({ name }) => name))

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -25,6 +25,14 @@ export interface TapCommandOptionSchema {
   type: 'string' | 'number' | 'boolean'
   required: boolean
   description: string
+  // Absent ⇒ forwarded to the instance. A view-only option shapes how the CLI
+  // renders a result rather than what the instance returns, so it is declared in
+  // the command's help like any other but never sent, never reaches a handler,
+  // and is left out of the advertised schema. The CLI reads it from its own
+  // bundled copy of this contract, which is what lets `--depth` work against any
+  // instance that has the command at all rather than only one new enough to
+  // advertise the flag.
+  viewOnly?: true
 }
 
 export interface TapCommandSchema {
@@ -55,12 +63,16 @@ export type TapExecResult =
 // the same way: entries matching `Present` are keys the handler can rely on, the
 // rest may be absent, and each wire `type` maps through `Scalars`.
 type SchemaObject<
-  Entries extends readonly { name: string, type: TapCommandParamSchema['type'] }[],
+  Entry extends { name: string, type: TapCommandParamSchema['type'] },
   Present,
   Scalars extends Record<TapCommandParamSchema['type'], unknown>,
 > =
-  { [E in Entries[number] as E extends Present ? E['name'] : never]: Scalars[E['type']] } &
-  { [E in Entries[number] as E extends Present ? never : E['name']]?: Scalars[E['type']] }
+  { [E in Entry as E extends Present ? E['name'] : never]: Scalars[E['type']] } &
+  { [E in Entry as E extends Present ? never : E['name']]?: Scalars[E['type']] }
+
+// A view-only option is consumed by the CLI's renderer and never handed to a
+// handler on either side, so it is dropped before the option types are built.
+type ForwardedOption<O extends TapCommandOptionSchema> = O extends { viewOnly: true } ? never : O
 
 // App-side handlers see coerced values (the binding's exec coerces each wire
 // string to its declared scalar before dispatch): required params are present,
@@ -68,10 +80,10 @@ type SchemaObject<
 type CoercedScalars = { string: string, number: number, boolean: boolean }
 
 export type TapCoercedParams<P extends readonly TapCommandParamSchema[]> =
-  SchemaObject<P, { required: true }, CoercedScalars>
+  SchemaObject<P[number], { required: true }, CoercedScalars>
 
 export type TapCoercedOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<O, { required: true } | { type: 'boolean' }, CoercedScalars>
+  SchemaObject<ForwardedOption<O[number]>, { required: true } | { type: 'boolean' }, CoercedScalars>
 
 // CLI-side handlers see commander's values forwarded as raw strings (a set
 // boolean flag arrives as the string 'true'). Only required value options are
@@ -79,10 +91,10 @@ export type TapCoercedOptions<O extends readonly TapCommandOptionSchema[]> =
 type RawScalars = { string: string, number: string, boolean: string }
 
 export type TapRawParams<P extends readonly TapCommandParamSchema[]> =
-  SchemaObject<P, { required: true }, RawScalars>
+  SchemaObject<P[number], { required: true }, RawScalars>
 
 export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<O, { required: true, type: 'string' | 'number' }, RawScalars>
+  SchemaObject<ForwardedOption<O[number]>, { required: true, type: 'string' | 'number' }, RawScalars>
 
 // Options that recur across commands, defined once so their name, type, and help
 // text can't drift between the commands that expose them. `test-id` and
@@ -106,6 +118,7 @@ const commandMeta = {
     // that is not being rendered for reading room.
     { name: 'json', type: 'boolean', required: false, description: 'print the raw JSON result instead of the human-readable rendering — every console property in full, however long, rather than the long ones named by their length' },
     attemptField,
+    { name: 'depth', alias: 'd', type: 'string', required: false, viewOnly: true, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
   ],
 } as const satisfies TapCommandSchema
 
@@ -180,7 +193,7 @@ export const buildTapSchema = (cypressVersion: string): TapSchema => {
       description: command.description,
       ...('details' in command ? { details: command.details } : {}),
       params: (command.params as readonly TapCommandParamSchema[]).map((param) => ({ ...param })),
-      options: command.options.map((option) => ({ ...option })),
+      options: withoutViewOptions(command.options).map((option) => ({ ...option })),
       ...('hidden' in command && command.hidden ? { hidden: true } : {}),
     }
   })
@@ -332,39 +345,25 @@ export const TAP_NATIVE_COMMANDS = [
 
 export type TapNativeCommandName = typeof TAP_NATIVE_COMMANDS[number]['name']
 
+const allTapCommands: readonly (TapCommandSchema | TapNativeCommandSchema)[] = [...TAP_NATIVE_COMMANDS, ...TAP_COMMANDS]
+
 /**
- * View-only options: flags the CLI declares on a command on top of the ones its
- * schema advertises, parsed and rendered into its help like any other but never
- * forwarded to the instance, since they only shape how the result reads. They
- * live here so one place holds every name a tap invocation can carry.
+ * A command's view-only options, taken from this bundled contract rather than
+ * from the schema an attached instance advertises — which never carries them.
  */
-export const TAP_VIEW_OPTIONS: Partial<Record<TapCommandName | TapNativeCommandName, readonly TapCommandOptionSchema[]>> = {
-  command: [
-    { name: 'depth', alias: 'd', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
-  ],
+export const viewOptionsFor = (command: string): readonly TapCommandOptionSchema[] => {
+  const options = allTapCommands.find(({ name }) => name === command)?.options ?? []
+
+  return options.filter(({ viewOnly }) => viewOnly)
 }
 
-const allTapCommands: readonly (TapCommandSchema | TapNativeCommandSchema)[] = [...TAP_NATIVE_COMMANDS, ...TAP_COMMANDS]
+/** The options a command actually accepts: what an instance advertises and the CLI forwards. */
+export const withoutViewOptions = (options: readonly TapCommandOptionSchema[] = []): readonly TapCommandOptionSchema[] => {
+  return options.filter(({ viewOnly }) => !viewOnly)
+}
 
 /** Every command name this CLI ships, whether it dispatches to the instance or handles it itself. */
 export const KNOWN_COMMANDS: ReadonlySet<string> = new Set(allTapCommands.map(({ name }) => name))
-
-const declaredOptions: readonly TapCommandOptionSchema[] = [
-  ...allTapCommands.flatMap(({ options = [] }) => [...options]),
-  ...Object.values(TAP_VIEW_OPTIONS).flatMap((options) => options ?? []),
-]
-
-/**
- * Every option name this CLI declares, mapped to its canonical spelling so `-h`
- * and `--help` report as the one flag `help`. The seeded names belong to
- * `cypress tap` itself rather than to any command, so no command's options
- * carry them.
- */
-export const KNOWN_FLAGS: ReadonlyMap<string, string> = new Map<string, string>([
-  ...['instance', 'json', 'timeout', 'help'].map((name): [string, string] => [name, name]),
-  ['h', 'help'],
-  ...declaredOptions.flatMap(({ name, alias }): [string, string][] => alias ? [[name, name], [alias, name]] : [[name, name]]),
-])
 
 // Per-command result contracts live in `./contracts/`; re-exported here so the
 // app's deep import of this module and the package barrel both reach them.


### PR DESCRIPTION
- Closes [AW-31](https://cypress-io.atlassian.net/browse/AW-31) — capture high-touch events on the CLI side, like failed commands. Stacks on [#34550](https://github.com/cypress-io/cypress/pull/34550), which adds the `@packages/agent-info` detection this consumes. [#34551](https://github.com/cypress-io/cypress/pull/34551) above adds machine/user identity to these events.

### Additional details

The CLI has been silent about its own use. Nothing records how often an agent reaches for a tap command, or that it hit `NO_INSTANCE`, an unresponsive renderer, or an instance-side failure — the "failed commands" AW-31 asks about.

This follows the mechanism the app already has rather than inventing one. `recordEvent` (`packages/app/src/composables/useRecordEvent.ts` → `gql-Mutation.ts` → `EventCollectorActions`) is a fire-and-forget `POST` to the Cloud collector whose errors are swallowed to a `debug()`. The CLI is a separate process with no DataContext and no urql, but it already uses global `fetch`, so the same beacon is ~40 lines and no new dependency — and, importantly, it still reports when **no instance was found**, which is where a large share of the interesting failures live.

**One emit point.** `tapModule.start` gets a `finally` that reports the invocation; `runTap` was extracted out of it for that, which is most of the diff (reindentation). It is `await`ed rather than fired and forgotten because `cli.ts` calls `process.exit` the moment `start` returns, which would kill an in-flight POST. The 2s abort signal bounds it.

**Failures are named where they are rendered.** `renderFailure` notes the code it prints, so every path funnels through one place — including the CLI-native commands (`specs`, `status`, `run`) that handle their own discovery errors. What we report cannot drift from what the user was shown. Two codes have no render site and are set explicitly: `INVALID_USAGE` (commander prints its own message for a mistyped command or flag) and `UNHANDLED`.

Known tap errors (`tapCdpUnreachable`, `tapBindingNotFound`, `tapStaleHandle`, the schema-version mismatches) report **no** `errorCode`, because they genuinely have none — they carry only a description and a solution. If we want them classified, the honest fix is a `code` on each entry in the errors map (`invalidSmokeTestDisplayError` already has one), which felt like its own slice.

**The payload is a fixed field list, never derived text.** Tap error messages interpolate selectors, spec paths and project roots, and option *values* are selectors, spec paths and test titles — so:

| field | value |
|---|---|
| `command` | the subcommand, **only if** this CLI knows it (native or `TAP_COMMANDS`) or the instance advertised it and commander accepted it; otherwise `unknown` |
| `flags` | flag **names** only, canonicalized (`-h` and `--help` are one flag), taken from what commander parsed, capped at 25; a flag this CLI does not declare reports as no flag at all, under `INVALID_USAGE` |
| `agent` | which AI agent invoked the command, from a fixed list of names; absent when the environment names none |
| `instanceId` | the ephemeral `crypto.randomUUID()` the server mints per running Cypress — ties a sequence of calls to one open session; absent when nothing resolved |
| `exitCode` / `errorCode` / `durationMs` | the version rides in the `x-cypress-version` header, not the payload |

`--instance/--json/--timeout` are parsed off by the outer `cypress tap` command and never reach the operands, so they are read from the options it passes on.

**The collector URL is duplicated, not shared.** An earlier slice extracted the three Cloud URLs into a `@packages/cloud-urls` workspace so the CLI and `data-context` could read one map. That was more package than the problem deserved for three constants, so it was dropped: `cli/lib/tap/events.ts` carries its own copy and builds the collector path itself, and `data-context` keeps `src/util/cloudUrls.ts` untouched. The CLI cannot depend on `data-context` (browser/node hybrid, pulls urql/nexus/graphql), and the collector URL is all the CLI needs from it.

Which collector it posts to resolves the way the app resolves its own: `CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV` (the variable `EventCollectorActions` reads), then the `CYPRESS_INTERNAL_ENV` that one is normally derived from, then production. A value naming no URL this CLI has counts as naming no collector at all, so a typo cannot pass for naming one and land a source checkout's traffic in the production analytics.

`resolvedInstanceId()` is read from the discovery layer rather than threaded through every caller, because each tap command resolves its own instance — several of them below `exec/tap.ts`.

**Which agent is on the other end.** The event said what a command did but not who ran it, and tap exists to be driven by an agent, so that was the most useful dimension missing. The `agent` field carries the name `@packages/agent-info` detects (introduced in #34550 below); its closed union keeps the property above that only a fixed list of names and codes leaves the machine.

**No opt-out switch in this slice.** Nothing else in the repo reads a `CYPRESS_DISABLE_TELEMETRY` variable, so introducing a public one belongs in its own change with the documentation to match. The `CYPRESS_CRASH_REPORTS=0` that the server's crash/studio/cy-prompt reporters honor covers crash reporting only and does not suppress tap events.

Nothing here can decide a command's outcome. Reporting runs from the `finally` the CLI exits on, so the whole assemble-and-send path sits inside one `try`/`catch` that swallows to a `debug()` — a throw from version lookup or agent detection cannot replace the exit code of the command it was reporting on.

### Steps to test

Point the collector at a local listener so nothing reaches production, then watch what an invocation reports:

```bash
# terminal 1
nc -l 3000

# terminal 2 — with nothing running, this takes the NO_INSTANCE path
CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV=development node cli/bin/cypress tap dom --selector "#login .password" --instance 4242
```

Expect a `POST /anon-collect` whose payload names the flags but contains neither the selector nor the pid:

```json
{"command":"dom","flags":["selector","instance"],"agent":"claude","exitCode":1,"errorCode":"NO_INSTANCE","durationMs":1}
```

`agent` reflects the shell you ran it from. To check the detection paths, including that a raw `AI_AGENT` value never reaches the wire:

```bash
env -u CLAUDECODE -u AI_AGENT -u TERM_PROGRAM node cli/bin/cypress tap status   # no agent key at all
env -u CLAUDECODE AI_AGENT=claude-code_2-1-221_agent node cli/bin/cypress tap status   # "agent":"claude"
env -u CLAUDECODE AI_AGENT=some-internal-tool-v3 node cli/bin/cypress tap status       # "agent":"other"
```

Then with a Cypress instance open (`yarn dev`), run two commands against it and confirm both carry the same `instanceId` and that a successful one reports `exitCode: 0` with no `errorCode`. Finally swap `CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV=development` for `CYPRESS_INTERNAL_ENV=development` and confirm the same local listener is reached, and that with neither set nothing is sent from a source checkout at all.

### How has the user experience changed?

No change to any command's output, exit code or timing — a collector that is unreachable, slow or erroring is swallowed and only shows up under `DEBUG=cypress:cli:tap`.

The user-visible change is that `cypress tap` now makes an outbound request per invocation. It is anonymous and carries no values. (#34551 above links it to the machine and, when logged in, the cloud user.)

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- AW-31 -->
- [x] Have tests been added/updated? <!-- new events.spec.ts (14) and tap.validate-events.spec.ts (15); tap.spec.ts and cypress-instances.spec.ts extended -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

No `cli/CHANGELOG.md` entry: this lands inside the unreleased `feat/tap-cli-integration` stack, which carries the changelog for the tap CLI. The outbound request is worth a line there when the stack lands.

### Verification run locally

- `cli`: `test/lib/tap`, `test/lib/exec/tap*`, `cypress-instances.spec.ts` and `cli.spec.ts`, 509 passing at this slice's tip. The help-text snapshot mismatch noted on an earlier revision of this PR now passes.
- `yarn check-ts` clean, lint clean on every touched package.
- Verified end to end through `node cli/bin/cypress` against a rebuilt `cli/dist`, pointing the collector at a local listener and capturing the posted bodies: agent present, agent absent, version-bearing `AI_AGENT`, unrecognized `AI_AGENT`. Also confirmed the detection table is inlined into the tap chunk rather than left as a runtime require, since `@packages/*` deps are stripped from the published manifest.
- Collector resolution re-checked through the binary after the review: with neither variable set a source checkout logs `skipped tap event: development build`, and `CYPRESS_INTERNAL_ENV=development` alone posts to `localhost:3000`.

### Open item

The Cloud side indexes on `campaign` / `medium` / payload keys — currently `"Tap Command"` / `"tap-cli"`. Worth confirming those names with whoever owns the collector so the events are queryable on arrival rather than needing a rename later.


[AW-31]: https://cypress-io.atlassian.net/browse/AW-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds outbound telemetry and changes Commander exit handling for `exitOverride` commands; payload is intentionally minimal but still a new network path on every tap run, with reporting errors swallowed so command outcomes should stay unchanged.
> 
> **Overview**
> **`cypress tap` now emits one anonymous analytics event per invocation** (command, flag names only, exit/error codes, duration, optional agent and resolved `instanceId`) via a bounded `POST` to the Cloud collector, assembled in a `finally` on `tap.start` so it runs before `process.exit` kills in-flight requests.
> 
> Tracing hooks (`beginTapTrace`, `noteTapCommand`, `noteTapFailure`) record outcomes without sending user data values; failures funnel through `renderFailure` and explicit `INVALID_USAGE` / `UNHANDLED` codes. Instance discovery updates `resolvedInstanceId()` for the payload. Development builds skip reporting unless a collector env is set.
> 
> **CLI behavior fixes:** the global `unknownOption` patch delegates to Commander’s `exitOverride` callback when present so `tap` can finish reporting on bad flags instead of exiting early. **`--depth` for `command`** moves from CLI-only “view options” into the shared tap schema so it is declared once and forwarded like other instance options.
> 
> **`@packages/agent-info`** tightens `AI_AGENT` matching so short names (e.g. `pi`) cannot match longer unrelated values (`pipecat`). **`KNOWN_COMMANDS`** centralizes recognized subcommand names for reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d0f39d5b8fa219b0abb528b7ec8f5df0294205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





