### PR TITLE
test: update experimental retries mochaEvents snapshots for deduped afterEach retry event

### DIFF
--- a/packages/app/cypress/e2e/runner/snapshots/retries.experimentalRetries.mochaEvents.cy.ts.json
+++ b/packages/app/cypress/e2e/runner/snapshots/retries.experimentalRetries.mochaEvents.cy.ts.json
@@ -12422,60 +12422,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r7",
-        "order": 4,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h7",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h7",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            },
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 1,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r7",
@@ -38306,60 +38252,6 @@
         "currentRetry": 0,
         "retries": -1,
         "_slow": 10000
-      }
-    ],
-    [
-      "mocha",
-      "retry",
-      {
-        "id": "r7",
-        "order": 4,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h7",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h7",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            },
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 1,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
       }
     ],
     [

--- a/packages/app/cypress/e2e/runner/snapshots/runner.experimentalRetries.mochaEvents.cy.ts.json
+++ b/packages/app/cypress/e2e/runner/snapshots/runner.experimentalRetries.mochaEvents.cy.ts.json
@@ -2910,55 +2910,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 1,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -3216,55 +3167,6 @@
         "currentRetry": 0,
         "retries": -1,
         "_slow": 10000
-      }
-    ],
-    [
-      "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 2,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
       }
     ],
     [
@@ -3530,55 +3432,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 3,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -3836,55 +3689,6 @@
         "currentRetry": 0,
         "retries": -1,
         "_slow": 10000
-      }
-    ],
-    [
-      "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 4,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
       }
     ],
     [
@@ -12614,55 +12418,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 1,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -12924,55 +12679,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 2,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -13234,55 +12940,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 3,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -13544,55 +13201,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 4,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -13850,55 +13458,6 @@
         "currentRetry": 0,
         "retries": -1,
         "_slow": 10000
-      }
-    ],
-    [
-      "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 5,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
       }
     ],
     [
@@ -14164,55 +13723,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 6,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -14474,55 +13984,6 @@
     ],
     [
       "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 7,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
-      }
-    ],
-    [
-      "mocha",
       "hook end",
       {
         "id": "r3",
@@ -14780,55 +14241,6 @@
         "currentRetry": 0,
         "retries": -1,
         "_slow": 10000
-      }
-    ],
-    [
-      "mocha",
-      "retry",
-      {
-        "id": "r3",
-        "order": 1,
-        "title": "test 1",
-        "hookName": "after each",
-        "err": {
-          "message": "[error message]",
-          "name": "AssertionError",
-          "stack": "match.string",
-          "parsedStack": "match.array"
-        },
-        "state": "failed",
-        "pending": false,
-        "failedFromHookId": "h1",
-        "failedFromHookName": "after each",
-        "body": "[body]",
-        "type": "test",
-        "duration": "match.number",
-        "wallClockStartedAt": "match.date",
-        "timings": {
-          "lifecycle": "match.number",
-          "test": {
-            "fnDuration": "match.number",
-            "afterFnDuration": "match.number"
-          },
-          "after each": [
-            {
-              "hookId": "h1",
-              "fnDuration": "match.number",
-              "afterFnDuration": "match.number"
-            }
-          ]
-        },
-        "file": null,
-        "final": false,
-        "currentRetry": 8,
-        "retries": 9,
-        "_slow": 10000
-      },
-      {
-        "message": "[error message]",
-        "name": "AssertionError",
-        "stack": "match.string",
-        "parsedStack": "match.array"
       }
     ],
     [


### PR DESCRIPTION
- Closes N/A — this takes `develop` green again after https://github.com/cypress-io/cypress/pull/34545.

### Additional details

`run-app-integration-tests-chrome` has been failing on `develop` since https://github.com/cypress-io/cypress/pull/34545 landed (first red pipeline: [85455](https://app.circleci.com/pipelines/github/cypress-io/cypress/85455), commit 2b3fa5cb1824bf50ee3f45a586e59f5d13298bf8; the previous develop pipeline was green for these specs). Four tests fail, and every PR that merges `develop` inherits them:

- `Experimental retries: mochaEvents & test status tests detect-flake-and-pass-on-threshold can retry from [afterEach]`
- `Experimental retries: mochaEvents & test status tests detect-flake-but-always-fail can retry from [afterEach]`
- `experimental retries: runner tests detect-flake-and-pass-on-threshold tests finish with correct state hook failures fail in [afterEach]`
- `experimental retries: runner tests detect-flake-but-always-fail tests finish with correct state hook failures fail in [afterEach]`

#34545 moved the `runner:retry` emission inside the "mocha already requeued this attempt" guard in `packages/driver/src/cypress/runner.ts`. Under experimental retries, patched mocha requeues an attempt whose *body* passed (`hasAttemptPassed`) and emits its own `retry` **before** running the `afterEach` hooks — so when an `afterEach` then fails, the driver's `runner:retry` was a duplicate for that same attempt. These snapshots recorded the duplicate, and the fix intentionally removes it. Regenerating them is the correct resolution.

The snapshots were not updated in #34545 because `.circleci/scripts/generate-pipeline-parameters.sh` maps `packages/driver/*` to `run-driver-tests` + `run-system-tests` only — not `run-app-ui-tests` — so `run-app-integration-tests-chrome` halted on that PR and these specs never ran. Worth considering separately whether driver changes should also set `app_ui_tests=true`, since driver behavior is what these app runner snapshots capture.

Diff is 14 removed events, all `retry` events carrying `hookName: "after each"` for attempts ≥ 1, and nothing else — verified by parsing both snapshot files before/after and diffing the event sequences. Every attempt still records exactly one `retry` event: attempt 0 keeps the driver's (mocha does not requeue it), later attempts keep mocha's.

No user-facing impact, which is why nothing else needed regenerating:
- `packages/server/lib/reporter.ts` — with `experimentalStrategy`, the spec reporter logs attempt lines from `test:after:run`, not from `retry`, so `cypress run` output is unchanged (and no system-test snapshots moved).
- `packages/driver/src/cypress.ts` — `runner:retry` is only forwarded to the reporter when `isTextTerminal`, so open mode never consumed it.
- The `afterEach` failure still reaches consumers via `test:after:run` (`state: failed`, `final: false`), which is why the sibling `displays correct passed/failed tests` assertions were already passing on the red pipelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test snapshot updates only; no runtime or user-facing behavior changes.
> 
> **Overview**
> Updates **Cypress app runner snapshot fixtures** for experimental-retries specs so expected Mocha event streams match behavior after the driver stopped emitting a duplicate `runner:retry` when an `afterEach` fails on an attempt Mocha had already requeued.
> 
> The diff **removes 14 `["mocha","retry",…]` entries** (all with `hookName: "after each"` and `currentRetry` ≥ 1) from `retries.experimentalRetries.mochaEvents.cy.ts.json` and `runner.experimentalRetries.mochaEvents.cy.ts.json`. Each attempt still has a single retry event (attempt 0 from the driver; later attempts from Mocha). One sequence is corrected so a failing `afterEach` is represented as **`hook end`** instead of a spurious **`retry`**.
> 
> No production code changes—snapshot-only fix to get `run-app-integration-tests-chrome` green after #34545.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e9f2c28e94e4530eb6476f8c7989b9f831a034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
yarn workspace @packages/app cypress:run-cypress-in-cypress node ../../scripts/cypress run --project . --spec "cypress/e2e/runner/*mochaEvents*" --browser chrome --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true
```

Locally on macOS/Chrome the two regenerated specs pass (69/69). To confirm the snapshots are reproducible rather than hand-edited, `yarn workspace @packages/app cypress:run:e2e:update:snapshots` should leave the working tree clean.

### How has the user experience changed?

No change — test snapshots only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-snapshot update to take `develop` green after #34545; no behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
