### PR TITLE
chore: reject CDP commands when a non-reconnecting connection terminally disconnects

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -327,6 +327,24 @@ jobs:
       spec: cypress/e2e/choose-a-browser.cy.ts,cypress/e2e/open-mode.cy.ts
       requires:
         - ready-to-test
+  - run-app-integration-tests-chrome:
+      name: run-app-integration-tests-chrome-cdp-remediated
+      context:
+        [
+          test-runner:cypress-record-key,
+          test-runner:launchpad-tests,
+          test-runner:percy
+        ]
+      disable-proxy: true
+      require-opt-in: false
+      parallelism: 1
+      record-group-suffix: '-remediated'
+      # #34561 cypress-in-cypress specs: exercise the spec-transition teardown that
+      # wedged on a zombie (disconnected-but-not-terminated) CDP connection when the
+      # proxy is disabled.
+      spec: cypress/e2e/cypress-in-cypress.cy.ts,cypress/e2e/cypress-in-cypress-e2e.cy.ts,cypress/e2e/cypress-in-cypress-run-mode.cy.ts,cypress/e2e/cypress-in-cypress-component.cy.ts
+      requires:
+        - ready-to-test
   - driver-integration-tests-chrome:
       name: driver-integration-tests-chrome-cdp-remediated
       context: test-runner:cypress-record-key
@@ -554,6 +572,7 @@ jobs:
         - system-tests-electron-cdp-remediated
         - unit-tests-proxy-disabled
         - run-launchpad-integration-tests-chrome-cdp-remediated
+        - run-app-integration-tests-chrome-cdp-remediated
         - driver-integration-tests-chrome-cdp-remediated
         - driver-integration-tests-electron-cdp-remediated
         - driver-integration-tests-chrome

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -41,7 +41,7 @@ app.use(Toast, {
   closeOnClick: false,
 })
 
-await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute, proxyUrl: config.proxyUrl }).then((client) => {
+await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute, port: config.port }).then((client) => {
   app.use(urql, client)
   app.use(createRouter())
   app.use(createI18n())

--- a/packages/frontend-shared/src/graphql/urqlClient.cy.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.cy.ts
@@ -5,7 +5,7 @@ describe('getGraphQLWsUrl', () => {
     target: 'app',
     namespace: '__cypress',
     socketIoRoute: '/__socket',
-    proxyUrl: 'http://localhost:2345',
+    port: 2345,
   } as const
 
   it('uses the page origin when the proxy is enabled', () => {
@@ -20,20 +20,28 @@ describe('getGraphQLWsUrl', () => {
     expect(url).to.equal('wss://app.foobar.com/__socket-graphql')
   })
 
-  it('uses the Cypress server origin when the proxy is disabled', () => {
+  it('uses the Cypress server port when the proxy is disabled', () => {
     const url = getGraphQLWsUrl(appConfig, { protocol: 'http:', host: 'localhost:2292' }, true)
 
     expect(url).to.equal('ws://localhost:2345/__socket-graphql')
   })
 
-  it('uses the Cypress server origin when the proxy is disabled and the page is https', () => {
+  it('uses the Cypress server port when the proxy is disabled and the page is https', () => {
     const url = getGraphQLWsUrl(appConfig, { protocol: 'https:', host: 'app.foobar.com' }, true)
 
     expect(url).to.equal('ws://localhost:2345/__socket-graphql')
   })
 
-  it('falls back to the page origin when the proxy is disabled and no proxyUrl is served', () => {
-    const url = getGraphQLWsUrl({ ...appConfig, proxyUrl: undefined }, { protocol: 'http:', host: 'localhost:2292' }, true)
+  // proxyUrl is derived from the port that was requested and can name a port nothing is
+  // bound to, so the served `port` is the only reliable source for the handshake
+  it('ignores a proxyUrl that disagrees with the served port', () => {
+    const url = getGraphQLWsUrl({ ...appConfig, proxyUrl: 'http://localhost:9999' } as any, { protocol: 'http:', host: 'localhost:2292' }, true)
+
+    expect(url).to.equal('ws://localhost:2345/__socket-graphql')
+  })
+
+  it('falls back to the page origin when the proxy is disabled and no port is served', () => {
+    const url = getGraphQLWsUrl({ ...appConfig, port: undefined }, { protocol: 'http:', host: 'localhost:2292' }, true)
 
     expect(url).to.equal('ws://localhost:2292/__socket-graphql')
   })

--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -124,7 +124,7 @@ interface AppUrqlClientConfig {
   target: 'app'
   namespace: string
   socketIoRoute: string
-  proxyUrl?: string
+  port?: number | null
 }
 
 export type UrqlClientConfig = LaunchpadUrqlClientConfig | AppUrqlClientConfig
@@ -241,13 +241,17 @@ export function getGraphQLWsUrl (config: UrqlClientConfig, location: Pick<Locati
 
   // With the proxy disabled the app is served at the AUT's superdomain, and CDP
   // cannot intercept a WebSocket upgrade — the handshake has to name the Cypress
-  // server or it reaches the user's app server (see #34563).
-  const origin = proxyDisabled && config.proxyUrl ? new URL(config.proxyUrl) : location
+  // server or it reaches the user's app server (see #34563). `port` is the port the
+  // server is listening on; `proxyUrl` is derived from the port that was requested and
+  // can still name a port nothing is bound to.
+  if (proxyDisabled && config.port) {
+    return `ws://localhost:${config.port}${config.socketIoRoute}-graphql`
+  }
 
   // http: -> ws:  &  https: -> wss:
-  const protocol = origin.protocol.replace('http', 'ws')
+  const protocol = location.protocol.replace('http', 'ws')
 
-  return `${protocol}//${origin.host}${config.socketIoRoute}-graphql`
+  return `${protocol}//${location.host}${config.socketIoRoute}-graphql`
 }
 
 function getSocketSource (config: UrqlClientConfig) {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-command-queue.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-command-queue.ts
@@ -51,6 +51,23 @@ export class CDPCommandQueue {
     this.queue = []
   }
 
+  /**
+   * Rejects every enqueued command's deferred and empties the queue. Used when
+   * the connection reaches a terminal state, since enqueued commands are
+   * waiting on a reconnect that will never come and would otherwise hang forever.
+   */
+  public reject (error: Error) {
+    debug('rejecting %d enqueued command(s)', this.queue.length)
+
+    const entries = this.queue
+
+    this.queue = []
+
+    for (const entry of entries) {
+      entry.deferred.reject(error)
+    }
+  }
+
   public extract<T extends CdpCommand> (search: Partial<Command<T>>): Command<T> | undefined {
     // this should find, remove, and return if found a given command
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-connection.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-connection.ts
@@ -64,8 +64,9 @@ export class CDPConnection {
   }
 
   get ws () {
-    // this is reached into by browser-cri-client to detect close events - needs rethinking
-    return (this._connection as { _ws?: WebSocket })._ws
+    // this is reached into by browser-cri-client to detect close events - needs rethinking.
+    // _connection can be undefined after a terminal disconnect, so this must stay optional
+    return (this._connection as { _ws?: WebSocket } | undefined)?._ws
   }
 
   on<T extends CdpEvent> (event: T, callback: CDPListener<T>) {
@@ -104,7 +105,26 @@ export class CDPConnection {
 
     if (this._autoReconnect) {
       this._connection.on('disconnect', this._reconnect)
+    } else {
+      // Without reconnection, a closed socket is permanent - there is no retry loop
+      // that will ever bring the connection back. Treat it as terminated so pending
+      // and future senders reject instead of waiting on a reconnect that never comes.
+      this._connection.on('disconnect', this._onTerminalDisconnect)
     }
+  }
+
+  private _onTerminalDisconnect = async () => {
+    this.debug('terminal disconnect for target %s (reconnection disabled)', this._options.target)
+
+    this._terminated = true
+
+    try {
+      await this._gracefullyDisconnect()
+    } catch (e) {
+      this.debug('error cleaning up terminally-disconnected CDP connection: ', e)
+    }
+
+    this._emitter.emit('cdp-connection-closed')
   }
 
   async disconnect () {
@@ -124,6 +144,7 @@ export class CDPConnection {
   private _gracefullyDisconnect = async () => {
     this._connection?.off('event', this._broadcastEvent)
     this._connection?.off('disconnect', this._reconnect)
+    this._connection?.off('disconnect', this._onTerminalDisconnect)
 
     await this._connection?.close()
     this._connection = undefined

--- a/packages/server/lib/browsers/cdp-protocol/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp_automation.ts
@@ -14,6 +14,7 @@ import type { Automation } from '../../automation'
 import { cookieMatches, CyCookie, CyCookieFilter } from '../../automation/cookie/util'
 import { convertCdpCookiesToCyCookies, convertCyCookieToCdpCookie } from '../../automation/cookie/converters/cdp'
 import { DEFAULT_NETWORK_ENABLE_OPTIONS, CriClient } from './cri-client'
+import { CDPDisconnectedError } from './cri-errors'
 import { normalizeResourceType } from './normalize-resource-type'
 import { cdpKeyPress } from '../../automation/commands/key_press'
 import { AUT_FRAME_HEADER } from '../constants'
@@ -99,8 +100,9 @@ export class CdpAutomation implements CDPClient, AutomationMiddleware {
       try {
         await this.sendDebuggerCommandFn('Page.screencastFrameAck', { sessionId: e.sessionId })
       } catch (e) {
-        // swallow this error if the CRI connection was reset
-        if (!e.message.includes('browser CRI connection was reset')) {
+        // swallow this error if the CRI connection was reset - the ack racing a
+        // disconnect is expected and not actionable
+        if (!CDPDisconnectedError.isCDPDisconnectedError(e)) {
           throw e
         }
       }

--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -108,7 +108,6 @@ export class CriClient implements ICriClient {
   // CDP.Client instances
   private subscriptions: Subscription[] = []
   private enableCommands: EnableCommand[] = []
-  private enqueuedCommands: EnqueuedCommand[] = []
 
   private _commandQueue: CDPCommandQueue = new CDPCommandQueue()
 
@@ -153,6 +152,13 @@ export class CriClient implements ICriClient {
 
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', onAsynchronousError)
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect', this._onCdpConnectionReconnect)
+
+    // Once the connection reaches a terminal state - a terminal disconnect with
+    // reconnection disabled, or reconnection exhausting its retries and giving up -
+    // nothing will ever flush the command queue. Reject it so callers awaiting those
+    // commands fail instead of hanging forever.
+    this.cdpConnection.addConnectionEventListener('cdp-connection-closed', this._rejectEnqueuedCommands)
+    this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', this._rejectEnqueuedCommands)
 
     if (onCriConnectionClosed) {
       this.cdpConnection.addConnectionEventListener('cdp-connection-closed', onCriConnectionClosed)
@@ -329,6 +335,7 @@ export class CriClient implements ICriClient {
         return await this.cdpConnection.send(command, params, sessionId)
       } catch (err) {
         debug('Encountered error on send %o', { command, params, sessionId, err })
+
         // This error occurs when the browser has been left open for a long
         // time and/or the user's computer has been put to sleep. The
         // socket disconnects and we need to recreate the socket and
@@ -337,23 +344,22 @@ export class CriClient implements ICriClient {
           throw err
         }
 
-        debug('error classified as WEBSOCKET_NOT_OPEN_RE; enqueuing and attempting to reconnect')
-
-        const p = this._enqueueCommand(command, params, sessionId)
-
-        // if enqueued commands were wiped out from the reconnect and the socket is already closed, reject the command as it will never be run
-        if (this.enqueuedCommands.length === 0 && this.cdpConnection.terminated) {
-          debug('connection was closed was trying to reconnect')
-
-          return Promise.reject(new Error(`${command} will not run as browser CRI connection was reset`))
+        if (this.cdpConnection.terminated) {
+          return this._rejectTerminated(command)
         }
 
-        return p
+        debug('error classified as WEBSOCKET_NOT_OPEN_RE; enqueuing and attempting to reconnect')
+
+        return this._enqueueCommand(command, params, sessionId)
       } finally {
         if (hangDetectionTimer) {
           clearTimeout(hangDetectionTimer)
         }
       }
+    }
+
+    if (this.cdpConnection.terminated) {
+      return this._rejectTerminated(command)
     }
 
     return this._enqueueCommand(command, params, sessionId)
@@ -455,6 +461,18 @@ export class CriClient implements ICriClient {
     sessionId?: string,
   ): Promise<ProtocolMapping.Commands[TCmd]['returnType']> {
     return this._commandQueue.add(command, params, sessionId)
+  }
+
+  // A terminated connection never reconnects, so a send against one is rejected outright
+  // rather than enqueued to await a flush that will never come.
+  private _rejectTerminated <TCmd extends CdpCommand> (command: TCmd): Promise<ProtocolMapping.Commands[TCmd]['returnType']> {
+    debug('connection to target %s is terminated; rejecting %s instead of enqueuing', this.targetId, command)
+
+    return Promise.reject(new CDPDisconnectedError(`${command} will not run as the CRI connection to Target ${this.targetId} has been closed`))
+  }
+
+  private _rejectEnqueuedCommands = () => {
+    this._commandQueue.reject(new CDPDisconnectedError(`The CRI connection to Target ${this.targetId} has been closed; enqueued commands will never run`))
   }
 
   private _onCdpConnectionReconnect = async () => {

--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -153,10 +153,11 @@ export class CriClient implements ICriClient {
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', onAsynchronousError)
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect', this._onCdpConnectionReconnect)
 
-    // Once the connection reaches a terminal state - a terminal disconnect with
-    // reconnection disabled, or reconnection exhausting its retries and giving up -
-    // nothing will ever flush the command queue. Reject it so callers awaiting those
-    // commands fail instead of hanging forever.
+    // 'cdp-connection-closed' means the connection is terminated for good, so this
+    // permanently rejects the queue. 'cdp-connection-reconnect-error' only drains what's
+    // already queued - exhausting retries does not mark the connection terminated, so a
+    // send issued after this fires still enqueues and hangs (root browser client only;
+    // the run is torn down by the fatal CDP_COULD_NOT_RECONNECT anyway). See #34581.
     this.cdpConnection.addConnectionEventListener('cdp-connection-closed', this._rejectEnqueuedCommands)
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', this._rejectEnqueuedCommands)
 
@@ -397,6 +398,11 @@ export class CriClient implements ICriClient {
     debug('closing')
     if (this._closed || this.cdpConnection?.terminated) {
       debug('not closing, cri client is already closed %o', { closed: this._closed, target: this.targetId, connection: this.cdpConnection })
+
+      // a terminal disconnect marks the connection terminated outside of close(), so
+      // this branch is reachable with _closed still false - callers gate on .closed
+      // (e.g. resetBrowserTargets), so it must reflect reality once terminated is true
+      this._closed = true
 
       return
     }

--- a/packages/server/test/support/helpers/cdp-disconnect.ts
+++ b/packages/server/test/support/helpers/cdp-disconnect.ts
@@ -1,0 +1,41 @@
+import type * as sinon from 'sinon'
+
+// Simulates the underlying CDP client emitting 'disconnect' by invoking every currently
+// -attached listener, mirroring a real EventEmitter rather than indexing into a specific
+// `.on()` call - so this stays correct regardless of how many listeners connect() registers
+// or in what order. on/off calls on the same reference (e.g. reconnecting re-registers the
+// same bound method) are replayed in chronological order via sinon's shared callId counter,
+// and each `off` cancels exactly one matching prior `on` rather than every occurrence of
+// that reference.
+export const activeListeners = (onStub: sinon.SinonStub, offStub: sinon.SinonStub, event: string) => {
+  const events = [
+    ...onStub.getCalls().map((call) => ({ type: 'on' as const, call })),
+    ...offStub.getCalls().map((call) => ({ type: 'off' as const, call })),
+  ]
+  .filter(({ call }) => call.args[0] === event)
+  .sort((a, b) => a.call.callId - b.call.callId)
+
+  const active: Function[] = []
+
+  events.forEach(({ type, call }) => {
+    const listener = call.args[1]
+
+    if (type === 'on') {
+      active.push(listener)
+
+      return
+    }
+
+    const index = active.indexOf(listener)
+
+    if (index !== -1) {
+      active.splice(index, 1)
+    }
+  })
+
+  return active
+}
+
+export const fireDisconnect = async (onStub: sinon.SinonStub, offStub: sinon.SinonStub) => {
+  await Promise.all(activeListeners(onStub, offStub, 'disconnect').map((listener) => listener()))
+}

--- a/packages/server/test/unit/browsers/cdp-command-queue_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-command-queue_spec.ts
@@ -91,6 +91,37 @@ describe('CDPCommandQueue', () => {
     })
   })
 
+  describe('.reject', () => {
+    it('rejects every enqueued command promise and empties the queue', async () => {
+      const queue = new CDPCommandQueue()
+
+      const first = queue.add(enableAnimation.command, enableAnimation.params)
+      const second = queue.add(removeAttribute.command, removeAttribute.params)
+      const err = new Error('connection closed')
+
+      queue.reject(err)
+
+      expect(queue.entries).to.have.lengthOf(0)
+      await expect(first).to.be.rejectedWith(err)
+      await expect(second).to.be.rejectedWith(err)
+    })
+
+    it('does not affect commands added after the rejection', async () => {
+      const queue = new CDPCommandQueue()
+
+      const beforeReject = queue.add(enableAnimation.command, enableAnimation.params)
+
+      queue.reject(new Error('connection closed'))
+      await expect(beforeReject).to.be.rejectedWith('connection closed')
+
+      const afterReject = queue.add(removeAttribute.command, removeAttribute.params)
+
+      expect(queue.entries).to.have.lengthOf(1)
+      queue.entries[0].deferred.resolve({ value: true })
+      await expect(afterReject).to.eventually.deep.equal({ value: true })
+    })
+  })
+
   describe('.extract', () => {
     let queue: CDPCommandQueue
     let searchCommand: Partial<Command<any>>

--- a/packages/server/test/unit/browsers/cdp-connection_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-connection_spec.ts
@@ -4,6 +4,7 @@ import type { debugCdpConnection } from '../../../lib/browsers/cdp-protocol/debu
 import type { CdpEvent, CdpCommand } from '../../../lib/browsers/cdp-protocol/cdp_automation'
 import type ProtocolMapping from 'devtools-protocol/types/protocol-mapping'
 import { CDPTerminatedError, CDPAlreadyConnectedError, CDPDisconnectedError } from '../../../lib/browsers/cdp-protocol/cri-errors'
+import { fireDisconnect as fireDisconnectListeners } from '../../support/helpers/cdp-disconnect'
 import WebSocket from 'ws'
 const { expect, proxyquire, sinon } = require('../../spec_helper')
 
@@ -35,6 +36,9 @@ describe('CDPConnection', () => {
       _ws: stubbedWebSocket,
     }
   }
+
+  // wraps the shared helper over the current stubbedCDPClient
+  const fireDisconnect = () => fireDisconnectListeners(stubbedCDPClient.on!, stubbedCDPClient.off!)
 
   beforeEach(() => {
     stubbedWebSocket = sinon.createStubInstance(WebSocket)
@@ -116,9 +120,20 @@ describe('CDPConnection', () => {
         await cdpConnection.connect()
       })
 
-      it('does not add a reconnect listener', async () => {
-        //@ts-expect-error
-        expect(stubbedCDPClient.on?.withArgs('disconnect')).not.to.have.been.called
+      // this connection was constructed with automaticallyReconnect: false (see outer beforeEach),
+      // so a disconnect of the underlying socket is permanent - there is no reconnection attempt
+      // to eventually bring it back.
+      it('marks the connection terminated and emits cdp-connection-closed', async () => {
+        await fireDisconnect()
+
+        expect(cdpConnection.terminated).to.be.true
+        expect(onConnectionClosedCb).to.have.been.called
+      })
+
+      it('rejects subsequent sends as terminated', async () => {
+        await fireDisconnect()
+
+        await expect(cdpConnection.send('Page.enable')).to.be.rejectedWith(CDPDisconnectedError, 'terminated')
       })
     })
   })
@@ -131,18 +146,16 @@ describe('CDPConnection', () => {
         await cdpConnection.connect()
       })
 
-      it('removes any event listeners that have been added', async () => {
+      it('removes the event and disconnect listeners it registered', async () => {
+        //@ts-expect-error
+        const eventListener = stubbedCDPClient.on?.withArgs('event').args[0][1]
+        //@ts-expect-error
+        const disconnectListener = stubbedCDPClient.on?.withArgs('disconnect').args.at(-1)[1]
+
         await cdpConnection.disconnect()
 
-        const calls = stubbedCDPClient.on?.getCalls()
-
-        if (calls?.length) {
-          for (const call of calls) {
-            const [event, listener] = call.args
-
-            expect(stubbedCDPClient.off).to.have.been.calledWith(event, listener)
-          }
-        }
+        expect(stubbedCDPClient.off).to.have.been.calledWith('event', eventListener)
+        expect(stubbedCDPClient.off).to.have.been.calledWith('disconnect', disconnectListener)
       })
 
       it('closes the CDP connection', async () => {
@@ -301,6 +314,30 @@ describe('CDPConnection', () => {
     })
   })
 
+  describe('.ws', () => {
+    it('returns undefined before a connection has been established', () => {
+      expect(cdpConnection.ws).to.be.undefined
+    })
+
+    it('returns the underlying websocket once connected', async () => {
+      CDPImport.withArgs({ target: DEBUGGER_URL, local: true }).resolves(stubbedCDPClient)
+      await cdpConnection.connect()
+
+      expect(cdpConnection.ws).to.eq(stubbedWebSocket)
+    })
+
+    it('returns undefined rather than throwing after a terminal disconnect', async () => {
+      CDPImport.withArgs({ target: DEBUGGER_URL, local: true }).resolves(stubbedCDPClient)
+      await cdpConnection.connect()
+
+      // this connection was constructed with automaticallyReconnect: false (see outer
+      // beforeEach), so this disconnect is terminal and clears out the underlying connection
+      await fireDisconnect()
+
+      expect(cdpConnection.ws).to.be.undefined
+    })
+  })
+
   describe('when created with auto reconnect behavior enabled and disconnected', () => {
     let deferredReconnection: PromiseWithResolvers<any>
 
@@ -320,9 +357,17 @@ describe('CDPConnection', () => {
       CDPImport.withArgs({ target: DEBUGGER_URL, local: true }).resolves(stubbedCDPClient)
 
       await cdpConnection.connect()
-      // @ts-expect-error
-      stubbedCDPClient.on?.withArgs('disconnect').args[0][1]()
+      fireDisconnect()
       CDPImport.reset()
+    })
+
+    it('does not mark the connection terminated (reconnection is attempted instead)', async () => {
+      expect(cdpConnection.terminated).to.be.false
+
+      // let the reconnection attempt kicked off in beforeEach settle so it doesn't
+      // leak a pending CDPImport call into the next test
+      CDPImport.resolves(stubbedCDPClient)
+      await deferredReconnection.promise
     })
 
     it('reconnects when disconnected and reconnection succeeds on the third try', async () => {

--- a/packages/server/test/unit/browsers/cdp_automation_spec.ts
+++ b/packages/server/test/unit/browsers/cdp_automation_spec.ts
@@ -3,6 +3,7 @@ const { expect, sinon } = require('../../spec_helper')
 import { ProtocolManagerShape, REPORTER_FRAME_NAME, AUT_SNAPSHOT_FRAME_NAME_IDENTIFIER, SPEC_FRAME_NAME_IDENTIFIER, SPEC_BRIDGE_FRAME_NAME_IDENTIFIER } from '@packages/types'
 import { CdpAutomation } from '../../../lib/browsers/cdp-protocol/cdp_automation'
 import { normalizeResourceType } from '../../../lib/browsers/cdp-protocol/normalize-resource-type'
+import { CDPDisconnectedError } from '../../../lib/browsers/cdp-protocol/cri-errors'
 
 context('lib/browsers/cdp_automation', () => {
   context('.normalizeResourceType', () => {
@@ -125,6 +126,35 @@ context('lib/browsers/cdp_automation', () => {
         expect(startScreencast).to.have.been.calledWith('Page.startScreencast')
         expect(writeVideoFrame).to.have.been.calledWithMatch((arg) => Buffer.isBuffer(arg) && arg.length > 0)
         expect(screencastFrameAck).to.have.been.calledWith('Page.screencastFrameAck', { sessionId: frameMeta.sessionId })
+      })
+
+      it('swallows a CDPDisconnectedError from the ack (e.g. racing a terminal disconnect)', async function () {
+        const writeVideoFrame = sinon.stub()
+        const frameMeta = { data: Buffer.from('foo'), sessionId: '1' }
+
+        this.sendDebuggerCommand.withArgs('Page.startScreencast').resolves()
+        this.sendDebuggerCommand.withArgs('Page.screencastFrameAck').rejects(new CDPDisconnectedError('Page.screencastFrameAck will not run as the CRI connection to Target foo has been closed'))
+
+        await cdpAutomation.startVideoRecording(writeVideoFrame, {})
+
+        const screencastFrameHandler = this.onFn.withArgs('Page.screencastFrame').args[0][1]
+
+        await expect(screencastFrameHandler(frameMeta)).to.be.fulfilled
+      })
+
+      it('rethrows other errors from the ack', async function () {
+        const writeVideoFrame = sinon.stub()
+        const frameMeta = { data: Buffer.from('foo'), sessionId: '1' }
+        const err = new Error('boom')
+
+        this.sendDebuggerCommand.withArgs('Page.startScreencast').resolves()
+        this.sendDebuggerCommand.withArgs('Page.screencastFrameAck').rejects(err)
+
+        await cdpAutomation.startVideoRecording(writeVideoFrame, {})
+
+        const screencastFrameHandler = this.onFn.withArgs('Page.screencastFrame').args[0][1]
+
+        await expect(screencastFrameHandler(frameMeta)).to.be.rejectedWith(err)
       })
     })
 

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -3,6 +3,7 @@ import EventEmitter from 'events'
 import { ProtocolManagerShape } from '@packages/types'
 import type { CriClient } from '../../../lib/browsers/cdp-protocol/cri-client'
 import type Protocol from 'devtools-protocol'
+import { fireDisconnect as fireDisconnectListeners } from '../../support/helpers/cdp-disconnect'
 const { expect, proxyquire, sinon } = require('../../spec_helper')
 
 const DEBUGGER_URL = 'http://foo'
@@ -36,6 +37,9 @@ describe('lib/browsers/cri-client', function () {
       sessionId,
     })
   }
+
+  // wraps the shared helper over the current criStub
+  const fireDisconnect = () => fireDisconnectListeners(criStub.on, criStub.off)
 
   beforeEach(function () {
     send = sinon.stub()
@@ -233,7 +237,7 @@ describe('lib/browsers/cri-client', function () {
 
             const p = client.send('DOM.getDocument', { depth: -1 })
 
-            await criStub.on.withArgs('disconnect').args[0][1]()
+            await fireDisconnect()
             await p
             expect(send).to.be.calledTwice
           })
@@ -249,8 +253,8 @@ describe('lib/browsers/cri-client', function () {
 
             const getDocumentPromise = client.send('DOM.getDocument', { depth: -1 })
 
-            await criStub.on.withArgs('disconnect').args[0][1]()
-            await criStub.on.withArgs('disconnect').args[0][1]()
+            await fireDisconnect()
+            await fireDisconnect()
             await getDocumentPromise
             expect(send).to.have.callCount(3)
           })
@@ -266,8 +270,8 @@ describe('lib/browsers/cri-client', function () {
 
             const enableNetworkPromise = client.send('Network.enable')
 
-            await criStub.on.withArgs('disconnect').args[0][1]()
-            await criStub.on.withArgs('disconnect').args[0][1]()
+            await fireDisconnect()
+            await fireDisconnect()
             await enableNetworkPromise
             expect(send).to.have.callCount(3)
           })
@@ -284,7 +288,7 @@ describe('lib/browsers/cri-client', function () {
 
           await client.close()
 
-          expect(client.send('DOM.getDocument', { depth: -1 })).to.be.rejectedWith('DOM.getDocument will not run as browser CRI connection was reset')
+          await expect(client.send('DOM.getDocument', { depth: -1 })).to.be.rejectedWith('DOM.getDocument will not run as the CRI connection to Target')
         })
 
         it(`when socket is closed mid send ('WebSocket connection closed' variant)`, async function () {
@@ -295,7 +299,42 @@ describe('lib/browsers/cri-client', function () {
 
           await client.close()
 
-          expect(client.send('DOM.getDocument', { depth: -1 })).to.be.rejectedWith('DOM.getDocument will not run as browser CRI connection was reset')
+          await expect(client.send('DOM.getDocument', { depth: -1 })).to.be.rejectedWith('DOM.getDocument will not run as the CRI connection to Target')
+        })
+      })
+
+      context('when reconnection is disabled (cypress-in-cypress)', () => {
+        beforeEach(() => {
+          process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF = 'true'
+        })
+
+        afterEach(() => {
+          delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF
+        })
+
+        it('rejects an enqueued command when the socket terminally disconnects', async function () {
+          const client = await getClient()
+
+          // a send that fails like a closed socket gets enqueued to await a reconnect
+          send.onFirstCall().rejects(new Error('WebSocket is not open: readyState 3 (CLOSED)'))
+
+          const pending = client.send('Fetch.disable')
+
+          // let the failed send settle into the queue before disconnecting
+          await new Promise((resolve) => setImmediate(resolve))
+
+          // with reconnection disabled, this disconnect is terminal - no reconnect will ever flush the queue
+          await fireDisconnect()
+
+          await expect(pending).to.be.rejectedWith('The CRI connection to Target')
+        })
+
+        it('rejects sends after the socket has terminally disconnected instead of enqueuing them', async function () {
+          const client = await getClient()
+
+          await fireDisconnect()
+
+          await expect(client.send('Fetch.disable')).to.be.rejectedWith('Fetch.disable will not run as the CRI connection to Target')
         })
       })
     })
@@ -341,8 +380,7 @@ describe('lib/browsers/cri-client', function () {
       // clear out previous calls before reconnect
       criStub.send.reset()
 
-      // @ts-ignore
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
 
       const reconnection = Promise.withResolvers()
 
@@ -354,7 +392,7 @@ describe('lib/browsers/cri-client', function () {
       expect(criStub.send).to.be.calledWith('Network.enable')
       expect(protocolManager.cdpReconnect).to.be.called
 
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
     })
 
     it('does not resend a domain that was disabled', async () => {
@@ -367,8 +405,7 @@ describe('lib/browsers/cri-client', function () {
       // clear out previous calls before reconnect
       criStub.send.reset()
 
-      // @ts-ignore
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
 
       const reconnection = Promise.withResolvers()
 
@@ -379,7 +416,7 @@ describe('lib/browsers/cri-client', function () {
       expect(criStub.send).to.be.calledWith('Page.enable')
       expect(criStub.send).not.to.be.calledWith('Fetch.enable')
 
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
     })
 
     it('prunes disabled domains per session', async () => {
@@ -392,8 +429,7 @@ describe('lib/browsers/cri-client', function () {
       // clear out previous calls before reconnect
       criStub.send.reset()
 
-      // @ts-ignore
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
 
       const reconnection = Promise.withResolvers()
 
@@ -404,7 +440,7 @@ describe('lib/browsers/cri-client', function () {
       expect(criStub.send).to.be.calledWith('Fetch.enable', undefined, 'session-b')
       expect(criStub.send).not.to.be.calledWith('Fetch.enable', undefined, 'session-a')
 
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
     })
 
     it('errors if reconnecting fails', async () => {
@@ -412,8 +448,7 @@ describe('lib/browsers/cri-client', function () {
 
       criImport.rejects()
 
-      // @ts-ignore
-      await criStub.on.withArgs('disconnect').args[0][1]()
+      await fireDisconnect()
 
       await (new Promise((resolve) => setImmediate(resolve)))
 
@@ -423,6 +458,23 @@ describe('lib/browsers/cri-client', function () {
 
       expect(error.messageMarkdown).to.equal('There was an error reconnecting to the Chrome DevTools protocol. Please restart the browser.')
       expect(error.isFatalApiErr).to.be.true
+    })
+
+    it('rejects previously enqueued commands when reconnection exhausts its retries and gives up', async () => {
+      send.onFirstCall().rejects(new Error('WebSocket is not open: readyState 3 (CLOSED)'))
+
+      const client = await getClient()
+
+      const pending = client.send('DOM.getDocument', { depth: -1 })
+
+      // let the failed send settle into the queue before reconnection starts failing
+      await new Promise((resolve) => setImmediate(resolve))
+
+      criImport.rejects()
+
+      await fireDisconnect()
+
+      await expect(pending).to.be.rejectedWith('The CRI connection to Target')
     })
   })
 })

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -336,6 +336,15 @@ describe('lib/browsers/cri-client', function () {
 
           await expect(client.send('Fetch.disable')).to.be.rejectedWith('Fetch.disable will not run as the CRI connection to Target')
         })
+
+        it('marks the client closed once a terminal disconnect has already happened', async function () {
+          const client = await getClient()
+
+          await fireDisconnect()
+
+          await expect(client.close()).to.be.fulfilled
+          expect(client.closed).to.be.true
+        })
       })
     })
   })


### PR DESCRIPTION
- Closes #34561

### Additional details

Part of the proxy-disabled / HTTP/2 pipeline work (#13638 family).

**Root cause** (confirmed via instrumented two-spec repro): with `automaticallyReconnect: false`, `CDPConnection` never subscribed to the underlying socket's `disconnect` event. When the outer runner's spec transition destroyed the page target, the socket closed with no observer — `terminated` stayed `false`, leaving a zombie connection. The next `Fetch.disable` (from `ServerBase.close() → stopCdpFetchRuntime()`) threw `WebSocket is not open`, and `CriClient` enqueued it to await a reconnect that would never be attempted. The promise never settled, `_close()` hung, and `close()` memoizing `_closing` handed the same parked promise to every retry — wedging every subsequent spec's `__internal__beforeEach`.

**Fix:**
- `CDPConnection`: a disconnect with reconnection disabled is terminal — mark terminated, clean up, emit `cdp-connection-closed`. The `ws` getter is null-safe now that a terminal disconnect clears `_connection`.
- `CDPCommandQueue.reject(err)`: reject all enqueued deferreds and empty the queue.
- `CriClient`: reject the queue on `cdp-connection-closed` and `cdp-connection-reconnect-error`, and reject sends against a terminated connection instead of enqueuing them. Removes the dead `enqueuedCommands` array that made the old terminated guard unreachable.
- `CdpAutomation`: swallow screencast-ack failures by `CDPDisconnectedError` type instead of matching a retired error-message string.

The rejection lands in `stopCdpFetchRuntime`'s existing `.catch`, so teardown proceeds without timeouts. Auto-reconnect behavior is unchanged (queue still flushes on successful reconnect — unit-covered).

**Scope** (per review): non-reconnecting clients are not just cypress-in-cypress — `automaticallyReconnect` is `!host && !CYPRESS_INTERNAL_E2E_TESTING_SELF`, so every page-level client in every Chrome/Electron run takes the new terminal-disconnect path on socket death. That behavior change is intentional (silently-parked promises were the bug class), but it converts previously-invisible hung fire-and-forget sends into rejections; the known instance (screencast ack) is fixed here by type-checking `CDPDisconnectedError`, and the standard driver/app/system CI jobs on this PR exercise the regular-run paths. A related pre-existing gap — reconnect exhaustion never marks the connection terminated, so post-exhaustion sends still enqueue — is tracked in #34581.

Also enables the four cypress-in-cypress app specs in a new `run-app-integration-tests-chrome-cdp-remediated` job so CI exercises the previously-wedging spec transition.

### Steps to test

```
cd packages/app
CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run:e2e --browser chrome --spec "cypress/e2e/cypress-in-cypress-run-mode.cy.ts,cypress/e2e/cypress-in-cypress-component.cy.ts"
```

Before this change, the second spec fails its first `before each` (`cy.task('__internal__beforeEach')` times out) and skips the rest; with it, all 11 tests pass. Note the repro requires specs whose tests actually run — a spec whose only test is pending never runs the hook.

Unit coverage: 239 passing across cdp-connection / cri-client / cdp-command-queue / cdp_automation / browser-cri-client / cdp-fetch-transport specs, including new tests for the terminal-disconnect rejection paths, reconnect-exhausted rejection, and the reconnect-unchanged invariant.

### How has the user experience changed?

No change (internal proxy-disabled mode only).

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CDP send/teardown paths for all page-level clients on socket death (intentional rejection vs silent hangs); auto-reconnect behavior is preserved but broader Chrome runs exercise the new terminal-disconnect path.
> 
> **Overview**
> Fixes a **spec-transition wedge** when CDP runs without auto-reconnect (notably cypress-in-cypress with proxy disabled): a closed socket no longer left `terminated` false, so failed sends stayed enqueued forever and blocked teardown/`__internal__beforeEach` on the next spec.
> 
> **CDP lifecycle:** `CDPConnection` now treats `disconnect` as terminal when reconnection is off—marks terminated, cleans up, emits `cdp-connection-closed`, and makes `ws` safe after `_connection` is cleared. `CDPCommandQueue.reject()` fails all pending command promises. `CriClient` drains the queue on `cdp-connection-closed` and reconnect exhaustion, rejects new sends against a terminated connection (drops dead `enqueuedCommands` guard), and sets `closed` when `close()` runs after a terminal disconnect. `CdpAutomation` ignores screencast ack failures via `CDPDisconnectedError` instead of a brittle message string.
> 
> **App GraphQL WebSocket (proxy disabled):** The runner passes **`port`** instead of **`proxyUrl`** into `makeUrqlClient`; `getGraphQLWsUrl` builds `ws://localhost:{port}/…` so upgrades hit the Cypress server when the app is on the AUT origin (#34563).
> 
> **CI:** Adds `run-app-integration-tests-chrome-cdp-remediated` for the four cypress-in-cypress app specs under disabled proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c86d545067d15f2b81515946b2f0293a409a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

