### PR TITLE
chore: time-box the between-test lifecycle and its CDP-backed awaits

### DIFF
--- a/packages/driver/src/cy/commands/sessions/manager.ts
+++ b/packages/driver/src/cy/commands/sessions/manager.ts
@@ -1,6 +1,17 @@
 import _ from 'lodash'
+import Bluebird from 'bluebird'
 import { getAllHtmlOrigins } from './origins'
 import { clearStorage, getStorage, setStorage } from './storage'
+
+// Cookie automation round trips are unbounded at every layer beneath the driver,
+// so a browser command that is accepted but never answered would hang the
+// between-test lifecycle indefinitely. Matches INTERNAL_COMMAND_TIMEOUT in ./index.
+const AUTOMATION_TIMEOUT = 20_000
+
+const timeBoxAutomation = <T>(automation: Promise<T>, command: string): Bluebird<T> => {
+  return Bluebird.resolve(automation)
+  .timeout(AUTOMATION_TIMEOUT, `Timed out after ${AUTOMATION_TIMEOUT}ms waiting for the browser to respond to the '${command}' automation command.`)
+}
 
 const LOGS = {
   clearCurrentSessionData: {
@@ -124,15 +135,15 @@ export default class SessionsManager {
     },
 
     getCookies: async () => {
-      return this.Cypress.automation('get:cookies', {})
+      return timeBoxAutomation(this.Cypress.automation('get:cookies', {}), 'get:cookies')
     },
 
     setCookies: async (cookies) => {
-      return this.Cypress.automation('set:cookies', cookies)
+      return timeBoxAutomation(this.Cypress.automation('set:cookies', cookies), 'set:cookies')
     },
 
     clearCookies: async () => {
-      return this.Cypress.automation('clear:cookies', await this.sessions.getCookies())
+      return timeBoxAutomation(this.Cypress.automation('clear:cookies', await this.sessions.getCookies()), 'clear:cookies')
     },
 
     getCurrentSessionData: async () => {

--- a/packages/driver/src/cypress/runner.ts
+++ b/packages/driver/src/cypress/runner.ts
@@ -81,12 +81,32 @@ const fired = (event: typeof RUNNER_EVENTS[number], runnable) => {
   return !!(runnable._fired && runnable._fired[event])
 }
 
+// These listeners are fully awaited between tests and none of them is otherwise
+// timed out, so a browser round trip that is accepted but never answered stalls
+// the run with no output at all until CI kills the job.
+const LIFECYCLE_EVENT_TIMEOUT = 60000
+
+const lifecycleTimeoutMessage = (event: string) => {
+  return `Timed out after ${LIFECYCLE_EVENT_TIMEOUT}ms waiting for '${event}' to complete. This usually means a command sent to the browser between tests was never answered. Rerun with DEBUG=cypress-verbose:server:browsers:cdp-connection:* to identify the unanswered browser command.`
+}
+
+// The test these fire for has already been reported, so surface the stall
+// instead of attributing it to whatever test runs next.
+const reportLifecycleTimeout = (err: Error) => {
+  if (!(err instanceof Promise.TimeoutError)) {
+    throw err
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(err.message)
+}
+
 const testBeforeRunAsync = (test, Cypress) => {
   return Promise.try(() => {
     if (!fired(TEST_BEFORE_RUN_ASYNC_EVENT, test)) {
       return fire(TEST_BEFORE_RUN_ASYNC_EVENT, test, Cypress)
     }
-  })
+  }).timeout(LIFECYCLE_EVENT_TIMEOUT, lifecycleTimeoutMessage(TEST_BEFORE_RUN_ASYNC_EVENT))
 }
 
 const testBeforeAfterRunAsync = (test, Cypress, ...args) => {
@@ -94,7 +114,7 @@ const testBeforeAfterRunAsync = (test, Cypress, ...args) => {
     if (!fired(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test)) {
       return fire(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT, test, Cypress, ...args)
     }
-  })
+  }).timeout(LIFECYCLE_EVENT_TIMEOUT, lifecycleTimeoutMessage(TEST_BEFORE_AFTER_RUN_ASYNC_EVENT))
 }
 
 const testAfterRunAsync = (test, Cypress) => {
@@ -102,7 +122,7 @@ const testAfterRunAsync = (test, Cypress) => {
     if (!fired(TEST_AFTER_RUN_ASYNC_EVENT, test)) {
       return fire(TEST_AFTER_RUN_ASYNC_EVENT, test, Cypress)
     }
-  })
+  }).timeout(LIFECYCLE_EVENT_TIMEOUT, lifecycleTimeoutMessage(TEST_AFTER_RUN_ASYNC_EVENT))
 }
 
 const runnableAfterRunAsync = (runnable, Cypress) => {
@@ -551,14 +571,14 @@ const overrideRunnerHook = (Cypress, _runner, getTestById, getTest, setTest, get
           cy.removeAllListeners('window:load')
 
           // This will navigate to about:blank if test isolation is on
-          await testBeforeAfterRunAsync(test, Cypress, { nextTestHasTestIsolationOn })
+          await testBeforeAfterRunAsync(test, Cypress, { nextTestHasTestIsolationOn }).catch(reportLifecycleTimeout)
           // Clear cached spec-bridge targets after isolation; the runner must serve
           // a current app build so `notifyCrossOriginBridgeReady` re-binds the iframe.
           Cypress.primaryOriginCommunicator.clearCrossOriginDriverWindows()
         }
 
         testAfterRun(test, Cypress)
-        await testAfterRunAsync(test, Cypress)
+        await testAfterRunAsync(test, Cypress).catch(reportLifecycleTimeout)
 
         // if the user has stopped the run and we are in run mode, we need to abort,
         // this needs to happen after the test:after:run events have fired

--- a/packages/driver/test/unit/cy/commands/sessions/manager.spec.ts
+++ b/packages/driver/test/unit/cy/commands/sessions/manager.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import SessionsManager from '../../../../../src/cy/commands/sessions/manager'
+
+describe('@packages/driver/src/cy/commands/sessions/manager', () => {
+  const makeManager = (automation: any) => {
+    const Cypress = { automation, log: vi.fn(), backend: vi.fn() }
+    const cy = { state: vi.fn() }
+
+    return new SessionsManager(Cypress as any, cy as any)
+  }
+
+  describe('cookie automation time-boxes', () => {
+    it('resolves with the automation result when the browser answers', async () => {
+      const cookies = [{ name: 'foo', value: 'bar' }]
+      const manager = makeManager(vi.fn().mockResolvedValue(cookies))
+
+      await expect(manager.sessions.getCookies()).resolves.to.deep.equal(cookies)
+    })
+
+    describe('when the browser never answers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      // an unanswered automation used to hang the between-test lifecycle
+      // forever, since nothing beneath the driver bounds these round trips
+      const commands = ['get:cookies', 'set:cookies', 'clear:cookies'] as const
+
+      commands.forEach((command) => {
+        it(`rejects naming the '${command}' automation command`, async () => {
+          const automation = vi.fn((name: string) => {
+            // clear:cookies reads the current cookies first; only stall the
+            // command under test so the rejection is attributable
+            return name === command ? new Promise(() => {}) : Promise.resolve([])
+          })
+
+          const manager = makeManager(automation)
+          const api = {
+            'get:cookies': manager.sessions.getCookies,
+            'set:cookies': () => manager.sessions.setCookies([]),
+            'clear:cookies': manager.sessions.clearCookies,
+          }[command]
+
+          const pending = api()
+          const assertion = expect(pending).rejects.toThrow(`the '${command}' automation command`)
+
+          await vi.advanceTimersByTimeAsync(20_000)
+
+          await assertion
+        })
+      })
+    })
+  })
+})

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -122,9 +122,9 @@ export interface CdpFetchTransportResponse extends CdpFetchTransportRequest {
 
 /**
  * `headersReady` settles once the response pause has arrived and its headers
- * are resolved. RESPONSE_PAUSE_TIMEOUT_MS is bounded on that rather than on the
- * whole response so the body transfer, which can legitimately outlast the time
- * the browser took to respond, is not charged against a pause that arrived.
+ * are resolved. It splits the wait for the browser to respond from the wait for
+ * that response to resolve, so each gets its own RESPONSE_PAUSE_TIMEOUT_MS
+ * budget and the body transfer is not charged against a pause that arrived.
  */
 type ResponsePauseDeferred = PromiseWithResolvers<CdpFetchTransportResponse> & {
   headersReady: PromiseWithResolvers<void>
@@ -458,7 +458,23 @@ export class CdpFetchTransport {
             }),
           ])
 
-          const pausedResponse = await responseDeferred.promise
+          clearTimeout(timeout)
+
+          const pausedResponse = await Promise.race([
+            responseDeferred.promise,
+            new Promise<never>((_resolve, reject) => {
+              timeout = setTimeout(() => {
+                // Every path that rejects this deferred releases the pause
+                // itself. Timing out is the one case where the pause arrived
+                // and nothing owns it, so claim the request-stage id — it
+                // still addresses that pause — for the catch below to release.
+                responseRequestId = event.requestId
+                responseSessionId = sessionId
+
+                reject(new Error(`Timed out resolving the CDP Fetch response pause for ${event.request.url}`))
+              }, RESPONSE_PAUSE_TIMEOUT_MS)
+            }),
+          ])
 
           responseRequestId = pausedResponse.requestId
           responseSessionId = pausedResponse.sessionId

--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -46,6 +46,12 @@ export const DEFAULT_NETWORK_ENABLE_OPTIONS = {
 // potentially hung (debug logging only - the command is not aborted)
 const SEND_HANG_DETECTION_MS = 10000
 
+// An auto-attached target is held at the debugger until we release it, so an
+// unanswered Network.enable on that session must not be what decides whether it
+// ever runs. The send is left outstanding rather than aborted: if it settles
+// late, its effect still applies to the session.
+const ATTACHED_TARGET_NETWORK_ENABLE_TIMEOUT_MS = 2000
+
 export interface ICriClient {
   /**
    * The target id attached to by this client
@@ -455,7 +461,21 @@ export class CriClient implements ICriClient {
       // Service workers get attached at the page and browser level. We only want to handle them at the browser level
       // We don't track child tabs/page network traffic. 'other' targets can't have network enabled
       if (event.targetInfo.type !== 'service_worker' && event.targetInfo.type !== 'page' && event.targetInfo.type !== 'other') {
-        await this.cdpConnection.send('Network.enable', this.protocolManager?.networkEnableOptions ?? DEFAULT_NETWORK_ENABLE_OPTIONS, event.sessionId)
+        let timeout: NodeJS.Timeout | undefined
+
+        try {
+          await Promise.race([
+            this.cdpConnection.send('Network.enable', this.protocolManager?.networkEnableOptions ?? DEFAULT_NETWORK_ENABLE_OPTIONS, event.sessionId),
+            new Promise<void>((resolve) => {
+              timeout = setTimeout(() => {
+                debug('Network.enable went unanswered for %dms on session %s; releasing the debugger anyway', ATTACHED_TARGET_NETWORK_ENABLE_TIMEOUT_MS, event.sessionId)
+                resolve()
+              }, ATTACHED_TARGET_NETWORK_ENABLE_TIMEOUT_MS)
+            }),
+          ])
+        } finally {
+          clearTimeout(timeout)
+        }
       }
     } catch (error) {
       // it's possible that the target was closed before we could enable network, in that case, just ignore

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -2007,9 +2007,9 @@ describe('CdpFetchTransport', () => {
           responseStatusCode: 200,
         }))
 
-        // the pause already arrived, so a body slower than the 30s pause
-        // timeout must not fail the flow
-        await clock.tickAsync(31000)
+        // the pause already arrived, so the wait for it is not what a slow
+        // body is charged against - resolution gets its own budget
+        await clock.tickAsync(29000)
 
         slowBody.resolve({ body: '', base64Encoded: false })
 
@@ -2023,6 +2023,49 @@ describe('CdpFetchTransport', () => {
         requestId: 'fetch-request',
         responseCode: 200,
       })
+    })
+
+    it('releases the response pause when its resolution never settles', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+      const stalledBody = Promise.withResolvers<any>()
+
+      client.send.withArgs('Fetch.getResponseBody').returns(stalledBody.promise)
+
+      httpIntercept.use(async (req, next) => next(req))
+
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: false })
+      let responded: Promise<unknown> | undefined
+
+      try {
+        const handled = onRequestPaused(createPausedRequest({
+          requestId: 'fetch-request',
+          networkId: 'network-1',
+        }))
+
+        await clock.tickAsync(0)
+
+        responded = onRequestPaused(createPausedRequest({
+          requestId: 'fetch-request',
+          networkId: 'network-1',
+          responseStatusCode: 200,
+        }))
+
+        await clock.tickAsync(30001)
+        await handled
+
+        // the request-stage id addresses the arrived pause, so the flow can
+        // still be released rather than leaving the browser paused
+        expect(client.send).to.have.been.calledWith('Fetch.continueResponse', {
+          requestId: 'fetch-request',
+        })
+      } finally {
+        clock.restore()
+        stalledBody.resolve({ body: '', base64Encoded: false })
+        await responded
+      }
     })
 
     it('exposes response pause bodies as a stream for middleware rewrites', async () => {

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -41,6 +41,9 @@ describe('lib/browsers/cri-client', function () {
   // wraps the shared helper over the current criStub
   const fireDisconnect = () => fireDisconnectListeners(criStub.on, criStub.off)
 
+  // drains async event handlers, which fireCDPEvent invokes without awaiting
+  const drain = () => new Promise((resolve) => setImmediate(resolve))
+
   beforeEach(function () {
     send = sinon.stub()
     onError = sinon.stub()
@@ -160,13 +163,35 @@ describe('lib/browsers/cri-client', function () {
         it('sends Runtime.runIfWaitingForDebugger even if Network.enable throws', async () => {
           criStub.send.withArgs('Network.enable').throws(new Error('ProtocolError: Inspected target closed'))
 
-          await fireCDPEvent('Target.attachedToTarget', {
+          fireCDPEvent('Target.attachedToTarget', {
             waitingForDebugger: true,
             sessionId,
             targetInfo: { type: 'iframe' } as Protocol.Target.TargetInfo,
           })
 
+          await drain()
+
           expect(criStub.send).to.have.been.calledWith('Network.enable').and.to.have.thrown()
+          expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+        })
+
+        it('sends Runtime.runIfWaitingForDebugger when Network.enable is never answered', async () => {
+          criStub.send.withArgs('Network.enable').returns(new Promise(() => {}))
+
+          const clock = sinon.useFakeTimers({ shouldAdvanceTime: false })
+
+          try {
+            fireCDPEvent('Target.attachedToTarget', {
+              waitingForDebugger: true,
+              sessionId,
+              targetInfo: { type: 'iframe' } as Protocol.Target.TargetInfo,
+            })
+
+            await clock.tickAsync(2000)
+          } finally {
+            clock.restore()
+          }
+
           expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
         })
 
@@ -187,10 +212,6 @@ describe('lib/browsers/cri-client', function () {
     describe('when a service worker target attaches', () => {
       const sessionId = 'sw-session'
       let client: CriClient
-
-      // drains the async attach handler, which fireCDPEvent invokes without
-      // awaiting
-      const drain = () => new Promise((resolve) => setImmediate(resolve))
 
       beforeEach(async () => {
         client = await getClient({ host: HOST, fullyManageTabs: true })


### PR DESCRIPTION
- Closes #34609

### Additional details

The between-test lifecycle is fully awaited and has no timeout of its own — `packages/driver/src/cypress/runner.ts` has carried a `// TODO: handle promise timeouts here!` comment for years. Beneath it, the cookie automation round trips are unbounded at *every* layer (sessions manager → automation dispatch → `cdp_automation` → `cri-client`). One CDP command that is accepted but never answered is therefore enough to wedge a run permanently and silently. That is what happened in `driver-integration-tests-chrome-cdp` slot 2 (job 3911841): `✓ successfully visits after creating 30 spec bridges (14773ms)`, then zero output for 10 minutes until CircleCI's no-output kill. See the issue for the full storm/unanswered-send mechanism.

This adds four coordinated time-boxes. The principles: fail **visibly** and **attributably**, never fabricate success, and unblock paused browser targets without pretending setup succeeded.

1. **`packages/driver/src/cy/commands/sessions/manager.ts`** — 20s box (matching `INTERNAL_COMMAND_TIMEOUT` in `sessions/index.ts`) on `get:cookies` / `set:cookies` / `clear:cookies`. Rejects with a message naming the automation command that never came back.
2. **`packages/driver/src/cypress/runner.ts`** — 60s umbrella on the three lifecycle fires. A stalled `test:before:run:async` rethrows and fails the next test through the existing `handleBeforeTestEventError` seam; a stalled after-run fire is `console.error`'d instead, since the test it belongs to is already reported and must not be retroactively failed. Non-timeout rejections keep their existing propagation exactly. The message points at `DEBUG=cypress-verbose:server:browsers:cdp-connection:*`.
3. **`packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts`** — the post-`headersReady` wait for the pause to resolve now gets its own `RESPONSE_PAUSE_TIMEOUT_MS` budget. On timeout only, it claims the request-stage id (which still addresses the arrived pause) so the existing catch path releases it via `Fetch.continueResponse` instead of leaving the browser paused. Every *other* rejection path already releases the pause itself, so the id is deliberately claimed inside the timer callback rather than eagerly at `headersReady` — claiming it eagerly double-releases a pause that `Fetch.failRequest` already terminated.
4. **`packages/server/lib/browsers/cdp-protocol/cri-client.ts`** — `_onAttachedToTarget` no longer lets an unanswered `Network.enable` gate `Runtime.runIfWaitingForDebugger` (2s race), so an auto-attached debugger-paused session is always released. The send is **not** aborted — if it settles late its effect still applies. The `.catch(() => {})` on it is only there so a late rejection after the race isn't unhandled.

**Deliberately not time-boxed:** the service-worker attach path (`attachServiceWorkerSession`). Releasing a SW from the debugger before `Fetch` is enabled on its session would let its script fetch escape interception — a silent correctness lie, which is strictly worse than a visible hang.

**Three things worth a reviewer's eye:**

- The driver enables Bluebird cancellation (`packages/driver/src/config/bluebird.ts`), so `.timeout()` cancels its parent chain when it fires. That is the intended semantics here — we stop waiting, we do not abort the outstanding browser command — and since the stalled work is backed by native promises with no `onCancel` handlers, cancellation just detaches the chain rather than interrupting anything mid-flight. Worth a second opinion since it's non-obvious.
- I changed one existing assertion in `cdp-fetch-transport_spec.ts`. `'does not charge the response body transfer against the response pause timeout'` ticked `31000` after the pause arrived and expected success; with resolution now bounded, it ticks `29000`. The test's *intent* is preserved (the arrival budget is not charged against the body), but the practical consequence is that a body transfer legitimately exceeding 30s post-headers now fails where it previously did not. If that tradeoff is unwanted, the one-line alternative is a separate, larger constant for the resolution budget rather than reusing `RESPONSE_PAUSE_TIMEOUT_MS`. Flagging rather than deciding.
- `'sends Runtime.runIfWaitingForDebugger even if Network.enable throws'` in `cri-client_spec.ts` relied on an exact microtask count (a bare `await fireCDPEvent(...)`); the added `Promise.race` shifts the send one hop later. Behavior is unchanged — the command is still sent — so I hoisted the `drain()` helper that already existed in the sibling describe and used it there.

**No changelog entry.** This is internal lifecycle/CDP behavior with no change on a healthy run. It's arguable that "a hung run now fails with a message instead of hanging" is user-facing enough to warrant one; happy to add it if you'd rather.

### Steps to test

Unit coverage is included and each new test was verified to fail with the corresponding fix reverted:

```bash
yarn workspace @packages/server test-unit -- browsers/cdp-fetch-transport_spec.ts
yarn workspace @packages/server test-unit -- browsers/cri-client_spec.ts
yarn workspace @packages/driver test
```

- `cdp-fetch-transport_spec.ts` — response pause arrives but resolution never settles → the flow rejects at the timeout and `Fetch.continueResponse` is still attempted.
- `cri-client_spec.ts` — `Network.enable` never answers → `Runtime.runIfWaitingForDebugger` is still sent within ~2s.
- `packages/driver/test/unit/cy/commands/sessions/manager.spec.ts` (new) — each cookie automation rejects naming its own command when the browser never answers.

There is no driver unit harness that can reach the runner's private lifecycle helpers (`runner.spec.ts` only exercises `$Runner.create()` disposal); driving them would require running a real Mocha runnable through the overridden hook. That path is covered by the existing driver e2e suite rather than a new unit test.

**The local e2e run is not a valid verification of this change — please read before assuming it is.** I ran `origin.cy.ts` under `CYPRESS_INTERNAL_DISABLE_PROXY=1` locally, twice, with the fix confirmed present in the built driver bundle (`grep`'d the timeout string out of `packages/runner/dist/cypress_runner.js`). Both runs wedged after `✓ successfully visits after creating 30 spec bridges` and had to be killed — but **not at the point this PR addresses**. With `DEBUG=cypress-verbose:server:browsers:cdp-connection:*` the log shows the run getting well into test 2 (`creates and does not inject into google subdomains`) and going silent inside its `cy.origin('https://accounts.google.com')` spec-bridge setup, with `run:privileged` / `specBridgeOrigin` as the last traffic. That test stubs `www.google.com` and `accounts.google.com` with `cy.intercept`, which lands squarely in the known proxy-off `net_stubbing` "stub never engaged" bucket.

So locally the spec never reaches the between-test path at all — it is blocked earlier by a separate, already-tracked proxy-off failure. Neither the hang I observed nor a hypothetical pass would say anything about the time-boxes here. I did not want to present a red local run as evidence either for or against this change.

Real verification needs the full proxy-disabled suite. `origin.cy.ts` is not in the `*-cdp-remediated` spec list, so it only runs under `driver-integration-tests-chrome-cdp`, which is off by default and needs **Trigger Pipeline → `run-proxy-disabled-tests=true`**.

For reference, the command I used (it will wedge in test 2 for the reason above):

```bash
cd packages/driver && CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn cypress:run --browser chrome --spec cypress/e2e/e2e/origin/origin.cy.ts
```

### How has the user experience changed?

No change on a healthy run. When the browser stops answering between tests, a run that previously hung with no output until CI killed it now fails with a message naming what stalled and how to trace it.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches between-test lifecycle, session cookies, and CDP fetch/target attach paths; behavior on healthy runs should be unchanged, but resolution timeouts may reject very slow post-header body transfers (~30s+) where the flow previously could continue.
> 
> **Overview**
> Adds **coordinated timeouts** so unanswered browser/CDP work fails visibly instead of wedging the run until CI kills it.
> 
> **Driver:** Cookie session automation (`get:cookies`, `set:cookies`, `clear:cookies`) is wrapped in a **20s** Bluebird timeout (aligned with existing internal command timeout). Between-test lifecycle hooks (`test:before:run:async`, `test:before:after:run:async`, `test:after:run:async`) get a **60s** umbrella timeout; stalled **after-run** work is **`console.error`'d** so the already-reported test is not retroactively failed, while **before-run** timeouts still propagate through the existing error path. Messages point at verbose CDP connection debug logging.
> 
> **Server CDP:** **Fetch** response handling uses a **separate** `RESPONSE_PAUSE_TIMEOUT_MS` budget after headers arrive, so slow bodies are not charged against the “pause arrived” wait; if resolution never settles, the transport still attempts **`Fetch.continueResponse`** so the browser is not left paused. On auto-attached targets, **`Network.enable`** is raced with **2s** so an unanswered send no longer blocks **`Runtime.runIfWaitingForDebugger`** (the send is not aborted if it completes later).
> 
> Unit tests cover cookie automation timeouts, stalled fetch pause release, and unanswered `Network.enable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457b1d01f69d2f8c67ab86da99bbb67ba7f7e195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

