### PR TITLE
chore: take encoding.cy.ts green when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -335,9 +335,10 @@ jobs:
       parallelism: 1
       record-group-suffix: '-remediated'
       # #34467 continue unmodified CDP Fetch responses; #34465 extra-target shared
-      # middleware. Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
+      # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386).
+      # Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
       # never settles on the extra target's session. Add it here once that is fixed.
-      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts
+      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts
       requires:
         - ready-to-test
   - driver-integration-tests-electron:

--- a/packages/driver/cypress.config.ts
+++ b/packages/driver/cypress.config.ts
@@ -6,6 +6,9 @@ export const baseConfig: Cypress.ConfigOptions = {
   projectId: 'ypt4pf',
   experimentalMemoryManagement: true,
   experimentalWebKitSupport: true,
+  expose: {
+    PROXY_DISABLED: process.env.CYPRESS_INTERNAL_DISABLE_PROXY === '1',
+  },
   env: {
     CI: process.env.CI,
     CY_ENV_FOO: 'foo',

--- a/packages/driver/cypress/e2e/e2e/encoding.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/encoding.cy.ts
@@ -19,10 +19,13 @@ function waitAndAssertInterceptions (alias: string, contentEncoding: string) {
     interceptions.forEach((interception) => {
       expect(interception.response?.statusCode).to.eq(200)
 
-      if (Cypress.expose('PROXY_DISABLED')) {
-        // NOTE: accepted MITM → CDP drift (#34554): the interception carries a
-        // decoded body, so content-encoding is honestly absent. MITM reports the
-        // wire encoding on a body that no longer has it.
+      // NOTE: accepted MITM → CDP drift (#34554): browser-fetched responses reach
+      // net-stubbing already decoded, so content-encoding is honestly absent. The
+      // document is exempt — an intercept-matched visit is still resolved Node-side
+      // through the MITM pipeline, which reports the wire encoding on a decoded body.
+      const isBrowserFetched = Cypress.expose('PROXY_DISABLED') && !interception.request.url.endsWith('/html')
+
+      if (isBrowserFetched) {
         expect(interception.response?.headers?.['content-encoding']).to.be.undefined
       } else {
         expect(interception.response?.headers?.['content-encoding']).to.eq(contentEncoding)

--- a/packages/driver/cypress/e2e/e2e/encoding.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/encoding.cy.ts
@@ -18,7 +18,15 @@ function waitAndAssertInterceptions (alias: string, contentEncoding: string) {
   cy.wait([`@${alias}`, `@${alias}`, `@${alias}`]).then((interceptions) => {
     interceptions.forEach((interception) => {
       expect(interception.response?.statusCode).to.eq(200)
-      expect(interception.response?.headers?.['content-encoding']).to.eq(contentEncoding)
+
+      if (Cypress.expose('PROXY_DISABLED')) {
+        // NOTE: accepted MITM → CDP drift (#34554): the interception carries a
+        // decoded body, so content-encoding is honestly absent. MITM reports the
+        // wire encoding on a body that no longer has it.
+        expect(interception.response?.headers?.['content-encoding']).to.be.undefined
+      } else {
+        expect(interception.response?.headers?.['content-encoding']).to.eq(contentEncoding)
+      }
     })
   })
 }
@@ -163,9 +171,17 @@ describe('encoding', () => {
       // The request will be successful but since the content-encoding is br,
       // the browser will fail to decode
       cy.wait('@brJs').then((interception) => {
-        expect(interception.response?.statusCode).to.eq(200)
-        expect(interception.response?.headers?.['content-encoding']).to.eq('br')
-        expect(interception.request.headers['accept-encoding']).to.eq('gzip, deflate')
+        if (Cypress.expose('PROXY_DISABLED')) {
+          // NOTE: accepted MITM → CDP drift (#34384): the netstack rejects this br
+          // response before CDP emits any metadata-bearing event, so cy.intercept
+          // can only observe the request phase.
+          expect(interception.request).to.exist
+          expect(interception.response).to.be.undefined
+        } else {
+          expect(interception.response?.statusCode).to.eq(200)
+          expect(interception.response?.headers?.['content-encoding']).to.eq('br')
+          expect(interception.request.headers['accept-encoding']).to.eq('gzip, deflate')
+        }
       })
 
       // Assert that the encoding-js element is still gzip since br failed to decode
@@ -173,6 +189,23 @@ describe('encoding', () => {
     })
 
     it('fails when brotli is requested due to insecure host', (done) => {
+      if (Cypress.expose('PROXY_DISABLED')) {
+        // NOTE: accepted MITM → CDP drift (#34386): buffered cy.visit documents are
+        // fetched Node-side and fulfilled as identity bytes, so the browser never sees
+        // an encoding to reject and the document loads. Subresources stay
+        // browser-fetched, so br js and css still fail the insecure-host policy.
+        cy.visit('http://www.foobar.com:3500/encoding/br/html')
+
+        cy.get('#encoding-test').should('contain.text', expectedText('br', 'html'))
+        cy.get('#encoding-js').should('have.text', '')
+        cy.get('#encoding-test').then(($el) => {
+          expect(getComputedStyle($el[0]).fontSize).not.to.eq('42px')
+          done()
+        })
+
+        return
+      }
+
       cy.visit(`http://www.foobar.com:3500/encoding/br/html`, { timeout: 500 })
 
       // in firefox, the browser displays the encoded response whereas in other browsers, it fails to load the page
@@ -193,6 +226,23 @@ describe('encoding', () => {
     })
 
     it('fails even when brotli is explicitly requested in the accept-encoding header', (done) => {
+      if (Cypress.expose('PROXY_DISABLED')) {
+        // NOTE: accepted MITM → CDP drift (#34386): buffered cy.visit documents are
+        // fetched Node-side and fulfilled as identity bytes, so the browser never sees
+        // an encoding to reject and the document loads. Subresources stay
+        // browser-fetched, so br js and css still fail the insecure-host policy.
+        cy.visit('http://www.foobar.com:3500/encoding/br/html', { headers: { 'Accept-Encoding': 'br' } })
+
+        cy.get('#encoding-test').should('contain.text', expectedText('br', 'html'))
+        cy.get('#encoding-js').should('have.text', '')
+        cy.get('#encoding-test').then(($el) => {
+          expect(getComputedStyle($el[0]).fontSize).not.to.eq('42px')
+          done()
+        })
+
+        return
+      }
+
       cy.visit(`http://www.foobar.com:3500/encoding/br/html`, { timeout: 500, headers: { 'Accept-Encoding': 'br' } })
 
       // in firefox, the browser displays the encoded response whereas in other browsers, it fails to load the page


### PR DESCRIPTION
- Closes #34557
- Closes #34554
- Closes #34384
- Closes #34386

### Additional details

`encoding.cy.ts` was 10/17 proxy-off. All seven failures are accepted MITM → CDP drifts, already diagnosed and ruled on, and the pipeline fixes they were waiting on landed in #34424 and #34535. So there's no product code here: this pins each pipeline's real contract and promotes the spec into the always-on remediated job.

Expectations are gated on `Cypress.expose('PROXY_DISABLED')`, wired up from `CYPRESS_INTERNAL_DISABLE_PROXY` in the driver's `cypress.config.ts`.

| Drift | Tests | Contract pinned proxy-off |
| --- | --- | --- |
| #34554 | 4 | **Browser-fetched** responses reach net-stubbing already decoded, so `content-encoding` is **absent** — asserted rather than skipped, so the contract is pinned. The buffered document is exempt: an intercept-matched visit is still resolved Node-side through the MITM pipeline, so it keeps the wire header on a decoded body. MITM is unchanged. |
| #34384 | 1 | The netstack rejects the response before any metadata-bearing CDP event fires, so only the request phase is observable and `interception.response` stays `undefined`. |
| #34386 | 2 | Buffered `cy.visit` documents are fetched Node-side and fulfilled as identity bytes, so the document loads. Its br subresources are browser-fetched and still fail the insecure-host policy — production-exact. |

Two notes for review:

- **#34384's `interception.error` item is descoped, not implemented.** It needs a design call rather than an implementation pass — the CDP pipeline skips `SendToDriver` on errors because that path keys off `browserPreRequest`, absent with correlation off. Ergonomic gap, not a correctness one, and orthogonal to this spec. [Rationale on the issue](https://github.com/cypress-io/cypress/issues/34384#issuecomment-5253179013); tracked as #34565.
- **The two #34386 test titles still say "fails when brotli…"** while the proxy-off branch asserts a load. Kept for Cloud test-history continuity, with the NOTE comments carrying the explanation. Happy to rename them if you'd prefer transport-neutral titles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI configuration only; no runtime product behavior changes and MITM paths are untouched.
> 
> **Overview**
> Makes **`encoding.cy.ts`** pass in the always-on **proxy-disabled (CDP-remediated)** CI job by documenting accepted MITM → CDP behavioral differences in the spec, without changing product code.
> 
> **`Cypress.expose('PROXY_DISABLED')`** is wired from **`CYPRESS_INTERNAL_DISABLE_PROXY`** in the driver **`cypress.config.ts`**, and encoding tests branch on it for three pinned drifts: browser-fetched intercepts omit **`content-encoding`** (#34554), some insecure-host br JS intercepts expose only the request phase (#34384), and buffered **`cy.visit`** on insecure br HTML loads the document while subresources still fail (#34386). MITM assertions are unchanged.
> 
> **`encoding.cy.ts`** is added to the **`driver-integration-tests-chrome-cdp-remediated`** (and related) workflow specs so both pipelines enforce their contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99551fb6996e9f0957d5d7f4c17a1a4859a2a262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
cd packages/driver
yarn cypress:run --browser chrome --spec cypress/e2e/e2e/encoding.cy.ts
CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run --browser chrome --spec cypress/e2e/e2e/encoding.cy.ts
```

17/17 on both. I have not run either locally, so `driver-integration-tests-chrome-cdp-remediated` on this PR — which this change adds the spec to — is the first proxy-off signal. The MITM driver jobs cover the other branch of each gate.

### How has the user experience changed?

No change. The proxy-disabled pipeline isn't user-reachable yet, and MITM behavior and assertions are untouched.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change; the drifts are logged for the HTTP/2 pipeline's future migration notes. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
