### PR TITLE
chore: [spike] benchmark MITM vs CDP interception across CircleCI resource classes

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -208,6 +208,17 @@ executors:
     environment:
       PLATFORM: linux
 
+  # Separate from `linux-x64` because the gen2 VM resource classes are not offered
+  # on ubuntu-2004 - CircleCI rejects the job outright with `invalid-resource-class`
+  # - and the proxy benchmark's VM cell has to be generation-matched to the docker
+  # cell it is compared against. `unit-tests` keeps ubuntu-2004 untouched.
+  linux-x64-gen2: &linux-x64-gen2-executor
+    machine:
+      image: ubuntu-2604:current
+    resource_class: medium.gen2
+    environment:
+      PLATFORM: linux
+
 commands:
   # This command inserts SHOULD_PERSIST_ARTIFACTS into BASH_ENV. This way, we can define the variable in one place and use it in multiple steps.
   # Run this command in a job before you want to use the SHOULD_PERSIST_ARTIFACTS variable.
@@ -2361,7 +2372,9 @@ jobs:
       # wall-clock ratios this job measures.
       - when:
           condition:
-            equal: [ *linux-x64-executor, << parameters.executor >> ]
+            or:
+              - equal: [ *linux-x64-executor, << parameters.executor >> ]
+              - equal: [ *linux-x64-gen2-executor, << parameters.executor >> ]
           steps:
             - run:
                 name: Ensure Xvfb is present

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -208,17 +208,6 @@ executors:
     environment:
       PLATFORM: linux
 
-  # Separate from `linux-x64` because the gen2 VM resource classes are not offered
-  # on ubuntu-2004 - CircleCI rejects the job outright with `invalid-resource-class`
-  # - and the proxy benchmark's VM cell has to be generation-matched to the docker
-  # cell it is compared against. `unit-tests` keeps ubuntu-2004 untouched.
-  linux-x64-gen2: &linux-x64-gen2-executor
-    machine:
-      image: ubuntu-2604:current
-    resource_class: medium.gen2
-    environment:
-      PLATFORM: linux
-
 commands:
   # This command inserts SHOULD_PERSIST_ARTIFACTS into BASH_ENV. This way, we can define the variable in one place and use it in multiple steps.
   # Run this command in a job before you want to use the SHOULD_PERSIST_ARTIFACTS variable.
@@ -2372,9 +2361,7 @@ jobs:
       # wall-clock ratios this job measures.
       - when:
           condition:
-            or:
-              - equal: [ *linux-x64-executor, << parameters.executor >> ]
-              - equal: [ *linux-x64-gen2-executor, << parameters.executor >> ]
+            equal: [ *linux-x64-executor, << parameters.executor >> ]
           steps:
             - run:
                 name: Ensure Xvfb is present

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2311,15 +2311,83 @@ jobs:
 
   server-performance-tests:
     <<: *defaults
+    parameters:
+      <<: *defaultsParameters
+      resource_class:
+        type: string
+        default: medium.gen2
+      # '' runs the whole test/performance glob, which includes the cross-browser
+      # cy_visit_performance system test. A benchmark instance narrows to the proxy
+      # spec so a three-browser system test isn't competing for the same CPU it is
+      # trying to measure.
+      perf-spec:
+        type: string
+        default: ''
+      # cy_visit_performance_spec runs in firefox, so the full glob needs it
+      install-firefox:
+        type: boolean
+        default: true
+      # identifies the row this job contributes to the aggregated comparison
+      perf-label:
+        type: string
+        default: baseline
+      # reports the MITM-vs-CDP timings instead of asserting them, for instances
+      # deliberately run on constrained infrastructure where the expected result
+      # and a red build would otherwise be the same event
+      perf-report-only:
+        type: boolean
+        default: false
+      perf-retries:
+        type: string
+        default: ''
+      perf-h2-capture-timeout:
+        type: string
+        default: ''
+    resource_class: << parameters.resource_class >>
+    environment:
+      <<: *defaultsEnvironment
+      PROXY_PERF_LABEL: << parameters.perf-label >>
+      PROXY_PERF_RETRIES: << parameters.perf-retries >>
+      PROXY_PERF_H2_CAPTURE_TIMEOUT: << parameters.perf-h2-capture-timeout >>
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-server-tests >>
       - restore_cached_workspace
+      # Machine executors are a non-root user on a bare Ubuntu image: the docker
+      # image bakes in Xvfb, but `run.js` wraps mocha in `xvfb-maybe`, which
+      # rejects outright if `xvfb-run` is missing. `localhost` also resolves to a
+      # live ::1 on a VM and typically not in a container - Happy Eyeballs hides
+      # that as added connection latency, which would land straight in the
+      # wall-clock ratios this job measures.
+      - when:
+          condition:
+            equal: [ *linux-x64-executor, << parameters.executor >> ]
+          steps:
+            - run:
+                name: Ensure Xvfb is present
+                command: |
+                  if ! which xvfb-run > /dev/null; then
+                    sudo apt-get update && sudo apt-get install -y xvfb
+                  fi
+                  which xvfb-run Xvfb
+            - run:
+                name: Pin localhost to both address families
+                command: |
+                  cat \<<'EOF' | sudo tee /etc/hosts
+                  127.0.0.1 localhost
+                  ::1 localhost
+                  EOF
       - install-browsers:
           install-chrome: true
-          install-firefox: true
+          install-firefox: << parameters.install-firefox >>
       - run:
-          command: yarn workspace @packages/server test-performance
+          name: Proxy performance benchmark (<< parameters.perf-label >> / << parameters.resource_class >>)
+          environment:
+            PROXY_PERF_REPORT_ONLY: << parameters.perf-report-only >>
+          command: |
+            source ./scripts/ensure-node.sh
+            node -e "const os=require('os');console.log('cores seen:',os.cpus().length,'totalmem:',os.totalmem())"
+            yarn workspace @packages/server test-performance << parameters.perf-spec >>
       - store_artifacts:
           path: /tmp/artifacts
           when: always

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -149,7 +149,7 @@ jobs:
         - ready-to-test
   - server-performance-tests:
       name: server-performance-tests-machine-x64
-      executor: linux-x64
+      executor: linux-x64-gen2
       resource_class: medium.gen2
       perf-label: vm-medium.gen2
       perf-spec: proxy_performance_spec

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -60,534 +60,539 @@ jobs:
         - internal-pr-build
         - external-pr-build
         - approve-contributor-pr
-  - check-lockfile:
-      requires:
-        - internal-pr-build
-        - external-pr-build
-  - check-ts:
-      requires:
-        - internal-pr-build
-        - external-pr-build
-  - health-check:
-      requires:
-        - internal-pr-build
-        - external-pr-build
-  - lint:
-      name: linux-lint
-      requires:
-        - internal-pr-build
-        - external-pr-build
-  - lint-types:
-      requires:
-        - internal-pr-build
-        - external-pr-build
-  # The following jobs are only run for contributor PRs once they are approved.
-  # Each job checks its pipeline parameter at startup and halts early if the
-  # changed files don't require it to run.
-  - cli-visual-tests:
-      context: test-runner:percy
-      requires:
-        - ready-to-test
-  - unit-tests:
-      requires:
-        - ready-to-test
-  - server-unit-tests:
-      requires:
-        - ready-to-test
-  - server-integration-tests:
+#   - check-lockfile:
+#       requires:
+#         - internal-pr-build
+#         - external-pr-build
+#   - check-ts:
+#       requires:
+#         - internal-pr-build
+#         - external-pr-build
+#   - health-check:
+#       requires:
+#         - internal-pr-build
+#         - external-pr-build
+#   - lint:
+#       name: linux-lint
+#       requires:
+#         - internal-pr-build
+#         - external-pr-build
+#   - lint-types:
+#       requires:
+#         - internal-pr-build
+#         - external-pr-build
+#   # The following jobs are only run for contributor PRs once they are approved.
+#   # Each job checks its pipeline parameter at startup and halts early if the
+#   # changed files don't require it to run.
+#   - cli-visual-tests:
+#       context: test-runner:percy
+#       requires:
+#         - ready-to-test
+#   - unit-tests:
+#       requires:
+#         - ready-to-test
+#   - server-unit-tests:
+#       requires:
+#         - ready-to-test
+#   - server-integration-tests:
+#       requires:
+#         - ready-to-test
+  # EXPERIMENT - DO NOT MERGE: benchmarks MITM vs CDP interception across
+  # resource classes. Every cell runs the same spec with the same capture window,
+  # so only the machine size varies. The docker rungs give the vCPU curve; the
+  # linux-x64 cell is generation-matched to docker-medium.gen2 and exists to
+  # separate CPU scarcity from thread-pool oversubscription, since a container
+  # reports the host core count while a VM reports its own.
+  - server-performance-tests:
+      name: server-performance-tests-small
+      resource_class: small.gen2
+      perf-label: docker-small.gen2
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
   - server-performance-tests:
+      name: server-performance-tests-medium
+      resource_class: medium.gen2
+      perf-label: docker-medium.gen2
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
-  - system-tests-node-modules-install:
-      context: test-runner:performance-tracking
+  - server-performance-tests:
+      name: server-performance-tests-medium-plus
+      resource_class: medium+.gen2
+      perf-label: docker-medium+.gen2
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
-  - system-tests-chrome:
-      context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-electron:
-      context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-firefox:
-      context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-webkit:
-      context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-non-root:
-      context: test-runner:performance-tracking
-      executor: non-root-docker-user
-      requires:
-        - system-tests-node-modules-install
-  - driver-integration-tests-chrome:
-      context: test-runner:cypress-record-key
+  - server-performance-tests:
+      name: server-performance-tests-large
+      resource_class: large.gen2
+      perf-label: docker-large.gen2
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
-  - h2-dual-stack-tests:
-      context: test-runner:performance-tracking
+  - server-performance-tests:
+      name: server-performance-tests-machine-x64
+      executor: linux-x64
+      resource_class: medium.gen2
+      perf-label: vm-medium.gen2
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
-  - driver-integration-tests-chrome-inject-document-domain:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome-beta:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome-beta-inject-document-domain:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-tests-firefox:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-tests-electron:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-tests-webkit:
-      context: test-runner:cypress-record-key
-      requires:
-        - ready-to-test
-  - driver-integration-memory-tests:
-      requires:
-        - ready-to-test
-  - run-frontend-shared-component-tests-chrome:
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      percy: true
-      requires:
-        - ready-to-test
-  - run-launchpad-integration-tests-chrome:
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      percy: true
-      requires:
-        - ready-to-test
-  - run-launchpad-component-tests-chrome:
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      percy: true
-      requires:
-        - ready-to-test
-  - run-app-integration-tests-chrome:
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      percy: true
-      requires:
-        - ready-to-test
-  - run-webpack-dev-server-integration-tests:
-      context: [ test-runner:cypress-record-key, test-runner:percy ]
-      requires:
-        - system-tests-node-modules-install
-  - run-vite-dev-server-integration-tests:
-      context: [ test-runner:cypress-record-key, test-runner:percy ]
-      requires:
-        - system-tests-node-modules-install
-  - run-app-component-tests-chrome:
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      percy: true
-      requires:
-        - ready-to-test
-  - run-reporter-component-tests-chrome:
-      context: [ test-runner:cypress-record-key, test-runner:percy ]
-      percy: true
-      requires:
-        - ready-to-test
-  - reporter-integration-tests:
-      context: [ test-runner:cypress-record-key, test-runner:percy ]
-      requires:
-        - ready-to-test
-  - npm-webpack-dev-server:
-      requires:
-        - system-tests-node-modules-install
-  - npm-vite-dev-server:
-      requires:
-        - ready-to-test
-  - npm-vite-plugin-cypress-esm:
-      requires:
-        - ready-to-test
-  - npm-webpack-preprocessor:
-      requires:
-        - ready-to-test
-  - npm-webpack-batteries-included-preprocessor:
-      requires:
-        - ready-to-test
-  - npm-vue:
-      requires:
-        - ready-to-test
-  - npm-puppeteer-unit-tests:
-      requires:
-        - ready-to-test
-  - npm-puppeteer-cypress-tests:
-      requires:
-        - ready-to-test
-  - npm-react:
-      requires:
-        - ready-to-test
-  - npm-angular:
-      requires:
-        - ready-to-test
-  - npm-angular-zoneless:
-      requires:
-        - ready-to-test
-  - npm-mount-utils:
-      requires:
-        - ready-to-test
-  - npm-grep:
-      requires:
-        - ready-to-test
-  - npm-eslint-plugin-dev:
-      requires:
-        - ready-to-test
-  - npm-cypress-schematic:
-      requires:
-        - ready-to-test
-  - v8-integration-tests:
-      requires:
-        - system-tests-node-modules-install
+#   - system-tests-node-modules-install:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - ready-to-test
+#   - system-tests-chrome:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-electron:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-firefox:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-webkit:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-non-root:
+#       context: test-runner:performance-tracking
+#       executor: non-root-docker-user
+#       requires:
+#         - system-tests-node-modules-install
+#   - driver-integration-tests-chrome:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - h2-dual-stack-tests:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-chrome-inject-document-domain:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-chrome-beta:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-chrome-beta-inject-document-domain:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-firefox:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-electron:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-webkit:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - ready-to-test
+#   - driver-integration-memory-tests:
+#       requires:
+#         - ready-to-test
+#   - run-frontend-shared-component-tests-chrome:
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - run-launchpad-integration-tests-chrome:
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - run-launchpad-component-tests-chrome:
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - run-app-integration-tests-chrome:
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - run-webpack-dev-server-integration-tests:
+#       context: [ test-runner:cypress-record-key, test-runner:percy ]
+#       requires:
+#         - system-tests-node-modules-install
+#   - run-vite-dev-server-integration-tests:
+#       context: [ test-runner:cypress-record-key, test-runner:percy ]
+#       requires:
+#         - system-tests-node-modules-install
+#   - run-app-component-tests-chrome:
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - run-reporter-component-tests-chrome:
+#       context: [ test-runner:cypress-record-key, test-runner:percy ]
+#       percy: true
+#       requires:
+#         - ready-to-test
+#   - reporter-integration-tests:
+#       context: [ test-runner:cypress-record-key, test-runner:percy ]
+#       requires:
+#         - ready-to-test
+#   - npm-webpack-dev-server:
+#       requires:
+#         - system-tests-node-modules-install
+#   - npm-vite-dev-server:
+#       requires:
+#         - ready-to-test
+#   - npm-vite-plugin-cypress-esm:
+#       requires:
+#         - ready-to-test
+#   - npm-webpack-preprocessor:
+#       requires:
+#         - ready-to-test
+#   - npm-webpack-batteries-included-preprocessor:
+#       requires:
+#         - ready-to-test
+#   - npm-vue:
+#       requires:
+#         - ready-to-test
+#   - npm-puppeteer-unit-tests:
+#       requires:
+#         - ready-to-test
+#   - npm-puppeteer-cypress-tests:
+#       requires:
+#         - ready-to-test
+#   - npm-react:
+#       requires:
+#         - ready-to-test
+#   - npm-angular:
+#       requires:
+#         - ready-to-test
+#   - npm-angular-zoneless:
+#       requires:
+#         - ready-to-test
+#   - npm-mount-utils:
+#       requires:
+#         - ready-to-test
+#   - npm-grep:
+#       requires:
+#         - ready-to-test
+#   - npm-eslint-plugin-dev:
+#       requires:
+#         - ready-to-test
+#   - npm-cypress-schematic:
+#       requires:
+#         - ready-to-test
+#   - v8-integration-tests:
+#       requires:
+#         - system-tests-node-modules-install
 
-  # Proxy-disabled CDP remediations (*-cdp-remediated): known-green subsets that
-  # always run when their path filters match (require-opt-in: false). Append
-  # specs here as fixes land. When a remediations list covers the full suite,
-  # flip the matching *-cdp job to always-on and delete *-cdp-remediated.
-  # #34464 cookie coverage that stays green under DISABLE_PROXY is jar sync +
-  # OAuth only (system-tests-cookies-cdp). The full e2e cookies 80/443 matrix
-  # is deferred to #34508 (under #34353).
-  - system-tests-chrome:
-      name: system-tests-chrome-cdp-remediated
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
-      # #34514 strategy:file origin serving + #34379 intercept-matched visit pre-flights (visits, web security, service workers).
-      # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
-      # concurrent large-body CDP Fetch (47 unmatched localhost requests); Electron was green.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-cookies-cdp:
-      context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-electron:
-      name: system-tests-electron-cdp-remediated
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses.
-      # proxy_correlation_spec omitted — see chrome-cdp-remediated note above.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js
-      requires:
-        - system-tests-node-modules-install
-  - run-launchpad-integration-tests-chrome:
-      name: run-launchpad-integration-tests-chrome-cdp-remediated
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      record-group-suffix: '-remediated'
-      # #34353 Invalid InterceptionId body-stream crash
-      spec: cypress/e2e/choose-a-browser.cy.ts,cypress/e2e/open-mode.cy.ts
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome:
-      name: driver-integration-tests-chrome-cdp-remediated
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      record-group-suffix: '-remediated'
-      # #34467 continue unmodified CDP Fetch responses; #34465 extra-target shared
-      # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386);
-      # #34555 service worker session interception. Excludes downloads_basic_auth.cy.ts
-      # — #34512 Network.enable never settles on the extra target's session. Add it
-      # here once that is fixed.
-      spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js
-      requires:
-        - ready-to-test
-  - driver-integration-tests-electron:
-      name: driver-integration-tests-electron-cdp-remediated
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      record-group-suffix: '-remediated'
-      # #34465 extra-target shared middleware; #34555 service worker session
-      # interception. Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
-      # never settles on the extra target's session. Add it here once that is fixed.
-      spec: cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/service-worker.cy.js
-      requires:
-        - ready-to-test
-  - unit-tests-proxy-disabled:
-      requires:
-        - ready-to-test
+#   # Proxy-disabled CDP remediations (*-cdp-remediated): known-green subsets that
+#   # always run when their path filters match (require-opt-in: false). Append
+#   # specs here as fixes land. When a remediations list covers the full suite,
+#   # flip the matching *-cdp job to always-on and delete *-cdp-remediated.
+#   # #34464 cookie coverage that stays green under DISABLE_PROXY is jar sync +
+#   # OAuth only (system-tests-cookies-cdp). The full e2e cookies 80/443 matrix
+#   # is deferred to #34508 (under #34353).
+#   - system-tests-chrome:
+#       name: system-tests-chrome-cdp-remediated
+#       context: test-runner:performance-tracking
+#       disable-proxy: true
+#       require-opt-in: false
+#       parallelism: 1
+#       # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
+#       # #34514 strategy:file origin serving + #34379 intercept-matched visit pre-flights (visits, web security, service workers).
+#       # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
+#       # concurrent large-body CDP Fetch (47 unmatched localhost requests); Electron was green.
+#       spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-cookies-cdp:
+#       context: test-runner:performance-tracking
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-electron:
+#       name: system-tests-electron-cdp-remediated
+#       context: test-runner:performance-tracking
+#       disable-proxy: true
+#       require-opt-in: false
+#       parallelism: 1
+#       # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses.
+#       # proxy_correlation_spec omitted — see chrome-cdp-remediated note above.
+#       spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js
+#       requires:
+#         - system-tests-node-modules-install
+#   - run-launchpad-integration-tests-chrome:
+#       name: run-launchpad-integration-tests-chrome-cdp-remediated
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       disable-proxy: true
+#       require-opt-in: false
+#       parallelism: 1
+#       record-group-suffix: '-remediated'
+#       # #34353 Invalid InterceptionId body-stream crash
+#       spec: cypress/e2e/choose-a-browser.cy.ts,cypress/e2e/open-mode.cy.ts
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-chrome:
+#       name: driver-integration-tests-chrome-cdp-remediated
+#       context: test-runner:cypress-record-key
+#       disable-proxy: true
+#       require-opt-in: false
+#       parallelism: 1
+#       record-group-suffix: '-remediated'
+#       # #34467 continue unmodified CDP Fetch responses; #34465 extra-target shared
+#       # middleware; #34557 encoding drifts pinned per-pipeline (#34554, #34384, #34386);
+#       # #34555 service worker session interception. Excludes downloads_basic_auth.cy.ts
+#       # — #34512 Network.enable never settles on the extra target's session. Add it
+#       # here once that is fixed.
+#       spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-electron:
+#       name: driver-integration-tests-electron-cdp-remediated
+#       context: test-runner:cypress-record-key
+#       disable-proxy: true
+#       require-opt-in: false
+#       parallelism: 1
+#       record-group-suffix: '-remediated'
+#       # #34465 extra-target shared middleware; #34555 service worker session
+#       # interception. Excludes downloads_basic_auth.cy.ts — #34512 Network.enable
+#       # never settles on the extra target's session. Add it here once that is fixed.
+#       spec: cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/e2e/service-worker.cy.js
+#       requires:
+#         - ready-to-test
+#   - unit-tests-proxy-disabled:
+#       requires:
+#         - ready-to-test
 
-  # Full proxy-disabled (CDP Fetch) coverage (*-cdp) — off by default.
-  # Enable with Trigger Pipeline → run-proxy-disabled-tests=true.
-  # Omitted from all-jobs-passed so failures stay non-blocking when enabled.
-  # Promote known-green specs into *-cdp-remediated above rather than flipping
-  # these full suites on until remediations cover the entire suite.
-  - driver-integration-tests-chrome:
-      name: driver-integration-tests-chrome-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-tests-chrome-inject-document-domain:
-      name: driver-integration-tests-chrome-inject-document-domain-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-tests-electron:
-      name: driver-integration-tests-electron-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-memory-tests:
-      name: driver-integration-memory-tests-cdp
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - system-tests-chrome:
-      name: system-tests-chrome-cdp
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-electron:
-      name: system-tests-electron-cdp
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      requires:
-        - system-tests-node-modules-install
-  - run-app-integration-tests-chrome:
-      name: run-app-integration-tests-chrome-cdp
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - run-launchpad-integration-tests-chrome:
-      name: run-launchpad-integration-tests-chrome-cdp
-      context:
-        [
-          test-runner:cypress-record-key,
-          test-runner:launchpad-tests,
-          test-runner:percy
-        ]
-      disable-proxy: true
-      requires:
-        - ready-to-test
+#   # Full proxy-disabled (CDP Fetch) coverage (*-cdp) — off by default.
+#   # Enable with Trigger Pipeline → run-proxy-disabled-tests=true.
+#   # Omitted from all-jobs-passed so failures stay non-blocking when enabled.
+#   # Promote known-green specs into *-cdp-remediated above rather than flipping
+#   # these full suites on until remediations cover the entire suite.
+#   - driver-integration-tests-chrome:
+#       name: driver-integration-tests-chrome-cdp
+#       context: test-runner:cypress-record-key
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-chrome-inject-document-domain:
+#       name: driver-integration-tests-chrome-inject-document-domain-cdp
+#       context: test-runner:cypress-record-key
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
+#   - driver-integration-tests-electron:
+#       name: driver-integration-tests-electron-cdp
+#       context: test-runner:cypress-record-key
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
+#   - driver-integration-memory-tests:
+#       name: driver-integration-memory-tests-cdp
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
+#   - system-tests-chrome:
+#       name: system-tests-chrome-cdp
+#       context: test-runner:performance-tracking
+#       disable-proxy: true
+#       requires:
+#         - system-tests-node-modules-install
+#   - system-tests-electron:
+#       name: system-tests-electron-cdp
+#       context: test-runner:performance-tracking
+#       disable-proxy: true
+#       requires:
+#         - system-tests-node-modules-install
+#   - run-app-integration-tests-chrome:
+#       name: run-app-integration-tests-chrome-cdp
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
+#   - run-launchpad-integration-tests-chrome:
+#       name: run-launchpad-integration-tests-chrome-cdp
+#       context:
+#         [
+#           test-runner:cypress-record-key,
+#           test-runner:launchpad-tests,
+#           test-runner:percy
+#         ]
+#       disable-proxy: true
+#       requires:
+#         - ready-to-test
 
-  - create-and-trigger-packaging-artifacts:
-      context:
-        - test-runner:upload
-        - test-runner:build-binary
-        - publish-binary
-      requires:
-        - node_modules_install
-        - internal-pr-build
-      filters:
-        branches:
-          ignore: /^pull\/[0-9]+/
-  - wait-for-binary-publish:
-      type: approval
-      requires:
-        - create-and-trigger-packaging-artifacts
-  - get-published-artifacts:
-      context:
-        - publish-binary
-        - test-runner:commit-status-checks
-      requires:
-        - wait-for-binary-publish
-  - test-kitchensink:
-      requires:
-        - ready-to-test
-  - test-npm-module-on-minimum-node-version:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - test-types-cypress-and-jest:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - test-full-typescript-project:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - test-binary-against-kitchensink:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - test-binary-as-specific-user:
-      name: "test binary as a non-root user"
-      executor: non-root-docker-user
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - test-binary-as-specific-user:
-      name: "test binary as a root user"
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-  - binary-system-tests:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-        - system-tests-node-modules-install
-  - yarn-pnp-preprocessor-system-test:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-        - system-tests-node-modules-install
-  - svelte-webpack-system-test:
-      context: publish-binary
-      requires:
-        - get-published-artifacts
-        - system-tests-node-modules-install
+#   - create-and-trigger-packaging-artifacts:
+#       context:
+#         - test-runner:upload
+#         - test-runner:build-binary
+#         - publish-binary
+#       requires:
+#         - node_modules_install
+#         - internal-pr-build
+#       filters:
+#         branches:
+#           ignore: /^pull\/[0-9]+/
+#   - wait-for-binary-publish:
+#       type: approval
+#       requires:
+#         - create-and-trigger-packaging-artifacts
+#   - get-published-artifacts:
+#       context:
+#         - publish-binary
+#         - test-runner:commit-status-checks
+#       requires:
+#         - wait-for-binary-publish
+#   - test-kitchensink:
+#       requires:
+#         - ready-to-test
+#   - test-npm-module-on-minimum-node-version:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - test-types-cypress-and-jest:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - test-full-typescript-project:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - test-binary-against-kitchensink:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - test-binary-as-specific-user:
+#       name: "test binary as a non-root user"
+#       executor: non-root-docker-user
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - test-binary-as-specific-user:
+#       name: "test binary as a root user"
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#   - binary-system-tests:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#         - system-tests-node-modules-install
+#   - yarn-pnp-preprocessor-system-test:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#         - system-tests-node-modules-install
+#   - svelte-webpack-system-test:
+#       context: publish-binary
+#       requires:
+#         - get-published-artifacts
+#         - system-tests-node-modules-install
 
-  # Finalization jobs
-  - percy-finalize:
-      context: test-runner:percy
-      required_env_var: PERCY_TOKEN
-      requires:
-        - cli-visual-tests
-        - reporter-integration-tests
-        - run-app-component-tests-chrome
-        - run-app-integration-tests-chrome
-        - run-frontend-shared-component-tests-chrome
-        - run-launchpad-component-tests-chrome
-        - run-launchpad-integration-tests-chrome
-        - run-reporter-component-tests-chrome
-        - run-webpack-dev-server-integration-tests
-        - run-vite-dev-server-integration-tests
-  # Cypress run must be completed to fetch Accessibility report
-  - verify-accessibility-results:
-      context: test-runner:cypress-record-key
-      requires:
-        - reporter-integration-tests
-        - run-app-component-tests-chrome
-        - run-app-integration-tests-chrome
-        - run-frontend-shared-component-tests-chrome
-        - run-launchpad-component-tests-chrome
-        - run-launchpad-integration-tests-chrome
-        - run-reporter-component-tests-chrome
-        - run-webpack-dev-server-integration-tests
-        - run-vite-dev-server-integration-tests
-        - driver-integration-tests-firefox
-        - driver-integration-tests-chrome
-        - driver-integration-tests-chrome-inject-document-domain
-        - driver-integration-tests-chrome-beta-inject-document-domain
-        - driver-integration-tests-electron
-        - driver-integration-tests-webkit
-        - driver-integration-memory-tests
+#   # Finalization jobs
+#   - percy-finalize:
+#       context: test-runner:percy
+#       required_env_var: PERCY_TOKEN
+#       requires:
+#         - cli-visual-tests
+#         - reporter-integration-tests
+#         - run-app-component-tests-chrome
+#         - run-app-integration-tests-chrome
+#         - run-frontend-shared-component-tests-chrome
+#         - run-launchpad-component-tests-chrome
+#         - run-launchpad-integration-tests-chrome
+#         - run-reporter-component-tests-chrome
+#         - run-webpack-dev-server-integration-tests
+#         - run-vite-dev-server-integration-tests
+#   # Cypress run must be completed to fetch Accessibility report
+#   - verify-accessibility-results:
+#       context: test-runner:cypress-record-key
+#       requires:
+#         - reporter-integration-tests
+#         - run-app-component-tests-chrome
+#         - run-app-integration-tests-chrome
+#         - run-frontend-shared-component-tests-chrome
+#         - run-launchpad-component-tests-chrome
+#         - run-launchpad-integration-tests-chrome
+#         - run-reporter-component-tests-chrome
+#         - run-webpack-dev-server-integration-tests
+#         - run-vite-dev-server-integration-tests
+#         - driver-integration-tests-firefox
+#         - driver-integration-tests-chrome
+#         - driver-integration-tests-chrome-inject-document-domain
+#         - driver-integration-tests-chrome-beta-inject-document-domain
+#         - driver-integration-tests-electron
+#         - driver-integration-tests-webkit
+#         - driver-integration-memory-tests
 
-  # Fan-in aggregator — the only required GitHub status check for PRs.
-  # Required jobs fan into this one. Jobs that halt early (pipeline parameter
-  # false) still complete successfully. Full proxy-disabled *-cdp jobs above are
-  # opt-in (run-proxy-disabled-tests) and intentionally omitted from this gate;
-  # *-cdp-remediated known-green subsets are included.
+  # Fan-in aggregator - the only required GitHub status check for PRs.
+  # EXPERIMENT - DO NOT MERGE: trimmed to the benchmark matrix. CircleCI rejects a
+  # `requires` naming a job that is not in the workflow, so this list has to be
+  # trimmed in lockstep with the jobs commented out above. Reverting this file
+  # restores both.
   - all-jobs-passed:
       requires:
-        # Always-run jobs
-        - linux-lint
-        - check-lockfile
-        - check-ts
-        - health-check
-        - lint-types
-        - test-kitchensink
-        # Conditional jobs (halt early when not needed)
-        - cli-visual-tests
-        - unit-tests
-        - server-unit-tests
-        - server-integration-tests
-        - server-performance-tests
-        - system-tests-chrome
-        - system-tests-electron
-        - system-tests-firefox
-        - system-tests-webkit
-        - system-tests-non-root
-        - h2-dual-stack-tests
-        - system-tests-chrome-cdp-remediated
-        - system-tests-cookies-cdp
-        - system-tests-electron-cdp-remediated
-        - unit-tests-proxy-disabled
-        - run-launchpad-integration-tests-chrome-cdp-remediated
-        - driver-integration-tests-chrome-cdp-remediated
-        - driver-integration-tests-electron-cdp-remediated
-        - driver-integration-tests-chrome
-        - driver-integration-tests-chrome-inject-document-domain
-        - driver-integration-tests-chrome-beta
-        - driver-integration-tests-chrome-beta-inject-document-domain
-        - driver-integration-tests-firefox
-        - driver-integration-tests-electron
-        - driver-integration-tests-webkit
-        - driver-integration-memory-tests
-        - run-frontend-shared-component-tests-chrome
-        - run-launchpad-integration-tests-chrome
-        - run-launchpad-component-tests-chrome
-        - run-app-integration-tests-chrome
-        - run-app-component-tests-chrome
-        - run-reporter-component-tests-chrome
-        - reporter-integration-tests
-        - run-webpack-dev-server-integration-tests
-        - run-vite-dev-server-integration-tests
-        - npm-webpack-dev-server
-        - npm-vite-dev-server
-        - npm-vite-plugin-cypress-esm
-        - npm-webpack-preprocessor
-        - npm-webpack-batteries-included-preprocessor
-        - npm-vue
-        - npm-puppeteer-unit-tests
-        - npm-puppeteer-cypress-tests
-        - npm-react
-        - npm-angular
-        - npm-angular-zoneless
-        - npm-mount-utils
-        - npm-grep
-        - npm-eslint-plugin-dev
-        - npm-cypress-schematic
-        - v8-integration-tests
+        - server-performance-tests-small
+        - server-performance-tests-medium
+        - server-performance-tests-medium-plus
+        - server-performance-tests-large
+        - server-performance-tests-machine-x64

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -147,11 +147,29 @@ jobs:
       perf-h2-capture-timeout: '180000'
       requires:
         - ready-to-test
+  # The container-vs-VM pair, matched at gen1 rather than gen2. The gen2 VM classes
+  # need a machine image newer than ubuntu-2004, and on ubuntu-2604 the image's
+  # default node (v24) wins over the repo's pinned 22.19.0 in `unpack-dependencies`,
+  # which does not re-source ensure-node.sh - the restored node_modules then fail to
+  # load. gen1 `medium` on ubuntu-2004 is the combination `unit-tests` already runs,
+  # so the workspace restore is known to work there. Pairing it against a gen1 docker
+  # cell keeps the comparison free of a CPU-generation confound.
   - server-performance-tests:
       name: server-performance-tests-machine-x64
-      executor: linux-x64-gen2
-      resource_class: medium.gen2
-      perf-label: vm-medium.gen2
+      executor: linux-x64
+      resource_class: medium
+      perf-label: vm-medium
+      perf-spec: proxy_performance_spec
+      install-firefox: false
+      perf-report-only: true
+      perf-retries: '0'
+      perf-h2-capture-timeout: '180000'
+      requires:
+        - ready-to-test
+  - server-performance-tests:
+      name: server-performance-tests-docker-gen1
+      resource_class: medium
+      perf-label: docker-medium
       perf-spec: proxy_performance_spec
       install-firefox: false
       perf-report-only: true
@@ -596,3 +614,4 @@ jobs:
         - server-performance-tests-medium-plus
         - server-performance-tests-large
         - server-performance-tests-machine-x64
+        - server-performance-tests-docker-gen1

--- a/packages/server/test/performance/proxy_performance_spec.js
+++ b/packages/server/test/performance/proxy_performance_spec.js
@@ -301,8 +301,23 @@ const CAPTURE_TIMEOUT_MS = Number(process.env.PROXY_PERF_CAPTURE_TIMEOUT) || 150
 // The latency origin's MITM captures are queueing-bound at ~1000 x 50ms / ~6
 // connections ≈ 9-10s, and the no-h2 assertion allows up to 2x that — the
 // capture window has to outlast the assertion boundary, or a slow-but-assertable
-// run dies as a capture timeout before the assertion can fail it.
-const HTTP2_LATENCY_CAPTURE_TIMEOUT_MS = 45000
+// run dies as a capture timeout before the assertion can fail it. On a
+// CPU-starved runner both sides stretch well past that, so the window is
+// overridable rather than fixed.
+const HTTP2_LATENCY_CAPTURE_TIMEOUT_MS = Number(process.env.PROXY_PERF_H2_CAPTURE_TIMEOUT) || 45000
+
+// The default is sized for a flaky fixture host, where a retry gets a different
+// page. A slow box is not flaky - it fails every attempt - so re-measuring both
+// sides 16 times only multiplies the runtime. An unset CI parameter arrives as an
+// empty string, which has to mean "default" rather than Number('') === 0.
+const RETRIES = process.env.PROXY_PERF_RETRIES ? Number(process.env.PROXY_PERF_RETRIES) : 15
+
+// The comparative timing assertions encode an environment: they hold where CPU
+// is cheap enough for the CDP pipeline to stay off the critical path. When
+// benchmarking deliberately-constrained infrastructure, the expected outcome and
+// a red build are the same event, so the timings are reported and the
+// wire-protocol assertions - which are correctness, not performance - stay on.
+const REPORT_ONLY = ['1', 'true'].includes(process.env.PROXY_PERF_REPORT_ONLY)
 
 // When the fixture host serves something other than the fixture - a GitHub Pages error
 // page, say - the symptom is an oddly small request count with nothing pending, so the
@@ -315,6 +330,72 @@ const REPORTED_URL_COUNT = 5
 // let the retry pick up a load that got the real page. This beat covers initiation lagging
 // the load event.
 const BAD_PAGE_GRACE_MS = 1000
+
+/**
+ * Reads a cgroup controller file for this process, or null when it cannot be read
+ * (not Linux, no cgroup, or an unconstrained cgroup).
+ *
+ * cgroup v2 reports a single `0::/<path>` entry in `/proc/self/cgroup`, relative to
+ * the cgroup mount. Inside a container the cgroup namespace maps that to the mount
+ * root, but on a bare host the controller files live under the sub-cgroup, so the
+ * base has to be resolved rather than assumed.
+ */
+const readCgroupValue = async (file) => {
+  try {
+    const raw = await fse.readFile('/proc/self/cgroup', 'utf8')
+    const relative = raw.split('\n').find((line) => line.startsWith('0::'))?.slice(3).trim().replace(/^\/+/, '')
+
+    return (await fse.readFile(path.join('/sys/fs/cgroup', relative || '', file), 'utf8')).trim()
+  } catch {
+    return null
+  }
+}
+
+// `os.cpus()` reports the host's core count inside a container, not the cgroup
+// budget, so Chrome and libuv size their thread pools for a machine they do not
+// have. Recording what was seen alongside what was actually granted is what makes
+// a cross-size comparison interpretable.
+const describeEnvironment = async () => {
+  return {
+    label: process.env.PROXY_PERF_LABEL || 'local',
+    coresSeen: os.cpus().length,
+    totalMemBytes: os.totalmem(),
+    cgroupCpuMax: await readCgroupValue('cpu.max'),
+    cgroupMemoryMax: await readCgroupValue('memory.max'),
+  }
+}
+
+/**
+ * Appends one JSON line per measurement to `$CIRCLE_ARTIFACTS/proxy-perf.jsonl`.
+ * `console.table` is readable in a single job's log but does not aggregate across
+ * a matrix of them, which is what the comparison actually needs.
+ */
+const recordBenchmark = async (record) => {
+  const line = JSON.stringify({ ...await describeEnvironment(), ...record })
+
+  debug('benchmark record %s', line)
+
+  const artifacts = process.env.CIRCLE_ARTIFACTS
+
+  if (!artifacts) return
+
+  await fse.ensureDir(artifacts)
+  await fse.appendFile(path.join(artifacts, 'proxy-perf.jsonl'), `${line}\n`)
+}
+
+/**
+ * Asserts `actual` is under `bound`, unless REPORT_ONLY - in which case the
+ * comparison is reported and the run stays green.
+ */
+const expectTiming = (actual, bound, message) => {
+  if (REPORT_ONLY) {
+    process.stdout.write(`report-only: ${message} - ${actual} vs bound ${bound} (${actual < bound ? 'within' : 'over'})\n`)
+
+    return
+  }
+
+  expect(actual, message).to.be.lessThan(bound)
+}
 
 const createHarCaptureHooks = (captureTimeoutMs = CAPTURE_TIMEOUT_MS) => {
   const started = new Set()
@@ -948,13 +1029,20 @@ describe('Proxy Performance', function () {
   })
 
   describe(`${HTTP2_LATENCY_ORIGIN_URL} (synthetic latency origin)`, function () {
-    this.retries(15)
+    this.retries(RETRIES)
     // each test here is a paired measurement — two full captures per attempt
     this.timeout(2 * HTTP2_LATENCY_CAPTURE_TIMEOUT_MS + (30 * 1000))
 
     const mitmCase = makeTestCase({ name: 'With Cypress proxy, Intercepted', cyProxy: true, cyIntercept: true })
     const proxyDisabledCase = makeTestCase({ name: 'With proxy disabled, Intercepted (CDP)', proxyDisabled: true })
     const proxyDisabledNoH2Case = makeTestCase({ name: 'With proxy disabled, Intercepted (CDP) w/o HTTP/2', proxyDisabled: true, disableHttp2: true })
+
+    before(async () => {
+      // emitted before any measurement so a cell that never finishes a capture
+      // still appears in the aggregated comparison as a failure mode rather than
+      // as a missing row
+      await recordBenchmark({ test: 'environment' })
+    })
 
     after(() => {
       const testCases = [mitmCase, proxyDisabledCase, proxyDisabledNoH2Case]
@@ -984,6 +1072,15 @@ describe('Proxy Performance', function () {
 
       debug('latency-origin paired totals: mitm %d proxy-disabled %d', mitmResults['Total'], proxyDisabledResults['Total'])
 
+      await recordBenchmark({
+        test: 'cdp-h2-vs-mitm',
+        mitmTotal: mitmResults['Total'],
+        cdpTotal: proxyDisabledResults['Total'],
+        cdpAvgWait: proxyDisabledResults['Avg Wait'],
+        mitmAvgWait: mitmResults['Avg Wait'],
+        h2Preserved: proxyDisabledWire.http1_1StatusLines === 0,
+      })
+
       expect(mitmWire.http1_1StatusLines, 'MITM responses received over HTTP/1.1').to.be.at.least(1000)
       expect(proxyDisabledWire.responses, 'proxy-disabled wire responses observed').to.be.at.least(1000)
       expect(proxyDisabledWire.http1_1StatusLines, 'proxy-disabled responses received over HTTP/1.1').to.eq(0)
@@ -991,7 +1088,7 @@ describe('Proxy Performance', function () {
       // the injected per-response delay makes this hold in any environment:
       // ~6 HTTP/1.1 connections pay 1000 x delay / 6 in queueing, HTTP/2
       // multiplexing does not
-      expect(proxyDisabledResults['Total'], 'proxy-disabled HTTP/2 Total vs MITM intercepted Total').to.be.lessThan(mitmResults['Total'])
+      expectTiming(proxyDisabledResults['Total'], mitmResults['Total'], 'proxy-disabled HTTP/2 Total vs MITM intercepted Total')
     })
 
     it('With proxy disabled, Intercepted (CDP) w/o HTTP/2 loads 1000 delayed images within 2x of MITM interception', async function () {
@@ -1004,11 +1101,17 @@ describe('Proxy Performance', function () {
         wireEvidence = wire
       } })
 
+      await recordBenchmark({
+        test: 'cdp-no-h2-vs-mitm',
+        mitmTotal: mitmResults['Total'],
+        cdpNoH2Total: results['Total'],
+      })
+
       expect(wireEvidence.http1_1StatusLines, 'responses fell back to HTTP/1.1 on the wire').to.be.at.least(1000)
 
       // both sides are connection-queueing-bound here; 2x bounds the CDP
       // pipeline's added per-request cost at equal protocol
-      expect(results['Total']).to.be.lessThan(2 * mitmResults['Total'])
+      expectTiming(results['Total'], 2 * mitmResults['Total'], 'proxy-disabled w/o HTTP/2 Total vs 2x MITM intercepted Total')
     })
   })
 })

--- a/scripts/aggregate-proxy-perf.js
+++ b/scripts/aggregate-proxy-perf.js
@@ -1,0 +1,201 @@
+/* eslint-disable no-console */
+
+// Aggregates the `proxy-perf.jsonl` records emitted by
+// `packages/server/test/performance/proxy_performance_spec.js` into a single
+// markdown comparison table. Each benchmark job contributes one row; re-running
+// the pipeline contributes additional trials, which are reduced to a median.
+//
+// Usage:
+//   node scripts/aggregate-proxy-perf.js <path-to-jsonl> [...]
+//   node scripts/aggregate-proxy-perf.js --build=3883810 [--build=...]
+//
+// `--build` reads a CircleCI job's stored artifacts through the unauthenticated
+// v1.1 API, so no token is needed for a public project.
+
+const fs = require('fs')
+const https = require('https')
+
+const PROJECT = process.env.PROXY_PERF_PROJECT || 'gh/cypress-io/cypress'
+const ARTIFACT_NAME = 'proxy-perf.jsonl'
+
+const get = (url) => {
+  return new Promise((resolve, reject) => {
+    https.get(url, (res) => {
+      // the artifact CDN redirects, and v1.1 may too
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        res.resume()
+
+        return get(res.headers.location).then(resolve, reject)
+      }
+
+      if (res.statusCode !== 200) {
+        res.resume()
+
+        return reject(new Error(`GET ${url} responded ${res.statusCode}`))
+      }
+
+      let body = ''
+
+      res.setEncoding('utf8')
+      res.on('data', (chunk) => {
+        body += chunk
+      })
+
+      res.on('end', () => resolve(body))
+    }).on('error', reject)
+  })
+}
+
+const fetchBuildRecords = async (build) => {
+  const artifacts = JSON.parse(await get(`https://circleci.com/api/v1.1/project/${PROJECT}/${build}/artifacts`))
+  const matching = artifacts.filter((a) => a.path && a.path.endsWith(ARTIFACT_NAME))
+
+  if (!matching.length) {
+    console.error(`build ${build}: no ${ARTIFACT_NAME} artifact found`)
+
+    return []
+  }
+
+  const bodies = await Promise.all(matching.map((a) => get(a.url)))
+
+  return bodies.flatMap(parseRecords)
+}
+
+const parseRecords = (body) => {
+  return body.split('\n')
+  .filter((line) => line.trim())
+  .map((line) => {
+    try {
+      return JSON.parse(line)
+    } catch {
+      console.error(`skipping unparseable line: ${line.slice(0, 120)}`)
+
+      return null
+    }
+  })
+  .filter(Boolean)
+}
+
+const median = (values) => {
+  const nums = values.filter((v) => typeof v === 'number' && !Number.isNaN(v)).sort((a, b) => a - b)
+
+  if (!nums.length) return null
+
+  const mid = Math.floor(nums.length / 2)
+
+  return nums.length % 2 ? nums[mid] : Math.round((nums[mid - 1] + nums[mid]) / 2)
+}
+
+// `cpu.max` is "<quota> <period>" in microseconds, or "max <period>" when the
+// cgroup is unconstrained. quota/period is the vCPU budget the container actually
+// got, which is the number `os.cpus()` fails to report.
+const vcpuFromCgroup = (cpuMax) => {
+  if (!cpuMax) return null
+
+  const [quota, period] = cpuMax.split(/\s+/)
+
+  if (quota === 'max' || !period) return null
+
+  const budget = Number(quota) / Number(period)
+
+  return Number.isFinite(budget) ? Math.round(budget * 100) / 100 : null
+}
+
+const formatBytes = (bytes) => {
+  if (!bytes || Number.isNaN(Number(bytes))) return '?'
+
+  return `${(Number(bytes) / 1024 ** 3).toFixed(1)} GB`
+}
+
+const buildRow = (label, records) => {
+  const env = records.find((r) => r.cgroupCpuMax !== undefined) || records[0] || {}
+  const h2 = records.filter((r) => r.test === 'cdp-h2-vs-mitm')
+  const noH2 = records.filter((r) => r.test === 'cdp-no-h2-vs-mitm')
+
+  const mitm = median([...h2, ...noH2].map((r) => r.mitmTotal))
+  const cdp = median(h2.map((r) => r.cdpTotal))
+  const cdpNoH2 = median(noH2.map((r) => r.cdpNoH2Total))
+
+  const cgroupVcpu = vcpuFromCgroup(env.cgroupCpuMax)
+  const prefix = ['vm', 'docker'].find((p) => label.startsWith(`${p}-`))
+
+  return {
+    cell: label,
+    // fall back to cgroup evidence rather than guessing from an unrecognized label
+    kind: prefix === 'vm' ? 'VM' : prefix === 'docker' ? 'docker' : (env.cgroupCpuMax ? 'docker' : 'host'),
+    class: prefix ? label.slice(prefix.length + 1) : label,
+    // without a cpu quota - a VM, or a bare host - the cores it sees really are
+    // the cores it may use
+    vcpu: String(cgroupVcpu !== null ? cgroupVcpu : (env.coresSeen ?? '?')),
+    coresSeen: env.coresSeen === undefined ? '?' : String(env.coresSeen),
+    ram: formatBytes(env.cgroupMemoryMax && env.cgroupMemoryMax !== 'max' ? env.cgroupMemoryMax : env.totalMemBytes),
+    mitm: mitm === null ? 'no data' : String(mitm),
+    cdp: cdp === null ? 'no data' : String(cdp),
+    win: mitm !== null && cdp ? `${(mitm / cdp).toFixed(2)}x` : '—',
+    cdpNoH2: cdpNoH2 === null ? 'no data' : String(cdpNoH2),
+    // absent rather than false when nothing measured, so a missing row is not
+    // silently reported as an h2 regression
+    h2Kept: h2.length ? (h2.every((r) => r.h2Preserved) ? 'yes' : 'NO') : '—',
+    trials: h2.length || noH2.length,
+  }
+}
+
+const renderTable = (rows) => {
+  const headers = ['Cell', 'Kind', 'Class', 'vCPU', 'Cores seen', 'RAM', 'MITM', 'CDP h2', 'CDP win', 'CDP no-h2', 'h2 kept', 'Trials']
+  const order = ['cell', 'kind', 'class', 'vcpu', 'coresSeen', 'ram', 'mitm', 'cdp', 'win', 'cdpNoH2', 'h2Kept', 'trials']
+
+  const lines = [
+    `| ${headers.join(' | ')} |`,
+    `|${headers.map(() => '---').join('|')}|`,
+    ...rows.map((r) => `| ${order.map((k) => String(r[k])).join(' | ')} |`),
+  ]
+
+  return lines.join('\n')
+}
+
+const main = async () => {
+  const args = process.argv.slice(2)
+
+  if (!args.length) {
+    console.error('usage: node scripts/aggregate-proxy-perf.js <jsonl-path|--build=N> ...')
+    process.exit(1)
+  }
+
+  const records = []
+
+  for (const arg of args) {
+    if (arg.startsWith('--build=')) {
+      records.push(...await fetchBuildRecords(arg.slice('--build='.length)))
+    } else {
+      records.push(...parseRecords(fs.readFileSync(arg, 'utf8')))
+    }
+  }
+
+  if (!records.length) {
+    console.error('no records found')
+    process.exit(1)
+  }
+
+  const byLabel = new Map()
+
+  for (const record of records) {
+    const label = record.label || 'unlabelled'
+
+    if (!byLabel.has(label)) byLabel.set(label, [])
+
+    byLabel.get(label).push(record)
+  }
+
+  // smallest vCPU budget first, so the ladder reads in the direction of the question
+  const rows = [...byLabel.entries()]
+  .map(([label, group]) => buildRow(label, group))
+  .sort((a, b) => (Number(a.vcpu) || 99) - (Number(b.vcpu) || 99) || a.cell.localeCompare(b.cell))
+
+  console.log('Times are milliseconds, median across trials. `CDP win` is MITM / CDP-h2 — above 1.00x means CDP is faster.\n')
+  console.log(renderTable(rows))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Spike / investigation — not for merge

This is an investigation branch, opened as ready-for-review only because this repo runs no CI on draft PRs. **There is nothing to review and no reviewers are assigned.** It exists to get the CI run. Once we have the numbers, this PR gets closed and only the reusable parts (if any) come back as a real PR.

## What we're investigating

Every proxy benchmark number we have is a 2 vCPU number. `server-performance-tests` declares `<<: *defaults` with no `resource_class` of its own, so it inherits the `cy-docker` executor's `medium.gen2` — that's the machine behind every reading recorded so far, including the MITM ~10.7s vs CDP-h2 ~1.3s figures from #34428.

That matters because the two interception paths are bound by *different* resources:

- **MITM** is latency-bound. It climbs roughly linearly with per-request delay, because ~6 HTTP/1.1 connections have to queue 1000 requests through.
- **CDP** is CPU-bound. It sits on a flat pipeline floor, ferrying every response body over the devtools websocket (`getResponseBody` + `fulfillRequest` per request).

So "CDP wins" is a claim that holds *where CPU is cheap*. We've never measured what happens when it isn't — which is exactly the environment a lot of our users' CI runs in. If CDP's advantage collapses or inverts on a small container, that's something we want to know before leaning on it further.

## What this PR does to find out

Parameterizes the job on `resource_class` and instantiates it across a vCPU ladder plus one container-vs-VM pair:

| Cell | Environment | vCPU / RAM |
|---|---|---|
| `server-performance-tests-small` | docker `small.gen2` | 1 / 2 GB |
| `server-performance-tests-medium` | docker `medium.gen2` | 2 / 4 GB |
| `server-performance-tests-medium-plus` | docker `medium+.gen2` | 3 / 6 GB |
| `server-performance-tests-large` | docker `large.gen2` | 4 / 8 GB |
| `server-performance-tests-machine-x64` | `linux-x64` VM `medium.gen2` | 2 / 8 GiB |

`small.gen2` is the floor — it's the smallest Docker class CircleCI offers, and no VM class goes below 2 vCPU.

The VM cell is there for one specific reason: **a container reports the *host's* core count from `os.cpus()`, not its cgroup budget**, so Chrome and libuv size their thread pools for a machine they don't have. Pairing a generation-matched VM against `medium.gen2` at equal vCPU separates "CDP is slow because CPU is scarce" from "CDP is slow because it's oversubscribing threads." The second one would be fixable; the first wouldn't.

Every cell runs the same spec with the same capture window, so only machine size varies.

### Spec changes

Three env knobs, because the existing constants encode the 2 vCPU environment:

- **`PROXY_PERF_H2_CAPTURE_TIMEOUT`** — the synthetic block's capture window was hardcoded at 45s, sized for a queueing-bound MITM capture at 2 vCPU. At 1 vCPU both sides stretch past it and the run dies as a capture timeout before producing any number at all.
- **`PROXY_PERF_RETRIES`** — the default `15` is sized for a flaky fixture host, where a retry gets a different page. A slow box isn't flaky; it fails every attempt, so retries only multiply runtime by 16.
- **`PROXY_PERF_REPORT_ONLY`** — reports the comparative timings instead of asserting them. The wire-protocol assertions stay on, since "did h2 actually survive interception" is correctness, not performance. Without this, the most interesting possible outcome and a red build are the same event.

Plus a `proxy-perf.jsonl` artifact carrying both totals alongside `os.cpus().length`, `os.totalmem()`, and the cgroup cpu/memory quota — so each row records what the box *actually* was, not what we asked for. `scripts/aggregate-proxy-perf.js` reduces those across runs into one markdown table.

### Scope guard

Matrix cells narrow to `proxy_performance_spec` and skip the Firefox install, because `cy_visit_performance_spec.ts` shares the `test/performance` glob and is a three-browser system test — not something we want competing for the 1 vCPU we're trying to measure.

**The unparameterized invocation in `@main.yml` keeps today's behavior exactly**: full glob, Firefox installed, assertions enforced, `medium.gen2`.

## Why the rest of CI is commented out

`pull-request.yml` is trimmed to just this matrix, and `all-jobs-passed` is trimmed in lockstep. Both are required, not cosmetic:

- Any `.circleci/*` change is a **global trigger** in `generate-pipeline-parameters.sh`, setting every `run-*` parameter true. So `halt-if-skipped` can't save us here — without the trim, adding the matrix would run the entire pipeline, and we want to re-run this several times to get medians.
- CircleCI rejects a `requires` naming a job that isn't in the workflow, so the aggregator's ~58-entry list has to shrink alongside.

Reverting that one file restores both. It must never reach `develop`.

## Verification so far

- `yarn pack-ci --validate` clean; packed output parsed to confirm all 5 cells carry the right class/executor/params (12 workflow entries total)
- spec runs 2 passing / 17 pending in ~35s **both** with and without the new env vars — default path unchanged, real assertions still enforced
- jsonl → aggregator verified end to end, including a no-data row rendering as `no data` rather than silently blank
- eslint clean, `yarn check-ts` green across 43 projects

CI has never run this, so the first pipeline is the real test — particularly the VM cell, since `install-browsers` has never run on a Linux machine executor in this repo. I've added an xvfb probe with an apt fallback (`run.js` wraps mocha in `xvfb-maybe`, which rejects outright if `xvfb-run` is missing — headless Chrome doesn't make it optional) and pinned `localhost` to both address families, since a VM has a live `::1` and a container usually doesn't, and Happy-Eyeballs fallback latency would land straight in the wall-clock ratios.

## Expected shape of the answer

If the CPU-bound model is right, CDP's advantage shrinks monotonically as vCPU drops, possibly inverting at `small.gen2`. An inversion that does **not** reproduce on the VM cell at equal vCPU points at thread oversubscription rather than raw scarcity — which would be the most actionable outcome here.

A cell that can't complete at 1 vCPU is itself a result about resource-constrained environments, so the aggregator renders those as an explicit failure mode rather than a blank.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> If merged, PR workflows would skip almost all tests and gate only on experimental perf jobs; reusable job/spec changes are isolated but the workflow trim is catastrophic for normal CI.
> 
> **Overview**
> **Spike / not for merge** — PR CI is temporarily reduced to a six-cell benchmark matrix so MITM vs CDP proxy timings can be compared across CircleCI sizes without running the full pipeline.
> 
> The `server-performance-tests` job is **parameterized** (`resource_class`, narrowed `perf-spec`, optional Firefox, labels, report-only mode, retries, H2 capture timeout) and gains **linux-x64 VM setup** (Xvfb install, dual-stack `localhost` in `/etc/hosts`) so machine executors measure wall-clock ratios fairly.
> 
> `proxy_performance_spec.js` adds **env-driven** capture timeout, retries, and **report-only** comparative assertions (wire-protocol checks still fail the build), plus **`proxy-perf.jsonl` artifacts** with cgroup/cpu/memory context per run. New **`scripts/aggregate-proxy-perf.js`** merges those lines (or CircleCI build artifacts) into a comparison table.
> 
> `pull-request.yml` **comments out** the normal lint/test/binary jobs and **`all-jobs-passed`** only waits on the six benchmark jobs — revert that file to restore standard PR gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da1aeeb9e3c7a760d33193b582e445d7694e731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->