### PR TITLE
chore: remove the electron CI jobs for the browser-side network path

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2118,17 +2118,11 @@ jobs:
       resource_class:
         type: string
         default: medium.gen2
-      disable-proxy:
-        description: run with the MITM proxy disabled (CDP Fetch network interception path)
-        type: boolean
-        default: false
     resource_class: << parameters.resource_class >>
     parallelism: 1
     steps:
       - halt-if-skipped:
           guard: << pipeline.parameters.run-driver-tests >>
-      - halt-unless-proxy-disabled-enabled:
-          disable-proxy: << parameters.disable-proxy >>
       - restore_cached_workspace
       # this is a temporary work around while we wait for circle to resolve issues with packages
       # with an @ character in windows during save_cache.
@@ -2149,10 +2143,6 @@ jobs:
               # these are missing on Circle and there is no way to pre-install them on Arm
               sudo apt-get update
               sudo apt-get install -y libgbm-dev
-            fi
-
-            if << parameters.disable-proxy >> ; then
-              export CYPRESS_INTERNAL_DISABLE_PROXY=1
             fi
 
             CYPRESS_INTERNAL_MEMORY_SAVE_STATS=true \
@@ -2548,33 +2538,15 @@ jobs:
           spec: << parameters.spec >>
           guard: << pipeline.parameters.run-system-tests >>
 
+  # electron is deprecated as a test browser, so it only runs on the HTTP/1 proxy
+  # path (no disable-proxy parameter)
   system-tests-electron:
     <<: *defaults
-    parameters:
-      <<: *defaultsParameters
-      disable-proxy:
-        description: run with the MITM proxy disabled (CDP Fetch network interception path)
-        type: boolean
-        default: false
-      require-opt-in:
-        description: when disable-proxy is true, halt unless run-proxy-disabled-tests=true
-        type: boolean
-        default: true
-      spec:
-        description: optional space-separated system-test paths; empty runs the full suite
-        type: string
-        default: ''
-      parallelism:
-        type: integer
-        default: 8
     resource_class: medium+.gen2
-    parallelism: << parameters.parallelism >>
+    parallelism: 8
     steps:
       - run-system-tests:
           browser: electron
-          disable-proxy: << parameters.disable-proxy >>
-          require-opt-in: << parameters.require-opt-in >>
-          spec: << parameters.spec >>
           guard: << pipeline.parameters.run-system-tests >>
 
   system-tests-firefox:
@@ -2837,38 +2809,15 @@ jobs:
           browser: firefox
           guard: << pipeline.parameters.run-driver-tests >>
 
+  # electron is deprecated as a test browser, so it only runs on the HTTP/1 proxy
+  # path (no disable-proxy parameter)
   driver-integration-tests-electron:
     <<: *defaults
-    parameters:
-      <<: *defaultsParameters
-      disable-proxy:
-        description: run with the MITM proxy disabled (CDP Fetch network interception path)
-        type: boolean
-        default: false
-      require-opt-in:
-        description: when disable-proxy is true, halt unless run-proxy-disabled-tests=true
-        type: boolean
-        default: true
-      spec:
-        description: optional Cypress --spec glob(s); empty runs the full driver suite
-        type: string
-        default: ''
-      record-group-suffix:
-        description: optional Cypress Cloud group name suffix
-        type: string
-        default: ''
-      parallelism:
-        type: integer
-        default: 5
     resource_class: medium+.gen2
-    parallelism: << parameters.parallelism >>
+    parallelism: 5
     steps:
       - run-driver-integration-tests:
           browser: electron
-          disable-proxy: << parameters.disable-proxy >>
-          require-opt-in: << parameters.require-opt-in >>
-          spec: << parameters.spec >>
-          record-group-suffix: << parameters.record-group-suffix >>
           guard: << pipeline.parameters.run-driver-tests >>
 
   driver-integration-tests-webkit:

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -280,6 +280,8 @@ jobs:
   # always run when their path filters match (require-opt-in: false). Append
   # specs here as fixes land. When a remediations list covers the full suite,
   # flip the matching *-cdp job to always-on and delete *-cdp-remediated.
+  # Electron has no *-cdp job: it is deprecated as a test browser and stays on
+  # the HTTP/1 proxy.
   # #34464 cookie coverage that stays green under DISABLE_PROXY is jar sync +
   # OAuth only (system-tests-cookies-cdp). The full e2e cookies 80/443 matrix
   # is deferred to #34508 (under #34353).
@@ -294,24 +296,12 @@ jobs:
       # #34563 graphql-ws upgrades target the Cypress server origin (request_spec); non_proxied_spec asserts proxy
       # semantics that do not exist here and skips itself.
       # proxy_correlation_spec omitted: Chrome CI flakes on CorrelateBrowserPreRequest timeouts under
-      # concurrent large-body CDP Fetch (47 unmatched localhost requests); Electron was green.
+      # concurrent large-body CDP Fetch (47 unmatched localhost requests).
       spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/base_url_spec.js test/visit_spec.js test/web_security_spec.js test/service_worker_spec.js test/service_worker_protocol_spec.js test/request_spec.ts test/non_proxied_spec.ts
       requires:
         - system-tests-node-modules-install
   - system-tests-cookies-cdp:
       context: test-runner:performance-tracking
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-electron:
-      name: system-tests-electron-cdp-remediated
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      # #34351 upstream HTTP_PROXY/NO_PROXY; #34271 strategy:file downloads; #34467 continue unmodified CDP Fetch responses;
-      # #34563 graphql-ws upgrades target the Cypress server origin.
-      # proxy_correlation_spec omitted — see chrome-cdp-remediated note above.
-      spec: test/network_error_handling_spec.js test/downloads_spec.ts test/proxying_spec.ts test/images_spec.js test/form_submissions_spec.js test/page_loading_spec.js test/interception_spec.js test/cache_spec.js test/request_spec.ts
       requires:
         - system-tests-node-modules-install
   - run-launchpad-integration-tests-chrome:
@@ -363,18 +353,6 @@ jobs:
       spec: cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/issues/3890.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/cypress/downloads_basic_auth.cy.ts,cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/service-worker.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/commands/prompt/prompt.cy.ts
       requires:
         - ready-to-test
-  - driver-integration-tests-electron:
-      name: driver-integration-tests-electron-cdp-remediated
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      require-opt-in: false
-      parallelism: 1
-      record-group-suffix: '-remediated'
-      # #34465 extra-target shared middleware; #34512 extra-target Network.enable
-      # hang (downloads_basic_auth); #34555 service worker session interception.
-      spec: cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/cypress/downloads_basic_auth.cy.ts,cypress/e2e/e2e/service-worker.cy.js
-      requires:
-        - ready-to-test
   - unit-tests-proxy-disabled:
       requires:
         - ready-to-test
@@ -396,25 +374,8 @@ jobs:
       disable-proxy: true
       requires:
         - ready-to-test
-  - driver-integration-tests-electron:
-      name: driver-integration-tests-electron-cdp
-      context: test-runner:cypress-record-key
-      disable-proxy: true
-      requires:
-        - ready-to-test
-  - driver-integration-memory-tests:
-      name: driver-integration-memory-tests-cdp
-      disable-proxy: true
-      requires:
-        - ready-to-test
   - system-tests-chrome:
       name: system-tests-chrome-cdp
-      context: test-runner:performance-tracking
-      disable-proxy: true
-      requires:
-        - system-tests-node-modules-install
-  - system-tests-electron:
-      name: system-tests-electron-cdp
       context: test-runner:performance-tracking
       disable-proxy: true
       requires:
@@ -573,12 +534,10 @@ jobs:
         - h2-dual-stack-tests
         - system-tests-chrome-cdp-remediated
         - system-tests-cookies-cdp
-        - system-tests-electron-cdp-remediated
         - unit-tests-proxy-disabled
         - run-launchpad-integration-tests-chrome-cdp-remediated
         - run-app-integration-tests-chrome-cdp-remediated
         - driver-integration-tests-chrome-cdp-remediated
-        - driver-integration-tests-electron-cdp-remediated
         - driver-integration-tests-chrome
         - driver-integration-tests-chrome-inject-document-domain
         - driver-integration-tests-chrome-beta


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34590

### Additional details

Electron is [deprecated as a test browser in Cypress 16](https://github.com/cypress-io/cypress/issues/33560), so it is out of scope for the HTTP/2 work and no longer needs CI jobs exercising it on the browser-side (CDP Fetch) network interception path.

**CI-only.** Removes `system-tests-electron-cdp-remediated`, `driver-integration-tests-electron-cdp-remediated`, `driver-integration-tests-electron-cdp`, `system-tests-electron-cdp`, and `driver-integration-memory-tests-cdp` (whose underlying job hardcodes `--browser electron`), their `all-jobs-passed` entries, and the job parameters that existed only to serve them. Chrome's equivalents and the shared command parameters are untouched.

**Why no runtime change.** Deleting Electron's browser-side wiring now would leave it on *neither* path — it would stop handing interception to the browser-side runtime, and there is no proxy to point at, since the proxy is not started when that path is selected. The wiring only becomes dead once the path is resolved per browser, so it is removed with the `forceHttp1` feature in Cypress 16.

### Steps to test

CI is the verification — the removed jobs are the change. Electron should behave exactly as before:

```
yarn workspace @packages/driver cypress:run -- --browser electron
yarn workspace @tooling/system-tests test:ci --browser electron
```

### How has the user experience changed?

No change. CI jobs only; no runtime code touched.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated? — CI-only change.
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CircleCI workflow and job definition changes only; no application runtime or test runner code is modified.
> 
> **Overview**
> **CI-only:** Drops Electron from the proxy-disabled (CDP Fetch) network path in CircleCI, since Electron is deprecated as a test browser and is out of scope for HTTP/2 / browser-side interception work.
> 
> Removes workflow jobs `system-tests-electron-cdp-remediated`, `system-tests-electron-cdp`, `driver-integration-tests-electron-cdp-remediated`, `driver-integration-tests-electron-cdp`, and `driver-integration-memory-tests-cdp`, plus their `all-jobs-passed` dependencies. Standard Electron jobs (`system-tests-electron`, `driver-integration-tests-electron`, `driver-integration-memory-tests`) stay on the HTTP/1 proxy path only.
> 
> Simplifies `@pipeline.yml` by stripping `disable-proxy` / opt-in / spec parameters from `system-tests-electron`, `driver-integration-tests-electron`, and `driver-integration-memory-tests`, and documents that Electron no longer has `*-cdp` variants. Chrome CDP remediated/full jobs and shared command parameters are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189daf32aac4a5849135b83fcce70dcf9a3eaab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->