### PR TITLE
chore: deliver a network error requested from a cy.intercept response handler

### DIFF
--- a/packages/proxy/lib/http/index.ts
+++ b/packages/proxy/lib/http/index.ts
@@ -206,7 +206,17 @@ export function _runStage (type: HttpStages, ctx: any, onError: Function) {
 
       function onClose () {
         if (!ctx.res.writableFinished) {
-          _onError(createBrowserConnectionClosedError())
+          const error: Error & { isForceNetworkError?: boolean } = createBrowserConnectionClosedError()
+
+          // forceNetworkError destroys the res itself, so this close is our own
+          // teardown rather than a browser cancel. Carry the tag forward or it
+          // is lost here — this handler runs after the requested error already
+          // set ctx.error, and replaces it.
+          if ((ctx.error as Error & { isForceNetworkError?: boolean } | undefined)?.isForceNetworkError) {
+            error.isForceNetworkError = true
+          }
+
+          _onError(error)
         }
       }
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -604,6 +604,15 @@ export class CdpFetchTransport {
             requestId: event.requestId,
           }, sessionId)
         }
+      } else if ((err as Error & { isForceNetworkError?: boolean })?.isForceNetworkError) {
+        // A network error requested from a response handler
+        // (res.send({ forceNetworkError: true })) must reach the page as one
+        // too. The request stage already continued, so the pause in hand is the
+        // response — fail it rather than releasing the origin's response.
+        await this.safeSend('Fetch.failRequest', {
+          requestId: response?.requestId ?? responseRequestId ?? event.requestId,
+          errorReason: 'Failed',
+        }, response?.sessionId ?? responseSessionId ?? sessionId)
       } else {
         const continueRequestId = response?.requestId ?? responseRequestId
 

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -1848,10 +1848,11 @@ describe('CdpFetchTransport', () => {
 
       await tick()
 
+      // postData is a CDP binary param: base64 of the utf8 body, not the body
       expect(client.send).to.have.been.calledWith('Fetch.continueRequest', {
         requestId: 'fetch-request',
         method: 'POST',
-        postData: 'cGF5bG9hZA==',
+        postData: Buffer.from('payload', 'utf8').toString('base64'),
         headers: [{
           name: 'accept-encoding',
           value: 'gzip, deflate',
@@ -1985,6 +1986,40 @@ describe('CdpFetchTransport', () => {
       })
 
       expect(client.send).not.to.have.been.calledWith('Fetch.continueRequest', {
+        requestId: 'fetch-request',
+      })
+    })
+
+    it('fails the response pause when a response handler requests a network error', async () => {
+      // res.send({ forceNetworkError: true }) raises after the request has
+      // continued, so the pause in hand is the response one — it must still
+      // reach the page as a network error, not as the origin's response
+      const client = createClient()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+      const { transport } = createTransport(client, { httpIntercept })
+      const onRequestPaused = await startTransport(transport, client)
+
+      httpIntercept.use(async (req, next) => {
+        await next(req)
+
+        const err: Error & { isForceNetworkError?: boolean } = new Error('forceNetworkError called')
+
+        err.isForceNetworkError = true
+        throw err
+      })
+
+      const handled = onRequestPaused(createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1' }))
+
+      await tick()
+      await onRequestPaused(createPausedRequest({ requestId: 'fetch-request', networkId: 'network-1', responseStatusCode: 200 }))
+      await handled
+
+      expect(client.send).to.have.been.calledWith('Fetch.failRequest', {
+        requestId: 'fetch-request',
+        errorReason: 'Failed',
+      })
+
+      expect(client.send).not.to.have.been.calledWith('Fetch.continueResponse', {
         requestId: 'fetch-request',
       })
     })


### PR DESCRIPTION
<!-- comment to trigger the PR template checks -->

- Closes #34624

### Additional details

With `CYPRESS_INTERNAL_DISABLE_PROXY=1`, `res.send({ forceNetworkError: true })` from a response handler left the page with the origin's **real** response instead of a network error. The request-stage form (`req.reply({ forceNetworkError: true })`) was fixed in #34606; this is its response-stage sibling.

**Why the existing fix didn't cover it.** #34606 established the chain: `sendStaticResponse` tags the error, the pipeline carries the tag onto the error it throws, and the transport maps a tagged rejection to `Fetch.failRequest`. The tag was being applied here too — but it never survived to the transport:

1. `res.send({ forceNetworkError: true })` raises **inside the response phase**, after the request continued to the origin.
2. The Error stage's `DestroyResponse` destroys the synthetic res, which emits `close`.
3. `_runStage` registers `res.on('close', onClose)` for the response phase, and `onClose` synthesizes a fresh **untagged** `BrowserConnectionClosedError` that replaces `ctx.error` — so the pipeline's `if (ctx.error) throw ctx.error` rethrew the untagged one.
4. The transport saw an ordinary failure with the request already continued, and released the pause with the response it had.

Instrumented trace before the fix — the tag is applied, then lost:

```
[fne] sendStaticResponse tagging + calling onError
[fne] after response stage; ctx.error = The browser closed the connection... tagged = undefined
[fne] transport catch: requestContinued = true tagged = undefined
```

**The fix** is two small pieces:

- `onClose` carries the `isForceNetworkError` tag forward when it synthesizes its close error. That close *is* our own teardown (forceNetworkError destroyed the res), not a browser cancel — the same reasoning #34606 applied at the request→response transition, one layer up.
- The transport fails the **response** pause for a tagged rejection instead of continuing it. `Fetch.failRequest` on a response-stage pause is valid — verified empirically, it was the open question here.

**MITM is unaffected by construction**: it delivers the network error by destroying a real socket, and never reads the tag. The synthesized error's type, the error-stage re-run, and every other close path are unchanged.

Also folds in a review follow-up from #34606: the `postData: 'cGF5bG9hZA=='` literal in the transport spec is now `Buffer.from('payload', 'utf8').toString('base64')` with a one-line note, so it reads as the CDP binary-param contract rather than an incidental value.

### Steps to test

Verified locally with Chrome:

- **proxy-off** (`CYPRESS_INTERNAL_DISABLE_PROXY=1`): the request now lands as `status: 0, statusText: 'error', readyState: 0`; before the fix it was the origin's `404`.
- **proxy-on regression** — `net_stubbing.cy.ts` **256 passing, 0 failing**, confirming the shared-pipeline change leaves MITM behavior intact.
- unit: `cdp-fetch-transport` 109 passing (new test pins that a tagged rejection after the request continued fails the response pause and does not continue it), `@packages/proxy` 1525, `@packages/net-stubbing` 17. eslint clean.

The proxy-off spec run for the whole file lands in the follow-up gating PR, which stacks on this branch.

### How has the user experience changed?

N/A — internal `CYPRESS_INTERNAL_DISABLE_PROXY` behavior only. (Under the flag, a `forceNetworkError` from a response handler now actually produces a network error.)

### PR Tasks

- [ ] Have tests been added/updated? — yes, `cdp-fetch-transport_spec`
- [ ] Has the original issue or this PR been tagged in a changelog entry? — N/A (internal flag)
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? — N/A
- [ ] Have new configuration options been added to the [`cypress.schema.json`](https://github.com/cypress-io/cypress/blob/develop/cli/schema/cypress.schema.json)? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared proxy error propagation and CDP Fetch pause release logic for network interception; scope is narrow (tag preservation + one new failure branch) with targeted tests, but incorrect tagging could mis-handle real browser cancels vs forced errors.
> 
> **Overview**
> Fixes **`res.send({ forceNetworkError: true })`** (and equivalent response-stage stubs) under **`CYPRESS_INTERNAL_DISABLE_PROXY`**, where the page previously saw the **origin response** instead of a network error after the request had already continued.
> 
> The proxy response-phase **`res` `close`** handler no longer drops the **`isForceNetworkError`** tag when it replaces the error with a synthetic **`BrowserConnectionClosedError`**—that teardown is from **`forceNetworkError`** destroying the response, not a browser cancel.
> 
> The **CDP Fetch transport** now maps a tagged rejection **after** **`Fetch.continueRequest`** to **`Fetch.failRequest`** on the **response** pause instead of **`Fetch.continueResponse`**. Request-stage **`forceNetworkError`** behavior is unchanged; MITM proxy mode is unaffected.
> 
> Adds a **cdp-fetch-transport** unit test for the response-handler path and clarifies **`postData`** base64 expectations in an existing spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5361adf2fd25f7bfa065710e79a04a22b4dc6ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->