### PR TITLE
chore: propagate browser request cancellation into the CDP Fetch runtime when the proxy is disabled

### DIFF
--- a/packages/proxy/lib/adapters/synthetic-express-context.ts
+++ b/packages/proxy/lib/adapters/synthetic-express-context.ts
@@ -123,6 +123,11 @@ export type SyntheticCypressResponse = CypressOutgoingResponseLike & {
   getCapturedStatusCode (): number
 }
 
+export type SyntheticExpressContext = {
+  req: CypressIncomingRequest
+  res: SyntheticCypressResponse
+}
+
 class SyntheticResponse extends Writable {
   private readonly kOutHeaders = Symbol('kOutHeaders')
   isInitial: null | boolean = null
@@ -279,10 +284,24 @@ export function createSyntheticIncomingResponse (response: HttpResponse): Incomi
   return incomingRes
 }
 
-export function createSyntheticExpressContext (request: HttpRequest): {
-  req: CypressIncomingRequest
-  res: SyntheticCypressResponse
-} {
+/**
+ * Reproduces what a browser-canceled request leaves behind on the MITM path,
+ * where the proxy socket dies: `req` destroyed and `res` closed. The legacy
+ * pipeline keys its cancellation handling on exactly those two signals
+ * (CorrelateBrowserPreRequest's `close` listener, and the `res.destroyed`
+ * check after the request stage), so nothing else has to know this transport
+ * has no socket to close.
+ */
+export function abortSyntheticExpressContext ({ req, res }: SyntheticExpressContext): void {
+  if (res.destroyed) {
+    return
+  }
+
+  req.destroy()
+  res.destroy()
+}
+
+export function createSyntheticExpressContext (request: HttpRequest): SyntheticExpressContext {
   const req = createRequestBodyStream(request.body) as CypressIncomingRequest
   const headers = lowercaseHeaders(request.headers ?? {})
 

--- a/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
+++ b/packages/proxy/lib/adapters/synthetic-proxy-codec.ts
@@ -3,11 +3,12 @@ import type { HttpRequest, HttpResponse, TransportCodecPort } from '@packages/ne
 import type { HttpMiddlewareCtx } from '../http'
 import { createProxyHttpCodec } from './http-codec'
 import {
+  abortSyntheticExpressContext,
   createRequestBodyStream,
   createSyntheticExpressContext,
   createSyntheticIncomingResponse,
 } from './synthetic-express-context'
-import type { SyntheticCypressResponse } from './synthetic-express-context'
+import type { SyntheticCypressResponse, SyntheticExpressContext } from './synthetic-express-context'
 import type { ResponseInterceptionMiddlewareCtx } from './types'
 
 const WIRE_ENCODING_HEADERS = new Set(['content-encoding', 'content-length', 'transfer-encoding'])
@@ -98,6 +99,16 @@ type SyntheticProxyCodecOptions = {
   ) => HttpMiddlewareCtx<any>
 }
 
+export type SyntheticProxyCodec = TransportCodecPort<HttpMiddlewareCtx<any>, HttpMiddlewareCtx<any>> & {
+  /**
+   * Tears down the synthetic exchange for an in-flight request the browser
+   * canceled. A transport whose cancellation signal is out of band (CDP
+   * Network.loadingFailed) has no other way to reach the exchange, and without
+   * it the flow sits in pre-request correlation until that timer expires.
+   */
+  abortRequest (id: string): void
+}
+
 /**
  * Proxy codec variant for transports that start from a neutral HttpRequest
  * (e.g. CDP Fetch) instead of a real Express req/res. Synthesizes the middleware
@@ -106,18 +117,28 @@ type SyntheticProxyCodecOptions = {
  */
 export function createSyntheticProxyCodec (
   options: SyntheticProxyCodecOptions,
-): TransportCodecPort<HttpMiddlewareCtx<any>, HttpMiddlewareCtx<any>> {
+): SyntheticProxyCodec {
   const coreCodec = createProxyHttpCodec()
+  const inFlightExchanges = new Map<string, SyntheticExpressContext>()
 
   return {
     encodeRequest (request: HttpRequest): HttpMiddlewareCtx<any> {
-      const { req, res } = createSyntheticExpressContext(request)
-      const ctx = options.createMiddlewareContext(req, res)
+      const exchange = createSyntheticExpressContext(request)
+      const ctx = options.createMiddlewareContext(exchange.req, exchange.res)
 
       ctx.id = request.id
       coreCodec.decodeRequest(ctx)
+      inFlightExchanges.set(request.id, exchange)
 
       return ctx
+    },
+
+    abortRequest (id: string): void {
+      const exchange = inFlightExchanges.get(id)
+
+      if (exchange) {
+        abortSyntheticExpressContext(exchange)
+      }
     },
 
     decodeRequest (ctx: HttpMiddlewareCtx<any>): HttpRequest {
@@ -169,6 +190,7 @@ export function createSyntheticProxyCodec (
     },
 
     releaseRequest (id: string): void {
+      inFlightExchanges.delete(id)
       coreCodec.releaseRequest?.(id)
     },
   }

--- a/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
+++ b/packages/proxy/test/unit/adapters/synthetic-proxy-codec.spec.ts
@@ -660,4 +660,76 @@ describe('createSyntheticProxyCodec', () => {
     expect(maybeSetBasicAuthHeadersRan).to.equal(true)
     expect(skippedMiddlewareRan).to.equal(false)
   })
+
+  describe('abortRequest', () => {
+    function createCodec () {
+      return createSyntheticProxyCodec({
+        createMiddlewareContext: (req, res) => {
+          return {
+            req,
+            res,
+          } as any
+        },
+      })
+    }
+
+    it('destroys the exchange of an in-flight request', async () => {
+      const codec = createCodec()
+      const ctx = codec.encodeRequest({
+        id: 'network-abort',
+        url: 'https://example.test/1mb',
+        method: 'GET',
+        headers: {},
+      })
+
+      const closed = new Promise<void>((resolve) => ctx.res.once('close', () => resolve()))
+
+      codec.abortRequest('network-abort')
+
+      await closed
+
+      expect(ctx.req.destroyed, 'req destroyed').to.equal(true)
+      expect(ctx.res.destroyed, 'res destroyed').to.equal(true)
+    })
+
+    it('is a no-op for an unknown request id', () => {
+      expect(() => createCodec().abortRequest('never-seen')).not.to.throw()
+    })
+
+    it('is a no-op once the request has been released', () => {
+      const codec = createCodec()
+      const ctx = codec.encodeRequest({
+        id: 'network-released',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      codec.releaseRequest?.('network-released')
+      codec.abortRequest('network-released')
+
+      expect(ctx.res.destroyed).to.equal(false)
+    })
+
+    it('does not re-destroy an exchange that is already aborted', () => {
+      const codec = createCodec()
+      const ctx = codec.encodeRequest({
+        id: 'network-twice',
+        url: 'https://example.test/',
+        method: 'GET',
+        headers: {},
+      })
+
+      let closeCount = 0
+
+      ctx.res.on('close', () => closeCount++)
+
+      codec.abortRequest('network-twice')
+      codec.abortRequest('network-twice')
+
+      return new Promise<void>((resolve) => setTimeout(resolve, 10)).then(() => {
+        expect(closeCount).to.equal(1)
+      })
+    })
+  })
 })

--- a/packages/proxy/test/unit/http/index.spec.ts
+++ b/packages/proxy/test/unit/http/index.spec.ts
@@ -4,6 +4,9 @@ import { BrowserPreRequest } from '../../../lib'
 import type CyServer from '@packages/server'
 import { HttpIntercept } from '@packages/network-interception'
 import { proxyHttpCodec } from '../../../lib/adapters/http-codec'
+import { correlateBrowserPreRequest } from '../../../lib/adapters/correlate-browser-pre-request'
+import { createSyntheticProxyCodec } from '../../../lib/adapters/synthetic-proxy-codec'
+import RequestMiddleware from '../../../lib/http/request-middleware'
 import * as sendRequestOutgoingModule from '../../../lib/http/send-request-outgoing'
 
 describe('http', function () {
@@ -593,6 +596,77 @@ describe('http', function () {
       http.handleServiceWorkerClientEvent(event)
 
       expect(handleServiceWorkerClientEventStub).toHaveBeenCalledWith(event)
+    })
+  })
+
+  // The synthetic exchange has no socket, so browser cancellation reaches the
+  // pipeline out of band (the CDP Fetch transport calls abortRequest) rather
+  // than through a dying connection the way the MITM path does.
+  describe('createLegacyProxyPipeline over a synthetic exchange', function () {
+    function createSyntheticPipeline () {
+      const http = new Http({
+        config: {} as CyServer.Config,
+        shouldCorrelatePreRequests: () => true,
+        networkInterceptionCore: { correlateBrowserPreRequest } as any,
+        request: { rp: vi.fn() },
+        middleware: {
+          [HttpStages.IncomingRequest]: {
+            CorrelateBrowserPreRequest: RequestMiddleware.CorrelateBrowserPreRequest,
+          },
+          [HttpStages.IncomingResponse]: {},
+          [HttpStages.Error]: {
+            error () {
+              this.end()
+            },
+          },
+        },
+      } as unknown as ServerCtx & { middleware?: HttpMiddlewareStacks })
+
+      const codec = createSyntheticProxyCodec({
+        createMiddlewareContext: (req, res) => http.createMiddlewareContext(req, res),
+      })
+
+      return { http, codec, pipeline: http.createLegacyProxyPipeline(codec) }
+    }
+
+    const request = {
+      id: 'network-1',
+      url: 'http://localhost:3500/1mb',
+      method: 'GET',
+      headers: {},
+    }
+
+    it('releases the pending pre-request when the request is aborted', async function () {
+      const { http, codec, pipeline } = createSyntheticPipeline()
+      const next = vi.fn()
+      const handled = pipeline(request, next)
+
+      await vi.waitFor(() => {
+        expect(http.preRequests.pendingRequests.length).toEqual(1)
+      })
+
+      codec.abortRequest('network-1')
+
+      await expect(handled).rejects.toThrow('The browser closed the connection before the response completed.')
+
+      // the pre-request timer is cleared with it — an expiry is what logs the
+      // "Never received pre-request" warning and inflates unmatchedRequests
+      expect(http.preRequests.pendingRequests.length).toEqual(0)
+      expect(next, 'origin fetch').not.toHaveBeenCalled()
+    })
+
+    it('keeps waiting on the pre-request while the request is not aborted', async function () {
+      const { http, pipeline } = createSyntheticPipeline()
+
+      pipeline(request, vi.fn())
+
+      await vi.waitFor(() => {
+        expect(http.preRequests.pendingRequests.length).toEqual(1)
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      expect(http.preRequests.pendingRequests.length).toEqual(1)
     })
   })
 })

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -100,6 +100,12 @@ type CdpFetchTransportOptions = {
    * once) while the page keeps its impersonated URL.
    */
   resolveOriginRedirect?: (url: string) => { url: string, headers: Record<string, string> } | undefined
+  /**
+   * Called with the HttpIntercept request id when the browser cancels a
+   * request that is still paused in the middleware onion, so the pipeline can
+   * tear the flow down the way a closed proxy socket does on the MITM path.
+   */
+  onRequestCanceled?: (requestId: string) => void
 }
 
 export interface CdpFetchTransportRequest extends CdpFetchRequest {
@@ -128,10 +134,18 @@ export interface CdpFetchTransportResponse extends CdpFetchTransportRequest {
  */
 type ResponsePauseDeferred = PromiseWithResolvers<CdpFetchTransportResponse> & {
   headersReady: PromiseWithResolvers<void>
+  // key into inFlightByNetworkId; absent when the pause carried no networkId
+  networkKey?: string
 }
 
 export class CdpFetchTransport {
   private readonly inFlightRequests = new Map<string, ResponsePauseDeferred>()
+  /**
+   * The same flows as `inFlightRequests`, keyed by session-scoped Network
+   * request id. Cancellation only ever arrives on the Network domain
+   * (`Network.loadingFailed`), which knows nothing about Fetch request ids.
+   */
+  private readonly inFlightByNetworkId = new Map<string, ResponsePauseDeferred>()
   /**
    * Prefix for HttpIntercept / synthetic-codec request ids when this transport
    * owns an extra-target session. CDP network/request ids are only unique per
@@ -216,6 +230,9 @@ export class CdpFetchTransport {
     debug('starting CDP Fetch transport')
     this.client.on('Fetch.requestPaused', this.interceptRequest)
     this.client.on('Fetch.requestPaused', this.resolveResponse)
+    // The Fetch domain reports nothing when a paused request is canceled, so
+    // the Network domain is the only signal that a flow is never coming back.
+    this.client.on('Network.loadingFailed', this.onLoadingFailed)
     // Set-Cookie never appears on Fetch response pauses — the raw cookie
     // headers only arrive on the Network extraInfo events tracked here.
     this.networkExtraInfo.start()
@@ -228,6 +245,7 @@ export class CdpFetchTransport {
     } catch (err) {
       this.client.off('Fetch.requestPaused', this.interceptRequest)
       this.client.off('Fetch.requestPaused', this.resolveResponse)
+      this.client.off('Network.loadingFailed', this.onLoadingFailed)
       this.networkExtraInfo.stop()
       this.isStarted = false
 
@@ -283,11 +301,51 @@ export class CdpFetchTransport {
     } finally {
       this.client.off('Fetch.requestPaused', this.interceptRequest)
       this.client.off('Fetch.requestPaused', this.resolveResponse)
+      this.client.off('Network.loadingFailed', this.onLoadingFailed)
       this.rejectAll(new Error('CDP Fetch transport stopped'))
       this.networkExtraInfo.stop()
       this.isStarted = false
       debug('CDP Fetch transport stopped')
     }
+  }
+
+  /**
+   * The browser canceling a paused request — test isolation navigating to
+   * about:blank is the common case — leaves its flow with nothing to wait for:
+   * CDP emits no Fetch event for an abandoned pause, and the request never
+   * reaches the network, so no pre-request or response pause is ever coming.
+   *
+   * Propagating the cancellation lets the pipeline's existing teardown run,
+   * which on the MITM path is driven by the dying proxy socket. Both halves
+   * are needed and neither is a no-op for the other's case: the abort covers a
+   * flow still in request middleware (typically parked in pre-request
+   * correlation, whose 2s timer would otherwise expire and log a warning), the
+   * rejection covers one already continued and waiting on a response pause.
+   */
+  private onLoadingFailed = (event: Protocol.Network.LoadingFailedEvent, sessionId?: string): void => {
+    // A request that failed on the wire still gets a Fetch response pause
+    // carrying its error reason — resolveResponse owns those, and treating
+    // them as cancellations here would silence a real failure.
+    if (!event.canceled) {
+      return
+    }
+
+    const networkKey = this.getNetworkKey(event.requestId, sessionId)
+    const deferred = this.inFlightByNetworkId.get(networkKey)
+
+    if (!deferred) {
+      return
+    }
+
+    debug('browser canceled in-flight request %s', networkKey)
+
+    this.inFlightByNetworkId.delete(networkKey)
+    this.options.onRequestCanceled?.(`${this.requestIdPrefix}${event.requestId}`)
+    deferred.reject(new Error(`CDP Fetch request canceled by the browser: ${networkKey}`))
+  }
+
+  private getNetworkKey (networkRequestId: string, sessionId?: string): string {
+    return `${sessionId ?? 'root'}:${networkRequestId}`
   }
 
   private interceptRequest = async (event: Protocol.Fetch.RequestPausedEvent, sessionId?: string): Promise<void> => {
@@ -408,6 +466,7 @@ export class CdpFetchTransport {
       const responseDeferred: ResponsePauseDeferred = {
         ...Promise.withResolvers<CdpFetchTransportResponse>(),
         headersReady: Promise.withResolvers<void>(),
+        ...(event.networkId ? { networkKey: this.getNetworkKey(event.networkId, sessionId) } : {}),
       }
 
       // reset()/stop() may reject this before the continue callback races on
@@ -422,6 +481,10 @@ export class CdpFetchTransport {
       deferred = responseDeferred
 
       this.inFlightRequests.set(fetchRequestId, deferred)
+
+      if (deferred.networkKey) {
+        this.inFlightByNetworkId.set(deferred.networkKey, deferred)
+      }
 
       response = await this.httpIntercept.handle(request, async (outbound) => {
         const headers = await this.continueRequestHeaders(event, outbound)
@@ -764,6 +827,10 @@ export class CdpFetchTransport {
     }
 
     this.inFlightRequests.delete(fetchRequestId)
+
+    if (deferred?.networkKey && this.inFlightByNetworkId.get(deferred.networkKey) === deferred) {
+      this.inFlightByNetworkId.delete(deferred.networkKey)
+    }
   }
 
   private rejectAll (err: Error): void {

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -204,12 +204,18 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
 
   networkProxy.withIntercept(expressInterception)
 
+  const syntheticCodec = createSyntheticProxyCodec({
+    createMiddlewareContext: (req, res) => networkProxy.http.createMiddlewareContext(req, res),
+  })
+
   const networkInterception = attachStages(
     new HttpIntercept(createCdpFetchCodec()),
-    createSyntheticProxyCodec({
-      createMiddlewareContext: (req, res) => networkProxy.http.createMiddlewareContext(req, res),
-    }),
+    syntheticCodec,
   )
+
+  // Every transport shares one synthetic codec, so a canceled request is torn
+  // down through the same exchange map no matter which target it paused on.
+  const onRequestCanceled = (requestId: string) => syntheticCodec.abortRequest(requestId)
 
   // Send strategy:file requests to the origin server over the wire, and let
   // Express serve them from the file server, rather than answering the pause
@@ -251,6 +257,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     // pre-register so CorrelateBrowserPreRequest does not wait the full timeout.
     addPendingUrlWithoutPreRequest: (url) => networkProxy.addPendingUrlWithoutPreRequest(url),
     resolveOriginRedirect,
+    onRequestCanceled,
   })
 
   // Extra-target transports share networkInterception so they cannot drift from
@@ -288,6 +295,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
       const extraTransport = new CdpFetchTransport(client, networkInterception, {
         isFromExtraTarget: true,
         resolveOriginRedirect,
+        onRequestCanceled,
       })
 
       await extraTransport.start()

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -62,15 +62,32 @@ function createTransport (client: ReturnType<typeof createClient>, options: {
   isAUTFrame?: (frameId: string) => Promise<boolean>
   isFromExtraTarget?: boolean
   addPendingUrlWithoutPreRequest?: (url: string) => void
+  onRequestCanceled?: (requestId: string) => void
 } = {}) {
   const networkExtraInfo = createNetworkExtraInfo()
   const transport = new CdpFetchTransport(client as any, options.httpIntercept, {
     isAUTFrame: options.isAUTFrame,
     isFromExtraTarget: options.isFromExtraTarget,
     addPendingUrlWithoutPreRequest: options.addPendingUrlWithoutPreRequest,
+    onRequestCanceled: options.onRequestCanceled,
   }, networkExtraInfo as any)
 
   return { transport, networkExtraInfo }
+}
+
+function onLoadingFailed (client: ReturnType<typeof createClient>, event: {
+  requestId: string
+  canceled?: boolean
+  errorText?: string
+}, sessionId?: string) {
+  client.on.withArgs('Network.loadingFailed').getCalls().forEach((call) => {
+    call.args[1]({
+      canceled: false,
+      errorText: 'net::ERR_ABORTED',
+      type: 'Fetch',
+      ...event,
+    } as Protocol.Network.LoadingFailedEvent, sessionId)
+  })
 }
 
 async function startTransport (transport: CdpFetchTransport, client: ReturnType<typeof createClient>) {
@@ -2328,6 +2345,7 @@ describe('CdpFetchTransport', () => {
       expect(client.on.getCalls().map((call) => call.args[0])).to.deep.equal([
         'Fetch.requestPaused',
         'Fetch.requestPaused',
+        'Network.loadingFailed',
       ])
 
       expect(networkExtraInfo.start).to.have.been.calledOnce
@@ -2363,6 +2381,7 @@ describe('CdpFetchTransport', () => {
       expect(client.on.getCalls().map((call) => call.args[0])).to.deep.equal([
         'Fetch.requestPaused',
         'Fetch.requestPaused',
+        'Network.loadingFailed',
       ])
 
       expect(networkExtraInfo.start).to.have.been.calledTwice
@@ -2794,6 +2813,194 @@ describe('CdpFetchTransport', () => {
         responseHeaders: [],
         body: Buffer.from('mutated').toString('base64'),
       })
+    })
+  })
+
+  describe('browser request cancellation', () => {
+    // Parks a flow in the middleware onion the way pre-request correlation
+    // does, so the cancellation arrives while the request pause is still held.
+    function parkedIntercept () {
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const parked = Promise.withResolvers<any>()
+
+      httpIntercept.use(async () => parked.promise)
+
+      return { httpIntercept, parked }
+    }
+
+    it('aborts a flow still paused in the middleware onion', async () => {
+      const client = createClient()
+      const { httpIntercept, parked } = parkedIntercept()
+      const onRequestCanceled = sinon.stub().callsFake(() => {
+        parked.reject(new Error('request destroyed before browser pre-request was received'))
+      })
+
+      const { transport } = createTransport(client, { httpIntercept, onRequestCanceled })
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.continueRequest')
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true })
+
+      await handled
+
+      expect(onRequestCanceled).to.have.been.calledOnceWith('network-1')
+      // the pause is released rather than left held; the request is already
+      // gone, so CDP rejecting this is expected and swallowed
+      expect(client.send).to.have.been.calledWith('Fetch.continueRequest', {
+        requestId: 'fetch-request',
+      })
+    })
+
+    it('does not strand a continueResponse when the cancellation lands after the request was continued', async () => {
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      expect(client.send).to.have.been.calledWith('Fetch.continueRequest', {
+        requestId: 'fetch-request',
+      })
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true })
+
+      await handled
+
+      // no response pause ever arrived for this flow, so there is no pause left
+      // to release — sending one would target a request id CDP no longer knows
+      expect(client.send).not.to.have.been.calledWith('Fetch.continueResponse')
+      expect(client.send).not.to.have.been.calledWith('Fetch.fulfillRequest')
+    })
+
+    it('leaves a genuine network failure to the response error pause', async () => {
+      const client = createClient()
+      const { httpIntercept, parked } = parkedIntercept()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { httpIntercept, onRequestCanceled })
+      const onRequestPaused = await startTransport(transport, client)
+
+      onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: false, errorText: 'net::ERR_CONNECTION_REFUSED' })
+
+      expect(onRequestCanceled).not.to.have.been.called
+
+      parked.reject(new Error('unparked'))
+      await tick()
+    })
+
+    it('ignores a cancellation for a request it never paused', async () => {
+      const client = createClient()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { onRequestCanceled })
+
+      await startTransport(transport, client)
+
+      onLoadingFailed(client, { requestId: 'never-paused', canceled: true })
+
+      expect(onRequestCanceled).not.to.have.been.called
+    })
+
+    it('scopes cancellation to the session the request paused on', async () => {
+      const client = createClient()
+      const { httpIntercept, parked } = parkedIntercept()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { httpIntercept, onRequestCanceled })
+      const onRequestPaused = await startTransport(transport, client)
+
+      onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }), 'service-worker-session')
+
+      await tick()
+
+      // CDP request ids are only unique per session
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true })
+
+      expect(onRequestCanceled).not.to.have.been.called
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true }, 'service-worker-session')
+
+      expect(onRequestCanceled).to.have.been.calledOnceWith('network-1')
+
+      parked.reject(new Error('unparked'))
+      await tick()
+    })
+
+    it('namespaces the canceled request id for an extra-target transport', async () => {
+      const client = createClient()
+      const { httpIntercept, parked } = parkedIntercept()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { httpIntercept, onRequestCanceled, isFromExtraTarget: true })
+      const onRequestPaused = await startTransport(transport, client)
+
+      onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true })
+
+      // must match the id the shared HttpIntercept was handed
+      expect(onRequestCanceled.firstCall.args[0]).to.match(/^extra-\d+:network-1$/)
+
+      parked.reject(new Error('unparked'))
+      await tick()
+    })
+
+    it('stops cancelling once the flow has completed', async () => {
+      const client = createClient()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { onRequestCanceled })
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+      }))
+
+      await tick()
+
+      await onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        responseStatusCode: 200,
+      }))
+
+      await handled
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: true })
+
+      expect(onRequestCanceled).not.to.have.been.called
+    })
+
+    it('unsubscribes from Network.loadingFailed on stop', async () => {
+      const client = createClient()
+      const { transport } = createTransport(client)
+
+      await transport.start()
+      await transport.stop()
+
+      expect(client.off).to.have.been.calledWith('Network.loadingFailed')
     })
   })
 })


### PR DESCRIPTION
- Closes #34613

### Additional details

Under `CYPRESS_INTERNAL_DISABLE_PROXY=1`, a request the browser cancels while it is paused at the CDP Fetch request stage strands its flow in the middleware onion. CDP emits no Fetch-domain event for an abandoned pause, and the request never reaches the network, so neither a pre-request nor a response pause is ever coming. The flow burns its full 2s pre-request correlation timeout, logs `Never received pre-request or url without pre-request for request ...`, and inflates `unmatchedRequests`. That warning is exactly what `proxy_correlation_spec` asserts must be absent, which is why it fails 7 of 8 proxy-off runs.

The MITM path is immune at precisely this seam: browser cancellation destroys the proxy socket, `CorrelateBrowserPreRequest`'s `res.once('close')` listener fires, and `onError` → `removePendingRequest` clears the timer silently. The synthetic exchange has no socket, so nothing fires.

This propagates the cancellation into the CDP Fetch runtime so that **existing** cleanup path runs, rather than adding new cleanup:

- `CdpFetchTransport` indexes in-flight flows by session-scoped Network request id (CDP request ids are only unique per session) and subscribes to `Network.loadingFailed`.
- On a canceled flow it calls the new `onRequestCanceled` hook and rejects the response-pause deferred. Both halves are load-bearing: the hook covers a flow still in request middleware, the rejection covers one already continued and waiting on a response pause, which would otherwise wait out the 30s response-pause timeout.
- `createSyntheticProxyCodec` gains `abortRequest(id)`, which destroys that request's synthetic `req`/`res`. Those are the two signals the legacy pipeline already keys its cancellation handling on, so the teardown is byte-for-byte the MITM cancellation path — timer cleared, no warning, nothing surfaced to the user.
- `network-runtime` wires the hook to the shared synthetic codec for both the main transport and extra-target (popup/`_blank`) transports.

Deliberate scoping:

- Gated strictly on `event.canceled`. A request that fails on the wire still produces a Fetch response pause carrying its error reason, and `resolveResponse` owns those — treating them as cancellations would silence a real failure.
- No changes to `PreRequests`, and no MITM-path changes at all. `createSyntheticProxyCodec` is only used by the CDP Fetch runtime, and `createProxyRuntime` is untouched.
- Releasing a pause for an already-canceled request throws in CDP; those sends go through the existing `safeSend`, which swallows it.

Known residual gap, not addressed here: cancellation is only propagated for a request whose in-flight entry already exists. For non-`Document` resources the entry is registered synchronously while handling the pause, so the window is closed; a `Document` pause awaits `isAUTFrame` (one CDP round trip) first, so a document canceled inside that window still falls back to today's behavior. Closing it needs unbounded tombstone state for a single request, which is a worse trade than the narrow race.

No changelog entry — internal flag, no user-facing change.

### Steps to test

Covered by unit tests; both were verified to fail with the fix removed.

- `yarn workspace @packages/proxy test -- test/unit/adapters/synthetic-proxy-codec.spec.ts test/unit/http/index.spec.ts`
- `yarn workspace @packages/server test-unit -- browsers/cdp-fetch-transport_spec.ts`

The pipeline-level test in `packages/proxy/test/unit/http/index.spec.ts` drives a real `PreRequests` through `createLegacyProxyPipeline` over a synthetic exchange and asserts the pending pre-request is released on abort, with a control case asserting it is still pending without one. With the fix removed that test takes 2006 ms (the pre-request timer expiring); the transport's post-continue test hangs past a 10s mocha timeout (the response-pause timeout).

End to end, the system test this fixes cannot run in my environment:

```
CYPRESS_INTERNAL_DISABLE_PROXY=1 yarn test-system --spec test/proxy_correlation_spec.js
```

### How has the user experience changed?

No change. `CYPRESS_INTERNAL_DISABLE_PROXY=1` is an internal flag, off by default; the MITM path is untouched.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP Fetch lifecycle and shared synthetic codec maps for all targets; scoped to canceled loads and internal proxy-off mode, with MITM path unchanged.
> 
> **Overview**
> When **`CYPRESS_INTERNAL_DISABLE_PROXY=1`**, a browser-canceled request paused at CDP Fetch could sit in pre-request correlation until the 2s timer fired (warnings and flaky `proxy_correlation_spec`). The MITM path already tears down via a closed socket; synthetic exchanges have no socket.
> 
> **`CdpFetchTransport`** listens for **`Network.loadingFailed`** with **`canceled`**, tracks in-flight flows by session-scoped network id, and on cancel invokes **`onRequestCanceled`** plus rejects the response-pause promise so middleware and post-continue waits both unwind.
> 
> **`createSyntheticProxyCodec`** keeps in-flight synthetic **`req`/`res`** pairs and exposes **`abortRequest(id)`**, which **`abortSyntheticExpressContext`** uses to **`destroy`** them—matching the signals **`CorrelateBrowserPreRequest`** already uses. **`network-runtime`** wires **`onRequestCanceled`** to that codec for the main and extra-target transports.
> 
> Unit tests cover codec abort, pipeline pre-request release, and transport cancellation edge cases (wire failures vs cancel, session scoping, extra-target id prefix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be1ca987fde806d94908c427cefa3d88ee7c591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->