### PR TITLE
deprecation: deprecate `cy.exec()` in favor of `cy.task()`

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Deprecations:**
 
-- [`cy.exec()`](https://on.cypress.io/exec) has been deprecated and will be removed in a future major release of Cypress. Because it runs a command through a shell, its behavior depends on the operating system, the shell, the login environment, and whether a terminal is attached, which is a long-running source of hangs and "command not found" failures that are difficult to diagnose. Use [`cy.task()`](https://on.cypress.io/task) instead, which runs in the Node process that loads your Cypress configuration, so there is no shell resolution and no per-platform quoting rules, and it can return structured values rather than stdout that has to be parsed. Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
+- [`cy.exec()`](https://on.cypress.io/exec) has been deprecated and will be removed in a future major release of Cypress. Use [`cy.task()`](https://on.cypress.io/task) instead, which runs in Node without depending on the operating system, shell, or terminal of the machine running Cypress. Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
 
 **Features:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 **Deprecations:**
 
-- [`cy.exec()`](https://on.cypress.io/exec) has been deprecated and will be removed in a future major release of Cypress. Use [`cy.task()`](https://on.cypress.io/task) instead, which runs in Node without depending on the operating system, shell, or terminal of the machine running Cypress. Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
+- [`cy.exec()`](https://on.cypress.io/exec) has been deprecated and will be removed in a future major release of Cypress. Use [`cy.task()`](https://on.cypress.io/task) instead, which runs in Node without depending on the operating system, shell, or terminal of the machine running Cypress. The [`execTimeout`](https://docs.cypress.io/app/references/configuration#Timeouts) configuration option is deprecated alongside it, in favor of [`taskTimeout`](https://docs.cypress.io/app/references/configuration#Timeouts). Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
 
 **Features:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
 ## 15.21.0
 
+**Deprecations:**
+
+- [`cy.exec()`](https://on.cypress.io/exec) has been deprecated and will be removed in a future major release of Cypress. Because it runs a command through a shell, its behavior depends on the operating system, the shell, the login environment, and whether a terminal is attached, which is a long-running source of hangs and "command not found" failures that are difficult to diagnose. Use [`cy.task()`](https://on.cypress.io/task) instead, which runs in the Node process that loads your Cypress configuration, so there is no shell resolution and no per-platform quoting rules, and it can return structured values rather than stdout that has to be parsed. Addresses [#34639](https://github.com/cypress-io/cypress/issues/34639).
+
 **Features:**
 
 - Added the `cypress tap` command, which gives your AI agent direct access to your open-mode Cypress session. It lists the open-mode Cypress sessions running on the machine, starts and reruns a spec, reports a run's status and results, prints a failing test's error and Command Log, and inspects the DOM and accessibility tree of the application under test. Every subcommand prints readable output by default and machine-readable JSON with `--json`. Run `cypress tap --help` for the full list of subcommands. Addresses [#34036](https://github.com/cypress-io/cypress/issues/34036).

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -1392,6 +1392,10 @@ declare namespace Cypress {
 
     /**
      * Execute a system command.
+     *
+     * @deprecated `cy.exec()` has been deprecated and will be removed in a future major release.
+     * Use {@linkcode Chainable.task cy.task()} instead, which runs in Node without depending on
+     * the operating system, shell, or terminal of the machine running Cypress.
      * @see https://on.cypress.io/exec
      */
     exec(command: string, options?: Partial<ExecOptions>): Chainable<Exec>

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3090,6 +3090,9 @@ declare namespace Cypress {
     /**
      * Time, in milliseconds, to wait for a system command to finish executing during a [cy.exec()](https://on.cypress.io/exec) command
      * @default 60000
+     * @deprecated `execTimeout` has been deprecated along with {@linkcode Chainable.exec cy.exec()} and will be
+     * removed in a future major release. Use {@linkcode ResolvedConfigOptions.taskTimeout taskTimeout} with
+     * {@linkcode Chainable.task cy.task()} instead.
      */
     execTimeout: number
     /**
@@ -3767,6 +3770,9 @@ declare namespace Cypress {
 
   /**
    * Options object to change the default behavior of cy.exec().
+   *
+   * @deprecated `ExecOptions` has been deprecated along with {@linkcode Chainable.exec cy.exec()} and will be
+   * removed in a future major release.
    */
   interface ExecOptions extends Loggable, Timeoutable {
     /**
@@ -6635,6 +6641,12 @@ declare namespace Cypress {
     set(options: Partial<EnqueuedCommandAttributes>): Log
   }
 
+  /**
+   * The result yielded by cy.exec().
+   *
+   * @deprecated `Exec` has been deprecated along with {@linkcode Chainable.exec cy.exec()} and will be
+   * removed in a future major release.
+   */
   interface Exec {
     exitCode: number
     stdout: string


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34639

### Additional details

Marks `cy.exec()` as deprecated so users are steered toward `cy.task()` ahead of the command's removal in a future major version.

This follows the pattern already used to deprecate `cy.end()` in #33707, which is the only existing precedent in this repo for deprecating a command:

1. A `@deprecated` JSDoc tag in `cli/types/cypress.d.ts`, so editors show the strikethrough and surface the replacement on hover.
2. A `**Deprecations:**` entry in `cli/CHANGELOG.md`.

The `{@linkcode Chainable.task cy.task()}` link style matches how the `Cypress.env()` deprecation points at its replacements.

The three types that exist only to serve `cy.exec()` are deprecated alongside it, so a user who references them directly gets the same signal:

| Symbol | Only reference |
| --- | --- |
| `ExecOptions` | `exec()`'s options parameter (and the driver's internal `InternalExecOptions`) |
| `Exec` | `exec()`'s yield type |
| `execTimeout` | read only by `packages/driver/src/cy/commands/exec.ts` |

`execTimeout` points users at `taskTimeout`. Because it is also `Pick`ed into `TestConfigOverrides` and `SuiteConfigOverrides`, the deprecation carries into test-level config overrides as well.

There is no runtime deprecation warning. Neither `cy.end()` nor any other deprecated command emits one today — the `Cypress.env()` warning is a server-side error tied to the `allowCypressEnv` configuration option, which is a substantially larger change than this issue calls for. Note that `packages/config` does have a mechanism for warning on deprecated config options (`breakingOptions`, as used by `injectDocumentDomain`), so `execTimeout` could be wired up to print a terminal warning in a follow-up if the team wants that.

### Steps to test

No behavior change to test at runtime. To verify the type changes, in an editor with TypeScript support:

1. Open a spec that calls `cy.exec('ls')` — `cy.exec` renders with a strikethrough, and hovering it shows the deprecation notice recommending `cy.task()`.
2. Open a `cypress.config.ts` that sets `execTimeout` — the key renders with a strikethrough recommending `taskTimeout`.

### How has the user experience changed?

`cy.exec()` and `execTimeout` continue to work exactly as before. The only user-visible change is in editors, where these symbols are now struck through with a tooltip. For `cy.exec`:

> **@deprecated** `cy.exec()` has been deprecated and will be removed in a future major release. Use `cy.task()` instead, which runs in Node without depending on the operating system, shell, or terminal of the machine running Cypress.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated? <!-- No runtime code changed — this is type definition annotations and a changelog entry. -->
- [x] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation) - https://github.com/cypress-io/cypress-documentation/pull/6815
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and TypeScript annotations only; no runtime or test-runner behavior changes.
> 
> **Overview**
> **Deprecates `cy.exec()`** ahead of removal in a future major release, steering users toward **`cy.task()`** for Node-side work without shell/OS coupling.
> 
> Adds a **`Deprecations`** entry in **`cli/CHANGELOG.md`** (15.21.0) and **`@deprecated` JSDoc** on **`Chainable.exec`**, **`execTimeout`**, **`ExecOptions`**, and **`Exec`** in **`cli/types/cypress.d.ts`**, with links to **`cy.task()`** and **`taskTimeout`**. Editors should show strikethrough and hover guidance; **runtime behavior is unchanged** (no new console warnings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181e12c9a6b594905f1e399cd8a74f50e9d0654b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->