### PR TITLE
fix(grep): ignore empty parts in a semicolon-separated grep title

### DIFF
--- a/npm/grep/src/utils.ts
+++ b/npm/grep/src/utils.ts
@@ -14,6 +14,10 @@ export const parseTitleGrep = (s: string): TitleGrep | null => {
   }
 
   s = s.trim()
+  if (!s) {
+    return null
+  }
+
   if (s.startsWith('-')) {
     return {
       title: s.substring(1),
@@ -32,7 +36,7 @@ export const parseFullTitleGrep = (s: string): TitleGrep[] => {
     return []
   }
 
-  return s.split(';').map(parseTitleGrep)
+  return s.split(';').map(parseTitleGrep).filter((g): g is TitleGrep => g !== null)
 }
 
 export const parseTagsGrep = (s?: string): TagGrep[][] => {

--- a/npm/grep/test/unit.spec.ts
+++ b/npm/grep/test/unit.spec.ts
@@ -54,6 +54,10 @@ describe('utils', () => {
 
       expect(parsed).toEqual(null)
     })
+
+    it('returns null for a whitespace-only string', () => {
+      expect(parseTitleGrep('   ')).toEqual(null)
+    })
   })
 
   describe('parseFullTitleGrep', () => {
@@ -64,6 +68,17 @@ describe('utils', () => {
         { title: 'hello', invert: false },
         { title: 'one', invert: false },
         { title: 'two', invert: true },
+      ])
+    })
+
+    it('drops empty parts', () => {
+      expect(parseFullTitleGrep('hello;')).toEqual([
+        { title: 'hello', invert: false },
+      ])
+
+      expect(parseFullTitleGrep('hello;;  ;world')).toEqual([
+        { title: 'hello', invert: false },
+        { title: 'world', invert: false },
       ])
     })
   })
@@ -434,6 +449,12 @@ describe('utils', () => {
     it('passes for substring', () => {
       shouldIt('hello w', 'hello world', true)
       shouldIt('-hello w', 'hello world', false)
+    })
+
+    it('ignores a trailing separator', () => {
+      shouldIt('hello w;', 'hello world', true)
+      shouldIt('hello w; ', 'goodbye world', false)
+      shouldIt('-hello w;', 'hello world', false)
     })
   })
 


### PR DESCRIPTION
- Closes N/A — no existing issue. I searched open and closed issues under the `npm: @cypress/grep` label, every issue with `@cypress/grep` in the title, and the error text itself, and found nothing reporting this.

### Additional details

`@cypress/grep` lets you pass several title substrings separated by `;`:

```sh
npx cypress run --expose grep="login; logout; signup"
```

`parseTitleGrep` returns `null` for an empty segment, but `parseFullTitleGrep` typed its result `TitleGrep[]` and handed the array straight to `shouldTestRunTitle`, which dereferences `.invert` on every entry. Because the declared type hid the `null`, nothing downstream guarded against it. A trailing separator was enough to crash the run:

```
--expose grep="login;"
TypeError: Cannot read properties of null (reading 'invert')
```

A whitespace-only segment failed differently but just as quietly. It parsed to `{ title: '', invert: false }`, and `String.prototype.includes('')` is always true, so the empty part matched every test:

```
--expose grep="login; "   →  ran the whole suite instead of the matching tests
```

Both come from the same place: an empty segment is treated as a filter rather than as absent. The fix treats a segment that is empty after trimming as absent and drops it while parsing, so a filter narrows to the parts actually written. The type predicate on `.filter` also makes `parseFullTitleGrep`'s declared `TitleGrep[]` accurate.

| `grep` value | before | after |
| --- | --- | --- |
| `"login;"` | `TypeError` mid-run | filters on `login` |
| `"login; "` | ran every test | filters on `login` |
| `"login;;  ;logout"` | `TypeError` mid-run | filters on `login`, `logout` |
| `"login; logout"` | filters on both | unchanged |

Only `src/utils.ts` changes; `register.ts` and `plugin.ts` both reach this code through `parseGrep`, so the browser-side and spec-pre-filtering paths are fixed together.

### Steps to test

Against any project using `@cypress/grep`, with a test whose title contains `login`:

```sh
# before: TypeError: Cannot read properties of null (reading 'invert')
# after:  runs only the matching tests
npx cypress run --expose grep="login;"

# before: runs the entire suite
# after:  runs only the matching tests
npx cypress run --expose grep="login; "
```

Unit coverage: `yarn workspace @cypress/grep test`. Three cases were added — whitespace-only input to `parseTitleGrep`, empty/whitespace segments in `parseFullTitleGrep`, and end-to-end trailing-separator behavior through `shouldTestRunTitle` including the inverted `-hello w;` form.

### How has the user experience changed?

Two user-visible behavior changes, both listed in the table above: a `grep` value ending in a separator no longer crashes the run, and one ending in a separator plus whitespace no longer silently runs the whole suite. There is no visual change to the runner.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No issue exists for this; see the search notes at the top. Happy to open one first if you'd prefer that order. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- @cypress/grep is documented by npm/grep/README.md in this repo, and the documented `;` syntax is unchanged — this only fixes how malformed input is handled. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No public API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXFLVbbQT7pWSuwUhE2TKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXFLVbbQT7pWSuwUhE2TKf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parsing change in `@cypress/grep` with unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **malformed semicolon-separated `--expose grep` title filters** so empty segments are ignored instead of crashing or matching every test.
> 
> `parseTitleGrep` now returns `null` when the input is only whitespace after trim. `parseFullTitleGrep` drops those `null` entries (with a type predicate) before `shouldTestRunTitle` runs, so values like `login;` no longer throw on `.invert`, and `login; ` no longer behaves like an empty substring that matches all titles.
> 
> Unit tests cover whitespace-only `parseTitleGrep`, dropped empty parts in `parseFullTitleGrep`, and trailing-separator behavior through `shouldTestRunTitle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3a784f3d3e03064a1d5e2589d6d96408ffb862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->