### PR TITLE
chore: build the graphql-ws url from the served port when the proxy is disabled

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -41,7 +41,7 @@ app.use(Toast, {
   closeOnClick: false,
 })
 
-await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute, proxyUrl: config.proxyUrl }).then((client) => {
+await makeUrqlClient({ target: 'app', namespace: config.namespace, socketIoRoute: config.socketIoRoute, port: config.port }).then((client) => {
   app.use(urql, client)
   app.use(createRouter())
   app.use(createI18n())

--- a/packages/frontend-shared/src/graphql/urqlClient.cy.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.cy.ts
@@ -5,7 +5,7 @@ describe('getGraphQLWsUrl', () => {
     target: 'app',
     namespace: '__cypress',
     socketIoRoute: '/__socket',
-    proxyUrl: 'http://localhost:2345',
+    port: 2345,
   } as const
 
   it('uses the page origin when the proxy is enabled', () => {
@@ -20,20 +20,28 @@ describe('getGraphQLWsUrl', () => {
     expect(url).to.equal('wss://app.foobar.com/__socket-graphql')
   })
 
-  it('uses the Cypress server origin when the proxy is disabled', () => {
+  it('uses the Cypress server port when the proxy is disabled', () => {
     const url = getGraphQLWsUrl(appConfig, { protocol: 'http:', host: 'localhost:2292' }, true)
 
     expect(url).to.equal('ws://localhost:2345/__socket-graphql')
   })
 
-  it('uses the Cypress server origin when the proxy is disabled and the page is https', () => {
+  it('uses the Cypress server port when the proxy is disabled and the page is https', () => {
     const url = getGraphQLWsUrl(appConfig, { protocol: 'https:', host: 'app.foobar.com' }, true)
 
     expect(url).to.equal('ws://localhost:2345/__socket-graphql')
   })
 
-  it('falls back to the page origin when the proxy is disabled and no proxyUrl is served', () => {
-    const url = getGraphQLWsUrl({ ...appConfig, proxyUrl: undefined }, { protocol: 'http:', host: 'localhost:2292' }, true)
+  // proxyUrl is derived from the port that was requested and can name a port nothing is
+  // bound to, so the served `port` is the only reliable source for the handshake
+  it('ignores a proxyUrl that disagrees with the served port', () => {
+    const url = getGraphQLWsUrl({ ...appConfig, proxyUrl: 'http://localhost:9999' } as any, { protocol: 'http:', host: 'localhost:2292' }, true)
+
+    expect(url).to.equal('ws://localhost:2345/__socket-graphql')
+  })
+
+  it('falls back to the page origin when the proxy is disabled and no port is served', () => {
+    const url = getGraphQLWsUrl({ ...appConfig, port: undefined }, { protocol: 'http:', host: 'localhost:2292' }, true)
 
     expect(url).to.equal('ws://localhost:2292/__socket-graphql')
   })

--- a/packages/frontend-shared/src/graphql/urqlClient.ts
+++ b/packages/frontend-shared/src/graphql/urqlClient.ts
@@ -124,7 +124,7 @@ interface AppUrqlClientConfig {
   target: 'app'
   namespace: string
   socketIoRoute: string
-  proxyUrl?: string
+  port?: number | null
 }
 
 export type UrqlClientConfig = LaunchpadUrqlClientConfig | AppUrqlClientConfig
@@ -241,13 +241,17 @@ export function getGraphQLWsUrl (config: UrqlClientConfig, location: Pick<Locati
 
   // With the proxy disabled the app is served at the AUT's superdomain, and CDP
   // cannot intercept a WebSocket upgrade — the handshake has to name the Cypress
-  // server or it reaches the user's app server (see #34563).
-  const origin = proxyDisabled && config.proxyUrl ? new URL(config.proxyUrl) : location
+  // server or it reaches the user's app server (see #34563). `port` is the port the
+  // server is listening on; `proxyUrl` is derived from the port that was requested and
+  // can still name a port nothing is bound to.
+  if (proxyDisabled && config.port) {
+    return `ws://localhost:${config.port}${config.socketIoRoute}-graphql`
+  }
 
   // http: -> ws:  &  https: -> wss:
-  const protocol = origin.protocol.replace('http', 'ws')
+  const protocol = location.protocol.replace('http', 'ws')
 
-  return `${protocol}//${origin.host}${config.socketIoRoute}-graphql`
+  return `${protocol}//${location.host}${config.socketIoRoute}-graphql`
 }
 
 function getSocketSource (config: UrqlClientConfig) {


### PR DESCRIPTION
- Fixes the `run-app-integration-tests-chrome-cdp-remediated` failure on #34574

### Additional details

Targets `issue-34561-cdp-terminal-disconnect` so #34574's new remediated job goes green on its own PR. Not a stack — this is the only PR for the fix.

**Root cause.** #34579 named the Cypress server in the graphql-ws handshake via `proxyUrl`, but `proxyUrl` is derived from the port that was *requested*, not the one the server bound (`setUrls` computes `http://localhost:${port}` once, and `ProjectBase.open` only recomputes when `cfg.port` was unset). In cypress-in-cypress component testing, `e2ePluginSetup.__internal_openProject` opens the inner project with `--port 4456` and the server ends up on 4455, so the served config carries:

```
port: 4455    proxyUrl: http://localhost:4456    appServerPort: 4455
```

With the proxy disabled the app reads `proxyUrl`, so the handshake went to a port with nothing bound. Only the subscription path breaks — everything reachable by refetch or client-side routing keeps working — which is why exactly one test failed: `cypress-in-cypress-component.cy.ts` → "redirects to the specs list with error if an open spec is not found when specs list updates", the only one of those 41 tests that waits on a server-pushed `pushFragment`.

**Fix.** Build the URL from the served `port`, which is the port the server is actually listening on. `proxyUrl` is no longer read by the app.

### Steps to test

```
yarn workspace @packages/app build
cd packages/app && CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run:e2e --browser chrome --spec "cypress/e2e/cypress-in-cypress-component.cy.ts"
```

Note the `build` — `cypress:run:e2e` serves the prebuilt `packages/app/dist`, so client-side edits have no effect without it. A revert/bisect A/B is invalid unless each arm is rebuilt.

Verified locally on this branch:

- Fresh-bundle A/B on the base commit: unfixed 6/7, fixed 7/7
- All four cypress-in-cypress specs proxy-off (the remediated job's spec list): 41/41
- Six `getGraphQLWsUrl` unit tests updated, including one pinning this failure mode — a `proxyUrl` that disagrees with the served `port` must be ignored
- `check-ts` and lint clean for `@packages/app` and `@packages/frontend-shared`

Not verified locally: the proxy-enabled path. A cypress-in-cypress MITM run dies on a cy-prompt stub at `localhost:1234` before any test runs, which reproduces with this change stashed, so it is environmental. The new branch is gated behind `proxyDisabled`, leaving proxy-enabled behavior byte-identical, and the standard `run-app-integration-tests-chrome` job covers it.

### How has the user experience changed?

No change — internal proxy-disabled mode only.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? (follow-up to #34563 / #34579)
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to internal proxy-disabled mode; proxy-enabled paths are unchanged and covered by existing tests.
> 
> **Overview**
> When **`CYPRESS_INTERNAL_DISABLE_PROXY`** is on, GraphQL subscriptions must connect to the real Cypress server (CDP cannot proxy WebSocket upgrades). The app was using **`proxyUrl`**, which can reflect the *requested* port rather than the port the server actually bound—breaking **`pushFragment`** subscriptions in cypress-in-cypress when those differ.
> 
> **`makeUrqlClient`** now takes **`port`** instead of **`proxyUrl`**. In **`getGraphQLWsUrl`**, proxy-disabled mode with a served port builds **`ws://localhost:{port}{socketIoRoute}-graphql`**; proxy-enabled behavior still uses the page origin. Unit tests cover the mismatch case and the no-port fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e79c4597f30fd3d194dc918011f57f0cd3bb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->