### PR TITLE
fix: reconnect page CDP clients after disconnect

### DIFF
--- a/packages/server/lib/browsers/cdp-protocol/cri-client.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cri-client.ts
@@ -157,8 +157,7 @@ export class CriClient implements ICriClient {
       local: true,
       useHostName: true,
     }, {
-      // Only automatically reconnect if: this is the root browser cri target (no host), or cy in cy
-      automaticallyReconnect: !this.host && !process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF,
+      automaticallyReconnect: !process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF,
     })
 
     this.cdpConnection.addConnectionEventListener('cdp-connection-reconnect-error', onAsynchronousError)

--- a/packages/server/test/integration/cdp_spec.ts
+++ b/packages/server/test/integration/cdp_spec.ts
@@ -160,6 +160,36 @@ describe('CDP Clients', () => {
   })
 
   context('reconnect after disconnect', () => {
+    it('reconnects page target clients and restores Runtime bindings', async function () {
+      const reconnect = Promise.withResolvers<void>()
+      const onReconnectAttempt = sinon.stub()
+
+      criClient = await CriClient.create({
+        target: `ws://127.0.0.1:${wsServerPort}`,
+        host: '127.0.0.1',
+        onAsynchronousError: reconnect.reject,
+        onReconnect: reconnect.resolve,
+        onReconnectAttempt,
+      })
+
+      await criClient.send('Runtime.addBinding', { name: 'cypressSendToServer-test' })
+      onMessage.resetHistory()
+
+      await Promise.all([
+        clientDisconnected(),
+        closeWsServer(),
+      ])
+
+      wsSrv = await startWsServer()
+      await reconnect.promise
+
+      expect(onReconnectAttempt).to.have.been.called
+      expect(onMessage).to.have.been.calledWithMatch({
+        method: 'Runtime.addBinding',
+        params: { name: 'cypressSendToServer-test' },
+      })
+    })
+
     it('retries to connect', async () => {
       const stub = sinon.stub()
 


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34637

### Additional details

The runner uses a separate CDP connection for the page target. This connection did not reconnect when its WebSocket closed.

After a refresh, Cypress could try to use browser bindings that were not restored. This left the runner blank and caused `window[this._namespace] is not a function` errors.

This change enables the existing reconnect logic for page target clients. The reconnect logic restores Runtime bindings before queued messages are sent.

### Steps to test

1. Open a spec in Chrome.
2. Disconnect the page target CDP WebSocket.
3. Refresh the Cypress runner.
4. Check that the runner reconnects and loads normally.

Automated checks:

- `yarn workspace @packages/server test-integration cdp_spec.ts`
- `yarn workspace @packages/server test-unit cri-client_spec.ts`
- `yarn workspace @packages/server check-ts`
- ESLint for the changed files

### How has the user experience changed?

The Cypress runner recovers when the page CDP connection is interrupted instead of showing a blank page.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the type definitions?
