### PR TITLE
test: cover browser recovery from a stale keep-alive socket

### DIFF
--- a/system-tests/projects/e2e/cypress/e2e/network_error_form_retry.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/network_error_form_retry.cy.js
@@ -1,0 +1,18 @@
+// Separate from the other network error specs because only the Node MITM proxy
+// re-sends the body, so this holds in one proxy mode rather than both.
+describe('network error handling', function () {
+  context('cy.visit() retries', function () {
+    it('re-sends a <form> body on failures', function () {
+      cy.visit({
+        url: '/print-body-third-time-form',
+      })
+      .get('input[type=text]')
+      .type('bar')
+
+      cy.get('input[type=submit]')
+      .click()
+
+      cy.contains('{"foo":"bar"}')
+    })
+  })
+})

--- a/system-tests/projects/e2e/cypress/e2e/network_error_handling.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/network_error_handling.cy.js
@@ -20,19 +20,6 @@ describe('network error handling', function () {
       })
       .contains('ok')
     })
-
-    it('re-sends a <form> body on failures', function () {
-      cy.visit({
-        url: '/print-body-third-time-form',
-      })
-      .get('input[type=text]')
-      .type('bar')
-
-      cy.get('input[type=submit]')
-      .click()
-
-      cy.contains('{"foo":"bar"}')
-    })
   })
 
   context('cy.request() retries', function () {

--- a/system-tests/projects/e2e/cypress/e2e/network_error_stale_keepalive.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/network_error_stale_keepalive.cy.js
@@ -1,0 +1,34 @@
+// Recovering a request written to a dead pooled socket is the browser's job now
+// that Cypress no longer replays traffic through Node. Cypress must let it, and
+// must not report the recovered attempt twice.
+const PAIRS = 3
+
+describe('stale keep-alive sockets', function () {
+  it('recovers without surfacing the failed attempt to the test', function () {
+    cy.intercept({ pathname: '/stale-socket' }).as('staleSocket')
+
+    cy.visit('/stale-keepalive.html')
+
+    cy.window().then((win) => {
+      // the warm request leaves a pooled socket behind; the raced one reuses it
+      // and is met with a FIN, the shape of a keep-alive timeout crossing a request
+      const pair = (i) => {
+        return win.fetch(`/stale-socket?warm=${i}`)
+        .then((res) => res.text())
+        .then(() => win.fetch(`/stale-socket?race=${i}`))
+        .then((res) => {
+          expect(res.status, 'the browser retried the dead socket on a new connection').to.eq(200)
+        })
+      }
+
+      return Cypress.Promise.each(Array.from({ length: PAIRS }, (_, i) => i), pair)
+    })
+
+    // a change in connection pooling would otherwise leave this racing nothing
+    cy.request('/stale-socket-stats').its('body.killedOnReusedSocket').should('be.gte', 1)
+
+    // the wire saw more requests than this — a browser-level retry sits below the
+    // layer Cypress intercepts at
+    cy.get('@staleSocket.all').should('have.length', PAIRS * 2)
+  })
+})

--- a/system-tests/test/network_error_handling_spec.js
+++ b/system-tests/test/network_error_handling_spec.js
@@ -2,13 +2,9 @@ const _ = require('lodash')
 const express = require('express')
 const path = require('path')
 const debug = require('debug')('cypress:server:network-error-handling-spec')
-const Promise = require('bluebird')
 const bodyParser = require('body-parser')
 const DebugProxy = require('@cypress/debugging-proxy')
-const launcher = require('@packages/launcher')
-const chrome = require('@packages/server/lib/browsers/chrome')
 const systemTests = require('../lib/system-tests').default
-const random = require('@packages/server/lib/util/random')
 const Fixtures = require('../lib/fixtures')
 
 const PORT = 13370
@@ -28,31 +24,6 @@ let counts = {}
 let killedOnReusedSocket = 0
 
 const servedSockets = new WeakSet()
-
-const launchBrowser = (url, opts = {}) => {
-  return launcher.detect().then((browsers) => {
-    const browser = _.find(browsers, { name: 'chrome' })
-
-    const args = [
-      `--user-data-dir=/tmp/cy-e2e-${random.id()}`,
-    // headless breaks automatic retries
-    // "--headless"
-    ].concat(
-      chrome._getArgs(browser),
-    ).filter((arg) => {
-      return ![
-        // seems to break chrome's automatic retries
-        '--enable-automation',
-      ].includes(arg)
-    })
-
-    if (opts.withProxy) {
-      args.push(`--proxy-server=http://localhost:${PORT}`)
-    }
-
-    return launcher.launch(browser, url, args)
-  })
-}
 
 const controllers = {
   loadScriptNetError (req, res) {
@@ -94,26 +65,6 @@ const controllers = {
     return req.socket.destroy()
   },
 
-  afterHeadersReset (req, res) {
-    res.writeHead(200)
-    res.write('')
-
-    return setTimeout(() => {
-      return req.socket.destroy()
-    }
-    , 1000)
-  },
-
-  duringBodyReset (req, res) {
-    res.writeHead(200)
-    res.write('<html>')
-
-    return setTimeout(() => {
-      return req.socket.destroy()
-    }
-    , 1000)
-  },
-
   worksThirdTime (req, res) {
     if (counts[req.url] === 3) {
       return res.send('ok')
@@ -128,22 +79,6 @@ const controllers = {
     }
 
     return res.sendStatus(500)
-  },
-
-  proxyInternalServerError (req, res) {
-    return res.sendStatus(500)
-  },
-
-  proxyBadGateway (req, res) {
-    // https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.3
-    // "The server, while acting as a gateway or proxy, received an invalid response"
-    return res.sendStatus(502)
-  },
-
-  proxyServiceUnavailable (req, res) {
-    // https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.4
-    // "The implication is that this is a temporary condition which will be alleviated after some delay."
-    return res.sendStatus(503)
   },
 
   load304 (req, res) {
@@ -201,8 +136,6 @@ describe('e2e network error handling', function () {
           app.use(bodyParser.urlencoded({ extended: true }))
 
           app.get('/immediate-reset', controllers.immediateReset)
-          app.get('/after-headers-reset', controllers.afterHeadersReset)
-          app.get('/during-body-reset', controllers.duringBodyReset)
           app.get('/works-third-time/:id', controllers.worksThirdTime)
           app.get('/works-third-time-else-500/:id', controllers.worksThirdTimeElse500)
           app.post('/print-body-third-time', controllers.printBodyThirdTime)
@@ -216,22 +149,6 @@ describe('e2e network error handling', function () {
           app.get('/print-body-third-time-form', controllers.printBodyThirdTimeForm)
 
           return app.get('*', (req, res) => {
-            // pretending we're a http proxy
-            const controller = ({
-              'http://immediate-reset.invalid/': controllers.immediateReset,
-              'http://after-headers-reset.invalid/': controllers.afterHeadersReset,
-              'http://during-body-reset.invalid/': controllers.duringBodyReset,
-              'http://proxy-internal-server-error.invalid/': controllers.proxyInternalServerError,
-              'http://proxy-bad-gateway.invalid/': controllers.proxyBadGateway,
-              'http://proxy-service-unavailable.invalid/': controllers.proxyServiceUnavailable,
-            })[req.url]
-
-            if (controller) {
-              debug('got controller for request')
-
-              return controller(req, res)
-            }
-
             return res.sendStatus(404)
           })
         },
@@ -278,102 +195,6 @@ describe('e2e network error handling', function () {
   afterEach(() => {
     onVisit = null
     counts = {}
-  })
-
-  // NOTE: We can just skip these tests, they are really only useful for learning
-  // about how Chrome does it.
-  context.skip('Google Chrome', () => {
-    const testRetries = (path) => {
-      return launchBrowser(`http://127.0.0.1:${PORT}${path}`)
-      .then((proc) => {
-        return Promise.fromCallback((cb) => {
-          return onVisit = function () {
-            if (counts[path] >= 3) {
-              return cb()
-            }
-          }
-        }).then(() => {
-          proc.kill(9)
-
-          expect(counts[path]).to.be.at.least(3)
-        })
-      })
-    }
-
-    const testNoRetries = (path) => {
-      return launchBrowser(`http://localhost:${PORT}${path}`)
-      .delay(6000)
-      .then((proc) => {
-        proc.kill(9)
-
-        expect(counts[path]).to.eq(1)
-      })
-    }
-
-    it('retries 3+ times when receiving immediate reset', () => {
-      return testRetries('/immediate-reset')
-    })
-
-    it('retries 3+ times when receiving reset after headers', () => {
-      return testRetries('/after-headers-reset')
-    })
-
-    it('does not retry if reset during body', () => {
-      return testNoRetries('/during-body-reset')
-    })
-
-    context('behind a proxy server', () => {
-      const testProxiedRetries = (url) => {
-        return launchBrowser(url, { withProxy: true })
-        .then((proc) => {
-          return Promise.fromCallback((cb) => {
-            return onVisit = function () {
-              if (counts[url] >= 3) {
-                return cb()
-              }
-            }
-          }).then(() => {
-            proc.kill(9)
-
-            expect(counts[url]).to.be.at.least(3)
-          })
-        })
-      }
-
-      const testProxiedNoRetries = (url) => {
-        return launchBrowser('http://during-body-reset.invalid/', { withProxy: true })
-        .delay(6000)
-        .then((proc) => {
-          proc.kill(9)
-
-          expect(counts[url]).to.eq(1)
-        })
-      }
-
-      it('retries 3+ times when receiving immediate reset', () => {
-        return testProxiedRetries('http://immediate-reset.invalid/')
-      })
-
-      it('retries 3+ times when receiving reset after headers', () => {
-        return testProxiedRetries('http://after-headers-reset.invalid/')
-      })
-
-      it('does not retry if reset during body', () => {
-        return testProxiedNoRetries('http://during-body-reset.invalid/')
-      })
-
-      it('does not retry on \'500 Internal Server Error\'', () => {
-        return testProxiedNoRetries('http://proxy-internal-server-error.invalid/')
-      })
-
-      it('does not retry on \'502 Bad Gateway\'', () => {
-        return testProxiedNoRetries('http://proxy-bad-gateway.invalid/')
-      })
-
-      it('does not retry on \'503 Service Unavailable\'', () => {
-        return testProxiedNoRetries('http://proxy-service-unavailable.invalid/')
-      })
-    })
   })
 
   context('Cypress', () => {
@@ -449,6 +270,29 @@ describe('e2e network error handling', function () {
             port: HTTPS_PORT,
           })
         })
+      })
+    })
+
+    it('retries network errors for cy.visit, cy.request, and subresources', function () {
+      return systemTests.exec(this, {
+        spec: 'network_error_handling.cy.js',
+        config: {
+          baseUrl: `http://localhost:${PORT}`,
+        },
+        expectedExitCode: 2,
+      })
+    })
+
+    // NOTE: only the Node hop replays a POST body — the browser will not replay a
+    // non-idempotent request — so this holds only while Cypress proxies.
+    const itReplaysFormBody = process.env.CYPRESS_INTERNAL_DISABLE_PROXY === '1' ? it.skip : it
+
+    itReplaysFormBody('re-sends a <form> body when the origin resets the connection', function () {
+      return systemTests.exec(this, {
+        spec: 'network_error_form_retry.cy.js',
+        config: {
+          baseUrl: `http://localhost:${PORT}`,
+        },
       })
     })
 

--- a/system-tests/test/network_error_handling_spec.js
+++ b/system-tests/test/network_error_handling_spec.js
@@ -25,6 +25,9 @@ const getElapsed = () => {
 
 let onVisit = null
 let counts = {}
+let killedOnReusedSocket = 0
+
+const servedSockets = new WeakSet()
 
 const launchBrowser = (url, opts = {}) => {
   return launcher.detect().then((browsers) => {
@@ -146,6 +149,28 @@ const controllers = {
   load304 (req, res) {
     return res.type('html').end('<img src="/static/javascript-logo.png"/>')
   },
+
+  staleKeepAlivePage (req, res) {
+    return res.type('html').end('<html><body>stale keep-alive</body></html>')
+  },
+
+  // A request on an already-served socket is met with a FIN and no response — what
+  // a client sees when the origin's keep-alive timeout crosses a request in flight.
+  staleSocket (req, res) {
+    if (servedSockets.has(req.socket)) {
+      killedOnReusedSocket++
+
+      return req.socket.end()
+    }
+
+    servedSockets.add(req.socket)
+
+    return res.send('ok')
+  },
+
+  staleSocketStats (req, res) {
+    return res.json({ killedOnReusedSocket })
+  },
 }
 
 describe('e2e network error handling', function () {
@@ -183,6 +208,9 @@ describe('e2e network error handling', function () {
           app.post('/print-body-third-time', controllers.printBodyThirdTime)
 
           app.get('/load-304.html', controllers.load304)
+          app.get('/stale-keepalive.html', controllers.staleKeepAlivePage)
+          app.get('/stale-socket', controllers.staleSocket)
+          app.get('/stale-socket-stats', controllers.staleSocketStats)
           app.get('/load-img-net-error.html', controllers.loadImgNetError)
           app.get('/load-script-net-error.html', controllers.loadScriptNetError)
           app.get('/print-body-third-time-form', controllers.printBodyThirdTimeForm)
@@ -420,6 +448,26 @@ describe('e2e network error handling', function () {
             host: 'localhost',
             port: HTTPS_PORT,
           })
+        })
+      })
+    })
+
+    // NOTE: only with the proxy disabled does the browser reach the origin
+    // directly, so this contract exists solely in that mode.
+    const contextStaleKeepAlive = process.env.CYPRESS_INTERNAL_DISABLE_PROXY === '1' ? context : context.skip
+
+    contextStaleKeepAlive('stale keep-alive sockets', () => {
+      beforeEach(() => {
+        killedOnReusedSocket = 0
+      })
+
+      it('lets the browser recover a request written to a dead pooled socket', function () {
+        return systemTests.exec(this, {
+          spec: 'network_error_stale_keepalive.cy.js',
+          browser: 'chrome',
+          config: {
+            baseUrl: `http://localhost:${PORT}`,
+          },
         })
       })
     })


### PR DESCRIPTION
- Closes n/a — refs [#24716](https://github.com/cypress-io/cypress/issues/24716)

### Additional details

With `CYPRESS_INTERNAL_DISABLE_PROXY=1` browser traffic no longer goes through the Node MITM proxy — Cypress pauses requests via CDP Fetch and lets Chrome make them. Recovering from a request written to a dead pooled keep-alive socket therefore stops being Cypress's job and becomes the browser's, which leaves Cypress with an implicit dependency on Chromium's network stack that nothing tested.

**1. New test for that dependency.** `network_error_stale_keepalive.cy.js` runs warm/race fetch pairs against an origin that answers the first request on a connection and meets any request on a reused socket with a FIN and no response. It asserts three things:

- the raced fetch still gets a 200 (the browser recovered);
- the origin actually killed at least one reused socket, via a stats route — so a change in connection pooling cannot quietly turn this into a test that never races anything;
- `cy.intercept` fired exactly once per logical request — this is the fragile property, and what would catch a Chromium change or a Cypress change that moved interception above the retry layer.

It is gated on `CYPRESS_INTERNAL_DISABLE_PROXY === '1'`, mirroring `non_proxied_spec.ts` and `cookies_spec.ts`, so it activates when the flag flips.

**2. Removed the skipped `Google Chrome` context (9 tests).** These could not simply be unskipped — they were bit-rotted. `launchBrowser` calls the private `chrome._getArgs(browser)` with one argument while that helper now takes `(browser, options, port)`, so every test threw `TypeError: Cannot read properties of undefined (reading 'userAgent')` before a browser launched. They also drove a raw browser rather than Cypress, so a failure described Chrome rather than anything Cypress guarantees. Removed along with the helpers, controllers and routes only they reached.

**3. Wired up `network_error_handling.cy.js`, which was orphaned.** It holds 9 Cypress-level tests (`cy.visit`/`cy.request`/subresource retries) and nothing in the repo referenced it, so it never ran — while seven harness routes existed solely to serve it. It now runs, with `expectedExitCode: 2` for the two `fails after retrying 5x` tests that fail by design.

Its `<form>` body case only holds while Cypress proxies the traffic: with the proxy disabled the browser owns the retry and will not replay a non-idempotent request, so it times out. That case moved to its own spec which the harness selects by proxy mode. **This is worth a reviewer's attention** — the behavior change looks intentional, but nothing currently asserts either way, and if it is intentional a positive assertion pinning the new contract (a POST is *not* replayed when unproxied) would be a good follow-up.

Net effect: −9 dead tests, +9 live ones, 8 of which run in both proxy modes.

### Steps to test

```sh
cd system-tests
CYPRESS_INTERNAL_DISABLE_PROXY=1 node ./scripts/run.js --glob-in-dir="test" network_error_handling
node ./scripts/run.js --glob-in-dir="test" network_error_handling
```

Results observed locally:

| | with flag | without flag |
|---|---|---|
| Passing | 6 | 6 |
| Pending | 2 (SNI + gated form test) | 1 (stale keep-alive) |
| Failing | 0 | 1 |

The one failure without the flag is `does not connect to the upstream proxy for the SNI server request`, which fails identically on `develop` in the same environment — a sandbox networking limitation interfering with `DebugProxy`, not a regression from this change.

Determinism of the socket-kill assertion was checked separately: instrumenting the stats route showed `killedOnReusedSocket=5` on 5 consecutive runs, never varying, against a threshold of 1.

One caveat on verification: no Google Chrome build was installable in the sandbox, so the new test was exercised against Chromium 141.0.7390.37 rather than branded Chrome. Same version and network stack, but CI will be the first run on the exact binary.

### How has the user experience changed?

No change — test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-only change covering the browser-recovery dependency described in #24716; no product behavior is modified. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


---
_Generated by [Claude Code](https://claude.ai/code/session_01XrvQo3bxCQTAM7vDx1m3Py)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to system-test specs, harness routes, and conditional skips; no product runtime code is modified.
> 
> **Overview**
> **Test-only** refresh of network error system tests around proxy vs. direct-browser (`CYPRESS_INTERNAL_DISABLE_PROXY`) behavior.
> 
> **Stale keep-alive:** Adds `network_error_stale_keepalive.cy.js` and harness routes that simulate a FIN on a reused pooled socket. The spec checks the browser still gets 200, the server actually killed a reused socket, and `cy.intercept` only sees one event per logical request (no double-reporting of browser-level retries). That suite runs **only** when the internal proxy is disabled.
> 
> **Previously orphaned Cypress retries:** `network_error_handling.cy.js` is now executed from the harness (including the two tests that are expected to fail after max retries). The **form POST body replay** case moves to `network_error_form_retry.cy.js` and runs **only** when the Node MITM proxy is enabled, since body replay on reset is a proxy behavior.
> 
> **Cleanup:** Removes the skipped raw-Chrome `launchBrowser` context and related dead routes/controllers (proxy-invalid hosts, mid-response resets, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5257ebbd5855a2312196b43dea9a1c8108c2a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->