### PR TITLE
chore: fulfill internal-route loopback responses as identity under CDP Fetch

### DIFF
--- a/packages/proxy/lib/adapters/index.ts
+++ b/packages/proxy/lib/adapters/index.ts
@@ -8,6 +8,6 @@ export { ProxyCookieStateAdapter } from './proxy-cookie-state'
 
 export { ProxyCommandLogAdapter } from './proxy-command-log'
 
-export { createSyntheticProxyCodec } from './synthetic-proxy-codec'
+export { createSyntheticProxyCodec, toIdentityResponse } from './synthetic-proxy-codec'
 
 export { createSyntheticExpressContext } from './synthetic-express-context'

--- a/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
@@ -55,7 +55,7 @@ const CONTENT_DECODERS: Record<string, (body: Buffer) => Buffer> = {
  * way, so we keep the response self-describing instead of stripping the header
  * and claiming plaintext bytes that are not.
  */
-function toIdentityResponse (response: HttpResponse): HttpResponse {
+export function toIdentityResponse (response: HttpResponse): HttpResponse {
   const headers = response.headers ?? {}
   const contentEncoding = Object.entries(headers).find(([name]) => name.toLowerCase() === 'content-encoding')?.[1]
   const encodings = String(contentEncoding ?? '')

--- a/packages/proxy/lib/index.ts
+++ b/packages/proxy/lib/index.ts
@@ -12,6 +12,7 @@ export {
   ProxyCommandLogAdapter,
   createSyntheticProxyCodec,
   createSyntheticExpressContext,
+  toIdentityResponse,
 } from './adapters'
 
 export { createProxyNetworkInterception } from './adapters/create-proxy-network-interception'

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -1,3 +1,4 @@
+import { toIdentityResponse } from '@packages/proxy'
 import type { HttpHeaders, HttpRequest, InterceptMiddleware } from '@packages/network-interception'
 import type { Request as ServerRequest } from '../request'
 import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, isCloudBundleRoute, isInternalCypressRoute, isTrustedInternalLoopback, resolveProxyUrlBase } from './internal-routes'
@@ -115,6 +116,33 @@ export function createServeInternalRoutesMiddleware ({
       method: request.method ?? 'GET',
       headers: {
         ...filterHeaders(request.headers),
+        // In Cypress-in-Cypress runs this loopback takes a second hop, and
+        // that hop gzips the response:
+        //
+        //   1. The child project's app (the AUT, http://localhost:4455) asks
+        //      for /__cypress-studio/app-studio.js on its own origin.
+        //   2. The parent Cypress's CDP interception pauses the request, and
+        //      this middleware (the parent's instance) loops it back to the
+        //      parent's own Express server.
+        //   3. The parent has no studio routes of its own — its cy-in-cy
+        //      passthrough (routes.ts) re-enters the proxy pipeline to
+        //      forward the request to the child at 4455, where the real
+        //      cloud-bundle routes live.
+        //   4. StripUnsupportedAcceptEncoding runs on that forwarding hop and
+        //      rewrites a MISSING accept-encoding (filterHeaders strips it
+        //      above) to 'gzip,identity', so the child's studio route
+        //      responds gzipped.
+        //
+        // Fetch.fulfillRequest bodies are identity-only — the browser runs no
+        // decoders on fulfilled responses — so a gzipped body reaches the
+        // page as unparseable bytes. An explicit 'identity' survives the
+        // rewrite (only br/gzip tokens are kept, with 'identity' as the
+        // fallback), so every hop in the chain serves an unencoded body.
+        // Single-hop loopbacks (real users) already serve identity for an
+        // absent header, so this is only needed where the second hop exists.
+        ...(process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE || process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
+          ? { 'accept-encoding': 'identity' }
+          : {}),
         [CYPRESS_INTERNAL_LOOPBACK_HEADER]: url.href,
         [CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]: cypressInternalLoopbackToken,
       },
@@ -126,12 +154,16 @@ export function createServeInternalRoutesMiddleware ({
       simple: false,
     }, true)
 
-    return {
+    // Fetch.fulfillRequest bodies are identity-only — the browser runs no
+    // content-encoding decoders on fulfilled responses. A hop past the loopback
+    // can still compress (the cy-in-cy parent's proxy re-adds accept-encoding),
+    // so normalize the same way the synthetic codec does before fulfilling.
+    return toIdentityResponse({
       id: request.id,
       url: request.url,
       statusCode: response.statusCode,
       headers: filterHeaders(response.headers),
       body: response.body,
-    }
+    })
   }
 }

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -66,6 +66,8 @@ describe('lib/adapters/internal-routes', () => {
 describe('lib/adapters/serve-internal-routes', () => {
   afterEach(() => {
     delete process.env.CYPRESS_INTERNAL_DISABLE_PROXY
+    delete process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
+    delete process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE
   })
 
   function createMiddleware (response: any = {
@@ -316,5 +318,102 @@ describe('lib/adapters/serve-internal-routes', () => {
       },
       body: Buffer.from('created'),
     })
+  })
+
+  it('asks the loopback for an identity-encoded response in cypress-in-cypress', async () => {
+    // The cy-in-cy parent forwards cloud-bundle loopbacks through its proxy
+    // pipeline, which rewrites a missing accept-encoding to 'gzip,identity' —
+    // and Fetch.fulfillRequest bodies are identity-only, so the loopback must
+    // ask for identity explicitly.
+    process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT = '1'
+
+    const { middleware, serverRequest } = createMiddleware()
+    const next = sinon.stub()
+
+    await middleware({
+      id: 'req-1',
+      url: 'http://localhost:1234/__cypress/xhrs/foo',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip, deflate, br',
+      },
+    }, next)
+
+    expect(serverRequest.create).to.have.been.calledWithMatch({
+      headers: {
+        'accept-encoding': 'identity',
+      },
+    }, true)
+  })
+
+  it('sends no accept-encoding on the loopback outside cypress-in-cypress', async () => {
+    // Single-hop loopbacks terminate at our own Express routes, which already
+    // serve identity when the header is absent.
+    const { middleware, serverRequest } = createMiddleware()
+    const next = sinon.stub()
+
+    await middleware({
+      id: 'req-1',
+      url: 'http://localhost:1234/__cypress/xhrs/foo',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip, deflate, br',
+      },
+    }, next)
+
+    const headers = serverRequest.create.firstCall.args[0].headers
+
+    expect(headers).not.to.have.property('accept-encoding')
+  })
+
+  it('decodes a gzip response body and drops the content-encoding header', async () => {
+    process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
+    const zlib = require('zlib')
+    const source = 'export default { StudioPanel: true }'
+    const { middleware } = createMiddleware({
+      statusCode: 200,
+      headers: {
+        'content-type': 'application/javascript',
+        'content-encoding': 'gzip',
+      },
+      body: zlib.gzipSync(source),
+    })
+    const next = sinon.stub()
+
+    const response = await middleware({
+      id: 'req-1',
+      url: 'http://localhost:1234/__cypress-studio/app-studio.js',
+      method: 'GET',
+    }, next)
+
+    expect(response.headers).to.deep.equal({ 'content-type': 'application/javascript' })
+    expect(response.body.toString()).to.equal(source)
+  })
+
+  it('drops content-encoding from an empty-body 304 without decoding', async () => {
+    process.env.CYPRESS_INTERNAL_DISABLE_PROXY = '1'
+
+    const { middleware } = createMiddleware({
+      statusCode: 304,
+      headers: {
+        'content-encoding': 'gzip',
+        etag: 'W/"80a-abc"',
+      },
+      body: Buffer.alloc(0),
+    })
+    const next = sinon.stub()
+
+    const response = await middleware({
+      id: 'req-1',
+      url: 'http://localhost:1234/__cypress-studio/app-studio.js',
+      method: 'GET',
+    }, next)
+
+    expect(response.statusCode).to.equal(304)
+    // the cached entry being revalidated holds the identity bytes fulfilled
+    // earlier, so the refreshed headers must not claim an encoding
+    expect(response.headers).to.deep.equal({ etag: 'W/"80a-abc"' })
+    expect(response.body.length).to.equal(0)
   })
 })


### PR DESCRIPTION
<!-- comment to trigger the PR template checks -->

- Closes #34601

### Additional details

In Cypress-in-Cypress runs with the proxy disabled, the internal-route loopback takes a second hop, and that hop gzips the studio bundle:

1. The child project's app (the AUT, `http://localhost:4455`) asks for `/__cypress-studio/app-studio.js` on its own origin.
2. The parent Cypress's CDP interception pauses the request, and `serve-internal-routes` (the parent's instance) loops it back to the parent's own Express server (cloud-bundle paths are internal routes under proxy-off since #34578).
3. The parent has no studio routes of its own — its cy-in-cy passthrough (`routes.ts`) re-enters the proxy pipeline to forward the request to the child at 4455, where the real cloud-bundle routes live.
4. `StripUnsupportedAcceptEncoding` runs on that forwarding hop and rewrites the MISSING `accept-encoding` (the loopback strips it) to `gzip,identity`, so the child's studio route responds gzipped.
5. `Fetch.fulfillRequest` hands the browser those gzip bytes as-is — fulfilled bodies are never decoded — so the module federation `import()` fails with a SyntaxError.
6. `loadRemote().catch()` swallows the error, so the panel shows the error state with a clean-looking 200, no console error, and none of the bundle's `assets/*` follow-up requests. Every test that waits on the real panel UI times out.

Confirmed via Test Replay on run 73666: the failing `app-studio.js` response carried `content-encoding: gzip` plus `origin-agent-cluster: ?0`, a header only the parent's pipeline adds — proof the request took the second hop.

The fix, in `serve-internal-routes`:

- ask the loopback for `accept-encoding: identity` explicitly in cypress-in-cypress (`CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT` / `CYPRESS_INTERNAL_SIMULATE_OPEN_MODE`) — `identity` survives the pipeline's rewrite because only `br`/`gzip` tokens are kept, so no hop compresses
- normalize any still-encoded loopback response with the synthetic codec's `toIdentityResponse` (now exported from `@packages/proxy`) before fulfilling

Real users are unaffected: outside cypress-in-cypress the loopback terminates at the server's own Express routes in one hop, which already serve identity for an absent header.

### Steps to test

- full-suite proof runs on the companion verification PR (bugbash config; its `run-app-integration-tests-chrome-cdp` should drop from 61 failures to ~2 — the remaining `debug.cy.ts` pair is a separate cy.intercept-visibility issue). This PR's own CI only runs the curated `-cdp-remediated` jobs.
- locally: `cd packages/app && CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run:e2e --browser chrome --spec cypress/e2e/studio/studio-state-management.cy.ts`
- unit: `yarn workspace @packages/server test-unit -- serve-internal-routes` (20 passing) and `yarn workspace @packages/proxy test -- synthetic-proxy-codec` (27 passing)

### How has the user experience changed?

N/A — internal `CYPRESS_INTERNAL_DISABLE_PROXY` behavior only.

### PR Tasks

- [x] Have tests been added/updated? — yes, unit coverage in `serve-internal-routes_spec`
- [x] Has the original issue or this PR been tagged in a changelog entry? — N/A (internal flag)
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? — N/A
- [x] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CDP internal-route fulfillment and shared response decoding, but only on internal Cypress routes and internal env flags—not typical user proxy flows.
> 
> **Overview**
> Fixes **Cypress-in-Cypress** internal-route loopbacks where a second proxy hop could return **gzip** studio bundles that **CDP `Fetch.fulfillRequest`** then handed to the browser as raw compressed bytes (no decoder), breaking module federation loads.
> 
> In **`serve-internal-routes`**, loopback requests now send **`accept-encoding: identity`** when `CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT` or `CYPRESS_INTERNAL_SIMULATE_OPEN_MODE` is set, so the cy-in-cy forwarding chain does not re-compress. Loopback responses are normalized with **`toIdentityResponse`** (newly exported from **`@packages/proxy`**) before fulfillment, decoding gzip and stripping **`content-encoding`** when needed (including empty **304** bodies).
> 
> Unit tests cover the cy-in-cy header behavior, normal single-hop loopbacks (no forced accept-encoding), and gzip/304 normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f214e47463bf8ae64d19112f8ea8709ca6e6901e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

