### PR TITLE
test: cover cy.wait retrying in an afterEach hook after a failure

### DIFF
--- a/packages/driver/cypress/e2e/commands/waiting.cy.js
+++ b/packages/driver/cypress/e2e/commands/waiting.cy.js
@@ -943,6 +943,38 @@ describe('src/cy/commands/waiting', () => {
       return null
     })
 
+    describe('retries in afterEach hook when the test failed', () => {
+      beforeEach(() => {
+        cy.visit('/fixtures/jquery.html')
+      })
+
+      it('yields the aliased request', () => {
+        cy.on('fail', (err) => {
+          expect(err.message).contain('expected true to be false')
+
+          return false
+        })
+
+        expect(true).to.be.false
+      })
+
+      afterEach(() => {
+        const resp = { foo: 'foo' }
+        const win = cy.state('window')
+
+        cy.on('command:retry', _.once(() => {
+          xhrGet(win, '/users?afterEach=1')
+        }))
+
+        cy
+        .intercept(/users/, resp).as('getUsersAfterEach')
+        .wait('@getUsersAfterEach').then((xhr) => {
+          expect(xhr.request.url).to.include('/users?afterEach=1')
+          expect(xhr.response.body).to.deep.eq(resp)
+        })
+      })
+    })
+
     describe('errors', () => {
       describe('invalid 1st argument', {
         defaultCommandTimeout: 50,


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/26983

### Additional details

While verifying whether #26983 still reproduces, I found it was already fixed but never closed, and that the fix has a coverage gap.

`ended()` in the retry loop used to bail on `state('error')`:

```js
return state('canceled') || state('error') || runnableHasChanged()
```

`cy.fail()` sets `state('error')` and state is not cleared until the next test begins, so once a test failed, every retrying command in the trailing `after`/`afterEach` hook short-circuited on its first tick. For `cy.wait()` that meant resolving with `undefined` instead of the intercepted request, which is what produced the `Cannot destructure property 'response' of 'undefined'` reported in #26983.

#30831 removed that condition and shipped in `14.0.2`, but it referenced only #2831 and added regression tests for `.click()` and `.type()` — not `cy.wait()`. This adds that case so the wait behavior is pinned down too.

No production code changes; test-only, so no changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only addition with no changes to driver or retry logic; risk is limited to CI/runtime of the new spec case.
> 
> **Overview**
> Adds a regression test in `waiting.cy.js` so **`cy.wait()`** on a route alias still retries and yields the intercepted XHR when it runs in an **`afterEach`** hook after the test body has failed.
> 
> The scenario matches existing coverage for **`.click()`** and **`.type()`**: the `it` block intentionally fails (with `cy.on('fail')` swallowing the assertion error), then the hook sets up **`intercept`**, triggers the request on **`command:retry`**, and asserts **`wait('@alias')`** returns the expected request/response instead of **`undefined`**.
> 
> **No production or driver runtime changes**—test-only, closing the coverage gap for [#26983](https://github.com/cypress-io/cypress/issues/26983) after the retry-loop fix in 14.0.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ef9becc1f8648459396646e996147d1d644e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/waiting.cy.js
```

The new test lives in the `retries in afterEach hook when the test failed` block. To confirm it actually reproduces the original bug, re-add the removed condition to `ended()` in `packages/driver/src/cy/retries.ts`:

```js
return state('canceled') || state('error') || runnableHasChanged()
```

rebuild the runner (`yarn workspace @packages/runner build`) and re-run. The test fails with `Cannot read properties of undefined (reading 'request')` — `cy.wait()` yielding `undefined`, matching the issue report. It passes on `develop` as-is.

### How has the user experience changed?

No change.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNK9HxwwBU9VRQjNFQ68ak)_