### PR TITLE
Default to body in dom and aria

### DIFF
--- a/cli/lib/tap/build-program.ts
+++ b/cli/lib/tap/build-program.ts
@@ -1,6 +1,7 @@
 import commander from 'commander'
 
 import { tapCliCommands } from './commands'
+import { DEFAULT_CDP_TIMEOUT_MS } from './cdp-timeout'
 import type { TapCliCommand } from './types'
 import type { TapCommandOptionSchema, TapCommandParamSchema, TapSchema } from '@packages/cypress-instances'
 
@@ -26,6 +27,14 @@ const argumentDescriptions = (params: readonly TapCommandParamSchema[]): Record<
 
 const JSON_DESCRIPTION = 'print the raw JSON result instead of the human-readable rendering'
 
+// commander both applies a declared default and appends `(default: …)` to the
+// help it generates, which is the whole reason a schema carries one. Its types
+// cap the value at a string, but it stores and renders whatever it is handed,
+// and a number has to arrive as one to render as 30000 rather than "30000".
+const declareOption = (command: commander.Command, flags: string, description: string, defaultValue?: string | number): void => {
+  command.option(flags, description, defaultValue as string | undefined)
+}
+
 // Every tap command accepts `--instance`, `--json` and `--timeout`; all are
 // consumed by the top-level `cypress tap` command before a subprogram parses, so
 // declaring them on a command is purely so they render in its generated help.
@@ -34,7 +43,7 @@ const JSON_DESCRIPTION = 'print the raw JSON result instead of the human-readabl
 const declareSharedOptions = (command: commander.Command, jsonDescription: string): void => {
   command.option('-i, --instance <pid>', 'target a specific running Cypress instance by its server process id (pid)')
   command.option('--json', jsonDescription)
-  command.option('--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds (default 30000)')
+  declareOption(command, '--timeout <ms>', 'how long to wait on any single call into the running Cypress, in milliseconds', DEFAULT_CDP_TIMEOUT_MS)
 }
 
 const declareOptions = (command: commander.Command, options: readonly TapCommandOptionSchema[]): void => {
@@ -43,14 +52,15 @@ const declareOptions = (command: commander.Command, options: readonly TapCommand
   // so the schema contributes only its description.
   const json = options.find(({ name }) => name === 'json')
 
-  for (const { name, alias, type, required, description } of options.filter((option) => option !== json)) {
+  for (const option of options.filter((candidate) => candidate !== json)) {
+    const { name, alias, type, required, description } = option
     const lead = alias ? `-${alias}, ` : ''
     const flags = type === 'boolean' ? `${lead}--${name}` : `${lead}--${name} <${name}>`
 
     if (required && type !== 'boolean') {
       command.requiredOption(flags, description)
     } else {
-      command.option(flags, description)
+      declareOption(command, flags, description, option.defaultValue)
     }
   }
 

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -1,5 +1,3 @@
-import { TAP_DEFAULT_SELECTOR } from '@packages/cypress-instances'
-
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
 import { withResolvedAutFrame } from '../aut/frame'
@@ -9,10 +7,6 @@ import type { AXProperty, AXValue } from '../aut/cdp'
 import { withAmbiguous } from '../aut/single-match'
 import type { FrameAmbiguousResult } from '../aut/single-match'
 import { defineNativeCommand } from './definition'
-
-// The accessibility tree of a real app is deep; cap the projection so it stays
-// affordable for an LLM. A selector roots it at a subtree for finer reads.
-const DEFAULT_MAX_NODES = 200
 
 // Structural/text roles carry no semantic signal on their own — dropping them
 // yields the compact role/name tree DevTools shows, not the raw render tree.
@@ -204,5 +198,5 @@ export const extractAria = (
 }
 
 export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractAria(session, frame, commandOptions.selector ?? TAP_DEFAULT_SELECTOR, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'), parseIndex(commandOptions.at))
+  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], 'max-nodes'), parseIndex(commandOptions.at))
 }, 'aria'))

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -1,3 +1,5 @@
+import { TAP_DEFAULT_SELECTOR } from '@packages/cypress-instances'
+
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
 import { withResolvedAutFrame } from '../aut/frame'
@@ -202,5 +204,5 @@ export const extractAria = (
 }
 
 export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'), parseIndex(commandOptions.at))
+  return extractAria(session, frame, commandOptions.selector ?? TAP_DEFAULT_SELECTOR, parsePositiveInt(commandOptions['max-nodes'], DEFAULT_MAX_NODES, 'max-nodes'), parseIndex(commandOptions.at))
 }, 'aria'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -1,3 +1,5 @@
+import { TAP_DEFAULT_SELECTOR } from '@packages/cypress-instances'
+
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
@@ -11,11 +13,11 @@ import { defineNativeCommand } from './definition'
 
 const DEFAULT_MAX_CHARS = 30000
 
-/** What `cypress tap dom` returns: the whole document, or the matched element. */
+/** What `cypress tap dom` returns: the matched element, or the whole document. */
 export interface FrameDomResult {
   /** Whether the selector matched — present only in selector mode. */
   found?: boolean
-  /** The matched element's outerHTML, or the whole document in whole-page mode. */
+  /** The matched element's outerHTML, or the whole document when no selector was given. */
   html?: string
   /** Present (always `true`) when the browser-side cap clipped the output. */
   truncated?: true
@@ -56,5 +58,5 @@ export const extractDom = (
 })
 
 export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'), parseIndex(commandOptions.at))
+  return extractDom(session, frame, commandOptions.selector ?? TAP_DEFAULT_SELECTOR, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'), parseIndex(commandOptions.at))
 }, 'dom'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -1,5 +1,3 @@
-import { TAP_DEFAULT_SELECTOR } from '@packages/cypress-instances'
-
 import type { TapSession } from '../tap-session'
 import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
@@ -11,13 +9,11 @@ import { readDom } from '../aut/scripts'
 import type { DomReadResult } from '../aut/scripts'
 import { defineNativeCommand } from './definition'
 
-const DEFAULT_MAX_CHARS = 30000
-
-/** What `cypress tap dom` returns: the matched element, or the whole document. */
+/** What `cypress tap dom` returns: the element the selector matched. */
 export interface FrameDomResult {
   /** Whether the selector matched — present only in selector mode. */
   found?: boolean
-  /** The matched element's outerHTML, or the whole document when no selector was given. */
+  /** The matched element's outerHTML. */
   html?: string
   /** Present (always `true`) when the browser-side cap clipped the output. */
   truncated?: true
@@ -58,5 +54,5 @@ export const extractDom = (
 })
 
 export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractDom(session, frame, commandOptions.selector ?? TAP_DEFAULT_SELECTOR, parsePositiveInt(commandOptions['max-chars'], DEFAULT_MAX_CHARS, 'max-chars'), parseIndex(commandOptions.at))
+  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], 'max-chars'), parseIndex(commandOptions.at))
 }, 'dom'))

--- a/cli/lib/tap/utils.ts
+++ b/cli/lib/tap/utils.ts
@@ -26,11 +26,7 @@ export const parseIndex = (raw: string | undefined): number | undefined => {
   return value
 }
 
-export const parsePositiveInt = (raw: string | undefined, fallback: number, label: string): number => {
-  if (raw === undefined) {
-    return fallback
-  }
-
+export const parsePositiveInt = (raw: string, label: string): number => {
   const value = parseWholeNumber(raw)
 
   if (value === undefined || value <= 0) {

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1207,7 +1207,7 @@ describe('lib/exec/tap', () => {
           --json                print the raw JSON result instead of the human-readable
                                 rendering
           --timeout <ms>        how long to wait on any single call into the running
-                                Cypress, in milliseconds (default 30000)
+                                Cypress, in milliseconds (default: 30000)
           -h, --help            display help for command
 
         Commands:
@@ -1280,7 +1280,7 @@ describe('lib/exec/tap', () => {
                                          property in full, however long, rather than
                                          the long ones named by their length
           --timeout <ms>                 how long to wait on any single call into the
-                                         running Cypress, in milliseconds (default
+                                         running Cypress, in milliseconds (default:
                                          30000)
           -h, --help                     display help for command
         "

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1057,11 +1057,13 @@ describe('lib/exec/tap', () => {
       expect(resolveInstance).not.toHaveBeenCalled()
     })
 
-    it('forwards the parsed selector and --max-chars to the DOM reader', async () => {
-      let forwarded: unknown
+    // Runs a native frame command against a stubbed browser, returning the
+    // arguments of every in-page call it made: the single-element guard counts
+    // matches first, then the read itself follows.
+    const frameCallArguments = async (argv: string[]): Promise<unknown[]> => {
+      let forwarded: unknown[] = []
 
       vi.mocked(withResolvedAutFrame).mockImplementation(async (_options, read) => {
-        // The single-element guard counts matches first; the read follows.
         const callFunctionOn = vi.fn()
         .mockResolvedValueOnce({ result: { value: { count: 1 } } })
         .mockResolvedValue({ result: { value: { html: '<html/>' } } })
@@ -1071,19 +1073,42 @@ describe('lib/exec/tap', () => {
           client: {
             Page: { createIsolatedWorld: vi.fn().mockResolvedValue({ executionContextId: 1 }) },
             Runtime: { callFunctionOn },
+            DOM: { enable: vi.fn() },
+            Accessibility: { enable: vi.fn(), getFullAXTree: vi.fn().mockResolvedValue({ nodes: [] }) },
           },
         } as unknown as TapSession
 
         await read(session, { frameId: 'f' } as AutFrame)
-        forwarded = callFunctionOn.mock.calls[1][0].arguments
+        forwarded = callFunctionOn.mock.calls.map(([params]) => params.arguments)
 
         return 0
       })
 
-      await tap.start(['dom', '--selector', '.btn', '--max-chars', '50'], {})
+      await tap.start(argv, {})
+
+      return forwarded
+    }
+
+    it('forwards the parsed selector and --max-chars to the DOM reader', async () => {
+      const [, read] = await frameCallArguments(['dom', '--selector', '.btn', '--max-chars', '50'])
 
       // selector and the coerced --max-chars reach the extractor as call arguments.
-      expect(forwarded).toEqual([{ value: '.btn' }, { value: 50 }, { value: 0 }])
+      expect(read).toEqual([{ value: '.btn' }, { value: 50 }, { value: 0 }])
+    })
+
+    it('reads the body when dom is given no selector', async () => {
+      const [guard, read] = await frameCallArguments(['dom'])
+
+      expect(guard).toEqual([{ value: 'body' }])
+      expect(read).toEqual([{ value: 'body' }, { value: 30000 }, { value: 0 }])
+    })
+
+    it('roots the tree at the body when aria is given no selector', async () => {
+      const [guard, read] = await frameCallArguments(['aria'])
+
+      expect(guard).toEqual([{ value: 'body' }])
+      // The body is then resolved as the element the projected tree is rooted at.
+      expect(read).toEqual([{ value: 'body' }, { value: 0 }])
     })
 
     it('rejects `inspect` with no selector, without reading the frame', async () => {
@@ -1192,11 +1217,11 @@ describe('lib/exec/tap', () => {
           specs [options]       list the specs the running Cypress instance can run,
                                 most recently modified first
           run [options] <spec>  run (or rerun) a spec by its project-relative path
-          dom [options]         read the app-under-test DOM as HTML: the whole page,
+          dom [options]         read the app-under-test DOM as HTML: the page body,
                                 or the one element a selector matches (with its
                                 subtree)
           aria [options]        read the accessibility (ARIA) tree of the
-                                app-under-test frame, or the subtree at a selector
+                                app-under-test page body, or the subtree at a selector
           inspect [options]     inspect the element a selector matches: its tag,
                                 attributes, computed styles, box model, and
                                 accessibility node

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -45,6 +45,24 @@ const schema: TapSchema = {
   ],
 }
 
+// A command whose options carry defaults, kept apart from `schema` so the tests
+// asserting that an unsupplied option is simply absent keep meaning something.
+const defaulting: TapSchema = {
+  schemaVersion: 1,
+  cypressVersion: '15.0.0',
+  commands: [
+    {
+      name: 'probe',
+      description: 'read something out of a running Cypress instance',
+      params: [],
+      options: [
+        { name: 'selector', alias: 's', type: 'string', required: false, defaultValue: 'body', description: 'a CSS selector' },
+        { name: 'max-chars', alias: 'm', type: 'number', required: false, defaultValue: 30_000, description: 'cap on returned characters' },
+      ],
+    },
+  ],
+}
+
 const subcommand = (program: commander.Command, name: string): commander.Command => {
   return program.commands.find((command) => command.name() === name)!
 }
@@ -295,6 +313,37 @@ describe('lib/tap/build-program', () => {
     program.parse(['launch', 'a.cy.js'], { from: 'user' })
 
     expect(dispatch).toHaveBeenCalledWith('launch', { spec: 'a.cy.js' }, {})
+  })
+
+  it('forwards a schema option’s default when the flag is absent, and the supplied value when it is not', () => {
+    const dispatch = vi.fn()
+    const program = buildTapProgram(defaulting, dispatch)
+
+    program.parse(['probe'], { from: 'user' })
+    program.parse(['probe', '--selector', '.btn', '--max-chars', '50'], { from: 'user' })
+
+    expect(dispatch).toHaveBeenNthCalledWith(1, 'probe', {}, { 'selector': 'body', 'max-chars': '30000' })
+    expect(dispatch).toHaveBeenNthCalledWith(2, 'probe', {}, { 'selector': '.btn', 'max-chars': '50' })
+  })
+
+  it('renders each declared default in the per-command help, quoting a string and not a number', () => {
+    const program = buildTapProgram(defaulting, vi.fn())
+    const help = subcommand(program, 'probe').helpInformation().replace(/\s+/g, ' ')
+
+    expect(help).toContain('-s, --selector <selector> a CSS selector (default: "body")')
+    expect(help).toContain('-m, --max-chars <max-chars> cap on returned characters (default: 30000)')
+  })
+
+  it('renders the dom and aria selector defaults from the shared contract, leaving inspect’s required selector without one', () => {
+    const program = buildTapProgram(buildTapSchema('15.0.0'), vi.fn())
+    const helpOf = (name: string): string => subcommand(program, name).helpInformation().replace(/\s+/g, ' ')
+
+    expect(helpOf('dom')).toContain('-s, --selector <selector> a CSS selector matching exactly one element (default: "body")')
+    expect(helpOf('aria')).toContain('-s, --selector <selector> a CSS selector matching exactly one element to root the tree at (default: "body")')
+
+    // inspect takes the same selector but requires it, so the only default it
+    // renders is the --timeout every command shares.
+    expect(helpOf('inspect').match(/\(default:/g)).toHaveLength(1)
   })
 
   it('throws a catchable unknownOption error for a flag not in the schema', () => {

--- a/cli/test/lib/tap/utils.spec.ts
+++ b/cli/test/lib/tap/utils.spec.ts
@@ -26,18 +26,17 @@ describe('lib/tap/utils parseIndex', () => {
 })
 
 describe('lib/tap/utils parsePositiveInt', () => {
-  it('falls back when the value is absent', () => {
-    expect(parsePositiveInt(undefined, 200, 'max-nodes')).to.eq(200)
-  })
-
   it('parses a positive integer, up to the largest one that survives the round trip', () => {
-    expect(parsePositiveInt('50', 200, 'max-nodes')).to.eq(50)
-    expect(parsePositiveInt('9007199254740991', 200, 'max-nodes')).to.eq(Number.MAX_SAFE_INTEGER)
+    expect(parsePositiveInt('50', 'max-nodes')).to.eq(50)
+    expect(parsePositiveInt('9007199254740991', 'max-nodes')).to.eq(Number.MAX_SAFE_INTEGER)
   })
 
-  it('rejects zero and every malformed value with INVALID_LIMIT', () => {
-    for (const bad of ['0', ...MALFORMED]) {
-      expect(() => parsePositiveInt(bad as any, 200, 'max-nodes'), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
+  // The caps these parse are declared with a default, so commander supplies one
+  // however the command was invoked — an absent value is malformed, not a cue to
+  // fall back to a second default the help never promised.
+  it('rejects zero, an absent value, and every malformed value with INVALID_LIMIT', () => {
+    for (const bad of ['0', undefined, ...MALFORMED]) {
+      expect(() => parsePositiveInt(bad as any, 'max-nodes'), JSON.stringify(bad)).to.throw(FrameCommandError).that.includes({ code: 'INVALID_LIMIT' })
     }
   })
 })

--- a/packages/app/src/tap/exec-args.cy.ts
+++ b/packages/app/src/tap/exec-args.cy.ts
@@ -84,6 +84,24 @@ describe('tap/exec-args', () => {
       })
     })
 
+    it('applies an absent option’s declared default, already the declared type', () => {
+      const withDefaults: TapCommandOptionSchema[] = [
+        ...OPTIONS,
+        { name: 'selector', type: 'string', required: false, defaultValue: 'body', description: 'a CSS selector' },
+        { name: 'max-chars', type: 'number', required: false, defaultValue: 30_000, description: 'a cap' },
+      ]
+
+      expect(coerceCommandOptions('run', PARAMS, withDefaults, { config: 'a.json' })).to.deep.eq({
+        ok: true,
+        options: { 'headed': false, 'config': 'a.json', 'selector': 'body', 'max-chars': 30_000 },
+      })
+
+      expect(coerceCommandOptions('run', PARAMS, withDefaults, { config: 'a.json', selector: '.btn', 'max-chars': '50' })).to.deep.eq({
+        ok: true,
+        options: { 'headed': false, 'config': 'a.json', 'selector': '.btn', 'max-chars': 50 },
+      })
+    })
+
     it('rejects a missing required option with a usage hint', () => {
       const outcome = coerceCommandOptions('run', PARAMS, OPTIONS, {})
 

--- a/packages/app/src/tap/exec-args.ts
+++ b/packages/app/src/tap/exec-args.ts
@@ -132,7 +132,9 @@ export const coerceCommandOptions = (name: string, params: readonly TapCommandPa
         return invalid(`"${name}" is missing the required --${option.name} option.`)
       }
 
-      if (option.type === 'boolean') {
+      if (option.defaultValue !== undefined) {
+        coerced[option.name] = option.defaultValue
+      } else if (option.type === 'boolean') {
         coerced[option.name] = false
       }
 

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -15,17 +15,29 @@ export interface TapCommandParamSchema {
   description: string
 }
 
-export interface TapCommandOptionSchema {
+interface TapCommandOptionBase {
   name: string
   // A single letter, rendered by the CLI as `-t, --test-id <test-id>`. Commander
   // accepts a letter claimed twice within one command and silently lets the last
   // declaration win, so an alias must be unique across the command's own options
   // and the `--instance` every command shares.
   alias?: string
-  type: 'string' | 'number' | 'boolean'
   required: boolean
   description: string
 }
+
+// `defaultValue` is the value a command sees when the flag is absent, so a
+// handler never restates a default its own help already promises. The CLI hands
+// it to commander, which both applies it and renders `(default: …)` — so a
+// description must not spell the default out a second time. Pairing it with
+// `type` keeps the two from disagreeing: a boolean flag is already
+// absent-means-false, so it takes none, and a required option can't need one.
+type TapCommandOptionDefault =
+  | { type: 'string', defaultValue?: string }
+  | { type: 'number', defaultValue?: number }
+  | { type: 'boolean', defaultValue?: never }
+
+export type TapCommandOptionSchema = TapCommandOptionBase & TapCommandOptionDefault
 
 export interface TapCommandSchema {
   name: string
@@ -62,6 +74,10 @@ type SchemaObject<
   { [E in Entry as E extends Present ? E['name'] : never]: Scalars[E['type']] } &
   { [E in Entry as E extends Present ? never : E['name']]?: Scalars[E['type']] }
 
+// An option carrying a default is present however it was invoked, so both sides
+// see it alongside the ones their caller is made to supply.
+type Defaulted = { defaultValue: string | number }
+
 // App-side handlers see coerced values (the binding's exec coerces each wire
 // string to its declared scalar before dispatch): required params are present,
 // and boolean options default to false when the flag is absent.
@@ -71,7 +87,7 @@ export type TapCoercedParams<P extends readonly TapCommandParamSchema[]> =
   SchemaObject<P[number], { required: true }, CoercedScalars>
 
 export type TapCoercedOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<O[number], { required: true } | { type: 'boolean' }, CoercedScalars>
+  SchemaObject<O[number], { required: true } | { type: 'boolean' } | Defaulted, CoercedScalars>
 
 // CLI-side handlers see commander's values forwarded as raw strings (a set
 // boolean flag arrives as the string 'true'). Only required value options are
@@ -82,7 +98,7 @@ export type TapRawParams<P extends readonly TapCommandParamSchema[]> =
   SchemaObject<P[number], { required: true }, RawScalars>
 
 export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
-  SchemaObject<O[number], { required: true, type: 'string' | 'number' }, RawScalars>
+  SchemaObject<O[number], { required: true, type: 'string' | 'number' } | Defaulted, RawScalars>
 
 // Options that recur across commands, defined once so their name, type, and help
 // text can't drift between the commands that expose them. `test-id` and
@@ -264,13 +280,13 @@ selector you meant.`
 
 // Where `dom` and `aria` read from with no selector: the document element only
 // adds a <head> of script and style text; `--selector html` still reads it.
-export const TAP_DEFAULT_SELECTOR = 'body'
+const TAP_DEFAULT_SELECTOR = 'body'
 
 // Shared by the three selector-taking reads, so the way you pick one match out
 // of several is identical across them.
 const atField = {
   name: 'at',
-  type: 'string',
+  type: 'number',
   required: false,
   description: '0-based index of the match to read, as listed by the index column when a selector matches several',
 } as const satisfies TapCommandOptionSchema
@@ -286,8 +302,8 @@ browser-side so a heavy page never ships megabytes at once.
 ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR}; defaults to ${TAP_DEFAULT_SELECTOR}` },
-    { name: 'max-chars', alias: 'm', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
+    { ...selectorField, defaultValue: TAP_DEFAULT_SELECTOR, description: SINGLE_ELEMENT_SELECTOR },
+    { name: 'max-chars', alias: 'm', type: 'number', required: false, defaultValue: 30_000, description: 'cap on returned HTML characters' },
     atField,
   ],
 } as const satisfies TapNativeCommandSchema
@@ -302,8 +318,10 @@ are dropped, leaving the compact role/name/state tree DevTools shows.
 ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at; defaults to ${TAP_DEFAULT_SELECTOR}` },
-    { name: 'max-nodes', alias: 'm', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
+    { ...selectorField, defaultValue: TAP_DEFAULT_SELECTOR, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at` },
+    // The accessibility tree of a real app is deep; the cap keeps the projection
+    // affordable for an LLM. A selector roots it at a subtree for finer reads.
+    { name: 'max-nodes', alias: 'm', type: 'number', required: false, defaultValue: 200, description: 'cap on the number of accessibility nodes returned' },
     atField,
   ],
 } as const satisfies TapNativeCommandSchema

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -92,7 +92,7 @@ export type TapRawOptions<O extends readonly TapCommandOptionSchema[]> =
 const testIdField = { name: 'test-id', alias: 't', type: 'string', description: 'test id, as listed by the reporter command' } as const
 const commandIdField = { name: 'command-id', alias: 'c', type: 'string', description: 'command id, as listed by the reporter command — a row number (test body first when duplicated), an e-prefixed event id, or hook-qualified like "h1:3"' } as const
 const attemptField = { name: 'attempt', alias: 'a', type: 'number', required: false, description: '1-based attempt (attempt 1 = first run); defaults to the latest' } as const
-const selectorField = { name: 'selector', alias: 's', type: 'string', required: false, description: 'a CSS selector; omit to read the whole document' } as const
+const selectorField = { name: 'selector', alias: 's', type: 'string', required: false, description: 'a CSS selector' } as const
 
 const commandMeta = {
   name: 'command',
@@ -262,6 +262,10 @@ read: the command answers with a numbered list of the matches, each with a
 unique selector. Re-run with --at <index> to read one of them, or with whichever
 selector you meant.`
 
+// Where `dom` and `aria` read from with no selector: the document element only
+// adds a <head> of script and style text; `--selector html` still reads it.
+export const TAP_DEFAULT_SELECTOR = 'body'
+
 // Shared by the three selector-taking reads, so the way you pick one match out
 // of several is identical across them.
 const atField = {
@@ -273,15 +277,16 @@ const atField = {
 
 const domMeta = {
   name: 'dom',
-  description: 'read the app-under-test DOM as HTML: the whole page, or the one element a selector matches (with its subtree)',
-  details: `Reads the app-under-test DOM as HTML: the whole page, or the outerHTML of the
-element a CSS selector matches (including its full subtree). Output is capped
+  description: 'read the app-under-test DOM as HTML: the page body, or the one element a selector matches (with its subtree)',
+  details: `Reads the app-under-test DOM as HTML: the outerHTML of the element a CSS
+selector matches, including its full subtree. Without --selector it reads the
+page body; pass --selector html for the whole document. Output is capped
 browser-side so a heavy page never ships megabytes at once.
 
 ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR}; omit to read the whole document` },
+    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR}; defaults to ${TAP_DEFAULT_SELECTOR}` },
     { name: 'max-chars', alias: 'm', type: 'string', required: false, description: 'cap on returned HTML characters (default 30000)' },
     atField,
   ],
@@ -289,15 +294,15 @@ ${AMBIGUOUS_SELECTOR_HELP}`,
 
 const ariaMeta = {
   name: 'aria',
-  description: 'read the accessibility (ARIA) tree of the app-under-test frame, or the subtree at a selector',
-  details: `Reads the accessibility (ARIA) tree of the app-under-test frame, or the
-subtree rooted at a CSS selector. Structural and text-only roles are dropped,
-leaving the compact role/name/state tree DevTools shows.
+  description: 'read the accessibility (ARIA) tree of the app-under-test page body, or the subtree at a selector',
+  details: `Reads the accessibility (ARIA) tree of the app under test, rooted at the page
+body or at the element a CSS selector matches. Structural and text-only roles
+are dropped, leaving the compact role/name/state tree DevTools shows.
 
 ${AMBIGUOUS_SELECTOR_HELP}`,
   params: [],
   options: [
-    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at; omit for the whole frame` },
+    { ...selectorField, description: `${SINGLE_ELEMENT_SELECTOR} to root the tree at; defaults to ${TAP_DEFAULT_SELECTOR}` },
     { name: 'max-nodes', alias: 'm', type: 'string', required: false, description: 'cap on the number of accessibility nodes returned (default 200)' },
     atField,
   ],

--- a/system-tests/test/tap_open_spec.ts
+++ b/system-tests/test/tap_open_spec.ts
@@ -166,13 +166,21 @@ describe('tap CLI against a settled run', function () {
     expect(result.json()).to.deep.include({ found: true, html: STATUS_DIV })
   })
 
-  it('reads the whole app-under-test DOM', async () => {
+  it('reads the app-under-test body when no selector is given', async () => {
     const result = await instance.tap(['--json', 'dom'])
 
     expect(result.exitCode).to.eq(0)
+    expect(result.json().found).to.eq(true)
     // `include`, not an equality: the proxy injects into the AUT document.
     expect(result.json().html).to.include('<h1>Tap fixture</h1>')
-    expect(result.json()).to.not.have.property('found')
+    expect(result.json().html, 'the default read is rooted at the body').to.match(/^<body[\s>]/)
+  })
+
+  it('reads the whole document with --selector html', async () => {
+    const result = await instance.tap(['--json', 'dom', '--selector', 'html'])
+
+    expect(result.exitCode).to.eq(0)
+    expect(result.json().html).to.include('<title>Tap AUT content</title>')
   })
 
   it('renders a DOM read for humans', async () => {
@@ -188,9 +196,9 @@ describe('tap CLI against a settled run', function () {
     const result = await instance.tap(['dom', '--max-chars', '120'])
 
     expect(result.exitCode).to.eq(0)
-    // Deliberately not snapshotted: at any cap the whole-page read starts with the
-    // proxy's injected script, so a snapshot would track that injection rather than
-    // this rendering. The truncation notice is the part worth asserting.
+    // Deliberately not snapshotted: a cap this low cuts the markup mid-tag, so a
+    // snapshot would pin whichever attribute the browser happened to serialize
+    // first. The truncation notice is the part worth asserting.
     expect(result.stdout).to.include('truncated')
   })
 
@@ -289,11 +297,12 @@ describe('tap CLI against a settled run', function () {
     expect(failureOutput(result)).to.include('pass --at 0-2')
   })
 
-  it('exits 1 when --at is given without a selector to index into', async () => {
+  it('exits 1 for an --at beyond the default selector’s single match', async () => {
     const result = await instance.tap(['dom', '--at', '1'])
 
     expect(result.exitCode).to.eq(1)
     expect(failureOutput(result)).to.include('INVALID_INDEX')
+    expect(failureOutput(result)).to.include('pass --at 0-0')
   })
 
   it('exits 1 for an invalid selector', async () => {
@@ -303,7 +312,7 @@ describe('tap CLI against a settled run', function () {
     expect(failureOutput(result)).to.include('is not a valid CSS selector')
   })
 
-  it('projects the accessibility tree', async () => {
+  it('projects the accessibility tree of the body', async () => {
     const result = await instance.tap(['--json', 'aria'])
 
     expect(result.exitCode).to.eq(0)
@@ -311,7 +320,10 @@ describe('tap CLI against a settled run', function () {
     const outcome = result.json()
     const roles = outcome.nodes.map((node: { role: string }) => node.role)
 
-    expect(outcome.nodes[0]).to.include({ depth: 0, role: 'RootWebArea' })
+    // The body itself projects to nothing — it is a structural role — so the
+    // fixture's own content sits at the top of the tree.
+    expect(outcome.nodes[0]).to.include({ depth: 0, role: 'heading', name: 'Tap fixture' })
+    expect(roles, 'the document root is above the body').to.not.include('RootWebArea')
     expect(outcome.nodeCount).to.eq(outcome.nodes.length)
     expect(roles).to.include.members(['heading', 'region', 'button', 'textbox', 'checkbox'])
 
@@ -500,7 +512,7 @@ describe('tap CLI against a Module-API-booted instance', function () {
     const result = await instance.tap(['--json', 'aria'])
 
     expect(result.exitCode).to.eq(0)
-    expect(result.json().nodes[0]).to.include({ depth: 0, role: 'RootWebArea' })
+    expect(result.json().nodes[0]).to.include({ depth: 0, role: 'heading', name: 'Tap fixture' })
   })
 
   it('still exits 1 for an ambiguous selector', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> [AW-104](https://cypress-io.atlassian.net/browse/AW-104)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default dom/aria scope for agents relying on whole-page reads, but behavior is explicit in help and covered by tests; schema default handling touches CLI parsing and in-app exec coercion.
> 
> **Overview**
> Adds **`defaultValue`** to the tap option schema so Commander and app-side **`coerceCommandOptions`** apply the same defaults and show them in help, removing duplicate fallbacks in command handlers.
> 
> **`cypress tap dom`** and **`aria`** without **`--selector`** now read the **page `body`** (not the full document/frame); use **`--selector html`** for the full document. **`--max-chars`** / **`--max-nodes`** defaults live in the contract (**30000** / **200**), and **`parsePositiveInt`** no longer treats a missing flag as a silent fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01ca8c364e408f1df087c6a92048d54e4df3613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-104]: https://cypress-io.atlassian.net/browse/AW-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ