### PR TITLE
fix: resolve the cloud env when the urql client is created

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Bugfixes:**
 
-- Fixed a regression in [15.20.0](#15-20-0) where the Cypress app sent all Cypress Cloud requests to `http://localhost:3000` instead of Cypress Cloud. Logging in could not complete, and the Runs and Debug pages reported no data. Addressed in [#34529](https://github.com/cypress-io/cypress/pull/34529).
+- Fixed a regression in [15.20.0](#15-20-0) where the Cypress app sent all Cypress Cloud requests to `http://localhost:3000` instead of Cypress Cloud. Logging in could not complete, and the Runs and Debug pages reported no data. Addressed in [#34536](https://github.com/cypress-io/cypress/pull/34536).
 - Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the AUT snapshot permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the AUT. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
 
 ## 15.20.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 **Bugfixes:**
 
+- Fixed a regression in [15.20.0](#15-20-0) where the Cypress app sent all Cypress Cloud requests to `http://localhost:3000` instead of Cypress Cloud. Logging in could not complete, and the Runs and Debug pages reported no data. Addressed in [#34529](https://github.com/cypress-io/cypress/pull/34529).
 - Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the AUT snapshot permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the AUT. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
 
 ## 15.20.0

--- a/packages/data-context/src/actions/EventCollectorActions.ts
+++ b/packages/data-context/src/actions/EventCollectorActions.ts
@@ -23,10 +23,6 @@ type EventInputs = {
 /**
  * Defaults to staging when doing development. To override to production for development,
  * explicitly set process.env.CYPRESS_INTERNAL_ENV to 'production`
- *
- * Read on each call rather than at module scope: this module is initialized while the V8
- * snapshot is built, so a module-level value would freeze into the binary and ignore the
- * environment the app actually starts with.
  */
 function resolveEventCollectorEnv () {
   return (process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV || 'production') as 'development' | 'staging' | 'production'

--- a/packages/data-context/src/actions/EventCollectorActions.ts
+++ b/packages/data-context/src/actions/EventCollectorActions.ts
@@ -23,17 +23,23 @@ type EventInputs = {
 /**
  * Defaults to staging when doing development. To override to production for development,
  * explicitly set process.env.CYPRESS_INTERNAL_ENV to 'production`
+ *
+ * Read on each call rather than at module scope: this module is initialized while the V8
+ * snapshot is built, so a module-level value would freeze into the binary and ignore the
+ * environment the app actually starts with.
  */
-const cloudEnv = (process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV || 'production') as 'development' | 'staging' | 'production'
+function resolveEventCollectorEnv () {
+  return (process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV || 'production') as 'development' | 'staging' | 'production'
+}
 
 export class EventCollectorActions {
   constructor (private ctx: DataContext) {
-    debug('Using %s environment for Event Collection', cloudEnv)
+    debug('Using %s environment for Event Collection', resolveEventCollectorEnv())
   }
 
   async recordEvent (event: CollectibleEvent, includeMachineId: boolean): Promise<boolean> {
     try {
-      const cloudUrl = this.ctx.cloud.getCloudUrl(cloudEnv)
+      const cloudUrl = this.ctx.cloud.getCloudUrl(resolveEventCollectorEnv())
       const eventUrl = includeMachineId ? `${cloudUrl}/machine-collect` : `${cloudUrl}/anon-collect`
       const headers = {
         'Content-Type': 'application/json',

--- a/packages/data-context/src/sources/CloudDataSource.ts
+++ b/packages/data-context/src/sources/CloudDataSource.ts
@@ -31,7 +31,6 @@ import { pathToArray } from 'graphql/jsutils/Path'
 export type CloudDataResponse<T = any> = ExecutionResult<T> & Partial<OperationResult<T | null>> & { executing?: Promise<ExecutionResult<T> & Partial<OperationResult<T | null>>> }
 
 const debug = debugLib('cypress:data-context:sources:CloudDataSource')
-const cloudEnv = resolveCloudEnv()
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type StartsWith<T, Prefix extends string> = T extends `${Prefix}${infer _U}` ? T : never
@@ -116,8 +115,11 @@ export class CloudDataSource {
   }
 
   reset () {
+    // Resolved here rather than at module scope: this module is initialized while the
+    // V8 snapshot is built, where CYPRESS_INTERNAL_ENV is always 'development', so a
+    // module-level value would freeze into the binary and point it at localhost.
     return this.#cloudUrqlClient = createClient({
-      url: `${this.getCloudUrl(cloudEnv)}/test-runner-graphql`,
+      url: `${this.getCloudUrl(resolveCloudEnv())}/test-runner-graphql`,
       exchanges: [
         dedupExchange,
         cacheExchange({

--- a/packages/data-context/src/sources/CloudDataSource.ts
+++ b/packages/data-context/src/sources/CloudDataSource.ts
@@ -115,9 +115,6 @@ export class CloudDataSource {
   }
 
   reset () {
-    // Resolved here rather than at module scope: this module is initialized while the
-    // V8 snapshot is built, where CYPRESS_INTERNAL_ENV is always 'development', so a
-    // module-level value would freeze into the binary and point it at localhost.
     return this.#cloudUrqlClient = createClient({
       url: `${this.getCloudUrl(resolveCloudEnv())}/test-runner-graphql`,
       exchanges: [

--- a/packages/data-context/test/unit/actions/EventCollectorActions.spec.ts
+++ b/packages/data-context/test/unit/actions/EventCollectorActions.spec.ts
@@ -65,5 +65,25 @@ describe('EventCollectorActions', () => {
 
       expect(result).toBe(false)
     })
+
+    // The module itself is initialized while the V8 snapshot is built, where this variable
+    // is absent. Reading it any earlier than the request freezes the wrong url into the binary.
+    it('resolves the environment when the event is recorded, not when the module loads', async () => {
+      const original = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
+
+      process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = 'staging'
+
+      try {
+        await actions.recordEvent({ campaign: '', medium: '', messageId: '', cohort: '' }, false)
+      } finally {
+        if (original === undefined) {
+          delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
+        } else {
+          process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV = original
+        }
+      }
+
+      expect(ctx.util.fetch).toHaveBeenNthCalledWith(1, 'https://cloud-staging.cypress.io/anon-collect', expect.anything())
+    })
   })
 })

--- a/packages/data-context/test/unit/actions/EventCollectorActions.spec.ts
+++ b/packages/data-context/test/unit/actions/EventCollectorActions.spec.ts
@@ -66,8 +66,6 @@ describe('EventCollectorActions', () => {
       expect(result).toBe(false)
     })
 
-    // The module itself is initialized while the V8 snapshot is built, where this variable
-    // is absent. Reading it any earlier than the request freezes the wrong url into the binary.
     it('resolves the environment when the event is recorded, not when the module loads', async () => {
       const original = process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
 

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -360,7 +360,7 @@ describe('CloudDataSource', () => {
       }
     })
 
-    it('resolves the environment when the client is created, not when the module loads', async () => {
+    it('does not freeze the environment at module load', async () => {
       process.env.CYPRESS_INTERNAL_ENV = 'production'
 
       const source = new CloudDataSource({

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -360,9 +360,6 @@ describe('CloudDataSource', () => {
       }
     })
 
-    // The module itself is initialized while the V8 snapshot is built, where
-    // CYPRESS_INTERNAL_ENV is always 'development'. Reading it any earlier than this
-    // freezes the wrong url into the binary.
     it('resolves the environment when the client is created, not when the module loads', async () => {
       process.env.CYPRESS_INTERNAL_ENV = 'production'
 

--- a/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/CloudDataSource.spec.ts
@@ -348,4 +348,39 @@ describe('CloudDataSource', () => {
       expect(fetchStub).toHaveBeenCalledTimes(1)
     })
   })
+
+  describe('cloud url', () => {
+    const originalEnv = process.env.CYPRESS_INTERNAL_ENV
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CYPRESS_INTERNAL_ENV
+      } else {
+        process.env.CYPRESS_INTERNAL_ENV = originalEnv
+      }
+    })
+
+    // The module itself is initialized while the V8 snapshot is built, where
+    // CYPRESS_INTERNAL_ENV is always 'development'. Reading it any earlier than this
+    // freezes the wrong url into the binary.
+    it('resolves the environment when the client is created, not when the module loads', async () => {
+      process.env.CYPRESS_INTERNAL_ENV = 'production'
+
+      const source = new CloudDataSource({
+        fetch: fetchStub,
+        getUser: getUserStub,
+        logout: logoutStub,
+        invalidateClientUrqlCache: invalidateCacheStub,
+      })
+
+      await source.executeRemoteGraphQL({
+        fieldName: 'cloudViewer',
+        operationDoc: FAKE_USER_QUERY,
+        operationVariables: {},
+        operationType: 'query',
+      })
+
+      expect(fetchStub).toHaveBeenCalledWith('https://cloud.cypress.io/test-runner-graphql', expect.anything())
+    })
+  })
 })

--- a/packages/server/lib/cloud/api/index.ts
+++ b/packages/server/lib/cloud/api/index.ts
@@ -17,7 +17,7 @@ import type { AfterSpecDurations } from '@packages/types'
 import { agent } from '@packages/network'
 import type { CombinedAgent } from '@packages/network'
 
-import { apiUrl, apiRoutes, makeRoutes } from '../routes'
+import { getApiUrl, apiRoutes, makeRoutes } from '../routes'
 import { getText } from '../../util/status_code'
 import * as enc from '../encryption'
 import getEnvInformationForProjectRoot from '../environment'
@@ -465,7 +465,7 @@ export default {
           projectId: options.projectId,
           testingType: options.testingType,
           cloudApi: {
-            url: apiUrl,
+            url: getApiUrl(),
             retryWithBackoff: this.retryWithBackoff,
             requestPromise: this.rp,
           },
@@ -634,6 +634,7 @@ export default {
     return retryWithBackoff(async (attemptIndex) => {
       const { projectRoot, timeout, ...preflightRequestBody } = preflightInfo
 
+      const apiUrl = getApiUrl()
       const preflightBaseProxy = apiUrl.replace('api', 'api-proxy')
 
       const envInformation = await getEnvInformationForProjectRoot(projectRoot, process.pid.toString())

--- a/packages/server/lib/cloud/routes.ts
+++ b/packages/server/lib/cloud/routes.ts
@@ -3,7 +3,15 @@ import UrlParse from 'url-parse'
 
 const app_config = require('../../config/app.json')
 
-export const apiUrl = app_config[process.env.CYPRESS_CONFIG_ENV || process.env.CYPRESS_INTERNAL_ENV || 'development'].api_url
+/**
+ * Read on each call rather than at module scope. This module is only kept out of the V8
+ * snapshot by its place in the generated deferred list, which is rebuilt from scratch
+ * whenever yarn.lock changes; a module-level value would freeze into the binary as
+ * `development` the moment that classification shifts.
+ */
+export const getApiUrl = (): string => {
+  return app_config[process.env.CYPRESS_CONFIG_ENV || process.env.CYPRESS_INTERNAL_ENV || 'development'].api_url
+}
 
 const CLOUD_ENDPOINTS = {
   api: '',
@@ -42,10 +50,10 @@ const parseArgs = function (url, args: any[] = []) {
   return url
 }
 
-const _makeRoutes = (baseUrl: string, routes: typeof CLOUD_ENDPOINTS) => {
+const _makeRoutes = (baseUrl: string | (() => string), routes: typeof CLOUD_ENDPOINTS) => {
   return _.reduce(routes, (memo, value, key) => {
     memo[key] = function (...args: any[]) {
-      let url = new UrlParse(baseUrl, true)
+      let url = new UrlParse(typeof baseUrl === 'function' ? baseUrl() : baseUrl, true)
 
       if (value) {
         url.set('pathname', value)
@@ -62,6 +70,6 @@ const _makeRoutes = (baseUrl: string, routes: typeof CLOUD_ENDPOINTS) => {
   }, {} as Record<keyof typeof CLOUD_ENDPOINTS, (...args: any[]) => string>)
 }
 
-export const apiRoutes = _makeRoutes(apiUrl, CLOUD_ENDPOINTS)
+export const apiRoutes = _makeRoutes(getApiUrl, CLOUD_ENDPOINTS)
 
 export const makeRoutes = (baseUrl) => _makeRoutes(baseUrl, CLOUD_ENDPOINTS)

--- a/packages/server/lib/cloud/routes.ts
+++ b/packages/server/lib/cloud/routes.ts
@@ -3,12 +3,6 @@ import UrlParse from 'url-parse'
 
 const app_config = require('../../config/app.json')
 
-/**
- * Read on each call rather than at module scope. This module is only kept out of the V8
- * snapshot by its place in the generated deferred list, which is rebuilt from scratch
- * whenever yarn.lock changes; a module-level value would freeze into the binary as
- * `development` the moment that classification shifts.
- */
 export const getApiUrl = (): string => {
   return app_config[process.env.CYPRESS_CONFIG_ENV || process.env.CYPRESS_INTERNAL_ENV || 'development'].api_url
 }

--- a/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
+++ b/packages/server/lib/cloud/studio/StudioLifecycleManager.ts
@@ -293,7 +293,7 @@ export class StudioLifecycleManager {
       projectId: currentProjectOptions.projectSlug,
       testingType: cfg.testingType,
       cloudApi: {
-        url: routes.apiUrl,
+        url: routes.getApiUrl(),
         retryWithBackoff: api.retryWithBackoff,
         requestPromise: api.rp,
       },

--- a/packages/server/test/unit/cloud/api/api_spec.ts
+++ b/packages/server/test/unit/cloud/api/api_spec.ts
@@ -419,6 +419,11 @@ describe('lib/cloud/api', () => {
 
     describe('errors', () => {
       it('[F1] POST /preflight TimeoutError', () => {
+        // Unlike its siblings this exercises `api` rather than `prodApi`, so drop the
+        // production override the surrounding beforeEach sets. The parent afterEach
+        // restores it.
+        delete process.env.CYPRESS_CONFIG_ENV
+
         preflightNock(API_BASEURL)
         .times(2)
         .delayConnection(5000)

--- a/packages/server/test/unit/cloud/api/api_spec.ts
+++ b/packages/server/test/unit/cloud/api/api_spec.ts
@@ -419,23 +419,25 @@ describe('lib/cloud/api', () => {
 
     describe('errors', () => {
       it('[F1] POST /preflight TimeoutError', () => {
-        // Unlike its siblings this exercises `api` rather than `prodApi`, so drop the
-        // production override the surrounding beforeEach sets. The parent afterEach
-        // restores it.
-        delete process.env.CYPRESS_CONFIG_ENV
-
-        preflightNock(API_BASEURL)
-        .times(2)
+        const scopeProxy = preflightNock(API_PROD_PROXY_BASEURL)
         .delayConnection(5000)
         .reply(200, {})
 
-        return api.sendPreflight({
+        const scopeApi = preflightNock(API_PROD_BASEURL)
+        .delayConnection(5000)
+        .reply(200, {})
+
+        return prodApi.sendPreflight({
+          projectId: 'abc123',
           timeout: 100,
         })
         .then(() => {
           throw new Error('should have thrown here')
         })
         .catch((err) => {
+          scopeProxy.done()
+          scopeApi.done()
+
           expect(err.message).to.eq('Error: ESOCKETTIMEDOUT')
         })
       })

--- a/packages/server/test/unit/cloud/routes_spec.ts
+++ b/packages/server/test/unit/cloud/routes_spec.ts
@@ -96,5 +96,21 @@ describe('lib/cloud/routes', () => {
 
       expect(routes().apiRoutes.api()).to.eq('https://api-staging.cypress.io/')
     })
+
+    // Deliberately reuses one already-loaded module. This module is only kept out of the
+    // V8 snapshot by the generated deferred list, so the url has to be resolved per call
+    // rather than when the module is first evaluated.
+    it('resolves per call rather than when the module is evaluated', () => {
+      process.env.CYPRESS_INTERNAL_ENV = 'staging'
+
+      const loaded = routes()
+
+      expect(loaded.apiRoutes.api()).to.eq('https://api-staging.cypress.io/')
+
+      process.env.CYPRESS_INTERNAL_ENV = 'production'
+
+      expect(loaded.apiRoutes.api()).to.eq('https://api.cypress.io/')
+      expect(loaded.getApiUrl()).to.eq('https://api.cypress.io/')
+    })
   })
 })

--- a/packages/server/test/unit/cloud/routes_spec.ts
+++ b/packages/server/test/unit/cloud/routes_spec.ts
@@ -97,9 +97,6 @@ describe('lib/cloud/routes', () => {
       expect(routes().apiRoutes.api()).to.eq('https://api-staging.cypress.io/')
     })
 
-    // Deliberately reuses one already-loaded module. This module is only kept out of the
-    // V8 snapshot by the generated deferred list, so the url has to be resolved per call
-    // rather than when the module is first evaluated.
     it('resolves per call rather than when the module is evaluated', () => {
       process.env.CYPRESS_INTERNAL_ENV = 'staging'
 

--- a/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
+++ b/packages/server/test/unit/cloud/studio/StudioLifecycleManager_spec.ts
@@ -106,7 +106,7 @@ describe('StudioLifecycleManager', () => {
         }),
       },
       '../routes': {
-        apiUrl: 'http://localhost:1234/',
+        getApiUrl: () => 'http://localhost:1234/',
       },
       './telemetry/TelemetryManager': {
         telemetryManager: {


### PR DESCRIPTION
- Closes <!-- no issue; reported internally in Slack -->

### Additional details

In 15.20.0 the app sends every Cypress Cloud GraphQL request to `http://localhost:3000` instead of `https://cloud.cypress.io`. `cloudViewer` comes back `null`, logging in never completes, and the Runs and Debug pages have no data. Studio and cy-prompt are unaffected because `get_cloud_metadata.ts` and `CyPromptLifecycleManager` resolve the cloud environment themselves, at call time, defaulting to `production`.

`CloudDataSource` resolved the environment in a module-level `const`:

```ts
const cloudEnv = resolveCloudEnv()
```

Module scope means that runs while the **V8 snapshot is built**, not at app startup. Inside the snapshot, `tooling/v8-snapshot/src/generator/blueprint.ts` swaps `process` for a stub whose `env` holds only `NODE_ENV` and `CYPRESS_INTERNAL_ENV`, and `install-snapshot.ts` never overrides the generator default of `cypressInternalEnv: 'development'`. So the value freezes as `development` and the binary ships pointing at localhost. The packaged `Resources/app/index.js` sets `CYPRESS_INTERNAL_ENV=production` before loading anything, which is exactly why the observed value proves it was never resolved at runtime.

**Which 15.20.0 change flipped this is not yet identified**, and I would rather leave that open than guess. Two plausible mechanisms have been ruled out by evidence:

- *`getenv` was deferred and kept the module out of the snapshot.* Ruled out: `CloudDataSource.ts` is in v15.19.0's committed `healthy` list, and `healthy` is only populated on a completed verification, so its initialization did not throw.
- *The bundler's lazy-accessor rewrite covered the old expression.* Ruled out: bundling `resolveCloudEnv({ CYPRESS_INTERNAL_ENV: process.env.CYPRESS_INTERNAL_ENV || 'development' })` — the shape of the pre-#34430 `getenv(...)` call — compiles to an eager `var`, exactly like the current expression.

Worth knowing for review: the bundler *does* rewrite some module-scope declarations into lazy `__get_X__()` accessors, but the heuristic is opaque and not predictable from the source. Probed in a single bundle, `(process.env.X || 'production')` and `String(process.env.X || 'dev')` become lazy, while `!process.env.X && !process.env.Y`, `process.env.A ?? (process.env.B || 'dev')`, and any imported call are left eager. So whether a given module-scope read is safe today is close to accidental, which is the argument for resolving these at call time in the source rather than relying on the build.

The fix resolves the environment inside `reset()`, matching how every other Cloud consumer already does it. Note that no environment variable can work around the shipped 15.20.0 binary: the value is already baked, so `CYPRESS_INTERNAL_CLOUD_ENV` and `CYPRESS_INTERNAL_ENV` are both ignored. This needs a patch release.

`EventCollectorActions.ts` reads `CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV` at module scope and is changed here too, but **it is not currently broken** — inspecting the bundle shows the rewriter already converts that declaration into a lazy `__get_cloudEnv__()` accessor, first called from the constructor at runtime. This change is belt-and-braces: it puts the laziness in the source instead of depending on the heuristic described above.

Adding these modules to the snapshot `deferred` list was considered and rejected. There is no checked-in force-defer list (`forceNorewrite` has one; defer does not), so it would mean hand-editing three generated `snapshot-meta.json` files that are keyed to `yarn.lock` and regenerated from scratch on any dependency change. That is exactly how this bug arrived: 15.19.0 was protected only because `getenv` happened to be deferred, and that protection vanished the moment the dependency was dropped. Keeping the reads lazy puts the invariant in the code, where the tests can hold it.

`packages/server/lib/cloud/routes.ts` is fixed here for the same reason, even though it is not broken today. It computes `apiUrl` — the login and recording API — at module scope, and is safe *only* because it currently sits in the generated deferred list. That is the identical accidental protection that just evaporated for `CloudDataSource`, and a dependency bump could remove it with no test to catch the fallout. `apiUrl` becomes `getApiUrl()`, and `_makeRoutes` accepts a thunk so `apiRoutes` resolves its base url when a route is called; consumers are unchanged apart from the five sites reading the export directly.

One note for reviewers on that last change: `[F1] POST /preflight TimeoutError` in `api_spec.ts` had to be updated. It drove `api` while the surrounding `beforeEach` sets `CYPRESS_CONFIG_ENV=production` and resets preflight state for `prodApi`, so it was quietly depending on the frozen-at-import url. It now nocks both production hosts and drives `prodApi`, matching the two sibling error cases in the same block, and asserts both scopes are consumed. It passes against `develop`'s source as well as this branch's, so it no longer depends on freeze semantics in either direction.

Passing `cypressInternalEnv` through `install-snapshot.ts` was considered and rejected for this bug class. It would make a baked value *right* without making it any less frozen, which converts a loud failure (`localhost:3000`, caught in a day) into a silent one — the override quietly stops working and the GraphQL layer split-brains against `get_cloud_metadata`, which resolves at call time. It has separate merit for genuinely build-time constants such as the `worker.js` / `worker-shim.js` choice in `rewriter/lib/threads/index.ts`, but that is a different problem and belongs in its own PR.

The durable follow-up, prototyped and measured but deliberately not included here, is to make `process.env` a throwing proxy inside the snapshot stub while `includeStrictVerifiers` is set, so the doctor defers any module that reads a non-allowlisted variable at initialization rather than freezing a build-time value. Against develop's pre-fix code on darwin it correctly deferred `CloudDataSource.ts`, left `EventCollectorActions.ts` alone (already lazy), and surfaced two previously unknown instances of the same class — `cloud/protocol.ts` (`CAPTURE_ERRORS`, `DELETE_DB`) and `util/print-run.ts` (`UPLOAD_ACTIVITY_INTERVAL`), whose environment variables are silently dead in the shipped binary today. Cost was 9 of 3090 modules leaving the snapshot, with doctor runtime going from 5.5 to 28.6 minutes.

It is not in this PR because the classification cache is keyed on `yarn.lock` alone (`determine-deferred.ts` → `findHashFile`), so the guard has no effect until the doctor re-runs; landing it means regenerating and committing `snapshot-meta.json` for all three platforms. It also still needs a startup measurement and a fix to `warnings-processor`, whose defer regexes do not match the existing bare-string `cannotAccess` throw — anything reading `process.nextTick` at module scope would `assert.fail` the doctor instead of deferring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Cloud GraphQL, event collection, and recording API routing; incorrect resolution would break login and Cloud features, but the change is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes the **15.20.0 regression** where the app sent Cypress Cloud GraphQL and related traffic to `http://localhost:3000`, breaking login, Runs, and Debug. Module-scope reads of `CYPRESS_INTERNAL_ENV` / collector env were **frozen during the V8 snapshot build** as `development`; this PR resolves those values **when requests are made**.
> 
> **`CloudDataSource`** now calls `resolveCloudEnv()` inside `reset()` when building the urql client URL instead of a top-level constant. **`EventCollectorActions`** uses `resolveEventCollectorEnv()` on each `recordEvent`. **`routes.ts`** replaces exported `apiUrl` with **`getApiUrl()`**, and **`apiRoutes`** resolves the base URL per route invocation via a thunk in `_makeRoutes`. Server call sites (`api`, Studio lifecycle, preflight) use the getter.
> 
> Adds regression tests that env changes after module load affect fetch URLs, updates the preflight timeout spec to nock production and drive `prodApi`, and documents the fix in **15.20.1** changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f0977a15f2627d767a96b68637afc80dcd3e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Both regression tests fail on `develop` and pass with this change — `CloudDataSource.spec.ts` with `Received: "http://localhost:3000/test-runner-graphql"`, and `EventCollectorActions.spec.ts` with `Received: "https://cloud.cypress.io/anon-collect"` where `https://cloud-staging.cypress.io/anon-collect` was expected:

```
yarn workspace @packages/data-context test -- test/unit/sources/CloudDataSource.spec.ts test/unit/actions/EventCollectorActions.spec.ts
```

`routes_spec.ts` gains a case that deliberately reuses one already-loaded module instead of busting the require cache like its neighbours, so it fails without the change with `expected 'https://api-staging.cypress.io/' to equal 'https://api.cypress.io/'`:

```
yarn workspace @packages/server test-unit -- cloud/routes_spec.ts
```

The wider server cloud suite is unchanged at 466 passing. It reports one failure, `CloudRequest createCloudRequest can skip installing logging`, which is a pre-existing debug-format assertion that reproduces identically on `develop`.

To confirm against a real binary, listen on port 3000, then open the app and watch where the Cloud request lands:

```
node -e 'require("http").createServer((q,s)=>{console.log("HIT",q.method,q.url,q.headers.host);s.end("{}")}).listen(3000)'
```

With 15.20.0 this logs `HIT POST /test-runner-graphql localhost:3000` shortly after launch (while logged in). With this fix the request goes to `cloud.cypress.io` and nothing reaches the listener.

### How has the user experience changed?

Login, the Runs page, and the Debug page work again. No intentional visual change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Regression reported internally in Slack; no public issue. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?




