### PR TITLE
feat: give tap CLI options short aliases

### DIFF
--- a/cli/lib/cli.ts
+++ b/cli/lib/cli.ts
@@ -590,7 +590,7 @@ const cliModule = {
     .description('Interacts with a running Cypress instance')
     .helpOption(false)
     .allowUnknownOption(true)
-    .option('--instance <pid>', text('instance'), coerceAnyStringToInt)
+    .option('-i, --instance <pid>', text('instance'), coerceAnyStringToInt)
     .option('--json', text('json'))
     .option('--timeout <ms>', text('tapTimeout'), coerceAnyStringToInt)
     .action(async function (this: any, opts: any, args: string[]) {

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -30,7 +30,7 @@ const JSON_DESCRIPTION = 'print the raw JSON result instead of the human-readabl
 // Every tap command accepts `--instance`, `--json` and `--timeout`; all are
 // consumed by the top-level `cypress tap` command before a subprogram parses, so
 // declaring them on a command is purely so they render in its generated help.
-// `--timeout` keeps no alias: `-t` is worth more to `--testId`, which is typed
+// `--timeout` keeps no alias: `-t` is worth more to `--test-id`, which is typed
 // far more often, and the shared flags have to spell the same on every command.
 const declareSharedOptions = (command: commander.Command, jsonDescription: string): void => {
   command.option('-i, --instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')

--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -27,6 +27,17 @@ const argumentDescriptions = (params: readonly TapCommandParamSchema[]): Record<
 
 const JSON_DESCRIPTION = 'print the raw JSON result instead of the human-readable rendering'
 
+// Every tap command accepts `--instance`, `--json` and `--timeout`; all are
+// consumed by the top-level `cypress tap` command before a subprogram parses, so
+// declaring them on a command is purely so they render in its generated help.
+// `--timeout` keeps no alias: `-t` is worth more to `--testId`, which is typed
+// far more often, and the shared flags have to spell the same on every command.
+const declareSharedOptions = (command: commander.Command, jsonDescription: string): void => {
+  command.option('-i, --instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
+  command.option('--json', jsonDescription)
+  command.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
+}
+
 const declareOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
   // A command that declares `--json` in its schema does so to receive it, not to
   // add a second flag — it is declared below with the ones every command shares,
@@ -44,12 +55,7 @@ const declareOptions = (command: commander.Command, options: readonly TapCommand
     }
   }
 
-  // Every tap command accepts `--instance`, `--json` and `--timeout`; all are
-  // consumed by the top-level `cypress tap` command before a subprogram parses,
-  // so declaring them here is purely so they render in each command's generated help.
-  command.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
-  command.option('--json', json?.description ?? JSON_DESCRIPTION)
-  command.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
+  declareSharedOptions(command, json?.description ?? JSON_DESCRIPTION)
 }
 
 const forwardedArgs = (params: readonly TapCommandParamSchema[], args: readonly string[]): Record<string, string> => {
@@ -145,9 +151,7 @@ export const buildTapProgram = (schema: TapSchema, dispatch: TapDispatch): comma
   // before this program runs, so they never reach here — declared only so help
   // lists them. The outer command disables its own help, making this the sole
   // place they surface.
-  program.option('--instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
-  program.option('--json', JSON_DESCRIPTION)
-  program.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
+  declareSharedOptions(program, JSON_DESCRIPTION)
 
   for (const native of tapCliCommands) {
     declareCommand(program, native)

--- a/cli/lib/tap/render/console-props.ts
+++ b/cli/lib/tap/render/console-props.ts
@@ -30,7 +30,7 @@ const MIN_VALUE_WIDTH = 24
 const MAX_KEY_WIDTH = 32
 
 export const consolePropsOptions: readonly TapCommandOptionSchema[] = [
-  { name: 'depth', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
+  { name: 'depth', alias: 'd', type: 'string', required: false, description: 'how many levels of nested console properties to expand before summarizing the rest as "{n keys}" / "[n items]": a number or "all" (default 3, and a section over 8 rows folds at any depth unless this is passed)' },
 ]
 
 export interface ConsolePropsOptions {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -226,8 +226,8 @@ describe('lib/exec/tap', () => {
       const consoleProps = { name: 'request', type: 'command', props: { body: 'x'.repeat(2_000) } }
       const call = mockSession(buildTapSchema('15.0.0'), { result: { id: '1', consoleProps } })
 
-      expect(await tap.start(['command', '--testId', 'r2', '--commandId', '1'], { json: true })).toBe(0)
-      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'testId': 'r2', 'commandId': '1', 'json': 'true' }])
+      expect(await tap.start(['command', '--test-id', 'r2', '--command-id', '1'], { json: true })).toBe(0)
+      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'test-id': 'r2', 'command-id': '1', 'json': 'true' }])
       expect(JSON.parse(logger.print()).consoleProps).toEqual(consoleProps)
     })
 
@@ -242,8 +242,8 @@ describe('lib/exec/tap', () => {
       const commandView = { id: '1', name: 'visit', hook: { hookId: 'r2', hookName: 'test body' }, snapshots: [] }
       const call = mockSession(buildTapSchema('15.0.0'), { result: commandView })
 
-      expect(await tap.start(['command', '--testId', 'r2', '--commandId', '1'], {})).toBe(0)
-      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { testId: 'r2', commandId: '1' }])
+      expect(await tap.start(['command', '--test-id', 'r2', '--command-id', '1'], {})).toBe(0)
+      expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'test-id': 'r2', 'command-id': '1' }])
     })
 
     it('resolves the target from --instance and the cwd, then opens a session against it', async () => {
@@ -1280,7 +1280,7 @@ describe('lib/exec/tap', () => {
                                 row, the DOM snapshots pinnable on it, and its console
                                 properties
           reporter [options]    render a test’s full reporter view — its routes,
-                                hooks, and command log — or, without --testId, the
+                                hooks, and command log — or, without --test-id, the
                                 spec-level overview: run stats and every suite’s tests
           pin [options]         pin a command’s DOM snapshot into the live
                                 app-under-test frame so the dom/aria/inspect commands
@@ -1312,27 +1312,28 @@ describe('lib/exec/tap', () => {
         detail one command log entry of a test — its reporter row, the DOM snapshots pinnable on it, and its console properties
 
         Options:
-          -t, --testId <testId>        test id, as listed by the reporter command
-          -c, --commandId <commandId>  command id, as listed by the reporter command —
-                                       a row number (test body first when duplicated),
-                                       an e-prefixed event id, or hook-qualified like
-                                       "h1:3"
-          -a, --attempt <attempt>      1-based attempt (attempt 1 = first run);
-                                       defaults to the latest
-          -d, --depth <depth>          how many levels of nested console properties to
-                                       expand before summarizing the rest as "{n keys}"
-                                       / "[n items]": a number or "all" (default 3, and
-                                       a section over 8 rows folds at any depth unless
-                                       this is passed)
-          -i, --instance <pid>         target a specific running Cypress instance by
-                                       its server process id (pid)
-          --json                       print the raw JSON result instead of the
-                                       human-readable rendering — every console
-                                       property in full, however long, rather than the
-                                       long ones named by their length
-          --timeout <ms>               how long to wait on any single call into the
-                                       running Cypress, in milliseconds (default 30000)
-          -h, --help                   display help for command
+          -t, --test-id <test-id>        test id, as listed by the reporter command
+          -c, --command-id <command-id>  command id, as listed by the reporter command
+                                         — a row number (test body first when
+                                         duplicated), an e-prefixed event id, or
+                                         hook-qualified like "h1:3"
+          -a, --attempt <attempt>        1-based attempt (attempt 1 = first run);
+                                         defaults to the latest
+          -d, --depth <depth>            how many levels of nested console properties
+                                         to expand before summarizing the rest as "{n
+                                         keys}" / "[n items]": a number or "all"
+                                         (default 3, and a section over 8 rows folds at
+                                         any depth unless this is passed)
+          -i, --instance <pid>           target a specific running Cypress instance by
+                                         its server process id (pid)
+          --json                         print the raw JSON result instead of the
+                                         human-readable rendering — every console
+                                         property in full, however long, rather than
+                                         the long ones named by their length
+          --timeout <ms>                 how long to wait on any single call into the
+                                         running Cypress, in milliseconds (default
+                                         30000)
+          -h, --help                     display help for command
         "
       `)
     })

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1164,7 +1164,7 @@ describe('lib/exec/tap', () => {
 
     it('rejects `inspect` with no selector, without reading the frame', async () => {
       expect(await tap.start(['inspect'], {})).toBe(1)
-      expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`required option '--selector <selector>' not specified`)
+      expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`required option '-s, --selector <selector>' not specified`)
       expect(withResolvedAutFrame).not.toHaveBeenCalled()
     })
 
@@ -1253,7 +1253,7 @@ describe('lib/exec/tap', () => {
         Interacts with a running Cypress instance
 
         Options:
-          --instance <pid>      target a specific running Cypress instance by its
+          -i, --instance <pid>  target a specific running Cypress instance by its
                                 server process id (pid)
           --json                print the raw JSON result instead of the human-readable
                                 rendering
@@ -1312,26 +1312,27 @@ describe('lib/exec/tap', () => {
         detail one command log entry of a test — its reporter row, the DOM snapshots pinnable on it, and its console properties
 
         Options:
-          --testId <testId>        test id, as listed by the reporter command
-          --commandId <commandId>  command id, as listed by the reporter command — a
-                                   row number (test body first when duplicated), an
-                                   e-prefixed event id, or hook-qualified like "h1:3"
-          --attempt <attempt>      1-based attempt (attempt 1 = first run); defaults to
-                                   the latest
-          --depth <depth>          how many levels of nested console properties to
-                                   expand before summarizing the rest as "{n keys}" /
-                                   "[n items]": a number or "all" (default 3, and a
-                                   section over 8 rows folds at any depth unless this
-                                   is passed)
-          --instance <pid>         target a specific running Cypress instance by its
-                                   server process id (pid)
-          --json                   print the raw JSON result instead of the
-                                   human-readable rendering — every console property in
-                                   full, however long, rather than the long ones named
-                                   by their length
-          --timeout <ms>           how long to wait on any single call into the running
-                                   Cypress, in milliseconds (default 30000)
-          -h, --help               display help for command
+          -t, --testId <testId>        test id, as listed by the reporter command
+          -c, --commandId <commandId>  command id, as listed by the reporter command —
+                                       a row number (test body first when duplicated),
+                                       an e-prefixed event id, or hook-qualified like
+                                       "h1:3"
+          -a, --attempt <attempt>      1-based attempt (attempt 1 = first run);
+                                       defaults to the latest
+          -d, --depth <depth>          how many levels of nested console properties to
+                                       expand before summarizing the rest as "{n keys}"
+                                       / "[n items]": a number or "all" (default 3, and
+                                       a section over 8 rows folds at any depth unless
+                                       this is passed)
+          -i, --instance <pid>         target a specific running Cypress instance by
+                                       its server process id (pid)
+          --json                       print the raw JSON result instead of the
+                                       human-readable rendering — every console
+                                       property in full, however long, rather than the
+                                       long ones named by their length
+          --timeout <ms>               how long to wait on any single call into the
+                                       running Cypress, in milliseconds (default 30000)
+          -h, --help                   display help for command
         "
       `)
     })

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -198,26 +198,26 @@ describe('lib/tap/build-program', () => {
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
     const help = subcommand(program, 'reporter').helpInformation()
 
-    expect(help).toContain('--testId <testId>')
+    expect(help).toContain('--test-id <test-id>')
     expect(help).toContain('--attempt <attempt>')
 
-    program.parse(['reporter', '--testId', 'r2', '--attempt', '1'], { from: 'user' })
+    program.parse(['reporter', '--test-id', 'r2', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { testId: 'r2', attempt: '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('reporter', {}, { 'test-id': 'r2', attempt: '1' }, {})
   })
 
-  it('declares and forwards command --commandId from the shared contract', () => {
+  it('declares and forwards command --command-id from the shared contract', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
     const help = subcommand(program, 'command').helpInformation()
 
-    expect(help).toContain('--testId <testId>')
-    expect(help).toContain('--commandId <commandId>')
+    expect(help).toContain('--test-id <test-id>')
+    expect(help).toContain('--command-id <command-id>')
     expect(help).toContain('--attempt <attempt>')
 
-    program.parse(['command', '--testId', 'r2', '--commandId', 'log-3', '--attempt', '1'], { from: 'user' })
+    program.parse(['command', '--test-id', 'r2', '--command-id', 'log-3', '--attempt', '1'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'testId': 'r2', 'commandId': 'log-3', 'attempt': '1' }, {})
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': 'log-3', 'attempt': '1' }, {})
   })
 
   // `command` declares --json in its schema so the instance can be told, but the
@@ -243,12 +243,12 @@ describe('lib/tap/build-program', () => {
     expect(help).toContain('--depth <depth>')
     expect(help).not.toContain('--path')
 
-    program.parse(['command', '--testId', 'r2', '--commandId', '3', '--depth', '2'], { from: 'user' })
+    program.parse(['command', '--test-id', 'r2', '--command-id', '3', '--depth', '2'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith(
       'command',
       {},
-      { testId: 'r2', commandId: '3' },
+      { 'test-id': 'r2', 'command-id': '3' },
       { depth: '2' },
     )
   })
@@ -268,13 +268,13 @@ describe('lib/tap/build-program', () => {
 
     program.parse(['command', '-t', 'r2', '-c', '3', '-a', '1', '-d', '2'], { from: 'user' })
 
-    expect(dispatch).toHaveBeenCalledWith('command', {}, { testId: 'r2', commandId: '3', attempt: '1' }, { depth: '2' })
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { 'test-id': 'r2', 'command-id': '3', attempt: '1' }, { depth: '2' })
   })
 
   it('renders each alias alongside its long spelling in the generated help', () => {
     const program = buildTapProgram(buildTapSchema('15.0.0'), vi.fn())
 
-    expect(subcommand(program, 'command').helpInformation()).toContain('-t, --testId <testId>')
+    expect(subcommand(program, 'command').helpInformation()).toContain('-t, --test-id <test-id>')
     expect(subcommand(program, 'aria').helpInformation()).toContain('-s, --selector <selector>')
     expect(subcommand(program, 'status').helpInformation()).toContain('-i, --instance <pid>')
   })

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -229,7 +229,7 @@ describe('lib/tap/build-program', () => {
 
     expect(help.match(/--json/g)).toHaveLength(1)
     expect(help.replace(/\s+/g, ' ')).toContain('every console property in full')
-    expect(subcommand(program, 'reporter').helpInformation()).toContain('--json               print the raw JSON result')
+    expect(subcommand(program, 'reporter').helpInformation().replace(/\s+/g, ' ')).toContain('--json print the raw JSON result')
   })
 
   // The CLI's own view options ride in the schema commands' help, but they shape
@@ -260,6 +260,36 @@ describe('lib/tap/build-program', () => {
     program.parse(['launch', 'a.cy.js', '-b', 'firefox'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, { browser: 'firefox' }, {})
+  })
+
+  it('resolves the shared contract’s aliases, schema and view options alike', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(buildTapSchema('15.0.0'), dispatch)
+
+    program.parse(['command', '-t', 'r2', '-c', '3', '-a', '1', '-d', '2'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenCalledWith('command', {}, { testId: 'r2', commandId: '3', attempt: '1' }, { depth: '2' })
+  })
+
+  it('renders each alias alongside its long spelling in the generated help', () => {
+    const program = buildTapProgram(buildTapSchema('15.0.0'), vi.fn())
+
+    expect(subcommand(program, 'command').helpInformation()).toContain('-t, --testId <testId>')
+    expect(subcommand(program, 'aria').helpInformation()).toContain('-s, --selector <selector>')
+    expect(subcommand(program, 'status').helpInformation()).toContain('-i, --instance <pid>')
+  })
+
+  // Commander accepts a short flag claimed twice within one command and silently
+  // lets the last declaration win, so nothing but this catches an alias that
+  // collides with another option, with a view-only one, or with -h.
+  it('claims each short flag at most once per command', () => {
+    const program = buildTapProgram(buildTapSchema('15.0.0'), vi.fn())
+
+    for (const command of [program, ...program.commands]) {
+      const shorts = ['-h', ...command.options.map((option) => option.short).filter(Boolean)]
+
+      expect(new Set(shorts).size, `${command.name()} declares a short flag twice`).toBe(shorts.length)
+    }
   })
 
   it('omits options the user did not supply', () => {

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -39,7 +39,7 @@ const firstTestCommands = async (binding: TapBinding): Promise<{ testId: string,
   const tests = await specTests(binding)
   const testId = tests[0].id as string
 
-  return { testId, commands: await reporterCommands(binding, { testId }) }
+  return { testId, commands: await reporterCommands(binding, { 'test-id': testId }) }
 }
 
 const commandNamed = (commands: Array<Record<string, any>>, name: string): Record<string, any> => {
@@ -64,7 +64,7 @@ const leanEntries = async (binding: TapBinding, testId: string, rows: Array<Reco
   const entries: Array<Record<string, any>> = []
 
   for (const row of rows) {
-    const outcome = await binding.exec('command', {}, { testId, commandId: row.id as string })
+    const outcome = await binding.exec('command', {}, { 'test-id': testId, 'command-id': row.id as string })
 
     if (!('result' in outcome)) {
       throw new Error(`row ${row.id} is expected to resolve, got ${JSON.stringify(outcome)}`)
@@ -100,7 +100,7 @@ describe('tap binding', () => {
       expect(names).to.include.members(['command', 'reporter', 'pin', 'run-state', 'resolve-selector'])
       expect(names).not.to.include('console-props')
       // The two list subcommands folded into reporter: its spec overview lists
-      // the run's tests, and its --testId view lists one test's command log.
+      // the run's tests, and its --test-id view lists one test's command log.
       expect(names).not.to.include('tests')
       expect(names).not.to.include('commands')
 
@@ -108,7 +108,7 @@ describe('tap binding', () => {
 
       expect((unknown as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')
 
-      const commandWithoutCommandId = await binding.exec('command', {}, { testId: 'r1' })
+      const commandWithoutCommandId = await binding.exec('command', {}, { 'test-id': 'r1' })
 
       expect((commandWithoutCommandId as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
 
@@ -117,11 +117,11 @@ describe('tap binding', () => {
 
       expect((specViewBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
-      const commandBeforeRun = await binding.exec('command', {}, { testId: 'r1', commandId: '1' })
+      const commandBeforeRun = await binding.exec('command', {}, { 'test-id': 'r1', 'command-id': '1' })
 
       expect((commandBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
-      const reporterBeforeRun = await binding.exec('reporter', {}, { testId: 'r1' })
+      const reporterBeforeRun = await binding.exec('reporter', {}, { 'test-id': 'r1' })
 
       expect((reporterBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
@@ -185,7 +185,7 @@ describe('tap binding', () => {
 
       const testId = tests[0].id as string
 
-      const view = await reporterResult(binding, { testId })
+      const view = await reporterResult(binding, { 'test-id': testId })
 
       expect(view.test).to.deep.eq({
         id: testId,
@@ -199,7 +199,7 @@ describe('tap binding', () => {
       expect(view.hooks).to.deep.eq([{ hookId: testId, hookName: 'test body' }])
       expect(view.error).to.be.undefined
 
-      const missingTest = await binding.exec('reporter', {}, { testId: 'not-a-test' })
+      const missingTest = await binding.exec('reporter', {}, { 'test-id': 'not-a-test' })
 
       expect((missingTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
@@ -216,11 +216,11 @@ describe('tap binding', () => {
         expect(Object.keys(entry), `command ${entry.id}`).to.satisfy(withinKeys(ENTRY_KEYS))
       }
 
-      const missingCommandTest = await binding.exec('command', {}, { testId: 'not-a-test', commandId: commands[0].id as string })
+      const missingCommandTest = await binding.exec('command', {}, { 'test-id': 'not-a-test', 'command-id': commands[0].id as string })
 
       expect((missingCommandTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
-      const missingSelectedCommand = await binding.exec('command', {}, { testId, commandId: 'not-a-command' })
+      const missingSelectedCommand = await binding.exec('command', {}, { 'test-id': testId, 'command-id': 'not-a-command' })
 
       expect((missingSelectedCommand as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
 
@@ -326,13 +326,13 @@ describe('tap binding with a retrying spec', () => {
       expect(tests[0].attempts).to.have.length(2)
       expect(tests[0].attempts.map((attempt: Record<string, unknown>) => attempt.state)).to.deep.eq(['failed', 'passed'])
 
-      const latest = await reporterResult(binding, { testId })
+      const latest = await reporterResult(binding, { 'test-id': testId })
 
       expect(latest.test.state).to.eq('passed')
       // The passing latest attempt has no error panel.
       expect(latest.error).to.be.undefined
 
-      const first = await reporterResult(binding, { testId, attempt: '1' })
+      const first = await reporterResult(binding, { 'test-id': testId, attempt: '1' })
 
       expect(first.test.id).to.eq(testId)
       expect(first.test.fullTitle).to.eq(latest.test.fullTitle)
@@ -340,11 +340,11 @@ describe('tap binding with a retrying spec', () => {
       expect(Object.keys(first.error)).to.satisfy(withinKeys(['name', 'message', 'stack', 'codeFrame']))
       expect(first.error.message).to.be.a('string')
 
-      const second = await reporterResult(binding, { testId, attempt: '2' })
+      const second = await reporterResult(binding, { 'test-id': testId, attempt: '2' })
 
       expect(second).to.deep.eq(latest)
 
-      const outOfRange = await binding.exec('reporter', {}, { testId, attempt: '3' })
+      const outOfRange = await binding.exec('reporter', {}, { 'test-id': testId, attempt: '3' })
 
       expect((outOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
 
@@ -363,8 +363,8 @@ describe('tap binding with a retrying spec', () => {
       expect(failedCommand, 'failed command from attempt 1').to.exist
 
       const firstAttemptCommand = await binding.exec('command', {}, {
-        testId,
-        commandId: failedCommand!.id as string,
+        'test-id': testId,
+        'command-id': failedCommand!.id as string,
         attempt: '1',
       })
 
@@ -377,7 +377,7 @@ describe('tap binding with a retrying spec', () => {
       // The console properties travel with the row, read from the same attempt.
       expect(entry.consoleProps).to.include({ name: failedCommand!.name, type: 'command' })
 
-      const attemptOutOfRange = await binding.exec('command', {}, { testId, commandId: failedCommand!.id as string, attempt: '3' })
+      const attemptOutOfRange = await binding.exec('command', {}, { 'test-id': testId, 'command-id': failedCommand!.id as string, attempt: '3' })
 
       expect((attemptOutOfRange as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
     })
@@ -406,7 +406,7 @@ describe('tap binding console properties', () => {
 
       expect(getToggle, 'the get #toggle command').to.exist
 
-      const selectedCommand = await binding.exec('command', {}, { testId, commandId: getToggle!.id as string })
+      const selectedCommand = await binding.exec('command', {}, { 'test-id': testId, 'command-id': getToggle!.id as string })
 
       const selected = (selectedCommand as { result: Record<string, unknown> }).result
 
@@ -434,7 +434,7 @@ describe('tap binding console properties', () => {
         expect(snapshot.timestamp).to.be.a('number')
       })
 
-      const missingCommand = await binding.exec('command', {}, { testId })
+      const missingCommand = await binding.exec('command', {}, { 'test-id': testId })
 
       expect((missingCommand as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
 
@@ -454,7 +454,7 @@ describe('tap binding console properties', () => {
 
       // A row the driver holds no details for still reports its row, with no
       // console properties on it.
-      const unavailable = await binding.exec('command', {}, { testId, commandId: emptyConsoleProps.id as string })
+      const unavailable = await binding.exec('command', {}, { 'test-id': testId, 'command-id': emptyConsoleProps.id as string })
       const withoutProps = (unavailable as { result: Record<string, unknown> }).result
 
       expect(withoutProps).to.have.property('id', emptyConsoleProps.id)
@@ -472,7 +472,7 @@ describe('tap binding console properties', () => {
       const { testId, commands } = await firstTestCommands(binding)
       const commandId = commandNamed(commands, 'deep-console-props').id as string
       const propsOf = async (options: Record<string, string> = {}) => {
-        const result = await binding.exec('command', {}, { testId, commandId, ...options })
+        const result = await binding.exec('command', {}, { 'test-id': testId, 'command-id': commandId, ...options })
 
         return (result as { result: Record<string, any> }).result.consoleProps
       }
@@ -532,7 +532,7 @@ describe('tap binding pin lifecycle', () => {
       const binding = getBinding(win)
 
       const { testId, commands } = await firstTestCommands(binding)
-      const outcome = await binding.exec('pin', {}, { testId, commandId: commandNamed(commands, 'click').id as string, at: 'before' })
+      const outcome = await binding.exec('pin', {}, { 'test-id': testId, 'command-id': commandNamed(commands, 'click').id as string, at: 'before' })
 
       expect('result' in outcome).to.eq(true)
     })
@@ -554,7 +554,7 @@ describe('tap binding pin lifecycle', () => {
 
       expect(clearNoop).to.deep.eq({ result: { cleared: false } })
 
-      const beforeRun = await binding.exec('pin', {}, { testId: 'r2', commandId: '1' })
+      const beforeRun = await binding.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
       expect((beforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
     })
@@ -570,21 +570,21 @@ describe('tap binding pin lifecycle', () => {
       const { testId, commands } = await firstTestCommands(binding)
       const commandId = commandNamed(commands, 'click').id as string
 
-      const missingTest = await binding.exec('pin', {}, { testId: 'not-a-test', commandId })
+      const missingTest = await binding.exec('pin', {}, { 'test-id': 'not-a-test', 'command-id': commandId })
 
       expect((missingTest as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
-      const missingCommand = await binding.exec('pin', {}, { testId, commandId: 'not-a-command' })
+      const missingCommand = await binding.exec('pin', {}, { 'test-id': testId, 'command-id': 'not-a-command' })
 
       expect((missingCommand as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
 
-      const missingSnapshot = await binding.exec('pin', {}, { testId, commandId, at: 'during' })
+      const missingSnapshot = await binding.exec('pin', {}, { 'test-id': testId, 'command-id': commandId, at: 'during' })
 
       expect((missingSnapshot as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
       expect((missingSnapshot as { error: { message: string } }).error.message).to.contain('"before" (1)')
 
       // The default pin lands on the click's final snapshot.
-      const pinOutcome = (await binding.exec('pin', {}, { testId, commandId })) as { result: Record<string, any> }
+      const pinOutcome = (await binding.exec('pin', {}, { 'test-id': testId, 'command-id': commandId })) as { result: Record<string, any> }
 
       expect(Object.keys(pinOutcome.result)).to.satisfy((keys: string[]) => keys.every((key) => ['pinned', 'url'].includes(key)))
       expect(Object.keys(pinOutcome.result.pinned)).to.satisfy((keys: string[]) => keys.every((key) => ['test', 'command', 'hookName', 'at'].includes(key)))
@@ -597,7 +597,7 @@ describe('tap binding pin lifecycle', () => {
       expect(pinOutcome.result.pinned.at).to.deep.eq({ index: 2, total: 2, name: 'after' })
 
       // Re-running pin on the pinned command moves it in place.
-      const moved = (await binding.exec('pin', {}, { testId, commandId, at: 'before' })) as { result: Record<string, any> }
+      const moved = (await binding.exec('pin', {}, { 'test-id': testId, 'command-id': commandId, at: 'before' })) as { result: Record<string, any> }
 
       expect(moved.result.pinned.at).to.deep.eq({ index: 1, total: 2, name: 'before' })
 
@@ -805,14 +805,14 @@ describe('tap binding with network activity', () => {
     cy.window().then(async (win) => {
       const binding = getBinding(win)
 
-      const missing = await binding.exec('reporter', {}, { testId: 'not-a-test' })
+      const missing = await binding.exec('reporter', {}, { 'test-id': 'not-a-test' })
 
       expect((missing as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
 
       const tests = await specTests(binding)
       const testId = tests[0].id as string
 
-      const view = await reporterResult(binding, { testId })
+      const view = await reporterResult(binding, { 'test-id': testId })
 
       expect(Object.keys(view)).to.deep.eq(['test', 'hooks', 'sessions', 'agents', 'routes', 'commands'])
       expect(view.test).to.deep.eq({
@@ -980,8 +980,8 @@ describe('tap binding run lifecycle', () => {
       const binding = getBinding(win)
       const refused = await Promise.all([
         binding.exec('reporter'),
-        binding.exec('command', {}, { testId: 'r1', commandId: '1' }),
-        binding.exec('pin', {}, { testId: 'r1', commandId: '1' }),
+        binding.exec('command', {}, { 'test-id': 'r1', 'command-id': '1' }),
+        binding.exec('pin', {}, { 'test-id': 'r1', 'command-id': '1' }),
       ])
 
       for (const outcome of refused) {

--- a/packages/app/src/tap/commands/command.cy.ts
+++ b/packages/app/src/tap/commands/command.cy.ts
@@ -295,8 +295,8 @@ describe('tap/commands/command', () => {
     stubTests(getSerializedConsolePropsForLog)
 
     const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, {
-      'testId': 'r2',
-      'commandId': '1',
+      'test-id': 'r2',
+      'command-id': '1',
       'json': 'true',
     })
 

--- a/packages/app/src/tap/commands/command.cy.ts
+++ b/packages/app/src/tap/commands/command.cy.ts
@@ -69,7 +69,7 @@ describe('tap/commands/command', () => {
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       error: {
         code: 'NO_RUN',
         message: 'No spec has been started yet. Use the run command to start a spec.',
@@ -80,7 +80,7 @@ describe('tap/commands/command', () => {
   it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'nope', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'nope', 'command-id': '1' })).to.deep.eq({
       error: {
         code: 'TEST_NOT_FOUND',
         message: 'no test of this run matches the id "nope" — use the reporter command to list this run’s tests',
@@ -91,7 +91,7 @@ describe('tap/commands/command', () => {
   it('returns one command entry, keeping only the listed fields', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: 'h1:1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': 'h1:1' })).to.deep.eq({
       result: { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent', hook: { hookId: 'h1', hookName: 'before each' }, snapshots: [] },
     })
   })
@@ -101,7 +101,7 @@ describe('tap/commands/command', () => {
   it('names the hook a row ran in, falling back to its id alone', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: 'h1:1', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': 'h1:1', attempt: '1' })).to.deep.eq({
       result: { id: '1', name: 'visit', message: '/login', state: 'passed', type: 'parent', hook: { hookId: 'h1' }, snapshots: [] },
     })
   })
@@ -112,7 +112,7 @@ describe('tap/commands/command', () => {
   it('resolves a duplicated row number to the test body, not the hook', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -120,7 +120,7 @@ describe('tap/commands/command', () => {
   it('returns the entry from the requested attempt', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1', attempt: '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'failed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -137,7 +137,7 @@ describe('tap/commands/command', () => {
 
     stubSnapshots(getSnapshotPropsForLog)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       result: {
         id: '1',
         name: 'get',
@@ -158,7 +158,7 @@ describe('tap/commands/command', () => {
     stubTests()
     stubSnapshots(() => ({ snapshots: [null, { timestamp: 1767276202481 }] }))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [{ index: 1, timestamp: 1767276202481 }] },
     })
   })
@@ -167,7 +167,7 @@ describe('tap/commands/command', () => {
     stubTests()
     stubSnapshots(() => ({ snapshots: null }))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -175,7 +175,7 @@ describe('tap/commands/command', () => {
   it('fails with ATTEMPT_NOT_FOUND when the attempt is out of range', async () => {
     stubTests()
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '3' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1', attempt: '3' })).to.deep.eq({
       error: {
         code: 'ATTEMPT_NOT_FOUND',
         message: 'test "r2" has 2 attempts; pass --attempt 1–2 (defaults to the latest)',
@@ -188,10 +188,10 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '9', attempt: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '9', attempt: '1' })).to.deep.eq({
       error: {
         code: 'COMMAND_NOT_FOUND',
-        message: 'no command of this test matches the id "9" — use the reporter command (with --testId) to list this test’s commands',
+        message: 'no command of this test matches the id "9" — use the reporter command (with --test-id) to list this test’s commands',
       },
     })
 
@@ -215,7 +215,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-2', undefined)
     expect(outcome).to.deep.eq({
@@ -238,7 +238,7 @@ describe('tap/commands/command', () => {
       }
     })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { result: { consoleProps: unknown } }).result.consoleProps).to.deep.eq({
       name: 'get',
@@ -253,7 +253,7 @@ describe('tap/commands/command', () => {
 
     stubTests(getSerializedConsolePropsForLog)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1', attempt: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1', attempt: '1' })
 
     expect(getSerializedConsolePropsForLog).to.have.been.calledOnceWith('r2', 'log-b', undefined)
     expect((outcome as { result: { consoleProps: unknown } }).result.consoleProps).to.deep.eq(consoleProps)
@@ -264,7 +264,7 @@ describe('tap/commands/command', () => {
 
     stubTests(() => cleanup)
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r4', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r4', 'command-id': '1' })).to.deep.eq({
       result: {
         id: '1',
         name: 'visit',
@@ -283,7 +283,7 @@ describe('tap/commands/command', () => {
   it('omits console properties the driver has none of', async () => {
     stubTests(() => ({}))
 
-    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { testId: 'r2', commandId: '1' })).to.deep.eq({
+    expect(await new TapManager(CYPRESS_VERSION).exec('command', {}, { 'test-id': 'r2', 'command-id': '1' })).to.deep.eq({
       result: { id: '1', name: 'get', message: '#user', state: 'passed', type: 'parent', hook: TEST_BODY, snapshots: [] },
     })
   })
@@ -309,8 +309,8 @@ describe('tap/commands/command', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    expect((await manager.exec('command', {}, { testId: 'r2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
-    expect((await manager.exec('command', {}, { commandId: '1' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect((await manager.exec('command', {}, { 'test-id': 'r2' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
+    expect((await manager.exec('command', {}, { 'command-id': '1' }) as { error: { code: string } }).error.code).to.eq('INVALID_OPTIONS')
     expect(getRunner).not.to.have.been.called
   })
 })

--- a/packages/app/src/tap/commands/command.ts
+++ b/packages/app/src/tap/commands/command.ts
@@ -21,7 +21,7 @@ const consolePropsOf = (props: ConsolePropsResult | undefined): ConsolePropsResu
 }
 
 export const commandCommand = defineCommand('command', async (_params, options): Promise<CommandResult> => {
-  const { testId: test, attempt, commandId: command, json } = options
+  const { 'test-id': test, attempt, 'command-id': command, json } = options
 
   const runner = tapManagerDataSource.getRunner()
 
@@ -41,7 +41,7 @@ export const commandCommand = defineCommand('command', async (_params, options):
   const resolved = resolveCommand(selection.attempt, command, test)
 
   if (!resolved) {
-    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --testId) to list this test’s commands`)
+    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --test-id) to list this test’s commands`)
   }
 
   const snapshotProps = tapManagerDataSource.getSnapshotRunner()?.getSnapshotPropsForLog(test, resolved.logId)

--- a/packages/app/src/tap/commands/pin.cy.ts
+++ b/packages/app/src/tap/commands/pin.cy.ts
@@ -54,7 +54,7 @@ describe('tap/commands/pin', () => {
   it('pins the last snapshot by default, driving the app pin', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     // Default --at is the last snapshot (the command's final state), index 1.
     // The tap id '1' resolved to the driver log id, which is what the app pin
@@ -78,7 +78,7 @@ describe('tap/commands/pin', () => {
   it('pins a named snapshot via --at', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'before' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 0, 'r2', 'log-1')
     expect((outcome as { result: any }).result.pinned.at).to.deep.eq({ index: 1, total: 2, name: 'before' })
@@ -87,7 +87,7 @@ describe('tap/commands/pin', () => {
   it('fails with SNAPSHOT_NOT_FOUND when --at matches nothing, without driving the app pin', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1', at: 'during' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'during' })
 
     expect(outcome).to.deep.eq({
       error: { code: 'SNAPSHOT_NOT_FOUND', message: 'no snapshot of this command matches "during" — available snapshots: "before" (1), "after" (2)' },
@@ -101,8 +101,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
-    const switched = await manager.exec('pin', {}, { testId: 'r2', commandId: '2' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
+    const switched = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '2' })
 
     expect((switched as { result: any }).result.pinned.command.id).to.eq('2')
     expect(pinSnapshot).to.have.been.calledTwice
@@ -117,8 +117,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
-    const failed = await manager.exec('pin', {}, { testId: 'r2', commandId: '2', at: 'during' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
+    const failed = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '2', at: 'during' })
 
     expect((failed as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
 
@@ -136,8 +136,8 @@ describe('tap/commands/pin', () => {
     const manager = new TapManager(CYPRESS_VERSION)
 
     // First pin lands on the last snapshot (index 1, "after").
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
-    const moved = await manager.exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
+    const moved = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'before' })
 
     // The move re-selects the snapshot in place: no re-pin, only a state switch
     // to "before" (index 0).
@@ -156,8 +156,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
-    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1', at: 'during' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
+    const outcome = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'during' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_NOT_FOUND')
     // The pin never moved, so no state switch happened.
@@ -179,8 +179,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
-    const outcome = await manager.exec('pin', {}, { testId: 'r3', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
+    const outcome = await manager.exec('pin', {}, { 'test-id': 'r3', 'command-id': '1' })
 
     // A log id names a row only within its test, so the app pin has to be
     // re-keyed onto the other test rather than moved within the one it holds.
@@ -200,7 +200,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
 
     // The app's unpin is the whole release — it restores the page the pin
@@ -208,7 +208,7 @@ describe('tap/commands/pin', () => {
     expect(unpinSnapshot).to.have.been.calledOnce
     expect(cleared).to.deep.eq({ result: { cleared: true } })
 
-    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
   })
@@ -218,7 +218,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
     unpinInApp()
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -227,7 +227,7 @@ describe('tap/commands/pin', () => {
     // Already released app-side — unpinning again would be the command's own doing.
     expect(unpinSnapshot).not.to.have.been.called
 
-    const outcome = await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
   })
@@ -237,7 +237,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
     isRunning.returns(true)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -251,7 +251,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
     getRunner.returns(undefined)
 
     const cleared = await manager.exec('pin', {}, { clear: 'true' })
@@ -273,7 +273,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     const outcome = await manager.exec('run-state')
 
@@ -290,7 +290,7 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect(await manager.exec('run-state')).to.deep.eq({ result: { spec: null, totalSpecs: 0 } })
   })
@@ -342,7 +342,7 @@ describe('tap/commands/pin', () => {
 
       const manager = new TapManager(CYPRESS_VERSION)
 
-      await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+      await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
       // The snapshot toggle over the AUT selects "before" — the app's index is the
       // one to report, whoever last set it.
@@ -377,7 +377,7 @@ describe('tap/commands/pin', () => {
 
       const manager = new TapManager(CYPRESS_VERSION)
 
-      await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+      await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
       // A log id resolves only within its test, so the pin is the other test's row.
       pinInApp('log-1', 0, 'r3')
 
@@ -409,7 +409,7 @@ describe('tap/commands/pin', () => {
 
       pinInApp('log-1', 1)
 
-      const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
+      const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'before' })
 
       // The pin the app holds is the pin, whoever made it, so --at moves this one
       // rather than replacing it.
@@ -425,7 +425,7 @@ describe('tap/commands/pin', () => {
 
       const manager = new TapManager(CYPRESS_VERSION)
 
-      await manager.exec('pin', {}, { testId: 'r2', commandId: '1' })
+      await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
       // Clicking another command in the reporter re-pins with no unpin event, so
       // the command that was pinned no longer describes the AUT.
@@ -437,7 +437,7 @@ describe('tap/commands/pin', () => {
 
       // --at on the superseded command is a fresh pin of it, not a move of the
       // command the app is showing.
-      await manager.exec('pin', {}, { testId: 'r2', commandId: '1', at: 'before' })
+      await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '1', at: 'before' })
       expect(changeSnapshotState).not.to.have.been.called
       expect(pinSnapshot).to.have.been.calledTwice
 
@@ -474,7 +474,7 @@ describe('tap/commands/pin', () => {
   it('requires a test and command (or --clear) before attempting a pin', async () => {
     const { pinSnapshot } = stubSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('PIN_TARGET_REQUIRED')
     // A malformed pin never drives the app pin.
@@ -484,7 +484,7 @@ describe('tap/commands/pin', () => {
   it('fails with NO_RUN when no runner has mounted', async () => {
     stubSource({ runner: undefined })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('NO_RUN')
   })
@@ -492,7 +492,7 @@ describe('tap/commands/pin', () => {
   it('refuses to pin while a spec is running', async () => {
     stubSource({ running: true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { error: { code: string, message: string } }).error).to.deep.eq({
       code: 'RUN_IN_PROGRESS',
@@ -505,8 +505,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    expect((await manager.exec('pin', {}, { testId: 'nope', commandId: '1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
-    expect((await manager.exec('pin', {}, { testId: 'r2', commandId: '9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
+    expect((await manager.exec('pin', {}, { 'test-id': 'nope', 'command-id': '1' }) as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
+    expect((await manager.exec('pin', {}, { 'test-id': 'r2', 'command-id': '9' }) as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
   })
 
   // Numbers restart per hook section, so a plain handle can be duplicated —
@@ -538,7 +538,7 @@ describe('tap/commands/pin', () => {
   it('resolves a duplicated plain number to the test body row', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r5', 'command-id': '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-t1')
     expect((outcome as { result: any }).result.pinned.command.id).to.eq('1')
@@ -547,7 +547,7 @@ describe('tap/commands/pin', () => {
   it('resolves a hook-qualified handle to that section’s row', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: 'h2:1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r5', 'command-id': 'h2:1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r5', 'log-h2a')
   })
@@ -555,7 +555,7 @@ describe('tap/commands/pin', () => {
   it('refuses to guess between hooks: a number duplicated outside the test body is AMBIGUOUS_COMMAND', async () => {
     const { pinSnapshot } = stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: '2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r5', 'command-id': '2' })
 
     expect(outcome).to.deep.eq({
       error: {
@@ -570,7 +570,7 @@ describe('tap/commands/pin', () => {
   it('fails with COMMAND_NOT_FOUND for a qualifier that matches no section', async () => {
     stubHookedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r5', commandId: 'h9:1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r5', 'command-id': 'h9:1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('COMMAND_NOT_FOUND')
   })
@@ -581,7 +581,7 @@ describe('tap/commands/pin', () => {
       getSnapshotPropsForLog: () => ({ snapshots: null }),
     } })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r2', commandId: '1' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r2', 'command-id': '1' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('SNAPSHOT_UNAVAILABLE')
   })
@@ -611,7 +611,7 @@ describe('tap/commands/pin', () => {
   it('resolves command ids against the latest attempt by default', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r6', 'command-id': '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a2')
   })
@@ -619,7 +619,7 @@ describe('tap/commands/pin', () => {
   it('resolves command ids against the attempt named by --attempt', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '1' })
+    await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r6', 'command-id': '1', attempt: '1' })
 
     expect(pinSnapshot).to.have.been.calledOnceWith({ url: SNAPSHOT_PROPS.url, snapshots: SNAPSHOTS }, 1, 'r6', 'log-a1')
   })
@@ -627,7 +627,7 @@ describe('tap/commands/pin', () => {
   it('fails with ATTEMPT_NOT_FOUND when --attempt is out of range', async () => {
     const { pinSnapshot } = stubRetriedSource()
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '5' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('pin', {}, { 'test-id': 'r6', 'command-id': '1', attempt: '5' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('ATTEMPT_NOT_FOUND')
     expect(pinSnapshot).not.to.have.been.called
@@ -638,8 +638,8 @@ describe('tap/commands/pin', () => {
 
     const manager = new TapManager(CYPRESS_VERSION)
 
-    await manager.exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '1' })
-    await manager.exec('pin', {}, { testId: 'r6', commandId: '1', attempt: '2' })
+    await manager.exec('pin', {}, { 'test-id': 'r6', 'command-id': '1', attempt: '1' })
+    await manager.exec('pin', {}, { 'test-id': 'r6', 'command-id': '1', attempt: '2' })
 
     // Each attempt has its own log, so this is a fresh pin, not a snapshot move.
     expect(changeSnapshotState).not.to.have.been.called

--- a/packages/app/src/tap/commands/pin.ts
+++ b/packages/app/src/tap/commands/pin.ts
@@ -97,7 +97,7 @@ const resolveAt = (snapshots: PinSnapshotEntry[], at: string | undefined): numbe
   throw new TapCommandError('SNAPSHOT_NOT_FOUND', `no snapshot of this command matches "${at}" — available snapshots: ${available}`)
 }
 
-export const pinCommand = defineCommand('pin', async (_params, { testId: test, commandId: command, at, clear, attempt }): Promise<PinResult | ClearResult> => {
+export const pinCommand = defineCommand('pin', async (_params, { 'test-id': test, 'command-id': command, at, clear, attempt }): Promise<PinResult | ClearResult> => {
   const runner = tapManagerDataSource.getSnapshotRunner()
 
   if (clear) {
@@ -133,7 +133,7 @@ export const pinCommand = defineCommand('pin', async (_params, { testId: test, c
   const logId = resolveCommandLogId(selection.attempt, command, test)
 
   if (logId === undefined) {
-    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --testId) to list this test’s commands`)
+    throw new TapCommandError('COMMAND_NOT_FOUND', `no command of this test matches the id "${command}" — use the reporter command (with --test-id) to list this test’s commands`)
   }
 
   const props = runner.getSnapshotPropsForLog(test, logId)

--- a/packages/app/src/tap/commands/reporter.cy.ts
+++ b/packages/app/src/tap/commands/reporter.cy.ts
@@ -144,7 +144,7 @@ describe('tap/commands/reporter', () => {
   it('fails with NO_RUN when no spec has mounted a runner yet', async () => {
     stubRunner(undefined)
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r2' })
 
     expect(outcome).to.deep.eq({
       error: {
@@ -157,7 +157,7 @@ describe('tap/commands/reporter', () => {
   it('fails with TEST_NOT_FOUND when no test of the run has that id', async () => {
     stubRunner({ getTestState: () => undefined, isRunComplete: () => false })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'nope' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'nope' })
 
     expect((outcome as { error: { code: string } }).error.code).to.eq('TEST_NOT_FOUND')
   })
@@ -165,7 +165,7 @@ describe('tap/commands/reporter', () => {
   it('returns the full reporter view: test header, hooks with a synthesized test body, routes, and enriched commands', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => false })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r2' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r2' })
 
     expect(outcome).to.deep.eq({
       result: {
@@ -215,7 +215,7 @@ describe('tap/commands/reporter', () => {
   it('carries a failed attempt’s error panel — messaging fields and code frame, extras trimmed', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r4' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r4' })
 
     expect((outcome as { result: Record<string, unknown> }).result.error).to.deep.eq({
       name: 'AssertionError',
@@ -233,7 +233,7 @@ describe('tap/commands/reporter', () => {
   it('drops non-string error fields from a non-Error throw', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r6' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r6' })
 
     expect((outcome as { result: { error: Record<string, unknown> } }).result.error).to.deep.eq({})
   })
@@ -241,7 +241,7 @@ describe('tap/commands/reporter', () => {
   it('carries alias names, not the badge text `.as()` writes onto the log', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r7' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r7' })
 
     expect((outcome as { result: { commands: Array<Record<string, unknown>> } }).result.commands).to.deep.eq([
       { id: '1', name: 'find', message: 'button', state: 'passed', type: 'child', hookId: 'r7', aliases: ['firstBtn'], aliasType: 'dom' },
@@ -256,7 +256,7 @@ describe('tap/commands/reporter', () => {
   it('reports an unreached test with empty collections and just the test-body pseudo-hook', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r3' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r3' })
 
     expect(outcome).to.deep.eq({
       result: {
@@ -273,7 +273,7 @@ describe('tap/commands/reporter', () => {
   it('orders the synthesized test body between the before and after hooks', async () => {
     stubRunner({ getTestState: (id: string) => TESTS_STATE[id], isRunComplete: () => true })
 
-    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { testId: 'r5' })
+    const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { 'test-id': 'r5' })
 
     expect((outcome as { result: { hooks: unknown } }).result.hooks).to.deep.eq([
       { hookId: 'h-ba', hookName: 'before all' },
@@ -412,7 +412,7 @@ describe('tap/commands/reporter', () => {
       expect((outcome as { result: { stats: { duration: number } } }).result.stats.duration).to.eq(10400)
     })
 
-    it('rejects --attempt without --testId', async () => {
+    it('rejects --attempt without --test-id', async () => {
       stubRunner(treeRunner())
 
       const outcome = await new TapManager(CYPRESS_VERSION).exec('reporter', {}, { attempt: '1' })
@@ -420,7 +420,7 @@ describe('tap/commands/reporter', () => {
       expect(outcome).to.deep.eq({
         error: {
           code: 'ATTEMPT_NOT_FOUND',
-          message: 'the --attempt option applies only when rendering a single test; pass --testId <id>',
+          message: 'the --attempt option applies only when rendering a single test; pass --test-id <id>',
         },
       })
     })

--- a/packages/app/src/tap/commands/reporter.ts
+++ b/packages/app/src/tap/commands/reporter.ts
@@ -3,7 +3,7 @@ import { defineCommand, noRunError, TapCommandError } from './definition'
 import { attemptSelectionError, selectTestAttempt, serializeReporterSpecView, serializeReporterView } from '../test-state'
 import type { TapReporterSpecView, TapReporterView } from '../contract'
 
-export const reporterCommand = defineCommand('reporter', async (_params, { testId: test, attempt }): Promise<TapReporterView | TapReporterSpecView> => {
+export const reporterCommand = defineCommand('reporter', async (_params, { 'test-id': test, attempt }): Promise<TapReporterView | TapReporterSpecView> => {
   const runner = tapManagerDataSource.getRunner()
 
   if (!runner) {
@@ -12,7 +12,7 @@ export const reporterCommand = defineCommand('reporter', async (_params, { testI
 
   if (test === undefined) {
     if (attempt !== undefined) {
-      throw new TapCommandError('ATTEMPT_NOT_FOUND', 'the --attempt option applies only when rendering a single test; pass --testId <id>')
+      throw new TapCommandError('ATTEMPT_NOT_FOUND', 'the --attempt option applies only when rendering a single test; pass --test-id <id>')
     }
 
     return serializeReporterSpecView(runner, tapManagerDataSource.getActiveSpecRelative())

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -65,12 +65,12 @@ describe('cypress-instances contract', () => {
   })
 
   describe('tap command contract', () => {
-    it('lists reporter as a command taking --testId and --attempt, advertised on the wire schema', () => {
+    it('lists reporter as a command taking --test-id and --attempt, advertised on the wire schema', () => {
       const reporter = TAP_COMMANDS.find(({ name }) => name === 'reporter')!
 
       expect(reporter.params).toEqual([])
       expect(reporter.options.map(({ name, required }) => ({ name, required }))).toEqual([
-        { name: 'testId', required: false },
+        { name: 'test-id', required: false },
         { name: 'attempt', required: false },
       ])
 

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -17,7 +17,7 @@ export interface TapCommandParamSchema {
 
 export interface TapCommandOptionSchema {
   name: string
-  // A single letter, rendered by the CLI as `-t, --testId <testId>`. Commander
+  // A single letter, rendered by the CLI as `-t, --test-id <test-id>`. Commander
   // accepts a letter claimed twice within one command and silently lets the last
   // declaration win, so an alias must be unique across the command's own options,
   // the CLI's view-only ones, and the `--instance` every command shares.
@@ -85,12 +85,12 @@ export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
   SchemaObject<O, { required: true, type: 'string' | 'number' }, RawScalars>
 
 // Options that recur across commands, defined once so their name, type, and help
-// text can't drift between the commands that expose them. `testId` and
-// `commandId` are required in some commands and optional in others, so each use
+// text can't drift between the commands that expose them. `test-id` and
+// `command-id` are required in some commands and optional in others, so each use
 // spreads it and sets `required`; the rest are identical everywhere and used
 // directly.
-const testIdField = { name: 'testId', alias: 't', type: 'string', description: 'test id, as listed by the reporter command' } as const
-const commandIdField = { name: 'commandId', alias: 'c', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
+const testIdField = { name: 'test-id', alias: 't', type: 'string', description: 'test id, as listed by the reporter command' } as const
+const commandIdField = { name: 'command-id', alias: 'c', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
 const attemptField = { name: 'attempt', alias: 'a', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
 const selectorField = { name: 'selector', alias: 's', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' } as const
 
@@ -111,15 +111,15 @@ const commandMeta = {
 
 const reporterMeta = {
   name: 'reporter',
-  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --testId, the spec-level overview: run stats and every suite’s tests',
+  description: 'render a test’s full reporter view — its routes, hooks, and command log — or, without --test-id, the spec-level overview: run stats and every suite’s tests',
   details: `Shows test results the way the Cypress app's reporter panel does, right in
-your terminal. Pass --testId <id> (test ids come from the spec overview this
-same command prints with no --testId) to see one
+your terminal. Pass --test-id <id> (test ids come from the spec overview this
+same command prints with no --test-id) to see one
 test's full story: its network routes, the hooks that ran, the complete
 command log, and the failure output when something went wrong. Add --attempt
 to view an earlier retry.
 
-Leave --testId off to get the spec-level overview instead: the run's pass/fail
+Leave --test-id off to get the spec-level overview instead: the run's pass/fail
 stats and every suite's tests at a glance.`,
   params: [],
   options: [

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -17,6 +17,10 @@ export interface TapCommandParamSchema {
 
 export interface TapCommandOptionSchema {
   name: string
+  // A single letter, rendered by the CLI as `-t, --testId <testId>`. Commander
+  // accepts a letter claimed twice within one command and silently lets the last
+  // declaration win, so an alias must be unique across the command's own options,
+  // the CLI's view-only ones, and the `--instance` every command shares.
   alias?: string
   type: 'string' | 'number' | 'boolean'
   required: boolean
@@ -85,10 +89,10 @@ export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
 // `commandId` are required in some commands and optional in others, so each use
 // spreads it and sets `required`; the rest are identical everywhere and used
 // directly.
-const testIdField = { name: 'testId', type: 'string', description: 'test id, as listed by the reporter command' } as const
-const commandIdField = { name: 'commandId', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
-const attemptField = { name: 'attempt', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
-const selectorField = { name: 'selector', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' } as const
+const testIdField = { name: 'testId', alias: 't', type: 'string', description: 'test id, as listed by the reporter command' } as const
+const commandIdField = { name: 'commandId', alias: 'c', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
+const attemptField = { name: 'attempt', alias: 'a', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
+const selectorField = { name: 'selector', alias: 's', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' } as const
 
 const commandMeta = {
   name: 'command',
@@ -277,7 +281,7 @@ ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
     { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR}; omit to read the whole document` },
-    { name: 'max-chars', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
+    { name: 'max-chars', alias: 'm', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
     atField,
   ],
 } as const satisfies TapNativeCommandSchema
@@ -293,7 +297,7 @@ ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
     { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at; omit for the whole frame` },
-    { name: 'max-nodes', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
+    { name: 'max-nodes', alias: 'm', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
     atField,
   ],
 } as const satisfies TapNativeCommandSchema


### PR DESCRIPTION
- Closes [AW-98](https://cypress-io.atlassian.net/browse/AW-98)

### Additional details

The plumbing for short option aliases already existed and was unused: `TapCommandOptionSchema` declares an optional `alias`, and `declareOptions` in `cli/lib/tap/build-program.ts` already renders it as `-t, --test-id <test-id>`. No command in `TAP_COMMANDS` or `TAP_NATIVE_COMMANDS` set one, so every tap option was long-form only and the only short flag that worked anywhere was commander's built-in `-h`.

This claims a letter on the options that get typed by hand, spelled the way `cypress open --help` spells them:

| Flag | Alias | Commands |
|---|---|---|
| `--test-id` | `-t` | `command`, `reporter`, `pin` |
| `--command-id` | `-c` | `command`, `pin` |
| `--attempt` | `-a` | `command`, `reporter`, `pin` |
| `--selector` | `-s` | `dom`, `aria`, `inspect` |
| `--max-chars` / `--max-nodes` | `-m` | `dom` / `aria` |
| `--depth` | `-d` | `command` |
| `--instance` | `-i` | every command |

Several obvious letters clash, so these stay long-form only:

- **`--timeout`** — `-t` is worth more to `--test-id`, which is typed far more often, and a shared flag has to spell the same on every command.
- **`--json`** — deliberately left alone.
- **`--at`** — collides with `--attempt` on `pin`, and it is already a four-character flag.
- **`pin --clear`** — `-c` is `--command-id` there, leaving only an uppercase `-C` for one boolean.

Aliases live in the shared contract (`packages/cypress-instances/lib/tap-contract.ts`), so the schema a running instance advertises over the binding and the one the CLI bakes in stay in step with no app-side change. `forwardedOptions` already resolved values by canonical name, so the instance still receives the same option key whichever spelling was typed.

**Second commit — `--testId`/`--commandId` are now `--test-id`/`--command-id`.** They were the only camelCased flags in the CLI; every other multi-word option (`--config-file`, `--reporter-options`, `--max-chars`) is kebab-cased. A schema option's `name` is also its wire key, so the rename reaches the app's handlers, which now destructure `{ 'test-id': test, 'command-id': command }`. Nothing new was needed to parse them — `forwardedOptions` already resolved a dashed schema name to commander's camelCased attribute (the path `--dry-run` fixtures covered). Both sides of the binding ship together on this branch, and the CLI builds its program from the schema the attached instance advertises, so the two spellings can't cross.

Two smaller things came along:

- `--instance`/`--json`/`--timeout` were declared verbatim in two places in `build-program.ts`; they are now one `declareSharedOptions` helper, so the shared flags cannot drift apart.
- Commander accepts a short flag claimed twice within one command and silently lets the last declaration win. A spec now walks the built program and asserts each command claims a letter at most once, counting its schema options, the CLI's view-only ones, the shared flags, and `-h`.

### Steps to test

```bash
cd cli && yarn build

# aliases and kebab-cased names render together
node bin/cypress tap command --help
node bin/cypress tap dom --help

# they parse, and the error names the alias
node bin/cypress tap inspect            # error: required option '-s, --selector <selector>' not specified
node bin/cypress tap dom -q             # error: unknown option: -q
node bin/cypress tap dom -i 4242 -s .btn  # same NO_INSTANCE(4242) as --instance 4242
```

Against a live `cypress open` instance, `tap reporter -t <id> -a 1` and `tap command --test-id <id> -c 3 -d all` should behave exactly as the long spellings do.

### How has the user experience changed?

`cypress tap <command> --help` now lists a short alias next to most options, and the two camelCased flags are kebab-cased:

```
Options:
  -t, --test-id <test-id>        test id, as listed by the reporter command
  -c, --command-id <command-id>  command id, as listed by the reporter command
                                 — a row number (test body first when
                                 duplicated), an e-prefixed event id, or
                                 hook-qualified like "h1:3"
  -a, --attempt <attempt>        1-based attempt (attempt 1 = first run);
                                 defaults to the latest
  -d, --depth <depth>            how many levels of nested console properties …
  -i, --instance <pid>           target a specific running Cypress instance by …
  --json                         print the raw JSON result instead of the …
  --timeout <ms>                 how long to wait on any single call into the …
  -h, --help                     display help for command
```

`--testId` and `--commandId` no longer work — a breaking change to `cypress tap`, which is unreleased and lives behind this feature branch.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- `cypress tap` is not yet documented publicly; it ships behind the feat/tap-cli-integration branch. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-98]: https://cypress-io.atlassian.net/browse/AW-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI flag names and coordinated CLI/app wire-key changes affect all tap `command`/`reporter`/`pin` flows; risk is moderated by broad test updates and unreleased tap scope.
> 
> **Overview**
> **`cypress tap` options get short aliases** defined in the shared tap contract (`-t`/`--test-id`, `-c`/`--command-id`, `-a`/`--attempt`, `-s`/`--selector`, `-m` for size caps, `-d`/`--depth`, `-i`/`--instance` on the root command and every subcommand). Help text and parsing now show both spellings; `--timeout`, `--json`, `--at`, and `pin --clear` stay long-only where letters would collide.
> 
> **Breaking rename for unreleased tap:** option keys are **`--test-id` and `--command-id`** instead of camelCase. The CLI forwards those dashed names to the app binding, and tap handlers (`command`, `reporter`, `pin`) and error messages were updated to match.
> 
> **CLI plumbing:** shared `--instance` / `--json` / `--timeout` declarations are centralized in **`declareSharedOptions`** so top-level and per-command help cannot drift. A new test walks the built program and asserts **no duplicate short flags** per command (Commander would otherwise let the last definition win silently).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641706762fd1d11f6abdf82d484f8d733e140ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->