### PR TITLE
chore: answer intercept-matched `cy.visit()` pre-flights when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -289,10 +289,11 @@ jobs:
       disable-proxy: true
       require-opt-in: false
       parallelism: 1
-      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses.
+      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
+      # #34514 strategy:file origin serving + #34379 intercept-matched visit pre-flights (visits, web security, service workers).
       # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
       # concurrent large-body CDP Fetch (47 unmatched localhost requests); Electron was green.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js
+      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js
       requires:
         - system-tests-node-modules-install
   - system-tests-cookies-cdp:

--- a/packages/proxy/lib/adapters/correlate-browser-pre-request.ts
+++ b/packages/proxy/lib/adapters/correlate-browser-pre-request.ts
@@ -46,6 +46,9 @@ export async function correlateBrowserPreRequest (mw: RequestInterceptionMiddlew
   if (mw.req.headers['x-cypress-resolving-url']) {
     mw.debug('skipping prerequest for resolve:url')
     delete mw.req.headers['x-cypress-resolving-url']
+    // The proxy-off forced loopback rides on the internal token — strip it so
+    // it never reaches a real origin on passthrough.
+    delete mw.req.headers['x-cypress-internal-loopback-token']
     const requestId = `cy.visit-${Date.now()}`
 
     mw.req.browserPreRequest = {

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -1212,14 +1212,19 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
         _.merge(options, {
           proxy: `http://127.0.0.1:${this._port()}`,
           agent: null,
+          // With the MITM proxy disabled, the server is not a proxy. The
+          // `proxy` option above still delivers this request in absolute form,
+          // so it lands on the direct-origin catch-all in routes.ts — the token
+          // is what marks it as our own loopback there, letting the catch-all
+          // route it through the interception pipeline so the stub can reply.
+          // `tunnel: false` keeps https URLs on that same absolute-form path:
+          // the default CONNECT tunnel would be rejected by onConnect, which
+          // refuses all CONNECTs when the proxy is disabled. Loopback-only —
+          // this request never leaves 127.0.0.1.
+          // Gated so proxy-on wire traffic is unchanged.
+          ...(isProxyDisabled() ? { tunnel: false } : {}),
           headers: {
             'x-cypress-resolving-url': '1',
-            // With the MITM proxy disabled, the server is not a proxy. The
-            // `proxy` option above still delivers this request in absolute form,
-            // so it lands on the direct-origin catch-all in routes.ts — the token
-            // is what marks it as our own loopback there, letting the catch-all
-            // route it through the interception pipeline so the stub can reply.
-            // Gated so proxy-on wire traffic is unchanged.
             ...(isProxyDisabled() ? { [CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]: cypressInternalLoopbackToken } : {}),
           },
         })

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -55,7 +55,7 @@ import type { CreateProxyRuntimeDeps, CdpFetchNetworkRuntime } from './network-r
 import { isProxyDisabled } from './util/is-proxy-disabled'
 import type { ForNetworkPolicyRegistration, NetworkInterceptionCore } from '@packages/network-interception'
 import type { ICriClient } from './browsers/cdp-protocol/cri-client'
-import { getTrustedLoopbackUrl, isTrustedInternalLoopback } from './adapters/internal-routes'
+import { CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, getTrustedLoopbackUrl, isTrustedInternalLoopback } from './adapters/internal-routes'
 
 const debug = Debug('cypress:server:server-base')
 
@@ -1214,6 +1214,13 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
           agent: null,
           headers: {
             'x-cypress-resolving-url': '1',
+            // With the MITM proxy disabled, the server is not a proxy. The
+            // `proxy` option above still delivers this request in absolute form,
+            // so it lands on the direct-origin catch-all in routes.ts — the token
+            // is what marks it as our own loopback there, letting the catch-all
+            // route it through the interception pipeline so the stub can reply.
+            // Gated so proxy-on wire traffic is unchanged.
+            ...(isProxyDisabled() ? { [CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]: cypressInternalLoopbackToken } : {}),
           },
         })
       }


### PR DESCRIPTION
- Closes #34379

> Stacked on #34534 — the fix builds directly on its direct-origin catch-all. Retarget to `develop` once that merges.

### Additional details

When a `cy.visit()` URL matches a `cy.intercept()` route, `_onResolveUrl` deliberately sends its URL-resolution pre-flight *through the Cypress server as an HTTP proxy* (`proxy: http://127.0.0.1:<port>` + `x-cypress-resolving-url`) so net-stubbing can see and stub the document. With `CYPRESS_INTERNAL_DISABLE_PROXY=1` the server is not a proxy — the absolute-form request fell through the router unanswered, and every test that stubs a visited document failed (500 before #34534's error-middleware arity fix, 404 after).

This keeps the loopback design but makes it answerable and authenticated:

- `_onResolveUrl` attaches the per-process loopback token to the forced pre-flight (proxy-off only — proxy-on wire traffic is byte-identical). The `x-cypress-resolving-url` marker alone is forgeable by AUT content; the token is not.
- #34534's direct-origin catch-all routes trusted absolute-form requests into the interception pipeline **without URL rewriting**, so net-stubbing matches the real target URL and replies.
- `CorrelateBrowserPreRequest` strips the token next to the `x-cypress-resolving-url` marker, so it never reaches a real origin on passthrough.

Also promotes `base_url`, `visit`, `web_security`, `service_worker`, and `service_worker_protocol` system specs to the proxy-off remediated CI job — these were verified with the full stack (this change plus #34534 and #34533).

### Steps to test

- `CYPRESS_INTERNAL_DISABLE_PROXY=1`, a spec with `cy.intercept('GET', url, { body: '<html>stub</html>' })` followed by `cy.visit(url)`: the stub renders. An unstubbed visit to the same URL still gets origin content — the gate does not hijack normal traffic.
- Unit coverage in #34534's `routes_spec.ts`: valid token routes to the pipeline without rewriting; a forged loopback header falls through.
- The promoted system specs run proxy-off in the `system-tests-chrome-cdp-remediated` job on this PR.

### How has the user experience changed?

No change (internal flag only).

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches visit resolution and net-stubbing loopback routing when the MITM proxy is disabled; changes are gated to that internal flag and strip sensitive headers before origin passthrough.
> 
> **Overview**
> When **`CYPRESS_INTERNAL_DISABLE_PROXY=1`**, intercept-matched **`cy.visit()`** URL-resolution pre-flights no longer die unanswered: **`_onResolveUrl`** still loops through **`127.0.0.1`**, but proxy-off requests now carry the **per-process internal loopback token**, use **`tunnel: false`** for HTTPS (CONNECT is blocked when the proxy is off), and hit the direct-origin catch-all so **net-stubbing** can stub the document.
> 
> **`CorrelateBrowserPreRequest`** strips that token alongside **`x-cypress-resolving-url`** so it never reaches a real origin. Proxy-on behavior is unchanged.
> 
> CI: the **proxy-off Chrome remediated** job now also runs **`base_url`**, **`visit`**, **`web_security`**, and **service worker** system specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80252416668e44b7b243dba660b27a1d05890399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->