### PR TITLE
chore: report CDP Fetch network errors as Node errors and stop synthesizing empty request bodies

### DIFF
--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-codec.ts
@@ -298,7 +298,13 @@ export function createCdpFetchCodec (): TransportCodecPort<CdpFetchTransportRequ
         transportRequest.headers = toNetworkHeaders(httpRequest.headers)
       }
 
-      if (httpRequest.body !== undefined) {
+      // The net-stubbing pipeline normalizes every intercepted request to a
+      // string body, so a request the browser paused without one arrives back
+      // here as `''` — indistinguishable from a body a handler emptied. Sending
+      // that as postData makes Chrome attach `Content-Length: 0` to requests
+      // that never had a body (#24407). Only an empty body the pause itself
+      // carried is a real change worth forwarding.
+      if (httpRequest.body !== undefined && (httpRequest.body.length > 0 || transportRequest.postData !== undefined)) {
         transportRequest.postData = toRequestPostData(httpRequest.body)
       }
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -9,6 +9,7 @@ import { digestBody } from './body-digest'
 import type { ICriClient } from './cri-client'
 import { createCdpFetchCodec } from './cdp-fetch-codec'
 import { CDPNetworkExtraInfo } from './cdp-network-extra-info'
+import { toNetworkError } from './cdp-network-error'
 import { AUT_FRAME_HEADER, EXTRA_TARGET_HEADER } from '../constants'
 import { normalizeResourceType } from './normalize-resource-type'
 import { shouldSkipResponseBody } from './should-skip-response-body'
@@ -581,7 +582,7 @@ export class CdpFetchTransport {
 
     if (event.responseErrorReason) {
       debug('response error pause for matched request %s: %s', event.request.url, event.responseErrorReason)
-      deferred.reject(new Error(`CDP Fetch response failed for ${event.request.url}: ${event.responseErrorReason}`))
+      deferred.reject(toNetworkError(event.request.url, event.responseErrorReason))
 
       await this.safeSend('Fetch.failRequest', {
         requestId: event.requestId,

--- a/packages/server/lib/browsers/cdp-protocol/cdp-network-error.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-network-error.ts
@@ -1,0 +1,75 @@
+import type { Protocol } from 'devtools-protocol'
+
+type NodeNetworkError = {
+  code: string
+  syscall: string
+  address?: 'host' | 'hostPort'
+}
+
+/**
+ * CDP net errors that name the same condition as a Node connection error.
+ *
+ * On the MITM path Cypress performs the upstream request itself, so a failed
+ * connection reaches `cy.intercept` as Node's own error — code and all. Under
+ * this transport the browser makes the request and reports the condition as a
+ * `Network.ErrorReason` instead. Translating the unambiguous ones keeps both
+ * the user-visible message and the driver's classification (`network-error.ts`
+ * selects the `responseTimeout` message off `ETIMEDOUT`/`ESOCKETTIMEDOUT`)
+ * independent of which transport ran.
+ *
+ * Reasons with no single Node equivalent — `Failed`, `Aborted`, `AccessDenied`,
+ * `BlockedByClient`, `BlockedByResponse`, `ConnectionFailed` — are deliberately
+ * absent: inventing a code for them would misreport what the browser saw.
+ */
+const NODE_NETWORK_ERRORS: Partial<Record<Protocol.Network.ErrorReason, NodeNetworkError>> = {
+  ConnectionRefused: { code: 'ECONNREFUSED', syscall: 'connect', address: 'hostPort' },
+  ConnectionReset: { code: 'ECONNRESET', syscall: 'read' },
+  ConnectionClosed: { code: 'ECONNRESET', syscall: 'read' },
+  ConnectionAborted: { code: 'ECONNABORTED', syscall: 'connect', address: 'hostPort' },
+  TimedOut: { code: 'ETIMEDOUT', syscall: 'connect', address: 'hostPort' },
+  NameNotResolved: { code: 'ENOTFOUND', syscall: 'getaddrinfo', address: 'host' },
+  AddressUnreachable: { code: 'EHOSTUNREACH', syscall: 'connect', address: 'hostPort' },
+  InternetDisconnected: { code: 'ENETUNREACH', syscall: 'connect', address: 'hostPort' },
+}
+
+// Node renders the peer as `host:port`, with an IPv6 literal unbracketed
+// (`connect ECONNREFUSED ::1:3333`).
+function formatAddress (url: string, address?: NodeNetworkError['address']): string {
+  if (!address) {
+    return ''
+  }
+
+  let parsed: URL
+
+  try {
+    parsed = new URL(url)
+  } catch {
+    return ''
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '')
+
+  if (address === 'host') {
+    return ` ${hostname}`
+  }
+
+  return ` ${hostname}:${parsed.port || (parsed.protocol === 'https:' ? '443' : '80')}`
+}
+
+/**
+ * Builds the error a failed CDP Fetch response pause rejects with, shaped like
+ * the Node error the MITM path would have produced for the same condition.
+ */
+export function toNetworkError (url: string, errorReason: Protocol.Network.ErrorReason): Error {
+  const mapped = NODE_NETWORK_ERRORS[errorReason]
+
+  if (!mapped) {
+    return new Error(`CDP Fetch response failed for ${url}: ${errorReason}`)
+  }
+
+  const err = new Error(`${mapped.syscall} ${mapped.code}${formatAddress(url, mapped.address)}`) as Error & { code: string }
+
+  err.code = mapped.code
+
+  return err
+}

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -5,6 +5,7 @@ import { HttpIntercept } from '@packages/network-interception'
 import { digestBody } from '../../../lib/browsers/cdp-protocol/body-digest'
 import { createCdpFetchCodec } from '../../../lib/browsers/cdp-protocol/cdp-fetch-codec'
 import { CdpFetchTransport } from '../../../lib/browsers/cdp-protocol/cdp-fetch-transport'
+import { toNetworkError } from '../../../lib/browsers/cdp-protocol/cdp-network-error'
 import { shouldSkipResponseBody } from '../../../lib/browsers/cdp-protocol/should-skip-response-body'
 
 function createPausedRequest (options: {
@@ -167,6 +168,64 @@ describe('CdpFetchTransport', () => {
     })
   })
 
+  describe('toNetworkError', () => {
+    it('reports a refused connection the way Node does', () => {
+      const err = toNetworkError('http://127.0.0.1:3333/should-err?_=1', 'ConnectionRefused') as Error & { code: string }
+
+      expect(err.message).to.equal('connect ECONNREFUSED 127.0.0.1:3333')
+      expect(err.code).to.equal('ECONNREFUSED')
+    })
+
+    it('infers the default port from the scheme when the URL omits it', () => {
+      expect(toNetworkError('https://example.test/thing', 'ConnectionRefused').message)
+      .to.equal('connect ECONNREFUSED example.test:443')
+
+      expect(toNetworkError('http://example.test/thing', 'ConnectionRefused').message)
+      .to.equal('connect ECONNREFUSED example.test:80')
+    })
+
+    it('unbrackets an IPv6 literal, matching Node', () => {
+      expect(toNetworkError('http://[::1]:3333/x', 'ConnectionRefused').message)
+      .to.equal('connect ECONNREFUSED ::1:3333')
+    })
+
+    it('carries a timeout code the driver classifies as a responseTimeout failure', () => {
+      const err = toNetworkError('http://example.test:8080/x', 'TimedOut') as Error & { code: string }
+
+      expect(err.message).to.equal('connect ETIMEDOUT example.test:8080')
+      expect(err.code).to.equal('ETIMEDOUT')
+    })
+
+    it('reports a DNS failure against the host alone', () => {
+      const err = toNetworkError('http://nope.invalid/x', 'NameNotResolved') as Error & { code: string }
+
+      expect(err.message).to.equal('getaddrinfo ENOTFOUND nope.invalid')
+      expect(err.code).to.equal('ENOTFOUND')
+    })
+
+    it('omits the address for reasons Node reports without one', () => {
+      const err = toNetworkError('http://example.test/x', 'ConnectionReset') as Error & { code: string }
+
+      expect(err.message).to.equal('read ECONNRESET')
+      expect(err.code).to.equal('ECONNRESET')
+    })
+
+    // Inventing a Node code for these would misreport what the browser saw.
+    it('falls back to naming the CDP reason when there is no Node equivalent', () => {
+      const err = toNetworkError('http://example.test/x', 'BlockedByClient') as Error & { code?: string }
+
+      expect(err.message).to.equal('CDP Fetch response failed for http://example.test/x: BlockedByClient')
+      expect(err.code).to.be.undefined
+    })
+
+    it('still produces a coded error when the URL cannot be parsed', () => {
+      const err = toNetworkError('not a url', 'ConnectionRefused') as Error & { code: string }
+
+      expect(err.message).to.equal('connect ECONNREFUSED')
+      expect(err.code).to.equal('ECONNREFUSED')
+    })
+  })
+
   describe('createCdpFetchCodec', () => {
     it('decodes CDP request pauses to the neutral request shape', () => {
       const codec = createCdpFetchCodec()
@@ -256,6 +315,68 @@ describe('CdpFetchTransport', () => {
           cookie: 'a=1; b=2',
         },
       })
+    })
+
+    // The net-stubbing pipeline hands every request back with a string body, so
+    // a bodyless GET returns as ''. Forwarding that as postData would make
+    // Chrome attach `Content-Length: 0` to a request that never had a body.
+    it('does not encode an empty body onto a request the browser paused without one', () => {
+      const codec = createCdpFetchCodec()
+      const transportRequest = {
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      }
+
+      const request = codec.decodeRequest(transportRequest)
+
+      codec.encodeRequest({
+        ...request,
+        headers: { foo: 'bar' },
+        body: '',
+      })
+
+      expect(transportRequest).not.to.have.property('postData')
+    })
+
+    it('encodes an emptied body when the pause carried one, so the change reaches the origin', () => {
+      const codec = createCdpFetchCodec()
+      const transportRequest = {
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'POST',
+        headers: {},
+        postData: 'original',
+      }
+
+      const request = codec.decodeRequest(transportRequest)
+
+      codec.encodeRequest({
+        ...request,
+        body: '',
+      })
+
+      expect(transportRequest.postData).to.equal('')
+    })
+
+    it('encodes a non-empty body onto a request the browser paused without one', () => {
+      const codec = createCdpFetchCodec()
+      const transportRequest = {
+        id: 'network-1',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      }
+
+      const request = codec.decodeRequest(transportRequest)
+
+      codec.encodeRequest({
+        ...request,
+        body: 'added',
+      })
+
+      expect(transportRequest).to.have.property('postData', 'added')
     })
 
     it('round trips CDP response pauses through the neutral response shape', () => {
@@ -1558,6 +1679,48 @@ describe('CdpFetchTransport', () => {
       // redirect hops reuse the network id — the next hop's Network events may
       // already be tracked, and wiping here would drop that hop's Set-Cookie
       expect(networkExtraInfo.clear).not.to.have.been.called
+    })
+
+    // The MITM path performs the upstream request itself, so cy.intercept sees
+    // Node's own connection error. The middleware must see the same thing here.
+    it('rejects a response error pause with the Node-shaped network error', async () => {
+      const client = createClient()
+      let capturedError: (Error & { code?: string }) | undefined
+
+      const httpIntercept = {
+        handle: async (request: any, next: (outbound: any) => Promise<any>) => {
+          try {
+            return await next(request)
+          } catch (err) {
+            capturedError = err as Error & { code?: string }
+
+            throw err
+          }
+        },
+      }
+
+      const { transport } = createTransport(client, { httpIntercept: httpIntercept as any })
+      const onRequestPaused = await startTransport(transport, client)
+
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        url: 'http://127.0.0.1:3333/should-err',
+      }))
+
+      await tick()
+
+      await onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        url: 'http://127.0.0.1:3333/should-err',
+        responseErrorReason: 'ConnectionRefused',
+      }))
+
+      await handled
+
+      expect(capturedError?.message).to.equal('connect ECONNREFUSED 127.0.0.1:3333')
+      expect(capturedError?.code).to.equal('ECONNREFUSED')
     })
 
     it('clears extraInfo tracking when the flow ends in a response error pause', async () => {

--- a/packages/server/test/unit/browsers/cdp-network-error_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-network-error_spec.ts
@@ -1,0 +1,115 @@
+const { expect } = require('../../spec_helper')
+
+import { toNetworkError } from '../../../lib/browsers/cdp-protocol/cdp-network-error'
+
+describe('lib/browsers/cdp-protocol/cdp-network-error', () => {
+  context('reasons with a Node equivalent produce the error the MITM path would have', () => {
+    // On the MITM path Cypress makes the upstream request itself, so cy.intercept
+    // and the driver's error classification see Node's own connection errors.
+    // These mappings keep message and `code` transport-independent.
+
+    it('ConnectionRefused → connect ECONNREFUSED host:port', () => {
+      const err = toNetworkError('http://127.0.0.1:3333/should-err', 'ConnectionRefused')
+
+      expect(err.message).to.equal('connect ECONNREFUSED 127.0.0.1:3333')
+      expect(err).to.have.property('code', 'ECONNREFUSED')
+    })
+
+    it('ConnectionReset → read ECONNRESET, with no peer address', () => {
+      // a reset happens mid-stream, after connect — Node reports the syscall
+      // that failed (read) and no address
+      const err = toNetworkError('http://localhost:3500/reset', 'ConnectionReset')
+
+      expect(err.message).to.equal('read ECONNRESET')
+      expect(err).to.have.property('code', 'ECONNRESET')
+    })
+
+    it('ConnectionClosed → read ECONNRESET, matching how Node surfaces an early close', () => {
+      const err = toNetworkError('http://localhost:3500/closed', 'ConnectionClosed')
+
+      expect(err.message).to.equal('read ECONNRESET')
+      expect(err).to.have.property('code', 'ECONNRESET')
+    })
+
+    it('ConnectionAborted → connect ECONNABORTED host:port', () => {
+      const err = toNetworkError('http://localhost:3500/aborted', 'ConnectionAborted')
+
+      expect(err.message).to.equal('connect ECONNABORTED localhost:3500')
+      expect(err).to.have.property('code', 'ECONNABORTED')
+    })
+
+    it('TimedOut → connect ETIMEDOUT host:port, which the driver classifies as a response timeout', () => {
+      // network-error.ts in the driver selects the responseTimeout message off
+      // ETIMEDOUT/ESOCKETTIMEDOUT — this mapping is what keeps that working
+      // when the browser, not Node, owns the connection
+      const err = toNetworkError('http://localhost:3500/slow', 'TimedOut')
+
+      expect(err.message).to.equal('connect ETIMEDOUT localhost:3500')
+      expect(err).to.have.property('code', 'ETIMEDOUT')
+    })
+
+    it('NameNotResolved → getaddrinfo ENOTFOUND host, with no port', () => {
+      // DNS failures name only the host — Node never got far enough to use a port
+      const err = toNetworkError('http://no.such.host.invalid:3500/x', 'NameNotResolved')
+
+      expect(err.message).to.equal('getaddrinfo ENOTFOUND no.such.host.invalid')
+      expect(err).to.have.property('code', 'ENOTFOUND')
+    })
+
+    it('AddressUnreachable → connect EHOSTUNREACH host:port', () => {
+      const err = toNetworkError('http://10.255.255.1:3500/x', 'AddressUnreachable')
+
+      expect(err.message).to.equal('connect EHOSTUNREACH 10.255.255.1:3500')
+      expect(err).to.have.property('code', 'EHOSTUNREACH')
+    })
+
+    it('InternetDisconnected → connect ENETUNREACH host:port', () => {
+      const err = toNetworkError('http://example.com:8080/x', 'InternetDisconnected')
+
+      expect(err.message).to.equal('connect ENETUNREACH example.com:8080')
+      expect(err).to.have.property('code', 'ENETUNREACH')
+    })
+  })
+
+  context('peer address formatting matches Node', () => {
+    it('fills the default port for https urls', () => {
+      const err = toNetworkError('https://example.com/x', 'ConnectionRefused')
+
+      expect(err.message).to.equal('connect ECONNREFUSED example.com:443')
+    })
+
+    it('fills the default port for http urls', () => {
+      const err = toNetworkError('http://example.com/x', 'ConnectionRefused')
+
+      expect(err.message).to.equal('connect ECONNREFUSED example.com:80')
+    })
+
+    it('renders IPv6 literals unbracketed, as Node does', () => {
+      const err = toNetworkError('http://[::1]:3333/x', 'ConnectionRefused')
+
+      expect(err.message).to.equal('connect ECONNREFUSED ::1:3333')
+    })
+
+    it('omits the address when the url cannot be parsed', () => {
+      const err = toNetworkError('not-a-url', 'ConnectionRefused')
+
+      expect(err.message).to.equal('connect ECONNREFUSED')
+      expect(err).to.have.property('code', 'ECONNREFUSED')
+    })
+  })
+
+  context('reasons with no single Node equivalent stay self-describing', () => {
+    // Inventing a Node code for these would misreport what the browser saw —
+    // e.g. `BlockedByClient` is not a connection failure at all.
+    const unmappedReasons = ['Failed', 'Aborted', 'AccessDenied', 'BlockedByClient', 'BlockedByResponse', 'ConnectionFailed'] as const
+
+    unmappedReasons.forEach((reason) => {
+      it(`${reason} → descriptive CDP message with no error code`, () => {
+        const err = toNetworkError('http://localhost:3500/x', reason)
+
+        expect(err.message).to.equal(`CDP Fetch response failed for http://localhost:3500/x: ${reason}`)
+        expect(err).not.to.have.property('code')
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- comment to trigger the PR template checks -->

- Refs #34611

Closes the two parity-fixable items from #34611. That issue also documents four drift families it does **not** close — the 304/cache, cancellation, `responseTimeout`, and request `content-length` failures — so it stays open.

### Additional details

Two MITM → CDP parity bugs behind `net_stubbing.cy.ts` failures under `CYPRESS_INTERNAL_DISABLE_PROXY=1`. Both were verified against a real headless Chrome 151 with a direct CDP probe before being fixed, the same way #34606 was.

**1. Network errors named the CDP reason instead of the Node error.** A failed response pause rejected with `CDP Fetch response failed for <url>: ConnectionRefused`, where the MITM path — which makes the upstream request itself and therefore surfaces Node's own error — reports `connect ECONNREFUSED 127.0.0.1:3333`.

The new `cdp-network-error.ts` maps the `Network.ErrorReason` values that name the same condition as a Node connection error onto that error's shape, `code` included. The code matters beyond the message: the driver's `network-error.ts` picks the `responseTimeout` error template off `ETIMEDOUT`/`ESOCKETTIMEDOUT`, so a timeout reported by the browser now classifies the same way one reported by Node does.

Deliberately **not** mapped: `Failed`, `Aborted`, `AccessDenied`, `BlockedByClient`, `BlockedByResponse`, `ConnectionFailed`. None has a single unambiguous Node equivalent, and assigning one would misreport what the browser saw — they keep naming the CDP reason. `Aborted` in particular may want to become a `BrowserConnectionClosedError` as part of the cancellation work described in #34611, but that needs its own evidence.

**2. `Content-Length: 0` was added to requests that never had a body.** `handle-intercept-request.ts` normalizes every intercepted request to a *string* body, so a request the browser paused without one comes back through the codec as `''`. The codec forwarded that as `Fetch.continueRequest`'s `postData`, and Chrome attaches `Content-Length: 0` to any request carrying one — so an intercepted bodyless GET reached the origin with a header it never had. This is exactly what the #24407 regression test (`does not calculate content-length on spied request if one does not exist on the initial request`) checks.

The codec now forwards an empty body only when the pause itself carried one, which keeps the case that matters in the other direction working: a handler emptying a real body still sends `postData: ''` so the change reaches the origin.

Probe output, Chrome 151, same GET continued two ways:

```
=== S2: GET continued with an empty-string postData ===
  ORIGIN saw content-length: "0"        <- today
=== S2b: same GET continued with headers only (no postData) ===
  ORIGIN saw content-length: undefined  <- after this change
```

**Conflict note.** #34606 (`bill/proxy-off-net-stubbing-cdp-contract`) also targets develop and edits `encodeRequest` in `cdp-fetch-codec.ts` a few lines from the change here, plus the `postData` gate in the transport. The two changes are complementary — that PR makes `postData` a correctly base64-encoded binary param, this one stops sending it when there is nothing to send — but whichever lands second will need a small textual merge in `encodeRequest`. Landing #34606 first is the easier order.

### Steps to test

Unit, all run locally on this branch:

- `yarn workspace @packages/server test-unit -- cdp-fetch-transport` — 98 passing (was 87; +11 new: 7 for the error mapping, 3 for the empty-body encoding, 1 asserting the mapped error reaches the middleware through the transport)
- `yarn workspace @packages/net-stubbing test` — 17 passing
- `yarn workspace @packages/proxy test` — 1519 passing
- `yarn workspace @packages/server check-ts` — clean
- `yarn lint --scope @packages/server` — 0 errors

Not run: the driver e2e spec itself (`net_stubbing.cy.ts`) does not run in this environment, so the end-to-end claim rests on the CDP probe plus unit coverage rather than a green spec. The proof run is `driver-integration-tests-chrome-cdp` — expect `fails test if network error occurs retrieving response and response is intercepted` and `does not calculate content-length on spied request if one does not exist on the initial request (if merging)` to flip to passing.

### How has the user experience changed?

No change for released behavior — `CYPRESS_INTERNAL_DISABLE_PROXY` is internal and off by default. Within that mode, `cy.intercept` network errors now read like the proxy-on ones (`connect ECONNREFUSED 127.0.0.1:3333` rather than `CDP Fetch response failed for ...: ConnectionRefused`).

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? — #34611
- [x] Have tests been added/updated? — 11 new unit tests
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — internal flag only
- [na] Have API changes been updated in the `type definitions`? — no API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP Fetch request continuation and intercept error propagation; scoped to internal proxy-off mode but affects how network failures and spied request headers behave in tests.
> 
> **Overview**
> Brings **CDP Fetch** net-stubbing behavior in line with the MITM proxy path when `CYPRESS_INTERNAL_DISABLE_PROXY` is on (refs #34611).
> 
> **Network errors:** Failed response pauses no longer reject with generic `CDP Fetch response failed for …: <reason>`. New `toNetworkError` maps unambiguous Chrome `Network.ErrorReason` values to Node-shaped errors (`message`, `code`, host/port formatting). `CdpFetchTransport` uses this on matched response error pauses so `cy.intercept` and driver logic (e.g. `responseTimeout` via `ETIMEDOUT`) match proxy-on behavior. Reasons without a clear Node equivalent still use the descriptive CDP message.
> 
> **Request bodies:** `encodeRequest` in `cdp-fetch-codec` no longer forwards an empty `postData` when the original pause had no body. Net-stubbing normalizes bodyless requests to `body: ''`, which previously made Chrome send `Content-Length: 0` (#24407). Empty bodies are still sent when the pause originally had `postData`, so handlers that clear a real body keep working.
> 
> Unit tests cover the mapper, codec empty-body rules, and end-to-end error propagation through the transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd89e320b073bfda86a7b2e3a5dd7f5f7dd9fceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->