### PR TITLE
chore: serve cloud-bundle routes (studio, cy-prompt) from the Cypress origin when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -340,9 +340,10 @@ jobs:
       # #34467 continue unmodified CDP Fetch responses; #34465 extra-target shared
       # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386);
       # #34555 service worker session interception; #34562 synthetic request query +
-      # httpVersion drift. Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
-      # never settles on the extra target's session. Add it here once that is fixed.
-      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts
+      # httpVersion drift; #34559 cloud-bundle loopback routes. Excludes
+      # downloads_basic_auth.cy.ts — #34512 Network.enable never settles on the
+      # extra target's session. Add it here once that is fixed.
+      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/commands/prompt/prompt.cy.ts
       requires:
         - ready-to-test
   - driver-integration-tests-electron:

--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -69,6 +69,21 @@ function matchesPathPrefix (pathname: string, route: string): boolean {
   return pathname === normalizedRoute || pathname.startsWith(`${normalizedRoute}/`)
 }
 
+// Cloud-delivered bundle namespaces (studio, cy-prompt) served by Express
+// routes outside /__cypress — see packages/server/lib/routes.ts. In
+// cypress-in-cypress the parent's Express handlers for these paths re-enter
+// the proxy to forward to the child project, so the loopback re-entry guard
+// must let them continue instead of 404ing.
+export const CYPRESS_STUDIO_ROUTE = '/__cypress-studio'
+
+export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
+
+const CLOUD_BUNDLE_ROUTES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
+
+export function isCloudBundleRoute (pathname: string): boolean {
+  return CLOUD_BUNDLE_ROUTES.some((route) => matchesPathPrefix(pathname, route))
+}
+
 export function isInternalCypressRoute (pathname: string, config: InternalRouteConfig): boolean {
   // Component-testing app/spec assets are served by the bundler under
   // /__cypress/src (or a custom public path). Matching the whole namespace
@@ -82,6 +97,7 @@ export function isInternalCypressRoute (pathname: string, config: InternalRouteC
     config.clientRoute,
     config.socketIoRoute,
     config.socketIoRoute ? `${config.socketIoRoute}-graphql` : undefined,
+    ...CLOUD_BUNDLE_ROUTES,
   ].filter((route): route is string => Boolean(route))
 
   return internalRoutes.some((route) => matchesPathPrefix(pathname, route))

--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -1,4 +1,5 @@
 import { id as randomId } from '../util/random'
+import { isProxyDisabled } from '../util/is-proxy-disabled'
 
 // Fields are optional at the type level because RuntimeConfigOptions extends
 // Partial<...>. At runtime, `port` is required before loopback (toLoopbackUrl
@@ -74,6 +75,10 @@ function matchesPathPrefix (pathname: string, route: string): boolean {
 // cypress-in-cypress the parent's Express handlers for these paths re-enter
 // the proxy to forward to the child project, so the loopback re-entry guard
 // must let them continue instead of 404ing.
+//
+// Only internal with the proxy disabled. Under MITM these reach Express
+// through the legacy pipeline; looping them back skips later intercept
+// stages and breaks studio.
 export const CYPRESS_STUDIO_ROUTE = '/__cypress-studio'
 
 export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
@@ -97,7 +102,7 @@ export function isInternalCypressRoute (pathname: string, config: InternalRouteC
     config.clientRoute,
     config.socketIoRoute,
     config.socketIoRoute ? `${config.socketIoRoute}-graphql` : undefined,
-    ...CLOUD_BUNDLE_ROUTES,
+    ...(isProxyDisabled() ? CLOUD_BUNDLE_ROUTES : []),
   ].filter((route): route is string => Boolean(route))
 
   return internalRoutes.some((route) => matchesPathPrefix(pathname, route))

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -10,11 +10,6 @@ type CreateServeInternalRoutesMiddlewareOptions = {
   request: ServerRequest
 }
 
-const LOOPBACK_HEADERS = new Set([
-  CYPRESS_INTERNAL_LOOPBACK_HEADER,
-  CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER,
-])
-
 const HOP_BY_HOP_HEADERS = new Set([
   'accept-encoding',
   'connection',
@@ -27,21 +22,18 @@ const HOP_BY_HOP_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
-  ...LOOPBACK_HEADERS,
+  CYPRESS_INTERNAL_LOOPBACK_HEADER,
+  CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER,
 ])
 
-function omitHeaders (headers: HttpHeaders = {}, omit: Set<string>): HttpHeaders {
+function filterHeaders (headers: HttpHeaders = {}): HttpHeaders {
   return Object.entries(headers).reduce<HttpHeaders>((memo, [key, value]) => {
-    if (!omit.has(key.toLowerCase())) {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
       memo[key] = value
     }
 
     return memo
   }, {})
-}
-
-function filterHeaders (headers: HttpHeaders = {}): HttpHeaders {
-  return omitHeaders(headers, HOP_BY_HOP_HEADERS)
 }
 
 function toLoopbackUrl (requestUrl: string, config: ServeInternalRoutesConfig): string {
@@ -86,10 +78,15 @@ export function createServeInternalRoutesMiddleware ({
       // Cloud-bundle routes re-enter on purpose: the cypress-in-cypress parent's
       // Express handlers forward them through the proxy to the child project.
       // Hand them to the legacy pipeline instead of swallowing the forward.
-      // Drop the loopback headers first — the token authenticates re-entry and
-      // must never ride the outbound request to the child project or the AUT.
+      // The token authenticates re-entry and must not reach the child project
+      // or the AUT.
       if (isCloudBundleRoute(url.pathname)) {
-        return next({ ...request, headers: omitHeaders(request.headers, LOOPBACK_HEADERS) })
+        const headers = { ...request.headers }
+
+        delete headers[CYPRESS_INTERNAL_LOOPBACK_HEADER]
+        delete headers[CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]
+
+        return next({ ...request, headers })
       }
 
       // Otherwise no route handler owned this path and the catch-all proxy saw

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -1,6 +1,6 @@
 import type { HttpHeaders, HttpRequest, InterceptMiddleware } from '@packages/network-interception'
 import type { Request as ServerRequest } from '../request'
-import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, isInternalCypressRoute, isTrustedInternalLoopback, resolveProxyUrlBase } from './internal-routes'
+import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, isCloudBundleRoute, isInternalCypressRoute, isTrustedInternalLoopback, resolveProxyUrlBase } from './internal-routes'
 import type { InternalRouteConfig } from './internal-routes'
 
 type ServeInternalRoutesConfig = InternalRouteConfig
@@ -72,10 +72,18 @@ export function createServeInternalRoutesMiddleware ({
       return next(request)
     }
 
-    // Re-entry after our own Express loopback: no route handler owned this path,
-    // so the catch-all proxy saw it again. Stop instead of looping forever.
-    // Require the process token — AUT content can forge the URL header alone.
+    // Re-entry after our own Express loopback. Require the process token —
+    // AUT content can forge the URL header alone.
     if (isTrustedInternalLoopback(request.headers)) {
+      // Cloud-bundle routes re-enter on purpose: the cypress-in-cypress parent's
+      // Express handlers forward them through the proxy to the child project.
+      // Hand them to the legacy pipeline instead of swallowing the forward.
+      if (isCloudBundleRoute(url.pathname)) {
+        return next(request)
+      }
+
+      // Otherwise no route handler owned this path and the catch-all proxy saw
+      // it again. Stop instead of looping forever.
       return {
         id: request.id,
         url: request.url,

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -10,6 +10,11 @@ type CreateServeInternalRoutesMiddlewareOptions = {
   request: ServerRequest
 }
 
+const LOOPBACK_HEADERS = new Set([
+  CYPRESS_INTERNAL_LOOPBACK_HEADER,
+  CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER,
+])
+
 const HOP_BY_HOP_HEADERS = new Set([
   'accept-encoding',
   'connection',
@@ -22,18 +27,21 @@ const HOP_BY_HOP_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
-  CYPRESS_INTERNAL_LOOPBACK_HEADER,
-  CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER,
+  ...LOOPBACK_HEADERS,
 ])
 
-function filterHeaders (headers: HttpHeaders = {}): HttpHeaders {
+function omitHeaders (headers: HttpHeaders = {}, omit: Set<string>): HttpHeaders {
   return Object.entries(headers).reduce<HttpHeaders>((memo, [key, value]) => {
-    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+    if (!omit.has(key.toLowerCase())) {
       memo[key] = value
     }
 
     return memo
   }, {})
+}
+
+function filterHeaders (headers: HttpHeaders = {}): HttpHeaders {
+  return omitHeaders(headers, HOP_BY_HOP_HEADERS)
 }
 
 function toLoopbackUrl (requestUrl: string, config: ServeInternalRoutesConfig): string {
@@ -78,8 +86,10 @@ export function createServeInternalRoutesMiddleware ({
       // Cloud-bundle routes re-enter on purpose: the cypress-in-cypress parent's
       // Express handlers forward them through the proxy to the child project.
       // Hand them to the legacy pipeline instead of swallowing the forward.
+      // Drop the loopback headers first — the token authenticates re-entry and
+      // must never ride the outbound request to the child project or the AUT.
       if (isCloudBundleRoute(url.pathname)) {
-        return next(request)
+        return next({ ...request, headers: omitHeaders(request.headers, LOOPBACK_HEADERS) })
       }
 
       // Otherwise no route handler owned this path and the catch-all proxy saw

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -23,7 +23,7 @@ import files from './controllers/files'
 import * as plugins from './plugins'
 import { privilegedCommandsManager } from './privileged-commands/privileged-commands-manager'
 import { isProxyDisabled } from './util/is-proxy-disabled'
-import { isTrustedInternalLoopback, resolveProxyUrlBase } from './adapters/internal-routes'
+import { CYPRESS_CY_PROMPT_ROUTE, CYPRESS_STUDIO_ROUTE, isTrustedInternalLoopback, resolveProxyUrlBase } from './adapters/internal-routes'
 
 const debug = Debug('cypress:server:routes')
 
@@ -111,7 +111,7 @@ export const createCommonRoutes = ({
   // If we are in cypress in cypress we need to pass along the studio and cy-prompt routes
   // to the child project. We also add a utility route for testing HTTP status code UI
   if (process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT) {
-    router.get('/__cypress-studio/*', async (req, res) => {
+    router.get(`${CYPRESS_STUDIO_ROUTE}/*`, async (req, res) => {
       const proxy = resolveNetworkProxy()
 
       if (!proxy) {
@@ -123,7 +123,7 @@ export const createCommonRoutes = ({
       return
     })
 
-    router.get('/__cypress-cy-prompt/*', async (req, res) => {
+    router.get(`${CYPRESS_CY_PROMPT_ROUTE}/*`, async (req, res) => {
       const proxy = resolveNetworkProxy()
 
       if (!proxy) {

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -24,10 +24,11 @@ describe('lib/adapters/internal-routes', () => {
     expect(isInternalCypressRoute('/__cypress/src/spec-0.js', config)).to.be.false
   })
 
-  it('does not match studio or cy-prompt module-federation entries', () => {
-    // Parent cy-in-cy Express handlers re-enter the proxy for these paths.
-    expect(isInternalCypressRoute('/__cypress-studio/app-studio.js', config)).to.be.false
-    expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config)).to.be.false
+  it('matches studio and cy-prompt module-federation entries', () => {
+    // Served by Express routes outside /__cypress; the loopback re-entry
+    // guard lets the parent cy-in-cy forwarders continue for these paths.
+    expect(isInternalCypressRoute('/__cypress-studio/app-studio.js', config)).to.be.true
+    expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config)).to.be.true
   })
 
   it('does not match internal route lookalikes', () => {
@@ -180,6 +181,26 @@ describe('lib/adapters/serve-internal-routes', () => {
       headers: { 'content-type': 'text/plain' },
       body: 'Not Found',
     })
+  })
+
+  it('delegates trusted loopback re-entries for cloud-bundle routes to the next middleware', async () => {
+    // The cypress-in-cypress parent's Express handlers for studio/cy-prompt
+    // re-enter the proxy to forward to the child project — the legacy
+    // pipeline must receive the request instead of a loop-guard 404.
+    const { middleware, serverRequest } = createMiddleware()
+    const next = sinon.stub().resolves({ id: 'req-1', statusCode: 200 })
+
+    await middleware({
+      id: 'req-1',
+      url: 'http://127.0.0.1:1234/__cypress-cy-prompt/driver/cy-prompt.js',
+      headers: {
+        'x-cypress-internal-loopback': 'http://127.0.0.1:1234/__cypress-cy-prompt/driver/cy-prompt.js',
+        'x-cypress-internal-loopback-token': cypressInternalLoopbackToken,
+      },
+    }, next)
+
+    expect(next).to.have.been.calledOnce
+    expect(serverRequest.create).not.to.have.been.called
   })
 
   it('does not short-circuit on a spoofed loopback header without the process token', async () => {

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -13,6 +13,10 @@ const config = {
 } as any
 
 describe('lib/adapters/internal-routes', () => {
+  afterEach(() => {
+    delete process.env.CYPRESS_INTERNAL_DISABLE_PROXY
+  })
+
   it('matches Cypress internal route prefixes', () => {
     expect(isInternalCypressRoute('/__cypress/xhrs/foo', config)).to.be.true
     expect(isInternalCypressRoute('/__/assets/app.js', config)).to.be.true
@@ -24,11 +28,20 @@ describe('lib/adapters/internal-routes', () => {
     expect(isInternalCypressRoute('/__cypress/src/spec-0.js', config)).to.be.false
   })
 
-  it('matches studio and cy-prompt module-federation entries', () => {
-    // Served by Express routes outside /__cypress; the loopback re-entry
-    // guard lets the parent cy-in-cy forwarders continue for these paths.
+  it('matches studio and cy-prompt module-federation entries when the proxy is disabled', () => {
+    process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
     expect(isInternalCypressRoute('/__cypress-studio/app-studio.js', config)).to.be.true
     expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config)).to.be.true
+  })
+
+  it('does not match studio or cy-prompt module-federation entries under the MITM proxy', () => {
+    // The legacy pipeline already delivers these to Express; looping them back
+    // skips later intercept stages and breaks studio.
+    delete process.env.CYPRESS_INTERNAL_DISABLE_PROXY
+
+    expect(isInternalCypressRoute('/__cypress-studio/app-studio.js', config)).to.be.false
+    expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config)).to.be.false
   })
 
   it('does not match internal route lookalikes', () => {
@@ -51,6 +64,10 @@ describe('lib/adapters/internal-routes', () => {
 })
 
 describe('lib/adapters/serve-internal-routes', () => {
+  afterEach(() => {
+    delete process.env.CYPRESS_INTERNAL_DISABLE_PROXY
+  })
+
   function createMiddleware (response: any = {
     statusCode: 200,
     headers: {},
@@ -187,6 +204,8 @@ describe('lib/adapters/serve-internal-routes', () => {
     // The cypress-in-cypress parent's Express handlers for studio/cy-prompt
     // re-enter the proxy to forward to the child project — the legacy
     // pipeline must receive the request instead of a loop-guard 404.
+    process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
     const { middleware, serverRequest } = createMiddleware()
     const next = sinon.stub().resolves({ id: 'req-1', statusCode: 200 })
 
@@ -206,6 +225,8 @@ describe('lib/adapters/serve-internal-routes', () => {
   it('strips the loopback headers from delegated cloud-bundle re-entries', async () => {
     // The token authenticates re-entry — forwarding it to the child project or
     // the AUT would hand a real origin the means to forge a trusted loopback.
+    process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
     const { middleware } = createMiddleware()
     const next = sinon.stub().resolves({ id: 'req-1', statusCode: 200 })
 

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -203,6 +203,25 @@ describe('lib/adapters/serve-internal-routes', () => {
     expect(serverRequest.create).not.to.have.been.called
   })
 
+  it('strips the loopback headers from delegated cloud-bundle re-entries', async () => {
+    // The token authenticates re-entry — forwarding it to the child project or
+    // the AUT would hand a real origin the means to forge a trusted loopback.
+    const { middleware } = createMiddleware()
+    const next = sinon.stub().resolves({ id: 'req-1', statusCode: 200 })
+
+    await middleware({
+      id: 'req-1',
+      url: 'http://127.0.0.1:1234/__cypress-cy-prompt/driver/cy-prompt.js',
+      headers: {
+        'accept-encoding': 'gzip',
+        'x-cypress-internal-loopback': 'http://127.0.0.1:1234/__cypress-cy-prompt/driver/cy-prompt.js',
+        'x-cypress-internal-loopback-token': cypressInternalLoopbackToken,
+      },
+    }, next)
+
+    expect(next.firstCall.args[0].headers).to.deep.equal({ 'accept-encoding': 'gzip' })
+  })
+
   it('does not short-circuit on a spoofed loopback header without the process token', async () => {
     const { middleware, serverRequest } = createMiddleware({
       statusCode: 200,


### PR DESCRIPTION
- Closes #34559

### Additional details

With the proxy disabled (`CYPRESS_INTERNAL_DISABLE_PROXY=1`), `cy.prompt` failed with a misleading "Cloud code needs to be refreshed" error.

The driver loads the cy.prompt bundle via module federation from `/__cypress-cy-prompt` on the AUT origin. `isInternalCypressRoute` deliberately excluded the `/__cypress-studio` and `/__cypress-cy-prompt` namespaces, so with the proxy disabled those requests were not recognized as internal, escaped to the real AUT server, and 404'd. The driver surfaced the 404 as a refresh error rather than a missing route.

The reason for the original exclusion was cypress-in-cypress: the parent project's Express handlers for these two namespaces re-enter the proxy on purpose to forward the request to the child project, and the loopback re-entry guard would have 404'd that forward. So rather than just adding the namespaces, this splits the two cases:

- `internal-routes.ts` gains exported `CYPRESS_STUDIO_ROUTE` / `CYPRESS_CY_PROMPT_ROUTE` constants and an `isCloudBundleRoute()` helper, and both namespaces are now matched by `isInternalCypressRoute`.
- `serve-internal-routes.ts` keeps the loop guard for everything else, but when a *trusted* loopback re-entry (process token required — the URL header alone is forgeable by AUT content) is for a cloud-bundle route, it delegates to `next(request)` so the legacy pipeline carries the cy-in-cy forward instead of swallowing it in a 404.
- `routes.ts` uses the new constants for the cy-in-cy forwarder routes so the namespaces are defined in one place.

Both network runtimes install this middleware, so the studio/cy-prompt namespaces are matched only when the proxy is disabled — under MITM they keep flowing through the legacy pipeline untouched. `serve-internal-routes_spec.ts` asserts both sides of that gate.

Also promotes `cypress/e2e/commands/prompt/prompt.cy.ts` into the `driver-integration-tests-chrome-cdp-remediated` job so the proxy-disabled pipeline keeps cy.prompt green.

No changelog entry — this is an internal, env-gated change behind the disabled-proxy work.

### Steps to test

1. Unit coverage: `yarn workspace @packages/server test-unit -- adapters/serve-internal-routes_spec.ts`
2. The end-to-end verification is the `driver-integration-tests-chrome-cdp-remediated` job on this PR, which now includes `prompt.cy.ts`. That spec needs a record key, so it can't be run meaningfully outside CI.
3. To see the original failure locally, run the driver with `CYPRESS_INTERNAL_DISABLE_PROXY=1` on `develop` and watch the network tab: `/__cypress-cy-prompt/driver/cy-prompt.js` 404s and the driver reports "Cloud code needs to be refreshed". On this branch that request is served from the Cypress origin instead.
4. Confirm no regression with the proxy enabled — cy.prompt and studio behave as before, including cypress-in-cypress runs where the parent forwards these paths to the child.

### How has the user experience changed?

No change with the default (proxy enabled) configuration. With the proxy disabled, `cy.prompt` now loads its bundle instead of failing with a misleading "Cloud code needs to be refreshed" error.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request routing and loopback security headers in the proxy-disabled network path; behavior is env-gated and MITM paths are explicitly preserved, but mistakes could affect studio/cy-prompt or cypress-in-cypress forwarding.
> 
> **Overview**
> Fixes **cy.prompt** (and studio bundle loads) when **`CYPRESS_INTERNAL_DISABLE_PROXY`** is on: requests to `/__cypress-cy-prompt` and `/__cypress-studio` are now treated as Cypress-internal and looped to Express instead of escaping to the AUT and 404ing.
> 
> **`internal-routes.ts`** adds shared route constants, `isCloudBundleRoute()`, and includes those paths in `isInternalCypressRoute` **only when the proxy is disabled** (MITM behavior unchanged so studio keeps using the legacy pipeline).
> 
> **`serve-internal-routes.ts`** changes the trusted loopback guard: re-entries on cloud-bundle paths **delegate to `next()`** (with loopback headers stripped) so cypress-in-cypress parent forwards to the child still work; other unmatched loopbacks still return 404.
> 
> **`routes.ts`** uses the new constants for cy-in-cy forwarder routes. Unit tests cover the proxy-disabled vs MITM gate and delegation/stripping. **`prompt.cy.ts`** is added to **`driver-integration-tests-chrome-cdp-remediated`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a047a6fde43960978aefc096c04ff2b78c61eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

