### PR TITLE
chore: drop ServerBase's write-only network runtime pointer fields

### DIFF
--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -53,7 +53,6 @@ import type { ResourceType, RequestCredentialLevel } from '@packages/proxy'
 import { GracefulExit } from './util/graceful-exit'
 import { createCdpFetchRuntime, createProxyRuntime } from './network-runtime'
 import type { CreateProxyRuntimeDeps, CdpFetchNetworkRuntime, ProxyNetworkRuntime } from './network-runtime'
-import type { ForNetworkPolicyRegistration, NetworkInterceptionCore } from '@packages/network-interception'
 import type { ICriClient } from './browsers/cdp-protocol/cri-client'
 import { CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, getTrustedLoopbackUrl, isTrustedInternalLoopback } from './adapters/internal-routes'
 
@@ -203,8 +202,11 @@ type WarningErr = Record<string, any>
  */
 type NetworkMode = 'browser' | 'proxy'
 
-// The three pointers that must always name the same runtime as `_networkMode`.
-type NetworkRuntimePointers = Pick<ProxyNetworkRuntime, 'networkProxy' | 'networkPolicyRegistration' | 'networkInterceptionCore'>
+// The pointer that must always name the same runtime as `_networkMode`. The
+// runtime's interception core (and the policy registration built into it) is
+// constructed into its NetworkProxy, so it travels with this pointer and
+// cannot drift on its own.
+type NetworkRuntimePointers = Pick<ProxyNetworkRuntime, 'networkProxy'>
 
 interface OpenServerOptions {
   SocketCtor: typeof SocketE2E | typeof SocketCt
@@ -228,8 +230,6 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
   protected _nodeProxy?: httpProxy
   protected _networkProxy?: NetworkProxy
   protected _netStubbingState?: NetStubbingState
-  protected _networkPolicyRegistration?: ForNetworkPolicyRegistration
-  protected _networkInterceptionCore?: NetworkInterceptionCore
   protected _cdpFetchRuntime?: CdpFetchNetworkRuntime
   protected _proxyRuntime?: ProxyNetworkRuntime
   protected _openConfig?: Cfg
@@ -651,16 +651,14 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
   }
 
   /**
-   * Installs a network runtime's pointers and, when given, the mode that names
-   * it. Both must move together and without an await in between: any window
-   * where `_networkMode` and `_networkProxy` disagree routes requests into the
-   * wrong pipeline (an absolute-form request handed to the browser-interception
-   * branch, or a path-only one handed to the MITM proxy).
+   * Installs a network runtime's NetworkProxy and, when given, the mode that
+   * names it. Both must move together and without an await in between: any
+   * window where `_networkMode` and `_networkProxy` disagree routes requests
+   * into the wrong pipeline (an absolute-form request handed to the
+   * browser-interception branch, or a path-only one handed to the MITM proxy).
    */
   private useNetworkRuntime (runtime: NetworkRuntimePointers | undefined, mode?: NetworkMode) {
     this._networkProxy = runtime?.networkProxy
-    this._networkPolicyRegistration = runtime?.networkPolicyRegistration
-    this._networkInterceptionCore = runtime?.networkInterceptionCore
 
     if (mode) {
       this._networkMode = mode

--- a/packages/server/test/unit/server-base_spec.ts
+++ b/packages/server/test/unit/server-base_spec.ts
@@ -227,8 +227,6 @@ describe('lib/server-base', () => {
       this.server._openConfig = this.config
       this.server._proxyRuntime = {
         networkProxy: { id: 'mitm' },
-        networkPolicyRegistration: { id: 'mitm-policy' },
-        networkInterceptionCore: { id: 'mitm-core' },
       }
 
       this.netStubbingState = { id: 'owned-by-open' }
@@ -278,8 +276,6 @@ describe('lib/server-base', () => {
       expect(stop).to.have.been.called
       expect(this.server._cdpFetchRuntime).to.be.undefined
       expect(this.server._networkProxy).to.eq(this.server._proxyRuntime.networkProxy)
-      expect(this.server._networkPolicyRegistration).to.eq(this.server._proxyRuntime.networkPolicyRegistration)
-      expect(this.server._networkInterceptionCore).to.eq(this.server._proxyRuntime.networkInterceptionCore)
       // the server owns the netStubbingState, so a runtime handoff must not move it
       expect(this.server._netStubbingState).to.eq(this.netStubbingState)
     })
@@ -446,10 +442,12 @@ describe('lib/server-base', () => {
       })
 
       expect(this.server._cdpFetchRuntime).to.exist
-      expect(this.server._networkProxy).to.exist
       expect(this.server._netStubbingState).to.exist
-      expect(this.server._networkPolicyRegistration).to.exist
-      expect(this.server._networkInterceptionCore).to.exist
+      // The request-time ctx reads its interception core off the installed
+      // NetworkProxy, so this observes the pointers production middleware
+      // observes.
+      expect(this.server._networkProxy).to.eq(this.server._cdpFetchRuntime.networkProxy)
+      expect(this.server._networkProxy.http.networkInterceptionCore).to.eq(this.server._cdpFetchRuntime.networkInterceptionCore)
     })
 
     // Publishing the mode any earlier would point the request-time gates at a
@@ -500,6 +498,39 @@ describe('lib/server-base', () => {
       expect(this.server.isBrowserNetworkMode()).to.be.false
       expect(this.server._netStubbingState).to.equal(state)
       expect(this.server._networkProxy.http.netStubbingState).to.equal(state)
+    })
+
+    // Each runtime constructs its interception core (and the policy
+    // registration inside it) into its own NetworkProxy, and the middleware
+    // ctx reads the core off whichever NetworkProxy is installed. So the
+    // handoff invariant — every shared runtime pointer moves with
+    // `_networkMode` in one synchronous step — is observable here: after each
+    // switch, the middleware-visible core must be the active runtime's, never
+    // the other one's.
+    it('hands the middleware-visible interception core over with the runtime, in both directions', async function () {
+      _.extend(this.config, { port: 54321 })
+      sinon.stub(this.server, 'createExpressApp').returns({ use: sinon.stub() })
+      sinon.stub(this.server, 'createServer').resolves()
+      sinon.stub(this.server, 'ensureHttpsProxy').resolves()
+
+      await this.server.open(this.config, getOpenOptions())
+
+      const mitmCore = this.server._proxyRuntime.networkInterceptionCore
+
+      expect(this.server._networkProxy.http.networkInterceptionCore).to.equal(mitmCore)
+
+      await this.server.createCdpFetchNetworkRuntime(createClient())
+
+      const cdpCore = this.server._cdpFetchRuntime.networkInterceptionCore
+
+      expect(cdpCore).not.to.equal(mitmCore)
+      expect(this.server.isBrowserNetworkMode()).to.be.true
+      expect(this.server._networkProxy.http.networkInterceptionCore).to.equal(cdpCore)
+
+      await this.server.setNetworkMode(false)
+
+      expect(this.server.isBrowserNetworkMode()).to.be.false
+      expect(this.server._networkProxy.http.networkInterceptionCore).to.equal(mitmCore)
     })
 
     it('applies a previously stored protocol manager to the late-bound CDP NetworkProxy', async function () {


### PR DESCRIPTION
- Follow-up to #34633 (merged); targets `release/16.0.0`, rebased onto it

### Additional details

#34633 left two write-only fields on `ServerBase` — `_networkPolicyRegistration` and `_networkInterceptionCore`. They are assigned in the runtime handoff but never read in production: middleware reaches the interception core through the request ctx that `Http` builds from the installed `NetworkProxy`, and the policy registration is a construction-time closure of that core with no other reachable path.

Their only readers were assertions in `server-base_spec` guarding the handoff invariant — *all shared runtime pointers move with `_networkMode` in one synchronous step, so a browser switch can never leave the mode naming a runtime that is not installed*. Deleting the fields would have deleted that guard, which is why #34633 kept them and deferred this.

This replaces the guard with one that observes the pointers **production actually reads**, then removes the fields:

- a round-trip test (open → CDP launch → switch back) asserts `_networkProxy.http.networkInterceptionCore` is instance-identical to the active runtime's core after each direction of the handoff
- the CDP-launch assertions move from "these fields exist" to runtime identity (`_networkProxy === cdpRuntime.networkProxy`, and its core is the CDP runtime's core)
- the test also asserts the CDP core is *not* the MITM core, so the identity checks cannot pass vacuously

The policy registration needs no direct assertion: it is a constructor closure of that exact core instance and is reachable through nothing else, so pinning the core pins it.

Removing the fields also makes the original failure mode unrepresentable rather than merely tested against — the core now travels only inside `networkProxy`, so `ServerBase` can no longer hold a core from one runtime while `_networkProxy` is another's.

### Steps to test

Verified by mutation, since a guard that cannot fail is not a guard. Publishing the pointer one tick late while the mode stays synchronous —

```js
setImmediate(() => { this._networkProxy = runtime?.networkProxy })
```

— fails **13** tests including the new guard. Restored, the suite is **75 passing**.

Also run: `yarn workspace @packages/server check-ts` (clean) and eslint on both touched files (no new errors; `server-base.ts` has 4 pre-existing `import/no-duplicates` errors on the baseline).

### How has the user experience changed?

No change. Test-and-internals only; no production behavior is affected.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- follow-up carved out of #33847 / #34633 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internals and test-only refactor with no production behavior change; it narrows how runtime pointers are stored so interception core cannot drift from `_networkProxy`.
> 
> **Overview**
> **`ServerBase` no longer mirrors network interception state in separate fields.** `_networkPolicyRegistration` and `_networkInterceptionCore` are removed; `useNetworkRuntime` only installs `networkProxy`, on the assumption that each runtime’s interception core (and policy registration) lives on that proxy and is what request middleware actually reads.
> 
> **Tests now guard the handoff the way production does.** Specs stop asserting the deleted fields and instead check `_networkProxy ===` the active runtime’s proxy and `_networkProxy.http.networkInterceptionCore` matches that runtime’s core after CDP launch and after switching back to MITM, including that CDP and MITM cores are distinct instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90abcfe7892d75e9c82f3553ef698b9c829e2722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
