### PR TITLE
chore: intercept service worker sessions when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -335,10 +335,11 @@ jobs:
       parallelism: 1
       record-group-suffix: '-remediated'
       # #34467 continue unmodified CDP Fetch responses; #34465 extra-target shared
-      # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386).
-      # Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
-      # never settles on the extra target's session. Add it here once that is fixed.
-      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts
+      # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386);
+      # #34555 service worker session interception. Excludes downloads_basic_auth.cy.ts
+      # — #34512 Network.enable never settles on the extra target's session. Add it
+      # here once that is fixed.
+      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js
       requires:
         - ready-to-test
   - driver-integration-tests-electron:
@@ -348,10 +349,10 @@ jobs:
       require-opt-in: false
       parallelism: 1
       record-group-suffix: '-remediated'
-      # #34465 extra-target shared middleware. Excludes
-      # downloads_basic_auth.cy.ts — #34512 Network.enable never settles on the
-      # extra target's session. Add it here once that is fixed.
-      spec: cypress/e2e/cypress/downloads.cy.ts
+      # #34465 extra-target shared middleware; #34555 service worker session
+      # interception. Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
+      # never settles on the extra target's session. Add it here once that is fixed.
+      spec: cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/service-worker.cy.js
       requires:
         - ready-to-test
   - unit-tests-proxy-disabled:

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -20,6 +20,16 @@ type CdpFetchRequest = Protocol.Fetch.RequestPausedEvent['request']
 const RESPONSE_PAUSE_TIMEOUT_MS = 30000
 const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308]
 
+// Shared by every session this transport enables so none of them can drift
+// into pausing a different set of requests than the others.
+const FETCH_PATTERNS: Protocol.Fetch.EnableRequest = {
+  patterns: [{
+    requestStage: 'Request',
+  }, {
+    requestStage: 'Response',
+  }],
+}
+
 // CDP refuses Fetch.getResponseBody for a pause in the redirect-received state,
 // and documents a redirect status plus a location header as the way to tell that
 // state apart from response-received. Drift from MITM: redirect bodies are
@@ -159,16 +169,40 @@ export class CdpFetchTransport {
   }
 
   /**
-   * Enables the CDP Fetch domain and starts intercepting requests.
+   * Enables the Fetch domain on a single CDP session.
    *
-   * This transport must be the sole owner of the Fetch domain on its CDP
-   * session. `Fetch.enable` is not additive: the last call on a session
-   * replaces the pattern list, while `Fetch.requestPaused` handlers stack.
-   * Enabling this alongside `cdp_automation._handlePausedRequests` on the
-   * same session clobbers patterns and races `continueRequest` calls, which
-   * can drop the `X-Cypress-Is-AUT-Frame` header or hang document requests
-   * until the response-pause timeout. Coordinating the two owners is out of
-   * scope; do not enable both on one session.
+   * `Fetch.enable` is scoped to the session it is sent on. Omitting
+   * `sessionId` enables the connection's own session — the target this
+   * transport was constructed for, plus its subframes — and reaches nothing
+   * else. Sibling sessions on the same connection keep their own Fetch state,
+   * so each one whose traffic must run the middleware onion needs its own
+   * call; without it, that session's requests never pause and go straight to
+   * the network.
+   *
+   * Only the enable is per-session. Pauses from every enabled session arrive
+   * on the shared connection carrying their own `sessionId`, which
+   * `interceptRequest`/`resolveResponse` thread back through each reply, so
+   * one pair of handlers serves all of them.
+   *
+   * Within a session, enabling is not additive: the last call replaces the
+   * pattern list (while `Fetch.requestPaused` handlers stack). This transport
+   * must therefore be the sole owner of the Fetch domain on every session it
+   * enables. Enabling alongside `cdp_automation._handlePausedRequests` on one
+   * session clobbers patterns and races `continueRequest` calls, which can
+   * drop the `X-Cypress-Is-AUT-Frame` header or hang document requests until
+   * the response-pause timeout. Coordinating two owners is out of scope; do
+   * not enable both on one session.
+   */
+  private async enableFetch (sessionId?: string): Promise<void> {
+    debug('enabling CDP Fetch on session %s', sessionId ?? '<own>')
+
+    await this.client.send('Fetch.enable', FETCH_PATTERNS, sessionId)
+  }
+
+  /**
+   * Attaches the Fetch handlers and enables interception on this transport's
+   * own session. Sessions that attach later come through
+   * `attachServiceWorkerSession`.
    */
   async start (): Promise<void> {
     if (this.isStarted) {
@@ -186,13 +220,7 @@ export class CdpFetchTransport {
     this.isStarted = true
 
     try {
-      await this.client.send('Fetch.enable', {
-        patterns: [{
-          requestStage: 'Request',
-        }, {
-          requestStage: 'Response',
-        }],
-      })
+      await this.enableFetch()
 
       debug('CDP Fetch transport started')
     } catch (err) {
@@ -203,6 +231,27 @@ export class CdpFetchTransport {
 
       throw err
     }
+  }
+
+  /**
+   * Enables interception on a service worker session attached to this
+   * transport's connection. A service worker's script fetch and its
+   * fetch-handler requests run on that session rather than the page's, so
+   * without this they bypass the middleware onion — and `cy.intercept` —
+   * entirely.
+   *
+   * Must run while the target is still waiting for the debugger; the caller
+   * (CriClient._onAttachedToTarget) sequences this before
+   * Runtime.runIfWaitingForDebugger.
+   */
+  async attachServiceWorkerSession (sessionId: string): Promise<void> {
+    if (!this.isStarted) {
+      debug('attachServiceWorkerSession skipped (transport not started)')
+
+      return
+    }
+
+    await this.enableFetch(sessionId)
   }
 
   /**

--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -86,6 +86,15 @@ export interface ICriClient {
    * Unregisters callback for particular event.
    */
   off: OffFn
+  /**
+   * When set, service worker targets attaching to this connection await this
+   * callback before being released from their waiting-for-debugger pause.
+   * The CDP Fetch runtime uses it to enable Fetch on the service worker's
+   * session — a service worker's script fetch and fetch-handler requests run
+   * on its own session, so without this they bypass interception entirely
+   * when the proxy is disabled.
+   */
+  onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
 }
 
 type DeferredPromise = { resolve: Function, reject: Function }
@@ -118,6 +127,8 @@ export class CriClient implements ICriClient {
 
   private _crashed = false
   private cdpConnection: CDPConnection
+
+  public onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
 
   private constructor (
     public targetId: string,
@@ -437,6 +448,17 @@ export class CriClient implements ICriClient {
     } catch (error) {
       // it's possible that the target was closed before we could enable network, in that case, just ignore
       debug('error attaching to target cri: %o', { error, event })
+    }
+
+    if (event.targetInfo.type === 'service_worker' && this.onServiceWorkerTargetAttached) {
+      try {
+        // Must complete while the target is still paused — releasing the
+        // debugger first lets the service worker's script fetch escape
+        // uninterceptable.
+        await this.onServiceWorkerTargetAttached(event.sessionId)
+      } catch (error) {
+        debug('error enabling service worker interception: %o', { error, event })
+      }
     }
 
     if (event.waitingForDebugger) {

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -40,7 +40,9 @@ export type ProxyNetworkRuntime = NetworkInterceptionRuntime & {
 }
 
 export type CreateCdpFetchRuntimeDeps = {
-  client: Pick<ICriClient, 'send' | 'on' | 'off'>
+  // onServiceWorkerTargetAttached is a settable hook: the runtime assigns it
+  // so service worker sessions get Fetch enabled before they start running.
+  client: Pick<ICriClient, 'send' | 'on' | 'off' | 'onServiceWorkerTargetAttached'>
   isAUTFrame?: (frameId: string) => Promise<boolean>
   // Protocol-neutral subscription to AUT document navigation commits,
   // provided by the automation layer (CdpAutomation.onAUTFrameNavigated).
@@ -317,9 +319,17 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     async start () {
       unsubscribeAUTFrameNavigated = deps.onAUTFrameNavigated?.(onAUTFrameNavigated)
 
+      // A service worker's network runs on its own CDP session — without
+      // enabling Fetch there, its script fetch and fetch-handler requests
+      // bypass the middleware onion (and cy.intercept) entirely.
+      deps.client.onServiceWorkerTargetAttached = (sessionId) => {
+        return fetchTransport.attachServiceWorkerSession(sessionId)
+      }
+
       try {
         await fetchTransport.start()
       } catch (err) {
+        deps.client.onServiceWorkerTargetAttached = undefined
         unsubscribeAUTFrameNavigated?.()
         unsubscribeAUTFrameNavigated = undefined
 
@@ -337,6 +347,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     },
     async stop () {
       stopped = true
+      deps.client.onServiceWorkerTargetAttached = undefined
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
 

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -336,6 +336,104 @@ describe('CdpFetchTransport', () => {
     })
   })
 
+  // Fetch.enable is scoped to the session it is sent on, so every session
+  // whose traffic must run the middleware onion needs its own enable — with
+  // one shared pattern list, since a session pausing a different set of stages
+  // than its siblings would silently skip middleware for that traffic.
+  describe('session-scoped Fetch interception', () => {
+    const FETCH_PATTERNS = {
+      patterns: [{
+        requestStage: 'Request',
+      }, {
+        requestStage: 'Response',
+      }],
+    }
+
+    it('enables Fetch on its own session at start', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+
+      await transport.start()
+
+      expect(client.send).to.have.been.calledWith('Fetch.enable', FETCH_PATTERNS, undefined)
+    })
+
+    it('enables a service worker session with the same patterns as its own session', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+
+      await transport.start()
+      await transport.attachServiceWorkerSession('sw-session')
+
+      const enableCalls = client.send.getCalls().filter((call) => call.args[0] === 'Fetch.enable')
+
+      expect(enableCalls).to.have.length(2)
+      expect(enableCalls.map((call) => call.args[2])).to.deep.equal([undefined, 'sw-session'])
+      // one pattern list for every session — not two that can drift apart
+      expect(enableCalls[1].args[1]).to.equal(enableCalls[0].args[1])
+      expect(enableCalls[1].args[1]).to.deep.equal(FETCH_PATTERNS)
+    })
+
+    it('does not enable a service worker session before the transport has started', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+
+      await transport.attachServiceWorkerSession('sw-session')
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.enable')
+    })
+
+    it('rejects when a service worker session cannot be enabled so the caller can report it', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+
+      await transport.start()
+
+      client.send.withArgs('Fetch.enable', sinon.match.any, 'sw-session')
+      .rejects(new Error('ProtocolError: Inspected target closed'))
+
+      await expect(transport.attachServiceWorkerSession('sw-session'))
+      .to.be.rejectedWith('Inspected target closed')
+    })
+
+    // The whole point of enabling per session rather than per transport: pauses
+    // from every session land on the shared connection handlers, and each reply
+    // has to go back to the session the pause came from.
+    it('intercepts a service worker session pause and replies on that session', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+      const onRequestPaused = await startTransport(transport, client)
+
+      await transport.attachServiceWorkerSession('sw-session')
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'sw-fetch-request',
+        networkId: 'sw-network-1',
+        url: 'https://example.test/fixtures/service-worker.js',
+      }), 'sw-session')
+
+      await tick()
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueRequest', {
+        requestId: 'sw-fetch-request',
+      }, 'sw-session')
+
+      await onRequestPaused(createPausedRequest({
+        requestId: 'sw-fetch-request',
+        networkId: 'sw-network-1',
+        url: 'https://example.test/fixtures/service-worker.js',
+        responseStatusCode: 200,
+      }), 'sw-session')
+
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
+        requestId: 'sw-fetch-request',
+        responseCode: 200,
+      }, 'sw-session')
+    })
+  })
+
   describe('request pause handling', () => {
     it('continues the request and resolves the pending flow from a matching response pause', async () => {
       const client = createClient()

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -180,6 +180,88 @@ describe('lib/browsers/cri-client', function () {
       })
     })
 
+    describe('when a service worker target attaches', () => {
+      const sessionId = 'sw-session'
+      let client: CriClient
+
+      // drains the async attach handler, which fireCDPEvent invokes without
+      // awaiting
+      const drain = () => new Promise((resolve) => setImmediate(resolve))
+
+      beforeEach(async () => {
+        client = await getClient({ host: HOST, fullyManageTabs: true })
+        criStub.send.resolves()
+      })
+
+      it('enables interception on the session before releasing the debugger', async () => {
+        const enabled = Promise.withResolvers<void>()
+
+        client.onServiceWorkerTargetAttached = sinon.stub().returns(enabled.promise)
+
+        fireCDPEvent('Target.attachedToTarget', {
+          waitingForDebugger: true,
+          sessionId,
+          targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
+        })
+
+        await drain()
+
+        expect(client.onServiceWorkerTargetAttached).to.have.been.calledOnceWith(sessionId)
+
+        // a worker released before its session is intercepted fetches its own
+        // script straight off the network, bypassing the middleware onion
+        expect(criStub.send).not.to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
+
+        enabled.resolve()
+        await drain()
+
+        expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      })
+
+      it('does not enable interception for other target types', async () => {
+        client.onServiceWorkerTargetAttached = sinon.stub().resolves()
+
+        await Promise.all(['page', 'other', 'iframe'].map((type) => {
+          return fireCDPEvent('Target.attachedToTarget', {
+            waitingForDebugger: true,
+            sessionId,
+            targetInfo: { type } as Protocol.Target.TargetInfo,
+          })
+        }))
+
+        await drain()
+
+        expect(client.onServiceWorkerTargetAttached).not.to.have.been.called
+      })
+
+      it('releases the debugger even when enabling interception fails', async () => {
+        client.onServiceWorkerTargetAttached = sinon.stub().rejects(new Error('ProtocolError: Inspected target closed'))
+
+        fireCDPEvent('Target.attachedToTarget', {
+          waitingForDebugger: true,
+          sessionId,
+          targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
+        })
+
+        await drain()
+
+        // losing interception on one worker must not strand the target paused
+        expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      })
+
+      it('releases the debugger when no interception hook is registered', async () => {
+        fireCDPEvent('Target.attachedToTarget', {
+          waitingForDebugger: true,
+          sessionId,
+          targetInfo: { type: 'service_worker' } as Protocol.Target.TargetInfo,
+        })
+
+        await drain()
+
+        expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      })
+    })
+
     context('#send', function () {
       it('calls cri.send with command and data', async function () {
         send.resolves()

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -881,6 +881,62 @@ describe('lib/network-runtime', () => {
     await runtime.stop()
   })
 
+  it('createCdpFetchRuntime enables Fetch on service worker sessions that attach to the page connection', async () => {
+    const client: {
+      send: sinon.SinonStub
+      on: sinon.SinonStub
+      off: sinon.SinonStub
+      onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+    } = {
+      send: sinon.stub().resolves({}),
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+    expect(client.onServiceWorkerTargetAttached, 'hook is not registered before start').to.not.exist
+
+    await runtime.start()
+    client.send.resetHistory()
+
+    await client.onServiceWorkerTargetAttached!('sw-session')
+
+    // A service worker's script fetch and fetch-handler requests run on its own
+    // session, so they only reach the middleware onion (and cy.intercept) if
+    // Fetch is enabled there too.
+    expect(client.send).to.have.been.calledWith('Fetch.enable', {
+      patterns: [{
+        requestStage: 'Request',
+      }, {
+        requestStage: 'Response',
+      }],
+    }, 'sw-session')
+
+    await runtime.stop()
+
+    // The page client outlives the runtime, so a stale hook would enable Fetch
+    // against a transport that has already dropped its handlers.
+    expect(client.onServiceWorkerTargetAttached, 'hook is cleared on stop').to.not.exist
+  })
+
+  it('createCdpFetchRuntime clears the service worker hook when Fetch.enable fails', async () => {
+    const client: {
+      send: sinon.SinonStub
+      on: sinon.SinonStub
+      off: sinon.SinonStub
+      onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+    } = {
+      send: sinon.stub().rejects(new Error('enable failed')),
+      on: sinon.stub(),
+      off: sinon.stub(),
+    }
+    const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+    await expect(runtime.start()).to.be.rejectedWith('enable failed')
+
+    expect(client.onServiceWorkerTargetAttached).to.not.exist
+  })
+
   it('createCdpFetchRuntime stop also stops attached extra-target transports', async () => {
     const mainClient = {
       send: sinon.stub().resolves({}),


### PR DESCRIPTION
- Closes #34555

### Additional details

Under `CYPRESS_INTERNAL_DISABLE_PROXY=1`, interception runs through CDP `Fetch.enable`, which is scoped to the session it is sent on. A service worker's script fetch and its fetch-handler requests run on the worker's own session, where nothing enabled Fetch — so that traffic bypassed the middleware onion and `cy.intercept` entirely, and every test in `service-worker.cy.js` failed proxy-off with a 404 on the intercept-stubbed `service-worker.js`.

Three changes in `@packages/server`, plus promoting `service-worker.cy.js` into the chrome and electron `*-cdp-remediated` spec lists:

- **`cri-client.ts`** — settable `onServiceWorkerTargetAttached(sessionId)` hook, awaited for `service_worker` targets before `Runtime.runIfWaitingForDebugger` so the worker cannot run before its session is intercepted.
- **`cdp-fetch-transport.ts`** — both enables route through one `enableFetch(sessionId?)` sharing a single pattern list. Only the enable is per-session; pauses arrive on the shared connection carrying their own `sessionId`, which the existing handlers already thread back through each reply.
- **`network-runtime.ts`** — registers the hook on `start()`, clears it on `stop()`. It only exists when the proxy is disabled, so the MITM path is untouched.

**Ordering caveat.** The worker also attaches to the browser connection, which awaits `Network.enable` before its own release. CDP does not answer that while a target is paused, so it cannot release the worker ahead of us — safe today, but by coincidence rather than contract.

**Out of scope:** Set-Cookie for SW-session responses (#34568, low priority — with the proxy off, simulated-top rewriting is its only consumer, and a service worker has no top), and popup-registered service workers, whose raw extra-target clients have no attach hook to carry the enable.

### Steps to test

`service-worker.cy.js` goes 0/28 → 28/28 proxy-off on chrome and electron, and stays 28/28 on MITM.

```bash
DISABLE_SNAPSHOT_REQUIRE=1 CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/e2e/service-worker.cy.js --browser chrome
```

Unit coverage: `yarn workspace @packages/server test-unit -- browsers/cdp-fetch-transport_spec.ts` (also `browsers/cri-client_spec.ts`, `network-runtime_spec.ts`).

### How has the user experience changed?

No change — this is behind `CYPRESS_INTERNAL_DISABLE_PROXY=1`, which is not a supported user-facing configuration.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP target-attach ordering and Fetch interception for service workers, which is timing-sensitive network infrastructure. Scope is limited to the internal proxy-disabled path and covered by new unit and driver tests.
> 
> **Overview**
> Fixes proxy-disabled interception so **service worker** script fetches and fetch-handler requests no longer bypass the middleware onion and `cy.intercept`.
> 
> Adds an `onServiceWorkerTargetAttached` hook on `CriClient` that enables Fetch on the worker session **before** `Runtime.runIfWaitingForDebugger`. `CdpFetchTransport` centralizes enable through a shared `FETCH_PATTERNS` list and exposes `attachServiceWorkerSession`; `createCdpFetchRuntime` registers and clears the hook on start/stop.
> 
> Promotes `service-worker.cy.js` into the chrome and electron `*-cdp-remediated` CI lists, with unit coverage for the attach/enable path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66781cfe46b67ae3f5386ee4576db960b044d792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

