### PR TITLE
chore: enable CDP Fetch on auto-attached iframe sessions when the proxy is disabled

### DIFF
--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -203,8 +203,8 @@ export class CdpFetchTransport {
 
   /**
    * Attaches the Fetch handlers and enables interception on this transport's
-   * own session. Sessions that attach later come through
-   * `attachServiceWorkerSession`.
+   * own session. Child sessions that attach later (service workers,
+   * origin-isolated iframes) come through `attachChildSession`.
    */
   async start (): Promise<void> {
     if (this.isStarted) {
@@ -236,19 +236,20 @@ export class CdpFetchTransport {
   }
 
   /**
-   * Enables interception on a service worker session attached to this
-   * transport's connection. A service worker's script fetch and its
-   * fetch-handler requests run on that session rather than the page's, so
-   * without this they bypass the middleware onion — and `cy.intercept` —
-   * entirely.
+   * Enables interception on a child session attached to this transport's
+   * connection. Those targets run their network on their own session rather
+   * than the page's — a service worker's script fetch and fetch handlers, an
+   * out-of-process iframe's (OOPIF) subresources — so without this their
+   * requests bypass the middleware onion (and `cy.intercept`) entirely and
+   * escape to the real origin.
    *
    * Must run while the target is still waiting for the debugger; the caller
    * (CriClient._onAttachedToTarget) sequences this before
    * Runtime.runIfWaitingForDebugger.
    */
-  async attachServiceWorkerSession (sessionId: string): Promise<void> {
+  async attachChildSession (sessionId: string): Promise<void> {
     if (!this.isStarted) {
-      debug('attachServiceWorkerSession skipped (transport not started)')
+      debug('attachChildSession skipped (transport not started)')
 
       return
     }

--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -94,7 +94,7 @@ export interface ICriClient {
    * on its own session, so without this they bypass interception entirely
    * when the proxy is disabled.
    */
-  onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+  onChildTargetAttached?: (sessionId: string) => Promise<void>
 }
 
 type DeferredPromise = { resolve: Function, reject: Function }
@@ -127,7 +127,7 @@ export class CriClient implements ICriClient {
   private _crashed = false
   private cdpConnection: CDPConnection
 
-  public onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+  public onChildTargetAttached?: (sessionId: string) => Promise<void>
 
   private constructor (
     public targetId: string,
@@ -462,14 +462,22 @@ export class CriClient implements ICriClient {
       debug('error attaching to target cri: %o', { error, event })
     }
 
-    if (event.targetInfo.type === 'service_worker' && this.onServiceWorkerTargetAttached) {
+    // Chromium hosts a frame in its own renderer process when its site needs
+    // one — a cross-site frame under site isolation, or an origin-keyed agent
+    // cluster (e.g. https google origins). An out-of-process iframe's (OOPIF)
+    // network runs on its own CDP session, exactly like a service worker's:
+    // without enabling interception there, a cross-origin spec bridge's
+    // runner-bundle fetch escapes to the real origin (real
+    // accounts.google.com answers 404 and cy.origin waits forever on
+    // bridge:ready).
+    if ((event.targetInfo.type === 'service_worker' || event.targetInfo.type === 'iframe') && this.onChildTargetAttached) {
       try {
         // Must complete while the target is still paused — releasing the
-        // debugger first lets the service worker's script fetch escape
+        // debugger first lets the target's first fetches escape
         // uninterceptable.
-        await this.onServiceWorkerTargetAttached(event.sessionId)
+        await this.onChildTargetAttached(event.sessionId)
       } catch (error) {
-        debug('error enabling service worker interception: %o', { error, event })
+        debug('error enabling child-session interception: %o', { error, event })
       }
     }
 

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -43,9 +43,10 @@ export type ProxyNetworkRuntime = NetworkInterceptionRuntime & {
 }
 
 export type CreateCdpFetchRuntimeDeps = {
-  // onServiceWorkerTargetAttached is a settable hook: the runtime assigns it
-  // so service worker sessions get Fetch enabled before they start running.
-  client: Pick<ICriClient, 'send' | 'on' | 'off' | 'onServiceWorkerTargetAttached'>
+  // onChildTargetAttached is a settable hook: the runtime assigns it so
+  // child sessions (service workers, origin-isolated iframes) get Fetch
+  // enabled before they start running.
+  client: Pick<ICriClient, 'send' | 'on' | 'off' | 'onChildTargetAttached'>
   isAUTFrame?: (frameId: string) => Promise<boolean>
   // Protocol-neutral subscription to AUT document navigation commits,
   // provided by the automation layer (CdpAutomation.onAUTFrameNavigated).
@@ -329,17 +330,19 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     async start () {
       unsubscribeAUTFrameNavigated = deps.onAUTFrameNavigated?.(onAUTFrameNavigated)
 
-      // A service worker's network runs on its own CDP session — without
-      // enabling Fetch there, its script fetch and fetch-handler requests
-      // bypass the middleware onion (and cy.intercept) entirely.
-      deps.client.onServiceWorkerTargetAttached = (sessionId) => {
-        return fetchTransport.attachServiceWorkerSession(sessionId)
+      // Service workers and out-of-process iframes have their own CDP
+      // session — without enabling Fetch there, a worker's script fetch and an
+      // out-of-process iframe's (OOPIF) subresources (e.g. a cross-origin spec
+      // bridge's runner bundle) bypass the middleware onion entirely and
+      // escape to the real origin.
+      deps.client.onChildTargetAttached = (sessionId) => {
+        return fetchTransport.attachChildSession(sessionId)
       }
 
       try {
         await fetchTransport.start()
       } catch (err) {
-        deps.client.onServiceWorkerTargetAttached = undefined
+        deps.client.onChildTargetAttached = undefined
         unsubscribeAUTFrameNavigated?.()
         unsubscribeAUTFrameNavigated = undefined
 
@@ -357,7 +360,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     },
     async stop () {
       stopped = true
-      deps.client.onServiceWorkerTargetAttached = undefined
+      deps.client.onChildTargetAttached = undefined
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
 

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -521,7 +521,7 @@ describe('CdpFetchTransport', () => {
       const { transport } = createTransport(client)
 
       await transport.start()
-      await transport.attachServiceWorkerSession('sw-session')
+      await transport.attachChildSession('sw-session')
 
       const enableCalls = client.send.getCalls().filter((call) => call.args[0] === 'Fetch.enable')
 
@@ -536,7 +536,7 @@ describe('CdpFetchTransport', () => {
       const client = createClient()
       const { transport } = createTransport(client)
 
-      await transport.attachServiceWorkerSession('sw-session')
+      await transport.attachChildSession('sw-session')
 
       expect(client.send).not.to.have.been.calledWith('Fetch.enable')
     })
@@ -550,7 +550,7 @@ describe('CdpFetchTransport', () => {
       client.send.withArgs('Fetch.enable', sinon.match.any, 'sw-session')
       .rejects(new Error('ProtocolError: Inspected target closed'))
 
-      await expect(transport.attachServiceWorkerSession('sw-session'))
+      await expect(transport.attachChildSession('sw-session'))
       .to.be.rejectedWith('Inspected target closed')
     })
 
@@ -562,7 +562,7 @@ describe('CdpFetchTransport', () => {
       const { transport } = createTransport(client)
       const onRequestPaused = await startTransport(transport, client)
 
-      await transport.attachServiceWorkerSession('sw-session')
+      await transport.attachChildSession('sw-session')
 
       const handled = onRequestPaused(createPausedRequest({
         requestId: 'sw-fetch-request',

--- a/packages/server/test/unit/browsers/cri-client_spec.ts
+++ b/packages/server/test/unit/browsers/cri-client_spec.ts
@@ -184,7 +184,7 @@ describe('lib/browsers/cri-client', function () {
       })
     })
 
-    describe('when a service worker target attaches', () => {
+    describe('when a child target (service worker / out-of-process iframe) attaches', () => {
       const sessionId = 'sw-session'
       let client: CriClient
 
@@ -200,7 +200,7 @@ describe('lib/browsers/cri-client', function () {
       it('enables interception on the session before releasing the debugger', async () => {
         const enabled = Promise.withResolvers<void>()
 
-        client.onServiceWorkerTargetAttached = sinon.stub().returns(enabled.promise)
+        client.onChildTargetAttached = sinon.stub().returns(enabled.promise)
 
         fireCDPEvent('Target.attachedToTarget', {
           waitingForDebugger: true,
@@ -210,7 +210,7 @@ describe('lib/browsers/cri-client', function () {
 
         await drain()
 
-        expect(client.onServiceWorkerTargetAttached).to.have.been.calledOnceWith(sessionId)
+        expect(client.onChildTargetAttached).to.have.been.calledOnceWith(sessionId)
 
         // a worker released before its session is intercepted fetches its own
         // script straight off the network, bypassing the middleware onion
@@ -222,10 +222,36 @@ describe('lib/browsers/cri-client', function () {
         expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
       })
 
-      it('does not enable interception for other target types', async () => {
-        client.onServiceWorkerTargetAttached = sinon.stub().resolves()
+      it('enables interception on origin-isolated iframe sessions before releasing the debugger', async () => {
+        // an out-of-process iframe's (OOPIF) subresources are fetched on its
+        // own session (e.g. an https spec-bridge iframe on an origin-keyed
+        // google origin); released uninstrumented, its runner bundle request
+        // escapes to the real origin
+        const enabled = Promise.withResolvers<void>()
 
-        await Promise.all(['page', 'other', 'iframe'].map((type) => {
+        client.onChildTargetAttached = sinon.stub().returns(enabled.promise)
+
+        fireCDPEvent('Target.attachedToTarget', {
+          waitingForDebugger: true,
+          sessionId,
+          targetInfo: { type: 'iframe' } as Protocol.Target.TargetInfo,
+        })
+
+        await drain()
+
+        expect(client.onChildTargetAttached).to.have.been.calledOnceWith(sessionId)
+        expect(criStub.send).not.to.have.been.calledWith('Runtime.runIfWaitingForDebugger')
+
+        enabled.resolve()
+        await drain()
+
+        expect(criStub.send).to.have.been.calledWith('Runtime.runIfWaitingForDebugger', undefined, sessionId)
+      })
+
+      it('does not enable interception for other target types', async () => {
+        client.onChildTargetAttached = sinon.stub().resolves()
+
+        await Promise.all(['page', 'other'].map((type) => {
           return fireCDPEvent('Target.attachedToTarget', {
             waitingForDebugger: true,
             sessionId,
@@ -235,11 +261,11 @@ describe('lib/browsers/cri-client', function () {
 
         await drain()
 
-        expect(client.onServiceWorkerTargetAttached).not.to.have.been.called
+        expect(client.onChildTargetAttached).not.to.have.been.called
       })
 
       it('releases the debugger even when enabling interception fails', async () => {
-        client.onServiceWorkerTargetAttached = sinon.stub().rejects(new Error('ProtocolError: Inspected target closed'))
+        client.onChildTargetAttached = sinon.stub().rejects(new Error('ProtocolError: Inspected target closed'))
 
         fireCDPEvent('Target.attachedToTarget', {
           waitingForDebugger: true,

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -965,7 +965,7 @@ describe('lib/network-runtime', () => {
       send: sinon.SinonStub
       on: sinon.SinonStub
       off: sinon.SinonStub
-      onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+      onChildTargetAttached?: (sessionId: string) => Promise<void>
     } = {
       send: sinon.stub().resolves({}),
       on: sinon.stub(),
@@ -973,12 +973,12 @@ describe('lib/network-runtime', () => {
     }
     const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
 
-    expect(client.onServiceWorkerTargetAttached, 'hook is not registered before start').to.not.exist
+    expect(client.onChildTargetAttached, 'hook is not registered before start').to.not.exist
 
     await runtime.start()
     client.send.resetHistory()
 
-    await client.onServiceWorkerTargetAttached!('sw-session')
+    await client.onChildTargetAttached!('sw-session')
 
     // A service worker's script fetch and fetch-handler requests run on its own
     // session, so they only reach the middleware onion (and cy.intercept) if
@@ -995,7 +995,7 @@ describe('lib/network-runtime', () => {
 
     // The page client outlives the runtime, so a stale hook would enable Fetch
     // against a transport that has already dropped its handlers.
-    expect(client.onServiceWorkerTargetAttached, 'hook is cleared on stop').to.not.exist
+    expect(client.onChildTargetAttached, 'hook is cleared on stop').to.not.exist
   })
 
   it('createCdpFetchRuntime clears the service worker hook when Fetch.enable fails', async () => {
@@ -1003,7 +1003,7 @@ describe('lib/network-runtime', () => {
       send: sinon.SinonStub
       on: sinon.SinonStub
       off: sinon.SinonStub
-      onServiceWorkerTargetAttached?: (sessionId: string) => Promise<void>
+      onChildTargetAttached?: (sessionId: string) => Promise<void>
     } = {
       send: sinon.stub().rejects(new Error('enable failed')),
       on: sinon.stub(),
@@ -1013,7 +1013,7 @@ describe('lib/network-runtime', () => {
 
     await expect(runtime.start()).to.be.rejectedWith('enable failed')
 
-    expect(client.onServiceWorkerTargetAttached).to.not.exist
+    expect(client.onChildTargetAttached).to.not.exist
   })
 
   it('createCdpFetchRuntime stop also stops attached extra-target transports', async () => {


### PR DESCRIPTION
<!-- comment to trigger the PR template checks -->

- Closes #34609

### Additional details

With `CYPRESS_INTERNAL_DISABLE_PROXY=1`, `origin.cy.ts` stalled silently at `cy.origin('https://accounts.google.com')` on every run (2× CI kills after 10 minutes of no output, 4× locally) — the last reproducible hang in the proxy-disabled driver suite. Root cause, established by probing the live wedged browser over CDP (full forensics on #34609):

1. The spec-bridge iframe's **navigation** is intercepted fine — it pauses on the parent session, Express serves the bridge HTML via the internal-route loopback, and `Fetch.fulfillRequest` is acknowledged. The document commits.
2. Google origins are origin-keyed, so the committed frame becomes an **OOPIF with its own CDP session** — and nothing ever enabled Fetch on iframe-type auto-attached sessions.
3. The bridge document's request for `cypress_cross_origin_runner.js` therefore escapes interception to the **real** accounts.google.com, which answers with its own 404 (`server: GSE`, ~300 bytes — captured by fetching from inside the wedged frame).
4. No bundle → no `Cypress` in the bridge → `bridge:ready` never posts → `cy.origin` waits with no timeout → silence until CI's no-output kill.

The first test's 30 bridges pass because its plain-http fake domains stay in-process — their subresources ride the parent session's interception. Only origin-isolated frames hit the gap.

This is the third member of the missing-session-enablement family: #34555 covered service workers, #34481/#34567 covered extra-target pages, and this covers OOPIF iframes. The fix routes `iframe`-type target attachments through the same enable-interception-before-releasing-the-debugger hook the service-worker fix added — the ordering guarantee (Fetch enabled while the target is still debugger-paused) is what prevents the frame's very first fetch from escaping. Since the hook now serves two target types, it and the transport method are renamed to match their scope: `onChildTargetAttached` / `attachChildSession`.

### Steps to test

Verified locally under `CYPRESS_INTERNAL_DISABLE_PROXY=1` (Chrome):
- `origin.cy.ts` — **24/24 passing in 13s** (previously wedged at test 2 on every single run)
- `service-worker.cy.js` — 28/28 (shared-seam regression sentinel)
- unit: `cri-client` 84 passing (new test pins the iframe enable-before-release ordering; the old test pinning iframes as *not* intercepted is corrected), `cdp-fetch-transport` 86, `network-runtime` 30
- `yarn check-ts` — no new errors (two pre-existing baseline errors exist on develop, unrelated files)

Full-suite proof: `driver-integration-tests-chrome-cdp` on the bugbash verification branch — slot with `origin.cy.ts` should complete instead of being killed for silence.

### How has the user experience changed?

N/A — internal `CYPRESS_INTERNAL_DISABLE_PROXY` behavior only. (Under the flag, `cy.origin` against origin-isolated https origins goes from hanging forever to working.)

### PR Tasks

- [ ] Have tests been added/updated? — yes, `cri-client_spec` iframe-session coverage
- [ ] Has the original issue or this PR been tagged in a changelog entry? — N/A (internal flag)
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? — N/A
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP target attach ordering and network interception for all auto-attached iframe sessions when the proxy is off; incorrect sequencing could still let first fetches bypass middleware, but behavior mirrors the existing service-worker path with new test coverage.
> 
> **Overview**
> Fixes **`cy.origin` hanging indefinitely** under `CYPRESS_INTERNAL_DISABLE_PROXY` when the spec-bridge frame becomes an **out-of-process iframe (OOPIF)** with its own CDP session. Bridge navigation could still be intercepted on the parent session, but subresource fetches (e.g. `cypress_cross_origin_runner.js`) were not, so they hit the real origin and **`bridge:ready` never fired**.
> 
> **`iframe`-type** `Target.attachedToTarget` events now use the same pre-release hook as service workers: enable CDP **Fetch** on the child session **before** `Runtime.runIfWaitingForDebugger`. The hook and transport API are renamed to **`onChildTargetAttached`** / **`attachChildSession`** to reflect both target kinds. Unit tests cover iframe ordering and updated hook wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56c420f5b25589b3d4e9e13c887265333319a6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->