### PR TITLE
chore: fulfill CDP Fetch responses when a `cy.intercept()` modifies the `content-type`

### DIFF
--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -181,17 +181,46 @@ function toRequestPostData (body?: string | Buffer): string | undefined {
   return typeof body === 'string' ? body : body.toString('utf8')
 }
 
+function contentTypeOf (entries?: Protocol.Fetch.HeaderEntry[]): string | undefined {
+  const values = entries
+    ?.filter(({ name }) => name.toLowerCase() === 'content-type')
+    .map(({ value }) => value)
+
+  return values?.length ? values.join(', ') : undefined
+}
+
 /**
+ * Fulfill only when continueResponse would leave the Network record out of
+ * sync with what the page received; continue everything else, since
+ * continueResponse preserves the wire semantics (extraInfo events, streaming,
+ * HTTP caching).
+ *
+ * continueResponse applies overrides to the renderer and records status and
+ * header overrides truthfully in Network.responseReceived — with one gap:
+ * mimeType and charset are derived from the WIRE content-type and are not
+ * recomputed for an override. Consumers of the record (e.g. Test Replay
+ * stylesheet handling keys off mimeType) would see the stale value. So when
+ * cy.intercept mutates either of these, the response takes
+ * Fetch.fulfillRequest:
+ *   - the body, which no longer matches the origin bytes
+ *   - the content-type, which mimeType and charset are derived from
+ * Spy-only, status, and other header intercepts stay on continueResponse.
+ * If Chrome ever derives another Network.responseReceived field from a header
+ * without recomputing it for overrides, that header joins the fulfill list.
+ *
  * The intercept pipeline always materializes a body on the response path, so
- * the presence of a body cannot decide fulfill vs continue on its own. Only a
- * body that differs from the origin bytes needs Fetch.fulfillRequest; header,
- * status, and spy-only intercepts release the origin body as it is.
+ * the presence of a body cannot decide fulfill vs continue on its own.
  */
 function encodePausedResponse (
   { originalBodyDigest, ...pausedResponse }: CdpFetchTransportResponse,
   response: CdpFetchHttpResponse,
 ): CdpFetchTransportResponse {
-  const fulfilled = response.body !== undefined && !isOriginBody(response.body, originalBodyDigest)
+  const bodyModified = response.body !== undefined && !isOriginBody(response.body, originalBodyDigest)
+  const middlewareContentType = contentTypeOf(toResponseHeaders(response.headers))
+  const contentTypeModified = middlewareContentType !== undefined
+    && middlewareContentType !== contentTypeOf(pausedResponse.responseHeaders)
+
+  const fulfilled = bodyModified || (contentTypeModified && response.body !== undefined)
 
   return {
     ...pausedResponse,

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -863,6 +863,107 @@ describe('CdpFetchTransport', () => {
       expect(client.send).not.to.have.been.calledWith('Fetch.fulfillRequest')
     })
 
+    // Network.responseReceived derives mimeType/charset from the wire
+    // content-type; a continueResponse header override does not update them,
+    // so a changed content-type must take the fulfill path to be recorded
+    // truthfully (e.g. Test Replay keys stylesheet handling off mimeType).
+    it('fulfills when middleware changes only the content-type of an untouched body', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: Buffer.from('.x { color: red; }').toString('base64'),
+        base64Encoded: true,
+      })
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        return {
+          ...response,
+          body: await readStream(response.bodyStream!),
+          headers: {
+            ...response.headers,
+            'content-type': 'text/css',
+          },
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' }))
+
+      await tick()
+
+      const response = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 })
+
+      response.responseHeaders = [{ name: 'Content-Type', value: 'application/octet-stream' }]
+
+      await onRequestPaused(response)
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
+        requestId: 'fetch-request',
+        responseCode: 200,
+        responseHeaders: [{
+          name: 'content-type',
+          value: 'text/css',
+        }],
+        body: Buffer.from('.x { color: red; }').toString('base64'),
+      })
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.continueResponse')
+    })
+
+    // Overrides other than content-type are recorded truthfully by CDP on
+    // continueResponse, so they keep the cheaper wire release.
+    it('continues when middleware changes headers other than content-type', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      client.send.withArgs('Fetch.getResponseBody').resolves({
+        body: Buffer.from('.x { color: red; }').toString('base64'),
+        base64Encoded: true,
+      })
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        return {
+          ...response,
+          body: await readStream(response.bodyStream!),
+          headers: {
+            ...response.headers,
+            'x-custom': 'yes',
+          },
+        }
+      })
+
+      const handled = onRequestPaused(createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' }))
+
+      await tick()
+
+      const response = createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 })
+
+      response.responseHeaders = [{ name: 'Content-Type', value: 'application/octet-stream' }]
+
+      await onRequestPaused(response)
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
+        requestId: 'fetch-request',
+        responseCode: 200,
+        responseHeaders: [
+          { name: 'content-type', value: 'application/octet-stream' },
+          { name: 'x-custom', value: 'yes' },
+        ],
+      })
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.fulfillRequest')
+    })
+
     it('matches request and response pauses by fetch request id', async () => {
       const client = createClient()
       const { transport } = createTransport(client)
@@ -1786,8 +1887,10 @@ describe('CdpFetchTransport', () => {
         return {
           ...response,
           body: await readStream(response.bodyStream!),
+          // a content-type change would force the fulfill path (mimeType
+          // derivation) — use a neutral header to stay on continueResponse
           headers: {
-            'content-type': 'text/plain',
+            'x-verbatim': 'empty',
           },
           statusCode: 204,
         }
@@ -1816,8 +1919,8 @@ describe('CdpFetchTransport', () => {
         requestId: 'fetch-request',
         responseCode: 204,
         responseHeaders: [{
-          name: 'content-type',
-          value: 'text/plain',
+          name: 'x-verbatim',
+          value: 'empty',
         }],
       })
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34560

### Additional details

`Network.responseReceived` derives `mimeType`/`charset` from the wire content-type, and a `Fetch.continueResponse` header override doesn't recompute them — the page honors the override, but the protocol record keeps the stale value. Test Replay keys stylesheet handling off `mimeType`, so an intercept that rewrites `content-type` (e.g. `text/css` onto an extensionless stylesheet) replayed the page unstyled.

The #34493 digest gate decided fulfill-vs-continue on the body digest alone. This widens it: a changed `content-type` joins the modified-body case on `Fetch.fulfillRequest`, where the override is recorded truthfully. Status, other header, and spy-only intercepts stay on `continueResponse` (probe-verified truthful there), keeping its extraInfo/streaming/caching benefits everywhere the record already matches what the page received. Accepted drift: content-type-modified responses give up their extraInfo events, same as the existing modified-response rulings.

Internal-flag work (`CYPRESS_INTERNAL_DISABLE_PROXY`), so no changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CDP Fetch fulfill-vs-continue decision in the network interception path, so more content-type-rewritten responses lose continueResponse wire benefits. Scope is narrow and covered by unit tests.
> 
> **Overview**
> Widens the CDP Fetch fulfill-vs-continue gate so **`cy.intercept` content-type rewrites** take `Fetch.fulfillRequest` instead of `Fetch.continueResponse`.
> 
> Chrome derives `mimeType`/`charset` from the wire content-type and does not recompute them for continue overrides, which left Test Replay with a stale mime type (e.g. unstyled CSS). Body-modified responses already fulfilled; content-type changes with a materialized body now do too. Status, other-header, and spy-only intercepts still continue.
> 
> Adds unit coverage for both sides of the gate and adjusts an existing empty-body continue test to avoid content-type so it stays on the continue path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef87c5021825cc02f64a239913bc5b3b8cab7e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Two new unit tests pin the gate in both directions:

```
yarn workspace @packages/server test-unit -- cdp-fetch-transport_spec.ts
```

### How has the user experience changed?

MITM path is byte-identical — the change is confined to `encodePausedResponse` in the CDP Fetch codec. With the proxy disabled, Test Replay now records the intercepted `content-type` truthfully, so replays render styled.

Verified A/B against the capture-protocol harness: the proxy-off DB for `import-stylesheets-from-css-no-css-extension.cy.ts` records `text/css` and its `assets-css_2` / `assets-css-blob_2` replay-render specs go 6/6 (previously failing; proxy-on control passing). Transport suite 73 passing; lint and `check-ts` green.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
