### PR TITLE
refactor: rename the Cypress instance contract to session

### DIFF
--- a/cli/lib/cypress-sessions/index.ts
+++ b/cli/lib/cypress-sessions/index.ts
@@ -1,155 +1,155 @@
 import path from 'path'
 
-import { CypressInstanceError, isTapSupportedBrowser } from './record'
-import type { LiveInstanceState, ReadyInstanceState, CypressInstance } from './record'
-import { isPidAlive, verifyInstanceRecord } from './liveness'
-import { readLiveInstances } from './store'
+import { CypressSessionError, isTapSupportedBrowser } from './record'
+import type { LiveSessionState, ReadySessionState, CypressSession } from './record'
+import { isPidAlive, verifySessionRecord } from './liveness'
+import { readLiveSessions } from './store'
 
-export { CypressInstanceError, INSTANCES_DIRNAME, isTapSupportedBrowser } from './record'
+export { CypressSessionError, SESSIONS_DIRNAME, isTapSupportedBrowser } from './record'
 
-export type { LiveInstanceState, ReadyInstanceState, CypressInstanceErrorCode, CypressInstance } from './record'
+export type { LiveSessionState, ReadySessionState, CypressSessionErrorCode, CypressSession } from './record'
 
-export { isPidAlive, verifyInstanceRecord } from './liveness'
+export { isPidAlive, verifySessionRecord } from './liveness'
 
-export { getInstancesDir, pruneDeadInstanceRecords, readInstanceRecords } from './store'
+export { getSessionsDir, pruneDeadSessionRecords, readSessionRecords } from './store'
 
-export interface ListInstanceOptions {
-  /** Optional pid filter; omitted lists every matching instance. */
-  instance?: number
+export interface ListSessionOptions {
+  /** Optional pid filter; omitted lists every matching session. */
+  session?: number
   probeTimeoutMs?: number
 }
 
-const matchesProject = (record: CypressInstance, projectRoot: string): boolean => {
+const matchesProject = (record: CypressSession, projectRoot: string): boolean => {
   return path.resolve(record.projectRoot) === path.resolve(projectRoot)
 }
 
-// An undefined instance does not constrain, so an absent `--instance` lists
+// An undefined pid does not constrain, so an absent filter lists
 // every pid.
-const matchesInstance = (record: CypressInstance, instance: number | undefined): boolean => {
-  return instance === undefined || record.pid === instance
+const matchesSession = (record: CypressSession, session: number | undefined): boolean => {
+  return session === undefined || record.pid === session
 }
 
 // A dead pid is skipped without a probe (it proves the writer is gone); the
 // survivors carry the live browser CDP state from their probe response.
-const probeMatches = async (matches: CypressInstance[], probeTimeoutMs?: number): Promise<LiveInstanceState[]> => {
+const probeMatches = async (matches: CypressSession[], probeTimeoutMs?: number): Promise<LiveSessionState[]> => {
   const probed = await Promise.all(matches.map(async (record) => {
-    return isPidAlive(record.pid) ? verifyInstanceRecord(record, probeTimeoutMs) : null
+    return isPidAlive(record.pid) ? verifySessionRecord(record, probeTimeoutMs) : null
   }))
 
-  return probed.filter((instance): instance is LiveInstanceState => instance !== null)
+  return probed.filter((session): session is LiveSessionState => session !== null)
 }
 
-export const listLiveInstances = async (options: ListInstanceOptions = {}): Promise<LiveInstanceState[]> => {
-  const records = await readLiveInstances()
+export const listLiveSessions = async (options: ListSessionOptions = {}): Promise<LiveSessionState[]> => {
+  const records = await readLiveSessions()
 
-  const matches = records.filter((record) => matchesInstance(record, options.instance))
+  const matches = records.filter((record) => matchesSession(record, options.session))
 
   return probeMatches(matches, options.probeTimeoutMs)
 }
 
-export type InstanceSelectionReason = 'explicit' | 'only' | 'cwd-match' | 'arbitrary'
+export type SessionSelectionReason = 'explicit' | 'only' | 'cwd-match' | 'arbitrary'
 
-export interface InstanceSelection {
-  instance: ReadyInstanceState
-  reason: InstanceSelectionReason
+export interface SessionSelection {
+  session: ReadySessionState
+  reason: SessionSelectionReason
   candidateCount: number
 }
 
-// Like InstanceSelection, but the chosen instance may have no browser attached yet.
-export interface LiveInstanceSelection {
-  instance: LiveInstanceState
-  reason: InstanceSelectionReason
+// Like SessionSelection, but the chosen session may have no browser attached yet.
+export interface LiveSessionSelection {
+  session: LiveSessionState
+  reason: SessionSelectionReason
   candidateCount: number
 }
 
-export interface ResolveInstanceOptions {
-  instance?: number
+export interface ResolveSessionOptions {
+  session?: number
   cwd: string
   probeTimeoutMs?: number
 }
 
-export interface ResolvedInstanceIdentity {
-  instanceId: string
+export interface ResolvedSessionIdentity {
+  sessionId: string
   machineId: string | null
   userId: string | null
 }
 
-let lastResolvedIdentity: ResolvedInstanceIdentity | null = null
+let lastResolvedIdentity: ResolvedSessionIdentity | null = null
 
 // Read rather than threaded through every caller: each tap command resolves its
-// own instance, several of them below this module.
-export const resolvedInstanceIdentity = (): ResolvedInstanceIdentity | null => lastResolvedIdentity
+// own session, several of them below this module.
+export const resolvedSessionIdentity = (): ResolvedSessionIdentity | null => lastResolvedIdentity
 
-export const resolvedInstanceId = (): string | null => lastResolvedIdentity?.instanceId ?? null
+export const resolvedSessionId = (): string | null => lastResolvedIdentity?.sessionId ?? null
 
-const describeFilter = (instance: number | undefined): string => {
-  if (instance !== undefined) {
-    return ` with pid ${instance}`
+const describeFilter = (session: number | undefined): string => {
+  if (session !== undefined) {
+    return ` with pid ${session}`
   }
 
   return ''
 }
 
-const lowestPid = <T extends LiveInstanceState>(instances: T[]): T => {
-  return [...instances].sort((a, b) => a.pid - b.pid)[0]
+const lowestPid = <T extends LiveSessionState>(sessions: T[]): T => {
+  return [...sessions].sort((a, b) => a.pid - b.pid)[0]
 }
 
-const selectInstance = <T extends LiveInstanceState>(candidates: T[], options: ResolveInstanceOptions): { instance: T, reason: InstanceSelectionReason } => {
+const selectSession = <T extends LiveSessionState>(candidates: T[], options: ResolveSessionOptions): { session: T, reason: SessionSelectionReason } => {
   if (candidates.length === 1) {
-    const filtered = options.instance !== undefined
+    const filtered = options.session !== undefined
 
-    return { instance: candidates[0], reason: filtered ? 'explicit' : 'only' }
+    return { session: candidates[0], reason: filtered ? 'explicit' : 'only' }
   }
 
   const cwdMatches = candidates.filter((record) => matchesProject(record, options.cwd))
 
   if (cwdMatches.length > 0) {
-    return { instance: lowestPid(cwdMatches), reason: 'cwd-match' }
+    return { session: lowestPid(cwdMatches), reason: 'cwd-match' }
   }
 
-  return { instance: lowestPid(candidates), reason: 'arbitrary' }
+  return { session: lowestPid(candidates), reason: 'arbitrary' }
 }
 
-const describeInstance = (instances: LiveInstanceState[], instance: number | undefined): string => {
-  if (instances.length === 1) {
-    return ` (pid ${instances[0].pid}, ${instances[0].projectRoot})`
+const describeSession = (sessions: LiveSessionState[], session: number | undefined): string => {
+  if (sessions.length === 1) {
+    return ` (pid ${sessions[0].pid}, ${sessions[0].projectRoot})`
   }
 
-  return describeFilter(instance)
+  return describeFilter(session)
 }
 
-// Reads, filters by pid, and probes for liveness. Throws NO_INSTANCE when
-// nothing matches, STALE_INSTANCE when matches exist but none responds, and
+// Reads, filters by pid, and probes for liveness. Throws NO_SESSION when
+// nothing matches, STALE_SESSION when matches exist but none responds, and
 // UNSUPPORTED_BROWSER when every one that does has a browser tap cannot drive.
-const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanceState[]> => {
-  const { instance, probeTimeoutMs } = options
-  const records = await readLiveInstances()
+const liveMatches = async (options: ResolveSessionOptions): Promise<LiveSessionState[]> => {
+  const { session, probeTimeoutMs } = options
+  const records = await readLiveSessions()
 
-  const matches = records.filter((record) => matchesInstance(record, instance))
+  const matches = records.filter((record) => matchesSession(record, session))
 
   if (matches.length === 0) {
-    throw new CypressInstanceError(
-      'NO_INSTANCE',
-      `No Cypress instance found${describeFilter(instance)}. This command requires Cypress running in open mode. Start Cypress in open mode and try again.`,
+    throw new CypressSessionError(
+      'NO_SESSION',
+      `No Cypress session found${describeFilter(session)}. This command requires Cypress running in open mode. Start Cypress in open mode and try again.`,
     )
   }
 
   const live = await probeMatches(matches, probeTimeoutMs)
 
   if (live.length === 0) {
-    throw new CypressInstanceError(
-      'STALE_INSTANCE',
-      `Cypress was previously running${describeFilter(instance)}, but is no longer responding. Cypress likely exited uncleanly; start Cypress in open mode and try again.`,
+    throw new CypressSessionError(
+      'STALE_SESSION',
+      `Cypress was previously running${describeFilter(session)}, but is no longer responding. Cypress likely exited uncleanly; start Cypress in open mode and try again.`,
     )
   }
 
-  // Dropped before selection so an instance running an unsupported browser never
+  // Dropped before selection so a session running an unsupported browser never
   // shadows one that can serve the command; when it is the only candidate the
   // caller hears why rather than "no browser attached".
   const supported = live.filter((record) => isTapSupportedBrowser(record.browserFamily))
 
   if (supported.length === 0) {
-    throw new CypressInstanceError(
+    throw new CypressSessionError(
       'UNSUPPORTED_BROWSER',
       'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.',
     )
@@ -158,37 +158,37 @@ const liveMatches = async (options: ResolveInstanceOptions): Promise<LiveInstanc
   return supported
 }
 
-// Resolves a live instance without requiring a browser; `status` reports
-// instances that have no browser attached yet.
-export const resolveLiveInstance = async (options: ResolveInstanceOptions): Promise<LiveInstanceSelection> => {
+// Resolves a live session without requiring a browser; `status` reports
+// sessions that have no browser attached yet.
+export const resolveLiveSession = async (options: ResolveSessionOptions): Promise<LiveSessionSelection> => {
   const live = await liveMatches(options)
 
-  const { instance, reason } = selectInstance(live, options)
+  const { session, reason } = selectSession(live, options)
 
-  lastResolvedIdentity = { instanceId: instance.instanceId, machineId: instance.machineId, userId: instance.userId }
+  lastResolvedIdentity = { sessionId: session.sessionId, machineId: session.machineId, userId: session.userId }
 
-  return { instance, reason, candidateCount: live.length }
+  return { session, reason, candidateCount: live.length }
 }
 
-// Adds the browser-readiness requirement to resolveLiveInstance: the instance
+// Adds the browser-readiness requirement to resolveLiveSession: the session
 // it returns is guaranteed to have a browser attached. Gate on the browser
-// before selecting so a browserless instance never shadows a ready one that
+// before selecting so a browserless session never shadows a ready one that
 // could serve the command.
-export const resolveInstance = async (options: ResolveInstanceOptions): Promise<InstanceSelection> => {
+export const resolveSession = async (options: ResolveSessionOptions): Promise<SessionSelection> => {
   const live = await liveMatches(options)
 
-  const ready = live.filter((record): record is ReadyInstanceState => record.cdpBrowserWsUrl !== null)
+  const ready = live.filter((record): record is ReadySessionState => record.cdpBrowserWsUrl !== null)
 
   if (ready.length === 0) {
-    throw new CypressInstanceError(
+    throw new CypressSessionError(
       'NO_BROWSER_ATTACHED',
-      `Cypress is running${describeInstance(live, options.instance)}, but no test browser is open. Open a browser in Cypress and try again.`,
+      `Cypress is running${describeSession(live, options.session)}, but no test browser is open. Open a browser in Cypress and try again.`,
     )
   }
 
-  const { instance: selected, reason } = selectInstance(ready, options)
+  const { session: selected, reason } = selectSession(ready, options)
 
-  lastResolvedIdentity = { instanceId: selected.instanceId, machineId: selected.machineId, userId: selected.userId }
+  lastResolvedIdentity = { sessionId: selected.sessionId, machineId: selected.machineId, userId: selected.userId }
 
-  return { instance: selected, reason, candidateCount: ready.length }
+  return { session: selected, reason, candidateCount: ready.length }
 }

--- a/cli/lib/cypress-sessions/liveness.ts
+++ b/cli/lib/cypress-sessions/liveness.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 
-import { instancesProbePath } from './record'
-import type { LiveInstanceState, CypressInstance } from './record'
+import { sessionProbePath } from './record'
+import type { LiveSessionState, CypressSession } from './record'
 
 const debug = Debug('cypress:cli:cypress-sessions')
 
@@ -47,8 +47,8 @@ const cdpEndpointReachable = async (cdpBrowserWsUrl: string, timeoutMs: number):
   }
 }
 
-export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS): Promise<LiveInstanceState | null> => {
-  const url = `http://${PROBE_HOST}:${record.serverPort}${instancesProbePath(record.instanceId)}`
+export const verifySessionRecord = async (record: CypressSession, timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS): Promise<LiveSessionState | null> => {
+  const url = `http://${PROBE_HOST}:${record.serverPort}${sessionProbePath(record.sessionId)}`
 
   try {
     const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
@@ -57,16 +57,16 @@ export const verifyInstanceRecord = async (record: CypressInstance, timeoutMs: n
       return null
     }
 
-    const live = await response.json() as { instanceId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown, browserFamily?: unknown, machineId?: unknown, userId?: unknown }
+    const live = await response.json() as { sessionId?: unknown, cdpBrowserWsUrl?: unknown, browserName?: unknown, browserFamily?: unknown, machineId?: unknown, userId?: unknown }
 
-    if (live.instanceId !== record.instanceId) {
+    if (live.sessionId !== record.sessionId) {
       return null
     }
 
     const cdpBrowserWsUrl = typeof live.cdpBrowserWsUrl === 'string' ? live.cdpBrowserWsUrl : null
     const attached = cdpBrowserWsUrl !== null && await cdpEndpointReachable(cdpBrowserWsUrl, timeoutMs)
 
-    // The browser identity describes what the instance has open, not what is
+    // The browser identity describes what the session has open, not what is
     // reachable over CDP — a browser tap cannot drive still has to be nameable.
     return {
       ...record,

--- a/cli/lib/cypress-sessions/record.ts
+++ b/cli/lib/cypress-sessions/record.ts
@@ -1,32 +1,32 @@
 export {
-  INSTANCES_DIRNAME,
+  SESSIONS_DIRNAME,
   isCompatibleRecord,
   isTapSupportedBrowser,
   parseRecordPid,
-  cypressInstancesDir,
-  instancesProbePath,
+  cypressSessionsDir,
+  sessionProbePath,
 } from '@packages/cypress-sessions'
 
 export type {
-  CypressInstance,
-  LiveInstanceState,
-  ReadyInstanceState,
-  InstanceTestingType,
+  CypressSession,
+  LiveSessionState,
+  ReadySessionState,
+  SessionTestingType,
 } from '@packages/cypress-sessions'
 
-export type CypressInstanceErrorCode =
-  | 'NO_INSTANCE'
-  | 'STALE_INSTANCE'
+export type CypressSessionErrorCode =
+  | 'NO_SESSION'
+  | 'STALE_SESSION'
   | 'NO_BROWSER_ATTACHED'
   | 'UNSUPPORTED_BROWSER'
   | 'RENDERER_UNRESPONSIVE'
 
-export class CypressInstanceError extends Error {
-  code: CypressInstanceErrorCode
+export class CypressSessionError extends Error {
+  code: CypressSessionErrorCode
 
-  constructor (code: CypressInstanceErrorCode, message: string) {
+  constructor (code: CypressSessionErrorCode, message: string) {
     super(message)
-    this.name = 'CypressInstanceError'
+    this.name = 'CypressSessionError'
     this.code = code
   }
 }

--- a/cli/lib/cypress-sessions/store.ts
+++ b/cli/lib/cypress-sessions/store.ts
@@ -3,14 +3,14 @@ import path from 'path'
 import Debug from 'debug'
 
 import state from '../tasks/state'
-import { isCompatibleRecord, parseRecordPid, cypressInstancesDir } from './record'
-import type { CypressInstance } from './record'
-import { isPidAlive, verifyInstanceRecord } from './liveness'
+import { isCompatibleRecord, parseRecordPid, cypressSessionsDir } from './record'
+import type { CypressSession } from './record'
+import { isPidAlive, verifySessionRecord } from './liveness'
 
 const debug = Debug('cypress:cli:cypress-sessions')
 
-export const getInstancesDir = (): string => {
-  return cypressInstancesDir(state.getCacheDir())
+export const getSessionsDir = (): string => {
+  return cypressSessionsDir(state.getCacheDir())
 }
 
 interface RecordFile {
@@ -44,19 +44,19 @@ const listRecordFiles = async (dir: string): Promise<RecordFile[]> => {
   return files
 }
 
-const readCompatibleRecord = async (filePath: string): Promise<CypressInstance | null> => {
+const readCompatibleRecord = async (filePath: string): Promise<CypressSession | null> => {
   let record: unknown
 
   try {
     record = await fs.readJson(filePath)
   } catch (err) {
-    debug('could not read cypress instances record %s: %o', filePath, err)
+    debug('could not read cypress sessions record %s: %o', filePath, err)
 
     return null
   }
 
   if (!isCompatibleRecord(record)) {
-    debug('incompatible cypress instances record %s', filePath)
+    debug('incompatible cypress sessions record %s', filePath)
 
     return null
   }
@@ -66,7 +66,7 @@ const readCompatibleRecord = async (filePath: string): Promise<CypressInstance |
 
 // Reaps a record whose writer process is gone, returning whether it was dead.
 // Removal is best-effort: a file we can't delete (permissions, a Windows lock)
-// must not abort discovery of the other, live instances, so the failure is
+// must not abort discovery of the other, live sessions, so the failure is
 // swallowed and the record is still reported dead.
 const reapIfDead = async (file: { path: string, pid: number }): Promise<boolean> => {
   const { path, pid } = file
@@ -76,31 +76,31 @@ const reapIfDead = async (file: { path: string, pid: number }): Promise<boolean>
   }
 
   await fs.remove(path).catch((err) => {
-    debug('failed to reap dead cypress instances record %s: %o', path, err)
+    debug('failed to reap dead cypress sessions record %s: %o', path, err)
   })
 
   return true
 }
 
 /**
- * Reads all the current cypress instance records, including dead ones whose writer
- * process has exited. Use `readLiveInstances` when only live records are wanted.
+ * Reads all the current cypress session records, including dead ones whose writer
+ * process has exited. Use `readLiveSessions` when only live records are wanted.
  */
-export const readInstanceRecords = async (): Promise<CypressInstance[]> => {
-  const files = await listRecordFiles(getInstancesDir())
+export const readSessionRecords = async (): Promise<CypressSession[]> => {
+  const files = await listRecordFiles(getSessionsDir())
   const records = await Promise.all(files.map((file) => readCompatibleRecord(file.path)))
 
-  return records.filter((record): record is CypressInstance => record !== null)
+  return records.filter((record): record is CypressSession => record !== null)
 }
 
 /**
- * Reads all the current cypress instance records that are still live (i.e. the writer process is still running).
+ * Reads all the current cypress session records that are still live (i.e. the writer process is still running).
  * Reaps any dead records.
  */
-export const readLiveInstances = async (): Promise<CypressInstance[]> => {
-  const files = await listRecordFiles(getInstancesDir())
+export const readLiveSessions = async (): Promise<CypressSession[]> => {
+  const files = await listRecordFiles(getSessionsDir())
 
-  const records = await Promise.all(files.map(async (file): Promise<CypressInstance | null> => {
+  const records = await Promise.all(files.map(async (file): Promise<CypressSession | null> => {
     const record = await readCompatibleRecord(file.path)
 
     if (!record) {
@@ -114,11 +114,11 @@ export const readLiveInstances = async (): Promise<CypressInstance[]> => {
     return record
   }))
 
-  return records.filter((record): record is CypressInstance => record !== null)
+  return records.filter((record): record is CypressSession => record !== null)
 }
 
-export const pruneDeadInstanceRecords = async (probeTimeoutMs?: number): Promise<number> => {
-  const files = await listRecordFiles(getInstancesDir())
+export const pruneDeadSessionRecords = async (probeTimeoutMs?: number): Promise<number> => {
+  const files = await listRecordFiles(getSessionsDir())
 
   const pruned = await Promise.all(files.map(async (file): Promise<boolean> => {
     if (await reapIfDead(file)) {
@@ -131,7 +131,7 @@ export const pruneDeadInstanceRecords = async (probeTimeoutMs?: number): Promise
       return false
     }
 
-    if (!(await verifyInstanceRecord(record, probeTimeoutMs))) {
+    if (!(await verifySessionRecord(record, probeTimeoutMs))) {
       await fs.remove(file.path)
 
       return true
@@ -142,7 +142,7 @@ export const pruneDeadInstanceRecords = async (probeTimeoutMs?: number): Promise
 
   const removed = pruned.filter(Boolean).length
 
-  debug('pruned %d dead cypress instances record(s)', removed)
+  debug('pruned %d dead cypress sessions record(s)', removed)
 
   return removed
 }

--- a/cli/lib/exec/tap.ts
+++ b/cli/lib/exec/tap.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 import commander from 'commander'
 
-import { CypressInstanceError, resolveInstance } from '../cypress-sessions'
+import { CypressSessionError, resolveSession } from '../cypress-sessions'
 import { withTapConnection, throwTapError, validateExecResult } from '../tap/tap-connection'
 import type { TapConnection } from '../tap/tap-connection'
 import { buildTapProgram, buildNativeProgram } from '../tap/build-program'
@@ -57,7 +57,7 @@ const buildCommandInfo = (operands: string[]): CommandInfo => {
 // `--json` is parsed by the outer `cypress tap` command, so commander never
 // routes it to the command being run. A command that declares it in its own
 // schema needs it anyway — for that command the flag also changes what the
-// instance returns, not just how the CLI prints it — so it is handed over here.
+// session returns, not just how the CLI prints it — so it is handed over here.
 const withJson = (schema: TapSchema, name: string, options: Record<string, string>, json: boolean | undefined): Record<string, string> => {
   const declared = schema.commands.find((command) => command.name === name)?.options.some((option) => option.name === 'json')
 
@@ -106,9 +106,9 @@ const execCommand = async (connection: TapConnection, command: string, commandAr
   return 0
 }
 
-// With no instance to query, fall back to the schema this CLI ships with so the
+// With no session to query, fall back to the schema this CLI ships with so the
 // help listing still reflects every command the CLI knows — the query path stays
-// authoritative when an instance is attached (it may run a different version).
+// authoritative when a session is attached (it may run a different version).
 const renderKnownSchema = (command: string | undefined): number => {
   const schema = buildTapSchema(util.pkgVersion())
   const program = buildTapProgram(schema, () => {})
@@ -124,9 +124,9 @@ const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options:
   }
 
   try {
-    const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
+    const selection = await resolveSession({ session: options.instance, cwd: process.cwd() })
 
-    return await withTapConnection(selection.instance, async (connection) => {
+    return await withTapConnection(selection.session, async (connection) => {
       const schema = validateSchema(await connection.call(TAP_SCHEMA_METHOD))
 
       let dispatchCode = 0
@@ -154,7 +154,7 @@ const runTap = async ({ wantsHelp, positionals, command }: CommandInfo, options:
       return dispatchCode
     }, options.timeout)
   } catch (err: any) {
-    if (err instanceof CypressInstanceError) {
+    if (err instanceof CypressSessionError) {
       if (wantsHelp || !command) {
         return renderKnownSchema(command)
       }

--- a/cli/lib/tap/AGENTS.md
+++ b/cli/lib/tap/AGENTS.md
@@ -1,12 +1,12 @@
 # tap CLI
 
-The experimental `cypress tap` subcommands and their AUT-frame/CDP plumbing — commands an LLM agent runs against a live Cypress instance.
+The experimental `cypress tap` subcommands and their AUT-frame/CDP plumbing — commands an LLM agent runs against a live Cypress session.
 
 ## User-facing help must not leak internals
 
-Help text describes WHAT a command does and its observable output/behavior — never how it gets there. Do not name the transport (CDP), the find-instance/liveness mechanism, or in-browser binding internals.
+Help text describes WHAT a command does and its observable output/behavior — never how it gets there. Do not name the transport (CDP), the find-session/liveness mechanism, or in-browser binding internals.
 
-Banned vocabulary (the class, not just these literals): "over CDP", "tap binding", "liveness probe", "isolated world", "backend node id", server PIDs / handshake internals — CDP protocol details, the find-instance/liveness mechanism, and in-browser binding internals.
+Banned vocabulary (the class, not just these literals): "over CDP", "tap binding", "liveness probe", "isolated world", "backend node id", server PIDs / handshake internals — CDP protocol details, the find-session/liveness mechanism, and in-browser binding internals.
 
 Before → after:
 

--- a/cli/lib/tap/aut/frame.ts
+++ b/cli/lib/tap/aut/frame.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug'
 import type CRI from 'chrome-remote-interface'
 
-import { CypressInstanceError, resolveInstance } from '../../cypress-sessions'
+import { CypressSessionError, resolveSession } from '../../cypress-sessions'
 import { withTapConnection, validateExecResult } from '../tap-connection'
 import type { TapConnection } from '../tap-connection'
 import { renderOutcome, renderFailure, renderKnownFailure } from '../output'
@@ -105,7 +105,7 @@ export const assertFrameReadable = async (connection: TapConnection): Promise<vo
 }
 
 /**
- * Shared flow for the AUT-frame commands: resolve a running instance, open a
+ * Shared flow for the AUT-frame commands: resolve a running session, open a
  * tap connection, gate on the run lifecycle, locate the AUT frame, run `read`, and
  * render the result. Maps the CLI-native `FrameCommandError` and the
  * discovery/transport failures to the same rendered output the schema commands
@@ -117,9 +117,9 @@ export const withResolvedAutFrame = async (
   command: string,
 ): Promise<number> => {
   try {
-    const selection = await resolveInstance({ instance: options.instance, cwd: process.cwd() })
+    const selection = await resolveSession({ session: options.instance, cwd: process.cwd() })
 
-    return await withTapConnection(selection.instance, async (connection) => {
+    return await withTapConnection(selection.session, async (connection) => {
       try {
         await assertFrameReadable(connection)
 
@@ -144,7 +144,7 @@ export const withResolvedAutFrame = async (
       }
     }, options.timeout)
   } catch (err: any) {
-    if (err instanceof CypressInstanceError) {
+    if (err instanceof CypressSessionError) {
       renderFailure(err)
 
       return 1

--- a/cli/lib/tap/aut/single-match.ts
+++ b/cli/lib/tap/aut/single-match.ts
@@ -26,16 +26,16 @@ export interface FrameAmbiguousResult {
   /**
    * One entry per match, in document order, each carrying the index of the match
    * it names and a selector unique to it — `null` where none could be derived.
-   * May be shorter than `count`: the instance only derives so many.
+   * May be shorter than `count`: the session only derives so many.
    */
   selectors: ResolveSelectorMatch[]
 }
 
 /**
  * A unique selector for each match, to offer in place of the ambiguous one.
- * Best effort: these come from the instance itself, which derives them the way
+ * Best effort: these come from the session itself, which derives them the way
  * its Selector Playground does — so they honor any selectorPriority the project
- * configured, and are selectors the user's own tests would use. An instance that
+ * configured, and are selectors the user's own tests would use. A session that
  * can't reach its app under test (a secondary origin inside `cy.origin`) just
  * leaves the match count to speak for itself.
  */

--- a/cli/lib/tap/cdp-timeout.ts
+++ b/cli/lib/tap/cdp-timeout.ts
@@ -1,6 +1,6 @@
 import type CRI from 'chrome-remote-interface'
 
-import { CypressInstanceError } from '../cypress-sessions'
+import { CypressSessionError } from '../cypress-sessions'
 
 /** Bound for a protocol call, including one awaiting app-side work. */
 export const DEFAULT_CDP_TIMEOUT_MS = 30_000
@@ -10,17 +10,17 @@ export const DEFAULT_CDP_TIMEOUT_MS = 30_000
  * these in milliseconds, so keeping them short is what lets the scan skip an
  * unresponsive target rather than stop on it.
  */
-export const FIND_INSTANCE_TIMEOUT_MS = 2_000
+export const FIND_SESSION_TIMEOUT_MS = 2_000
 
-const unresponsive = (what: string, ms: number): CypressInstanceError => {
-  return new CypressInstanceError(
+const unresponsive = (what: string, ms: number): CypressSessionError => {
+  return new CypressSessionError(
     'RENDERER_UNRESPONSIVE',
     `The targeted Cypress instance did not answer ${what} within ${ms}ms. The browser is reachable, but the page running Cypress is not responding — it may be paused in devtools, stuck in a loop, or starved of memory. Pass --timeout <ms> to wait longer.`,
   )
 }
 
 export const isRendererUnresponsive = (err: unknown): boolean => {
-  return err instanceof CypressInstanceError && err.code === 'RENDERER_UNRESPONSIVE'
+  return err instanceof CypressSessionError && err.code === 'RENDERER_UNRESPONSIVE'
 }
 
 /**

--- a/cli/lib/tap/commands/instances.ts
+++ b/cli/lib/tap/commands/instances.ts
@@ -1,15 +1,15 @@
-import { isTapSupportedBrowser, listLiveInstances } from '../../cypress-sessions'
-import type { LiveInstanceState, ReadyInstanceState } from '../../cypress-sessions'
+import { isTapSupportedBrowser, listLiveSessions } from '../../cypress-sessions'
+import type { LiveSessionState, ReadySessionState } from '../../cypress-sessions'
 import { renderOutcome, renderResult } from '../output'
 import { withTapConnection } from '../tap-connection'
-import { FIND_INSTANCE_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
+import { FIND_SESSION_TIMEOUT_MS, isRendererUnresponsive } from '../cdp-timeout'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
 
 const NO_INSTANCES_GUIDANCE = 'No running Cypress instance found. Start Cypress in open mode (e.g. `cypress open`) and select a testing type to get started.'
 
 /** One row of `cypress tap instances`: a reachable open-mode Cypress instance. */
-export interface TapInstanceSummary {
+export interface TapSessionSummary {
   /** Process id — the handle other tap commands accept via `--instance`. */
   pid: number
   /** Absolute path of the project the instance has open. */
@@ -34,20 +34,20 @@ export interface TapInstanceSummary {
 // Bounded, and never throws: `instances` is what a caller reaches for when
 // everything else is failing, so an unanswered probe is a reported fact rather
 // than an error. Absent means there was nothing to ask, not that it went unasked.
-const probeRenderer = async (instance: LiveInstanceState, timeoutMs: number): Promise<boolean | undefined> => {
+const probeRenderer = async (instance: LiveSessionState, timeoutMs: number): Promise<boolean | undefined> => {
   if (instance.cdpBrowserWsUrl === null) {
     return undefined
   }
 
   try {
-    return await withTapConnection(instance as ReadyInstanceState, async () => true, timeoutMs)
+    return await withTapConnection(instance as ReadySessionState, async () => true, timeoutMs)
   } catch (err) {
     return isRendererUnresponsive(err) ? false : undefined
   }
 }
 
 const listInstances = async (options: TapCliOptions): Promise<number> => {
-  const instances = await listLiveInstances({ instance: options.instance })
+  const instances = await listLiveSessions({ session: options.instance })
 
   if (instances.length === 0) {
     renderResult(NO_INSTANCES_GUIDANCE)
@@ -55,10 +55,10 @@ const listInstances = async (options: TapCliOptions): Promise<number> => {
     return 0
   }
 
-  const timeoutMs = options.timeout ?? FIND_INSTANCE_TIMEOUT_MS
+  const timeoutMs = options.timeout ?? FIND_SESSION_TIMEOUT_MS
   const responsive = await Promise.all(instances.map((instance) => probeRenderer(instance, timeoutMs)))
 
-  const summaries: TapInstanceSummary[] = instances.map((instance, index) => ({
+  const summaries: TapSessionSummary[] = instances.map((instance, index) => ({
     pid: instance.pid,
     projectRoot: instance.projectRoot,
     testingType: instance.testingType,

--- a/cli/lib/tap/commands/run.ts
+++ b/cli/lib/tap/commands/run.ts
@@ -1,6 +1,6 @@
-import { CypressInstanceError, resolveLiveInstance } from '../../cypress-sessions'
-import { LiveInstanceState, TapSpecsOperation, tapRunSpecOperation } from '@packages/cypress-sessions'
-import { queryInstanceGraphql } from '../instance-gql'
+import { CypressSessionError, resolveLiveSession } from '../../cypress-sessions'
+import { LiveSessionState, TapSpecsOperation, tapRunSpecOperation } from '@packages/cypress-sessions'
+import { querySessionGraphql } from '../session-gql'
 import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { defineNativeCommand } from './definition'
 import type { TapCliOptions } from '../types'
@@ -18,8 +18,8 @@ export interface TapRunResult {
 
 const RUN_SPEC_TIMEOUT_MS = 60_000
 
-const findTargetSpec = async (instance: LiveInstanceState, relative: string) => {
-  const specsData = await queryInstanceGraphql(instance, TapSpecsOperation)
+const findTargetSpec = async (session: LiveSessionState, relative: string) => {
+  const specsData = await querySessionGraphql(session, TapSpecsOperation)
   const wanted = posixify(relative)
 
   return (specsData.currentProject?.specs ?? []).find((spec) => posixify(spec.relative) === wanted)
@@ -27,9 +27,9 @@ const findTargetSpec = async (instance: LiveInstanceState, relative: string) => 
 
 const runSpec = async (options: TapCliOptions, args: { spec: string }): Promise<number> => {
   try {
-    const { instance } = await resolveLiveInstance({ instance: options.instance, cwd: process.cwd() })
+    const { session } = await resolveLiveSession({ session: options.instance, cwd: process.cwd() })
 
-    const match = await findTargetSpec(instance, args.spec)
+    const match = await findTargetSpec(session, args.spec)
 
     if (!match) {
       renderFailure({ code: 'SPEC_NOT_FOUND', message: `No spec matches the path "${args.spec}" — use the specs command to list runnable specs.` })
@@ -37,7 +37,7 @@ const runSpec = async (options: TapCliOptions, args: { spec: string }): Promise<
       return 1
     }
 
-    const { runSpec: result } = await queryInstanceGraphql(instance, tapRunSpecOperation(match.absolute), RUN_SPEC_TIMEOUT_MS)
+    const { runSpec: result } = await querySessionGraphql(session, tapRunSpecOperation(match.absolute), RUN_SPEC_TIMEOUT_MS)
 
     if (result?.__typename === 'RunSpecResponse') {
       const launched: TapRunResult = {
@@ -53,13 +53,13 @@ const runSpec = async (options: TapCliOptions, args: { spec: string }): Promise<
 
     const failure = result?.__typename === 'RunSpecError'
       ? { code: result.code, message: result.detailMessage ?? `The spec "${args.spec}" could not be run.` }
-      : { code: 'RUN_FAILED', message: `The instance returned no result for running "${args.spec}".` }
+      : { code: 'RUN_FAILED', message: `The session returned no result for running "${args.spec}".` }
 
     renderFailure(failure)
 
     return 1
   } catch (err: any) {
-    if (err instanceof CypressInstanceError) {
+    if (err instanceof CypressSessionError) {
       renderFailure(err)
 
       return 1

--- a/cli/lib/tap/commands/specs.ts
+++ b/cli/lib/tap/commands/specs.ts
@@ -1,6 +1,6 @@
-import { CypressInstanceError, resolveLiveInstance } from '../../cypress-sessions'
+import { CypressSessionError, resolveLiveSession } from '../../cypress-sessions'
 import { TapSpecsOperation } from '@packages/cypress-sessions'
-import { queryInstanceGraphql } from '../instance-gql'
+import { querySessionGraphql } from '../session-gql'
 import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { defineNativeCommand } from './definition'
 import type { TapSpecsQuery } from '@packages/cypress-sessions'
@@ -51,14 +51,14 @@ const toSpecList = (data: TapSpecsQuery): TapSpecEntry[] => {
 
 const listSpecs = async (options: TapCliOptions): Promise<number> => {
   try {
-    const { instance } = await resolveLiveInstance({ instance: options.instance, cwd: process.cwd() })
-    const data = await queryInstanceGraphql(instance, TapSpecsOperation)
+    const { session } = await resolveLiveSession({ session: options.instance, cwd: process.cwd() })
+    const data = await querySessionGraphql(session, TapSpecsOperation)
 
     renderOutcome('specs', toSpecList(data), options.json)
 
     return 0
   } catch (err: any) {
-    if (err instanceof CypressInstanceError) {
+    if (err instanceof CypressSessionError) {
       renderFailure(err)
 
       return 1

--- a/cli/lib/tap/commands/status.ts
+++ b/cli/lib/tap/commands/status.ts
@@ -1,5 +1,5 @@
-import { CypressInstanceError, resolveLiveInstance } from '../../cypress-sessions'
-import type { ReadyInstanceState } from '../../cypress-sessions'
+import { CypressSessionError, resolveLiveSession } from '../../cypress-sessions'
+import type { ReadySessionState } from '../../cypress-sessions'
 import { withTapConnection, validateExecResult } from '../tap-connection'
 import { renderFailure, renderKnownFailure, renderOutcome } from '../output'
 import { TAP_EXEC_METHOD } from '@packages/cypress-sessions'
@@ -30,10 +30,10 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   let selection
 
   try {
-    selection = await resolveLiveInstance({ instance: options.instance, cwd: process.cwd() })
+    selection = await resolveLiveSession({ session: options.instance, cwd: process.cwd() })
   } catch (err) {
-    if (err instanceof CypressInstanceError) {
-      // Polling cannot outlast an instance tap will never be able to drive, so
+    if (err instanceof CypressSessionError) {
+      // Polling cannot outlast an session tap will never be able to drive, so
       // that one is a failure where every other resolution error is a status a
       // poller waits on.
       if (err.code === 'UNSUPPORTED_BROWSER') {
@@ -50,16 +50,16 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
     throw err
   }
 
-  const { instance } = selection
-  const browserAttached = instance.cdpBrowserWsUrl !== null
+  const { session } = selection
+  const browserAttached = session.cdpBrowserWsUrl !== null
 
   const base: TapStatus = {
     status: 'browser not selected',
-    pid: instance.pid,
-    projectRoot: instance.projectRoot,
-    testingType: instance.testingType,
+    pid: session.pid,
+    projectRoot: session.projectRoot,
+    testingType: session.testingType,
     browserAttached,
-    browserName: instance.browserName,
+    browserName: session.browserName,
   }
 
   if (!browserAttached) {
@@ -69,7 +69,7 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
   }
 
   try {
-    const outcome = await withTapConnection(instance as ReadyInstanceState, async (connection) => {
+    const outcome = await withTapConnection(session as ReadySessionState, async (connection) => {
       return validateExecResult(await connection.call(TAP_EXEC_METHOD, ['run-state', {}, {}]))
     }, options.timeout)
 
@@ -83,9 +83,9 @@ const reportStatus = async (options: TapCliOptions): Promise<number> => {
 
     return 0
   } catch (err: any) {
-    // A degraded instance reached this far carries a code (e.g. an unresponsive
-    // renderer); the earlier catch only covers instances that never resolved.
-    if (err instanceof CypressInstanceError) {
+    // A degraded session reached this far carries a code (e.g. an unresponsive
+    // renderer); the earlier catch only covers sessions that never resolved.
+    if (err instanceof CypressSessionError) {
       renderFailure(err)
 
       return 1

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -2,7 +2,7 @@ import Debug from 'debug'
 import { randomUUID } from 'crypto'
 
 import util, { DEVELOPMENT_VERSION } from '../util'
-import { resolvedInstanceIdentity } from '../cypress-sessions'
+import { resolvedSessionIdentity } from '../cypress-sessions'
 import { detectAgent } from '@packages/agent-info'
 import type { ReportedInvocation } from './reported-invocation'
 
@@ -97,21 +97,21 @@ export const reportTapTrace = async (exitCode: number): Promise<void> => {
       return
     }
 
-    const identity = resolvedInstanceIdentity()
+    const identity = resolvedSessionIdentity()
 
     const payload = {
       command: trace.command,
       flags: trace.flags.slice(0, MAX_REPORTED_FLAGS),
       agent: detectAgent(),
-      instanceId: identity?.instanceId ?? undefined,
+      sessionId: identity?.sessionId ?? undefined,
       userId: identity?.userId ?? undefined,
       exitCode,
       errorCode: trace.errorCode,
       durationMs: Date.now() - trace.startedAt,
     }
 
-    // The identity travels in the instance probe response, so an invocation that
-    // never resolved an instance has no machineId and stays on the anonymous
+    // The identity travels in the session probe response, so an invocation that
+    // never resolved a session has no machineId and stays on the anonymous
     // collector, mirroring EventCollectorActions.recordEvent app-side.
     const machineId = identity?.machineId ?? undefined
     const url = eventCollectorUrl(machineId !== undefined)

--- a/cli/lib/tap/output.ts
+++ b/cli/lib/tap/output.ts
@@ -3,7 +3,7 @@ import commander from 'commander'
 import logger from '../logger'
 import { renderingFor } from './render'
 import { noteTapFailure } from './events'
-import type { InstanceSelection } from '../cypress-sessions'
+import type { SessionSelection } from '../cypress-sessions'
 import type { TapSchema } from '@packages/cypress-sessions'
 
 // Codes whose message already reads as a complete explanation with its own
@@ -53,16 +53,16 @@ const unknownCommandMessage = (program: commander.Command, schema: TapSchema, co
   return `"${command}" is not a command of this Cypress (v${schema.cypressVersion}). Available commands: ${available}.`
 }
 
-const instanceBanner = (schema: TapSchema, selection: InstanceSelection): string => {
-  const { instance, candidateCount } = selection
+const sessionBanner = (schema: TapSchema, selection: SessionSelection): string => {
+  const { session, candidateCount } = selection
 
   const target = `Target:
-  ${instance.projectRoot}
+  ${session.projectRoot}
   v${schema.cypressVersion}
-  pid:${instance.pid}`
+  pid:${session.pid}`
 
   if (candidateCount > 1) {
-    return `${target}\n${candidateCount} running instances matched; targeting pid ${instance.pid}. Pass --instance <pid> to target another.`
+    return `${target}\n${candidateCount} running instances matched; targeting pid ${session.pid}. Pass --instance <pid> to target another.`
   }
 
   return target
@@ -99,8 +99,8 @@ const renderHelp = (program: commander.Command, schema: TapSchema, command: stri
   return 0
 }
 
-export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: InstanceSelection, command: string | undefined): number => {
-  return renderHelp(program, schema, command, instanceBanner(schema, selection))
+export const renderSchemaHelp = (program: commander.Command, schema: TapSchema, selection: SessionSelection, command: string | undefined): number => {
+  return renderHelp(program, schema, command, sessionBanner(schema, selection))
 }
 
 export const renderStaticHelp = (program: commander.Command, schema: TapSchema, command: string | undefined): number => {

--- a/cli/lib/tap/render/index.ts
+++ b/cli/lib/tap/render/index.ts
@@ -1,6 +1,6 @@
 import type { ClearResult, PinResult, TapCommandName, TapCommandResult, TapNativeCommandName, TapReporterSpecView, TapReporterView } from '@packages/cypress-sessions'
 import type { TapRunResult } from '../commands/run'
-import type { TapInstanceSummary } from '../commands/instances'
+import type { TapSessionSummary } from '../commands/instances'
 import type { TapSpecEntry } from '../commands/specs'
 import type { TapStatus } from '../types'
 import type { FrameDomResult } from '../commands/dom'
@@ -60,7 +60,7 @@ const renderings: Partial<Record<TapCommandName | TapNativeCommandName, TapComma
     },
   },
   run: { renderHuman: (result) => renderRunHuman(result as TapRunResult) },
-  instances: { renderHuman: (result) => renderInstancesHuman(result as TapInstanceSummary[]) },
+  instances: { renderHuman: (result) => renderInstancesHuman(result as TapSessionSummary[]) },
   specs: { renderHuman: (result) => renderSpecsHuman(result as TapSpecEntry[]) },
   status: { renderHuman: (result) => renderStatusHuman(result as TapStatus) },
   dom: { renderHuman: orAmbiguous<FrameDomResult>(renderDomHuman) },

--- a/cli/lib/tap/render/instances.ts
+++ b/cli/lib/tap/render/instances.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import type { TapInstanceSummary } from '../commands/instances'
+import type { TapSessionSummary } from '../commands/instances'
 import { color, columns, layout, panel } from './format'
 
 /** The facts an instance row shows — carried by a summary, and by a status. */
@@ -74,6 +74,6 @@ export const instanceColumns = (instances: InstanceRow[]): string[] => {
 }
 
 // The reachable open-mode instances under a counted heading.
-export const renderInstancesHuman = (instances: TapInstanceSummary[]): string => {
+export const renderInstancesHuman = (instances: TapSessionSummary[]): string => {
   return layout([panel('INSTANCES', instances.length, instanceColumns(instances))])
 }

--- a/cli/lib/tap/session-gql.ts
+++ b/cli/lib/tap/session-gql.ts
@@ -2,8 +2,8 @@ import Debug from 'debug'
 
 import { errors } from '../errors'
 import { throwTapError } from './tap-connection'
-import type { LiveInstanceState } from '../cypress-sessions'
-import { INSTANCE_ID_HEADER } from '@packages/cypress-sessions'
+import type { LiveSessionState } from '../cypress-sessions'
+import { SESSION_ID_HEADER } from '@packages/cypress-sessions'
 import type { TapGraphqlOperation } from '@packages/cypress-sessions'
 
 const debug = Debug('cypress:cli:tap')
@@ -45,7 +45,7 @@ const validateEnvelope = <T>(operationName: string, envelope: GraphqlEnvelope | 
   return envelope.data as T
 }
 
-export const queryInstanceGraphql = async <TResult>(instance: LiveInstanceState, operation: TapGraphqlOperation<TResult>, timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS): Promise<TResult> => {
+export const querySessionGraphql = async <TResult>(instance: LiveSessionState, operation: TapGraphqlOperation<TResult>, timeoutMs: number = DEFAULT_QUERY_TIMEOUT_MS): Promise<TResult> => {
   const { operationName, query, variables } = operation
   const url = `http://${GRAPHQL_HOST}:${instance.serverPort}${GRAPHQL_PATH}/${operationName}`
 
@@ -54,7 +54,7 @@ export const queryInstanceGraphql = async <TResult>(instance: LiveInstanceState,
   try {
     response = await fetch(url, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', [INSTANCE_ID_HEADER]: instance.instanceId },
+      headers: { 'content-type': 'application/json', [SESSION_ID_HEADER]: instance.sessionId },
       body: JSON.stringify({ operationName, query, variables: variables ?? {} }),
       signal: AbortSignal.timeout(timeoutMs),
     })

--- a/cli/lib/tap/tap-connection.ts
+++ b/cli/lib/tap/tap-connection.ts
@@ -2,8 +2,8 @@ import Debug from 'debug'
 import CRI from 'chrome-remote-interface'
 
 import { errors } from '../errors'
-import { DEFAULT_CDP_TIMEOUT_MS, FIND_INSTANCE_TIMEOUT_MS, boundCdpCalls, isRendererUnresponsive, withCdpDeadline } from './cdp-timeout'
-import type { ReadyInstanceState } from '../cypress-sessions'
+import { DEFAULT_CDP_TIMEOUT_MS, FIND_SESSION_TIMEOUT_MS, boundCdpCalls, isRendererUnresponsive, withCdpDeadline } from './cdp-timeout'
+import type { ReadySessionState } from '../cypress-sessions'
 import { TAP_BINDING_GLOBAL, TAP_EXEC_METHOD } from '@packages/cypress-sessions'
 import type { TapExecResult } from '@packages/cypress-sessions'
 
@@ -114,17 +114,17 @@ const evaluateBinding = (client: CRI.Client, sessionId: string) => {
   return client.Runtime.evaluate({ expression: `window.${TAP_BINDING_GLOBAL}` }, sessionId)
 }
 
-const probeForBinding = async (client: CRI.Client, sessionId: string, findInstanceMs: number): Promise<boolean> => {
+const probeForBinding = async (client: CRI.Client, sessionId: string, findSessionMs: number): Promise<boolean> => {
   const { result, exceptionDetails } = await withCdpDeadline(
     evaluateBinding(client, sessionId),
     'the runner-page probe',
-    findInstanceMs,
+    findSessionMs,
   )
 
   return !exceptionDetails && result.type !== 'undefined' && !!result.objectId
 }
 
-const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[], findInstanceMs: number): Promise<string> => {
+const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTargetInfo[], findSessionMs: number): Promise<string> => {
   let unresponsive: unknown
 
   for (const target of targetInfos) {
@@ -137,7 +137,7 @@ const findRunnerPageSession = async (client: CRI.Client, targetInfos: PageTarget
     try {
       sessionId = await attachToPage(client, target.targetId)
 
-      if (await probeForBinding(client, sessionId, findInstanceMs)) {
+      if (await probeForBinding(client, sessionId, findSessionMs)) {
         debug('matched runner page target %o', { targetId: target.targetId, url: target.url })
 
         return sessionId
@@ -180,11 +180,11 @@ const resolveBindingObjectId = async (client: CRI.Client, sessionId: string): Pr
   const { result, exceptionDetails } = evaluated
 
   if (exceptionDetails) {
-    return throwTapError(errors.tapCdpUnreachable, `Failed to connect to the instance.`)
+    return throwTapError(errors.tapCdpUnreachable, `Failed to connect to the session.`)
   }
 
   if (result.type === 'undefined' || !result.objectId) {
-    return throwTapError(errors.tapBindingNotFound, `Connected to an unsupported instance.`)
+    return throwTapError(errors.tapBindingNotFound, `Connected to an unsupported session.`)
   }
 
   return result.objectId
@@ -241,16 +241,16 @@ const callBindingWithRetry = async (client: CRI.Client, sessionId: string, metho
 }
 
 export const withTapConnection = async <T> (
-  instance: ReadyInstanceState,
+  session: ReadySessionState,
   fn: (connection: TapConnection) => Promise<T>,
   timeoutMs?: number,
 ): Promise<T> => {
   const callMs = timeoutMs ?? DEFAULT_CDP_TIMEOUT_MS
-  const findInstanceMs = timeoutMs ?? FIND_INSTANCE_TIMEOUT_MS
+  const findSessionMs = timeoutMs ?? FIND_SESSION_TIMEOUT_MS
 
-  debug('opening tap connection for instance %o', { pid: instance.pid, cdpBrowserWsUrl: instance.cdpBrowserWsUrl, callMs, findInstanceMs })
+  debug('opening tap connection for session %o', { pid: session.pid, cdpBrowserWsUrl: session.cdpBrowserWsUrl, callMs, findSessionMs })
 
-  const client = await connectToBrowser(instance.cdpBrowserWsUrl)
+  const client = await connectToBrowser(session.cdpBrowserWsUrl)
 
   boundCdpCalls(client, callMs)
 
@@ -258,7 +258,7 @@ export const withTapConnection = async <T> (
     const attach = async (): Promise<string> => {
       const { targetInfos } = await listTargets(client)
 
-      return findRunnerPageSession(client, targetInfos, findInstanceMs)
+      return findRunnerPageSession(client, targetInfos, findSessionMs)
     }
 
     let sessionId = await attach()

--- a/cli/lib/tasks/cache.ts
+++ b/cli/lib/tasks/cache.ts
@@ -10,14 +10,14 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import chalk from 'chalk'
 import _ from 'lodash'
 import getFolderSize from './get-folder-size'
-import { INSTANCES_DIRNAME, pruneDeadInstanceRecords } from '../cypress-sessions'
+import { SESSIONS_DIRNAME, pruneDeadSessionRecords } from '../cypress-sessions'
 
 dayjs.extend(relativeTime)
 
-// Subdirs under the cache root that are not binary version dirs. INSTANCES_DIRNAME
+// Subdirs under the cache root that are not binary version dirs. SESSIONS_DIRNAME
 // is sourced from cypress-sessions so a rename there can't silently make prune
 // treat the instances dir as a stale binary cache and delete live records.
-const EXTERNAL_CACHE_ENTRIES = new Set(['bundles', INSTANCES_DIRNAME])
+const EXTERNAL_CACHE_ENTRIES = new Set(['bundles', SESSIONS_DIRNAME])
 
 // output colors for the table
 const colors = {
@@ -64,7 +64,7 @@ const prune = async (): Promise<void> => {
       logger.always(`No binary caches found to prune.`)
     }
 
-    await pruneDeadInstanceRecords()
+    await pruneDeadSessionRecords()
   } catch (e: any) {
     if (e.code === 'ENOENT') {
       logger.always(`No Cypress cache was found at ${cacheDir}. Nothing to prune.`)

--- a/cli/test/lib/cypress-sessions.spec.ts
+++ b/cli/test/lib/cypress-sessions.spec.ts
@@ -7,16 +7,16 @@ import type { AddressInfo } from 'net'
 import state from '../../lib/tasks/state'
 import {
   isPidAlive,
-  verifyInstanceRecord,
-  readInstanceRecords,
-  resolveInstance,
-  resolveLiveInstance,
-  listLiveInstances,
-  getInstancesDir,
-  pruneDeadInstanceRecords,
-  resolvedInstanceId,
-  resolvedInstanceIdentity,
-  CypressInstanceError,
+  verifySessionRecord,
+  readSessionRecords,
+  resolveSession,
+  resolveLiveSession,
+  listLiveSessions,
+  getSessionsDir,
+  pruneDeadSessionRecords,
+  resolvedSessionId,
+  resolvedSessionIdentity,
+  CypressSessionError,
 } from '../../lib/cypress-sessions'
 
 vi.mock('../../lib/tasks/state', async (importActual) => {
@@ -32,9 +32,9 @@ vi.mock('../../lib/tasks/state', async (importActual) => {
 })
 
 const CACHE_DIR = '/.cache/Cypress'
-const INSTANCES_DIR = `${CACHE_DIR}/instances`
+const SESSIONS_DIR = `${CACHE_DIR}/sessions`
 const PROJECT = '/projects/app'
-const INSTANCE_ID = 'a1b2c3d4-0000-4000-8000-000000000000'
+const SESSION_ID = 'a1b2c3d4-0000-4000-8000-000000000000'
 
 const makeRecord = (overrides: Record<string, any> = {}) => {
   return JSON.stringify({
@@ -42,7 +42,7 @@ const makeRecord = (overrides: Record<string, any> = {}) => {
     pid: 1234,
     projectRoot: PROJECT,
     serverPort: 1,
-    instanceId: INSTANCE_ID,
+    sessionId: SESSION_ID,
     testingType: 'e2e',
     ...overrides,
   })
@@ -70,15 +70,15 @@ const stubKill = ({ alive = [], eperm = [] }: { alive?: number[], eperm?: number
 describe('lib/cypress-sessions', () => {
   const servers: http.Server[] = []
 
-  const startFakeInstance = async ({ instanceId = INSTANCE_ID, respondWith = null as Record<string, any> | null, hang = false } = {}): Promise<number> => {
+  const startFakeSession = async ({ sessionId = SESSION_ID, respondWith = null as Record<string, any> | null, hang = false } = {}): Promise<number> => {
     const server = http.createServer((req, res) => {
       if (hang) {
         return
       }
 
-      if (req.url === `/__cypress/instances/${instanceId}`) {
+      if (req.url === `/__cypress/sessions/${sessionId}`) {
         res.setHeader('content-type', 'application/json')
-        res.end(JSON.stringify(respondWith ?? { instanceId }))
+        res.end(JSON.stringify(respondWith ?? { sessionId }))
 
         return
       }
@@ -139,9 +139,9 @@ describe('lib/cypress-sessions', () => {
     servers.length = 0
   })
 
-  describe('.getInstancesDir', () => {
-    it('joins the cache dir with instances/', () => {
-      expect(getInstancesDir()).to.equal(INSTANCES_DIR)
+  describe('.getSessionsDir', () => {
+    it('joins the cache dir with sessions/', () => {
+      expect(getSessionsDir()).to.equal(SESSIONS_DIR)
     })
   })
 
@@ -162,16 +162,16 @@ describe('lib/cypress-sessions', () => {
     })
   })
 
-  describe('.verifyInstanceRecord', () => {
-    const recordFor = (serverPort: number, instanceId = INSTANCE_ID) => {
-      return JSON.parse(makeRecord({ serverPort, instanceId }))
+  describe('.verifySessionRecord', () => {
+    const recordFor = (serverPort: number, sessionId = SESSION_ID) => {
+      return JSON.parse(makeRecord({ serverPort, sessionId }))
     }
 
-    it('resolves the record with the live CDP state and browser when the instance echoes the instanceId', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome', browserFamily: 'chromium', machineId: 'machine-hash', userId: 'cloud-user-1' } })
+    it('resolves the record with the live CDP state and browser when the session echoes the sessionId', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: CDP_WS_URL, browserName: 'Chrome', browserFamily: 'chromium', machineId: 'machine-hash', userId: 'cloud-user-1' } })
       const record = recordFor(port)
 
-      expect(await verifyInstanceRecord(record)).toEqual({
+      expect(await verifySessionRecord(record)).toEqual({
         ...record,
         cdpBrowserWsUrl: CDP_WS_URL,
         browserName: 'Chrome',
@@ -181,67 +181,67 @@ describe('lib/cypress-sessions', () => {
       })
     })
 
-    it('normalizes identity fields an older instance omits (or junks) to null', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, machineId: 42 } })
-      const live = await verifyInstanceRecord(recordFor(port))
+    it('normalizes identity fields an older session omits (or junks) to null', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, machineId: 42 } })
+      const live = await verifySessionRecord(recordFor(port))
 
       expect(live!.machineId).toBeNull()
       expect(live!.userId).toBeNull()
     })
 
-    it('keeps the browser the instance has open even when the CDP endpoint is unreachable', async () => {
+    it('keeps the browser the session has open even when the CDP endpoint is unreachable', async () => {
       const deadCdpPort = await getClosedPort()
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc`, browserName: 'Chrome', browserFamily: 'chromium' } })
-      const live = await verifyInstanceRecord(recordFor(port))
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc`, browserName: 'Chrome', browserFamily: 'chromium' } })
+      const live = await verifySessionRecord(recordFor(port))
 
       expect(live!.cdpBrowserWsUrl).toBeNull()
       expect(live!.browserName).toBe('Chrome')
       expect(live!.browserFamily).toBe('chromium')
     })
 
-    it('normalizes a browser an older instance omits (or junks) to null', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserFamily: 42 } })
-      const live = await verifyInstanceRecord(recordFor(port))
+    it('normalizes a browser an older session omits (or junks) to null', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, browserFamily: 42 } })
+      const live = await verifySessionRecord(recordFor(port))
 
       expect(live!.browserName).toBeNull()
       expect(live!.browserFamily).toBeNull()
     })
 
     it('normalizes a missing or junk cdpBrowserWsUrl in the probe response to null', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: 42 } })
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: 42 } })
 
-      expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
+      expect((await verifySessionRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
     })
 
     it('nulls the CDP endpoint when the browser is gone, even though the probe still echoes a url', async () => {
       const deadCdpPort = await getClosedPort()
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc` } })
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: `ws://127.0.0.1:${deadCdpPort}/devtools/browser/abc` } })
 
-      expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
+      expect((await verifySessionRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
     })
 
     it('nulls a malformed cdpBrowserWsUrl that has no reachable endpoint to derive', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: 'not-a-ws-url' } })
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: 'not-a-ws-url' } })
 
-      expect((await verifyInstanceRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
+      expect((await verifySessionRecord(recordFor(port)))!.cdpBrowserWsUrl).toBeNull()
     })
 
     it('is null when nothing is listening on the recorded port', async () => {
       const port = await getClosedPort()
 
-      expect(await verifyInstanceRecord(recordFor(port))).toBeNull()
+      expect(await verifySessionRecord(recordFor(port))).toBeNull()
     })
 
-    it('is null when the responder does not know the instanceId (recycled port)', async () => {
-      const port = await startFakeInstance({ instanceId: 'some-other-instance' })
+    it('is null when the responder does not know the sessionId (recycled port)', async () => {
+      const port = await startFakeSession({ sessionId: 'some-other-session' })
 
-      expect(await verifyInstanceRecord(recordFor(port))).toBeNull()
+      expect(await verifySessionRecord(recordFor(port))).toBeNull()
     })
 
-    it('is null when the echoed instanceId does not match', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: 'impostor' } })
+    it('is null when the echoed sessionId does not match', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: 'impostor' } })
 
-      expect(await verifyInstanceRecord(recordFor(port))).toBeNull()
+      expect(await verifySessionRecord(recordFor(port))).toBeNull()
     })
 
     it('is null when the response is not JSON', async () => {
@@ -252,26 +252,26 @@ describe('lib/cypress-sessions', () => {
 
       const { port } = server.address() as AddressInfo
 
-      expect(await verifyInstanceRecord(recordFor(port))).toBeNull()
+      expect(await verifySessionRecord(recordFor(port))).toBeNull()
     })
 
     it('is null when the probe times out', async () => {
-      const port = await startFakeInstance({ hang: true })
+      const port = await startFakeSession({ hang: true })
 
-      expect(await verifyInstanceRecord(recordFor(port), 100)).toBeNull()
+      expect(await verifySessionRecord(recordFor(port), 100)).toBeNull()
     })
   })
 
-  describe('.readInstanceRecords', () => {
-    it('returns [] when the instances dir does not exist', async () => {
+  describe('.readSessionRecords', () => {
+    it('returns [] when the sessions dir does not exist', async () => {
       mockfs({ [CACHE_DIR]: {} })
 
-      expect(await readInstanceRecords()).toEqual([])
+      expect(await readSessionRecords()).toEqual([])
     })
 
     it('parses <pid>.json records and skips temp/junk/corrupt/incompatible files', async () => {
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111 }),
           '222.json.tmp': 'partial write',
           'notes.txt': 'not a record',
@@ -281,195 +281,195 @@ describe('lib/cypress-sessions', () => {
         },
       })
 
-      const records = await readInstanceRecords()
+      const records = await readSessionRecords()
 
       expect(records.map((r) => r.pid)).toEqual([111])
     })
 
     it('reads e2e, component, and null testing types', async () => {
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, testingType: 'e2e' }),
           '222.json': makeRecord({ pid: 222, testingType: 'component' }),
           '333.json': makeRecord({ pid: 333, testingType: null }),
         },
       })
 
-      const byPid = Object.fromEntries((await readInstanceRecords()).map((r) => [r.pid, r.testingType]))
+      const byPid = Object.fromEntries((await readSessionRecords()).map((r) => [r.pid, r.testingType]))
 
       expect(byPid).toEqual({ 111: 'e2e', 222: 'component', 333: null })
     })
   })
 
-  describe('.resolveInstance', () => {
-    // resolveInstance requires an attached browser, so its happy-path fake instance
+  describe('.resolveSession', () => {
+    // resolveSession requires an attached browser, so its happy-path fake session
     // must echo a CDP endpoint in the probe response.
-    const startReadyInstance = (instanceId: string) => {
-      return startFakeInstance({ instanceId, respondWith: { instanceId, cdpBrowserWsUrl: CDP_WS_URL } })
+    const startReadySession = (sessionId: string) => {
+      return startFakeSession({ sessionId, respondWith: { sessionId, cdpBrowserWsUrl: CDP_WS_URL } })
     }
 
-    it('uses a lone live instance wherever it lives, ignoring the cwd (reason: only)', async () => {
-      const port = await startReadyInstance(INSTANCE_ID)
+    it('uses a lone live session wherever it lives, ignoring the cwd (reason: only)', async () => {
+      const port = await startReadySession(SESSION_ID)
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const selection = await resolveInstance({ cwd: '/somewhere/unrelated' })
+      const selection = await resolveSession({ cwd: '/somewhere/unrelated' })
 
-      expect(selection.instance.pid).toBe(111)
+      expect(selection.session.pid).toBe(111)
       expect(selection.reason).toBe('only')
       expect(selection.candidateCount).toBe(1)
       // The live CDP endpoint comes from the probe response, not the disk record.
-      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      expect(selection.session.cdpBrowserWsUrl).toBe(CDP_WS_URL)
     })
 
-    it('throws NO_INSTANCE when no record matches the filters', async () => {
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
+    it('throws NO_SESSION when no record matches the filters', async () => {
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
       stubKill({ alive: [111] })
 
-      await expect(resolveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+      await expect(resolveSession({ session: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_SESSION' })
     })
 
-    it('remembers the id of the instance it selected', async () => {
-      const port = await startReadyInstance(INSTANCE_ID)
+    it('remembers the id of the session it selected', async () => {
+      const port = await startReadySession(SESSION_ID)
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await resolveInstance({ cwd: PROJECT })
+      await resolveSession({ cwd: PROJECT })
 
-      expect(resolvedInstanceId()).toBe(INSTANCE_ID)
+      expect(resolvedSessionId()).toBe(SESSION_ID)
     })
 
-    it('remembers the identity the probe carried for the instance it selected', async () => {
-      const port = await startFakeInstance({
-        respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL, machineId: 'machine-hash', userId: 'cloud-user-1' },
+    it('remembers the identity the probe carried for the session it selected', async () => {
+      const port = await startFakeSession({
+        respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: CDP_WS_URL, machineId: 'machine-hash', userId: 'cloud-user-1' },
       })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await resolveInstance({ cwd: PROJECT })
+      await resolveSession({ cwd: PROJECT })
 
-      expect(resolvedInstanceIdentity()).toEqual({ instanceId: INSTANCE_ID, machineId: 'machine-hash', userId: 'cloud-user-1' })
+      expect(resolvedSessionIdentity()).toEqual({ sessionId: SESSION_ID, machineId: 'machine-hash', userId: 'cloud-user-1' })
     })
 
-    it('reaps the leftover record and throws NO_INSTANCE when the only match’s process is dead', async () => {
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
+    it('reaps the leftover record and throws NO_SESSION when the only match’s process is dead', async () => {
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
       stubKill({ alive: [] })
 
-      const err = await resolveInstance({ cwd: PROJECT }).catch((e) => e)
+      const err = await resolveSession({ cwd: PROJECT }).catch((e) => e)
 
-      expect(err).toBeInstanceOf(CypressInstanceError)
-      expect(err.code).toBe('NO_INSTANCE')
+      expect(err).toBeInstanceOf(CypressSessionError)
+      expect(err.code).toBe('NO_SESSION')
       // The dead-process leftover is reaped, so it stops masquerading as a
-      // still-running-but-unresponsive (stale) instance on later commands.
-      expect(fs.existsSync(`${INSTANCES_DIR}/111.json`)).toBe(false)
+      // still-running-but-unresponsive (stale) session on later commands.
+      expect(fs.existsSync(`${SESSIONS_DIR}/111.json`)).toBe(false)
     })
 
-    it('throws STALE_INSTANCE when the pid is taken but nothing answers the probe (recycled pid)', async () => {
+    it('throws STALE_SESSION when the pid is taken but nothing answers the probe (recycled pid)', async () => {
       const port = await getClosedPort()
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'STALE_INSTANCE' })
+      await expect(resolveSession({ cwd: PROJECT })).rejects.toMatchObject({ code: 'STALE_SESSION' })
       // An alive-but-unresponsive process is genuinely stale, not gone — its
       // record is kept (only dead-pid leftovers are reaped).
-      expect(fs.existsSync(`${INSTANCES_DIR}/111.json`)).toBe(true)
+      expect(fs.existsSync(`${SESSIONS_DIR}/111.json`)).toBe(true)
     })
 
-    it('throws NO_BROWSER_ATTACHED when the chosen instance is live but has no browser', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null } })
+    it('throws NO_BROWSER_ATTACHED when the chosen session is live but has no browser', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: null } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await expect(resolveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
+      await expect(resolveSession({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_BROWSER_ATTACHED' })
     })
 
-    it('throws UNSUPPORTED_BROWSER when the only instance runs a browser tap cannot drive', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
+    it('throws UNSUPPORTED_BROWSER when the only session runs a browser tap cannot drive', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const err = await resolveInstance({ instance: 111, cwd: PROJECT }).catch((e) => e)
+      const err = await resolveSession({ session: 111, cwd: PROJECT }).catch((e) => e)
 
-      // Not NO_BROWSER_ATTACHED: a Firefox instance never attaches one, so the
+      // Not NO_BROWSER_ATTACHED: a Firefox session never attaches one, so the
       // "open a browser" guidance would send the user in a circle.
       expect(err.code).toBe('UNSUPPORTED_BROWSER')
       expect(err.message).toBe('The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.')
     })
 
-    it('resolves a Chromium instance over a live one at the cwd running an unsupported browser', async () => {
-      const readyPort = await startReadyInstance('ready-instance')
-      const firefoxPort = await startFakeInstance({ instanceId: 'firefox-instance', respondWith: { instanceId: 'firefox-instance', cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
+    it('resolves a Chromium session over a live one at the cwd running an unsupported browser', async () => {
+      const readyPort = await startReadySession('ready-session')
+      const firefoxPort = await startFakeSession({ sessionId: 'firefox-session', respondWith: { sessionId: 'firefox-session', cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' } })
 
       mockfs({
-        [INSTANCES_DIR]: {
-          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: firefoxPort, instanceId: 'firefox-instance' }),
-          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, instanceId: 'ready-instance' }),
+        [SESSIONS_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: firefoxPort, sessionId: 'firefox-session' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, sessionId: 'ready-session' }),
         },
       })
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ cwd: PROJECT })
+      const selection = await resolveSession({ cwd: PROJECT })
 
-      expect(selection.instance.pid).toBe(222)
+      expect(selection.session.pid).toBe(222)
       expect(selection.candidateCount).toBe(1)
     })
 
-    it('resolves a browser-attached instance over a live one at the cwd that has none', async () => {
-      const readyPort = await startReadyInstance('ready-instance')
-      const browserlessPort = await startFakeInstance({ instanceId: 'browserless-instance', respondWith: { instanceId: 'browserless-instance', cdpBrowserWsUrl: null } })
+    it('resolves a browser-attached session over a live one at the cwd that has none', async () => {
+      const readyPort = await startReadySession('ready-session')
+      const browserlessPort = await startFakeSession({ sessionId: 'browserless-session', respondWith: { sessionId: 'browserless-session', cdpBrowserWsUrl: null } })
 
       mockfs({
-        [INSTANCES_DIR]: {
-          // The cwd-rooted instance has no browser, so it cannot be the target
+        [SESSIONS_DIR]: {
+          // The cwd-rooted session has no browser, so it cannot be the target
           // even though it would otherwise win by cwd-match.
-          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: browserlessPort, instanceId: 'browserless-instance' }),
-          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, instanceId: 'ready-instance' }),
+          '111.json': makeRecord({ pid: 111, projectRoot: PROJECT, serverPort: browserlessPort, sessionId: 'browserless-session' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: readyPort, sessionId: 'ready-session' }),
         },
       })
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ cwd: PROJECT })
+      const selection = await resolveSession({ cwd: PROJECT })
 
-      expect(selection.instance.pid).toBe(222)
-      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
-      // Only the browser-attached instance is a candidate.
+      expect(selection.session.pid).toBe(222)
+      expect(selection.session.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      // Only the browser-attached session is a candidate.
       expect(selection.reason).toBe('only')
       expect(selection.candidateCount).toBe(1)
     })
 
     it('skips a stale record and resolves the live one', async () => {
       const closedPort = await getClosedPort()
-      const livePort = await startReadyInstance('live-instance')
+      const livePort = await startReadySession('live-session')
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: closedPort }),
-          '222.json': makeRecord({ pid: 222, serverPort: livePort, instanceId: 'live-instance' }),
+          '222.json': makeRecord({ pid: 222, serverPort: livePort, sessionId: 'live-session' }),
         },
       })
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ cwd: PROJECT })
+      const selection = await resolveSession({ cwd: PROJECT })
 
-      expect(selection.instance.pid).toBe(222)
+      expect(selection.session.pid).toBe(222)
       // Only the verified-live record counts as a candidate.
       expect(selection.candidateCount).toBe(1)
     })
 
-    it('targets a specific instance by pid (reason: explicit)', async () => {
-      const port = await startReadyInstance(INSTANCE_ID)
+    it('targets a specific session by pid (reason: explicit)', async () => {
+      const port = await startReadySession(SESSION_ID)
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: port }),
           '222.json': makeRecord({ pid: 222, serverPort: port }),
         },
@@ -477,160 +477,160 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ instance: 222, cwd: PROJECT })
+      const selection = await resolveSession({ session: 222, cwd: PROJECT })
 
-      expect(selection.instance.pid).toBe(222)
+      expect(selection.session.pid).toBe(222)
       expect(selection.reason).toBe('explicit')
-      await expect(resolveInstance({ instance: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
+      await expect(resolveSession({ session: 999, cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_SESSION' })
     })
 
-    it('prefers the instance rooted at the cwd when several are live (reason: cwd-match)', async () => {
-      const appPort = await startReadyInstance('app-instance')
-      const otherPort = await startReadyInstance('other-instance')
+    it('prefers the session rooted at the cwd when several are live (reason: cwd-match)', async () => {
+      const appPort = await startReadySession('app-session')
+      const otherPort = await startReadySession('other-session')
 
       mockfs({
-        [INSTANCES_DIR]: {
-          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, instanceId: 'app-instance' }),
-          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, instanceId: 'other-instance' }),
+        [SESSIONS_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, sessionId: 'app-session' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, sessionId: 'other-session' }),
         },
       })
 
       stubKill({ alive: [111, 222] })
 
-      const selection = await resolveInstance({ cwd: '/projects/other' })
+      const selection = await resolveSession({ cwd: '/projects/other' })
 
-      expect(selection.instance.pid).toBe(222)
+      expect(selection.session.pid).toBe(222)
       expect(selection.reason).toBe('cwd-match')
       expect(selection.candidateCount).toBe(2)
     })
 
     it('falls back to the lowest pid when several are live and none match the cwd (reason: arbitrary)', async () => {
-      const aPort = await startReadyInstance('a-instance')
-      const bPort = await startReadyInstance('b-instance')
+      const aPort = await startReadySession('a-session')
+      const bPort = await startReadySession('b-session')
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           // '1000.json' sorts before '999.json', so the read order is 1000 then
           // 999 — picking 999 proves the choice is by lowest pid, not read order.
-          '1000.json': makeRecord({ pid: 1000, projectRoot: '/projects/a', serverPort: aPort, instanceId: 'a-instance' }),
-          '999.json': makeRecord({ pid: 999, projectRoot: '/projects/b', serverPort: bPort, instanceId: 'b-instance' }),
+          '1000.json': makeRecord({ pid: 1000, projectRoot: '/projects/a', serverPort: aPort, sessionId: 'a-session' }),
+          '999.json': makeRecord({ pid: 999, projectRoot: '/projects/b', serverPort: bPort, sessionId: 'b-session' }),
         },
       })
 
       stubKill({ alive: [1000, 999] })
 
-      const selection = await resolveInstance({ cwd: '/unrelated/dir' })
+      const selection = await resolveSession({ cwd: '/unrelated/dir' })
 
-      expect(selection.instance.pid).toBe(999)
+      expect(selection.session.pid).toBe(999)
       expect(selection.reason).toBe('arbitrary')
       expect(selection.candidateCount).toBe(2)
     })
   })
 
-  describe('.resolveLiveInstance', () => {
-    it('resolves a live instance that has no browser attached, instead of throwing', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: null } })
+  describe('.resolveLiveSession', () => {
+    it('resolves a live session that has no browser attached, instead of throwing', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: null } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const selection = await resolveLiveInstance({ cwd: PROJECT })
+      const selection = await resolveLiveSession({ cwd: PROJECT })
 
-      expect(selection.instance.pid).toBe(111)
+      expect(selection.session.pid).toBe(111)
       expect(selection.reason).toBe('only')
-      expect(selection.instance.cdpBrowserWsUrl).toBeNull()
+      expect(selection.session.cdpBrowserWsUrl).toBeNull()
     })
 
     it('carries the live CDP endpoint when a browser is attached', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, cdpBrowserWsUrl: CDP_WS_URL } })
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, cdpBrowserWsUrl: CDP_WS_URL } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const selection = await resolveLiveInstance({ cwd: PROJECT })
+      const selection = await resolveLiveSession({ cwd: PROJECT })
 
-      expect(selection.instance.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      expect(selection.session.cdpBrowserWsUrl).toBe(CDP_WS_URL)
     })
 
-    it('throws NO_INSTANCE when no record matches the filters', async () => {
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, projectRoot: '/other/project' }) } })
+    it('throws NO_SESSION when no record matches the filters', async () => {
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, projectRoot: '/other/project' }) } })
       stubKill({ alive: [111] })
 
-      const err = await resolveLiveInstance({ instance: 999, cwd: PROJECT }).catch((e) => e)
+      const err = await resolveLiveSession({ session: 999, cwd: PROJECT }).catch((e) => e)
 
-      expect(err.code).toBe('NO_INSTANCE')
-      // resolveLiveInstance serves pre-browser commands (specs/status), so the
+      expect(err.code).toBe('NO_SESSION')
+      // resolveLiveSession serves pre-browser commands (specs/status), so the
       // guidance must not tell the user to open a browser.
       expect(err.message).not.toMatch(/browser/i)
     })
 
-    it('reaps the leftover record and throws NO_INSTANCE when the only match’s process is dead', async () => {
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
+    it('reaps the leftover record and throws NO_SESSION when the only match’s process is dead', async () => {
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111 }) } })
       stubKill({ alive: [] })
 
-      await expect(resolveLiveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_INSTANCE' })
-      expect(fs.existsSync(`${INSTANCES_DIR}/111.json`)).toBe(false)
+      await expect(resolveLiveSession({ cwd: PROJECT })).rejects.toMatchObject({ code: 'NO_SESSION' })
+      expect(fs.existsSync(`${SESSIONS_DIR}/111.json`)).toBe(false)
     })
 
     // The commands that never need a browser (specs/status) still run against the
-    // instance's own runner, so an unsupported browser rules them out too.
-    it('throws UNSUPPORTED_BROWSER when the only instance runs a browser tap cannot drive', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserName: 'WebKit', browserFamily: 'webkit' } })
+    // session's own runner, so an unsupported browser rules them out too.
+    it('throws UNSUPPORTED_BROWSER when the only session runs a browser tap cannot drive', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, browserName: 'WebKit', browserFamily: 'webkit' } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      await expect(resolveLiveInstance({ cwd: PROJECT })).rejects.toMatchObject({ code: 'UNSUPPORTED_BROWSER' })
+      await expect(resolveLiveSession({ cwd: PROJECT })).rejects.toMatchObject({ code: 'UNSUPPORTED_BROWSER' })
     })
   })
 
-  describe('.listLiveInstances', () => {
-    it('returns every verified-live instance across all projects, with its CDP state', async () => {
-      const appPort = await startFakeInstance({ instanceId: 'app-instance', respondWith: { instanceId: 'app-instance', cdpBrowserWsUrl: CDP_WS_URL } })
-      const otherPort = await startFakeInstance({ instanceId: 'other-instance' })
+  describe('.listLiveSessions', () => {
+    it('returns every verified-live session across all projects, with its CDP state', async () => {
+      const appPort = await startFakeSession({ sessionId: 'app-session', respondWith: { sessionId: 'app-session', cdpBrowserWsUrl: CDP_WS_URL } })
+      const otherPort = await startFakeSession({ sessionId: 'other-session' })
 
       mockfs({
-        [INSTANCES_DIR]: {
-          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, instanceId: 'app-instance' }),
-          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, instanceId: 'other-instance' }),
+        [SESSIONS_DIR]: {
+          '111.json': makeRecord({ pid: 111, projectRoot: '/projects/app', serverPort: appPort, sessionId: 'app-session' }),
+          '222.json': makeRecord({ pid: 222, projectRoot: '/projects/other', serverPort: otherPort, sessionId: 'other-session' }),
         },
       })
 
       stubKill({ alive: [111, 222] })
 
-      const instances = await listLiveInstances()
+      const sessions = await listLiveSessions()
 
-      expect(instances.map((instance) => instance.pid).sort()).toEqual([111, 222])
-      expect(instances.find((instance) => instance.pid === 111)!.cdpBrowserWsUrl).toBe(CDP_WS_URL)
+      expect(sessions.map((session) => session.pid).sort()).toEqual([111, 222])
+      expect(sessions.find((session) => session.pid === 111)!.cdpBrowserWsUrl).toBe(CDP_WS_URL)
       // No endpoint in the probe response — no browser attached.
-      expect(instances.find((instance) => instance.pid === 222)!.cdpBrowserWsUrl).toBeNull()
+      expect(sessions.find((session) => session.pid === 222)!.cdpBrowserWsUrl).toBeNull()
     })
 
-    // Unlike the resolvers, listing is how a user finds out an instance is
+    // Unlike the resolvers, listing is how a user finds out a session is
     // running a browser tap cannot drive — so it must not hide one.
-    it('lists an instance running a browser tap cannot drive', async () => {
-      const port = await startFakeInstance({ respondWith: { instanceId: INSTANCE_ID, browserName: 'Firefox', browserFamily: 'firefox' } })
+    it('lists a session running a browser tap cannot drive', async () => {
+      const port = await startFakeSession({ respondWith: { sessionId: SESSION_ID, browserName: 'Firefox', browserFamily: 'firefox' } })
 
-      mockfs({ [INSTANCES_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
+      mockfs({ [SESSIONS_DIR]: { '111.json': makeRecord({ pid: 111, serverPort: port }) } })
       stubKill({ alive: [111] })
 
-      const instances = await listLiveInstances()
+      const sessions = await listLiveSessions()
 
-      expect(instances.map((instance) => instance.browserFamily)).toEqual(['firefox'])
+      expect(sessions.map((session) => session.browserFamily)).toEqual(['firefox'])
     })
 
     it('resolves an empty list when no record exists', async () => {
       mockfs({ [CACHE_DIR]: {} })
 
-      expect(await listLiveInstances()).toEqual([])
+      expect(await listLiveSessions()).toEqual([])
     })
 
     it('skips dead-pid and unverified (recycled-pid) records', async () => {
-      const livePort = await startFakeInstance()
+      const livePort = await startFakeSession()
       const closedPort = await getClosedPort()
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: livePort }),
           // pid is dead — skipped without a probe
           '222.json': makeRecord({ pid: 222, serverPort: livePort }),
@@ -641,14 +641,14 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111, 333] })
 
-      expect((await listLiveInstances()).map((instance) => instance.pid)).toEqual([111])
+      expect((await listLiveSessions()).map((session) => session.pid)).toEqual([111])
     })
 
-    it('still lists live instances when a dead record cannot be reaped', async () => {
-      const livePort = await startFakeInstance()
+    it('still lists live sessions when a dead record cannot be reaped', async () => {
+      const livePort = await startFakeSession()
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: livePort }),
           '222.json': makeRecord({ pid: 222, serverPort: livePort }),
         },
@@ -656,18 +656,18 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111] })
       // Reaping the dead 222 record fails (e.g. a Windows file lock); discovery of
-      // the live instance must not be aborted by an undeletable leftover.
+      // the live session must not be aborted by an undeletable leftover.
       const remove = vi.spyOn(fs, 'remove').mockRejectedValue(Object.assign(new Error('EPERM'), { code: 'EPERM' }))
 
-      expect((await listLiveInstances()).map((instance) => instance.pid)).toEqual([111])
+      expect((await listLiveSessions()).map((session) => session.pid)).toEqual([111])
       expect(remove).toHaveBeenCalled()
     })
 
     it('filters by pid', async () => {
-      const port = await startFakeInstance()
+      const port = await startFakeSession()
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: port }),
           '222.json': makeRecord({ pid: 222, serverPort: port }),
         },
@@ -675,17 +675,17 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111, 222] })
 
-      expect((await listLiveInstances({ instance: 222 })).map((instance) => instance.pid)).toEqual([222])
+      expect((await listLiveSessions({ session: 222 })).map((session) => session.pid)).toEqual([222])
     })
   })
 
-  describe('.pruneDeadInstanceRecords', () => {
+  describe('.pruneDeadSessionRecords', () => {
     it('removes dead-pid and unverified live-pid records, keeps verified ones and non-record files', async () => {
-      const livePort = await startFakeInstance()
+      const livePort = await startFakeSession()
       const closedPort = await getClosedPort()
 
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': makeRecord({ pid: 111, serverPort: livePort }),
           '222.json': makeRecord({ pid: 222 }),
           '333.json': makeRecord({ pid: 333, serverPort: closedPort }),
@@ -695,16 +695,16 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111, 333] })
 
-      expect(await pruneDeadInstanceRecords()).toBe(2)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/111.json`)).toBe(true)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/222.json`)).toBe(false)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/333.json`)).toBe(false)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/keep.txt`)).toBe(true)
+      expect(await pruneDeadSessionRecords()).toBe(2)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/111.json`)).toBe(true)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/222.json`)).toBe(false)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/333.json`)).toBe(false)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/keep.txt`)).toBe(true)
     })
 
     it('keeps unreadable or incompatible records while their pid is taken', async () => {
       mockfs({
-        [INSTANCES_DIR]: {
+        [SESSIONS_DIR]: {
           '111.json': '{ not valid json',
           '222.json': JSON.stringify({ schemaVersion: 0, pid: 222, projectRoot: PROJECT }),
         },
@@ -712,15 +712,15 @@ describe('lib/cypress-sessions', () => {
 
       stubKill({ alive: [111, 222] })
 
-      expect(await pruneDeadInstanceRecords()).toBe(0)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/111.json`)).toBe(true)
-      expect(await fs.pathExists(`${INSTANCES_DIR}/222.json`)).toBe(true)
+      expect(await pruneDeadSessionRecords()).toBe(0)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/111.json`)).toBe(true)
+      expect(await fs.pathExists(`${SESSIONS_DIR}/222.json`)).toBe(true)
     })
 
-    it('returns 0 when the instances dir does not exist', async () => {
+    it('returns 0 when the sessions dir does not exist', async () => {
       mockfs({ [CACHE_DIR]: {} })
 
-      expect(await pruneDeadInstanceRecords()).toBe(0)
+      expect(await pruneDeadSessionRecords()).toBe(0)
     })
   })
 })

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -1,11 +1,11 @@
 import { vi } from 'vitest'
 
 import logger from '../../../lib/logger'
-import { listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-sessions'
-import type { ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-sessions'
+import { listLiveSessions, resolveLiveSession, resolveSession } from '../../../lib/cypress-sessions'
+import type { ReadySessionState, SessionSelection } from '../../../lib/cypress-sessions'
 import { withTapConnection } from '../../../lib/tap/tap-connection'
 import type { TapConnection } from '../../../lib/tap/tap-connection'
-import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
+import { querySessionGraphql } from '../../../lib/tap/session-gql'
 import { withResolvedAutFrame } from '../../../lib/tap/aut/frame'
 import type { TapExecResult, TapSchema } from '@packages/cypress-sessions'
 
@@ -50,12 +50,12 @@ export const mockConnection = (connectionSchema: unknown = schema, execOutcome: 
   return call
 }
 
-export const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceState => ({
+export const readySession = (overrides: Partial<ReadySessionState> = {}): ReadySessionState => ({
   schemaVersion: 1,
   pid: 4242,
   projectRoot: '/projects/app',
   serverPort: 49200,
-  instanceId: 'inst-1',
+  sessionId: 'inst-1',
   testingType: 'e2e',
   cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
   browserName: 'Chrome',
@@ -65,10 +65,10 @@ export const readyInstance = (overrides: Partial<ReadyInstanceState> = {}): Read
   ...overrides,
 })
 
-export const mockResolved = (overrides: Partial<InstanceSelection> = {}): InstanceSelection => {
-  const selection: InstanceSelection = { instance: readyInstance(), reason: 'only', candidateCount: 1, ...overrides }
+export const mockResolved = (overrides: Partial<SessionSelection> = {}): SessionSelection => {
+  const selection: SessionSelection = { session: readySession(), reason: 'only', candidateCount: 1, ...overrides }
 
-  vi.mocked(resolveInstance).mockResolvedValue(selection)
+  vi.mocked(resolveSession).mockResolvedValue(selection)
 
   return selection
 }
@@ -84,10 +84,10 @@ export const resetTapMocks = (): void => {
   fetchMock.mockResolvedValue({ status: 200 })
   vi.stubGlobal('fetch', fetchMock)
   vi.mocked(withTapConnection).mockReset()
-  vi.mocked(queryInstanceGraphql).mockReset()
-  vi.mocked(listLiveInstances).mockReset()
-  vi.mocked(resolveLiveInstance).mockReset()
-  vi.mocked(resolveInstance).mockReset()
+  vi.mocked(querySessionGraphql).mockReset()
+  vi.mocked(listLiveSessions).mockReset()
+  vi.mocked(resolveLiveSession).mockReset()
+  vi.mocked(resolveSession).mockReset()
   vi.mocked(withResolvedAutFrame).mockReset()
   vi.mocked(withResolvedAutFrame).mockResolvedValue(0)
   mockResolved()

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import logger from '../../../lib/logger'
-import { CypressInstanceError, listLiveInstances, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-sessions'
-import type { LiveInstanceSelection, LiveInstanceState, ReadyInstanceState, InstanceSelection } from '../../../lib/cypress-sessions'
+import { CypressSessionError, listLiveSessions, resolveLiveSession, resolveSession } from '../../../lib/cypress-sessions'
+import type { LiveSessionSelection, LiveSessionState, ReadySessionState, SessionSelection } from '../../../lib/cypress-sessions'
 import { withTapConnection } from '../../../lib/tap/tap-connection'
-import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
-import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
+import { FIND_SESSION_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
+import { querySessionGraphql } from '../../../lib/tap/session-gql'
 import { tapCliCommands } from '../../../lib/tap/commands'
 import type { TapConnection } from '../../../lib/tap/tap-connection'
 import { withResolvedAutFrame } from '../../../lib/tap/aut/frame'
@@ -14,7 +14,7 @@ import { buildTapSchema } from '@packages/cypress-sessions'
 import type { TapExecResult, TapSchema } from '@packages/cypress-sessions'
 import { errors } from '../../../lib/errors'
 import tap from '../../../lib/exec/tap'
-import { mockResolved, mockConnection, readyInstance, resetTapMocks, schema, tapError } from './tap-fixtures'
+import { mockResolved, mockConnection, readySession, resetTapMocks, schema, tapError } from './tap-fixtures'
 
 // vi.mock is hoisted above these imports, so the factories cannot come from
 // ./tap-fixtures — everything they don't cover does.
@@ -22,16 +22,16 @@ vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
   return { ...await importActual<typeof import('../../../lib/tap/tap-connection')>(), withTapConnection: vi.fn() }
 })
 
-vi.mock('../../../lib/tap/instance-gql', () => {
-  return { queryInstanceGraphql: vi.fn() }
+vi.mock('../../../lib/tap/session-gql', () => {
+  return { querySessionGraphql: vi.fn() }
 })
 
 vi.mock('../../../lib/cypress-sessions', async (importActual) => {
   return {
     ...await importActual<typeof import('../../../lib/cypress-sessions')>(),
-    listLiveInstances: vi.fn(),
-    resolveLiveInstance: vi.fn(),
-    resolveInstance: vi.fn(),
+    listLiveSessions: vi.fn(),
+    resolveLiveSession: vi.fn(),
+    resolveSession: vi.fn(),
   }
 })
 
@@ -164,12 +164,12 @@ describe('lib/exec/tap', () => {
 
     it('resolves the target from --instance and the cwd, then opens a session against it', async () => {
       mockConnection()
-      const { instance } = mockResolved()
+      const { session } = mockResolved()
 
       await tap.start(['health'], { instance: 1234 })
 
-      expect(resolveInstance).toHaveBeenCalledWith({ instance: 1234, cwd: process.cwd() })
-      expect(vi.mocked(withTapConnection).mock.calls[0][0]).toBe(instance)
+      expect(resolveSession).toHaveBeenCalledWith({ session: 1234, cwd: process.cwd() })
+      expect(vi.mocked(withTapConnection).mock.calls[0][0]).toBe(session)
     })
 
     it('resolves with just the cwd tiebreak when --instance is absent', async () => {
@@ -177,7 +177,7 @@ describe('lib/exec/tap', () => {
 
       await tap.start(['health'], {})
 
-      expect(resolveInstance).toHaveBeenCalledWith({ instance: undefined, cwd: process.cwd() })
+      expect(resolveSession).toHaveBeenCalledWith({ session: undefined, cwd: process.cwd() })
     })
 
     it('renders an app-side domain failure ({ error }) with its code and exits 1', async () => {
@@ -286,7 +286,7 @@ describe('lib/exec/tap', () => {
 
     it('leads the help with a banner naming the resolved instance', async () => {
       mockConnection()
-      mockResolved({ instance: readyInstance({ pid: 7777, projectRoot: '/projects/app' }) })
+      mockResolved({ session: readySession({ pid: 7777, projectRoot: '/projects/app' }) })
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toContain('Target:\n  /projects/app\n  v15.0.0\n  pid:7777')
@@ -304,7 +304,7 @@ describe('lib/exec/tap', () => {
 
     it('notes which instance was auto-selected when several were live', async () => {
       mockConnection()
-      mockResolved({ instance: readyInstance({ pid: 7777 }), reason: 'arbitrary', candidateCount: 3 })
+      mockResolved({ session: readySession({ pid: 7777 }), reason: 'arbitrary', candidateCount: 3 })
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toContain('3 running instances matched; targeting pid 7777.')
@@ -376,12 +376,12 @@ describe('lib/exec/tap', () => {
   })
 
   describe('the CLI-native instances command', () => {
-    const liveInstance = (overrides: Partial<LiveInstanceState> = {}): LiveInstanceState => ({
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
       schemaVersion: 1,
       pid: 54321,
       projectRoot: '/projects/app',
       serverPort: 49200,
-      instanceId: 'inst-1',
+      sessionId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
@@ -394,9 +394,9 @@ describe('lib/exec/tap', () => {
     // Reporting whether the runner page answers takes a session, so this command
     // opens one — bounded, and only where there is a browser to ask.
     it('renders the live instances as a table and exits 0, probing only an instance with a browser attached', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
-        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
+      vi.mocked(listLiveSessions).mockResolvedValue([
+        liveSession({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
+        liveSession({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
       ])
 
       expect(await tap.start(['instances'], {})).toBe(0)
@@ -413,7 +413,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('bounds the renderer probe with --timeout', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111 })])
+      vi.mocked(listLiveSessions).mockResolvedValue([liveSession({ pid: 111 })])
 
       expect(await tap.start(['instances'], { timeout: 5000 })).toBe(0)
 
@@ -421,17 +421,17 @@ describe('lib/exec/tap', () => {
     })
 
     it('bounds the renderer probe with the find-instance default when --timeout is absent', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111 })])
+      vi.mocked(listLiveSessions).mockResolvedValue([liveSession({ pid: 111 })])
 
       expect(await tap.start(['instances'], {})).toBe(0)
 
-      expect(withTapConnection).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), FIND_INSTANCE_TIMEOUT_MS)
+      expect(withTapConnection).toHaveBeenCalledWith(expect.objectContaining({ pid: 111 }), expect.any(Function), FIND_SESSION_TIMEOUT_MS)
     })
 
     it('prints the raw instance summaries with --json', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
-        liveInstance({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
+      vi.mocked(listLiveSessions).mockResolvedValue([
+        liveSession({ pid: 111, projectRoot: '/projects/app', testingType: 'e2e', cdpBrowserWsUrl: 'ws://x', browserName: 'Chrome' }),
+        liveSession({ pid: 222, projectRoot: '/projects/other', testingType: 'component', cdpBrowserWsUrl: null, browserName: null }),
       ])
 
       expect(await tap.start(['instances'], { json: true })).toBe(0)
@@ -442,8 +442,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('lists an instance running a browser tap cannot drive, marked unsupported', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([
-        liveInstance({ pid: 111, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' }),
+      vi.mocked(listLiveSessions).mockResolvedValue([
+        liveSession({ pid: 111, cdpBrowserWsUrl: null, browserName: 'Firefox', browserFamily: 'firefox' }),
       ])
 
       expect(await tap.start(['instances'], {})).toBe(0)
@@ -456,21 +456,21 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports the testing type as null for an instance that has not chosen one', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, testingType: null })])
+      vi.mocked(listLiveSessions).mockResolvedValue([liveSession({ pid: 111, testingType: null })])
 
       expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())[0].testingType).toBeNull()
     })
 
     it('never exposes the internal serverPort', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([liveInstance({ pid: 111, serverPort: 49200 })])
+      vi.mocked(listLiveSessions).mockResolvedValue([liveSession({ pid: 111, serverPort: 49200 })])
 
       expect(await tap.start(['instances'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())[0]).not.toHaveProperty('serverPort')
     })
 
     it('prints guidance instead of an empty array when no instance is live', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([])
+      vi.mocked(listLiveSessions).mockResolvedValue([])
 
       expect(await tap.start(['instances'], {})).toBe(0)
 
@@ -482,42 +482,42 @@ describe('lib/exec/tap', () => {
     })
 
     it('forwards --instance as the discovery filter', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([])
+      vi.mocked(listLiveSessions).mockResolvedValue([])
 
       await tap.start(['instances'], { instance: 1234 })
 
-      expect(listLiveInstances).toHaveBeenCalledWith({ instance: 1234 })
+      expect(listLiveSessions).toHaveBeenCalledWith({ session: 1234 })
     })
 
     it('lists every live instance when --instance is absent', async () => {
-      vi.mocked(listLiveInstances).mockResolvedValue([])
+      vi.mocked(listLiveSessions).mockResolvedValue([])
 
       await tap.start(['instances'], {})
 
-      expect(listLiveInstances).toHaveBeenCalledWith({ instance: undefined })
+      expect(listLiveSessions).toHaveBeenCalledWith({ session: undefined })
     })
 
     it('prints instances usage for `instances --help` and exits 0, without enumerating', async () => {
       expect(await tap.start(['instances', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap instances')
-      expect(listLiveInstances).not.toHaveBeenCalled()
+      expect(listLiveSessions).not.toHaveBeenCalled()
       expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('exits 1 on an excess positional and never enumerates', async () => {
       expect(await tap.start(['instances', 'extra'], {})).toBe(1)
-      expect(listLiveInstances).not.toHaveBeenCalled()
+      expect(listLiveSessions).not.toHaveBeenCalled()
       expect(withTapConnection).not.toHaveBeenCalled()
     })
   })
 
   describe('the CLI-native status command', () => {
-    const liveInstance = (overrides: Partial<LiveInstanceState> = {}): LiveInstanceState => ({
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
       schemaVersion: 1,
       pid: 4242,
       projectRoot: '/projects/app',
       serverPort: 49200,
-      instanceId: 'inst-1',
+      sessionId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
@@ -527,16 +527,16 @@ describe('lib/exec/tap', () => {
       ...overrides,
     })
 
-    const mockLiveResolved = (instance: LiveInstanceState): LiveInstanceSelection => {
-      const selection: LiveInstanceSelection = { instance, reason: 'only', candidateCount: 1 }
+    const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
+      const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }
 
-      vi.mocked(resolveLiveInstance).mockResolvedValue(selection)
+      vi.mocked(resolveLiveSession).mockResolvedValue(selection)
 
       return selection
     }
 
     it('reports "not connected" and exits 0 when no instance is live', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'none'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'none'))
 
       expect(await tap.start(['status'], {})).toBe(0)
 
@@ -549,14 +549,14 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints the raw status object with --json', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'none'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'none'))
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({ status: 'not connected' })
     })
 
     it('reports "not connected" for a stale discovery record too', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('STALE_INSTANCE', 'stale'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('STALE_SESSION', 'stale'))
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({ status: 'not connected' })
@@ -565,7 +565,7 @@ describe('lib/exec/tap', () => {
     // Every other resolution failure is transient — an instance running a browser
     // tap cannot drive is not, so a poller must hear it rather than wait it out.
     it('fails instead of reporting "not connected" when the browser is unsupported', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('UNSUPPORTED_BROWSER', 'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('UNSUPPORTED_BROWSER', 'The Cypress session is running on an unsupported browser.\n\nRun Cypress open on a Chromium-based browser to use `cypress tap`.'))
 
       expect(await tap.start(['status'], {})).toBe(1)
 
@@ -578,7 +578,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports "browser not selected" without opening a session when no browser is attached', async () => {
-      mockLiveResolved(liveInstance({ pid: 111, cdpBrowserWsUrl: null, browserName: null }))
+      mockLiveResolved(liveSession({ pid: 111, cdpBrowserWsUrl: null, browserName: null }))
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({
@@ -595,7 +595,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports "spec not selected" with totalSpecs when a browser is attached and on the spec list', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, { result: { spec: null, totalSpecs: 3 } } satisfies TapExecResult)
 
       expect(await tap.start(['status'], { json: true })).toBe(0)
@@ -611,7 +611,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('merges the run state, active spec, and results when on a spec', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, {
         result: {
           spec: 'cypress/e2e/login.cy.ts',
@@ -640,7 +640,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports "loading" with no verdict and no run to name while the selected spec is still building', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'loading', startedAt: null },
       } satisfies TapExecResult)
@@ -660,7 +660,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports a spec that failed to build as failed, carrying the reason', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'failed', startedAt: '2026-07-29T10:15:00.000Z', error: 'Error: Webpack Compilation Error' },
       } satisfies TapExecResult)
@@ -681,7 +681,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('reports a null startedAt for an instance whose binding does not name the run', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, {
         result: { spec: 'cypress/e2e/login.cy.ts', totalSpecs: 3, state: 'passed', totalTests: 1, results: { passed: 1, failed: 0, pending: 0, skipped: 0 } },
       } satisfies TapExecResult)
@@ -693,7 +693,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('asks the binding for run-state over the session', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       const call = mockConnection(schema, { result: { spec: null, totalSpecs: 0 } } satisfies TapExecResult)
 
       await tap.start(['status'], {})
@@ -702,15 +702,15 @@ describe('lib/exec/tap', () => {
     })
 
     it('forwards --instance plus the cwd to discovery', async () => {
-      mockLiveResolved(liveInstance({ cdpBrowserWsUrl: null }))
+      mockLiveResolved(liveSession({ cdpBrowserWsUrl: null }))
 
       await tap.start(['status'], { instance: 1234 })
 
-      expect(resolveLiveInstance).toHaveBeenCalledWith({ instance: 1234, cwd: process.cwd() })
+      expect(resolveLiveSession).toHaveBeenCalledWith({ session: 1234, cwd: process.cwd() })
     })
 
     it('exits 1 and renders the failure when the instance is unreachable despite a browser', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       vi.mocked(withTapConnection).mockRejectedValue(tapError(errors.tapBindingNotFound, 'the instance may still be loading'))
 
       expect(await tap.start(['status'], {})).toBe(1)
@@ -718,7 +718,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('exits 1 and surfaces the binding error when the running Cypress lacks the run-state command', async () => {
-      mockLiveResolved(liveInstance())
+      mockLiveResolved(liveSession())
       mockConnection(schema, { error: { code: 'UNKNOWN_COMMAND', message: 'no such command' } } satisfies TapExecResult)
 
       expect(await tap.start(['status'], {})).toBe(1)
@@ -729,24 +729,24 @@ describe('lib/exec/tap', () => {
     it('prints status usage for `status --help` and exits 0, without resolving', async () => {
       expect(await tap.start(['status', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap status')
-      expect(resolveLiveInstance).not.toHaveBeenCalled()
+      expect(resolveLiveSession).not.toHaveBeenCalled()
       expect(withTapConnection).not.toHaveBeenCalled()
     })
 
     it('exits 1 on an excess positional and never resolves an instance', async () => {
       expect(await tap.start(['status', 'extra'], {})).toBe(1)
-      expect(resolveLiveInstance).not.toHaveBeenCalled()
+      expect(resolveLiveSession).not.toHaveBeenCalled()
       expect(withTapConnection).not.toHaveBeenCalled()
     })
   })
 
   describe('the CLI-native specs command', () => {
-    const liveInstance = (overrides: Partial<LiveInstanceState> = {}): LiveInstanceState => ({
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
       schemaVersion: 1,
       pid: 4242,
       projectRoot: '/projects/app',
       serverPort: 49200,
-      instanceId: 'inst-1',
+      sessionId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
@@ -756,17 +756,17 @@ describe('lib/exec/tap', () => {
       ...overrides,
     })
 
-    const mockLiveResolved = (instance: LiveInstanceState): LiveInstanceSelection => {
-      const selection: LiveInstanceSelection = { instance, reason: 'only', candidateCount: 1 }
+    const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
+      const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }
 
-      vi.mocked(resolveLiveInstance).mockResolvedValue(selection)
+      vi.mocked(resolveLiveSession).mockResolvedValue(selection)
 
       return selection
     }
 
     it('renders the live spec list as a headed list and exits 0, without opening a session', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [
           { relative: 'cypress/e2e/a.cy.ts', gitInfo: { lastModifiedHumanReadable: '2 hours ago', lastModifiedTimestamp: '2026-07-24 09:00:00 -0500' } },
           { relative: 'cypress/e2e/b.cy.ts', gitInfo: null },
@@ -787,8 +787,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints the raw spec entries (with git timestamps) via --json', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [
           { relative: 'cypress/e2e/a.cy.ts', gitInfo: { lastModifiedHumanReadable: '2 hours ago', lastModifiedTimestamp: '2026-07-24 09:00:00 -0500' } },
           { relative: 'cypress/e2e/b.cy.ts', gitInfo: null },
@@ -809,8 +809,8 @@ describe('lib/exec/tap', () => {
     // (`-0500`) and, for a file git has no commit for, a dayjs ctime (`-05:00`) —
     // and offsets differ, so they are compared as instants rather than as text.
     it('orders specs most recently modified first, listing specs git knows nothing about last', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [
           { relative: 'cypress/e2e/older.cy.ts', gitInfo: { lastModifiedTimestamp: '2026-07-20 09:00:00 -0500' } },
           { relative: 'cypress/e2e/untracked-first.cy.ts', gitInfo: null },
@@ -834,8 +834,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('lists specs even when the instance has no browser attached', async () => {
-      mockLiveResolved(liveInstance({ cdpBrowserWsUrl: null }))
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession({ cdpBrowserWsUrl: null }))
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [{ relative: 'cypress/e2e/a.cy.ts' }] },
       })
 
@@ -844,8 +844,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('normalizes OS-native (Windows) spec paths to POSIX so they match run/status', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [{ relative: 'cypress\\e2e\\win.cy.ts', gitInfo: null }] },
       })
 
@@ -854,35 +854,35 @@ describe('lib/exec/tap', () => {
     })
 
     it('queries the resolved instance with the TapSpecs operation', async () => {
-      const { instance } = mockLiveResolved(liveInstance())
+      const { session } = mockLiveResolved(liveSession())
 
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({ currentProject: { specs: [] } })
+      vi.mocked(querySessionGraphql).mockResolvedValue({ currentProject: { specs: [] } })
 
       await tap.start(['specs'], {})
 
-      expect(queryInstanceGraphql).toHaveBeenCalledWith(instance, expect.objectContaining({ operationName: 'TapSpecs' }))
+      expect(querySessionGraphql).toHaveBeenCalledWith(session, expect.objectContaining({ operationName: 'TapSpecs' }))
     })
 
     it('forwards --instance plus the cwd to discovery', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({ currentProject: { specs: [] } })
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({ currentProject: { specs: [] } })
 
       await tap.start(['specs'], { instance: 1234 })
 
-      expect(resolveLiveInstance).toHaveBeenCalledWith({ instance: 1234, cwd: process.cwd() })
+      expect(resolveLiveSession).toHaveBeenCalledWith({ session: 1234, cwd: process.cwd() })
     })
 
     it('renders an empty list when the instance has no project open', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({ currentProject: null })
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({ currentProject: null })
 
       expect(await tap.start(['specs'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual([])
     })
 
     it('drops malformed spec entries rather than rendering junk', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockResolvedValue({
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockResolvedValue({
         currentProject: { specs: [
           null,
           { relative: 42 },
@@ -902,16 +902,16 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders the discovery failure and exits 1 when no instance is live', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['specs'], {})).toBe(1)
-      expect(logger.print()).toBe('NO_INSTANCE: No running Cypress was found.')
-      expect(queryInstanceGraphql).not.toHaveBeenCalled()
+      expect(logger.print()).toBe('NO_SESSION: No running Cypress was found.')
+      expect(querySessionGraphql).not.toHaveBeenCalled()
     })
 
     it('renders a known data-layer failure and exits 1', async () => {
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockRejectedValue(tapError(errors.tapGraphqlUnreachable, 'Could not reach the instance to run TapSpecs: socket hang up'))
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockRejectedValue(tapError(errors.tapGraphqlUnreachable, 'Could not reach the instance to run TapSpecs: socket hang up'))
 
       expect(await tap.start(['specs'], {})).toBe(1)
       expect(logger.print()).toContain(errors.tapGraphqlUnreachable.description)
@@ -921,33 +921,33 @@ describe('lib/exec/tap', () => {
     it('prints specs usage for `specs --help` and exits 0, without resolving', async () => {
       expect(await tap.start(['specs', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap specs')
-      expect(resolveLiveInstance).not.toHaveBeenCalled()
-      expect(queryInstanceGraphql).not.toHaveBeenCalled()
+      expect(resolveLiveSession).not.toHaveBeenCalled()
+      expect(querySessionGraphql).not.toHaveBeenCalled()
     })
 
     it('exits 1 on an excess positional and never resolves an instance', async () => {
       expect(await tap.start(['specs', 'extra'], {})).toBe(1)
-      expect(resolveLiveInstance).not.toHaveBeenCalled()
-      expect(queryInstanceGraphql).not.toHaveBeenCalled()
+      expect(resolveLiveSession).not.toHaveBeenCalled()
+      expect(querySessionGraphql).not.toHaveBeenCalled()
     })
 
     it('rethrows unexpected errors for the generic CLI error path', async () => {
       const unexpected = new Error('boom')
 
-      mockLiveResolved(liveInstance())
-      vi.mocked(queryInstanceGraphql).mockRejectedValue(unexpected)
+      mockLiveResolved(liveSession())
+      vi.mocked(querySessionGraphql).mockRejectedValue(unexpected)
 
       await expect(tap.start(['specs'], {})).rejects.toBe(unexpected)
     })
   })
 
   describe('the CLI-native run command', () => {
-    const liveInstance = (overrides: Partial<LiveInstanceState> = {}): LiveInstanceState => ({
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
       schemaVersion: 1,
       pid: 4242,
       projectRoot: '/projects/app',
       serverPort: 49200,
-      instanceId: 'inst-1',
+      sessionId: 'inst-1',
       testingType: 'e2e',
       cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       browserName: 'Chrome',
@@ -957,10 +957,10 @@ describe('lib/exec/tap', () => {
       ...overrides,
     })
 
-    const mockLiveResolved = (instance: LiveInstanceState): LiveInstanceSelection => {
-      const selection: LiveInstanceSelection = { instance, reason: 'only', candidateCount: 1 }
+    const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
+      const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }
 
-      vi.mocked(resolveLiveInstance).mockResolvedValue(selection)
+      vi.mocked(resolveLiveSession).mockResolvedValue(selection)
 
       return selection
     }
@@ -971,15 +971,15 @@ describe('lib/exec/tap', () => {
 
     const launched = { __typename: 'RunSpecResponse', testingType: 'e2e', browser: { displayName: 'Chrome' }, spec: { relative: 'cypress/e2e/login.cy.ts' } }
 
-    const mockInstanceGraphql = ({ specs = [loginSpec], runSpec = launched }: { specs?: unknown[], runSpec?: unknown } = {}) => {
-      vi.mocked(queryInstanceGraphql).mockImplementation(async (_instance, operation) => {
+    const mockSessionGraphql = ({ specs = [loginSpec], runSpec = launched }: { specs?: unknown[], runSpec?: unknown } = {}) => {
+      vi.mocked(querySessionGraphql).mockImplementation(async (_instance, operation) => {
         return operation.operationName === 'TapSpecs' ? { currentProject: { specs } } : { runSpec }
       })
     }
 
     it('triggers the run and renders the launch outcome, without opening a session', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql()
+      mockLiveResolved(liveSession())
+      mockSessionGraphql()
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(0)
 
@@ -995,8 +995,8 @@ describe('lib/exec/tap', () => {
     })
 
     it('prints the raw launch outcome with --json', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql()
+      mockLiveResolved(liveSession())
+      mockSessionGraphql()
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], { json: true })).toBe(0)
       expect(JSON.parse(logger.print())).toEqual({
@@ -1007,44 +1007,44 @@ describe('lib/exec/tap', () => {
     })
 
     it('sends the matched spec\'s instance-reported absolute path to the TapRunSpec operation', async () => {
-      const { instance } = mockLiveResolved(liveInstance())
+      const { session } = mockLiveResolved(liveSession())
 
-      mockInstanceGraphql()
+      mockSessionGraphql()
 
       await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})
 
       // The mutation gets a launch-sized timeout: it can wait on a browser
       // launch and a testing-type switch, unlike ordinary data queries.
-      expect(queryInstanceGraphql).toHaveBeenCalledWith(instance, expect.objectContaining({
+      expect(querySessionGraphql).toHaveBeenCalledWith(session, expect.objectContaining({
         operationName: 'TapRunSpec',
         variables: { specPath: '/disk/real-project/cypress/e2e/login.cy.ts' },
       }), 60_000)
     })
 
     it('matches an OS-native (Windows) relative path from the instance against the POSIX input', async () => {
-      const { instance } = mockLiveResolved(liveInstance())
+      const { session } = mockLiveResolved(liveSession())
 
-      mockInstanceGraphql({ specs: [{ relative: 'cypress\\e2e\\login.cy.ts', absolute: 'C:\\projects\\app\\cypress\\e2e\\login.cy.ts' }] })
+      mockSessionGraphql({ specs: [{ relative: 'cypress\\e2e\\login.cy.ts', absolute: 'C:\\projects\\app\\cypress\\e2e\\login.cy.ts' }] })
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(0)
-      expect(queryInstanceGraphql).toHaveBeenCalledWith(instance, expect.objectContaining({
+      expect(querySessionGraphql).toHaveBeenCalledWith(session, expect.objectContaining({
         operationName: 'TapRunSpec',
         variables: { specPath: 'C:\\projects\\app\\cypress\\e2e\\login.cy.ts' },
       }), 60_000)
     })
 
     it('fails with SPEC_NOT_FOUND when the spec is not in the instance\'s list, without triggering a run', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql({ specs: [{ relative: 'cypress/e2e/other.cy.ts', absolute: '/disk/real-project/cypress/e2e/other.cy.ts' }] })
+      mockLiveResolved(liveSession())
+      mockSessionGraphql({ specs: [{ relative: 'cypress/e2e/other.cy.ts', absolute: '/disk/real-project/cypress/e2e/other.cy.ts' }] })
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(1)
       expect(logger.print()).toBe('SPEC_NOT_FOUND: No spec matches the path "cypress/e2e/login.cy.ts" — use the specs command to list runnable specs.')
-      expect(queryInstanceGraphql).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ operationName: 'TapRunSpec' }))
+      expect(querySessionGraphql).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ operationName: 'TapRunSpec' }))
     })
 
     it('surfaces a RunSpecError with the instance\'s own code and message, exiting 1', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql({
+      mockLiveResolved(liveSession())
+      mockSessionGraphql({
         runSpec: { __typename: 'RunSpecError', code: 'NO_SPEC_PATTERN_MATCH', detailMessage: 'Unable to determine testing type, spec does not match any configured specPattern' },
       })
 
@@ -1053,28 +1053,28 @@ describe('lib/exec/tap', () => {
     })
 
     it('exits 1 when the instance returns no run result', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql({ runSpec: null })
+      mockLiveResolved(liveSession())
+      mockSessionGraphql({ runSpec: null })
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(1)
       expect(logger.print()).toContain('RUN_FAILED')
     })
 
     it('forwards --instance plus the cwd to discovery', async () => {
-      mockLiveResolved(liveInstance())
-      mockInstanceGraphql()
+      mockLiveResolved(liveSession())
+      mockSessionGraphql()
 
       await tap.start(['run', 'cypress/e2e/login.cy.ts'], { instance: 1234 })
 
-      expect(resolveLiveInstance).toHaveBeenCalledWith({ instance: 1234, cwd: process.cwd() })
+      expect(resolveLiveSession).toHaveBeenCalledWith({ session: 1234, cwd: process.cwd() })
     })
 
     it('renders the discovery failure and exits 1 when no instance is live', async () => {
-      vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['run', 'cypress/e2e/login.cy.ts'], {})).toBe(1)
-      expect(logger.print()).toBe('NO_INSTANCE: No running Cypress was found.')
-      expect(queryInstanceGraphql).not.toHaveBeenCalled()
+      expect(logger.print()).toBe('NO_SESSION: No running Cypress was found.')
+      expect(querySessionGraphql).not.toHaveBeenCalled()
     })
   })
 
@@ -1087,7 +1087,7 @@ describe('lib/exec/tap', () => {
       expect(withResolvedAutFrame).toHaveBeenCalledTimes(1)
       expect(vi.mocked(withResolvedAutFrame).mock.calls[0][0]).toEqual({ instance: 7 })
       // A native command never consults the running instance's schema.
-      expect(resolveInstance).not.toHaveBeenCalled()
+      expect(resolveSession).not.toHaveBeenCalled()
     })
 
     // Runs a native frame command against a stubbed browser, returning the
@@ -1198,14 +1198,14 @@ describe('lib/exec/tap', () => {
   })
 
   describe('failure rendering', () => {
-    const failResolve = (err: unknown) => vi.mocked(resolveInstance).mockRejectedValue(err)
+    const failResolve = (err: unknown) => vi.mocked(resolveSession).mockRejectedValue(err)
     const failConnection = (err: unknown) => vi.mocked(withTapConnection).mockRejectedValue(err)
 
     it('renders discovery errors with their code and exits 1', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['health'], {})).toBe(1)
-      expect(logger.print()).toBe('NO_INSTANCE: No running Cypress was found.')
+      expect(logger.print()).toBe('NO_SESSION: No running Cypress was found.')
     })
 
     it('renders a known transport failure as its mapped description and solution, and exits 1', async () => {
@@ -1226,7 +1226,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('falls back to the baked-in CLI command help when no instance is found and help was wanted', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toMatchInlineSnapshot(`
@@ -1272,7 +1272,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('lists both native and schema commands when an unknown command is requested offline', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['instancs', '--help'], {})).toBe(1)
 
@@ -1285,7 +1285,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('renders the baked-in per-command help when no instance is found', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['command', '--help'], {})).toBe(0)
       expect(logger.print()).toMatchInlineSnapshot(`
@@ -1321,14 +1321,14 @@ describe('lib/exec/tap', () => {
     })
 
     it('falls back to generic help (exit 0) for a bare invocation with no instance found', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
     })
 
     it('falls back to generic help for --help when an instance is up but has no browser', async () => {
-      failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
+      failResolve(new CypressSessionError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
@@ -1336,7 +1336,7 @@ describe('lib/exec/tap', () => {
     })
 
     it('falls back to generic help for `<command> --help` when an instance is up but has no browser', async () => {
-      failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
+      failResolve(new CypressSessionError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
 
       expect(await tap.start(['run', '--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
@@ -1344,15 +1344,15 @@ describe('lib/exec/tap', () => {
     })
 
     it('falls back to generic help for --help when the matched instance is stale', async () => {
-      failResolve(new CypressInstanceError('STALE_INSTANCE', 'Cypress was previously running, but is no longer responding.'))
+      failResolve(new CypressSessionError('STALE_SESSION', 'Cypress was previously running, but is no longer responding.'))
 
       expect(await tap.start(['--help'], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
-      expect(logger.print()).not.toContain('STALE_INSTANCE')
+      expect(logger.print()).not.toContain('STALE_SESSION')
     })
 
     it('falls back to generic help (exit 0) for a bare invocation when an instance is up but has no browser', async () => {
-      failResolve(new CypressInstanceError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
+      failResolve(new CypressSessionError('NO_BROWSER_ATTACHED', 'Cypress is running (pid 4242, /projects/app), but no test browser is open. Open a browser in Cypress and try again.'))
 
       expect(await tap.start([], {})).toBe(0)
       expect(logger.print()).toContain('Usage: cypress tap')
@@ -1360,10 +1360,10 @@ describe('lib/exec/tap', () => {
     })
 
     it('still surfaces the discovery error when an actual command was requested', async () => {
-      failResolve(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+      failResolve(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
       expect(await tap.start(['health'], {})).toBe(1)
-      expect(logger.print()).toContain('NO_INSTANCE')
+      expect(logger.print()).toContain('NO_SESSION')
     })
 
     it('rethrows unexpected errors for the generic CLI error path', async () => {

--- a/cli/test/lib/exec/tap.validate-events.spec.ts
+++ b/cli/test/lib/exec/tap.validate-events.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { CypressInstanceError, resolveLiveInstance, resolveInstance } from '../../../lib/cypress-sessions'
+import { CypressSessionError, resolveLiveSession, resolveSession } from '../../../lib/cypress-sessions'
 import { withTapConnection } from '../../../lib/tap/tap-connection'
 import { buildTapSchema } from '@packages/cypress-sessions'
 import { errors } from '../../../lib/errors'
@@ -13,16 +13,16 @@ vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
   return { ...await importActual<typeof import('../../../lib/tap/tap-connection')>(), withTapConnection: vi.fn() }
 })
 
-vi.mock('../../../lib/tap/instance-gql', () => {
-  return { queryInstanceGraphql: vi.fn() }
+vi.mock('../../../lib/tap/session-gql', () => {
+  return { querySessionGraphql: vi.fn() }
 })
 
 vi.mock('../../../lib/cypress-sessions', async (importActual) => {
   return {
     ...await importActual<typeof import('../../../lib/cypress-sessions')>(),
-    listLiveInstances: vi.fn(),
-    resolveLiveInstance: vi.fn(),
-    resolveInstance: vi.fn(),
+    listLiveSessions: vi.fn(),
+    resolveLiveSession: vi.fn(),
+    resolveSession: vi.fn(),
   }
 })
 
@@ -63,20 +63,20 @@ describe('lib/exec/tap reporting the invocation', () => {
   // A schema command's flags are named by the schema, which a discovery failure
   // never fetched, so the code is all such an invocation has to report.
   it('reports a discovery failure by its code', async () => {
-    vi.mocked(resolveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+    vi.mocked(resolveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
     expect(await tap.start(['reporter', '--test-id', 'r2'], {})).toBe(1)
-    expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'NO_INSTANCE' })
+    expect(reportedEvent()).toMatchObject({ command: 'reporter', exitCode: 1, errorCode: 'NO_SESSION' })
     expect(reportedEvent().flags).toEqual([])
   })
 
   // A CLI-native command is dispatched before it looks for an instance, so it
   // reports what was typed as well as the code it failed with.
   it('reports a discovery failure a CLI-native command handled itself', async () => {
-    vi.mocked(resolveLiveInstance).mockRejectedValue(new CypressInstanceError('NO_INSTANCE', 'No running Cypress was found.'))
+    vi.mocked(resolveLiveSession).mockRejectedValue(new CypressSessionError('NO_SESSION', 'No running Cypress was found.'))
 
     expect(await tap.start(['run', 'cypress/e2e/a.cy.js'], {})).toBe(1)
-    expect(reportedEvent()).toMatchObject({ command: 'run', exitCode: 1, errorCode: 'NO_INSTANCE', flags: ['spec'] })
+    expect(reportedEvent()).toMatchObject({ command: 'run', exitCode: 1, errorCode: 'NO_SESSION', flags: ['spec'] })
     expect(JSON.stringify(reportedEvent())).not.toContain('a.cy.js')
   })
 
@@ -164,7 +164,7 @@ describe('lib/exec/tap reporting the invocation', () => {
   })
 
   it('reports an unexpected error before rethrowing it', async () => {
-    vi.mocked(resolveInstance).mockRejectedValue(new Error('boom'))
+    vi.mocked(resolveSession).mockRejectedValue(new Error('boom'))
 
     await expect(tap.start(['health'], {})).rejects.toThrow('boom')
     expect(reportedEvent()).toMatchObject({ exitCode: 1, errorCode: 'UNHANDLED' })

--- a/cli/test/lib/tap/events.spec.ts
+++ b/cli/test/lib/tap/events.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { beginTapTrace, noteTapCommand, noteTapFailure, reportTapTrace } from '../../../lib/tap/events'
-import { resolvedInstanceIdentity } from '../../../lib/cypress-sessions'
+import { resolvedSessionIdentity } from '../../../lib/cypress-sessions'
 import { detectAgent } from '@packages/agent-info'
 import util, { DEVELOPMENT_VERSION } from '../../../lib/util'
 
@@ -21,7 +21,7 @@ vi.mock('../../../lib/cypress-sessions', async (importActual) => {
 
   return {
     ...actual,
-    resolvedInstanceIdentity: vi.fn().mockReturnValue(null),
+    resolvedSessionIdentity: vi.fn().mockReturnValue(null),
   }
 })
 
@@ -52,7 +52,7 @@ describe('lib/tap/events', () => {
     delete process.env.CYPRESS_INTERNAL_EVENT_COLLECTOR_ENV
     delete process.env.CYPRESS_INTERNAL_ENV
     delete process.env.CYPRESS_DISABLE_GUEST_TELEMETRY
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue(null)
+    vi.mocked(resolvedSessionIdentity).mockReturnValue(null)
     vi.mocked(detectAgent).mockReturnValue(undefined)
     vi.mocked(util.pkgVersion).mockReturnValue('15.0.0')
     dateNow.mockReturnValue(1_000)
@@ -91,21 +91,21 @@ describe('lib/tap/events', () => {
   })
 
   it('carries the id of the instance the command resolved', async () => {
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'a1b2c3d4-0000-4000-8000-000000000000', machineId: null, userId: null })
+    vi.mocked(resolvedSessionIdentity).mockReturnValue({ sessionId: 'a1b2c3d4-0000-4000-8000-000000000000', machineId: null, userId: null })
 
     await reportTapTrace(0)
 
-    expect(posted(fetchMock).payload).toMatchObject({ instanceId: 'a1b2c3d4-0000-4000-8000-000000000000' })
+    expect(posted(fetchMock).payload).toMatchObject({ sessionId: 'a1b2c3d4-0000-4000-8000-000000000000' })
   })
 
   it('omits the instance id when the command never resolved one', async () => {
     await reportTapTrace(1)
 
-    expect(posted(fetchMock).payload).not.toHaveProperty('instanceId')
+    expect(posted(fetchMock).payload).not.toHaveProperty('sessionId')
   })
 
   it('reports to the machine collector with the machine id the instance carried', async () => {
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: null })
+    vi.mocked(resolvedSessionIdentity).mockReturnValue({ sessionId: 'inst-1', machineId: 'machine-hash', userId: null })
 
     await reportTapTrace(0)
 
@@ -115,7 +115,7 @@ describe('lib/tap/events', () => {
   })
 
   it('stays anonymous when the instance reports no machine id', async () => {
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: null, userId: null })
+    vi.mocked(resolvedSessionIdentity).mockReturnValue({ sessionId: 'inst-1', machineId: null, userId: null })
 
     await reportTapTrace(0)
 
@@ -124,7 +124,7 @@ describe('lib/tap/events', () => {
   })
 
   it('carries the cloud user id of the instance the command resolved', async () => {
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: 'cloud-user-1' })
+    vi.mocked(resolvedSessionIdentity).mockReturnValue({ sessionId: 'inst-1', machineId: 'machine-hash', userId: 'cloud-user-1' })
 
     await reportTapTrace(0)
 
@@ -132,7 +132,7 @@ describe('lib/tap/events', () => {
   })
 
   it('omits the user id when the instance has no logged-in user', async () => {
-    vi.mocked(resolvedInstanceIdentity).mockReturnValue({ instanceId: 'inst-1', machineId: 'machine-hash', userId: null })
+    vi.mocked(resolvedSessionIdentity).mockReturnValue({ sessionId: 'inst-1', machineId: 'machine-hash', userId: null })
 
     await reportTapTrace(0)
 
@@ -154,11 +154,11 @@ describe('lib/tap/events', () => {
   })
 
   it('carries the noted failure code', async () => {
-    noteTapFailure('NO_INSTANCE')
+    noteTapFailure('NO_SESSION')
 
     await reportTapTrace(1)
 
-    expect(posted(fetchMock).payload).toMatchObject({ exitCode: 1, errorCode: 'NO_INSTANCE' })
+    expect(posted(fetchMock).payload).toMatchObject({ exitCode: 1, errorCode: 'NO_SESSION' })
   })
 
   it('reuses one message id across the events of an invocation', async () => {
@@ -171,7 +171,7 @@ describe('lib/tap/events', () => {
   })
 
   it('starts a trace with no failure carried over from the previous command', async () => {
-    noteTapFailure('NO_INSTANCE')
+    noteTapFailure('NO_SESSION')
     beginTapTrace({ command: 'specs', flags: [] })
 
     await reportTapTrace(0)

--- a/cli/test/lib/tap/frame.spec.ts
+++ b/cli/test/lib/tap/frame.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import stripAnsi from 'strip-ansi'
 
 import logger from '../../../lib/logger'
-import { resolveInstance } from '../../../lib/cypress-sessions'
+import { resolveSession } from '../../../lib/cypress-sessions'
 import { withTapConnection } from '../../../lib/tap/tap-connection'
 import { resolveAutFrame, assertFrameReadable, withResolvedAutFrame } from '../../../lib/tap/aut/frame'
 import type { TapConnection } from '../../../lib/tap/tap-connection'
@@ -11,7 +11,7 @@ import type { TapCliOptions } from '../../../lib/tap/types'
 vi.mock('../../../lib/cypress-sessions', async (importActual) => {
   const actual = await importActual<typeof import('../../../lib/cypress-sessions')>()
 
-  return { ...actual, resolveInstance: vi.fn() }
+  return { ...actual, resolveSession: vi.fn() }
 })
 
 vi.mock('../../../lib/tap/tap-connection', async (importActual) => {
@@ -137,7 +137,7 @@ describe('lib/tap/aut/frame withResolvedAutFrame', () => {
       sessionId: SESSION_ID,
     } as unknown as TapConnection
 
-    vi.mocked(resolveInstance).mockResolvedValue({ instance: {}, reason: 'only', candidateCount: 1 } as any)
+    vi.mocked(resolveSession).mockResolvedValue({ instance: {}, reason: 'only', candidateCount: 1 } as any)
     vi.mocked(withTapConnection).mockImplementation((_instance: any, use: any) => use(session))
 
     logger.reset()

--- a/cli/test/lib/tap/inspect.spec.ts
+++ b/cli/test/lib/tap/inspect.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { CypressInstanceError } from '../../../lib/cypress-sessions'
+import { CypressSessionError } from '../../../lib/cypress-sessions'
 import { extractInspect } from '../../../lib/tap/commands/inspect'
 import type { TapConnection } from '../../../lib/tap/tap-connection'
 
@@ -120,7 +120,7 @@ describe('lib/tap/commands/inspect extractInspect', () => {
   it('fails instead of reporting a partial element when the renderer stops answering', async () => {
     const { session } = makeInspectSession({
       selectorObjectId: 'obj-1',
-      axError: new CypressInstanceError('RENDERER_UNRESPONSIVE', 'The targeted Cypress instance did not answer Accessibility.getPartialAXTree within 30000ms.'),
+      axError: new CypressSessionError('RENDERER_UNRESPONSIVE', 'The targeted Cypress instance did not answer Accessibility.getPartialAXTree within 30000ms.'),
     })
 
     await expect(extractInspect(session, frame, '.wedged')).rejects.toMatchObject({ code: 'RENDERER_UNRESPONSIVE' })

--- a/cli/test/lib/tap/render-instances.spec.ts
+++ b/cli/test/lib/tap/render-instances.spec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import stripAnsi from 'strip-ansi'
 
 import { renderInstancesHuman } from '../../../lib/tap/render/instances'
-import type { TapInstanceSummary } from '../../../lib/tap/commands/instances'
+import type { TapSessionSummary } from '../../../lib/tap/commands/instances'
 
-const render = (instances: TapInstanceSummary[]): string => stripAnsi(renderInstancesHuman(instances))
+const render = (instances: TapSessionSummary[]): string => stripAnsi(renderInstancesHuman(instances))
 
 describe('lib/tap/render/instances', () => {
   it('renders a padded table; missing testing type and detached browser show a dash', () => {

--- a/cli/test/lib/tap/session-gql.spec.ts
+++ b/cli/test/lib/tap/session-gql.spec.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { queryInstanceGraphql } from '../../../lib/tap/instance-gql'
-import type { LiveInstanceState } from '../../../lib/cypress-sessions'
+import { querySessionGraphql } from '../../../lib/tap/session-gql'
+import type { LiveSessionState } from '../../../lib/cypress-sessions'
 import { errors } from '../../../lib/errors'
 
-const instance: LiveInstanceState = {
+const instance: LiveSessionState = {
   schemaVersion: 1,
   pid: 4242,
   projectRoot: '/projects/app',
   serverPort: 49200,
-  instanceId: 'inst-1',
+  sessionId: 'inst-1',
   testingType: 'e2e',
   cdpBrowserWsUrl: null,
   browserName: null,
@@ -25,7 +25,7 @@ const request = {
 
 const jsonResponse = (payload: unknown, status = 200) => ({ status, json: async () => payload })
 
-describe('lib/tap/instance-gql', () => {
+describe('lib/tap/session-gql', () => {
   const fetchMock = vi.fn()
 
   beforeEach(() => {
@@ -40,7 +40,7 @@ describe('lib/tap/instance-gql', () => {
   it('posts the operation to the instance server port and returns the data', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ data: { currentProject: null } }))
 
-    const data = await queryInstanceGraphql(instance, request)
+    const data = await querySessionGraphql(instance, request)
 
     expect(data).toEqual({ currentProject: null })
 
@@ -48,14 +48,14 @@ describe('lib/tap/instance-gql', () => {
 
     expect(url).toBe('http://127.0.0.1:49200/__cypress/graphql/TapSpecs')
     expect(init.method).toBe('POST')
-    expect(init.headers).toEqual({ 'content-type': 'application/json', 'x-cypress-instance-id': 'inst-1' })
+    expect(init.headers).toEqual({ 'content-type': 'application/json', 'x-cypress-session-id': 'inst-1' })
     expect(JSON.parse(init.body)).toEqual({ ...request, variables: {} })
   })
 
   it('maps a network failure to the unreachable error', async () => {
     fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED'))
 
-    await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+    await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
       known: true,
       details: errors.tapGraphqlUnreachable,
       message: expect.stringContaining('ECONNREFUSED'),
@@ -65,7 +65,7 @@ describe('lib/tap/instance-gql', () => {
   it('maps a non-200 answer to the unreachable error', async () => {
     fetchMock.mockResolvedValue(jsonResponse({}, 500))
 
-    await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+    await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
       known: true,
       details: errors.tapGraphqlUnreachable,
       message: expect.stringContaining('500'),
@@ -75,7 +75,7 @@ describe('lib/tap/instance-gql', () => {
   it('reports an unsupported instance when the request is redirected away from GraphQL', async () => {
     fetchMock.mockResolvedValue({ status: 200, redirected: true, json: async () => '<!doctype html>' })
 
-    await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+    await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
       known: true,
       details: errors.tapOutdatedProtocol,
       message: expect.stringContaining('redirected'),
@@ -85,7 +85,7 @@ describe('lib/tap/instance-gql', () => {
   it('surfaces a GraphQL error payload with its message', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ errors: [{ message: 'resolver exploded' }] }))
 
-    await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+    await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
       known: true,
       details: errors.tapGraphqlFailed,
       message: expect.stringContaining('resolver exploded'),
@@ -96,7 +96,7 @@ describe('lib/tap/instance-gql', () => {
     for (const malformedErrors of [[null], ['boom'], [{}]]) {
       fetchMock.mockResolvedValue(jsonResponse({ errors: malformedErrors }))
 
-      await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+      await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
         known: true,
         details: errors.tapGraphqlFailed,
       })
@@ -108,7 +108,7 @@ describe('lib/tap/instance-gql', () => {
       throw new Error('unexpected token')
     } })
 
-    await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+    await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
       known: true,
       details: errors.tapGraphqlFailed,
     })
@@ -118,7 +118,7 @@ describe('lib/tap/instance-gql', () => {
     for (const payload of [null, 'junk', {}, { data: null }, { data: 'nope' }, { errors: [] }]) {
       fetchMock.mockResolvedValue(jsonResponse(payload))
 
-      await expect(queryInstanceGraphql(instance, request)).rejects.toMatchObject({
+      await expect(querySessionGraphql(instance, request)).rejects.toMatchObject({
         known: true,
         details: errors.tapGraphqlFailed,
       })

--- a/cli/test/lib/tap/tap-connection.spec.ts
+++ b/cli/test/lib/tap/tap-connection.spec.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CRI from 'chrome-remote-interface'
 
-import type { ReadyInstanceState } from '../../../lib/cypress-sessions'
+import type { ReadySessionState } from '../../../lib/cypress-sessions'
 import { CdpErrorMessage, withTapConnection } from '../../../lib/tap/tap-connection'
-import { FIND_INSTANCE_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
+import { FIND_SESSION_TIMEOUT_MS } from '../../../lib/tap/cdp-timeout'
 import { errors } from '../../../lib/errors'
 
 vi.mock('chrome-remote-interface', () => ({ default: vi.fn() }))
@@ -52,13 +52,13 @@ const makeClient = (overrides: FakeClientOverrides = {}) => {
   return client
 }
 
-const makeRecord = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceState => {
+const makeRecord = (overrides: Partial<ReadySessionState> = {}): ReadySessionState => {
   return {
     schemaVersion: 1,
     pid: 1234,
     projectRoot: PROJECT,
     serverPort: 5555,
-    instanceId: 'instance-abc',
+    sessionId: 'instance-abc',
     testingType: 'e2e',
     cdpBrowserWsUrl: BROWSER_WS_URL,
     browserName: 'Chrome',
@@ -69,9 +69,9 @@ const makeRecord = (overrides: Partial<ReadyInstanceState> = {}): ReadyInstanceS
   }
 }
 
-let instance: ReadyInstanceState
+let instance: ReadySessionState
 
-const setup = (client = makeClient(), overrides: Partial<ReadyInstanceState> = {}) => {
+const setup = (client = makeClient(), overrides: Partial<ReadySessionState> = {}) => {
   instance = makeRecord(overrides)
   mockConnect.mockResolvedValue(client)
 
@@ -505,7 +505,7 @@ describe('lib/tap/tap-connection', () => {
     try {
       const settled = callOnce().catch((e) => e)
 
-      await vi.advanceTimersByTimeAsync(FIND_INSTANCE_TIMEOUT_MS)
+      await vi.advanceTimersByTimeAsync(FIND_SESSION_TIMEOUT_MS)
 
       expect((await settled as Error & { code: string }).code).toBe('RENDERER_UNRESPONSIVE')
     } finally {

--- a/cli/test/lib/tasks/cache.spec.ts
+++ b/cli/test/lib/tasks/cache.spec.ts
@@ -293,12 +293,12 @@ describe('lib/tasks/cache', () => {
       expect(await fs.pathExists('/.cache/Cypress/bundles/cy-prompt/abc123/manifest.json')).toEqual(true)
     })
 
-    it('sweeps stale (dead-pid) runner instances records while keeping live ones', async function () {
+    it('sweeps stale (dead-pid) session records while keeping live ones', async function () {
       mockfs.restore()
       mockfs({
         '/.cache/Cypress': {
           '1.2.3': { 'Cypress': { 'file1': 'current' } },
-          'instances': {
+          'sessions': {
             [`${process.pid}.json`]: JSON.stringify({ pid: process.pid }),
             '999999.json': JSON.stringify({ pid: 999999 }),
             'notes.txt': 'not a record',
@@ -319,19 +319,19 @@ describe('lib/tasks/cache', () => {
 
       await cache.prune()
 
-      expect(await fs.pathExists(`/.cache/Cypress/instances/${process.pid}.json`)).toEqual(true)
-      expect(await fs.pathExists('/.cache/Cypress/instances/999999.json')).toEqual(false)
-      expect(await fs.pathExists('/.cache/Cypress/instances/notes.txt')).toEqual(true)
+      expect(await fs.pathExists(`/.cache/Cypress/sessions/${process.pid}.json`)).toEqual(true)
+      expect(await fs.pathExists('/.cache/Cypress/sessions/999999.json')).toEqual(false)
+      expect(await fs.pathExists('/.cache/Cypress/sessions/notes.txt')).toEqual(true)
       expect(await fs.pathExists('/.cache/Cypress/1.2.3')).toEqual(true)
     })
 
-    it('preserves the instances/ subdir while pruning old binary versions', async function () {
+    it('preserves the sessions/ subdir while pruning old binary versions', async function () {
       mockfs.restore()
       mockfs({
         '/.cache/Cypress': {
           '1.2.3': { 'Cypress': { 'file1': 'current' } },
           '2.3.4': { 'Cypress.app': {} },
-          'instances': { [`${process.pid}.json`]: JSON.stringify({ pid: process.pid }) },
+          'sessions': { [`${process.pid}.json`]: JSON.stringify({ pid: process.pid }) },
         },
       })
 
@@ -344,7 +344,7 @@ describe('lib/tasks/cache', () => {
 
       expect(await fs.pathExists('/.cache/Cypress/2.3.4')).toEqual(false)
       expect(await fs.pathExists('/.cache/Cypress/1.2.3')).toEqual(true)
-      expect(await fs.pathExists('/.cache/Cypress/instances')).toEqual(true)
+      expect(await fs.pathExists('/.cache/Cypress/sessions')).toEqual(true)
     })
   })
 

--- a/packages/app/cypress/e2e/tap-binding.cy.ts
+++ b/packages/app/cypress/e2e/tap-binding.cy.ts
@@ -126,7 +126,7 @@ describe('tap binding', () => {
       expect((reporterBeforeRun as { error: { code: string } }).error.code).to.eq('NO_RUN')
 
       // specs and run are CLI-native commands now — the CLI reads the spec list and
-      // triggers runs directly over the instance's GraphQL — so the binding no longer serves them.
+      // triggers runs directly over the session's GraphQL — so the binding no longer serves them.
       const specsOutcome = await binding.exec('specs')
 
       expect((specsOutcome as { error: { code: string } }).error.code).to.eq('UNKNOWN_COMMAND')

--- a/packages/cypress-sessions/AGENTS.md
+++ b/packages/cypress-sessions/AGENTS.md
@@ -1,6 +1,6 @@
-This package is the **cross-process contract** for Cypress instances: the shared
+This package is the **cross-process contract** for Cypress sessions: the shared
 schema, on-disk layout, and liveness-probe route that let an external process
-(the `cypress` CLI) find a running `cypress open` instance and attach to its
+(the `cypress` CLI) find a running `cypress open` session and attach to its
 browser over CDP.
 
 It is intentionally **pure, dependency-free TypeScript** — types, constants, and
@@ -11,9 +11,9 @@ CLI stay in agreement by construction instead of hand-mirrored copies.
 **Producer / Consumer**
 
 - **Producer** — `@packages/server` (`lib/cypress-sessions.ts`) writes `<pid>.json`
-  records into the `instances/` dir and serves the probe route in open mode.
+  records into the `sessions/` dir and serves the probe route in open mode.
 - **Consumer** — the CLI (`cli/lib/cypress-sessions/*`) reads those records,
-  checks pid liveness, and probes the route to confirm the instance and read the
+  checks pid liveness, and probes the route to confirm the session and read the
   live CDP endpoint.
 
 **Key Commands**
@@ -28,10 +28,10 @@ yarn workspace @packages/cypress-sessions test
 
 **Architecture**
 
-- `lib/index.ts` — the entire contract: `CypressInstance` / `LiveInstanceState`
-  / `ReadyInstanceState` interfaces, `isCompatibleRecord` validator, schema version
-  constants, `INSTANCES_DIRNAME`, `<pid>.json` filename helpers, and the
-  `INSTANCES_ROUTE_PREFIX` / `instancesProbePath` route helpers.
+- `lib/index.ts` — the entire contract: `CypressSession` / `LiveSessionState`
+  / `ReadySessionState` interfaces, `isCompatibleRecord` validator, schema version
+  constants, `SESSIONS_DIRNAME`, `<pid>.json` filename helpers, and the
+  `SESSIONS_ROUTE_PREFIX` / `sessionProbePath` route helpers.
 
 **Gotchas / Notes**
 

--- a/packages/cypress-sessions/lib/__spec__/index.spec.ts
+++ b/packages/cypress-sessions/lib/__spec__/index.spec.ts
@@ -4,10 +4,10 @@ import {
   isTapSupportedBrowser,
   recordFileName,
   parseRecordPid,
-  instancesProbePath,
+  sessionProbePath,
   buildTapSchema,
-  INSTANCES_ROUTE_PREFIX,
-  INSTANCES_DIRNAME,
+  SESSIONS_ROUTE_PREFIX,
+  SESSIONS_DIRNAME,
   SCHEMA_VERSION,
   TAP_COMMANDS,
 } from '../index'
@@ -17,7 +17,7 @@ const validRecord = {
   pid: 1234,
   projectRoot: '/projects/app',
   serverPort: 5000,
-  instanceId: 'a1b2c3d4-0000-4000-8000-000000000000',
+  sessionId: 'a1b2c3d4-0000-4000-8000-000000000000',
   testingType: 'e2e',
 }
 
@@ -36,7 +36,7 @@ describe('cypress-sessions contract', () => {
       expect(isCompatibleRecord(null)).toBe(false)
       expect(isCompatibleRecord({ ...validRecord, schemaVersion: 0 })).toBe(false)
       expect(isCompatibleRecord({ ...validRecord, serverPort: 1.5 })).toBe(false)
-      expect(isCompatibleRecord({ ...validRecord, instanceId: '' })).toBe(false)
+      expect(isCompatibleRecord({ ...validRecord, sessionId: '' })).toBe(false)
       expect(isCompatibleRecord({ ...validRecord, testingType: 'nope' })).toBe(false)
     })
   })
@@ -56,13 +56,13 @@ describe('cypress-sessions contract', () => {
 
   describe('probe route', () => {
     it('builds the probe path from the shared prefix', () => {
-      expect(instancesProbePath('abc')).toBe(`${INSTANCES_ROUTE_PREFIX}abc`)
-      expect(instancesProbePath('abc')).toBe('/__cypress/instances/abc')
+      expect(sessionProbePath('abc')).toBe(`${SESSIONS_ROUTE_PREFIX}abc`)
+      expect(sessionProbePath('abc')).toBe('/__cypress/sessions/abc')
     })
   })
 
-  it('exposes the instances dir name', () => {
-    expect(INSTANCES_DIRNAME).toBe('instances')
+  it('exposes the sessions dir name', () => {
+    expect(SESSIONS_DIRNAME).toBe('sessions')
   })
 
   describe('isTapSupportedBrowser', () => {

--- a/packages/cypress-sessions/lib/index.ts
+++ b/packages/cypress-sessions/lib/index.ts
@@ -10,30 +10,30 @@ export const SCHEMA_VERSION = 1
 
 export const MIN_SCHEMA_VERSION = 1
 
-export const INSTANCES_DIRNAME = 'instances'
+export const SESSIONS_DIRNAME = 'sessions'
 
 const RECORD_EXTENSION = '.json'
 
-export const INSTANCES_ROUTE_PREFIX = '/__cypress/instances/'
+export const SESSIONS_ROUTE_PREFIX = '/__cypress/sessions/'
 
-export const INSTANCE_ID_HEADER = 'x-cypress-instance-id'
+export const SESSION_ID_HEADER = 'x-cypress-session-id'
 
-export type InstanceTestingType = 'e2e' | 'component' | null
+export type SessionTestingType = 'e2e' | 'component' | null
 
-export interface CypressInstance {
+export interface CypressSession {
   schemaVersion: number
   pid: number
   projectRoot: string
   serverPort: number
-  instanceId: string
-  testingType: InstanceTestingType
+  sessionId: string
+  testingType: SessionTestingType
 }
 
-export interface LiveInstanceState extends CypressInstance {
+export interface LiveSessionState extends CypressSession {
   cdpBrowserWsUrl: string | null
-  /** Display name of the browser the instance has open (e.g. `Chrome`), or `null` when none is open. */
+  /** Display name of the browser the session has open (e.g. `Chrome`), or `null` when none is open. */
   browserName: string | null
-  /** Family of the browser the instance has open (e.g. `chromium`), or `null` when none is open. */
+  /** Family of the browser the session has open (e.g. `chromium`), or `null` when none is open. */
   browserFamily: string | null
   /** sha256 hash of the OS machine GUID (node-machine-id), or `null` when unresolvable. */
   machineId: string | null
@@ -41,7 +41,7 @@ export interface LiveInstanceState extends CypressInstance {
   userId: string | null
 }
 
-export interface ReadyInstanceState extends LiveInstanceState {
+export interface ReadySessionState extends LiveSessionState {
   cdpBrowserWsUrl: string
 }
 
@@ -67,30 +67,30 @@ export const parseRecordPid = (entry: string): number | null => {
   return Number.isInteger(pid) ? pid : null
 }
 
-export const cypressInstancesDir = (cacheRoot: string): string => {
-  return path.join(cacheRoot, INSTANCES_DIRNAME)
+export const cypressSessionsDir = (cacheRoot: string): string => {
+  return path.join(cacheRoot, SESSIONS_DIRNAME)
 }
 
 export const recordPath = (cacheRoot: string, pid: number): string => {
-  return path.join(cypressInstancesDir(cacheRoot), recordFileName(pid))
+  return path.join(cypressSessionsDir(cacheRoot), recordFileName(pid))
 }
 
-export const instancesProbePath = (instanceId: string): string => {
-  return `${INSTANCES_ROUTE_PREFIX}${instanceId}`
+export const sessionProbePath = (sessionId: string): string => {
+  return `${SESSIONS_ROUTE_PREFIX}${sessionId}`
 }
 
-const isValidTestingType = (value: any): value is InstanceTestingType => {
+const isValidTestingType = (value: any): value is SessionTestingType => {
   return value === 'e2e' || value === 'component' || value === null
 }
 
-export const isCompatibleRecord = (record: any): record is CypressInstance => {
+export const isCompatibleRecord = (record: any): record is CypressSession => {
   return Boolean(record)
     && typeof record.schemaVersion === 'number'
     && record.schemaVersion >= MIN_SCHEMA_VERSION
     && typeof record.pid === 'number'
     && typeof record.projectRoot === 'string'
     && Number.isInteger(record.serverPort)
-    && typeof record.instanceId === 'string'
-    && record.instanceId.length > 0
+    && typeof record.sessionId === 'string'
+    && record.sessionId.length > 0
     && isValidTestingType(record.testingType)
 }

--- a/packages/server/lib/browsers/browser-cri-client.ts
+++ b/packages/server/lib/browsers/browser-cri-client.ts
@@ -7,7 +7,7 @@ import { _connectAsync, _getDelayMsForRetry } from './protocol'
 import * as errors from '../errors'
 import type { CypressError } from '@packages/errors'
 import { CriClient, DEFAULT_NETWORK_ENABLE_OPTIONS } from './cdp-protocol/cri-client'
-import { cypressInstances } from '../cypress-sessions'
+import { cypressSessions } from '../cypress-sessions'
 import { serviceWorkerClientEventHandler, serviceWorkerClientEventHandlerName } from '@packages/proxy/lib/http/util/service-worker-manager'
 import type { CyPromptManagerShape, ProtocolManagerShape, CdpClientShape, OnExtraTargetCriClientReady, ExtraTargetDetach } from '@packages/types'
 import type { ServiceWorkerEventHandler } from '@packages/proxy/lib/http/util/service-worker-manager'
@@ -240,18 +240,18 @@ export class BrowserCriClient {
     return retryWithIncreasingDelay(async () => {
       const versionInfo = await CRI.Version({ host, port, useHostName: true })
 
-      const clearInstanceCdpUrl = () => cypressInstances.setCdpBrowserWsUrl(null)
+      const clearSessionCdpUrl = () => cypressSessions.setCdpBrowserWsUrl(null)
 
       const browserClient = await CriClient.create({
         target: versionInfo.webSocketDebuggerUrl,
         onAsynchronousError: (err) => {
-          clearInstanceCdpUrl()
+          clearSessionCdpUrl()
           onAsynchronousError(err)
         },
         onReconnect,
         protocolManager,
         fullyManageTabs,
-        onCriConnectionClosed: clearInstanceCdpUrl,
+        onCriConnectionClosed: clearSessionCdpUrl,
       })
 
       const browserCriClient = new BrowserCriClient({
@@ -267,7 +267,7 @@ export class BrowserCriClient {
         onExtraTargetCriClientReady,
       })
 
-      cypressInstances.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl)
+      cypressSessions.setCdpBrowserWsUrl(versionInfo.webSocketDebuggerUrl)
 
       if (fullyManageTabs) {
         await this._manageTabs({ browserClient, browserCriClient, browserName, host, onAsynchronousError, port, protocolManager })
@@ -807,7 +807,7 @@ export class BrowserCriClient {
 
     this.onClose && this.onClose(gracefulShutdown)
 
-    cypressInstances.setCdpBrowserWsUrl(null)
+    cypressSessions.setCdpBrowserWsUrl(null)
 
     if (this.connected === false) {
       debug('browser cri client is already closed')

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -3,7 +3,7 @@ import Bluebird from 'bluebird'
 import Debug from 'debug'
 import utils from './utils'
 import * as errors from '../errors'
-import { cypressInstances } from '../cypress-sessions'
+import { cypressSessions } from '../cypress-sessions'
 import { exec } from 'child_process'
 import util from 'util'
 import os from 'os'
@@ -137,7 +137,7 @@ const browsers = {
     const browserLauncher = await getBrowserLauncher(browser, options.browsers)
 
     await browserLauncher.connectToExisting(browser, options, automation, cdpSocketServer)
-    cypressInstances.setBrowser(browser)
+    cypressSessions.setBrowser(browser)
 
     return this.getBrowserInstance()
   },
@@ -236,7 +236,7 @@ const browsers = {
 
     instance = _instance
     instance.browser = browser
-    cypressInstances.setBrowser(browser)
+    cypressSessions.setBrowser(browser)
 
     // TODO: normalizing opening and closing / exiting
     // so that there is a default for each browser but
@@ -272,7 +272,7 @@ const browsers = {
 
       options.onBrowserClose()
       browserLauncher.clearInstanceState()
-      cypressInstances.setBrowser(null)
+      cypressSessions.setBrowser(null)
       instance = null
 
       if (browserDidCrash) {

--- a/packages/server/lib/cypress-sessions.ts
+++ b/packages/server/lib/cypress-sessions.ts
@@ -3,32 +3,32 @@ import path from 'path'
 import fs from 'fs-extra'
 import Debug from 'debug'
 import type { Browser, TestingType } from '@packages/types'
-import { SCHEMA_VERSION, cypressInstancesDir, recordPath } from '@packages/cypress-sessions'
-import type { CypressInstance, LiveInstanceState } from '@packages/cypress-sessions'
+import { SCHEMA_VERSION, cypressSessionsDir, recordPath } from '@packages/cypress-sessions'
+import type { CypressSession, LiveSessionState } from '@packages/cypress-sessions'
 import { resolveCypressCacheRoot } from './util/cypress-cache'
 
-export type { CypressInstance, LiveInstanceState } from '@packages/cypress-sessions'
+export type { CypressSession, LiveSessionState } from '@packages/cypress-sessions'
 
 const debug = Debug('cypress:server:cypress-sessions')
 
-export const getInstancesDir = (): string => {
-  return cypressInstancesDir(resolveCypressCacheRoot())
+export const getSessionsDir = (): string => {
+  return cypressSessionsDir(resolveCypressCacheRoot())
 }
 
 const getRecordPath = (pid: number): string => {
   return recordPath(resolveCypressCacheRoot(), pid)
 }
 
-let currentState: LiveInstanceState | null = null
+let currentState: LiveSessionState | null = null
 
 let persistChain: Promise<void> = Promise.resolve()
-const persist = (record: CypressInstance): Promise<void> => {
+const persist = (record: CypressSession): Promise<void> => {
   const run = async () => {
     const finalPath = getRecordPath(record.pid)
     const tmpPath = `${finalPath}.tmp`
 
     // Write to a temp file then rename: rename is atomic, so a concurrent reader
-    // (e.g. the CLI discovering live instances) always sees either the old record or
+    // (e.g. the CLI discovering live sessions) always sees either the old record or
     // the fully-written new one, never a partially-written/corrupt JSON file.
     await fs.ensureDir(path.dirname(finalPath))
     await fs.writeJson(tmpPath, record)
@@ -42,14 +42,14 @@ const persist = (record: CypressInstance): Promise<void> => {
   return next
 }
 
-export const cypressInstances = {
-  async addInstance ({ projectRoot, serverPort, testingType = null }: { projectRoot: string, serverPort: number, testingType?: TestingType | null }): Promise<void> {
-    const record: CypressInstance = {
+export const cypressSessions = {
+  async addSession ({ projectRoot, serverPort, testingType = null }: { projectRoot: string, serverPort: number, testingType?: TestingType | null }): Promise<void> {
+    const record: CypressSession = {
       schemaVersion: SCHEMA_VERSION,
       pid: process.pid,
       projectRoot: path.resolve(projectRoot),
       serverPort,
-      instanceId: crypto.randomUUID(),
+      sessionId: crypto.randomUUID(),
       testingType,
     }
 
@@ -59,9 +59,9 @@ export const cypressInstances = {
 
     try {
       await persist(record)
-      debug('wrote cypress instances record %o', record)
+      debug('wrote cypress sessions record %o', record)
     } catch (err) {
-      debug('failed to write cypress instances record: %o', err)
+      debug('failed to write cypress sessions record: %o', err)
     }
   },
 
@@ -74,7 +74,7 @@ export const cypressInstances = {
     }
 
     currentState = { ...currentState, browserName: browser?.displayName ?? null, browserFamily: browser?.family ?? null }
-    debug('cypress instances browser is now %o', browser ? { name: currentState.browserName, family: currentState.browserFamily } : null)
+    debug('cypress sessions browser is now %o', browser ? { name: currentState.browserName, family: currentState.browserFamily } : null)
   },
 
   setCdpBrowserWsUrl (cdpBrowserWsUrl: string | null): void {
@@ -83,10 +83,10 @@ export const cypressInstances = {
     }
 
     currentState = { ...currentState, cdpBrowserWsUrl }
-    debug('cypress instances cdpBrowserWsUrl is now %o', cdpBrowserWsUrl)
+    debug('cypress sessions cdpBrowserWsUrl is now %o', cdpBrowserWsUrl)
   },
 
-  getCurrent (): LiveInstanceState | null {
+  getCurrent (): LiveSessionState | null {
     return currentState
   },
 
@@ -103,15 +103,15 @@ export const cypressInstances = {
       await persistChain
 
       if (currentState) {
-        debug('skipping cypress instances removal; a newer record is live')
+        debug('skipping cypress sessions removal; a newer record is live')
 
         return
       }
 
       await fs.remove(getRecordPath(state.pid))
-      debug('removed cypress instances record for pid %d', state.pid)
+      debug('removed cypress sessions record for pid %d', state.pid)
     } catch (err) {
-      debug('failed to remove cypress instances record: %o', err)
+      debug('failed to remove cypress sessions record: %o', err)
     }
   },
 }

--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -17,7 +17,7 @@ import { SocketE2E } from './socket-e2e'
 import { ensureProp } from './util/class-helpers'
 import { isProxyDisabled } from './util/is-proxy-disabled'
 import * as system from './util/system'
-import { cypressInstances } from './cypress-sessions'
+import { cypressSessions } from './cypress-sessions'
 import type {
   BannersState,
   FoundBrowser,
@@ -255,10 +255,10 @@ export class ProjectBase extends EE {
       projectRoot: this.projectRoot,
     })
 
-    // Cypress instances only apply to an interactive (`cypress open`) session that an
+    // Cypress sessions only apply to an interactive (`cypress open`) session that an
     // external tool can attach to; skip it for headless `cypress run`.
     if (!cfg.isTextTerminal) {
-      await cypressInstances.addInstance({ projectRoot: this.projectRoot, serverPort: port, testingType: this.testingType })
+      await cypressSessions.addSession({ projectRoot: this.projectRoot, serverPort: port, testingType: this.testingType })
     }
 
     await this.saveState(stateToSave)
@@ -330,7 +330,7 @@ export class ProjectBase extends EE {
 
     await Promise.all([
       this.server?.close(),
-      cypressInstances.remove(),
+      cypressSessions.remove(),
     ])
 
     this._isServerOpen = false

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -22,8 +22,8 @@ import client from './controllers/client'
 import files from './controllers/files'
 import * as plugins from './plugins'
 import { privilegedCommandsManager } from './privileged-commands/privileged-commands-manager'
-import { cypressInstances } from './cypress-sessions'
-import { INSTANCES_ROUTE_PREFIX } from '@packages/cypress-sessions'
+import { cypressSessions } from './cypress-sessions'
+import { SESSIONS_ROUTE_PREFIX } from '@packages/cypress-sessions'
 import { isProxyDisabled } from './util/is-proxy-disabled'
 import { CYPRESS_CY_PROMPT_ROUTE, CYPRESS_STUDIO_ROUTE, isTrustedInternalLoopback, resolveProxyUrlBase } from './adapters/internal-routes'
 
@@ -250,19 +250,19 @@ export const createCommonRoutes = ({
     res.sendStatus(204)
   })
 
-  // Cypress instances only applies to an interactive (`cypress open`) session that an
+  // Cypress sessions only apply to an interactive (`cypress open`) session that an
   // external tool can attach to; the record is only written in open mode, so don't
   // expose the probe route for headless `cypress run`.
   if (!config.isTextTerminal) {
-    router.get(`${INSTANCES_ROUTE_PREFIX}:instanceId`, async (req, res) => {
-      const state = cypressInstances.getCurrent()
+    router.get(`${SESSIONS_ROUTE_PREFIX}:sessionId`, async (req, res) => {
+      const state = cypressSessions.getCurrent()
 
-      if (!state || req.params.instanceId !== state.instanceId) {
+      if (!state || req.params.sessionId !== state.sessionId) {
         return res.sendStatus(404)
       }
 
       // Identity is read at probe time rather than stored on the state: the
-      // logged-in user can change over the instance's lifetime.
+      // logged-in user can change over the session's lifetime.
       const ctx = getCtx()
 
       return res.json({

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -31,8 +31,8 @@ import { createInitialWorkers } from '@packages/rewriter'
 import type { Cfg } from './project-base'
 import type { Browser } from './browsers/types'
 import { InitializeRoutes, createCommonRoutes } from './routes'
-import { INSTANCES_ROUTE_PREFIX, INSTANCE_ID_HEADER } from '@packages/cypress-sessions'
-import { cypressInstances } from './cypress-sessions'
+import { SESSIONS_ROUTE_PREFIX, SESSION_ID_HEADER } from '@packages/cypress-sessions'
+import { cypressSessions } from './cypress-sessions'
 import type { FoundSpec, ProtocolManagerShape, TestingType, ExtraTargetDetach } from '@packages/types'
 import { RemoteStates } from '@packages/network-tools'
 import type { RemoteState } from '@packages/network-tools'
@@ -87,9 +87,9 @@ const _isNonProxiedRequest = (req) => {
   return req.proxiedUrl.startsWith('/')
 }
 
-const _hasValidInstanceIdHeader = (req): boolean => {
-  const provided = req.headers[INSTANCE_ID_HEADER]
-  const current = cypressInstances.getCurrent()?.instanceId
+const _hasValidSessionIdHeader = (req): boolean => {
+  const provided = req.headers[SESSION_ID_HEADER]
+  const current = cypressSessions.getCurrent()?.sessionId
 
   return Boolean(current) && typeof provided === 'string' && provided === current
 }
@@ -103,12 +103,12 @@ export const _forceProxyMiddleware = function (clientRoute, namespace = '__cypre
   ]
 
   const isCliTapRequest = (trimmedUrl: string, req) => {
-    return trimmedUrl.startsWith(`/${namespace}/graphql/`) && _hasValidInstanceIdHeader(req)
+    return trimmedUrl.startsWith(`/${namespace}/graphql/`) && _hasValidSessionIdHeader(req)
   }
 
   const isAllowedProxyBypass = (trimmedUrl: string, req) => {
     return ALLOWED_PROXY_BYPASS_URLS.includes(trimmedUrl) ||
-      trimmedUrl.startsWith(INSTANCES_ROUTE_PREFIX) ||
+      trimmedUrl.startsWith(SESSIONS_ROUTE_PREFIX) ||
       isCliTapRequest(trimmedUrl, req)
   }
 

--- a/packages/server/test/unit/browsers/browser-cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/browser-cri-client_spec.ts
@@ -7,7 +7,7 @@ import net from 'net'
 import { ProtocolManagerShape, CyPromptManagerShape, StudioManagerShape } from '@packages/types'
 import type { Protocol } from 'devtools-protocol'
 import { serviceWorkerClientEventHandlerName } from '@packages/proxy/lib/http/util/service-worker-manager'
-import { cypressInstances } from '../../../lib/cypress-sessions'
+import { cypressSessions } from '../../../lib/cypress-sessions'
 
 const HOST = '127.0.0.1'
 const PORT = 50505
@@ -135,16 +135,16 @@ describe('lib/browsers/browser-cri-client', function () {
       expect(criImport.Version).to.be.calledTwice
     })
 
-    it('advertises the browser websocket url to cypress instances once connected', async function () {
-      const setCdpBrowserWsUrl = sinon.stub(cypressInstances, 'setCdpBrowserWsUrl')
+    it('advertises the browser websocket url to cypress sessions once connected', async function () {
+      const setCdpBrowserWsUrl = sinon.stub(cypressSessions, 'setCdpBrowserWsUrl')
 
       await getClient()
 
       expect(setCdpBrowserWsUrl).to.be.calledWith('http://web/socket/url')
     })
 
-    it('clears the cypress instances cdp url when the browser connection is lost', async function () {
-      const setCdpBrowserWsUrl = sinon.stub(cypressInstances, 'setCdpBrowserWsUrl')
+    it('clears the cypress sessions cdp url when the browser connection is lost', async function () {
+      const setCdpBrowserWsUrl = sinon.stub(cypressSessions, 'setCdpBrowserWsUrl')
 
       await getClient()
 

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -13,7 +13,7 @@ import electron from '../../../lib/browsers/electron'
 import chrome from '../../../lib/browsers/chrome'
 import * as firefox from '../../../lib/browsers/firefox'
 import Promise from 'bluebird'
-import { cypressInstances } from '../../../lib/cypress-sessions'
+import { cypressSessions } from '../../../lib/cypress-sessions'
 import { deferred } from '../../support/helpers/deferred'
 import type { DataContext } from '@packages/data-context/src/DataContext'
 import type { BrowserInstance } from '../../../lib/browsers/types'
@@ -524,9 +524,9 @@ describe('lib/browsers/index', () => {
 
   // Recorded for every family, not just the ones that speak CDP, so an external
   // tool can tell a browser it cannot drive from no browser at all.
-  context('cypress instances browser', () => {
+  context('cypress sessions browser', () => {
     it('does not record the browser when launch fails', async () => {
-      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const setBrowser = sinon.spy(cypressSessions, 'setBrowser')
       const browser = { name: 'firefox', family: 'firefox', displayName: 'Firefox' }
       const launchError = new Error('failed to launch')
 
@@ -539,7 +539,7 @@ describe('lib/browsers/index', () => {
     })
 
     it('does not record the browser when connecting fails', async () => {
-      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const setBrowser = sinon.spy(cypressSessions, 'setBrowser')
       const browser = { name: 'firefox', family: 'firefox', displayName: 'Firefox' }
       const connectError = new Error('failed to connect')
 
@@ -551,7 +551,7 @@ describe('lib/browsers/index', () => {
     })
 
     it('records the browser on launch and clears it when the browser exits', async () => {
-      const setBrowser = sinon.spy(cypressInstances, 'setBrowser')
+      const setBrowser = sinon.spy(cypressSessions, 'setBrowser')
       const url: TestUrl = 'http://localhost:3000'
       const browserInstance = new EventEmitter() as BrowserInstance
 

--- a/packages/server/test/unit/cypress-sessions_spec.ts
+++ b/packages/server/test/unit/cypress-sessions_spec.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import os from 'os'
 import fs from 'fs-extra'
 import mockedEnv from 'mocked-env'
-import { cypressInstances, getInstancesDir, _resetForTesting } from '../../lib/cypress-sessions'
+import { cypressSessions, getSessionsDir, _resetForTesting } from '../../lib/cypress-sessions'
 
 describe('lib/cypress-sessions', () => {
   let restoreEnv: () => void
@@ -12,7 +12,7 @@ describe('lib/cypress-sessions', () => {
 
   beforeEach(() => {
     cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cy-cypress-sessions-'))
-    recordPath = path.join(cacheDir, 'instances', `${process.pid}.json`)
+    recordPath = path.join(cacheDir, 'sessions', `${process.pid}.json`)
 
     // resolveCypressCacheRoot also reads the npm_config_/npm_package_config_ variants,
     // so clear them to keep the dev environment from shadowing CYPRESS_CACHE_FOLDER.
@@ -32,19 +32,19 @@ describe('lib/cypress-sessions', () => {
     restoreEnv()
   })
 
-  describe('.getInstancesDir', () => {
-    it('resolves to an instances/ dir under the cache root', () => {
-      expect(getInstancesDir()).to.eq(path.join(cacheDir, 'instances'))
+  describe('.getSessionsDir', () => {
+    it('resolves to a sessions/ dir under the cache root', () => {
+      expect(getSessionsDir()).to.eq(path.join(cacheDir, 'sessions'))
     })
 
-    // ProjectBase.open() calls process.chdir(projectRoot) before the instance record is
+    // ProjectBase.open() calls process.chdir(projectRoot) before the session record is
     // written. A relative CYPRESS_CACHE_FOLDER must stay anchored to the launch cwd
     // (which the CLI reader resolves against), not drift to the project root — otherwise
     // the server writes the record to a tree the CLI never reads from.
     it('keeps a relative CYPRESS_CACHE_FOLDER anchored to the launch cwd across a chdir', () => {
       process.env.CYPRESS_CACHE_FOLDER = './.cypress-cache-relative'
 
-      const beforeChdir = getInstancesDir()
+      const beforeChdir = getSessionsDir()
 
       // Simulate ProjectBase.open() doing process.chdir(projectRoot) by stubbing the
       // reported cwd rather than mutating the real process state. The resolution must
@@ -54,14 +54,14 @@ describe('lib/cypress-sessions', () => {
 
       sinon.stub(process, 'cwd').returns(projectRoot)
 
-      expect(getInstancesDir()).to.eq(beforeChdir)
-      expect(getInstancesDir()).to.not.contain(projectRoot)
+      expect(getSessionsDir()).to.eq(beforeChdir)
+      expect(getSessionsDir()).to.not.contain(projectRoot)
     })
   })
 
-  describe('.addInstance', () => {
+  describe('.addSession', () => {
     it('writes a record named by pid with only immutable identity fields', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/some/project', serverPort: 4455, testingType: 'e2e' })
+      await cypressSessions.addSession({ projectRoot: '/some/project', serverPort: 4455, testingType: 'e2e' })
 
       const record = await fs.readJson(recordPath)
 
@@ -73,27 +73,27 @@ describe('lib/cypress-sessions', () => {
         testingType: 'e2e',
       })
 
-      expect(record.instanceId).to.be.a('string').and.match(/^[0-9a-f-]{36}$/)
+      expect(record.sessionId).to.be.a('string').and.match(/^[0-9a-f-]{36}$/)
 
       expect(record).to.not.have.property('cdpBrowserWsUrl')
     })
 
     it('records the selected testing type', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/some/project', serverPort: 4455, testingType: 'component' })
+      await cypressSessions.addSession({ projectRoot: '/some/project', serverPort: 4455, testingType: 'component' })
 
       expect(await fs.readJson(recordPath)).to.have.property('testingType', 'component')
     })
 
     it('defaults the testing type to null when none is selected', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/some/project', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/some/project', serverPort: 4455 })
 
       expect(await fs.readJson(recordPath)).to.have.property('testingType', null)
     })
 
     it('leaves no temp files behind (atomic write)', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      const entries = await fs.readdir(getInstancesDir())
+      const entries = await fs.readdir(getSessionsDir())
 
       expect(entries).to.eql([`${process.pid}.json`])
     })
@@ -104,21 +104,21 @@ describe('lib/cypress-sessions', () => {
       await fs.writeFile(filePath, 'x')
       process.env.CYPRESS_CACHE_FOLDER = filePath
 
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      expect(await fs.pathExists(path.join(filePath, 'instances'))).to.be.false
+      expect(await fs.pathExists(path.join(filePath, 'sessions'))).to.be.false
     })
   })
 
   describe('.setBrowser', () => {
     it('records the open browser without touching the disk record', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
       const onDiskBefore = await fs.readJson(recordPath)
 
-      cypressInstances.setBrowser({ displayName: 'Firefox', family: 'firefox' })
+      cypressSessions.setBrowser({ displayName: 'Firefox', family: 'firefox' })
 
-      expect(cypressInstances.getCurrent()).to.deep.include({
+      expect(cypressSessions.getCurrent()).to.deep.include({
         serverPort: 4455,
         browserName: 'Firefox',
         browserFamily: 'firefox',
@@ -128,31 +128,31 @@ describe('lib/cypress-sessions', () => {
     })
 
     it('clears the browser when it goes away', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
-      cypressInstances.setBrowser(null)
+      cypressSessions.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+      cypressSessions.setBrowser(null)
 
-      expect(cypressInstances.getCurrent()!.browserName).to.be.null
-      expect(cypressInstances.getCurrent()!.browserFamily).to.be.null
+      expect(cypressSessions.getCurrent()!.browserName).to.be.null
+      expect(cypressSessions.getCurrent()!.browserFamily).to.be.null
     })
 
     it('is a no-op when no record has been written yet', () => {
-      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+      cypressSessions.setBrowser({ displayName: 'Chrome', family: 'chromium' })
 
-      expect(cypressInstances.getCurrent()).to.be.null
+      expect(cypressSessions.getCurrent()).to.be.null
     })
   })
 
   describe('.setCdpBrowserWsUrl', () => {
     it('updates the live state without touching the disk record', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
       const onDiskBefore = await fs.readJson(recordPath)
 
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
+      cypressSessions.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
 
-      expect(cypressInstances.getCurrent()).to.deep.include({
+      expect(cypressSessions.getCurrent()).to.deep.include({
         serverPort: 4455,
         cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
       })
@@ -161,37 +161,37 @@ describe('lib/cypress-sessions', () => {
     })
 
     it('leaves the open browser in place when the endpoint goes away', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      cypressInstances.setBrowser({ displayName: 'Chrome', family: 'chromium' })
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
-      cypressInstances.setCdpBrowserWsUrl(null)
+      cypressSessions.setBrowser({ displayName: 'Chrome', family: 'chromium' })
+      cypressSessions.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
+      cypressSessions.setCdpBrowserWsUrl(null)
 
-      expect(cypressInstances.getCurrent()!.cdpBrowserWsUrl).to.be.null
-      expect(cypressInstances.getCurrent()!.browserName).to.eq('Chrome')
+      expect(cypressSessions.getCurrent()!.cdpBrowserWsUrl).to.be.null
+      expect(cypressSessions.getCurrent()!.browserName).to.eq('Chrome')
     })
 
     it('is a no-op when no record has been written yet', () => {
-      cypressInstances.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
+      cypressSessions.setCdpBrowserWsUrl('ws://127.0.0.1:9222/devtools/browser/abc')
 
-      expect(cypressInstances.getCurrent()).to.be.null
+      expect(cypressSessions.getCurrent()).to.be.null
     })
   })
 
   describe('.getCurrent', () => {
     it('is null before write and after remove', async () => {
-      expect(cypressInstances.getCurrent()).to.be.null
+      expect(cypressSessions.getCurrent()).to.be.null
 
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
-      await cypressInstances.remove()
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.remove()
 
-      expect(cypressInstances.getCurrent()).to.be.null
+      expect(cypressSessions.getCurrent()).to.be.null
     })
 
     it('is the disk record plus the memory-only browser CDP state', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      expect(cypressInstances.getCurrent()).to.deep.eq({
+      expect(cypressSessions.getCurrent()).to.deep.eq({
         ...await fs.readJson(recordPath),
         cdpBrowserWsUrl: null,
         browserName: null,
@@ -204,24 +204,24 @@ describe('lib/cypress-sessions', () => {
 
   describe('.remove', () => {
     it('deletes the record file', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
-      await cypressInstances.remove()
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.remove()
 
       expect(await fs.pathExists(recordPath)).to.be.false
     })
 
     it('is idempotent and never throws', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
-      await cypressInstances.remove()
-      await cypressInstances.remove()
+      await cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
+      await cypressSessions.remove()
+      await cypressSessions.remove()
 
       expect(await fs.pathExists(recordPath)).to.be.false
     })
 
     it('waits out an in-flight persist so the file cannot be resurrected', async () => {
-      const writing = cypressInstances.addInstance({ projectRoot: '/p', serverPort: 4455 })
+      const writing = cypressSessions.addSession({ projectRoot: '/p', serverPort: 4455 })
 
-      await cypressInstances.remove()
+      await cypressSessions.remove()
       await writing
 
       expect(await fs.pathExists(recordPath)).to.be.false
@@ -231,12 +231,12 @@ describe('lib/cypress-sessions', () => {
     // write() takes over the live state while the previous close()'s remove() is still
     // in flight. The stale remove() must not delete the freshly written record.
     it('does not delete a record a newer write took over on switch', async () => {
-      await cypressInstances.addInstance({ projectRoot: '/a', serverPort: 4455 })
+      await cypressSessions.addSession({ projectRoot: '/a', serverPort: 4455 })
 
       // begin removing the first record, then write the second before it completes
-      const removing = cypressInstances.remove()
+      const removing = cypressSessions.remove()
 
-      await cypressInstances.addInstance({ projectRoot: '/b', serverPort: 5566 })
+      await cypressSessions.addSession({ projectRoot: '/b', serverPort: 5566 })
       await removing
 
       expect(await fs.pathExists(recordPath)).to.be.true
@@ -246,7 +246,7 @@ describe('lib/cypress-sessions', () => {
         serverPort: 5566,
       })
 
-      expect(cypressInstances.getCurrent()).to.include({ serverPort: 5566 })
+      expect(cypressSessions.getCurrent()).to.include({ serverPort: 5566 })
     })
   })
 })

--- a/packages/server/test/unit/server-base_spec.ts
+++ b/packages/server/test/unit/server-base_spec.ts
@@ -7,7 +7,7 @@ import express from 'express'
 import { connect } from '@packages/network'
 import { setupFullConfigWithDefaults } from '@packages/config'
 import { ServerBase, _forceProxyMiddleware } from '../../lib/server-base'
-import { cypressInstances } from '../../lib/cypress-sessions'
+import { cypressSessions } from '../../lib/cypress-sessions'
 import { SocketE2E } from '../../lib/socket-e2e'
 import * as fileServer from '../../lib/file_server'
 import * as ensureUrl from '../../lib/util/ensure-url'
@@ -840,7 +840,7 @@ describe('lib/server-base', () => {
     let getCurrent
 
     beforeEach(() => {
-      getCurrent = sinon.stub(cypressInstances, 'getCurrent')
+      getCurrent = sinon.stub(cypressSessions, 'getCurrent')
     })
 
     afterEach(() => {
@@ -858,17 +858,17 @@ describe('lib/server-base', () => {
 
     const nonProxied = (proxiedUrl, headers = {}) => ({ proxiedUrl, headers })
 
-    it('lets a non-proxied graphql request through when the instance id header matches', () => {
-      getCurrent.returns({ instanceId: 'abc' })
+    it('lets a non-proxied graphql request through when the session id header matches', () => {
+      getCurrent.returns({ sessionId: 'abc' })
 
-      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-instance-id': 'abc' }))
+      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-session-id': 'abc' }))
 
       expect(next).to.be.calledOnce
       expect(res.redirect).not.to.be.called
     })
 
-    it('redirects a non-proxied graphql request whose instance id header is missing', () => {
-      getCurrent.returns({ instanceId: 'abc' })
+    it('redirects a non-proxied graphql request whose session id header is missing', () => {
+      getCurrent.returns({ sessionId: 'abc' })
 
       const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs'))
 
@@ -876,35 +876,35 @@ describe('lib/server-base', () => {
       expect(next).not.to.be.called
     })
 
-    it('redirects when the instance id header does not match the current instance', () => {
-      getCurrent.returns({ instanceId: 'abc' })
+    it('redirects when the session id header does not match the current session', () => {
+      getCurrent.returns({ sessionId: 'abc' })
 
-      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-instance-id': 'nope' }))
-
-      expect(res.redirect).to.be.calledWith(clientRoute)
-      expect(next).not.to.be.called
-    })
-
-    it('redirects when the instance id header is duplicated (array-valued)', () => {
-      getCurrent.returns({ instanceId: 'abc' })
-
-      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-instance-id': ['abc', 'abc'] }))
+      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-session-id': 'nope' }))
 
       expect(res.redirect).to.be.calledWith(clientRoute)
       expect(next).not.to.be.called
     })
 
-    it('redirects a graphql request when no instance is running', () => {
+    it('redirects when the session id header is duplicated (array-valued)', () => {
+      getCurrent.returns({ sessionId: 'abc' })
+
+      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-session-id': ['abc', 'abc'] }))
+
+      expect(res.redirect).to.be.calledWith(clientRoute)
+      expect(next).not.to.be.called
+    })
+
+    it('redirects a graphql request when no session is running', () => {
       getCurrent.returns(null)
 
-      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-instance-id': 'abc' }))
+      const { res, next } = run(nonProxied('/__cypress/graphql/TapSpecs', { 'x-cypress-session-id': 'abc' }))
 
       expect(res.redirect).to.be.calledWith(clientRoute)
       expect(next).not.to.be.called
     })
 
-    it('lets a proxied graphql request through without an instance id header', () => {
-      getCurrent.returns({ instanceId: 'abc' })
+    it('lets a proxied graphql request through without a session id header', () => {
+      getCurrent.returns({ sessionId: 'abc' })
 
       const { res, next } = run({ proxiedUrl: 'http://localhost:2020/__cypress/graphql/TapSpecs', headers: {} })
 
@@ -912,10 +912,10 @@ describe('lib/server-base', () => {
       expect(res.redirect).not.to.be.called
     })
 
-    it('still lets the read-only instances probe bypass without a header', () => {
-      getCurrent.returns({ instanceId: 'abc' })
+    it('still lets the read-only sessions probe bypass without a header', () => {
+      getCurrent.returns({ sessionId: 'abc' })
 
-      const { res, next } = run(nonProxied('/__cypress/instances/whatever'))
+      const { res, next } = run(nonProxied('/__cypress/sessions/whatever'))
 
       expect(next).to.be.calledOnce
       expect(res.redirect).not.to.be.called

--- a/system-tests/lib/tap-open.ts
+++ b/system-tests/lib/tap-open.ts
@@ -156,7 +156,7 @@ export interface TapInstance {
   /**
    * Freezes the server (and its process tree where supported): the record stays
    * and the pid stays alive while nothing answers, which is what reports
-   * STALE_INSTANCE rather than NO_INSTANCE. `kill` needs no resume first.
+   * STALE_SESSION rather than NO_SESSION. `kill` needs no resume first.
    */
   suspend (): Promise<void>
   resume (): Promise<void>
@@ -360,7 +360,7 @@ export const openTapInstance = async (project: ProjectFixtureDir, options: OpenT
 }
 
 const recordedPid = async (projectRoot: string): Promise<number | undefined> => {
-  const dir = path.join(CACHE_FOLDER, 'instances')
+  const dir = path.join(CACHE_FOLDER, 'sessions')
   const entries: string[] = await fs.readdir(dir).catch(() => [])
 
   for (const entry of entries) {

--- a/system-tests/test/tap_open_spec.ts
+++ b/system-tests/test/tap_open_spec.ts
@@ -160,18 +160,18 @@ describe('tap CLI with no running instance', function () {
     expect(result.json()).to.deep.eq({ status: 'not connected' })
   })
 
-  it('exits 1 with NO_INSTANCE for a read', async () => {
+  it('exits 1 with NO_SESSION for a read', async () => {
     const result = await tapWithoutInstance(['dom', '--selector', '#status'])
 
     expect(result.exitCode).to.eq(1)
-    expect(failureOutput(result)).to.include('NO_INSTANCE')
+    expect(failureOutput(result)).to.include('NO_SESSION')
   })
 
   it('names the pid that was asked for when --instance matches nothing', async () => {
     const result = await tapWithoutInstance(['--instance', '999999', 'inspect', '--selector', '#status'])
 
     expect(result.exitCode).to.eq(1)
-    expect(failureOutput(result)).to.include('NO_INSTANCE')
+    expect(failureOutput(result)).to.include('NO_SESSION')
     expect(failureOutput(result)).to.include('999999')
   })
 })
@@ -785,17 +785,17 @@ describe('tap CLI across the run lifecycle', function () {
     snapshotRendering('reporter failed command log', result.stdout)
   })
 
-  it('exits 1 with NO_INSTANCE once the instance is gone', async () => {
+  it('exits 1 with NO_SESSION once the instance is gone', async () => {
     // SIGKILL skips the record cleanup an orderly exit would run, so the record outlives
     // its writer. Discovery reaps it on the next read (`reapIfDead` in
-    // cypress-sessions/store.ts), so an unclean exit reports NO_INSTANCE rather than
-    // STALE_INSTANCE — the latter needs a pid that is alive but no longer answering.
+    // cypress-sessions/store.ts), so an unclean exit reports NO_SESSION rather than
+    // STALE_SESSION — the latter needs a pid that is alive but no longer answering.
     await instance.terminate()
 
     const result = await instance.tap(['dom', '--selector', '#status'])
 
     expect(result.exitCode).to.eq(1)
-    expect(failureOutput(result)).to.include('NO_INSTANCE')
+    expect(failureOutput(result)).to.include('NO_SESSION')
   })
 })
 
@@ -926,7 +926,7 @@ describe('tap CLI with more than one instance running', function () {
 
 /**
  * A pid alive but no longer answering: the only state that reports
- * STALE_INSTANCE rather than NO_INSTANCE.
+ * STALE_SESSION rather than NO_SESSION.
  */
 describe('tap CLI against an instance that stopped answering', function () {
   this.timeout(SUITE_TIMEOUT_MS)
@@ -944,11 +944,11 @@ describe('tap CLI against an instance that stopped answering', function () {
     await instance?.kill()
   })
 
-  it('exits 1 with STALE_INSTANCE, saying Cypress was running and is not now', async () => {
+  it('exits 1 with STALE_SESSION, saying Cypress was running and is not now', async () => {
     const result = await instance.tap(['dom', '--selector', '#status'])
 
     expect(result.exitCode).to.eq(1)
-    expect(failureOutput(result)).to.include('STALE_INSTANCE')
+    expect(failureOutput(result)).to.include('STALE_SESSION')
     expect(failureOutput(result)).to.include('no longer responding')
   })
 


### PR DESCRIPTION
- Closes N/A — part of the `instances` → `sessions` rename in this stack.

### Additional details

Third of four stacked PRs, and the substantive one: the discovery domain now speaks `session` end to end. The CLI surface (`tap instances`, `--instance`, help copy) is deliberately **unchanged here** and lands in the next PR.

**Types and API**

| before | after |
| --- | --- |
| `CypressInstance` | `CypressSession` |
| `LiveInstanceState` / `ReadyInstanceState` | `LiveSessionState` / `ReadySessionState` |
| `InstanceTestingType` | `SessionTestingType` |
| `CypressInstanceError(Code)` | `CypressSessionError(Code)` |
| `resolveInstance` / `resolveLiveInstance` | `resolveSession` / `resolveLiveSession` |
| `listLiveInstances` / `readLiveInstances` | `listLiveSessions` / `readLiveSessions` |
| `InstanceSelection` (`.instance`) | `SessionSelection` (`.session`) |
| `cypressInstances.addInstance` (server) | `cypressSessions.addSession` |
| `queryInstanceGraphql` / `instance-gql.ts` | `querySessionGraphql` / `session-gql.ts` |

**Wire and on-disk literals** — these change *value*, not just symbol name:

| | before | after |
| --- | --- | --- |
| cache subdir | `<cacheRoot>/instances/` | `<cacheRoot>/sessions/` |
| probe route | `/__cypress/instances/:id` | `/__cypress/sessions/:id` |
| id header | `x-cypress-instance-id` | `x-cypress-session-id` |
| record field | `instanceId` | `sessionId` |

**No back-compat, deliberately.** Tap is not in any release and is not on `develop`, so the literals change outright: no dual-read path, and `SCHEMA_VERSION` / `TAP_SCHEMA_VERSION` do **not** bump. This follows the precedent already set on this branch (`refactor: collapse the unreleased runner discovery record to schema v1`, and the earlier `runner-instances` → `cypress-instances` rename).

> [!NOTE]
> One practical consequence for reviewers: a `cypress open` already running from an older build writes the old record shape to the old directory, so a CLI from this branch will not find it and reports `NO_SESSION`. Restart `cypress open` after checking out.

**Error codes move with the layer that throws them.** `NO_INSTANCE` → `NO_SESSION` and `STALE_INSTANCE` → `STALE_SESSION`, along with their messages. These are user-visible, but they are raised by the discovery module being renamed here, so holding them back would have left one file half-renamed. `NO_BROWSER_ATTACHED` is unchanged.

**Three neighbouring domains keep `instance`** — verified untouched, not merely avoided:

- **Cloud recorded-run instances.** `packages/server/lib/project-base.ts` is the sharp edge: its tap calls at lines 20/261/333 are renamed while `instanceId: randomUUID()` at line 528 — the Cloud protocol's spec instance id — is not. Any file-scoped find/replace there would have corrupted the protocol call.
- **Launched browser instances** (`BrowserInstance`, `clearInstanceState`, `instanceToKill`).
- **Plain `instanceof`**, `reporterInstance`, `TelemetryReporter.getInstance()`.

`cy.session`'s vocabulary inside tap (`TapReporterSession`, the reporter's `SESSIONS` panel) is intentionally left as-is, so the contract barrel now exports both `CypressSession` and `TapReporterSession`.

> [!WARNING]
> **Cloud coordination.** `cli/lib/tap/events.ts` posts the tap invocation event to the Cloud event collector, and its `instanceId` key is now `sessionId`. That key is consumed by Cloud analytics outside this repo and needs a matching change there before tap events land correctly.

### Steps to test

```bash
yarn && yarn workspace @packages/cypress-sessions build
yarn workspace @packages/cypress-sessions test
cd cli && yarn test-unit
cd packages/server && CYPRESS_INTERNAL_ENV=test npx mocha --require ../ts/register.js \
  test/unit/cypress-sessions_spec.ts test/unit/browsers/browser-cri-client_spec.ts
```

To confirm the wire rename end to end: start `cypress open`, then check the record lands in `<cacheRoot>/sessions/<pid>.json` with a `sessionId` field, and that `cypress tap status` finds it.

### How has the user experience changed?

Two error codes and their messages change — `NO_INSTANCE` → `NO_SESSION` ("No Cypress session found…") and `STALE_INSTANCE` → `STALE_SESSION`. The commands, flags, and help text are untouched until the next PR in the stack.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? — rename on the unreleased tap feature branch.
- [x] Have tests been added/updated? — CLI, contract-package, and server specs updated, including the literals asserted in `packages/cypress-sessions/lib/__spec__/index.spec.ts`, `server-base_spec.ts`, and `cache.spec.ts`.
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? — tap is unreleased and undocumented publicly.
- [na] Have API changes been updated in the `type definitions`? — nothing in `cli/types`; these are internal `@packages/*` types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking wire and on-disk contract for tap discovery (no migration path) plus coordinated Cloud telemetry key rename; behavior is localized to unreleased tap but affects liveness probing and GraphQL targeting.
> 
> **Overview**
> Renames the **unreleased `cypress tap` discovery domain** from *instance* to *session* end to end: `@packages/cypress-sessions`, `cli/lib/cypress-sessions`, tap plumbing, and server hooks (e.g. `cypressSessions` when publishing CDP URLs).
> 
> **API and types** move together — e.g. `CypressInstance` → `CypressSession`, `resolveInstance` / `resolveLiveInstance` → `resolveSession` / `resolveLiveSession`, `CypressInstanceError` with `NO_INSTANCE` / `STALE_INSTANCE` → `CypressSessionError` with `NO_SESSION` / `STALE_SESSION`, and `queryInstanceGraphql` / `instance-gql.ts` → `querySessionGraphql` / `session-gql.ts`.
> 
> **On-disk and wire literals change outright** (no dual-read): cache subdir `instances/` → `sessions/`, probe `/__cypress/instances/:id` → `/__cypress/sessions/:id`, header `x-cypress-instance-id` → `x-cypress-session-id`, record field `instanceId` → `sessionId`. Schema versions do not bump; an older `cypress open` will not be discovered by a CLI from this branch until restart.
> 
> **User-facing tap CLI is intentionally unchanged here** — `cypress tap instances`, `--instance`, and related help still say "instance"; the next PR in the stack handles that. Tap telemetry in `events.ts` now sends `sessionId` instead of `instanceId`, which needs a matching Cloud analytics change.
> 
> Specs and cache prune behavior are updated for the new dirname and error codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32b8c459f3b55067c00b077f9bf661905713a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->