### PR TITLE
chore: skip the eager CDP Fetch body read for stream-shaped responses when the proxy is disabled

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -295,9 +295,10 @@ jobs:
       # #34514 strategy:file origin serving + #34379 intercept-matched visit pre-flights (visits, web security, service workers).
       # #34563 graphql-ws upgrades target the Cypress server origin (request_spec); non_proxied_spec asserts proxy
       # semantics that do not exist here and skips itself.
+      # #34470 skip the eager CDP Fetch body read for stream-shaped responses (SSE).
       # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
       # concurrent large-body CDP Fetch (47 unmatched localhost requests).
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js test/request_spec.ts test/non_proxied_spec.ts
+      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js test/request_spec.ts test/non_proxied_spec.ts test/server_sent_events_spec.js
       requires:
         - system-tests-node-modules-install
   - system-tests-cookies-cdp:

--- a/packages/network-interception/lib/ports/http-interception.ts
+++ b/packages/network-interception/lib/ports/http-interception.ts
@@ -18,6 +18,7 @@ export type HttpResponse = {
   id: string
   url: string
   body?: HttpBody
+  bodySkipped?: boolean
   bodyStream?: Readable
   headers?: HttpHeaders
   statusCode?: number

--- a/packages/proxy/lib/adapters/network-capture.ts
+++ b/packages/proxy/lib/adapters/network-capture.ts
@@ -12,6 +12,12 @@ export async function notifyResponseStreamReceived (mw: ResponseInterceptionMidd
     return mw.next()
   }
 
+  // A skipped body means the transport never read it, not that it was empty.
+  // Notifying Replay here would record a false zero-length capture.
+  if (mw.resBodySkipped) {
+    return mw.next()
+  }
+
   const preRequest = mw.req.browserPreRequest
   const requestId = getOriginalRequestId(preRequest.requestId)
 

--- a/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
@@ -8,6 +8,7 @@ import {
   createSyntheticIncomingResponse,
 } from './synthetic-express-context'
 import type { SyntheticCypressResponse } from './synthetic-express-context'
+import type { ResponseInterceptionMiddlewareCtx } from './types'
 
 const WIRE_ENCODING_HEADERS = new Set(['content-encoding', 'content-length', 'transfer-encoding'])
 
@@ -147,6 +148,10 @@ export function createSyntheticProxyCodec (
 
       ctx.incomingRes = createSyntheticIncomingResponse(response)
       ctx.incomingResStream = response.bodyStream ?? createRequestBodyStream(response.body)
+
+      if (response.bodySkipped) {
+        (ctx as unknown as ResponseInterceptionMiddlewareCtx).resBodySkipped = true
+      }
 
       return ctx
     },

--- a/packages/proxy/lib/http/response-middleware.ts
+++ b/packages/proxy/lib/http/response-middleware.ts
@@ -42,6 +42,12 @@ interface ResponseMiddlewareProps {
   incomingResHadEmptyBody: boolean
   incomingRes: IncomingMessage
   incomingResStream: Readable
+  /**
+   * Set by the synthetic proxy codec when the CDP Fetch transport deliberately
+   * never read the response body (stream-shaped, e.g. SSE). Consumed by the
+   * network capture adapter so it doesn't record a skipped body as an empty one.
+   */
+  resBodySkipped?: boolean
 }
 
 export type ResponseMiddleware = HttpMiddleware<ResponseMiddlewareProps>

--- a/packages/proxy/test/unit/adapters/proxy-network-capture.spec.ts
+++ b/packages/proxy/test/unit/adapters/proxy-network-capture.spec.ts
@@ -35,3 +35,49 @@ describe('ProxyNetworkCaptureAdapter', () => {
     expect(notifyResponseEndedWithEmptyBody).toHaveBeenCalledWith(ctx, { isCached: true })
   })
 })
+
+describe('notifyResponseStreamReceived', () => {
+  // The module is mocked above for the adapter delegation tests, so pull the
+  // real implementation here to exercise its guard logic directly.
+  async function importActualNotifyResponseStreamReceived () {
+    const actual = await vi.importActual<typeof import('../../../lib/adapters/network-capture')>('../../../lib/adapters/network-capture')
+
+    return actual.notifyResponseStreamReceived
+  }
+
+  it('skips the protocol notification when the body was deliberately not read', async () => {
+    const notifyResponseStreamReceived = await importActualNotifyResponseStreamReceived()
+    const responseStreamReceived = vi.fn()
+    const incomingResStream = {} as any
+    const mw: any = {
+      resBodySkipped: true,
+      protocolManager: { responseStreamReceived },
+      req: { browserPreRequest: { requestId: '1' } },
+      incomingResStream,
+      next: vi.fn(),
+    }
+
+    await notifyResponseStreamReceived(mw)
+
+    expect(responseStreamReceived).not.toHaveBeenCalled()
+    expect(mw.next).toHaveBeenCalledOnce()
+    expect(mw.incomingResStream).toBe(incomingResStream)
+  })
+
+  it('still notifies when the marker is absent', async () => {
+    const notifyResponseStreamReceived = await importActualNotifyResponseStreamReceived()
+    const responseStreamReceived = vi.fn().mockReturnValue(undefined)
+    const mw: any = {
+      protocolManager: { responseStreamReceived },
+      req: { browserPreRequest: { requestId: '1' } },
+      incomingRes: { headers: {} },
+      incomingResStream: {},
+      next: vi.fn(),
+    }
+
+    await notifyResponseStreamReceived(mw)
+
+    expect(responseStreamReceived).toHaveBeenCalledOnce()
+    expect(mw.next).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
@@ -559,6 +559,61 @@ describe('createSyntheticProxyCodec', () => {
     expect(ctx.req.headers['accept-encoding']).to.equal('gzip,identity')
   })
 
+  it('copies bodySkipped onto the ctx as resBodySkipped', () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-skipped',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    codec.encodeResponse({
+      id: 'network-skipped',
+      url: 'https://example.test/',
+      statusCode: 200,
+      bodySkipped: true,
+      bodyStream: Readable.from(['']),
+    })
+
+    expect(ctx.resBodySkipped).to.equal(true)
+  })
+
+  it('leaves resBodySkipped unset when bodySkipped is absent', () => {
+    const codec = createSyntheticProxyCodec({
+      createMiddlewareContext: (req, res) => {
+        return {
+          req,
+          res,
+        } as any
+      },
+    })
+
+    const ctx = codec.encodeRequest({
+      id: 'network-not-skipped',
+      url: 'https://example.test/',
+      method: 'GET',
+      headers: {},
+    })
+
+    codec.encodeResponse({
+      id: 'network-not-skipped',
+      url: 'https://example.test/',
+      statusCode: 200,
+      bodyStream: Readable.from(['origin']),
+    })
+
+    expect(ctx.resBodySkipped).to.be.undefined
+  })
+
   it('carries the extra-target marker so ExtractCypressMetadataHeaders can narrow middleware', async () => {
     const { ExtractCypressMetadataHeaders } = RequestMiddleware
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -321,6 +321,7 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
         bodyStream: transportResponse.bodyStream,
         headers: stripWireEncodingHeaders(toHttpHeaders(transportResponse.responseHeaders)),
         statusCode: transportResponse.responseCode,
+        ...(transportResponse.bodySkipped ? { bodySkipped: true } : {}),
       }
     },
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -613,6 +613,12 @@ export class CdpFetchTransport {
 
     if (bodySkipped) {
       debug('skipping eager body fetch for stream-shaped response %s (resourceType=%s)', event.request.url, event.resourceType)
+
+      // Stand in an empty body: its digest matches the empty body the
+      // middleware materializes, so an untouched response takes
+      // continueResponse and the browser reads the origin stream directly.
+      // Middleware that sets a body still diffs against this digest and
+      // fulfills.
       originalBody = Buffer.alloc(0)
     } else {
       try {

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -11,6 +11,7 @@ import { createCdpFetchCodec } from './cdp-fetch-codec'
 import { CDPNetworkExtraInfo } from './cdp-network-extra-info'
 import { AUT_FRAME_HEADER, EXTRA_TARGET_HEADER } from '../constants'
 import { normalizeResourceType } from './normalize-resource-type'
+import { shouldSkipResponseBody } from './should-skip-response-body'
 
 const debug = debugModule('cypress:server:browsers:cdp-fetch-transport')
 
@@ -110,6 +111,7 @@ export interface CdpFetchTransportRequest extends CdpFetchRequest {
 
 export interface CdpFetchTransportResponse extends CdpFetchTransportRequest {
   body?: string
+  bodySkipped?: boolean
   bodyStream?: Readable
   fulfilled?: boolean
   originalBodyDigest?: BodyDigest
@@ -606,18 +608,24 @@ export class CdpFetchTransport {
 
     deferred.headersReady.resolve()
 
+    const bodySkipped = shouldSkipResponseBody(event)
     let originalBody: Buffer
 
-    try {
-      originalBody = await this.fetchResponseBody(event, sessionId)
-    } catch (err) {
-      deferred.reject(new Error(`CDP Fetch response body unavailable for ${event.request.url}: ${(err as Error).message}`))
+    if (bodySkipped) {
+      debug('skipping eager body fetch for stream-shaped response %s (resourceType=%s)', event.request.url, event.resourceType)
+      originalBody = Buffer.alloc(0)
+    } else {
+      try {
+        originalBody = await this.fetchResponseBody(event, sessionId)
+      } catch (err) {
+        deferred.reject(new Error(`CDP Fetch response body unavailable for ${event.request.url}: ${(err as Error).message}`))
 
-      await this.safeSend('Fetch.continueResponse', {
-        requestId: event.requestId,
-      }, sessionId)
+        await this.safeSend('Fetch.continueResponse', {
+          requestId: event.requestId,
+        }, sessionId)
 
-      return
+        return
+      }
     }
 
     // reset() may have rejected this flow while the merge/fetch awaited CDP.
@@ -646,6 +654,7 @@ export class CdpFetchTransport {
       bodyStream: Readable.from(originalBody.length ? [originalBody] : []),
       originalBodyDigest: digestBody(originalBody),
       sessionId,
+      ...(bodySkipped ? { bodySkipped: true } : {}),
     })
   }
 

--- a/packages/server/lib/browsers/cdp-protocol/should-skip-response-body.ts
+++ b/packages/server/lib/browsers/cdp-protocol/should-skip-response-body.ts
@@ -5,7 +5,7 @@ import type { Protocol } from 'devtools-protocol'
 // which wedges the pause and the run along with it (#34470). Streaming the
 // body via Network.streamResourceContent instead was rejected: the
 // capture-loss PoC measured heavy render-critical body loss under load. See
-// cypress-io/engineering-documentation, technical-documentation/technical-decisions/tech-briefs/app/http2/supporting-documents/experimental-fetch/findings.md.
+// https://github.com/cypress-io/engineering-documentation/blob/main/technical-documentation/technical-decisions/tech-briefs/app/http2/supporting-documents/experimental-fetch/findings.md.
 // Deny-listing these provably stream-shaped responses and continuing them
 // untouched avoids the eager fetch entirely.
 const STREAM_CONTENT_TYPES = new Set(['text/event-stream', 'multipart/x-mixed-replace'])

--- a/packages/server/lib/browsers/cdp-protocol/should-skip-response-body.ts
+++ b/packages/server/lib/browsers/cdp-protocol/should-skip-response-body.ts
@@ -1,0 +1,29 @@
+import type { Protocol } from 'devtools-protocol'
+
+// Fetch.getResponseBody never resolves for a never-ending body (SSE, MJPEG
+// multipart streams) — it waits for the response to finish before returning,
+// which wedges the pause and the run along with it (#34470). Streaming the
+// body via Network.streamResourceContent instead was rejected: the
+// capture-loss PoC measured heavy render-critical body loss under load. See
+// cypress-io/engineering-documentation, technical-documentation/technical-decisions/tech-briefs/app/http2/supporting-documents/experimental-fetch/findings.md.
+// Deny-listing these provably stream-shaped responses and continuing them
+// untouched avoids the eager fetch entirely.
+const STREAM_CONTENT_TYPES = new Set(['text/event-stream', 'multipart/x-mixed-replace'])
+
+const getContentType = (responseHeaders?: Protocol.Fetch.HeaderEntry[]): string | undefined => {
+  const header = responseHeaders?.find(({ name }) => name.toLowerCase() === 'content-type')
+
+  return header?.value.toLowerCase().split(';')[0].trim()
+}
+
+export const shouldSkipResponseBody = (event: Protocol.Fetch.RequestPausedEvent): boolean => {
+  // Raw CDP field, not normalizeResourceType's output — that lowercases and
+  // allowlists, folding EventSource to 'other'.
+  if (event.resourceType === 'EventSource') {
+    return true
+  }
+
+  const contentType = getContentType(event.responseHeaders)
+
+  return !!contentType && STREAM_CONTENT_TYPES.has(contentType)
+}

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -2,8 +2,10 @@ const { expect, sinon } = require('../../spec_helper')
 
 import type { Protocol } from 'devtools-protocol'
 import { HttpIntercept } from '@packages/network-interception'
+import { digestBody } from '../../../lib/browsers/cdp-protocol/body-digest'
 import { createCdpFetchCodec } from '../../../lib/browsers/cdp-protocol/cdp-fetch-codec'
 import { CdpFetchTransport } from '../../../lib/browsers/cdp-protocol/cdp-fetch-transport'
+import { shouldSkipResponseBody } from '../../../lib/browsers/cdp-protocol/should-skip-response-body'
 
 function createPausedRequest (options: {
   requestId: string
@@ -99,6 +101,72 @@ async function readStream (stream: NodeJS.ReadableStream): Promise<string> {
 }
 
 describe('CdpFetchTransport', () => {
+  describe('shouldSkipResponseBody', () => {
+    it('skips an EventSource resourceType with no content-type header', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'EventSource',
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.true
+    })
+
+    it('skips a plain text/event-stream content-type', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.true
+    })
+
+    it('skips text/event-stream with a charset parameter', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: [{ name: 'content-type', value: 'text/event-stream;charset=utf-8' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.true
+    })
+
+    it('matches the content-type header name and value case-insensitively', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: [{ name: 'Content-Type', value: 'Text/Event-Stream' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.true
+    })
+
+    it('skips multipart/x-mixed-replace', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: [{ name: 'content-type', value: 'multipart/x-mixed-replace' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.true
+    })
+
+    it('does not skip text/html', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Document',
+        responseHeaders: [{ name: 'content-type', value: 'text/html' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.false
+    })
+
+    // deliberately NOT skipped — documented residual gap. ndjson responses can
+    // also never finish, but they carry no reliable, provable content-type or
+    // resourceType signal the way SSE and multipart streams do.
+    it('does not skip application/x-ndjson', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: [{ name: 'content-type', value: 'application/x-ndjson' }],
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.false
+    })
+
+    it('does not skip when the content-type is missing and resourceType is not EventSource', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.false
+    })
+
+    it('does not skip when responseHeaders is absent entirely', () => {
+      expect(shouldSkipResponseBody({
+        resourceType: 'Fetch',
+        responseHeaders: undefined,
+      } as Protocol.Fetch.RequestPausedEvent)).to.be.false
+    })
+  })
+
   describe('createCdpFetchCodec', () => {
     it('decodes CDP request pauses to the neutral request shape', () => {
       const codec = createCdpFetchCodec()
@@ -231,6 +299,96 @@ describe('CdpFetchTransport', () => {
       })
 
       expect(encoded.url).to.equal('https://example.test/response')
+    })
+
+    it('copies bodySkipped from the transport response onto the neutral response', () => {
+      const codec = createCdpFetchCodec()
+
+      codec.decodeRequest({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      const response = codec.decodeResponse({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+        requestId: 'fetch-request',
+        responseCode: 200,
+        responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
+        bodySkipped: true,
+      })
+
+      expect(response.bodySkipped).to.be.true
+    })
+
+    // SSE relies on this: an unchanged empty body must digest-match the empty
+    // origin body a skipped fetch produced, or every stream response would be
+    // (wrongly) fulfilled instead of released to the browser untouched.
+    it('continues (does not fulfill) a skipped response whose body was left untouched', () => {
+      const codec = createCdpFetchCodec()
+
+      codec.decodeRequest({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      const response = codec.decodeResponse({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+        requestId: 'fetch-request',
+        responseCode: 200,
+        responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
+        bodySkipped: true,
+        originalBodyDigest: digestBody(Buffer.alloc(0)),
+      })
+
+      const encoded = codec.encodeResponse(response)
+
+      expect(encoded.fulfilled).to.be.false
+      expect(encoded.body).to.be.undefined
+      // Unchanged headers are omitted so CDP keeps the browser's original set
+      // rather than a reconstruction of it (same rule continueRequestHeaders
+      // applies at the request stage).
+      expect(encoded.responseHeaders).to.be.undefined
+    })
+
+    it('fulfills a skipped response when middleware sets a body', () => {
+      const codec = createCdpFetchCodec()
+
+      codec.decodeRequest({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      const response = codec.decodeResponse({
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+        requestId: 'fetch-request',
+        responseCode: 200,
+        responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
+        bodySkipped: true,
+        originalBodyDigest: digestBody(Buffer.alloc(0)),
+      })
+
+      const encoded = codec.encodeResponse({
+        ...response,
+        body: 'stubbed',
+      })
+
+      expect(encoded.fulfilled).to.be.true
+      expect(encoded.body).to.equal(Buffer.from('stubbed').toString('base64'))
     })
 
     // A body we cannot prove came from the origin has to be fulfilled, or a
@@ -1766,6 +1924,59 @@ describe('CdpFetchTransport', () => {
 
       expect(client.send).to.have.been.calledWith('Fetch.getResponseBody', {
         requestId: 'fetch-request',
+      })
+    })
+
+    // Fetch.getResponseBody never resolves for a never-ending body (SSE), so
+    // a deny-listed response pause must skip the eager fetch entirely instead
+    // of wedging the pause (#34470).
+    it('skips the eager body fetch and continues untouched for a deny-listed (SSE) response pause', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const middlewareSawResponse = sinon.stub()
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      httpIntercept.use(async (req, next) => {
+        const response = await next(req)
+
+        middlewareSawResponse({
+          body: await readStream(response.bodyStream!),
+          bodySkipped: response.bodySkipped,
+        })
+
+        return response
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      const response = createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        responseStatusCode: 200,
+      })
+
+      response.responseHeaders = [{ name: 'content-type', value: 'text/event-stream' }]
+
+      await onRequestPaused(response)
+
+      await handled
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.getResponseBody')
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
+        requestId: 'fetch-request',
+        responseCode: 200,
+      })
+
+      expect(middlewareSawResponse).to.have.been.calledWith({
+        body: '',
+        bodySkipped: true,
       })
     })
 

--- a/system-tests/__snapshots__/server_sent_events_spec.js
+++ b/system-tests/__snapshots__/server_sent_events_spec.js
@@ -19,17 +19,18 @@ exports['e2e server sent events / passes'] = `
 
   server sent events
     ✓ does not crash
+    ✓ reads SSE framing from a fetch ReadableStream before cancelling
     ✓ aborts proxied connections to prevent client connection buildup
 
 
-  2 passing
+  3 passing
 
 
   (Results)
 
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ Tests:        2                                                                                │
-  │ Passing:      2                                                                                │
+  │ Tests:        3                                                                                │
+  │ Passing:      3                                                                                │
   │ Failing:      0                                                                                │
   │ Pending:      0                                                                                │
   │ Skipped:      0                                                                                │
@@ -47,9 +48,9 @@ exports['e2e server sent events / passes'] = `
 
        Spec                                              Tests  Passing  Failing  Pending  Skipped  
   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
-  │ ✔  server_sent_events.cy.js                 XX:XX        2        2        -        -        - │
+  │ ✔  server_sent_events.cy.js                 XX:XX        3        3        -        -        - │
   └────────────────────────────────────────────────────────────────────────────────────────────────┘
-    ✔  All specs passed!                        XX:XX        2        2        -        -        -  
+    ✔  All specs passed!                        XX:XX        3        3        -        -        -  
 
 
 `

--- a/system-tests/projects/e2e/cypress/e2e/server_sent_events.cy.js
+++ b/system-tests/projects/e2e/cypress/e2e/server_sent_events.cy.js
@@ -51,6 +51,36 @@ describe('server sent events', () => {
     }).should('deep.eq', ['1', '2', '3', '4', '5'])
   })
 
+  it('reads SSE framing from a fetch ReadableStream before cancelling', () => {
+    cy.window().then((win) => {
+      // the proxy only exempts a response from gzip compression when the
+      // request's accept header is exactly 'text/event-stream' - otherwise
+      // gzip buffers these tiny 100ms chunks indefinitely and the reader
+      // never sees a byte
+      return win.fetch('http://127.0.0.1:3039/sse', { headers: { accept: 'text/event-stream' } })
+      .then((response) => {
+        const reader = response.body.getReader()
+        const decoder = new win.TextDecoder()
+
+        // the server writes a leading `:ok` comment before the first `data:`
+        // frame, so keep reading chunks until an actual event arrives
+        const readUntilData = (received) => {
+          return reader.read().then(({ value, done }) => {
+            if (done) return received
+
+            const next = received + decoder.decode(value, { stream: true })
+
+            if (next.includes('data:')) return next
+
+            return readUntilData(next)
+          })
+        }
+
+        return readUntilData('').finally(() => reader.cancel())
+      })
+    }).should('include', 'data:')
+  })
+
   it('aborts proxied connections to prevent client connection buildup', () => {
     // there shouldn't be any leftover connections either
     cy.request('http://localhost:3038/clients')


### PR DESCRIPTION
- Closes #34470

### Additional details

On the proxy-disabled CDP Fetch path, `resolveResponse` eagerly called `Fetch.getResponseBody` for every response pause. That CDP command only resolves once the body completes, so a never-ending body (SSE, MJPEG) wedged the pause — and the run — indefinitely.

**What this does:**
- Adds a deny-list predicate (`should-skip-response-body.ts`) for provably stream-shaped responses: resourceType `EventSource` (read raw off the pause event — `normalizeResourceType` folds it to `other`), or response content-type `text/event-stream` / `multipart/x-mixed-replace`. Deny-listed pauses skip the eager body fetch and are resolved with an empty body; the existing body-digest logic then releases the origin stream untouched via `Fetch.continueResponse`. A body set by intercept middleware still diffs against the empty digest and fulfills, so stubbing a stream with a static body keeps working.
- Threads an internal `bodySkipped` marker (transport → codec → middleware ctx) so `notifyResponseStreamReceived` doesn't record a skipped body as a captured *empty* body in Test Replay. The MITM codec never sets the marker; the default path is unchanged.
- Adds a `fetch()`+ReadableStream test to the SSE fixture (exercises the content-type arm; requires `Accept: text/event-stream` since the MITM proxy only exempts such requests from gzip, which otherwise buffers the stream) and adds `server_sent_events_spec.js` to the `system-tests-chrome-cdp-remediated` job.

**Why not stream the body instead:** `Network.streamResourceContent` capture was evaluated and rejected — the experimental-fetch PoC (engineering-documentation, http2 tech brief supporting documents) measured ~98% render-critical body loss for stream-first capture under realistic load vs 0% for materialization. Materialization stays the capture mode; this PR only carves out bodies that provably never end.

**Accepted residual gap (follow-up issues to be filed):** endless bodies with unlisted content-types (ndjson, grpc-web, long-poll) still wedge the pause. Also follow-ups for a large-body materialization ceiling + `Network.loadNetworkResource` re-fetch, and for public intercept semantics of skipped bodies.

### Steps to test

```
# proxy-disabled (previously hung, now passes):
cd system-tests && CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn test test/server_sent_events_spec.js --browser chrome

# default MITM path (unchanged, still passes):
cd system-tests && yarn test test/server_sent_events_spec.js --browser chrome
```

Both verified locally on electron/chrome/firefox (plus 84 unit tests in `cdp-fetch-transport_spec.ts` and the `@packages/proxy` vitest suite).

### How has the user experience changed?

No change on the default proxy path. On the internal, unreleased proxy-disabled path: pages holding SSE/streaming connections no longer hang the run.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? — #34470
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — no released user-facing change (internal experimental path). A separate docs PR documenting the long-standing MITM streaming-intercept limitation is drafted and will be linked when opened.
- [na] Have API changes been updated in the type definitions?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CDP Fetch response handling and network capture on the experimental proxy-disabled path; default MITM behavior is unchanged but stream classification mistakes could affect continue vs fulfill behavior.
> 
> **Overview**
> Fixes **#34470**: on the internal proxy-disabled CDP Fetch path, **`resolveResponse` no longer always calls `Fetch.getResponseBody`**, which never completes for endless bodies (SSE, MJPEG) and previously wedged the run.
> 
> **Stream detection** (`should-skip-response-body.ts`) deny-lists `EventSource` resource type and `text/event-stream` / `multipart/x-mixed-replace` content-types. Those pauses use an empty stand-in body so existing digest logic **`continueResponse`s** untouched streams to the browser; intercept middleware that sets a body still **fulfills** as before.
> 
> A **`bodySkipped` → `resBodySkipped`** marker is threaded through the codec and proxy so **Test Replay capture** does not treat a deliberately unread body as a zero-length response.
> 
> CI adds **`server_sent_events_spec.js`** to the CDP-remediated Chrome job and a new e2e case that reads SSE framing via **`fetch()` + `ReadableStream`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab82243cc50354963cb3b0ed3e2623e4f0eb0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->