### PR TITLE
Display Non-chromium browsers error

### DIFF
--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 
-import { CypressInstanceError } from './record'
+import { CypressInstanceError, isTapSupportedBrowser } from './record'
 import type { LiveInstanceState, ReadyInstanceState, CypressInstance } from './record'
 import { isPidAlive, verifyInstanceRecord } from './liveness'
 import { readLiveInstances } from './store'
 
-export { CypressInstanceError, INSTANCES_DIRNAME } from './record'
+export { CypressInstanceError, INSTANCES_DIRNAME, isTapSupportedBrowser } from './record'
 
 export type { LiveInstanceState, ReadyInstanceState, CypressInstanceErrorCode, CypressInstance } from './record'
 
@@ -110,8 +110,17 @@ const selectInstance = <T extends LiveInstanceState>(candidates: T[], options: R
   return { instance: lowestPid(candidates), reason: 'arbitrary' }
 }
 
+const describeInstance = (instances: LiveInstanceState[], instance: number | undefined): string => {
+  if (instances.length === 1) {
+    return ` (pid ${instances[0].pid}, ${instances[0].projectRoot})`
+  }
+
+  return describeFilter(instance)
+}
+
 // Reads, filters by pid, and probes for liveness. Throws NO_INSTANCE when
-// nothing matches and STALE_INSTANCE when matches exist but none responds.
+// nothing matches, STALE_INSTANCE when matches exist but none responds, and
+// UNSUPPORTED_BROWSER when every one that does has a browser tap cannot drive.
 const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanceState[]> => {
   const { instance, probeTimeoutMs } = options
   const records = await readLiveInstances()
@@ -134,7 +143,19 @@ const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanc
     )
   }
 
-  return live
+  // Dropped before selection so an instance running an unsupported browser never
+  // shadows one that can serve the command; when it is the only candidate the
+  // caller hears why rather than "no browser attached".
+  const supported = live.filter((record) => isTapSupportedBrowser(record.browserFamily))
+
+  if (supported.length === 0) {
+    throw new CypressInstanceError(
+      'UNSUPPORTED_BROWSER',
+      'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.',
+    )
+  }
+
+  return supported
 }
 
 // Resolves a live instance without requiring a browser; `status` reports
@@ -159,13 +180,9 @@ export const resolveInstance = async (options: ResolveInstanceOptions): Promise<
   const ready = live.filter((record): record is ReadyInstanceState => record.cdpBrowserWsUrl !== null)
 
   if (ready.length === 0) {
-    const detail = live.length === 1
-      ? ` (pid ${live[0].pid}, ${live[0].projectRoot})`
-      : describeFilter(options.instance)
-
     throw new CypressInstanceError(
       'NO_BROWSER_ATTACHED',
-      `Cypress is running${detail}, but no test browser is open. Open a browser in Cypress and try again.`,
+      `Cypress is running${describeInstance(live, options.instance)}, but no test browser is open. Open a browser in Cypress and try again.`,
     )
   }
 

--- a/cli/lib/cypress-instances/index.ts
+++ b/cli/lib/cypress-instances/index.ts
@@ -151,7 +151,7 @@ const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanc
   if (supported.length === 0) {
     throw new CypressInstanceError(
       'UNSUPPORTED_BROWSER',
-      'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.',
+      'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.',
     )
   }
 

--- a/cli/lib/cypress-instances/liveness.ts
+++ b/cli/lib/cypress-instances/liveness.ts
@@ -57,7 +57,7 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       return null
     }
 
-    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown, machineId?: unknown, userId?: unknown }
+    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown, browserFamily?: unknown, machineId?: unknown, userId?: unknown }
 
     if (live.instanceId !== record.instanceId) {
       return null
@@ -66,10 +66,13 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
     const cdpBrowserWsUrl = typeof live.cdpBrowserWsUrl === 'string' ? live.cdpBrowserWsUrl : null
     const attached = cdpBrowserWsUrl !== null && await cdpEndpointReachable(cdpBrowserWsUrl, timeoutMs)
 
+    // The browser identity describes what the instance has open, not what is
+    // reachable over CDP — a browser tap cannot drive still has to be nameable.
     return {
       ...record,
       cdpBrowserWsUrl: attached ? cdpBrowserWsUrl : null,
-      browserName: attached && typeof live.browserName === 'string' ? live.browserName : null,
+      browserName: typeof live.browserName === 'string' ? live.browserName : null,
+      browserFamily: typeof live.browserFamily === 'string' ? live.browserFamily : null,
       machineId: typeof live.machineId === 'string' ? live.machineId : null,
       userId: typeof live.userId === 'string' ? live.userId : null,
     }

--- a/cli/lib/cypress-instances/record.ts
+++ b/cli/lib/cypress-instances/record.ts
@@ -1,6 +1,7 @@
 export {
   INSTANCES_DIRNAME,
   isCompatibleRecord,
+  isTapSupportedBrowser,
   parseRecordPid,
   cypressInstancesDir,
   instancesProbePath,
@@ -17,6 +18,7 @@ export type CypressInstanceErrorCode =
   | 'NO_INSTANCE'
   | 'STALE_INSTANCE'
   | 'NO_BROWSER_ATTACHED'
+  | 'UNSUPPORTED_BROWSER'
   | 'RENDERER_UNRESPONSIVE'
 
 export class CypressInstanceError extends Error {

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,4 +1,4 @@
-import { listLiveInstances } from '../../cypress-instances'
+import { isTapSupportedBrowser, listLiveInstances } from '../../cypress-instances'
 import type { LiveInstanceState, ReadyInstanceState } from '../../cypress-instances'
 import { renderOutcome, renderResult } from '../output'
 import { withTapSession } from '../tap-session'
@@ -18,8 +18,10 @@ export interface TapInstanceSummary {
   testingType: 'e2e' | 'component' | null
   /** Whether the instance has a browser attached over CDP. */
   browserAttached: boolean
-  /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
+  /** Display name of the browser the instance has open (e.g. `Chrome`), or `null` when none is open. */
   browserName: string | null
+  /** Whether tap can drive the browser the instance has open — tap supports only Chromium based browsers. */
+  browserSupported: boolean
   /**
    * Whether the runner page answered. `browserAttached` only says the browser
    * process is reachable, so this is what separates a healthy instance from one
@@ -62,6 +64,7 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     testingType: instance.testingType,
     browserAttached: instance.cdpBrowserWsUrl !== null,
     browserName: instance.browserName,
+    browserSupported: isTapSupportedBrowser(instance.browserFamily),
     ...(responsive[index] === undefined ? {} : { rendererResponsive: responsive[index] }),
   }))
 

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -32,8 +32,16 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   try {
     selection = await resolveLiveInstance({ instance: options.instance, cwd: process.cwd() })
   } catch (err) {
-    // No live instance is a status a poller waits on, not a failure.
     if (err instanceof CypressInstanceError) {
+      // Polling cannot outlast an instance tap will never be able to drive, so
+      // that one is a failure where every other resolution error is a status a
+      // poller waits on.
+      if (err.code === 'UNSUPPORTED_BROWSER') {
+        renderFailure(err)
+
+        return 1
+      }
+
       renderOutcome('status', { status: 'not connected' } satisfies TapStatus, options.json)
 
       return 0

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -6,9 +6,14 @@ import { noteTapFailure } from './events'
 import type { InstanceSelection } from '../cypress-instances'
 import type { TapSchema } from '@packages/cypress-instances'
 
+// Codes whose message already reads as a complete explanation with its own
+// guidance; printing the code in front of one adds noise rather than context.
+// The failure is still reported by code either way.
+const SELF_DESCRIBING_CODES = new Set(['UNSUPPORTED_BROWSER'])
+
 export const renderFailure = (err: { code: string, message: string }): void => {
   noteTapFailure(err.code)
-  logger.errorToStderr(`${err.code}: ${err.message}`)
+  logger.errorToStderr(SELF_DESCRIBING_CODES.has(err.code) ? err.message : `${err.code}: ${err.message}`)
 }
 
 export const renderKnownFailure = (err: { details: { description: string, solution: string } }): void => {

--- a/cli/lib/tap/render/instances.ts
+++ b/cli/lib/tap/render/instances.ts
@@ -9,7 +9,25 @@ export interface InstanceRow {
   projectRoot: string
   testingType: 'e2e' | 'component' | null
   browserName: string | null
+  browserAttached?: boolean
+  browserSupported?: boolean
   rendererResponsive?: boolean
+}
+
+// An open browser reads by its name alone only when tap can actually drive it;
+// each way that can fail — a browser tap does not support, one it has lost its
+// connection to, one whose page will not answer — is the state every other
+// command fails in, so each says which.
+const browserState = (instance: InstanceRow): string | null => {
+  if (instance.browserSupported === false) {
+    return 'unsupported'
+  }
+
+  if (instance.browserAttached === false) {
+    return 'not attached'
+  }
+
+  return instance.rendererResponsive === false ? 'not responding' : null
 }
 
 const browserCell = (instance: InstanceRow): string => {
@@ -17,9 +35,9 @@ const browserCell = (instance: InstanceRow): string => {
     return '—'
   }
 
-  // A browser that is attached but whose page will not answer is the state every
-  // other command fails in, so it reads differently from a healthy one.
-  return instance.rendererResponsive === false ? `${instance.browserName} (not responding)` : instance.browserName
+  const state = browserState(instance)
+
+  return state === null ? instance.browserName : `${instance.browserName} (${state})`
 }
 
 const browserColor = (instance: InstanceRow) => {
@@ -27,7 +45,13 @@ const browserColor = (instance: InstanceRow) => {
     return color.muted
   }
 
-  return instance.rendererResponsive === false ? color.aborted : color.pass
+  const state = browserState(instance)
+
+  if (state === null) {
+    return color.pass
+  }
+
+  return state === 'unsupported' ? color.warn : color.aborted
 }
 
 // One row per instance. PID is bold — it's the handle the other tap commands

--- a/cli/lib/tap/render/status.ts
+++ b/cli/lib/tap/render/status.ts
@@ -39,6 +39,7 @@ export const renderStatusHuman = (status: TapStatus): string => {
     projectRoot,
     testingType: status.testingType ?? null,
     browserName: status.browserName ?? null,
+    browserAttached: status.browserAttached,
   }
 
   const progress = [phaseLine(status)]

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -167,14 +167,15 @@ describe('lib/cypress-instances', () => {
       return JSON.parse(makeRecord({ serverPort, instanceId }))
     }
 
-    it('resolves the record with the live CDP state and browser name when the instance echoes the instanceId', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome', machineId: 'machine-hash', userId: 'cloud-user-1' } })
+    it('resolves the record with the live CDP state and browser when the instance echoes the instanceId', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome', browserFamily: 'chromium', machineId: 'machine-hash', userId: 'cloud-user-1' } })
       const record = recordFor(port)
 
       expect(await verifyInstanceRecord(record)).toEqual({
         ...record,
         cdpBrowserWsUrl: CDP_WS_URL,
         browserName: 'Chrome',
+        browserFamily: 'chromium',
         machineId: 'machine-hash',
         userId: 'cloud-user-1',
       })
@@ -188,11 +189,22 @@ describe('lib/cypress-instances', () => {
       expect(live!.userId).toBeNull()
     })
 
-    it('nulls the browser name when the CDP endpoint is unreachable', async () => {
+    it('keeps the browser the instance has open even when the CDP endpoint is unreachable', async () => {
       const deadCdpPort = await getClosedPort()
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc`, browserName: 'Chrome' } })
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc`, browserName: 'Chrome', browserFamily: 'chromium' } })
+      const live = await verifyInstanceRecord(recordFor(port))
 
-      expect((await verifyInstanceRecord(recordFor(port)))!.browserName).toBeNull()
+      expect(live!.cdpBrowserWsUrl).toBeNull()
+      expect(live!.browserName).toBe('Chrome')
+      expect(live!.browserFamily).toBe('chromium')
+    })
+
+    it('normalizes a browser an older instance omits (or junks) to null', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserFamily: 42 } })
+      const live = await verifyInstanceRecord(recordFor(port))
+
+      expect(live!.browserName).toBeNull()
+      expect(live!.browserFamily).toBeNull()
     })
 
     it('normalizes a missing or junk cdpBrowserWsUrl in the probe response to null', async () => {
@@ -376,6 +388,39 @@ describe('lib/cypress-instances', () => {
       await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
     })
 
+    it('throws UNSUPPORTED_BROWSER when the only instance runs a browser tap cannot drive', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      const err = await resolveInstance({ instance: 111, cwd: PROJECT }).catch((e) => e)
+
+      // Not NO_BROWSER_ATTACHED: a Firefox instance never attaches one, so the
+      // "open a browser" guidance would send the user in a circle.
+      expect(err.code).toBe('UNSUPPORTED_BROWSER')
+      expect(err.message).toBe('The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.')
+    })
+
+    it('resolves a Chromium instance over a live one at the cwd running an unsupported browser', async () => {
+      const readyPort = await startReadyInstance('ready-instance')
+      const firefoxPort = await startFakeInstance({ instanceId: 'firefox-instance', respondWith: { instanceId: 'firefox-instance', cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
+
+      mockfs({
+        [INSTANCES_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: firefoxPort, instanceId: 'firefox-instance' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, instanceId: 'ready-instance' }),
+        },
+      })
+
+      stubKill({ alive: [111, 222] })
+
+      const selection = await resolveInstance({ cwd: PROJECT })
+
+      expect(selection.instance.pid).toBe(222)
+      expect(selection.candidateCount).toBe(1)
+    })
+
     it('resolves a browser-attached instance over a live one at the cwd that has none', async () => {
       const readyPort = await startReadyInstance('ready-instance')
       const browserlessPort = await startFakeInstance({ instanceId: 'browserless-instance', respondWith: { instanceId: 'browserless-instance', cdpBrowserWsUrl: null } })
@@ -526,6 +571,17 @@ describe('lib/cypress-instances', () => {
       await expect(resolveLiveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
       expect(fs.existsSync(`${INSTANCES_DIR}/111.json`)).toBe(false)
     })
+
+    // The commands that never need a browser (specs/status) still run against the
+    // instance's own runner, so an unsupported browser rules them out too.
+    it('throws UNSUPPORTED_BROWSER when the only instance runs a browser tap cannot drive', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserName: 'WebKit', browserFamily: 'webkit' } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      await expect(resolveLiveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'UNSUPPORTED_BROWSER' })
+    })
   })
 
   describe('.listLiveInstances', () => {
@@ -548,6 +604,19 @@ describe('lib/cypress-instances', () => {
       expect(instances.find((instance) => instance.pid === 111)!.cdpBrowserWsUrl).toBe(CDP_WS_URL)
       // No endpoint in the probe response — no browser attached.
       expect(instances.find((instance) => instance.pid === 222)!.cdpBrowserWsUrl).toBeNull()
+    })
+
+    // Unlike the resolvers, listing is how a user finds out an instance is
+    // running a browser tap cannot drive — so it must not hide one.
+    it('lists an instance running a browser tap cannot drive', async () => {
+      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserName: 'Firefox', browserFamily: 'firefox' } })
+
+      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      stubKill({ alive: [111] })
+
+      const instances = await listLiveInstances()
+
+      expect(instances.map((instance) => instance.browserFamily)).toEqual(['firefox'])
     })
 
     it('resolves an empty list when no record exists', async () => {

--- a/cli/test/lib/cypress-instances.spec.ts
+++ b/cli/test/lib/cypress-instances.spec.ts
@@ -399,7 +399,7 @@ describe('lib/cypress-instances', () => {
       // Not NO_BROWSER_ATTACHED: a Firefox instance never attaches one, so the
       // "open a browser" guidance would send the user in a circle.
       expect(err.code).toBe('UNSUPPORTED_BROWSER')
-      expect(err.message).toBe('The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.')
+      expect(err.message).toBe('The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.')
     })
 
     it('resolves a Chromium instance over a live one at the cwd running an unsupported browser', async () => {

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -59,6 +59,7 @@ export const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): Read
   testingType: 'e2e',
   cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
   browserName: 'Chrome',
+  browserFamily: 'chromium',
   machineId: null,
   userId: null,
   ...overrides,

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -385,6 +385,7 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      browserFamily: 'chromium',
       machineId: null,
       userId: null,
       ...overrides,
@@ -435,9 +436,23 @@ describe('lib/exec/tap', () => {
 
       expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([
-        { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome' },
-        { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false, browserName: null },
+        { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', browserSupported: true },
+        { pid: 222, projectRoot: '/projects/other', testingType: 'component', browserAttached: false, browserName: null, browserSupported: true },
       ])
+    })
+
+    it('lists an instance running a browser tap cannot drive, marked unsupported', async () => {
+      vi.mocked(listLiveInstances).mockResolvedValue([
+        liveInstance({ pid: 111, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' }),
+      ])
+
+      expect(await tap.start(['instances'], {})).toBe(0)
+      expect(logger.print()).toContain('Firefox (unsupported)')
+
+      logger.reset()
+
+      expect(await tap.start(['instances'], { json: true })).toBe(0)
+      expect(JSON.parse(logger.print())[0]).toMatchObject({ browserName: 'Firefox', browserSupported: false })
     })
 
     it('reports the testing type as null for an instance that has not chosen one', async () => {
@@ -506,6 +521,7 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      browserFamily: 'chromium',
       machineId: null,
       userId: null,
       ...overrides,
@@ -544,6 +560,21 @@ describe('lib/exec/tap', () => {
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({ status: 'not connected' })
+    })
+
+    // Every other resolution failure is transient — an instance running a browser
+    // tap cannot drive is not, so a poller must hear it rather than wait it out.
+    it('fails instead of reporting "not connected" when the browser is unsupported', async () => {
+      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('UNSUPPORTED_BROWSER', 'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.'))
+
+      expect(await tap.start(['status'], {})).toBe(1)
+
+      const output = logger.print()
+
+      expect(output).toContain('running on an unsupported browser')
+      expect(output).toContain('Run Cypress open on a Chromium based browser')
+      // The message stands on its own, so it is not prefixed with its code.
+      expect(output).not.toContain('UNSUPPORTED_BROWSER')
     })
 
     it('reports "browser not selected" without opening a session when no browser is attached', async () => {
@@ -719,6 +750,7 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      browserFamily: 'chromium',
       machineId: null,
       userId: null,
       ...overrides,
@@ -919,6 +951,7 @@ describe('lib/exec/tap', () => {
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
+      browserFamily: 'chromium',
       machineId: null,
       userId: null,
       ...overrides,

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -565,14 +565,14 @@ describe('lib/exec/tap', () => {
     // Every other resolution failure is transient — an instance running a browser
     // tap cannot drive is not, so a poller must hear it rather than wait it out.
     it('fails instead of reporting "not connected" when the browser is unsupported', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('UNSUPPORTED_BROWSER', 'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium based browser to use cypress tap.'))
+      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('UNSUPPORTED_BROWSER', 'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.'))
 
       expect(await tap.start(['status'], {})).toBe(1)
 
       const output = logger.print()
 
       expect(output).toContain('running on an unsupported browser')
-      expect(output).toContain('Run Cypress open on a Chromium based browser')
+      expect(output).toContain('Run Cypress open on a Chromium-based browser')
       // The message stands on its own, so it is not prefixed with its code.
       expect(output).not.toContain('UNSUPPORTED_BROWSER')
     })

--- a/cli/test/lib/tap/instance-gql.spec.ts
+++ b/cli/test/lib/tap/instance-gql.spec.ts
@@ -13,6 +13,7 @@ const instance: LiveInstanceState = {
   testingType: 'e2e',
   cdpBrowserWsUrl: null,
   browserName: null,
+  browserFamily: null,
   machineId: null,
   userId: null,
 }

--- a/cli/test/lib/tap/render-instances.spec.ts
+++ b/cli/test/lib/tap/render-instances.spec.ts
@@ -9,8 +9,8 @@ const render = (instances: TapInstanceSummary[]): string => stripAnsi(renderInst
 describe('lib/tap/render/instances', () => {
   it('renders a padded table; missing testing type and detached browser show a dash', () => {
     const output = render([
-      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome' },
-      { pid: 222, projectRoot: '/projects/other', testingType: null, browserAttached: false, browserName: null },
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', browserSupported: true },
+      { pid: 222, projectRoot: '/projects/other', testingType: null, browserAttached: false, browserName: null, browserSupported: true },
     ])
 
     expect(output).toBe([
@@ -25,8 +25,8 @@ describe('lib/tap/render/instances', () => {
   // command fails in, so the row has to say so rather than read as healthy.
   it('marks an attached browser whose renderer is not answering', () => {
     const output = render([
-      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', rendererResponsive: false },
-      { pid: 222, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', rendererResponsive: true },
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', browserSupported: true, rendererResponsive: false },
+      { pid: 222, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: true, browserName: 'Chrome', browserSupported: true, rendererResponsive: true },
     ])
 
     expect(output).toBe([
@@ -34,6 +34,22 @@ describe('lib/tap/render/instances', () => {
       '  PID  PROJECT        TYPE  BROWSER',
       '  111  /projects/app  e2e   Chrome (not responding)',
       '  222  /projects/app  e2e   Chrome',
+    ].join('\n'))
+  })
+
+  // Every way an open browser can be undrivable reads differently from a healthy
+  // one, and from each other, so the row says which.
+  it('marks a browser tap cannot drive, and one it has not attached to yet', () => {
+    const output = render([
+      { pid: 111, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: false, browserName: 'Firefox', browserSupported: false },
+      { pid: 222, projectRoot: '/projects/app', testingType: 'e2e', browserAttached: false, browserName: 'Chrome', browserSupported: true },
+    ])
+
+    expect(output).toBe([
+      'INSTANCES (2)',
+      '  PID  PROJECT        TYPE  BROWSER',
+      '  111  /projects/app  e2e   Firefox (unsupported)',
+      '  222  /projects/app  e2e   Chrome (not attached)',
     ].join('\n'))
   })
 })

--- a/cli/test/lib/tap/tap-session.spec.ts
+++ b/cli/test/lib/tap/tap-session.spec.ts
@@ -62,6 +62,7 @@ const makeRecord = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceS
     testingType: 'e2e',
     cdpBrowserWsUrl: BROWSER_WS_URL,
     browserName: 'Chrome',
+    browserFamily: 'chromium',
     machineId: null,
     userId: null,
     ...overrides,

--- a/packages/cypress-instances/lib/__spec__/index.spec.ts
+++ b/packages/cypress-instances/lib/__spec__/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   isCompatibleRecord,
+  isTapSupportedBrowser,
   recordFileName,
   parseRecordPid,
   instancesProbePath,
@@ -62,6 +63,20 @@ describe('cypress-instances contract', () => {
 
   it('exposes the instances dir name', () => {
     expect(INSTANCES_DIRNAME).toBe('instances')
+  })
+
+  describe('isTapSupportedBrowser', () => {
+    it('accepts Chromium and rejects every other family', () => {
+      expect(isTapSupportedBrowser('chromium')).toBe(true)
+      expect(isTapSupportedBrowser('firefox')).toBe(false)
+      expect(isTapSupportedBrowser('webkit')).toBe(false)
+    })
+
+    // No browser open, or a record written before the family was reported — in
+    // neither case is there a browser to call unsupported.
+    it('accepts a null family', () => {
+      expect(isTapSupportedBrowser(null)).toBe(true)
+    })
   })
 
   describe('tap command contract', () => {

--- a/packages/cypress-instances/lib/index.ts
+++ b/packages/cypress-instances/lib/index.ts
@@ -31,8 +31,10 @@ export interface CypressInstance {
 
 export interface LiveInstanceState extends CypressInstance {
   cdpBrowserWsUrl: string | null
-  /** Display name of the attached browser (e.g. `Chrome`), or `null` when none is attached. */
+  /** Display name of the browser the instance has open (e.g. `Chrome`), or `null` when none is open. */
   browserName: string | null
+  /** Family of the browser the instance has open (e.g. `chromium`), or `null` when none is open. */
+  browserFamily: string | null
   /** sha256 hash of the OS machine GUID (node-machine-id), or `null` when unresolvable. */
   machineId: string | null
   /** Cloud user id of the logged-in user, or `null` when logged out or not yet resolved. */
@@ -41,6 +43,14 @@ export interface LiveInstanceState extends CypressInstance {
 
 export interface ReadyInstanceState extends LiveInstanceState {
   cdpBrowserWsUrl: string
+}
+
+export const TAP_SUPPORTED_BROWSER_FAMILY = 'chromium'
+
+// tap drives the browser over CDP, which only Chromium-based browsers speak. A
+// null family means no browser is open yet — nothing to call unsupported.
+export const isTapSupportedBrowser = (browserFamily: string | null): boolean => {
+  return browserFamily === null || browserFamily === TAP_SUPPORTED_BROWSER_FAMILY
 }
 
 export const recordFileName = (pid: number): string => {

--- a/packages/cypress-instances/lib/tap-contract.ts
+++ b/packages/cypress-instances/lib/tap-contract.ts
@@ -221,7 +221,11 @@ const instancesMeta = {
   name: 'instances',
   description: 'list the running Cypress instances this CLI can reach',
   details: `Lists the running Cypress instances this CLI can reach, as a JSON array. Pass
-an instance's pid to \`--instance\` to target it with another tap command.`,
+an instance's pid to \`--instance\` to target it with another tap command.
+
+tap only supports Chromium based browsers (Chrome, Chromium, Edge, Electron).
+An instance running any other browser is listed as unsupported, and every other
+tap command refuses it.`,
 } as const satisfies TapNativeCommandSchema
 
 const statusMeta = {

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -267,7 +267,7 @@ export class BrowserCriClient {
         onExtraTargetCriClientReady,
       })
 
-      cypressInstances.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl, browserName)
+      cypressInstances.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl)
 
       if (fullyManageTabs) {
         await this._manageTabs({ browserClient, browserCriClient, browserName, host, onAsynchronousError, port, protocolManager })

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -136,9 +136,8 @@ const browsers = {
   async connectToExisting (browser: Browser, options: BrowserLaunchOpts, automation: Automation, cdpSocketServer?: CDPSocketServer): Promise<BrowserInstance | null> {
     const browserLauncher = await getBrowserLauncher(browser, options.browsers)
 
-    cypressInstances.setBrowser(browser)
-
     await browserLauncher.connectToExisting(browser, options, automation, cdpSocketServer)
+    cypressInstances.setBrowser(browser)
 
     return this.getBrowserInstance()
   },
@@ -200,8 +199,6 @@ const browsers = {
 
     debug('opening browser %o', browser)
 
-    cypressInstances.setBrowser(browser)
-
     const _instance = await browserLauncher.open(browser, options.url, options, automation, ctx.coreData.servers.cdpSocketServer)
 
     debug(`browser opened for launch ${thisLaunchAttempt}`)
@@ -239,6 +236,7 @@ const browsers = {
 
     instance = _instance
     instance.browser = browser
+    cypressInstances.setBrowser(browser)
 
     // TODO: normalizing opening and closing / exiting
     // so that there is a default for each browser but

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -3,6 +3,7 @@ import Bluebird from 'bluebird'
 import Debug from 'debug'
 import utils from './utils'
 import * as errors from '../errors'
+import { cypressInstances } from '../cypress-instances'
 import { exec } from 'child_process'
 import util from 'util'
 import os from 'os'
@@ -135,6 +136,8 @@ const browsers = {
   async connectToExisting (browser: Browser, options: BrowserLaunchOpts, automation: Automation, cdpSocketServer?: CDPSocketServer): Promise<BrowserInstance | null> {
     const browserLauncher = await getBrowserLauncher(browser, options.browsers)
 
+    cypressInstances.setBrowser(browser)
+
     await browserLauncher.connectToExisting(browser, options, automation, cdpSocketServer)
 
     return this.getBrowserInstance()
@@ -196,6 +199,8 @@ const browsers = {
     if (!options.url) throw new Error('Missing url in browsers.open')
 
     debug('opening browser %o', browser)
+
+    cypressInstances.setBrowser(browser)
 
     const _instance = await browserLauncher.open(browser, options.url, options, automation, ctx.coreData.servers.cdpSocketServer)
 
@@ -269,6 +274,7 @@ const browsers = {
 
       options.onBrowserClose()
       browserLauncher.clearInstanceState()
+      cypressInstances.setBrowser(null)
       instance = null
 
       if (browserDidCrash) {

--- a/packages/server/lib/cypress-instances.ts
+++ b/packages/server/lib/cypress-instances.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 import path from 'path'
 import fs from 'fs-extra'
 import Debug from 'debug'
-import type { TestingType } from '@packages/types'
+import type { Browser, TestingType } from '@packages/types'
 import { SCHEMA_VERSION, cypressInstancesDir, recordPath } from '@packages/cypress-instances'
 import type { CypressInstance, LiveInstanceState } from '@packages/cypress-instances'
 import { resolveCypressCacheRoot } from './util/cypress-cache'
@@ -55,7 +55,7 @@ export const cypressInstances = {
 
     // machineId/userId are read fresh from the data context when the probe route
     // answers; the in-memory state only carries the browser attachment.
-    currentState = { ...record, cdpBrowserWsUrl: null, browserName: null, machineId: null, userId: null }
+    currentState = { ...record, cdpBrowserWsUrl: null, browserName: null, browserFamily: null, machineId: null, userId: null }
 
     try {
       await persist(record)
@@ -65,15 +65,25 @@ export const cypressInstances = {
     }
   },
 
-  setCdpBrowserWsUrl (cdpBrowserWsUrl: string | null, browserName: string | null = null): void {
+  // The browser Cypress has open, whether or not it speaks CDP: a consumer that
+  // cannot drive a non-Chromium browser still needs to know which one is open to
+  // say why. Recorded at launch rather than at CDP attach for that reason.
+  setBrowser (browser: Pick<Browser, 'displayName' | 'family'> | null): void {
     if (!currentState) {
       return
     }
 
-    // browserName is only meaningful while a browser is attached; clearing the
-    // url clears the name so the two never disagree.
-    currentState = { ...currentState, cdpBrowserWsUrl, browserName: cdpBrowserWsUrl ? browserName : null }
-    debug('cypress instances cdpBrowserWsUrl is now %o (browser %o)', cdpBrowserWsUrl, currentState.browserName)
+    currentState = { ...currentState, browserName: browser?.displayName ?? null, browserFamily: browser?.family ?? null }
+    debug('cypress instances browser is now %o', browser ? { name: currentState.browserName, family: currentState.browserFamily } : null)
+  },
+
+  setCdpBrowserWsUrl (cdpBrowserWsUrl: string | null): void {
+    if (!currentState) {
+      return
+    }
+
+    currentState = { ...currentState, cdpBrowserWsUrl }
+    debug('cypress instances cdpBrowserWsUrl is now %o', cdpBrowserWsUrl)
   },
 
   getCurrent (): LiveInstanceState | null {

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -135,12 +135,12 @@ describe('lib/browsers/browser-cri-client', function () {
       expect(criImport.Version).to.be.calledTwice
     })
 
-    it('advertises the browser websocket url and name to cypress instances once connected', async function () {
+    it('advertises the browser websocket url to cypress instances once connected', async function () {
       const setCdpBrowserWsUrl = sinon.stub(cypressInstances, 'setCdpBrowserWsUrl')
 
       await getClient()
 
-      expect(setCdpBrowserWsUrl).to.be.calledWith('http://web/socket/url', 'Chrome')
+      expect(setCdpBrowserWsUrl).to.be.calledWith('http://web/socket/url')
     })
 
     it('clears the cypress instances cdp url when the browser connection is lost', async function () {

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -525,6 +525,31 @@ describe('lib/browsers/index', () => {
   // Recorded for every family, not just the ones that speak CDP, so an external
   // tool can tell a browser it cannot drive from no browser at all.
   context('cypress instances browser', () => {
+    it('does not record the browser when launch fails', async () => {
+      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const browser = { name: 'firefox', family: 'firefox', displayName: 'Firefox' }
+      const launchError = new Error('failed to launch')
+
+      browsers._setInstance(null)
+      sinon.stub(firefox, 'open').rejects(launchError)
+
+      await expect(browsers.open(browser as any, { url: 'http://localhost:3000' } as any, null, ctx)).to.be.rejectedWith(launchError)
+
+      expect(setBrowser).not.to.be.calledWith(browser)
+    })
+
+    it('does not record the browser when connecting fails', async () => {
+      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const browser = { name: 'firefox', family: 'firefox', displayName: 'Firefox' }
+      const connectError = new Error('failed to connect')
+
+      sinon.stub(firefox, 'connectToExisting').rejects(connectError)
+
+      await expect(browsers.connectToExisting(browser as any, { browsers: [] } as any, null)).to.be.rejectedWith(connectError)
+
+      expect(setBrowser).not.to.be.calledWith(browser)
+    })
+
     it('records the browser on launch and clears it when the browser exits', async () => {
       const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
       const url: TestUrl = 'http://localhost:3000'

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -11,7 +11,9 @@ import util, { stripVTControlCharacters as stripAnsi } from 'util'
 import { createTestDataContext } from '../../support/helpers/data-context-helper'
 import electron from '../../../lib/browsers/electron'
 import chrome from '../../../lib/browsers/chrome'
+import * as firefox from '../../../lib/browsers/firefox'
 import Promise from 'bluebird'
+import { cypressInstances } from '../../../lib/cypress-instances'
 import { deferred } from '../../support/helpers/deferred'
 import type { DataContext } from '@packages/data-context/src/DataContext'
 import type { BrowserInstance } from '../../../lib/browsers/types'
@@ -517,6 +519,36 @@ describe('lib/browsers/index', () => {
       return browsers.open({ name: 'electron', family: 'chromium' } as any, { url } as any, null, ctx).then(browsers.close).then(() => {
         expect(ctx.coreData.didBrowserPreviouslyHaveUnexpectedExit).eq(true)
       })
+    })
+  })
+
+  // Recorded for every family, not just the ones that speak CDP, so an external
+  // tool can tell a browser it cannot drive from no browser at all.
+  context('cypress instances browser', () => {
+    it('records the browser on launch and clears it when the browser exits', async () => {
+      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const url: TestUrl = 'http://localhost:3000'
+      const browserInstance = new EventEmitter() as BrowserInstance
+
+      browserInstance.kill = () => {
+        browserInstance.emit('exit')
+      }
+
+      browsers._setInstance(browserInstance)
+
+      sinon.stub(firefox, 'open').resolves(browserInstance)
+      sinon.stub(firefox, 'clearInstanceState')
+      sinon.stub(Promise, 'delay').resolves()
+
+      const browser = { name: 'firefox', family: 'firefox', displayName: 'Firefox' }
+
+      await browsers.open(browser as any, { url, onBrowserClose: sinon.stub() } as any, null, ctx)
+
+      expect(setBrowser).to.be.calledWith(browser)
+
+      browserInstance.emit('exit')
+
+      expect(setBrowser).to.be.calledWith(null)
     })
   })
 

--- a/packages/server/test/unit/cypress-instances_spec.ts
+++ b/packages/server/test/unit/cypress-instances_spec.ts
@@ -110,31 +110,65 @@ describe('lib/cypress-instances', () => {
     })
   })
 
+  describe('.setBrowser', () => {
+    it('records the open browser without touching the disk record', async () => {
+      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+
+      const onDiskBefore = await fs.readJson(recordPath)
+
+      cypressInstances.setBrowser({ displayName: 'Firefox', family: 'firefox' })
+
+      expect(cypressInstances.getCurrent()).to.deep.include({
+        serverPort: 4455,
+        browserName: 'Firefox',
+        browserFamily: 'firefox',
+      })
+
+      expect(await fs.readJson(recordPath)).to.deep.eq(onDiskBefore)
+    })
+
+    it('clears the browser when it goes away', async () => {
+      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+
+      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+      cypressInstances.setBrowser(null)
+
+      expect(cypressInstances.getCurrent()!.browserName).to.be.null
+      expect(cypressInstances.getCurrent()!.browserFamily).to.be.null
+    })
+
+    it('is a no-op when no record has been written yet', () => {
+      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+
+      expect(cypressInstances.getCurrent()).to.be.null
+    })
+  })
+
   describe('.setCdpBrowserWsUrl', () => {
     it('updates the live state without touching the disk record', async () => {
       await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
 
       const onDiskBefore = await fs.readJson(recordPath)
 
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc', 'Chrome')
+      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
 
       expect(cypressInstances.getCurrent()).to.deep.include({
         serverPort: 4455,
         cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-        browserName: 'Chrome',
       })
 
       expect(await fs.readJson(recordPath)).to.deep.eq(onDiskBefore)
     })
 
-    it('clears the endpoint and browser name when the browser goes away', async () => {
+    it('leaves the open browser in place when the endpoint goes away', async () => {
       await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
 
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc', 'Chrome')
+      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
       cypressInstances.setCdpBrowserWsUrl(null)
 
       expect(cypressInstances.getCurrent()!.cdpBrowserWsUrl).to.be.null
-      expect(cypressInstances.getCurrent()!.browserName).to.be.null
+      expect(cypressInstances.getCurrent()!.browserName).to.eq('Chrome')
     })
 
     it('is a no-op when no record has been written yet', () => {
@@ -161,6 +195,7 @@ describe('lib/cypress-instances', () => {
         ...await fs.readJson(recordPath),
         cdpBrowserWsUrl: null,
         browserName: null,
+        browserFamily: null,
         machineId: null,
         userId: null,
       })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one --> [AW-100](https://cypress-io.atlassian.net/browse/AW-100)

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance discovery, probe payload, and browser lifecycle hooks used by all tap commands; behavior shifts for Firefox/WebKit users and multi-instance selection, though coverage is broad in unit tests.
> 
> **Overview**
> **`cypress tap` only drives Chromium-based browsers.** Open-mode instances now expose **`browserFamily`** (alongside name) from the server probe, with browser identity recorded at launch via **`setBrowser`** rather than only when CDP attaches—so Firefox/WebKit can be named even without a CDP URL.
> 
> Instance resolution **filters out unsupported families** before picking a target (unsupported instances no longer shadow a Chromium peer) and throws **`UNSUPPORTED_BROWSER`** with guidance to reopen on Chromium instead of misleading **`NO_BROWSER_ATTACHED`**. **`cypress tap instances`** still lists unsupported sessions but marks them **`browserSupported: false`** / **`(unsupported)`** in the table; **`cypress tap status`** treats **`UNSUPPORTED_BROWSER`** as a hard failure (exit 1) so pollers do not spin on a permanently invalid browser.
> 
> Failure output omits the error-code prefix for **`UNSUPPORTED_BROWSER`** because the message is self-explanatory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438439283b1c914044463cf21ce020637b7c5671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


[AW-100]: https://cypress-io.atlassian.net/browse/AW-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ