### PR TITLE
chore: disable Percy in CI unless percy-enabled pipeline parameter is set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ parameters:
   run-proxy-disabled-tests:
     type: boolean
     default: false
+  # Opt-in Percy visual snapshots. Default false so CI skips Percy; enable via
+  # Trigger Pipeline when a visual review is needed. Requires PERCY_TOKEN.
+  percy-enabled:
+    type: boolean
+    default: false
 
 commands:
   persist:
@@ -177,6 +182,7 @@ jobs:
               environment:
                 RUN_ALL_JOBS: << pipeline.parameters.run-all-jobs >>
                 RUN_PROXY_DISABLED_TESTS: << pipeline.parameters.run-proxy-disabled-tests >>
+                PERCY_ENABLED: << pipeline.parameters.percy-enabled >>
               command: |
                 bash .circleci/scripts/generate-pipeline-parameters.sh \
                   > /tmp/pipeline-parameters.json

--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -40,9 +40,16 @@ if [[ "${RUN_PROXY_DISABLED_TESTS:-false}" == "true" || "${RUN_PROXY_DISABLED_TE
   run_proxy_disabled_tests=true
 fi
 
+# Opt-in only — never enabled by path filtering or emit_all_true. Set via
+# Trigger Pipeline → percy-enabled=true (setup config forwards it).
+percy_enabled=false
+if [[ "${PERCY_ENABLED:-false}" == "true" || "${PERCY_ENABLED:-}" == "1" ]]; then
+  percy_enabled=true
+fi
+
 emit_json() {
   cat <<EOF
-{"run-driver-tests": $driver_tests, "run-server-tests": $server_tests, "run-app-ui-tests": $app_ui_tests, "run-launchpad-tests": $launchpad_tests, "run-reporter-tests": $reporter_tests, "run-frontend-shared-tests": $frontend_shared_tests, "run-system-tests": $system_tests, "run-v8-tests": $v8_tests, "run-cli-tests": $cli_tests, "run-unit-tests": $unit_tests, "run-npm-webpack-dev-server-tests": $npm_webpack_dev_server_tests, "run-npm-vite-dev-server-tests": $npm_vite_dev_server_tests, "run-npm-webpack-preprocessor-tests": $npm_webpack_preprocessor_tests, "run-npm-webpack-batteries-tests": $npm_webpack_batteries_tests, "run-npm-vue-tests": $npm_vue_tests, "run-npm-react-tests": $npm_react_tests, "run-npm-angular-tests": $npm_angular_tests, "run-npm-puppeteer-tests": $npm_puppeteer_tests, "run-npm-vite-plugin-esm-tests": $npm_vite_plugin_esm_tests, "run-npm-mount-utils-tests": $npm_mount_utils_tests, "run-npm-grep-tests": $npm_grep_tests, "run-npm-eslint-plugin-tests": $npm_eslint_plugin_tests, "run-npm-schematic-tests": $npm_schematic_tests, "run-proxy-disabled-tests": $run_proxy_disabled_tests}
+{"run-driver-tests": $driver_tests, "run-server-tests": $server_tests, "run-app-ui-tests": $app_ui_tests, "run-launchpad-tests": $launchpad_tests, "run-reporter-tests": $reporter_tests, "run-frontend-shared-tests": $frontend_shared_tests, "run-system-tests": $system_tests, "run-v8-tests": $v8_tests, "run-cli-tests": $cli_tests, "run-unit-tests": $unit_tests, "run-npm-webpack-dev-server-tests": $npm_webpack_dev_server_tests, "run-npm-vite-dev-server-tests": $npm_vite_dev_server_tests, "run-npm-webpack-preprocessor-tests": $npm_webpack_preprocessor_tests, "run-npm-webpack-batteries-tests": $npm_webpack_batteries_tests, "run-npm-vue-tests": $npm_vue_tests, "run-npm-react-tests": $npm_react_tests, "run-npm-angular-tests": $npm_angular_tests, "run-npm-puppeteer-tests": $npm_puppeteer_tests, "run-npm-vite-plugin-esm-tests": $npm_vite_plugin_esm_tests, "run-npm-mount-utils-tests": $npm_mount_utils_tests, "run-npm-grep-tests": $npm_grep_tests, "run-npm-eslint-plugin-tests": $npm_eslint_plugin_tests, "run-npm-schematic-tests": $npm_schematic_tests, "run-proxy-disabled-tests": $run_proxy_disabled_tests, "percy-enabled": $percy_enabled}
 EOF
 }
 

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -31,6 +31,11 @@ parameters:
   run-proxy-disabled-tests:
     type: boolean
     default: false
+  # Opt-in Percy visual snapshots. Default false; set true via Trigger Pipeline
+  # (the setup config forwards it). Requires PERCY_TOKEN (test-runner:percy context).
+  percy-enabled:
+    type: boolean
+    default: false
   # Set to true by the CircleCI Scheduled Pipeline that runs the `windows` workflow.
   # (can also be set manually to run the Windows workflow)
   run-windows-workflow:
@@ -1015,11 +1020,13 @@ commands:
                 SPEC_ARGS=(--spec "$SPEC")
               fi
 
+              # Percy only runs when the percy-enabled pipeline parameter is set
+              # (Trigger Pipeline → percy-enabled=true) and PERCY_TOKEN is available.
               DEBUG=<<parameters.debug>> \
               CYPRESS_CONFIG_ENV=production \
               CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
               PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
               PERCY_PARALLEL_TOTAL=-1 \
               CYPRESS_INTERNAL_ENABLE_TELEMETRY="true" \
               $cmd yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --record --parallel --group "$GROUP" "${SPEC_ARGS[@]}"
@@ -1048,7 +1055,7 @@ commands:
               DEBUG=<<parameters.debug>> \
               CYPRESS_CONFIG_ENV=production \
               PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
               PERCY_PARALLEL_TOTAL=-1 \
               yarn workspace @packages/<<parameters.package>> cypress:run:<<parameters.type>> --browser <<parameters.browser>> --spec $TESTFILES
             fi
@@ -1056,7 +1063,7 @@ commands:
           command: |
             if [[ <<parameters.package>> == 'app' && <<parameters.percy>> == 'true' && -d "packages/app/cypress/screenshots/runner/screenshot/screenshot.cy.tsx/percy" ]]; then
               PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-              PERCY_ENABLE=${PERCY_TOKEN:-0} \
+              PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
               PERCY_PARALLEL_TOTAL=-1 \
               yarn percy upload packages/app/cypress/screenshots/runner/screenshot/screenshot.cy.tsx/percy
             else
@@ -1932,6 +1939,14 @@ jobs:
       required_env_var:
         type: env_var_name
     steps:
+      - unless:
+          condition: << pipeline.parameters.percy-enabled >>
+          steps:
+            - run:
+                # Percy runs opt-in only (Trigger Pipeline → percy-enabled=true),
+                # so by default there is no Percy build to finalize.
+                name: Percy disabled — skipping finalize
+                command: circleci-agent step halt
       # Uses an inline when: not: or: instead of halt-if-skipped because this
       # job depends on multiple parameters. CircleCI boolean parameters cannot
       # express or: logic, so a multi-condition inline step is required here.
@@ -2054,7 +2069,7 @@ jobs:
           name: Upload CLI snapshots for diffing
           command: |
             PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
+            PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy snapshot ./cli/visual-snapshots
 
@@ -2864,7 +2879,7 @@ jobs:
             CYPRESS_CONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
             PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
+            PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \
             yarn cypress:run --record --parallel --group reporter --runner-ui
@@ -2887,7 +2902,7 @@ jobs:
             CYPRESS_CONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
             PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
+            PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \
             yarn cypress:run --record --parallel --group webpack-dev-server
@@ -2909,7 +2924,7 @@ jobs:
             CYPRESS_CONFIG_ENV=production \
             CYPRESS_RECORD_KEY=$MAIN_RECORD_KEY \
             PERCY_PARALLEL_NONCE=$CIRCLE_WORKFLOW_WORKSPACE_ID \
-            PERCY_ENABLE=${PERCY_TOKEN:-0} \
+            PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0) \
             PERCY_PARALLEL_TOTAL=-1 \
             yarn percy exec --parallel -- -- \
             yarn cypress:run --record --parallel --group vite-dev-server


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress-internal/issues/807

### Additional details

Percy visual snapshot runs are now **opt-in** in CI instead of always-on. A new `percy-enabled` boolean pipeline parameter (default `false`) controls them:

- **`.circleci/config.yml`** (setup pipeline) declares `percy-enabled` and forwards it as `PERCY_ENABLED` to the parameter-generation step, so it can be set from the CircleCI **Trigger Pipeline** UI or an API trigger.
- **`.circleci/scripts/generate-pipeline-parameters.sh`** emits `"percy-enabled"` in the continuation parameters. It is opt-in only — never enabled by path filtering, `run-all-jobs`, or the develop/release all-jobs branch override (same pattern as `run-proxy-disabled-tests`).
- **`.circleci/src/pipeline/@pipeline.yml`** declares the parameter and gates every Percy invocation site (all 7 `PERCY_ENABLE` env assignments across `run-new-ui-tests`, the app Percy screenshot upload, `cli-visual-tests`, `reporter-integration-tests`, and both dev-server integration jobs) with `PERCY_ENABLE=$([[ '<< pipeline.parameters.percy-enabled >>' == 'true' ]] && echo "${PERCY_TOKEN:-0}" || echo 0)`. The `percy-finalize` job halts early via `unless: << pipeline.parameters.percy-enabled >>`, keeping all of its `requires` edges green.

When the parameter is `true` and `PERCY_TOKEN` is present, behavior is byte-identical to the previous always-on configuration (including the external-PR halt in `percy-finalize`, since forks have no token). `PERCY_ENABLE=0` is a code path this config has always exercised on fork PRs, where the token is absent — `percy exec` passes the wrapped Cypress command through and `percy upload`/`percy snapshot` no-op with exit 0.

### Steps to test

1. Push/trigger a normal pipeline — Percy jobs log `Percy is disabled`, no Percy build is created, and `percy-finalize` halts green with `Percy disabled — skipping finalize`.
2. Trigger a pipeline from the CircleCI UI with parameter `percy-enabled` = `true` — Percy snapshots upload and `percy-finalize` finalizes the build as before.
3. Locally: `yarn pack-ci --validate` passes; `CIRCLE_BRANCH=develop PERCY_ENABLED=true bash .circleci/scripts/generate-pipeline-parameters.sh` emits `"percy-enabled": true` (and `false` without the env var).

### How has the user experience changed?

No change — CI-internal only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal CI configuration change -->
- [na] Have tests been added/updated? <!-- CI config only; validated via circleci config validate and script dry-runs -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only configuration with default-off behavior; no product or runtime code changes.
> 
> **Overview**
> **Percy is off by default in CI** and only runs when someone triggers a pipeline with `percy-enabled=true` (and `PERCY_TOKEN` is available).
> 
> A new **`percy-enabled`** boolean is wired through the setup pipeline (`.circleci/config.yml` → `PERCY_ENABLED` → `generate-pipeline-parameters.sh`). Like **`run-proxy-disabled-tests`**, it stays **false** on path-filtered PRs, `run-all-jobs`, and develop/release “run everything” paths—only manual **Trigger Pipeline** turns it on. Continuation JSON now includes `"percy-enabled"`.
> 
> Every Percy entry point sets **`PERCY_ENABLE`** only when `percy-enabled` is true (otherwise `0`): UI test runs, app screenshot upload, CLI snapshots, reporter and webpack/vite dev-server **`percy exec`** jobs. **`percy-finalize`** exits early with a green skip when Percy is disabled so workflow dependencies stay satisfied without creating or finalizing a build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb949ca2020174054797cbe4271264a7028de9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->