### PR TITLE
chore(grep): remove dead code and cover `specify` in CI

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -3136,6 +3136,7 @@ jobs:
       - run: yarn workspace @cypress/grep omit:specs
       - run: yarn workspace @cypress/grep or
       - run: yarn workspace @cypress/grep skip
+      - run: yarn workspace @cypress/grep specify
       - run: yarn workspace @cypress/grep tags:inverted
       - run: yarn workspace @cypress/grep tags:and
       - run: yarn workspace @cypress/grep tags:and:not

--- a/npm/grep/cypress/e2e/config.cy.ts
+++ b/npm/grep/cypress/e2e/config.cy.ts
@@ -1,5 +1,0 @@
-describe('tests that use config object', () => {
-  it('still works @config', { baseUrl: 'http://localhost:8000' }, () => {
-    expect(Cypress.config('baseUrl')).to.equal('http://localhost:8000')
-  })
-})

--- a/npm/grep/cypress/e2e/spec.cy.ts
+++ b/npm/grep/cypress/e2e/spec.cy.ts
@@ -1,9 +1,0 @@
-it('hello world', () => {})
-
-it('works', () => {})
-
-it('works 2 @tag1', { tags: '@tag1' }, () => {})
-
-it('works 2 @tag1 @tag2', { tags: ['@tag1', '@tag2'] }, () => {})
-
-it('works @tag2', { tags: '@tag2' }, () => {})

--- a/npm/grep/eslint.config.ts
+++ b/npm/grep/eslint.config.ts
@@ -27,7 +27,7 @@ export default [
     },
   },
   {
-    files: ['src/**/*.js', 'src/**/*.ts', 'expects/**/*.js', 'expects/**/*.ts'],
+    files: ['src/**/*.js', 'src/**/*.ts'],
     languageOptions: {
       globals: {
         process: 'readonly',

--- a/npm/grep/expected-json/specify.json
+++ b/npm/grep/expected-json/specify.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "specify.cy.ts",
+    "tests": [
+      {
+        "name": "hello world",
+        "state": "pending"
+      },
+      {
+        "name": "works",
+        "state": "pending"
+      },
+      {
+        "name": "works 2 @tag1",
+        "state": "passed"
+      },
+      {
+        "name": "works 2 @tag1 @tag2",
+        "state": "passed"
+      },
+      {
+        "name": "works @tag2",
+        "state": "pending"
+      }
+    ]
+  }
+]

--- a/npm/grep/package.json
+++ b/npm/grep/package.json
@@ -19,6 +19,7 @@
     "omit:specs": "PROJECT_NAME=omit-specs node ../../scripts/cypress.js run --expose grep='Test 2',grepOmitFiltered=true --config specPattern='**/tags/*.cy.ts'",
     "or": "PROJECT_NAME=or node ../../scripts/cypress.js run --expose grep='Test 1',grepTags='regression high' --config specPattern='**/tags/*.cy.ts'",
     "skip": "PROJECT_NAME=skip node ../../scripts/cypress.js run --config specPattern='**/*skip.cy.ts'",
+    "specify": "PROJECT_NAME=specify node ../../scripts/cypress.js run --expose grepTags=@tag1 --config specPattern='**/specify.cy.ts'",
     "tags:inverted": "PROJECT_NAME=tag-inverted node ../../scripts/cypress.js run --expose grepTags='-regression' --config specPattern='**/tags/*.cy.ts'",
     "tags": "PROJECT_NAME=tags node ../../scripts/cypress.js run --expose grepTags=smoke --config specPattern='**/tags/*.cy.ts'",
     "tags:and": "PROJECT_NAME=tags-and node ../../scripts/cypress.js run --expose grepTags='smoke+high' --config specPattern='**/tags/*.cy.ts'",

--- a/npm/grep/src/plugin.ts
+++ b/npm/grep/src/plugin.ts
@@ -66,16 +66,14 @@ export function plugin (config: CypressConfigOptions): CypressConfigOptions {
   }
 
   const { specPattern, excludeSpecPattern } = config
-  const integrationFolder = expose.grepIntegrationFolder || process.cwd()
 
   const grepFilterSpecs = expose.grepFilterSpecs === true || String(expose.grepFilterSpecs).toLowerCase() === 'true'
 
   if (grepFilterSpecs) {
     debug('specPattern', specPattern)
     debug('excludeSpecPattern', excludeSpecPattern)
-    debug('integrationFolder', integrationFolder)
     const specFiles = globbySync(specPattern, {
-      cwd: integrationFolder,
+      cwd: process.cwd(),
       ignore: Array.isArray(excludeSpecPattern) ? excludeSpecPattern : [excludeSpecPattern],
       absolute: true,
     })

--- a/npm/grep/src/utils.ts
+++ b/npm/grep/src/utils.ts
@@ -9,7 +9,7 @@ interface TagGrep {
 }
 
 export const parseTitleGrep = (s: string): TitleGrep | null => {
-  if (!s || typeof s !== 'string') {
+  if (!s) {
     return null
   }
 
@@ -32,7 +32,7 @@ export const parseTitleGrep = (s: string): TitleGrep | null => {
 }
 
 export const parseFullTitleGrep = (s: string): TitleGrep[] => {
-  if (!s || typeof s !== 'string') {
+  if (!s) {
     return []
   }
 
@@ -114,16 +114,6 @@ export const shouldTestRunTags = (parsedGrepTags: TagGrep[][], tags: string[] = 
 export const shouldTestRunTitle = (parsedGrep: TitleGrep[], testName: string): boolean => {
   if (!testName) {
     return true
-  }
-
-  if (!parsedGrep) {
-    return true
-  }
-
-  if (!Array.isArray(parsedGrep)) {
-    console.error('Invalid parsed title grep')
-    console.error(parsedGrep)
-    throw new Error('Expected title grep to be an array')
   }
 
   if (!parsedGrep.length) {


### PR DESCRIPTION
- Closes N/A

### Additional details

Dead-code cleanup in `npm/grep`. Each item below was verified unreachable before removal, not just assumed.

**1. `expose.grepIntegrationFolder` (`src/plugin.ts`)**

A pre-Cypress-10 `integrationFolder` holdover. `grepIntegrationFolder` appears exactly once in the whole monorepo — the line that reads it — so it always resolved to `process.cwd()`. Removed the variable and its `debug` line; `globbySync` now takes `cwd: process.cwd()` directly.

**2. Unreachable guards in `shouldTestRunTitle` (`src/utils.ts`)**

```js
if (!parsedGrep) return true

if (!Array.isArray(parsedGrep)) {
  console.error('Invalid parsed title grep')
  console.error(parsedGrep)
  throw new Error('Expected title grep to be an array')
}
```

The only entry points are `register.ts` and `plugin.ts` (two call sites), all of which go through `shouldTestRun(parseGrep(...))`. `parseGrep(...).title` is `parseFullTitleGrep(...)`, which returns `[]` or a `.map()` result — always an array. Both branches are dead in production, and no test asserts the throw.

**3. `typeof s !== 'string'` guards in the title parsers (`src/utils.ts`)**

`parseTitleGrep` only ever receives elements of `s.split(';')`, which are always strings. `parseFullTitleGrep` only receives values already normalized with `String(...)` or nullish ones, which the preceding `!s` already catches. The `!s` check still covers the one case a test exercises (`parseTitleGrep()` with no args → `null`).

These are internal: `package.json` `exports` only publishes `.` and `./plugin`, so `utils` is not reachable by consumers and no public behavior changes.

**4. Stale eslint glob (`eslint.config.ts`)**

`'expects/**/*.js', 'expects/**/*.ts'` — there is no `expects/` directory. The fixtures live in `expected-json/` and are all `.json`, so the `process` global override never applied to anything.

**5. Three e2e specs that nothing ran**

Every scenario script pins an explicit `--config specPattern=...`. Mapping all 19 spec files against all 25 patterns showed exactly three files matched by nothing: `config.cy.ts`, `spec.cy.ts`, and `specify.cy.ts`.

`config.cy.ts` and `spec.cy.ts` are deleted — their behavior is already covered by `config-tags.cy.ts` and the `tags/*.cy.ts` specs.

`specify.cy.ts` is **kept and wired up** instead. It is the only spec exercising `specify = it` in `register.ts`, so deleting it would make that coverage gap permanent. Since `specify` is a Mocha alias bound to the original `it` at interface-setup time, dropping that line would silently let every `specify(...)` test bypass grep filtering entirely — worth a guard. Added a `specify` npm script, the matching `expected-json/specify.json` fixture, and a step in the `npm-grep` CI job.

### Steps to test

```sh
yarn workspace @cypress/grep test        # unit tests
yarn workspace @cypress/grep specify     # the new scenario
yarn lint --scope @cypress/grep
```

All 25 grep scenarios were run locally against a full build and pass, including the new `specify` one. The `filter:specs` and `tags:filter:specs` scenarios specifically exercise the changed `globbySync` call in `plugin.ts`.

`yarn pack-ci --validate` could **not** be run — the CircleCI CLI is unavailable in this environment and the network policy blocks installing it. `.circleci/packed/` is gitignored and generated at CI runtime, so nothing committed is out of sync, but the official validation did not run. The `@pipeline.yml` change is one `- run:` line matching 24 sibling steps; parsing the file confirms the anchors resolve and the `npm-grep` job now has 26 run steps. **Worth running `yarn pack-ci --validate` before merge.**

### How has the user experience changed?

No change. `grepIntegrationFolder` was undocumented and referenced nowhere, and the removed guards were unreachable from either public entry point.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical dead-code removal; no behavior change. -->
- [x] Have tests been added/updated? <!-- `specify.cy.ts` wired into a running scenario + CI job, with fixture. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWKkB6gutzdmjQiSp1hwJf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal grep package changes with verified equivalent spec-filter cwd; no exported API changes and added CI coverage for `specify`.
> 
> **Overview**
> **@cypress/grep** internal cleanup with no intended public behavior change. Removes unused `grepIntegrationFolder` (always fell through to `process.cwd()`), unreachable guards in title/tag parsers and `shouldTestRunTitle`, and a stale ESLint glob for a non-existent `expects/` directory.
> 
> **Spec filtering** when `grepFilterSpecs` is on now resolves spec globs with `cwd: process.cwd()` directly instead of the removed integration-folder variable.
> 
> **CI / e2e:** Drops orphan `config.cy.ts` and `spec.cy.ts` (coverage already elsewhere). Adds a **`specify`** scenario—npm script, `expected-json/specify.json`, and an `npm-grep` CircleCI step—so Mocha’s `specify` alias (wired to grep-aware `it` in `register.ts`) stays covered by tag filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0309bc96cd9c011a0c1a1e2b5b5cf4ef5342cd73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->