### PR TITLE
chore: honor the CDP Fetch contract for cy.intercept static stubs when the proxy is disabled

### DIFF
--- a/packages/net-stubbing/lib/server/util.ts
+++ b/packages/net-stubbing/lib/server/util.ts
@@ -159,7 +159,12 @@ export async function sendStaticResponse (backendRequest: Pick<InterceptedReques
 
   if (staticResponse.forceNetworkError) {
     debug('forcing network error')
-    const err = new Error('forceNetworkError called')
+    const err: Error & { isForceNetworkError?: boolean } = new Error('forceNetworkError called')
+
+    // The CDP Fetch transport has no connection to reset, so it needs to tell
+    // a requested network error apart from a real pipeline failure to map it
+    // to Fetch.failRequest instead of releasing the pause untouched.
+    err.isForceNetworkError = true
 
     return onError(err)
   }

--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -400,7 +400,17 @@ export class Http {
         // If the response has been destroyed after handling the incoming request, it implies the that request was canceled by the browser.
         // In this case we don't want to run the response middleware and should just exit.
         if (ctx.res.destroyed) {
-          const error = createBrowserConnectionClosedError()
+          const error: Error & { isForceNetworkError?: boolean } = createBrowserConnectionClosedError()
+
+          // forceNetworkError destroys the res itself; carry its tag through
+          // so the CDP Fetch transport can map the rejection to
+          // Fetch.failRequest. Everything else about this path — the error
+          // stage re-run, the thrown type — is unchanged, so MITM behavior
+          // (where the destroyed socket already delivered the network error)
+          // is untouched.
+          if ((ctx.error as Error & { isForceNetworkError?: boolean } | undefined)?.isForceNetworkError) {
+            error.isForceNetworkError = true
+          }
 
           await onError(error)
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -183,8 +183,8 @@ function toRequestPostData (body?: string | Buffer): string | undefined {
 
 function contentTypeOf (entries?: Protocol.Fetch.HeaderEntry[]): string | undefined {
   const values = entries
-    ?.filter(({ name }) => name.toLowerCase() === 'content-type')
-    .map(({ value }) => value)
+  ?.filter(({ name }) => name.toLowerCase() === 'content-type')
+  .map(({ value }) => value)
 
   return values?.length ? values.join(', ') : undefined
 }
@@ -300,6 +300,13 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
 
       if (httpRequest.body !== undefined) {
         transportRequest.postData = toRequestPostData(httpRequest.body)
+
+        // A Buffer body must reach the transport as bytes: the utf8 string
+        // view above is lossy for binary payloads, and Fetch.continueRequest
+        // transmits base64-encoded bytes.
+        if (Buffer.isBuffer(httpRequest.body)) {
+          transportRequest.postDataBuffer = httpRequest.body
+        }
       }
 
       return transportRequest

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -1,5 +1,6 @@
 import type { Protocol } from 'devtools-protocol'
 import debugModule from 'debug'
+import { STATUS_CODES } from 'http'
 import { Readable } from 'stream'
 import type { ForHttpIntercept } from '@packages/network-interception'
 import { HttpIntercept } from '@packages/network-interception'
@@ -104,6 +105,9 @@ type CdpFetchTransportOptions = {
 
 export interface CdpFetchTransportRequest extends CdpFetchRequest {
   id: string
+  // Byte-accurate body for Fetch.continueRequest when middleware set a Buffer;
+  // postData is its lossy utf8 string view, kept for pause comparison.
+  postDataBuffer?: Buffer
   requestId?: string
   resourceType?: ResourceType
   sessionId?: string
@@ -440,7 +444,14 @@ export class CdpFetchTransport {
           requestId: event.requestId,
           ...(outbound.url !== event.request.url ? { url: outbound.url } : {}),
           ...(outbound.method !== event.request.method ? { method: outbound.method } : {}),
-          ...(outbound.postData !== event.request.postData ? { postData: outbound.postData } : {}),
+          // Fetch.continueRequest's postData is a CDP binary param (base64
+          // over JSON); the pause's event.request.postData is plaintext, so
+          // only the outgoing value is encoded. Sending plaintext makes CDP
+          // reject the continue ("invalid base64 string") — or worse, accept
+          // base64-shaped plaintext and hand the origin corrupted bytes.
+          ...(outbound.postDataBuffer || outbound.postData !== event.request.postData
+            ? { postData: (outbound.postDataBuffer ?? Buffer.from(outbound.postData ?? '', 'utf8')).toString('base64') }
+            : {}),
           ...(headers ? { headers } : {}),
         }, outbound.sessionId)
 
@@ -479,6 +490,11 @@ export class CdpFetchTransport {
         await this.client.send('Fetch.fulfillRequest', {
           requestId: response.requestId,
           responseCode: response.responseCode,
+          // CDP rejects a status code it has no built-in reason phrase for
+          // ("Invalid http status code or phrase"), which turns req.reply(777)
+          // into a silently released pause. Node's MITM path serves unknown
+          // codes with the phrase "unknown"; mirror that.
+          responsePhrase: STATUS_CODES[response.responseCode] ?? 'unknown',
           ...(response.responseHeaders ? { responseHeaders: response.responseHeaders } : {}),
           ...(response.body !== undefined ? { body: response.body } : {}),
         }, response.sessionId)
@@ -488,6 +504,10 @@ export class CdpFetchTransport {
         await this.client.send('Fetch.continueResponse', {
           requestId: response.requestId,
           responseCode: response.responseCode,
+          // Chrome rejects a code it has no built-in phrase for; for every
+          // known code, omit the phrase so the origin's own phrase survives
+          // the pass-through untouched.
+          ...(STATUS_CODES[response.responseCode] ? {} : { responsePhrase: 'unknown' }),
           ...(response.responseHeaders ? { responseHeaders: response.responseHeaders } : {}),
         }, response.sessionId)
       }
@@ -507,9 +527,19 @@ export class CdpFetchTransport {
       }
 
       if (!requestContinued) {
-        await this.safeSend('Fetch.continueRequest', {
-          requestId: event.requestId,
-        }, sessionId)
+        // A requested network error (cy.intercept forceNetworkError) must
+        // reach the page as one — MITM resets the connection; here the pause
+        // is failed. Everything else releases untouched as before.
+        if ((err as Error & { isForceNetworkError?: boolean })?.isForceNetworkError) {
+          await this.safeSend('Fetch.failRequest', {
+            requestId: event.requestId,
+            errorReason: 'Failed',
+          }, sessionId)
+        } else {
+          await this.safeSend('Fetch.continueRequest', {
+            requestId: event.requestId,
+          }, sessionId)
+        }
       } else {
         const continueRequestId = response?.requestId ?? responseRequestId
 

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -273,6 +273,7 @@ describe('CdpFetchTransport', () => {
         headers: {},
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -318,6 +319,7 @@ describe('CdpFetchTransport', () => {
         headers: {},
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
         bodySkipped: true,
       })
@@ -345,6 +347,7 @@ describe('CdpFetchTransport', () => {
         headers: {},
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
         bodySkipped: true,
         originalBodyDigest: digestBody(Buffer.alloc(0)),
@@ -377,6 +380,7 @@ describe('CdpFetchTransport', () => {
         headers: {},
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{ name: 'content-type', value: 'text/event-stream' }],
         bodySkipped: true,
         originalBodyDigest: digestBody(Buffer.alloc(0)),
@@ -411,6 +415,7 @@ describe('CdpFetchTransport', () => {
         headers: {},
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -426,6 +431,7 @@ describe('CdpFetchTransport', () => {
         body: Buffer.from('origin').toString('base64'),
         fulfilled: true,
         responseCode: 200,
+        responsePhrase: 'OK',
       })
     })
 
@@ -939,6 +945,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/html',
@@ -984,6 +991,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/html',
@@ -1063,6 +1071,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/css',
@@ -1355,6 +1364,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
         requestId: 'shared.0',
         responseCode: 0,
+        responsePhrase: 'unknown',
       })
     })
 
@@ -1451,6 +1461,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -1660,7 +1671,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.continueRequest', {
         requestId: 'fetch-request',
         method: 'POST',
-        postData: 'payload',
+        postData: 'cGF5bG9hZA==',
         headers: [{
           name: 'accept-encoding',
           value: 'gzip, deflate',
@@ -1739,6 +1750,65 @@ describe('CdpFetchTransport', () => {
       })
     })
 
+    it('continues the request with byte-accurate base64 when middleware sets a Buffer body', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      // bytes that a utf8 string round-trip would corrupt
+      const binaryBody = Buffer.from([0x23, 0x02, 0xff, 0x00, 0x9c])
+
+      httpIntercept.use(async (req, next) => {
+        req.body = binaryBody
+
+        return next(req)
+      })
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+      await onRequestPaused(createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 }))
+      await handled
+
+      const continueArgs = client.send.getCalls().find((call) => call.args[0] === 'Fetch.continueRequest')?.args[1]
+
+      expect(continueArgs.postData).to.equal(binaryBody.toString('base64'))
+    })
+
+    it('fails the request pause when middleware requests a network error', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      httpIntercept.use(async () => {
+        // cy.intercept forceNetworkError tags its error so the transport maps
+        // it to Fetch.failRequest instead of releasing the pause untouched
+        const err: Error & { isForceNetworkError?: boolean } = new Error('forceNetworkError called')
+
+        err.isForceNetworkError = true
+        throw err
+      })
+
+      await onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      expect(client.send).to.have.been.calledWith('Fetch.failRequest', {
+        requestId: 'fetch-request',
+        errorReason: 'Failed',
+      })
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.continueRequest', {
+        requestId: 'fetch-request',
+      })
+    })
+
     it('continues the request pause when middleware fails before the terminal path', async () => {
       const client = createClient()
       const httpIntercept = new HttpIntercept(createCdpFetchCodec())
@@ -1786,6 +1856,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 201,
+        responsePhrase: 'Created',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -2073,6 +2144,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 202,
+        responsePhrase: 'Accepted',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -2454,6 +2526,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -2503,6 +2576,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [{
           name: 'content-type',
           value: 'text/plain',
@@ -2791,6 +2865,7 @@ describe('CdpFetchTransport', () => {
       expect(client.send).to.have.been.calledWith('Fetch.fulfillRequest', {
         requestId: 'fetch-request',
         responseCode: 200,
+        responsePhrase: 'OK',
         responseHeaders: [],
         body: Buffer.from('mutated').toString('base64'),
       })


### PR DESCRIPTION
<!-- comment to trigger the PR template checks -->

- Closes #34605

### Additional details

Three CDP protocol violations in the Fetch transport made `cy.intercept` static stubs silently fall through to the wire under `CYPRESS_INTERNAL_DISABLE_PROXY=1`. All three are congenital (present since the transport's first commit, #34250), never caught because `net_stubbing.cy.ts` was never in a proxy-off gating job and the unit tests stub the CDP client. Each was verified against a real headless Chrome 151 with a direct CDP probe before fixing:

1. **Missing `responsePhrase`** — Chrome rejects `Fetch.fulfillRequest`/`Fetch.continueResponse` for any status code it has no built-in reason phrase for (`-32602 "Invalid http status code or phrase"`). The transport's catch then released the pause untouched, so `req.reply(777)` delivered the real origin 404. Fix: fulfilled (synthetic) responses always carry `STATUS_CODES[code] ?? 'unknown'`; `continueResponse` attaches a phrase **only when the code has no standard phrase** — for every known code it is omitted so the origin's own reason phrase survives the pass-through untouched.
2. **Plaintext `postData`** — `Fetch.continueRequest.postData` is a CDP binary param (base64 over JSON). Plaintext bodies failed deserialization (original body reached the origin); base64-shaped plaintext (e.g. `'quuz'`) was accepted and reached the origin as corrupted bytes. Fix: encode at the send site — the pause's own `event.request.postData` is plaintext, so the change-detection comparison stays as-is. **Implication worth reviewing:** a rejected `postData` previously discarded the *entire* `continueRequest` — method and header modifications riding the same call were silently dropped and the request went out pristine. With the encode in place, the full set of modifications now applies to requests that previously escaped untouched.
3. **`forceNetworkError` never produced a network error** — it maps to an error whose `DestroyResponse` stage destroys the synthetic res; the pipeline misread its own destroyed res as a browser cancel, clobbered the error, and the transport released the pause untouched. Fix: tag the requested error, and **carry the tag onto the browser-cancel error** the destroyed-res check already throws — the thrown type, the error-stage re-run, and every other destroyed-res path (browser cancels, unrelated middleware errors, MITM) are unchanged byte-for-byte; MITM already delivers the network error via the destroyed socket. The transport maps the tagged rejection to `Fetch.failRequest { errorReason: 'Failed' }` (`net::ERR_FAILED`, XHR status 0).

Two existing unit tests pinned the invalid parameter shapes (raw `postData`, phrase-less fulfill) as expected values; they're updated alongside, plus a new test for the failRequest mapping.

Fixes the "stub never engaged" (7 tests) and "request body not applied" (all 4 tests — the codec now threads Buffer bodies losslessly via `postDataBuffer`, so binary payloads reach the wire byte-accurate) families of `net_stubbing.cy.ts` failures. The remaining failures in that spec are known CDP-vs-MITM drift families (304/caching, abort semantics, error strings) tracked separately.

### Steps to test

- unit: `yarn workspace @packages/server test-unit -- cdp-fetch-transport` (87 passing), `yarn workspace @packages/net-stubbing test` (17), `yarn workspace @packages/proxy test` (1519)
- full-suite proof: this commit cherry-picked onto `bill/bugbash-cdp-full-suite` — `driver-integration-tests-chrome-cdp`'s `net_stubbing.cy.ts` failures should drop from 23 to ~11 (the remaining are the tracked drift families)

### How has the user experience changed?

N/A — internal `CYPRESS_INTERNAL_DISABLE_PROXY` behavior only.

### PR Tasks

- [ ] Have tests been added/updated? — yes (transport spec: new failRequest test + corrected contract expectations)
- [ ] Has the original issue or this PR been tagged in a changelog entry? — N/A (internal flag)
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? — N/A
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the network interception pipeline (proxy + CDP transport) used for cy.intercept under an internal flag; changes are targeted protocol fixes with broad unit coverage and limited blast radius outside proxy-off mode.
> 
> **Overview**
> Fixes three CDP Fetch protocol mismatches that made **`cy.intercept` static stubs silently hit the wire** when `CYPRESS_INTERNAL_DISABLE_PROXY=1` is set.
> 
> The CDP transport now sends **`responsePhrase`** on fulfill/continue (using Node’s `STATUS_CODES`, with **`unknown`** for non-standard codes), **base64-encodes `postData`** on `Fetch.continueRequest`, and maps **`forceNetworkError`** to **`Fetch.failRequest`** instead of releasing the pause. Net-stubbing tags forced network errors with **`isForceNetworkError`**, and the proxy pipeline rethrows that error when the synthetic response is destroyed so it is not treated as a browser cancel.
> 
> Unit expectations are updated for the corrected CDP shapes, including a new test for the fail-request path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f773189c2ad9de38bf39c7dbbd63bf1c7e141dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
