### PR TITLE
chore: target the Cypress server origin for graphql-ws upgrades when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -291,9 +291,11 @@ jobs:
       parallelism: 1
       # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
       # #34514 strategy:file origin serving + #34379 intercept-matched visit pre-flights (visits, web security, service workers).
+      # #34563 graphql-ws upgrades target the Cypress server origin (request_spec); non_proxied_spec asserts proxy
+      # semantics that do not exist here and skips itself.
       # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
       # concurrent large-body CDP Fetch (47 unmatched localhost requests); Electron was green.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js
+      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js test/request_spec.ts test/non_proxied_spec.ts
       requires:
         - system-tests-node-modules-install
   - system-tests-cookies-cdp:
@@ -306,9 +308,10 @@ jobs:
       disable-proxy: true
       require-opt-in: false
       parallelism: 1
-      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses.
+      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
+      # #34563 graphql-ws upgrades target the Cypress server origin.
       # proxy_correlation_spec omitted — see chrome-cdp-remediated note above.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js
+      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/request_spec.ts
       requires:
         - system-tests-node-modules-install
   - run-launchpad-integration-tests-chrome:

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -41,7 +41,7 @@ app.use(Toast, {
   closeOnClick: false,
 })
 
-await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute }).then((client) => {
+await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute, proxyUrl: config.proxyUrl }).then((client) => {
   app.use(urql, client)
   app.use(createRouter())
   app.use(createI18n())

--- a/packages/data-context/src/sources/HtmlDataSource.ts
+++ b/packages/data-context/src/sources/HtmlDataSource.ts
@@ -133,6 +133,7 @@ export class HtmlDataSource {
           window.__CYPRESS_BROWSER__ = ${JSON.stringify(this.ctx.coreData.activeBrowser)}
           ${telemetry.isEnabled() ? `window.__CYPRESS_TELEMETRY__ = ${JSON.stringify({ context: telemetry.getActiveContextObject(), resources: telemetry.getResources(), isVerbose: telemetry.isVerbose() })}` : ''}
           ${process.env.CYPRESS_INTERNAL_GQL_NO_SOCKET ? `window.__CYPRESS_GQL_NO_SOCKET__ = 'true';` : ''}
+          ${process.env.CYPRESS_INTERNAL_DISABLE_PROXY === '1' ? `window.__CYPRESS_PROXY_DISABLED__ = true;` : ''}
         </script>
     `)
   }

--- a/packages/frontend-shared/src/graphql/urqlClient.cy.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.cy.ts
@@ -1,0 +1,46 @@
+import { getGraphQLWsUrl } from './urqlClient'
+
+describe('getGraphQLWsUrl', () => {
+  const appConfig = {
+    target: 'app',
+    namespace: '__cypress',
+    socketIoRoute: '/__socket',
+    proxyUrl: 'http://localhost:2345',
+  } as const
+
+  it('uses the page origin when the proxy is enabled', () => {
+    const url = getGraphQLWsUrl(appConfig, { protocol: 'http:', host: 'localhost:2345' }, false)
+
+    expect(url).to.equal('ws://localhost:2345/__socket-graphql')
+  })
+
+  it('uses wss when the page is served over https and the proxy is enabled', () => {
+    const url = getGraphQLWsUrl(appConfig, { protocol: 'https:', host: 'app.foobar.com' }, false)
+
+    expect(url).to.equal('wss://app.foobar.com/__socket-graphql')
+  })
+
+  it('uses the Cypress server origin when the proxy is disabled', () => {
+    const url = getGraphQLWsUrl(appConfig, { protocol: 'http:', host: 'localhost:2292' }, true)
+
+    expect(url).to.equal('ws://localhost:2345/__socket-graphql')
+  })
+
+  it('uses the Cypress server origin when the proxy is disabled and the page is https', () => {
+    const url = getGraphQLWsUrl(appConfig, { protocol: 'https:', host: 'app.foobar.com' }, true)
+
+    expect(url).to.equal('ws://localhost:2345/__socket-graphql')
+  })
+
+  it('falls back to the page origin when the proxy is disabled and no proxyUrl is served', () => {
+    const url = getGraphQLWsUrl({ ...appConfig, proxyUrl: undefined }, { protocol: 'http:', host: 'localhost:2292' }, true)
+
+    expect(url).to.equal('ws://localhost:2292/__socket-graphql')
+  })
+
+  it('always uses the page origin for launchpad', () => {
+    const url = getGraphQLWsUrl({ target: 'launchpad' }, { protocol: 'http:', host: 'localhost:2345' }, true)
+
+    expect(url).to.equal('ws://localhost:2345/__launchpad/graphql-ws')
+  })
+})

--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -100,6 +100,7 @@ declare global {
      */
     __CYPRESS_GQL_NO_SOCKET__?: string
     __CYPRESS_MODE__: 'run' | 'open'
+    __CYPRESS_PROXY_DISABLED__?: boolean
     __RUN_MODE_SPECS__: SpecFile[]
     __CYPRESS_TESTING_TYPE__: 'e2e' | 'component'
     __CYPRESS_BROWSER__: Partial<Browser> & {majorVersion: string | number}
@@ -123,6 +124,7 @@ interface AppUrqlClientConfig {
   target: 'app'
   namespace: string
   socketIoRoute: string
+  proxyUrl?: string
 }
 
 export type UrqlClientConfig = LaunchpadUrqlClientConfig | AppUrqlClientConfig
@@ -232,14 +234,24 @@ function getPubSubSource (config: PubSubConfig) {
   })
 }
 
-function getSocketSource (config: UrqlClientConfig) {
-  // http: -> ws:  &  https: -> wss:
-  const protocol = window.location.protocol.replace('http', 'ws')
-  const wsUrl = config.target === 'launchpad'
-    ? `ws://${window.location.host}/__launchpad/graphql-ws`
-    : `${protocol}//${window.location.host}${config.socketIoRoute}-graphql`
+export function getGraphQLWsUrl (config: UrqlClientConfig, location: Pick<Location, 'protocol' | 'host'>, proxyDisabled: boolean) {
+  if (config.target === 'launchpad') {
+    return `ws://${location.host}/__launchpad/graphql-ws`
+  }
 
+  // With the proxy disabled the app is served at the AUT's superdomain, and CDP
+  // cannot intercept a WebSocket upgrade — the handshake has to name the Cypress
+  // server or it reaches the user's app server (see #34563).
+  const origin = proxyDisabled && config.proxyUrl ? new URL(config.proxyUrl) : location
+
+  // http: -> ws:  &  https: -> wss:
+  const protocol = origin.protocol.replace('http', 'ws')
+
+  return `${protocol}//${origin.host}${config.socketIoRoute}-graphql`
+}
+
+function getSocketSource (config: UrqlClientConfig) {
   return createWsClient({
-    url: wsUrl,
+    url: getGraphQLWsUrl(config, window.location, window.__CYPRESS_PROXY_DISABLED__ === true),
   })
 }

--- a/system-tests/test/non_proxied_spec.ts
+++ b/system-tests/test/non_proxied_spec.ts
@@ -1,6 +1,13 @@
 import systemTests from '../lib/system-tests'
 
-describe('e2e non-proxied spec', () => {
+const describeNonProxied = process.env.CYPRESS_INTERNAL_DISABLE_PROXY === '1'
+  ? describe.skip
+  : describe
+
+// NOTE: this spec screenshots what `Cypress.config('proxyUrl')` serves and asserts
+// WebSocket behavior through the proxy port — neither exists when the proxy is
+// disabled (#34563).
+describeNonProxied('e2e non-proxied spec', () => {
   systemTests.setup()
 
   systemTests.it('passes', {


### PR DESCRIPTION

- Closes https://github.com/cypress-io/cypress/issues/34563

### Additional details

Two specs fail on the full proxy-off system-tests job. The issue filed them both as accepted drift, but only one of them is.

`non_proxied_spec` screenshots what `proxyUrl` serves and asserts WebSocket behavior through the proxy port. With the proxy disabled that premise doesn't exist, so it skips itself using the same idiom as `cookies_spec.ts` and `network_error_handling_spec.js`.

`request_spec` turned out to be a real leak. The issue describes it as one *fewer* wire hit; it is actually one *extra* one. With the proxy disabled the Cypress app is served at the AUT's superdomain, and `getSocketSource` built the graphql-ws URL from `window.location`, so the subscription handshake went to `ws://localhost:2292/__socket-graphql` — the user's app server. CDP `Fetch` can't intercept a WebSocket upgrade, so nothing caught it. Under the MITM proxy this is invisible, because `proxyWebsockets` claims any upgrade whose path starts with `socketIoRoute` no matter which host it named.

So the count in `request_spec` needed no per-pipeline pin — the extra request shouldn't have been there at all.

graphql-ws was the last thing on this path still using the network. Queries and mutations already ride the socket.io `/data-context` channel as `graphql:request`, and socket.io itself uses `CDPBrowserSocket` in Chromium, which is a CDP binding transport with no socket at all. And `proxyWebsockets` already has a proxy-disabled branch that accepts socket-route upgrades arriving directly on the Cypress server (#34513) — the server was already prepared for this connection, the client was just naming the wrong origin. The fix points the handshake at `config.proxyUrl` when the proxy is disabled.

I deliberately left the MITM path alone. Proxied, an absolute `ws://localhost:<port>/…` upgrade reaches the proxy in absolute-form, so `req.url.startsWith(socketIoRoute)` is false and it falls through to the generic forwarding path and re-enters the server's upgrade handler behind a different allow-list check. That's real regression risk in a well-tested path for no benefit. Launchpad is untouched for the same reason — it always runs on the Cypress server origin and never hosts an AUT.

One thing worth recording, because it looks like a blocker and isn't: when the AUT superdomain is https, this becomes a `ws://localhost` handshake from an https page. That is gated by Chrome's Local Network Access check, which is address-space-based rather than scheme-based — an http public origin fails identically, and `http://localhost` succeeds. Cypress already disables that gate at launch for every Chromium browser (`chromium_flags.ts`, added in #34027 for #32708), so the handshake connects. Measured both ways in Chrome 151 rather than reasoned about.

The proxy-disabled signal reaches the app as `window.__CYPRESS_PROXY_DISABLED__`, injected next to the existing `window.__CYPRESS_GQL_NO_SOCKET__`. That's a stopgap: once `forceHttp1` (#33847) replaces `CYPRESS_INTERNAL_DISABLE_PROXY`, the app can read the resolved config value it already receives and the global goes away. `getGraphQLWsUrl` takes the flag as an argument, so that swap is a one-line change at the call site.

### Steps to test

Both specs now pass on both pipelines and are promoted into the `*-cdp-remediated` jobs, so CI covers this. To see it by hand:

```
cd system-tests && CYPRESS_INTERNAL_DISABLE_PROXY=1 node ./scripts/run.js test/request_spec.ts --browser chrome
cd system-tests && node ./scripts/run.js test/request_spec.ts --browser chrome
```

Before the fix, the proxy-off run fails `visits to a different superdomain will be resolved twice` with `localhost:2292: 3` against an expected `2`, and the fixture server logs a `GET /__socket-graphql`. After it, both runs pass and that request is gone.

I also confirmed the subscription actually works rather than just going quiet — the handshake reaches `101 Switching Protocols` and delivers subscription payloads (`errorWarningChange`, `specsChange`, `branchChange`) on both Chrome and Electron. A dead socket would have made the leaked request disappear too, which is why that check mattered.

### How has the user experience changed?

No change. The proxy-disabled pipeline is internal and env-gated, and the MITM path is untouched.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the app opens GraphQL subscription WebSockets, but only on the internal proxy-disabled path; the default MITM path is untouched.
> 
> **Overview**
> Fixes a proxy-off leak where the app's **graphql-ws** handshake used `window.location` and hit the AUT server instead of Cypress. CDP cannot intercept WebSocket upgrades, so that request escaped.
> 
> When `__CYPRESS_PROXY_DISABLED__` is set, `getGraphQLWsUrl` now builds the URL from `proxyUrl`. The flag is injected into app HTML, and `proxyUrl` is passed into `makeUrqlClient`. The proxied and launchpad paths are unchanged.
> 
> Also skips `non_proxied_spec` under proxy-off (it asserts proxy-only behavior) and promotes `request_spec` / `non_proxied_spec` into the CDP-remediated CI jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24fb962760a2ab795d449f5bbf1d2e4dd21fb50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->