### PR TITLE
test: cover cy.contains() with combined special characters

### DIFF
--- a/packages/driver/cypress/e2e/commands/querying/querying.cy.ts
+++ b/packages/driver/cypress/e2e/commands/querying/querying.cy.ts
@@ -1677,6 +1677,46 @@ space
           })
         })
       })
+
+      // https://github.com/cypress-io/cypress/issues/24911
+      // Reproducing this needs `=` and `[` in the same string, so the special
+      // characters are combined here rather than exercised one at a time.
+      describe('combined', () => {
+        const content = 'This is a custom label ~!@#$%^&*()_+=-[]{}\\|:",./? UID'
+
+        it('finds a descendant', () => {
+          const label = $('<label></label>').text(content).appendTo(cy.$$('body'))
+
+          cy.contains('label', content).then(($label) => {
+            expect($label.get(0)).to.eq(label.get(0))
+          })
+        })
+
+        it('finds the subject itself', () => {
+          // With no matching descendant, .contains() filters the subject, which
+          // runs the selector through jQuery's matchesSelector rather than find()
+          const label = $('<label id="combined-chars"></label>').text(content).appendTo(cy.$$('body'))
+
+          cy.get('#combined-chars').contains(content).then(($label) => {
+            expect($label.get(0)).to.eq(label.get(0))
+          })
+        })
+
+        it('asserts on the content', () => {
+          $('<label id="combined-chars-assertion"></label>').text(content).appendTo(cy.$$('body'))
+
+          cy.get('#combined-chars-assertion').should('contain', content)
+        })
+
+        it('reports missing content as not found', (done) => {
+          cy.on('fail', (err) => {
+            expect(err.message).to.include('Expected to find content')
+            done()
+          })
+
+          cy.contains('label', content, { timeout: 100 })
+        })
+      })
     })
 
     describe('.log', () => {


### PR DESCRIPTION
- Adds test to cover https://github.com/cypress-io/cypress/issues/24911 (which is already fixed)

### Additional details

#24911 reported that `cy.contains()` with a punctuation-heavy string failed with `Syntax error, unrecognized expression` rather than a normal not-found error. That bug is already fixed, but nothing in the suite guards it.

The root cause was jQuery 3.1.1's Sizzle, which rewrote selectors inside `matchesSelector`:

```js
expr = expr.replace( rattributeQuotes, "='$1']" )   // jquery 3.1.1 dist, line 1529
```

On the reported label the `=-[]` run became `='-[']`, producing an invalid selector — which is exactly the mangled string shown in the issue. Sizzle dropped that regex in jQuery 3.4.0, so the upgrade from `3.1.1` to `3.4.1` in #29837 (Cypress 13.13.1) fixed it incidentally. `develop` is now on 3.7.1.

Because the failure only triggers when `=` is immediately followed by `[`, the existing `special characters` coverage — which appends one character at a time — cannot reproduce it. This adds a `combined` block using the full string from the issue, covering the three call paths that were affected:

| Test | Path |
| --- | --- |
| `finds a descendant` | `find()` — the literal snippet from the issue report |
| `finds the subject itself` | `querying.ts` subject fallback → `matchesSelector` |
| `asserts on the content` | `chai.ts` `obj.is(selector)` |
| `reports missing content as not found` | absent text hits the same fallback; asserts a clean `Expected to find content` failure |

The last case is the reporter's actual symptom — their label did not match on text, so the fallback ran and threw a parse error instead of a not-found error.

Verified against real Chromium with jQuery 3.1.1, 3.4.1, and 3.7.1: every path except `find()` throws on 3.1.1 and passes on both later versions, so these tests fail against the original bug and pass today.

No production code is changed.

### Steps to test

```
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/querying/querying.cy.ts
```

The four new tests live under `#contains` → `special characters` → `combined`.

### How has the user experience changed?

No change — test-only.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #24911, labeled Triaged -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkLTXjjXsbf13QHq7kw7zg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions to the driver e2e suite; no runtime or API behavior changes.
> 
> **Overview**
> Adds regression coverage for **#24911**, where punctuation-heavy strings (notably `=` immediately before `[`) could make `cy.contains()` throw a jQuery **Syntax error, unrecognized expression** instead of a normal not-found message.
> 
> Under `#contains` → **special characters** → **`combined`**, four tests use the full reporter string and exercise paths the one-character-at-a-time suite cannot hit: descendant `find()`, subject fallback via `matchesSelector`, `should('contain', …)`, and missing content asserting **`Expected to find content`** rather than a selector parse error.
> 
> **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d4931ddb6943bb5705f79025390bef27df2169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->