### PR TITLE
chore: gate websocket upgrades on loopback remoteAddress when the proxy is disabled

### DIFF
--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -767,7 +767,14 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
     // bail if this is our own namespaced socket.io / graphql-ws request
 
     if (req.url.startsWith(socketIoRoute)) {
-      if (!this.socketAllowed.isRequestAllowed(req)) {
+      // Without the proxy, upgrades arrive on direct connections the CONNECT
+      // port allow-list never saw — a loopback remoteAddress is the only
+      // available gate (see #34513).
+      const isAllowed = isProxyDisabled()
+        ? this.socketAllowed.isRequestFromLocalhost(req)
+        : this.socketAllowed.isRequestAllowed(req)
+
+      if (!isAllowed) {
         socket.write('HTTP/1.1 400 Bad Request\r\n\r\nRequest not made via a Cypress-launched browser.')
         socket.end()
       }

--- a/packages/server/lib/util/socket_allowed.ts
+++ b/packages/server/lib/util/socket_allowed.ts
@@ -46,4 +46,18 @@ export class SocketAllowed {
 
     return isAllowed
   }
+
+  /**
+   * The port allow-list is populated by proxy CONNECT tracking, which never
+   * happens with the MITM proxy disabled — a loopback remoteAddress is the
+   * only available gate for direct websocket upgrades there.
+   */
+  isRequestFromLocalhost (req: Request) {
+    const { remoteAddress } = req.socket
+    const isAllowed = ['127.0.0.1', '::1'].includes(remoteAddress!)
+
+    debug('is incoming request from localhost? %o', { isAllowed, reqUrl: req.url, remoteAddress })
+
+    return isAllowed
+  }
 }

--- a/packages/server/test/unit/util/socket_allowed_spec.ts
+++ b/packages/server/test/unit/util/socket_allowed_spec.ts
@@ -39,4 +39,24 @@ describe('lib/util/socket_allowed', function () {
       expect(sw.isRequestAllowed(req)).to.be.false
     })
   })
+
+  context('#isRequestFromLocalhost', () => {
+    it('allows loopback remote addresses without any port allow-list entry', () => {
+      expect(sw.allowedLocalPorts).to.deep.eq([])
+
+      for (const remoteAddress of ['127.0.0.1', '::1']) {
+        const req = { socket: { remoteAddress } } as Request
+
+        expect(sw.isRequestFromLocalhost(req), remoteAddress).to.be.true
+      }
+    })
+
+    it('rejects non-loopback remote addresses', () => {
+      for (const remoteAddress of ['192.168.1.20', '10.0.0.5', undefined]) {
+        const req = { socket: { remoteAddress } } as Request
+
+        expect(sw.isRequestFromLocalhost(req), String(remoteAddress)).to.be.false
+      }
+    })
+  })
 })


### PR DESCRIPTION
- Closes #34513

### Additional details

With `CYPRESS_INTERNAL_DISABLE_PROXY=1`, socket.io / graphql-ws upgrade requests arrive on direct connections instead of proxied CONNECTs, so the CONNECT-tracked port allow-list (`socketAllowed`) never saw them and every upgrade was rejected with a 400. socket.io degrades to long-polling, but graphql-ws has no fallback — the runner app failed with an urql `CombinedError: [Network] undefined`.

When the proxy is disabled, the upgrade gate falls back to requiring a loopback `remoteAddress` on the connection — the only signal available without CONNECT tracking. Proxy-on behavior is unchanged.

### Steps to test

- `CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:open` against any project, open a spec in Chrome: the runner app loads and updates without GraphQL errors. Without this change, the app fails with the `CombinedError` above.
- Unit coverage in `packages/server/test/unit/util/socket_allowed_spec.ts` for the new `isRequestFromLocalhost`.

### How has the user experience changed?

No change (internal flag only).

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security gating for internal websocket upgrades on an internal code path; proxy-enabled behavior is unchanged, but proxy-disabled mode relies solely on loopback address.
> 
> **Overview**
> Fixes **rejected websocket upgrades** for Cypress’s namespaced socket.io and graphql-ws routes when `CYPRESS_INTERNAL_DISABLE_PROXY=1` (#34513). Direct upgrades never hit CONNECT tracking, so the port allow-list stayed empty and every upgrade got a 400—breaking graphql-ws (runner GraphQL errors) while socket.io could fall back to long-polling.
> 
> **`proxyWebsockets`** now branches on `isProxyDisabled()`: proxy-on still uses `isRequestAllowed` (port allow-list + loopback); proxy-off uses new **`SocketAllowed.isRequestFromLocalhost`**, which only requires `127.0.0.1` or `::1` on `req.socket.remoteAddress`. Unit tests cover the localhost helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e676985b711fb8474e0da9325e766523a57cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->