### PR TITLE
feat: report the machine and cloud user ids with tap CLI events

### DIFF
--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -68,11 +68,19 @@ export interface ResolveInstanceOptions {
   probeTimeoutMs?: number
 }
 
-let lastResolvedInstanceId: string | null = null
+export interface ResolvedInstanceIdentity {
+  instanceId: string
+  machineId: string | null
+  userId: string | null
+}
+
+let lastResolvedIdentity: ResolvedInstanceIdentity | null = null
 
 // Read rather than threaded through every caller: each tap command resolves its
 // own instance, several of them below this module.
-export const resolvedInstanceId = (): string | null => lastResolvedInstanceId
+export const resolvedInstanceIdentity = (): ResolvedInstanceIdentity | null => lastResolvedIdentity
+
+export const resolvedInstanceId = (): string | null => lastResolvedIdentity?.instanceId ?? null
 
 const describeFilter = (instance: number | undefined): string => {
   if (instance !== undefined) {
@@ -136,7 +144,7 @@ export const resolveLiveInstance = async (options: ResolveInstanceOptions): Prom
 
   const { instance, reason } = selectInstance(live, options)
 
-  lastResolvedInstanceId = instance.instanceId
+  lastResolvedIdentity = { instanceId: instance.instanceId, machineId: instance.machineId, userId: instance.userId }
 
   return { instance, reason, candidateCount: live.length }
 }
@@ -163,7 +171,7 @@ export const resolveInstance = async (options: ResolveInstanceOptions): Promise<
 
   const { instance: selected, reason } = selectInstance(ready, options)
 
-  lastResolvedInstanceId = selected.instanceId
+  lastResolvedIdentity = { instanceId: selected.instanceId, machineId: selected.machineId, userId: selected.userId }
 
   return { instance: selected, reason, candidateCount: ready.length }
 }

--- a/cli/lib/cypress-instances/liveness.ts
+++ b/cli/lib/cypress-instances/liveness.ts
@@ -57,7 +57,7 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       return null
     }
 
-    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown }
+    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown, machineId?: unknown, userId?: unknown }
 
     if (live.instanceId !== record.instanceId) {
       return null
@@ -70,6 +70,8 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       ...record,
       cdpBrowserWsUrl: attached ? cdpBrowserWsUrl : null,
       browserName: attached && typeof live.browserName === 'string' ? live.browserName : null,
+      machineId: typeof live.machineId === 'string' ? live.machineId : null,
+      userId: typeof live.userId === 'string' ? live.userId : null,
     }
   } catch (err) {
     debug('liveness probe failed for pid %d on port %d: %o', record.pid, record.serverPort, err)

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -2,7 +2,7 @@ import Debug from 'debug'
 import { randomUUID } from 'crypto'
 
 import util, { DEVELOPMENT_VERSION } from '../util'
-import { resolvedInstanceId } from '../cypress-instances'
+import { resolvedInstanceIdentity } from '../cypress-instances'
 import { detectAgent } from '@packages/agent-info'
 import type { ReportedInvocation } from './reported-invocation'
 
@@ -89,17 +89,24 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
       return
     }
 
+    const identity = resolvedInstanceIdentity()
+
     const payload = {
       command: trace.command,
       flags: trace.flags.slice(0, MAX_REPORTED_FLAGS),
       agent: detectAgent(),
-      instanceId: resolvedInstanceId() ?? undefined,
+      instanceId: identity?.instanceId ?? undefined,
+      userId: identity?.userId ?? undefined,
       exitCode,
       errorCode: trace.errorCode,
       durationMs: Date.now() - trace.startedAt,
     }
 
-    const url = eventCollectorUrl()
+    // The identity travels in the instance probe response, so an invocation that
+    // never resolved an instance has no machineId and stays on the anonymous
+    // collector, mirroring EventCollectorActions.recordEvent app-side.
+    const machineId = identity?.machineId ?? undefined
+    const url = eventCollectorUrl(machineId !== undefined)
 
     await fetch(url, {
       method: 'POST',
@@ -107,7 +114,7 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
         'Content-Type': 'application/json',
         'x-cypress-version': cypressVersion,
       },
-      body: JSON.stringify({ campaign: CAMPAIGN, medium: MEDIUM, messageId: trace.messageId, payload }),
+      body: JSON.stringify({ campaign: CAMPAIGN, medium: MEDIUM, messageId: trace.messageId, machineId, payload }),
       signal: AbortSignal.timeout(POST_TIMEOUT_MS),
     })
 

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -15,6 +15,7 @@ import {
   getInstancesDir,
   pruneDeadInstanceRecords,
   resolvedInstanceId,
+  resolvedInstanceIdentity,
   CypressInstanceError,
 } from '../../lib/cypress-instances'
 
@@ -167,14 +168,24 @@ describe('lib/cypress-instances', () => {
     }
 
     it('resolves the record with the live CDP state and browser name when the instance echoes the instanceId', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome' } })
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome', machineId: 'machine-hash', userId: 'cloud-user-1' } })
       const record = recordFor(port)
 
       expect(await verifyInstanceRecord(record)).toEqual({
         ...record,
         cdpBrowserWsUrl: CDP_WS_URL,
         browserName: 'Chrome',
+        machineId: 'machine-hash',
+        userId: 'cloud-user-1',
       })
+    })
+
+    it('normalizes identity fields an older instance omits (or junks) to null', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, machineId: 42 } })
+      const live = await verifyInstanceRecord(recordFor(port))
+
+      expect(live!.machineId).toBeNull()
+      expect(live!.userId).toBeNull()
     })
 
     it('nulls the browser name when the CDP endpoint is unreachable', async () => {
@@ -316,6 +327,19 @@ describe('lib/cypress-instances', () => {
       await resolveInstance({ cwd: PROJECT })
 
       expect(resolvedInstanceId()).toBe(INSTANCE_ID)
+    })
+
+    it('remembers the identity the probe carried for the instance it selected', async () => {
+      const port = await startFakeInstance({
+        respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, machineId: 'machine-hash', userId: 'cloud-user-1' },
+      })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      await resolveInstance({ cwd: PROJECT })
+
+      expect(resolvedInstanceIdentity()).toEqual({ instanceId: INSTANCE_ID, machineId: 'machine-hash', userId: 'cloud-user-1' })
     })
 
     it('reaps the leftover record and throws NO_INSTANCE when the only match’s process is dead', async () => {

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -59,6 +59,8 @@ export const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): Read
   testingType: 'e2e',
   cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
   browserName: 'Chrome',
+  machineId: null,
+  userId: null,
   ...overrides,
 })
 

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -385,6 +385,8 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      machineId: null,
+      userId: null,
       ...overrides,
     })
 
@@ -504,6 +506,8 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      machineId: null,
+      userId: null,
       ...overrides,
     })
 
@@ -715,6 +719,8 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      machineId: null,
+      userId: null,
       ...overrides,
     })
 
@@ -913,6 +919,8 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      machineId: null,
+      userId: null,
       ...overrides,
     })
 

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { beginTapTrace, noteTapCommand, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
-import { resolvedInstanceId } from '../../../lib/cypress-instances'
+import { resolvedInstanceIdentity } from '../../../lib/cypress-instances'
 import { detectAgent } from '@packages/agent-info'
 import util, { DEVELOPMENT_VERSION } from '../../../lib/util'
 
@@ -21,7 +21,7 @@ vi.mock('../../../lib/cypress-instances', async (importActual) => {
 
   return {
     ...actual,
-    resolvedInstanceId: vi.fn().mockReturnValue(null),
+    resolvedInstanceIdentity: vi.fn().mockReturnValue(null),
   }
 })
 
@@ -51,7 +51,7 @@ describe('lib/tap/events', () => {
     vi.stubGlobal('fetch', fetchMock)
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     delete process.env.CYPRESS_INTERNAL_ENV
-    vi.mocked(resolvedInstanceId).mockReturnValue(null)
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
     vi.mocked(util.pkgVersion).mockReturnValue('15.0.0')
     dateNow.mockReturnValue(1_000)
@@ -90,7 +90,7 @@ describe('lib/tap/events', () => {
   })
 
   it('carries the id of the instance the command resolved', async () => {
-    vi.mocked(resolvedInstanceId).mockReturnValue('a1b2c3d4-0000-4000-8000-000000000000')
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'a1b2c3d4-0000-4000-8000-000000000000', machineId: null, userId: null })
 
     await reportTapTrace(0)
 
@@ -101,6 +101,41 @@ describe('lib/tap/events', () => {
     await reportTapTrace(1)
 
     expect(posted(fetchMock).payload).not.toHaveProperty('instanceId')
+  })
+
+  it('reports to the machine collector with the machine id the instance carried', async () => {
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: null })
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/machine-collect')
+    expect(posted(fetchMock).machineId).toBe('machine-hash')
+    expect(posted(fetchMock).payload).not.toHaveProperty('machineId')
+  })
+
+  it('stays anonymous when the instance reports no machine id', async () => {
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: null, userId: null })
+
+    await reportTapTrace(0)
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://cloud.cypress.io/anon-collect')
+    expect(posted(fetchMock)).not.toHaveProperty('machineId')
+  })
+
+  it('carries the cloud user id of the instance the command resolved', async () => {
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: 'cloud-user-1' })
+
+    await reportTapTrace(0)
+
+    expect(posted(fetchMock).payload).toMatchObject({ userId: 'cloud-user-1' })
+  })
+
+  it('omits the user id when the instance has no logged-in user', async () => {
+    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: null })
+
+    await reportTapTrace(0)
+
+    expect(posted(fetchMock).payload).not.toHaveProperty('userId')
   })
 
   it('carries the agent that invoked the command', async () => {

--- a/cli/test/lib/tap/instance-gql.spec.ts
+++ b/cli/test/lib/tap/instance-gql.spec.ts
@@ -13,6 +13,8 @@ const instance: LiveInstanceState = {
   testingType: 'e2e',
   cdpBrowserWsUrl: null,
   browserName: null,
+  machineId: null,
+  userId: null,
 }
 
 const request = {

--- a/cli/test/lib/tap/tap-session.spec.ts
+++ b/cli/test/lib/tap/tap-session.spec.ts
@@ -62,6 +62,8 @@ const makeRecord = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceS
     testingType: 'e2e',
     cdpBrowserWsUrl: BROWSER_WS_URL,
     browserName: 'Chrome',
+    machineId: null,
+    userId: null,
     ...overrides,
   }
 }

--- a/packages/cypress-instances/lib/index.ts
+++ b/packages/cypress-instances/lib/index.ts
@@ -33,6 +33,10 @@ export interface LiveInstanceState extends CypressInstance {
   cdpBrowserWsUrl: string | null
   /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
   browserName: string | null
+  /** sha256 hash of the OS machine GUID (node-machine-id), or `null` when unresolvable. */
+  machineId: string | null
+  /** Cloud user id of the logged-in user, or `null` when logged out or not yet resolved. */
+  userId: string | null
 }
 
 export interface ReadyInstanceState extends LiveInstanceState {

--- a/packages/data-context/src/actions/AuthActions.ts
+++ b/packages/data-context/src/actions/AuthActions.ts
@@ -50,6 +50,16 @@ export class AuthActions {
       operationVariables: {},
     })
 
+    const viewerId = result.data?.cloudViewer?.id
+
+    if (viewerId) {
+      this.ctx.update((coreData) => {
+        if (coreData.user) {
+          coreData.user.id = viewerId
+        }
+      })
+    }
+
     if (!result.data?.cloudViewer && !result.error?.networkError) {
       this.ctx.coreData.user = null
       await this.logout()
@@ -118,6 +128,11 @@ export class AuthActions {
     }
 
     this.setAuthenticatedUser(user)
+
+    // The login callback carries no cloud user id; checkAuth backfills it.
+    this.checkAuth().catch((err) => {
+      this.ctx.logTraceError(err)
+    })
 
     this.#cancelActiveLogin = null
 

--- a/packages/data-context/test/unit/actions/AuthActions.spec.ts
+++ b/packages/data-context/test/unit/actions/AuthActions.spec.ts
@@ -26,6 +26,15 @@ describe('AuthActions', () => {
       expect(ctx.coreData.user).toEqual(expect.objectContaining({ name: 'steve', email: 'steve@apple.com', authToken: 'foo' }))
     })
 
+    it('kicks off a checkAuth to backfill the cloud user id', async () => {
+      const checkAuth = jest.spyOn(actions, 'checkAuth').mockResolvedValue(undefined)
+
+      // @ts-expect-error - incorrect number of arguments
+      await actions.login()
+
+      expect(checkAuth).toHaveBeenCalled()
+    })
+
     it('focuses the main window if there is no activeBrowser', async () => {
       ctx.coreData.activeBrowser = null
 
@@ -338,6 +347,47 @@ describe('AuthActions', () => {
       })
 
       expect(result.data?.autoProvisionedProjectId).toBe('my-project')
+    })
+  })
+
+  describe('.checkAuth', () => {
+    let ctx: DataContext
+    let actions: AuthActions
+
+    beforeEach(() => {
+      ctx = createTestDataContext('open')
+      ctx.coreData.user = { name: 'steve', email: 'steve@apple.com', authToken: 'foo' }
+      actions = new AuthActions(ctx)
+    })
+
+    it('backfills the cloud user id onto the cached user', async () => {
+      jest.spyOn(ctx.cloud, 'executeRemoteGraphQL').mockResolvedValue({
+        data: { cloudViewer: { id: 'cloud-user-1', email: 'steve@apple.com', fullName: 'steve' } },
+      } as any)
+
+      await actions.checkAuth()
+
+      expect(ctx.coreData.user?.id).toBe('cloud-user-1')
+    })
+
+    it('logs out instead when the cloud reports no viewer', async () => {
+      jest.spyOn(ctx.cloud, 'executeRemoteGraphQL').mockResolvedValue({ data: { cloudViewer: null } } as any)
+
+      await actions.checkAuth()
+
+      expect(ctx.coreData.user).toBeNull()
+    })
+
+    it('keeps the user logged in and id-less on a network error', async () => {
+      jest.spyOn(ctx.cloud, 'executeRemoteGraphQL').mockResolvedValue({
+        data: null,
+        error: { networkError: new Error('offline') },
+      } as any)
+
+      await actions.checkAuth()
+
+      expect(ctx.coreData.user).toEqual(expect.objectContaining({ name: 'steve' }))
+      expect(ctx.coreData.user?.id).toBeUndefined()
     })
   })
 

--- a/packages/server/lib/cypress-instances.ts
+++ b/packages/server/lib/cypress-instances.ts
@@ -53,7 +53,9 @@ export const cypressInstances = {
       testingType,
     }
 
-    currentState = { ...record, cdpBrowserWsUrl: null, browserName: null }
+    // machineId/userId are read fresh from the data context when the probe route
+    // answers; the in-memory state only carries the browser attachment.
+    currentState = { ...record, cdpBrowserWsUrl: null, browserName: null, machineId: null, userId: null }
 
     try {
       await persist(record)

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -254,14 +254,22 @@ export const createCommonRoutes = ({
   // external tool can attach to; the record is only written in open mode, so don't
   // expose the probe route for headless `cypress run`.
   if (!config.isTextTerminal) {
-    router.get(`${INSTANCES_ROUTE_PREFIX}:instanceId`, (req, res) => {
+    router.get(`${INSTANCES_ROUTE_PREFIX}:instanceId`, async (req, res) => {
       const state = cypressInstances.getCurrent()
 
       if (!state || req.params.instanceId !== state.instanceId) {
         return res.sendStatus(404)
       }
 
-      return res.json(state)
+      // Identity is read at probe time rather than stored on the state: the
+      // logged-in user can change over the instance's lifetime.
+      const ctx = getCtx()
+
+      return res.json({
+        ...state,
+        machineId: await ctx.coreData.machineId.catch(() => null),
+        userId: ctx.coreData.user?.id ?? null,
+      })
     })
   }
 

--- a/packages/server/test/unit/cypress-instances_spec.ts
+++ b/packages/server/test/unit/cypress-instances_spec.ts
@@ -161,6 +161,8 @@ describe('lib/cypress-instances', () => {
         ...await fs.readJson(recordPath),
         cdpBrowserWsUrl: null,
         browserName: null,
+        machineId: null,
+        userId: null,
       })
     })
   })


### PR DESCRIPTION
- Part of [AW-31](https://cypress-io.atlassian.net/browse/AW-31). Stacks on [#34521](https://github.com/cypress-io/cypress/pull/34521), which introduced the tap CLI event beacon this enriches.

### Additional details

The tap events below this slice are anonymous. To join tap usage to machines and Cloud accounts, each event now carries the machine identifier and, when the user is logged in, their cloud user id.

**The identity travels in the instance probe response.** The probe (`GET /__cypress/instances/:instanceId`) is the established seam for probe-carried live state (`cdpBrowserWsUrl`, `browserName`), and the CLI already hits it on every instance resolution. The server enriches the response at probe time with `machineId` (the `node-machine-id` hash the app already computes, memoized on `coreData`) and `userId` (`coreData.user?.id`), read fresh because login state changes over an instance's lifetime. The CLI gets both for free on the resolution it does anyway: no new dependency, no extra round trip, and the values are exactly what the app itself would report.

**The cloud user id existed nowhere locally.** The cache file stores only token, name and email, but `AuthActions.checkAuth` was already fetching `cloudViewer { id }` and throwing the id away. It now writes the id back onto `coreData.user`, and interactive login kicks off the same backfill (the OAuth callback carries no id). Logout already nulls the user, so `userId` clears automatically. A cold `cloudViewer` cache can briefly report no `userId` for a logged-in user; accepted for analytics.

**Wire shape mirrors `EventCollectorActions.recordEvent`.** When the probe returned a `machineId`, the event posts to `/machine-collect` with it as a top-level field; `userId` rides inside the payload next to `instanceId`. An invocation that never resolved an instance (usage errors, `NO_INSTANCE`) stays on `/anon-collect`. `userId` is the Cloud GraphQL node id, sent as-is.

Exposure is unchanged in kind: the probe route already requires the unguessable per-process instanceId and already serves the more sensitive CDP ws url to local callers. Compatibility both ways: an older server omits the fields and the CLI normalizes them to null (anonymous event); an older CLI ignores the extra JSON fields. The disk record schema is untouched (no `SCHEMA_VERSION` bump).

| new field | value |
|---|---|
| `machineId` (top-level) | sha256 of the OS machine GUID, identical to the `x-machine-id` the app sends the Cloud; absent when no instance resolved |
| `payload.userId` | cloud user id of the account logged into that instance; absent when logged out, when nothing resolved, or until `cloudViewer` has answered |

### Steps to test

With a Cypress instance open (`yarn dev`) and logged in:

```bash
# the probe itself now carries the identity
curl http://127.0.0.1:<serverPort>/__cypress/instances/<instanceId>

# events land on machine-collect with a top-level machineId and payload.userId
nc -l 3000   # terminal 1
CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV=development node cli/bin/cypress tap status   # terminal 2
```

Logged out, the probe reports `userId: null` and the event omits it. With no instance running, the event stays on `/anon-collect` with neither id. `CYPRESS_CRASH_REPORTS=0` still sends nothing at all.

### How has the user experience changed?

No change to any command's output, exit code or timing. The tap event stops being anonymous when an instance answered: it links to the machine (the same `node-machine-id` hash the app sends) and, when logged in, to the cloud user. It still never carries typed values. `CYPRESS_CRASH_REPORTS=0` turns all of it off.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- AW-31 -->
- [x] Have tests been added/updated? <!-- events.spec.ts identity cases, cypress-instances.spec.ts probe parsing/caching, AuthActions.spec.ts checkAuth backfill, server cypress-instances_spec.ts -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

No `cli/CHANGELOG.md` entry: this lands inside the unreleased `feat/tap-cli-integration` stack, which carries the changelog for the tap CLI.

### Verification run locally

- `cli`: `test/lib/tap`, `test/lib/exec/tap*` and `cypress-instances.spec.ts`, 411 passing (405 at the slice below; the 6 new cases cover endpoint selection, top-level `machineId`, `userId` present/omitted, and older-server probe responses).
- `@packages/data-context` `AuthActions.spec.ts` 26 passing (id backfill, no-viewer logout, network-error tolerance); `@packages/server` `cypress-instances_spec.ts` 16 passing; `@packages/cypress-instances` 9 passing.
- `yarn check-ts` clean, lint clean on every touched package.

### Open item

The Cloud collector needs to accept the new `userId` payload key; `machineId` uses the top-level field `/machine-collect` already accepts. Worth confirming with whoever owns the collector.


[AW-31]: https://cypress-io.atlassian.net/browse/AW-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth state backfill and analytics payload shape; probe exposure is comparable to existing local instance data, but Cloud must accept the new userId field.
> 
> **Overview**
> **Tap CLI analytics** can now be tied to a machine and Cloud account when a command resolves a running open-mode instance. The instance probe response gains **`machineId`** and **`userId`**, parsed by the CLI and cached as **`resolvedInstanceIdentity`** (replacing instance-id-only memory). **`reportTapTrace`** posts to **`/machine-collect`** with a top-level **`machineId`** when present, adds **`payload.userId`** when logged in, and stays on **`/anon-collect`** when no instance or no machine id—aligned with app **`EventCollectorActions`**.
> 
> The **open-mode probe route** enriches JSON at request time from **`coreData.machineId`** and **`coreData.user?.id`** so login changes are reflected without bumping the on-disk instance record schema. **`AuthActions.checkAuth`** now writes **`cloudViewer.id`** onto the cached user; **login** triggers **`checkAuth`** afterward because OAuth does not supply the id locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ec49cd43ddae206c2927d31b390914a902bd74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->