### PR TITLE
misc: report the overridden cache folder when the binary is missing in CI

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Fixed a regression in [15.18.0](#15-18-0) where pinning a command in the Command Log could leave the AUT snapshot permanently blank, with the pin stuck on. Stopping a run in open mode also no longer clears the AUT. Addressed in [#34502](https://github.com/cypress-io/cypress/pull/34502).
 
+**Misc:**
+
+- Fixed an issue where the error reported in CI when the Cypress binary is missing suggested caching and persisting the default binary cache location, ignoring any [`CYPRESS_CACHE_FOLDER`](https://docs.cypress.io/app/references/advanced-installation#Binary-cache) override. The suggestions now name the directory Cypress actually looked in. Addresses [#23009](https://github.com/cypress-io/cypress/discussions/23009). Addressed in [#34543](https://github.com/cypress-io/cypress/pull/34543).
+
 ## 15.20.0
 
 **Performance:**

--- a/cli/lib/errors.ts
+++ b/cli/lib/errors.ts
@@ -100,8 +100,8 @@ const notInstalledCI = (executable: string): any => {
 
     Reasons it may be missing:
 
-    - You're caching 'node_modules' but are not caching this path: ${util.getCacheDir()}
-    - You ran 'npm install' at an earlier build step but did not persist: ${util.getCacheDir()}
+    - You're caching 'node_modules' but are not caching this path: ${state.getCacheDir()}
+    - You ran 'npm install' at an earlier build step but did not persist: ${state.getCacheDir()}
 
     Properly caching the binary will fix this error and avoid downloading and unzipping Cypress.
 

--- a/cli/test/lib/errors.spec.ts
+++ b/cli/test/lib/errors.spec.ts
@@ -1,5 +1,6 @@
-import { vi, describe, beforeEach, it, expect } from 'vitest'
+import { vi, describe, beforeEach, afterEach, it, expect } from 'vitest'
 import os from 'os'
+import path from 'path'
 import si, { Systeminformation } from 'systeminformation'
 import util from '../../lib/util'
 import { errors, getError, formErrorText } from '../../lib/errors'
@@ -125,6 +126,31 @@ describe('errors', function () {
       const text: string = await formErrorText(errors.invalidSmokeTestDisplayError, 'current message', 'prev message')
 
       expect(text).toMatchSnapshot()
+    })
+  })
+
+  describe('.errors.notInstalledCI', function () {
+    const originalCacheFolder = process.env.CYPRESS_CACHE_FOLDER
+
+    afterEach(() => {
+      if (originalCacheFolder === undefined) {
+        delete process.env.CYPRESS_CACHE_FOLDER
+      } else {
+        process.env.CYPRESS_CACHE_FOLDER = originalCacheFolder
+      }
+    })
+
+    it('names the overridden cache folder in the paths to persist', async () => {
+      const cacheFolder = path.resolve('/tmp', 'custom-cypress-cache')
+
+      process.env.CYPRESS_CACHE_FOLDER = cacheFolder
+
+      const executable = path.join(cacheFolder, '1.2.3', 'Cypress', 'Cypress')
+      const text: string = await formErrorText(errors.notInstalledCI(executable))
+
+      expect(text).toContain(`are not caching this path: ${cacheFolder}`)
+      expect(text).toContain(`did not persist: ${cacheFolder}`)
+      expect(text).not.toContain(util.getCacheDir())
     })
   })
 })


### PR DESCRIPTION
- Closes N/A — no issue exists. Surfaced while investigating [discussion #23009](https://github.com/cypress-io/cypress/discussions/23009) (AWS CodeBuild, binary not found), which went unanswered for four years and was bumped again last month by a second user hitting the same wall.

### Additional details

`notInstalledCI` is the error shown when `cypress run` can't find the binary in CI. It renders three paths, and they didn't agree with each other:

- The **expected binary path** comes from `verify.ts` via `state.getBinaryDir()` → `state.getCacheDir()`, which honors `CYPRESS_CACHE_FOLDER`.
- The two **"Reasons it may be missing"** bullets called `util.getCacheDir()`, a bare `cachedir('Cypress')` that ignores the env var and always returns the platform default.

So a user who sets `CYPRESS_CACHE_FOLDER` was told to cache and persist a directory Cypress never looked in — directly contradicting the expected path printed two lines above. Following the suggestion verbatim caches the wrong path and leaves the build broken, which is exactly the dead end in #23009.

`cli/lib/errors.ts` was the only place in the CLI still using the non-env-aware `util.getCacheDir()` for display; every other call site (`cache.ts`, `install.ts`, `info.ts`, `state.ts`) already uses `state.getCacheDir()`. This change makes the error consistent with the rest. `state` was already imported in `errors.ts`, and `state.ts` imports only `util`, so there's no new import and no cycle.

### Steps to test

`notInstalledCI` only fires against a genuinely missing binary in CI, so the unit test is the practical check:

```bash
cd cli && yarn test-unit -- test/lib/errors.spec.ts
```

To see it fail without the fix, revert the two lines in `cli/lib/errors.ts` to `util.getCacheDir()` and re-run — the new test reports the default cache dir where the override belongs.

### How has the user experience changed?

Rendered output with `CYPRESS_CACHE_FOLDER=/codebuild/cypress-cache`.

**Before** — the bullets name a directory Cypress never checked:

```
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /codebuild/cypress-cache/15.20.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /root/.cache/Cypress
- You ran 'npm install' at an earlier build step but did not persist: /root/.cache/Cypress
```

**After** — all three paths agree:

```
The cypress npm package is installed, but the Cypress binary is missing.

We expected the binary to be installed here: /codebuild/cypress-cache/15.20.0/Cypress/Cypress

Reasons it may be missing:

- You're caching 'node_modules' but are not caching this path: /codebuild/cypress-cache
- You ran 'npm install' at an earlier build step but did not persist: /codebuild/cypress-cache
```

With no `CYPRESS_CACHE_FOLDER` set, `state.getCacheDir()` falls through to the same `util.getCacheDir()` default, so the message is unchanged for everyone not overriding the cache location.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No issue exists; this is a self-contained error-message correction found while investigating discussion #23009. Happy to open a tracking issue if preferred. -->
- [x] Have tests been added/updated? <!-- `notInstalledCI` had no coverage at all; added a regression test in cli/test/lib/errors.spec.ts asserting the bullets honor CYPRESS_CACHE_FOLDER. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No documented behavior changes; the error text now reports the path it already claimed to. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No public API surface touched. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJMPfFavVEzStwrCFenDgZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI error text only; behavior of install/cache is unchanged and default cache paths are unchanged when the env var is unset.
> 
> **Overview**
> When `cypress run` fails in CI because the Cypress binary is missing, the **"Reasons it may be missing"** bullets now use `state.getCacheDir()` instead of `util.getCacheDir()`. That aligns those paths with the expected binary location (which already respected **`CYPRESS_CACHE_FOLDER`**) so users are told to cache and persist the directory Cypress actually uses.
> 
> A regression test in `errors.spec.ts` sets a custom cache folder and asserts the formatted error mentions it. The **15.20.1** changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa5067ee00d0fe0f828cdfc722c8d87264791d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->