### PR TITLE
refactor: rename the tap CDP session handle to TapConnection

### DIFF
--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -2,8 +2,8 @@ import Debug from 'debug'
 import commander from 'commander'
 
 import { CypressInstanceError, resolveInstance } from '../cypress-instances'
-import { withTapSession, throwTapError, validateExecResult } from '../tap/tap-session'
-import type { TapSession } from '../tap/tap-session'
+import { withTapConnection, throwTapError, validateExecResult } from '../tap/tap-connection'
+import type { TapConnection } from '../tap/tap-connection'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
 import { renderFailure, renderKnownFailure, renderOutcome, renderSchemaHelp, renderStaticHelp, renderNativeHelp } from '../tap/output'
 import { tapCliCommands } from '../tap/commands'
@@ -92,8 +92,8 @@ const runNativeCommand = async (native: TapCliCommand, positionals: string[], op
   return dispatchCode ?? 1
 }
 
-const execCommand = async (session: TapSession, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>, json: boolean | undefined): Promise<number> => {
-  const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, [command, commandArgs, commandOptions]))
+const execCommand = async (connection: TapConnection, command: string, commandArgs: Record<string, string>, commandOptions: Record<string, string>, json: boolean | undefined): Promise<number> => {
+  const outcome = validateExecResult(await connection.call(TAP_EXEC_METHOD, [command, commandArgs, commandOptions]))
 
   if ('error' in outcome) {
     renderFailure(outcome.error)
@@ -126,13 +126,13 @@ const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options:
   try {
     const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
 
-    return await withTapSession(selection.instance, async (session) => {
-      const schema = validateSchema(await session.call(TAP_SCHEMA_METHOD))
+    return await withTapConnection(selection.instance, async (connection) => {
+      const schema = validateSchema(await connection.call(TAP_SCHEMA_METHOD))
 
       let dispatchCode = 0
       const program = buildTapProgram(schema, async (name, args, commandOptions) => {
         noteTapCommand(name, args, commandOptions)
-        dispatchCode = await execCommand(session, name, args, withJson(schema, name, commandOptions, options.json), options.json)
+        dispatchCode = await execCommand(connection, name, args, withJson(schema, name, commandOptions, options.json), options.json)
       })
 
       if (wantsHelp || !command) {

--- a/cli/lib/tap/aut/cdp.ts
+++ b/cli/lib/tap/aut/cdp.ts
@@ -1,4 +1,4 @@
-import type { TapSession } from '../tap-session'
+import type { TapConnection } from '../tap-connection'
 import type { AutFrame } from './frame'
 import { FrameCommandError } from './frame'
 
@@ -6,8 +6,8 @@ import { FrameCommandError } from './frame'
 // nothing the tap reads pollutes the page.
 const TAP_WORLD_NAME = 'cypress-tap'
 
-export const createFrameIsolatedWorld = async (session: TapSession, frame: AutFrame): Promise<number> => {
-  const { client, sessionId } = session
+export const createFrameIsolatedWorld = async (connection: TapConnection, frame: AutFrame): Promise<number> => {
+  const { client, sessionId } = connection
 
   const { executionContextId } = await client.Page.createIsolatedWorld({
     frameId: frame.frameId,
@@ -25,13 +25,13 @@ export const createFrameIsolatedWorld = async (session: TapSession, frame: AutFr
  * selector is valid but nothing matched.
  */
 export const querySelectorObjectId = async (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string,
   index: number,
 ): Promise<string | undefined> => {
-  const { client, sessionId } = session
-  const executionContextId = await createFrameIsolatedWorld(session, frame)
+  const { client, sessionId } = connection
+  const executionContextId = await createFrameIsolatedWorld(connection, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
     functionDeclaration: 'function (selector, index) { return document.querySelectorAll(selector)[index] }',

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -2,8 +2,8 @@ import Debug from 'debug'
 import type CRI from 'chrome-remote-interface'
 
 import { CypressInstanceError, resolveInstance } from '../../cypress-instances'
-import { withTapSession, validateExecResult } from '../tap-session'
-import type { TapSession } from '../tap-session'
+import { withTapConnection, validateExecResult } from '../tap-connection'
+import type { TapConnection } from '../tap-connection'
 import { renderOutcome, renderFailure, renderKnownFailure } from '../output'
 import type { TapCliOptions, TapRunState } from '../types'
 import type { FrameAmbiguousResult } from './single-match'
@@ -56,7 +56,7 @@ const findAutFrame = (node: FrameNode): { id: string, url: string } | undefined 
 /**
  * Locates the app-under-test frame within the runner page. Verified empirically:
  * the AUT is a same-process child frame of the runner-page target, so one
- * attached session reaches it — no separate target attach. A pinned snapshot is
+ * attached CDP session reaches it — no separate target attach. A pinned snapshot is
  * always same-super-domain, so it is reliably this child frame too.
  */
 export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Promise<AutFrame> => {
@@ -86,8 +86,8 @@ export const resolveAutFrame = async (client: CRI.Client, sessionId: string): Pr
  * errors a poller can branch on, mirroring the `status` lifecycle contract
  * (wait until `passed`/`failed`).
  */
-export const assertFrameReadable = async (session: TapSession): Promise<void> => {
-  const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
+export const assertFrameReadable = async (connection: TapConnection): Promise<void> => {
+  const outcome = validateExecResult(await connection.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
 
   if ('error' in outcome) {
     throw new FrameCommandError(outcome.error.code, outcome.error.message)
@@ -106,26 +106,26 @@ export const assertFrameReadable = async (session: TapSession): Promise<void> =>
 
 /**
  * Shared flow for the AUT-frame commands: resolve a running instance, open a
- * tap session, gate on the run lifecycle, locate the AUT frame, run `read`, and
+ * tap connection, gate on the run lifecycle, locate the AUT frame, run `read`, and
  * render the result. Maps the CLI-native `FrameCommandError` and the
  * discovery/transport failures to the same rendered output the schema commands
  * use.
  */
 export const withResolvedAutFrame = async (
   options: TapCliOptions,
-  read: (session: TapSession, frame: AutFrame) => Promise<unknown>,
+  read: (connection: TapConnection, frame: AutFrame) => Promise<unknown>,
   command: string,
 ): Promise<number> => {
   try {
     const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
 
-    return await withTapSession(selection.instance, async (session) => {
+    return await withTapConnection(selection.instance, async (connection) => {
       try {
-        await assertFrameReadable(session)
+        await assertFrameReadable(connection)
 
-        const frame = await resolveAutFrame(session.client, session.sessionId)
+        const frame = await resolveAutFrame(connection.client, connection.sessionId)
 
-        const result = await read(session, frame)
+        const result = await read(connection, frame)
 
         renderOutcome(command, result, options.json)
 

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -1,8 +1,8 @@
 import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
 import type { ResolveSelectorMatch, ResolveSelectorResult } from '@packages/cypress-instances'
 
-import { validateExecResult } from '../tap-session'
-import type { TapSession } from '../tap-session'
+import { validateExecResult } from '../tap-connection'
+import type { TapConnection } from '../tap-connection'
 import { createFrameIsolatedWorld } from './cdp'
 import { FrameCommandError } from './frame'
 import type { AutFrame } from './frame'
@@ -39,9 +39,9 @@ export interface FrameAmbiguousResult {
  * can't reach its app under test (a secondary origin inside `cy.origin`) just
  * leaves the match count to speak for itself.
  */
-const disambiguatingSelectors = async (session: TapSession, selector: string): Promise<ResolveSelectorMatch[]> => {
+const disambiguatingSelectors = async (connection: TapConnection, selector: string): Promise<ResolveSelectorMatch[]> => {
   try {
-    const outcome = validateExecResult(await session.call(TAP_EXEC_METHOD, ['resolve-selector', { selector }, {}]))
+    const outcome = validateExecResult(await connection.call(TAP_EXEC_METHOD, ['resolve-selector', { selector }, {}]))
 
     return 'error' in outcome ? [] : (outcome.result as ResolveSelectorResult).selectors
   } catch {
@@ -50,7 +50,7 @@ const disambiguatingSelectors = async (session: TapSession, selector: string): P
 }
 
 export const resolveAmbiguity = async (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string | undefined,
   at?: number,
@@ -63,8 +63,8 @@ export const resolveAmbiguity = async (
     return undefined
   }
 
-  const { client, sessionId } = session
-  const executionContextId = await createFrameIsolatedWorld(session, frame)
+  const { client, sessionId } = connection
+  const executionContextId = await createFrameIsolatedWorld(connection, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
     functionDeclaration: countMatches.toString(),
@@ -105,18 +105,18 @@ export const resolveAmbiguity = async (
     ambiguous: true,
     selector,
     count,
-    selectors: await disambiguatingSelectors(session, selector),
+    selectors: await disambiguatingSelectors(connection, selector),
   }
 }
 
 export const withAmbiguous = async <T>(
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string | undefined,
   at: number | undefined,
   read: () => Promise<T>,
 ): Promise<T | FrameAmbiguousResult> => {
-  const ambiguous = await resolveAmbiguity(session, frame, selector, at)
+  const ambiguous = await resolveAmbiguity(connection, frame, selector, at)
 
   return ambiguous ?? read()
 }

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -27,7 +27,7 @@ export const isRendererUnresponsive = (err: unknown): boolean => {
  * A pending CDP reply has no timer of its own, and the only thing that settles
  * one other than a matching reply is the browser-level socket closing — so a
  * target that stops answering leaves the promise orphaned forever. Stop waiting
- * on our side; the orphan settles when the session closes its client.
+ * on our side; the orphan settles when the connection closes its client.
  */
 export const withCdpDeadline = async <T> (work: Promise<T>, what: string, ms: number): Promise<T> => {
   let timer: NodeJS.Timeout | undefined
@@ -47,7 +47,7 @@ export const withCdpDeadline = async <T> (work: Promise<T>, what: string, ms: nu
 /**
  * Every domain shorthand (`client.Runtime.evaluate(...)`) is generated as a call
  * to `client.send`, so replacing that one method bounds every protocol call the
- * session makes, including the raw-client ones the frame extractors issue. Event
+ * connection makes, including the raw-client ones the frame extractors issue. Event
  * subscriptions and `close` don't go through it and stay unbounded.
  */
 export const boundCdpCalls = (client: CRI.Client, ms: number): void => {

--- a/cli/lib/tap/commands/aria.ts
+++ b/cli/lib/tap/commands/aria.ts
@@ -1,4 +1,4 @@
-import type { TapSession } from '../tap-session'
+import type { TapConnection } from '../tap-connection'
 import type { AutFrame } from '../aut/frame'
 import { withResolvedAutFrame } from '../aut/frame'
 import { parseIndex, parsePositiveInt } from '../utils'
@@ -121,13 +121,13 @@ const projectTree = (byId: Map<string, AXNode>, rootId: string, maxNodes: number
 }
 
 const resolveSelectorBackendNodeId = async (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string,
   index: number,
 ): Promise<number | undefined> => {
-  const { client, sessionId } = session
-  const objectId = await querySelectorObjectId(session, frame, selector, index)
+  const { client, sessionId } = connection
+  const objectId = await querySelectorObjectId(connection, frame, selector, index)
 
   if (objectId === undefined) {
     return undefined
@@ -139,15 +139,15 @@ const resolveSelectorBackendNodeId = async (
 }
 
 export const extractAria = (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string | undefined,
   maxNodes: number,
   at?: number,
 ): Promise<FrameAriaResult | FrameAmbiguousResult> => {
   // Ahead of the tree fetch: an ambiguous selector shouldn't cost a full AX tree.
-  return withAmbiguous(session, frame, selector, at, async (): Promise<FrameAriaResult> => {
-    const { client, sessionId } = session
+  return withAmbiguous(connection, frame, selector, at, async (): Promise<FrameAriaResult> => {
+    const { client, sessionId } = connection
 
     await client.DOM.enable({}, sessionId)
     await client.Accessibility.enable(sessionId)
@@ -165,7 +165,7 @@ export const extractAria = (
     let rootId: string | undefined
 
     if (selector !== undefined) {
-      const backendNodeId = await resolveSelectorBackendNodeId(session, frame, selector, at ?? 0)
+      const backendNodeId = await resolveSelectorBackendNodeId(connection, frame, selector, at ?? 0)
 
       if (backendNodeId === undefined) {
         // Selector matched nothing, or the match is absent from the a11y tree.
@@ -197,6 +197,6 @@ export const extractAria = (
   })
 }
 
-export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractAria(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], 'max-nodes'), parseIndex(commandOptions.at))
+export const ariaCommand = defineNativeCommand('aria', (options, _args, commandOptions) => withResolvedAutFrame(options, (connection, frame) => {
+  return extractAria(connection, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-nodes'], 'max-nodes'), parseIndex(commandOptions.at))
 }, 'aria'))

--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -1,4 +1,4 @@
-import type { TapSession } from '../tap-session'
+import type { TapConnection } from '../tap-connection'
 import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
 import { parseIndex, parsePositiveInt } from '../utils'
@@ -20,14 +20,14 @@ export interface FrameDomResult {
 }
 
 export const extractDom = (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string | undefined,
   maxChars: number,
   at?: number,
-): Promise<FrameDomResult | FrameAmbiguousResult> => withAmbiguous(session, frame, selector, at, async (): Promise<FrameDomResult> => {
-  const { client, sessionId } = session
-  const executionContextId = await createFrameIsolatedWorld(session, frame)
+): Promise<FrameDomResult | FrameAmbiguousResult> => withAmbiguous(connection, frame, selector, at, async (): Promise<FrameDomResult> => {
+  const { client, sessionId } = connection
+  const executionContextId = await createFrameIsolatedWorld(connection, frame)
 
   const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
     functionDeclaration: readDom.toString(),
@@ -53,6 +53,6 @@ export const extractDom = (
   }
 })
 
-export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractDom(session, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], 'max-chars'), parseIndex(commandOptions.at))
+export const domCommand = defineNativeCommand('dom', (options, _args, commandOptions) => withResolvedAutFrame(options, (connection, frame) => {
+  return extractDom(connection, frame, commandOptions.selector, parsePositiveInt(commandOptions['max-chars'], 'max-chars'), parseIndex(commandOptions.at))
 }, 'dom'))

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -1,4 +1,4 @@
-import type { TapSession } from '../tap-session'
+import type { TapConnection } from '../tap-connection'
 import type { AutFrame } from '../aut/frame'
 import { FrameCommandError, withResolvedAutFrame } from '../aut/frame'
 import { parseIndex } from '../utils'
@@ -71,8 +71,8 @@ const projectAria = (node: AXNode | undefined): FrameInspectResult['aria'] => {
   return Object.keys(aria).length ? aria : undefined
 }
 
-const readAriaNode = async (session: TapSession, objectId: string): Promise<FrameInspectResult['aria']> => {
-  const { client, sessionId } = session
+const readAriaNode = async (connection: TapConnection, objectId: string): Promise<FrameInspectResult['aria']> => {
+  const { client, sessionId } = connection
 
   try {
     const { node } = await client.DOM.describeNode({ objectId }, sessionId)
@@ -90,18 +90,18 @@ const readAriaNode = async (session: TapSession, objectId: string): Promise<Fram
 }
 
 export const extractInspect = (
-  session: TapSession,
+  connection: TapConnection,
   frame: AutFrame,
   selector: string,
   at?: number,
-): Promise<FrameInspectResult | FrameAmbiguousResult> => withAmbiguous(session, frame, selector, at, async (): Promise<FrameInspectResult> => {
-  const { client, sessionId } = session
+): Promise<FrameInspectResult | FrameAmbiguousResult> => withAmbiguous(connection, frame, selector, at, async (): Promise<FrameInspectResult> => {
+  const { client, sessionId } = connection
 
   await client.DOM.enable({}, sessionId)
   await client.Accessibility.enable(sessionId)
 
   const base: FrameInspectResult = { selector, found: false }
-  const objectId = await querySelectorObjectId(session, frame, selector, at ?? 0)
+  const objectId = await querySelectorObjectId(connection, frame, selector, at ?? 0)
 
   if (!objectId) {
     return base
@@ -119,7 +119,7 @@ export const extractInspect = (
   }
 
   const { tag, attributes, styles, box } = info.result.value as ElementInfo
-  const aria = await readAriaNode(session, objectId)
+  const aria = await readAriaNode(connection, objectId)
 
   return {
     ...base,
@@ -132,6 +132,6 @@ export const extractInspect = (
   }
 })
 
-export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => withResolvedAutFrame(options, (session, frame) => {
-  return extractInspect(session, frame, commandOptions.selector, parseIndex(commandOptions.at))
+export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => withResolvedAutFrame(options, (connection, frame) => {
+  return extractInspect(connection, frame, commandOptions.selector, parseIndex(commandOptions.at))
 }, 'inspect'))

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,7 +1,7 @@
 import { isTapSupportedBrowser, listLiveInstances } from '../../cypress-instances'
 import type { LiveInstanceState, ReadyInstanceState } from '../../cypress-instances'
 import { renderOutcome, renderResult } from '../output'
-import { withTapSession } from '../tap-session'
+import { withTapConnection } from '../tap-connection'
 import { FIND_INSTANCE_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
@@ -40,7 +40,7 @@ const probeRenderer = async (instance: LiveInstanceState, timeoutMs: number): Pr
   }
 
   try {
-    return await withTapSession(instance as ReadyInstanceState, async () => true, timeoutMs)
+    return await withTapConnection(instance as ReadyInstanceState, async () => true, timeoutMs)
   } catch (err) {
     return isRendererUnresponsive(err) ? false : undefined
   }

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -1,6 +1,6 @@
 import { CypressInstanceError, resolveLiveInstance } from '../../cypress-instances'
 import type { ReadyInstanceState } from '../../cypress-instances'
-import { withTapSession, validateExecResult } from '../tap-session'
+import { withTapConnection, validateExecResult } from '../tap-connection'
 import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { TAP_EXEC_METHOD } from '@packages/cypress-instances'
 import { defineNativeCommand } from './definition'
@@ -69,8 +69,8 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   }
 
   try {
-    const outcome = await withTapSession(instance as ReadyInstanceState, async (session) => {
-      return validateExecResult(await session.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
+    const outcome = await withTapConnection(instance as ReadyInstanceState, async (connection) => {
+      return validateExecResult(await connection.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
     }, options.timeout)
 
     if ('error' in outcome) {

--- a/cli/lib/tap/instance-gql.ts
+++ b/cli/lib/tap/instance-gql.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 
 import { errors } from '../errors'
-import { throwTapError } from './tap-session'
+import { throwTapError } from './tap-connection'
 import type { LiveInstanceState } from '../cypress-instances'
 import { INSTANCE_ID_HEADER } from '@packages/cypress-instances'
 import type { TapGraphqlOperation } from '@packages/cypress-instances'

--- a/cli/lib/tap/tap-connection.ts
+++ b/cli/lib/tap/tap-connection.ts
@@ -38,7 +38,7 @@ export const throwTapError = (details: { description: string, solution: string }
   throw err
 }
 
-export interface TapSession {
+export interface TapConnection {
   call (method: string, args?: unknown[]): Promise<unknown>
   // Raw CDP access for the frame extractors (dom/aria/inspect), which run
   // protocol domains
@@ -240,15 +240,15 @@ const callBindingWithRetry = async (client: CRI.Client, sessionId: string, metho
   }
 }
 
-export const withTapSession = async <T> (
+export const withTapConnection = async <T> (
   instance: ReadyInstanceState,
-  fn: (session: TapSession) => Promise<T>,
+  fn: (connection: TapConnection) => Promise<T>,
   timeoutMs?: number,
 ): Promise<T> => {
   const callMs = timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS
   const findInstanceMs = timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS
 
-  debug('opening tap session for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, callMs, findInstanceMs })
+  debug('opening tap connection for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, callMs, findInstanceMs })
 
   const client = await connectToBrowser(instance.cdpBrowserWsUrl)
 
@@ -295,7 +295,7 @@ export const withTapSession = async <T> (
       return response.result.value
     }
 
-    const session: TapSession = {
+    const connection: TapConnection = {
       call,
       client,
       get sessionId () {
@@ -303,7 +303,7 @@ export const withTapSession = async <T> (
       },
     }
 
-    return await fn(session)
+    return await fn(connection)
   } finally {
     await client.close().catch(() => {})
   }

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -3,8 +3,8 @@ import { vi } from 'vitest'
 import logger from '../../../lib/logger'
 import { listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
 import type { ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-instances'
-import { withTapSession } from '../../../lib/tap/tap-session'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import { withTapConnection } from '../../../lib/tap/tap-connection'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
 import { withResolvedAutFrame } from '../../../lib/tap/aut/frame'
 import type { TapExecResult, TapSchema } from '@packages/cypress-instances'
@@ -37,15 +37,15 @@ export const schema: TapSchema = {
   ],
 }
 
-export const mockSession = (sessionSchema: unknown = schema, execOutcome: unknown = { result: 'ok' } satisfies TapExecResult) => {
+export const mockConnection = (connectionSchema: unknown = schema, execOutcome: unknown = { result: 'ok' } satisfies TapExecResult) => {
   const call = vi.fn(async (method: string) => {
-    return method === 'getSchema' ? sessionSchema : execOutcome
+    return method === 'getSchema' ? connectionSchema : execOutcome
   })
 
   // These tests drive the binding exec/status paths, which use only `call`;
   // the frame extractors (dom/aria/inspect, which use client/sessionId) are
   // covered separately, so the session's CDP members are stubbed away here.
-  vi.mocked(withTapSession).mockImplementation(async (_runner, fn) => fn({ call } as unknown as TapSession))
+  vi.mocked(withTapConnection).mockImplementation(async (_runner, fn) => fn({ call } as unknown as TapConnection))
 
   return call
 }
@@ -83,7 +83,7 @@ export const resetTapMocks = (): void => {
   fetchMock.mockReset()
   fetchMock.mockResolvedValue({ status: 200 })
   vi.stubGlobal('fetch', fetchMock)
-  vi.mocked(withTapSession).mockReset()
+  vi.mocked(withTapConnection).mockReset()
   vi.mocked(queryInstanceGraphql).mockReset()
   vi.mocked(listLiveInstances).mockReset()
   vi.mocked(resolveLiveInstance).mockReset()

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -3,23 +3,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import logger from '../../../lib/logger'
 import { CypressInstanceError, listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
 import type { LiveInstanceSelection, LiveInstanceState, ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-instances'
-import { withTapSession } from '../../../lib/tap/tap-session'
+import { withTapConnection } from '../../../lib/tap/tap-connection'
 import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
 import { tapCliCommands } from '../../../lib/tap/commands'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 import { withResolvedAutFrame } from '../../../lib/tap/aut/frame'
 import type { AutFrame } from '../../../lib/tap/aut/frame'
 import { buildTapSchema } from '@packages/cypress-instances'
 import type { TapExecResult, TapSchema } from '@packages/cypress-instances'
 import { errors } from '../../../lib/errors'
 import tap from '../../../lib/exec/tap'
-import { mockResolved, mockSession, readyInstance, resetTapMocks, schema, tapError } from './tap-fixtures'
+import { mockResolved, mockConnection, readyInstance, resetTapMocks, schema, tapError } from './tap-fixtures'
 
 // vi.mock is hoisted above these imports, so the factories cannot come from
 // ./tap-fixtures — everything they don't cover does.
-vi.mock('../../../lib/tap/tap-session', async (importActual) => {
-  return { ...await importActual<typeof import('../../../lib/tap/tap-session')>(), withTapSession: vi.fn() }
+vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
+  return { ...await importActual<typeof import('../../../lib/tap/tap-connection')>(), withTapConnection: vi.fn() }
 })
 
 vi.mock('../../../lib/tap/instance-gql', () => {
@@ -50,7 +50,7 @@ describe('lib/exec/tap', () => {
 
   describe('dispatching a command', () => {
     it('fetches the schema, hands the command to exec, prints the unwrapped result, and exits 0', async () => {
-      const call = mockSession()
+      const call = mockConnection()
 
       expect(await tap.start(['health'], {})).toBe(0)
       expect(logger.print()).toBe('ok')
@@ -62,7 +62,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('forwards positional args to exec as raw strings keyed by param name, without interpreting them', async () => {
-      const call = mockSession(schema, { result: { status: 'started' } })
+      const call = mockConnection(schema, { result: { status: 'started' } })
 
       expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js'], {})).toBe(0)
 
@@ -70,7 +70,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('forwards parsed options to exec as raw strings, without interpreting them', async () => {
-      const call = mockSession(schema, { result: { status: 'started' } })
+      const call = mockConnection(schema, { result: { status: 'started' } })
 
       expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js', '--browser', 'chrome', '--headed'], {})).toBe(0)
 
@@ -78,7 +78,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('rejects an option the command does not advertise, without reaching exec', async () => {
-      const call = mockSession()
+      const call = mockConnection()
 
       expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js', '--nope'], {})).toBe(1)
       expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`unknown option '--nope'`)
@@ -86,7 +86,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints non-string results as readable JSON', async () => {
-      mockSession(schema, { result: { status: 'ok', browsers: 2 } })
+      mockConnection(schema, { result: { status: 'ok', browsers: 2 } })
 
       expect(await tap.start(['health'], {})).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({ status: 'ok', browsers: 2 })
@@ -115,7 +115,7 @@ describe('lib/exec/tap', () => {
     }
 
     it('prints a command’s human-readable rendering by default when it defines one', async () => {
-      const call = mockSession(reporterSchema, { result: reporterView })
+      const call = mockConnection(reporterSchema, { result: reporterView })
 
       expect(await tap.start(['reporter', '--test', 'r2'], {})).toBe(0)
       expect(call).toHaveBeenCalledWith('exec', ['reporter', {}, { test: 'r2' }])
@@ -129,7 +129,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints the raw JSON result when --json is passed', async () => {
-      mockSession(reporterSchema, { result: reporterView })
+      mockConnection(reporterSchema, { result: reporterView })
 
       expect(await tap.start(['reporter', '--test', 'r2'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual(reporterView)
@@ -140,7 +140,7 @@ describe('lib/exec/tap', () => {
     // the flag is handed over to it. Every other command keeps it to itself.
     it('forwards --json to the instance for a command whose schema declares it', async () => {
       const consoleProps = { name: 'request', type: 'command', props: { body: 'x'.repeat(2_000) } }
-      const call = mockSession(buildTapSchema('15.0.0'), { result: { id: '1', consoleProps } })
+      const call = mockConnection(buildTapSchema('15.0.0'), { result: { id: '1', consoleProps } })
 
       expect(await tap.start(['command', '--test-id', 'r2', '--command-id', '1'], { json: true })).toBe(0)
       expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'test-id': 'r2', 'command-id': '1', 'json': 'true' }])
@@ -148,7 +148,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('does not forward --json for a command whose schema does not declare it', async () => {
-      const call = mockSession(reporterSchema, { result: reporterView })
+      const call = mockConnection(reporterSchema, { result: reporterView })
 
       expect(await tap.start(['reporter', '--test', 'r2'], { json: true })).toBe(0)
       expect(call).toHaveBeenCalledWith('exec', ['reporter', {}, { test: 'r2' }])
@@ -156,24 +156,24 @@ describe('lib/exec/tap', () => {
 
     it('leaves the options alone without --json', async () => {
       const commandView = { id: '1', name: 'visit', hook: { hookId: 'r2', hookName: 'test body' }, snapshots: [] }
-      const call = mockSession(buildTapSchema('15.0.0'), { result: commandView })
+      const call = mockConnection(buildTapSchema('15.0.0'), { result: commandView })
 
       expect(await tap.start(['command', '--test-id', 'r2', '--command-id', '1'], {})).toBe(0)
       expect(call).toHaveBeenCalledWith('exec', ['command', {}, { 'test-id': 'r2', 'command-id': '1' }])
     })
 
     it('resolves the target from --instance and the cwd, then opens a session against it', async () => {
-      mockSession()
+      mockConnection()
       const { instance } = mockResolved()
 
       await tap.start(['health'], { instance: 1234 })
 
       expect(resolveInstance).toHaveBeenCalledWith({ instance: 1234, cwd: process.cwd() })
-      expect(vi.mocked(withTapSession).mock.calls[0][0]).toBe(instance)
+      expect(vi.mocked(withTapConnection).mock.calls[0][0]).toBe(instance)
     })
 
     it('resolves with just the cwd tiebreak when --instance is absent', async () => {
-      mockSession()
+      mockConnection()
 
       await tap.start(['health'], {})
 
@@ -181,7 +181,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders an app-side domain failure ({ error }) with its code and exits 1', async () => {
-      const call = mockSession(schema, {
+      const call = mockConnection(schema, {
         error: {
           code: 'INVALID_ARGUMENTS',
           message: '<spec> must be a string, but number was given.',
@@ -194,7 +194,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('treats an unrecognizable exec result as a transport failure', async () => {
-      mockSession(schema, 'not an envelope')
+      mockConnection(schema, 'not an envelope')
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapInvalidExecResult.description)
@@ -203,7 +203,7 @@ describe('lib/exec/tap', () => {
     it('treats a malformed error envelope as a transport failure, without crashing on renderFailure', async () => {
       for (const malformed of [{ error: null }, { error: 'boom' }, { error: {} }, { error: { code: 'X' } }]) {
         logger.reset()
-        mockSession(schema, malformed)
+        mockConnection(schema, malformed)
 
         expect(await tap.start(['health'], {})).toBe(1)
         expect(logger.print()).toContain(errors.tapInvalidExecResult.description)
@@ -215,7 +215,7 @@ describe('lib/exec/tap', () => {
     const stderr = (): string => vi.mocked(console.error).mock.calls.flat().join(' ')
 
     it('prints an app-side domain failure on stderr, leaving stdout clean under --json', async () => {
-      mockSession(schema, {
+      mockConnection(schema, {
         error: {
           code: 'INVALID_ARGUMENTS',
           message: '<spec> must be a string, but number was given.',
@@ -228,7 +228,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints a known tap error on stderr, leaving stdout clean under --json', async () => {
-      vi.mocked(withTapSession).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
+      vi.mocked(withTapConnection).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
 
       expect(await tap.start(['health'], { json: true })).toBe(1)
       expect(stderr()).toContain(errors.tapBindingNotFound.description)
@@ -238,7 +238,7 @@ describe('lib/exec/tap', () => {
 
   describe('commander validates the command against the live schema', () => {
     it('rejects a command the instance does not advertise, without reaching exec', async () => {
-      const call = mockSession()
+      const call = mockConnection()
 
       expect(await tap.start(['bogus'], {})).toBe(1)
       expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`unknown command 'bogus'`)
@@ -246,7 +246,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('rejects a missing required positional, without reaching exec', async () => {
-      const call = mockSession()
+      const call = mockConnection()
 
       expect(await tap.start(['fake-command-for-testing'], {})).toBe(1)
       expect(vi.mocked(console.error).mock.calls.flat().join(' ')).toContain(`missing required argument 'spec'`)
@@ -256,7 +256,7 @@ describe('lib/exec/tap', () => {
 
   describe('help', () => {
     it('prints the schema-derived overview for a bare invocation and exits 0', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
@@ -266,26 +266,26 @@ describe('lib/exec/tap', () => {
 
     // A bare invocation and --help print the same help, so they answer the same.
     it('answers a bare invocation exactly as it answers --help', async () => {
-      mockSession()
+      mockConnection()
       const bareCode = await tap.start([], {})
       const bareOutput = logger.print()
 
       logger.reset()
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['--help'], {})).toBe(bareCode)
       expect(logger.print()).toBe(bareOutput)
     })
 
     it('prints the overview and exits 0 for an explicit --help', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
     })
 
     it('leads the help with a banner naming the resolved instance', async () => {
-      mockSession()
+      mockConnection()
       mockResolved({ instance: readyInstance({ pid: 7777, projectRoot: '/projects/app' }) })
 
       expect(await tap.start(['--help'], {})).toBe(0)
@@ -293,7 +293,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('lists the CLI-native instances command at the top of the overview commands', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['--help'], {})).toBe(0)
       const help = logger.print()
@@ -303,7 +303,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('notes which instance was auto-selected when several were live', async () => {
-      mockSession()
+      mockConnection()
       mockResolved({ instance: readyInstance({ pid: 7777 }), reason: 'arbitrary', candidateCount: 3 })
 
       expect(await tap.start(['--help'], {})).toBe(0)
@@ -312,7 +312,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('omits the multi-instance note when only one instance was live', async () => {
-      mockSession()
+      mockConnection()
       mockResolved({ reason: 'only', candidateCount: 1 })
 
       expect(await tap.start(['--help'], {})).toBe(0)
@@ -320,7 +320,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints a rich per-command help for `<command> --help`, without reaching exec', async () => {
-      const call = mockSession()
+      const call = mockConnection()
 
       expect(await tap.start(['fake-command-for-testing', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap fake-command-for-testing')
@@ -332,7 +332,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders a schema command’s details prose in place of its one-liner for `<command> --help`', async () => {
-      mockSession({
+      mockConnection({
         ...schema,
         commands: [
           ...schema.commands,
@@ -352,7 +352,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('fails when help is requested for a command the instance does not advertise', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['bogus', '--help'], {})).toBe(1)
       expect(logger.print()).toContain('UNKNOWN_COMMAND')
@@ -360,7 +360,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('treats a hidden command as unknown for `<command> --help` and omits it from the listing', async () => {
-      mockSession({
+      mockConnection({
         ...schema,
         commands: [
           ...schema.commands,
@@ -409,7 +409,7 @@ describe('lib/exec/tap', () => {
       expect(output).toContain('Chrome')
       expect(() => JSON.parse(output)).toThrow()
 
-      expect(withTapSession).toHaveBeenCalledTimes(1)
+      expect(withTapConnection).toHaveBeenCalledTimes(1)
     })
 
     it('bounds the renderer probe with --timeout', async () => {
@@ -417,7 +417,7 @@ describe('lib/exec/tap', () => {
 
       expect(await tap.start(['instances'], { timeout: 5000 })).toBe(0)
 
-      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), 5000)
+      expect(withTapConnection).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), 5000)
     })
 
     it('bounds the renderer probe with the find-instance default when --timeout is absent', async () => {
@@ -425,7 +425,7 @@ describe('lib/exec/tap', () => {
 
       expect(await tap.start(['instances'], {})).toBe(0)
 
-      expect(withTapSession).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), FIND_INSTANCE_TIMEOUT_MS)
+      expect(withTapConnection).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), FIND_INSTANCE_TIMEOUT_MS)
     })
 
     it('prints the raw instance summaries with --json', async () => {
@@ -501,13 +501,13 @@ describe('lib/exec/tap', () => {
       expect(await tap.start(['instances', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap instances')
       expect(listLiveInstances).not.toHaveBeenCalled()
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('exits 1 on an excess positional and never enumerates', async () => {
       expect(await tap.start(['instances', 'extra'], {})).toBe(1)
       expect(listLiveInstances).not.toHaveBeenCalled()
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
   })
 
@@ -545,7 +545,7 @@ describe('lib/exec/tap', () => {
       expect(output).toContain('not connected')
       expect(() => JSON.parse(output)).toThrow()
       // Nothing live means nothing to connect to.
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('prints the raw status object with --json', async () => {
@@ -591,12 +591,12 @@ describe('lib/exec/tap', () => {
       })
 
       // The early lifecycle is reported from discovery alone.
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('reports "spec not selected" with totalSpecs when a browser is attached and on the spec list', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, { result: { spec: null, totalSpecs: 3 } } satisfies TapExecResult)
+      mockConnection(schema, { result: { spec: null, totalSpecs: 3 } } satisfies TapExecResult)
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({
@@ -612,7 +612,7 @@ describe('lib/exec/tap', () => {
 
     it('merges the run state, active spec, and results when on a spec', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, {
+      mockConnection(schema, {
         result: {
           spec: 'cypress/e2e/login.cy.ts',
           totalSpecs: 3,
@@ -641,7 +641,7 @@ describe('lib/exec/tap', () => {
 
     it('reports "loading" with no verdict and no run to name while the selected spec is still building', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, {
+      mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'loading', startedAt: null },
       } satisfies TapExecResult)
 
@@ -661,7 +661,7 @@ describe('lib/exec/tap', () => {
 
     it('reports a spec that failed to build as failed, carrying the reason', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, {
+      mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'failed', startedAt: '2026-07-29T10:15:00.000Z', error: 'Error: Webpack Compilation Error' },
       } satisfies TapExecResult)
 
@@ -682,7 +682,7 @@ describe('lib/exec/tap', () => {
 
     it('reports a null startedAt for an instance whose binding does not name the run', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, {
+      mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'passed', totalTests: 1, results: { passed: 1, failed: 0, pending: 0, skipped: 0 } },
       } satisfies TapExecResult)
 
@@ -694,7 +694,7 @@ describe('lib/exec/tap', () => {
 
     it('asks the binding for run-state over the session', async () => {
       mockLiveResolved(liveInstance())
-      const call = mockSession(schema, { result: { spec: null, totalSpecs: 0 } } satisfies TapExecResult)
+      const call = mockConnection(schema, { result: { spec: null, totalSpecs: 0 } } satisfies TapExecResult)
 
       await tap.start(['status'], {})
 
@@ -711,7 +711,7 @@ describe('lib/exec/tap', () => {
 
     it('exits 1 and renders the failure when the instance is unreachable despite a browser', async () => {
       mockLiveResolved(liveInstance())
-      vi.mocked(withTapSession).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
+      vi.mocked(withTapConnection).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
 
       expect(await tap.start(['status'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapBindingNotFound.description)
@@ -719,7 +719,7 @@ describe('lib/exec/tap', () => {
 
     it('exits 1 and surfaces the binding error when the running Cypress lacks the run-state command', async () => {
       mockLiveResolved(liveInstance())
-      mockSession(schema, { error: { code: 'UNKNOWN_COMMAND', message: 'no such command' } } satisfies TapExecResult)
+      mockConnection(schema, { error: { code: 'UNKNOWN_COMMAND', message: 'no such command' } } satisfies TapExecResult)
 
       expect(await tap.start(['status'], {})).toBe(1)
       expect(logger.print()).toContain('UNKNOWN_COMMAND: no such command')
@@ -730,13 +730,13 @@ describe('lib/exec/tap', () => {
       expect(await tap.start(['status', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap status')
       expect(resolveLiveInstance).not.toHaveBeenCalled()
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('exits 1 on an excess positional and never resolves an instance', async () => {
       expect(await tap.start(['status', 'extra'], {})).toBe(1)
       expect(resolveLiveInstance).not.toHaveBeenCalled()
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
   })
 
@@ -783,7 +783,7 @@ describe('lib/exec/tap', () => {
       expect(() => JSON.parse(output)).toThrow()
 
       // The spec list comes from the instance's data layer, not the browser.
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('prints the raw spec entries (with git timestamps) via --json', async () => {
@@ -991,7 +991,7 @@ describe('lib/exec/tap', () => {
       expect(() => JSON.parse(output)).toThrow()
 
       // The run is driven from the instance's data layer, not over a CDP session.
-      expect(withTapSession).not.toHaveBeenCalled()
+      expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('prints the raw launch outcome with --json', async () => {
@@ -1109,7 +1109,7 @@ describe('lib/exec/tap', () => {
             DOM: { enable: vi.fn() },
             Accessibility: { enable: vi.fn(), getFullAXTree: vi.fn().mockResolvedValue({ nodes: [] }) },
           },
-        } as unknown as TapSession
+        } as unknown as TapConnection
 
         await read(session, { frameId: 'f' } as AutFrame)
         forwarded = callFunctionOn.mock.calls.map(([params]) => params.arguments)
@@ -1174,14 +1174,14 @@ describe('lib/exec/tap', () => {
 
   describe('the schema handshake', () => {
     it('rejects an unrecognizable schema', async () => {
-      mockSession('not a schema')
+      mockConnection('not a schema')
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapInvalidSchema.description)
     })
 
     it('rejects a future protocol version, telling the user to update the CLI', async () => {
-      mockSession({ ...schema, schemaVersion: 2 })
+      mockConnection({ ...schema, schemaVersion: 2 })
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain('newer than this CLI')
@@ -1189,7 +1189,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('rejects an older protocol version, telling the user to update the running Cypress', async () => {
-      mockSession({ ...schema, schemaVersion: 0 })
+      mockConnection({ ...schema, schemaVersion: 0 })
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain('older than this CLI')
@@ -1199,7 +1199,7 @@ describe('lib/exec/tap', () => {
 
   describe('failure rendering', () => {
     const failResolve = (err: unknown) => vi.mocked(resolveInstance).mockRejectedValue(err)
-    const failSession = (err: unknown) => vi.mocked(withTapSession).mockRejectedValue(err)
+    const failConnection = (err: unknown) => vi.mocked(withTapConnection).mockRejectedValue(err)
 
     it('renders discovery errors with their code and exits 1', async () => {
       failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
@@ -1209,8 +1209,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders a known transport failure as its mapped description and solution, and exits 1', async () => {
-      mockSession()
-      failSession(tapError(errors.tapCdpUnreachable, 'Could not open a debugging connection to the browser: socket hang up'))
+      mockConnection()
+      failConnection(tapError(errors.tapCdpUnreachable, 'Could not open a debugging connection to the browser: socket hang up'))
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapCdpUnreachable.description)
@@ -1218,8 +1218,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders the binding-not-found failure as its mapped guidance', async () => {
-      mockSession()
-      failSession(tapError(errors.tapBindingNotFound, 'Failed to connect to the runner page.'))
+      mockConnection()
+      failConnection(tapError(errors.tapBindingNotFound, 'Failed to connect to the runner page.'))
 
       expect(await tap.start(['health'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapBindingNotFound.description)

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CypressInstanceError, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-instances'
-import { withTapSession } from '../../../lib/tap/tap-session'
+import { withTapConnection } from '../../../lib/tap/tap-connection'
 import { buildTapSchema } from '@packages/cypress-instances'
 import { errors } from '../../../lib/errors'
 import tap from '../../../lib/exec/tap'
-import { fetchMock, mockSession, reportedEvent, resetTapMocks, schema, tapError } from './tap-fixtures'
+import { fetchMock, mockConnection, reportedEvent, resetTapMocks, schema, tapError } from './tap-fixtures'
 
 // vi.mock is hoisted above these imports, so the factories cannot come from
 // ./tap-fixtures — everything they don't cover does.
-vi.mock('../../../lib/tap/tap-session', async (importActual) => {
-  return { ...await importActual<typeof import('../../../lib/tap/tap-session')>(), withTapSession: vi.fn() }
+vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
+  return { ...await importActual<typeof import('../../../lib/tap/tap-connection')>(), withTapConnection: vi.fn() }
 })
 
 vi.mock('../../../lib/tap/instance-gql', () => {
@@ -47,7 +47,7 @@ describe('lib/exec/tap reporting the invocation', () => {
   // `health` is advertised by this test's schema but is not a command this CLI
   // ships, standing in for a newer instance.
   it('reports a dispatched command that succeeded', async () => {
-    mockSession()
+    mockConnection()
 
     expect(await tap.start(['health'], {})).toBe(0)
 
@@ -81,7 +81,7 @@ describe('lib/exec/tap reporting the invocation', () => {
   })
 
   it('reports an instance-side failure by the code the instance gave', async () => {
-    mockSession(schema, { error: { code: 'INVALID_ARGUMENTS', message: '<spec> must be a string.' } })
+    mockConnection(schema, { error: { code: 'INVALID_ARGUMENTS', message: '<spec> must be a string.' } })
 
     expect(await tap.start(['fake-command-for-testing', 'cypress/e2e/a.cy.js'], {})).toBe(1)
     expect(reportedEvent()).toMatchObject({ exitCode: 1, errorCode: 'INVALID_ARGUMENTS' })
@@ -90,8 +90,8 @@ describe('lib/exec/tap reporting the invocation', () => {
   // A known transport failure has no code of its own to report, only the
   // description and solution the user was shown.
   it('reports a known transport failure without a code', async () => {
-    mockSession()
-    vi.mocked(withTapSession).mockRejectedValue(tapError(errors.tapCdpUnreachable, 'socket hang up'))
+    mockConnection()
+    vi.mocked(withTapConnection).mockRejectedValue(tapError(errors.tapCdpUnreachable, 'socket hang up'))
 
     expect(await tap.start(['health'], {})).toBe(1)
     expect(reportedEvent()).toMatchObject({ exitCode: 1 })
@@ -99,21 +99,21 @@ describe('lib/exec/tap reporting the invocation', () => {
   })
 
   it('reports a mistyped flag as invalid usage', async () => {
-    mockSession(buildTapSchema('15.0.0'))
+    mockConnection(buildTapSchema('15.0.0'))
 
     expect(await tap.start(['reporter', '--nope'], {})).toBe(1)
     expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'INVALID_USAGE' })
   })
 
   it('reports a command this CLI does not know as unknown', async () => {
-    mockSession()
+    mockConnection()
 
     expect(await tap.start(['../../etc/passwd'], {})).toBe(1)
     expect(reportedEvent()).toMatchObject({ command: 'unknown', exitCode: 1 })
   })
 
   it('reports a bare invocation under no command', async () => {
-    mockSession()
+    mockConnection()
 
     expect(await tap.start(['--help'], {})).toBe(0)
     expect(reportedEvent()).toMatchObject({ command: 'none', exitCode: 0, flags: ['help'] })
@@ -128,7 +128,7 @@ describe('lib/exec/tap reporting the invocation', () => {
     // The outer `cypress tap` command parses --instance/--json/--timeout off
     // before start() sees the operands, so they arrive as options instead.
     it('reports the flag names an invocation used, never their values', async () => {
-      mockSession(buildTapSchema('15.0.0'))
+      mockConnection(buildTapSchema('15.0.0'))
 
       expect(await tap.start(['reporter', '--test-id', 'r2'], { json: true, instance: 4242 })).toBe(0)
 
@@ -138,7 +138,7 @@ describe('lib/exec/tap reporting the invocation', () => {
     })
 
     it('reports an option by its canonical name whichever spelling was used', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['status', '-h'], {})).toBe(0)
       expect(reportedEvent().flags).toEqual(['help'])
@@ -147,7 +147,7 @@ describe('lib/exec/tap reporting the invocation', () => {
     // An undeclared flag is rejected before dispatch, so it reports as the usage
     // error it is, under no flag at all — and the value it carried stays home.
     it('reports no flag for one this CLI does not declare, and never its value', async () => {
-      mockSession(buildTapSchema('15.0.0'))
+      mockConnection(buildTapSchema('15.0.0'))
 
       expect(await tap.start(['reporter', '--secret-token=abc123'], {})).toBe(1)
       expect(reportedEvent()).toMatchObject({ command: 'reporter', errorCode: 'INVALID_USAGE' })
@@ -156,7 +156,7 @@ describe('lib/exec/tap reporting the invocation', () => {
     })
 
     it('reports no flags for an invocation that passed none', async () => {
-      mockSession()
+      mockConnection()
 
       expect(await tap.start(['health'], {})).toBe(0)
       expect(reportedEvent().flags).toEqual([])
@@ -171,7 +171,7 @@ describe('lib/exec/tap reporting the invocation', () => {
   })
 
   it('leaves the exit code alone when the collector cannot be reached', async () => {
-    mockSession()
+    mockConnection()
     fetchMock.mockRejectedValue(new Error('socket hang up'))
 
     expect(await tap.start(['health'], {})).toBe(0)
@@ -179,7 +179,7 @@ describe('lib/exec/tap reporting the invocation', () => {
 
   it('sends nothing when telemetry is turned off', async () => {
     vi.stubEnv('CYPRESS_DISABLE_GUEST_TELEMETRY', '1')
-    mockSession()
+    mockConnection()
 
     try {
       expect(await tap.start(['health'], {})).toBe(0)

--- a/cli/test/lib/tap/aria.spec.ts
+++ b/cli/test/lib/tap/aria.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { extractAria } from '../../../lib/tap/commands/aria'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 
 const SESSION_ID = 'S1'
 
@@ -52,7 +52,7 @@ describe('lib/tap/commands/aria extractAria', () => {
       Runtime: { callFunctionOn },
     }
 
-    return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapSession, client }
+    return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapConnection, client }
   }
 
   const frame = { frameId: 'aut-frame-id' }

--- a/cli/test/lib/tap/dom.spec.ts
+++ b/cli/test/lib/tap/dom.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { extractDom } from '../../../lib/tap/commands/dom'
 import { FrameCommandError } from '../../../lib/tap/aut/frame'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 
 const SESSION_ID = 'S1'
 
@@ -23,7 +23,7 @@ describe('lib/tap/commands/dom extractDom', () => {
       call: vi.fn(),
       client: { Page: { createIsolatedWorld }, Runtime: { callFunctionOn } },
       sessionId: SESSION_ID,
-    } as unknown as TapSession
+    } as unknown as TapConnection
 
     return { session, createIsolatedWorld, callFunctionOn }
   }

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -3,9 +3,9 @@ import stripAnsi from 'strip-ansi'
 
 import logger from '../../../lib/logger'
 import { resolveInstance } from '../../../lib/cypress-instances'
-import { withTapSession } from '../../../lib/tap/tap-session'
+import { withTapConnection } from '../../../lib/tap/tap-connection'
 import { resolveAutFrame, assertFrameReadable, withResolvedAutFrame } from '../../../lib/tap/aut/frame'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 import type { TapCliOptions } from '../../../lib/tap/types'
 
 vi.mock('../../../lib/cypress-instances', async (importActual) => {
@@ -14,10 +14,10 @@ vi.mock('../../../lib/cypress-instances', async (importActual) => {
   return { ...actual, resolveInstance: vi.fn() }
 })
 
-vi.mock('../../../lib/tap/tap-session', async (importActual) => {
-  const actual = await importActual<typeof import('../../../lib/tap/tap-session')>()
+vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
+  const actual = await importActual<typeof import('../../../lib/tap/tap-connection')>()
 
-  return { ...actual, withTapSession: vi.fn() }
+  return { ...actual, withTapConnection: vi.fn() }
 })
 
 const SESSION_ID = 'S1'
@@ -70,7 +70,7 @@ describe('lib/tap/aut/frame resolveAutFrame', () => {
 
 describe('lib/tap/aut/frame assertFrameReadable', () => {
   const sessionForRunState = (envelope: unknown) => {
-    return { call: vi.fn().mockResolvedValue(envelope) } as unknown as TapSession
+    return { call: vi.fn().mockResolvedValue(envelope) } as unknown as TapConnection
   }
 
   it('resolves once the run has settled to passed', async () => {
@@ -135,10 +135,10 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
       call: vi.fn().mockResolvedValue({ result: { spec: 'login.cy.js', totalSpecs: 1, state: 'passed' } }),
       client: makePageClient(frameTree()),
       sessionId: SESSION_ID,
-    } as unknown as TapSession
+    } as unknown as TapConnection
 
     vi.mocked(resolveInstance).mockResolvedValue({ instance: {}, reason: 'only', candidateCount: 1 } as any)
-    vi.mocked(withTapSession).mockImplementation((_instance: any, use: any) => use(session))
+    vi.mocked(withTapConnection).mockImplementation((_instance: any, use: any) => use(session))
 
     logger.reset()
     vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { CypressInstanceError } from '../../../lib/cypress-instances'
 import { extractInspect } from '../../../lib/tap/commands/inspect'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 
 const SESSION_ID = 'S1'
 
@@ -54,7 +54,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
       Runtime: { callFunctionOn },
     }
 
-    return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapSession }
+    return { session: { call: vi.fn(), client, sessionId: SESSION_ID } as unknown as TapConnection }
   }
 
   // A read returns the element; an ambiguous selector returns the candidates

--- a/cli/test/lib/tap/single-match.spec.ts
+++ b/cli/test/lib/tap/single-match.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { resolveAmbiguity } from '../../../lib/tap/aut/single-match'
-import type { TapSession } from '../../../lib/tap/tap-session'
+import type { TapConnection } from '../../../lib/tap/tap-connection'
 
 const SESSION_ID = 'S1'
 
@@ -23,7 +23,7 @@ describe('lib/tap/aut/single-match resolveAmbiguity', () => {
       call,
       client: { Page: { createIsolatedWorld }, Runtime: { callFunctionOn } },
       sessionId: SESSION_ID,
-    } as unknown as TapSession
+    } as unknown as TapConnection
 
     return { session, call, callFunctionOn, createIsolatedWorld }
   }

--- a/cli/test/lib/tap/tap-connection.spec.ts
+++ b/cli/test/lib/tap/tap-connection.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CRI from 'chrome-remote-interface'
 
 import type { ReadyInstanceState } from '../../../lib/cypress-instances'
-import { CdpErrorMessage, withTapSession } from '../../../lib/tap/tap-session'
+import { CdpErrorMessage, withTapConnection } from '../../../lib/tap/tap-connection'
 import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { errors } from '../../../lib/errors'
 
@@ -79,7 +79,7 @@ const setup = (client = makeClient(), overrides: Partial<ReadyInstanceState> = {
 }
 
 const callOnce = (method = 'health', args: unknown[] = []) => {
-  return withTapSession(instance, (session) => session.call(method, args))
+  return withTapConnection(instance, (session) => session.call(method, args))
 }
 
 const staleError = () => new Error(CdpErrorMessage.objectNotFound)
@@ -89,7 +89,7 @@ const UNRESPONSIVE_MS = 25
 const never = () => vi.fn().mockReturnValue(new Promise(() => {}))
 
 const callWithBound = () => {
-  return withTapSession(instance, (session) => session.call('health'), UNRESPONSIVE_MS)
+  return withTapConnection(instance, (session) => session.call('health'), UNRESPONSIVE_MS)
 }
 
 const expectUnresponsive = async (promise: Promise<any>) => {
@@ -110,7 +110,7 @@ const expectError = async (promise: Promise<any>, details: unknown) => {
   return err
 }
 
-describe('lib/tap/tap-session', () => {
+describe('lib/tap/tap-connection', () => {
   beforeEach(() => {
     mockConnect.mockReset()
   })
@@ -118,7 +118,7 @@ describe('lib/tap/tap-session', () => {
   it('connects to the browser ws, attaches a session, invokes the binding, and returns the decoded result', async () => {
     const { client } = setup()
 
-    const result = await withTapSession(instance, async (session) => {
+    const result = await withTapConnection(instance, async (session) => {
       return session.call('health')
     })
 
@@ -153,7 +153,7 @@ describe('lib/tap/tap-session', () => {
 
     const { client } = setup(makeClient({ callFunctionOn }))
 
-    const results = await withTapSession(instance, async (session) => {
+    const results = await withTapConnection(instance, async (session) => {
       return [await session.call('getSchema'), await session.call('health')]
     })
 
@@ -172,7 +172,7 @@ describe('lib/tap/tap-session', () => {
     const { client } = setup()
     const boom = new Error('boom')
 
-    const err = await withTapSession(instance, async () => {
+    const err = await withTapConnection(instance, async () => {
       throw boom
     }).catch((e) => e)
 

--- a/cli/test/lib/tap/tap-errors.spec.ts
+++ b/cli/test/lib/tap/tap-errors.spec.ts
@@ -6,7 +6,7 @@ import { errors } from '../../../lib/errors'
 // an error's description + solution only — no platform footer and no `----`
 // dividers (the runtime diagnostic stays on the Error for logs/--debug). Adding
 // or rewording a tap error should land here as a snapshot diff. Which failure
-// maps to which entry is covered by tap-session.spec.ts.
+// maps to which entry is covered by tap-connection.spec.ts.
 
 // eslint-disable-next-line no-control-regex
 const ANSI = /\[[0-9;]*m/g

--- a/knip.json
+++ b/knip.json
@@ -819,7 +819,7 @@
       "exports",
       "types"
     ],
-    "cli/lib/tap/tap-session.ts": [
+    "cli/lib/tap/tap-connection.ts": [
       "exports",
       "types"
     ],

--- a/system-tests/test/tap_open_spec.ts
+++ b/system-tests/test/tap_open_spec.ts
@@ -1959,11 +1959,13 @@ describe('tap CLI against a spec that cannot be built', function () {
 
   it('still answers the frame reads, with no app under test in them', async () => {
     // The app puts its own page in the frame, so these succeed and report an empty
-    // document. The reason is only in `status`.
+    // document. The reason is only in `status`. Both reads default to `body`, and
+    // that page's body carries nothing accessible, so the tree comes back empty
+    // rather than rooted at the frame.
     const aria = await instance.tap(['--json', 'aria'])
 
     expect(aria.exitCode).to.eq(0)
-    expect(aria.json()).to.deep.eq({ nodes: [{ depth: 0, role: 'RootWebArea' }], nodeCount: 1 })
+    expect(aria.json()).to.deep.eq({ nodes: [], nodeCount: 0 })
 
     const dom = await instance.tap(['--json', 'dom'])
 


### PR DESCRIPTION
- Closes N/A — groundwork for the `instances` → `sessions` rename in the rest of this stack.

### Additional details

First of four stacked PRs renaming the tap CLI's `instance` domain to `session`. This one changes no domain naming at all — it clears the word `session` so the later PRs can use it.

`TapSession` in `cli/lib/tap/tap-session.ts` is not a Cypress session. It is a short-lived CDP connection handle to the runner page: `{ call(), client, sessionId }`, created by `withTapSession`, closed in a `finally` when the command finishes. If `session` becomes the word for a running Cypress app, the signature reads `withTapSession(session, async (session) => …)` — two different kinds of session, one of them the opposite of the other's lifetime.

So the handle takes the name that describes what it is:

| before | after |
| --- | --- |
| `TapSession` | `TapConnection` |
| `withTapSession` | `withTapConnection` |
| `cli/lib/tap/tap-session.ts` | `cli/lib/tap/tap-connection.ts` |
| local `session` | local `connection` |

CDP's own vocabulary is deliberately left alone, because it genuinely describes a CDP page attachment rather than a Cypress session: `sessionId`, `sessionGoneMessages`, `isSessionGoneError`, `CdpErrorMessage.sessionNotFound`, and the `findRunnerPageSession` scan. After this PR the payoff is visible at the call site — `withTapConnection(session, (connection) => …)` in the next PRs reads unambiguously.

`cy.session`'s presence inside tap output (`TapReporterSession`, the reporter's `SESSIONS` panel) is untouched here and throughout the stack.

### A second, unrelated commit — a pre-existing base failure

This PR also carries `test: expect the body-rooted aria tree for a spec that cannot be built`, which fixes a failure that already exists on `feat/tap-cli-integration` and blocks CI for every PR in this stack. It sits at the bottom so all four inherit it.

`tap CLI against a spec that cannot be built > still answers the frame reads, with no app under test in them` asserts that `tap aria` with no selector returns the frame root:

```js
expect(aria.json()).to.deep.eq({ nodes: [{ depth: 0, role: 'RootWebArea' }], nodeCount: 1 })
```

That was written against a whole-frame read. #34597 ("Default to body in dom and aria") makes `--selector` default to `body`, so the read is now rooted at the body of the app's own error page — which carries nothing accessible — and returns `{ nodes: [], nodeCount: 0 }`.

It went unnoticed because of merge ordering, not because anyone was careless:

- #34584 added the test, and its `system-tests-chrome` passed — but that run was on `49428151771e`, which **predates** #34597. The green tick never covered the merged combination.
- The base branch's own `system-tests-chrome` fails earlier on unrelated network/timeout specs and **never reaches `tap_open_spec.ts`**, so the base looks red for other reasons and this stayed buried.

The expectation is updated to the value CI actually observed rather than one I guessed at. The `exitCode` assertion still carries the test's real intent ("still answers"), and the `dom` assertion below it is a negative check that holds either way.

### Steps to test

```bash
cd cli && yarn test-unit test/lib/tap test/lib/exec/tap
```

### How has the user experience changed?

No change. Nothing in this PR is user-visible — no command, flag, help text, or error message changes.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — internal rename on the unreleased tap feature branch, no behavior change.
- [x] Have tests been added/updated? — existing tap specs updated for the new names; `tap-session.spec.ts` → `tap-connection.spec.ts`.
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — no user-facing change.
- [na] Have API changes been updated in the `type definitions`? — internal CLI types only, nothing in `cli/types`.
