### PR TITLE
chore: separate consecutive config warnings with a blank line

### DIFF
--- a/packages/config/test/index.spec.ts
+++ b/packages/config/test/index.spec.ts
@@ -1,6 +1,8 @@
 import { vi, describe, it, expect } from 'vitest'
 import path from 'path'
+import errors from '@packages/errors'
 import * as configUtil from '../src/index'
+import { breakingOptions, breakingRootOptions, testingTypeBreakingOptions } from '../src/options'
 
 describe('config/src/index', () => {
   describe('.allowed', () => {
@@ -267,6 +269,30 @@ describe('config/src/index', () => {
         value: undefined,
         testingType: 'e2e',
         configFile: 'config.js',
+      })
+    })
+  })
+
+  describe('breaking option warnings', () => {
+    const warningOptions = [
+      ...breakingOptions,
+      ...breakingRootOptions,
+      ...Object.values(testingTypeBreakingOptions).flat(),
+    ].filter((option) => option.isWarning)
+
+    // a single run can print several of these one after another, so each has to
+    // end with a blank line or the messages run together in the terminal
+    warningOptions.forEach(({ errorKey, name, newName }) => {
+      it(`${errorKey} ends with a blank line`, () => {
+        const err = errors.get(errorKey, {
+          name,
+          newName,
+          value: undefined,
+          configFile: 'cypress.config.js',
+          testingType: 'e2e',
+        })
+
+        expect(err.message).toMatch(/\n$/)
       })
     })
   })

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -1279,7 +1279,8 @@ export const AllCypressErrors = {
     return errTemplate`\
         The ${fmt.highlight(`experimentalJustInTimeCompile`)} configuration option was removed in ${fmt.cypressVersion(`14.0.0`)}.
         A new ${fmt.highlightSecondary(`justInTimeCompile`)} configuration option is available and is now ${fmt.highlightSecondary(`true`)} by default.
-        You can safely remove this option from your config.`
+        You can safely remove this option from your config.
+    `
   },
   EXPERIMENTAL_SESSION_AND_ORIGIN_REMOVED: () => {
     return errTemplate`\
@@ -1288,7 +1289,8 @@ export const AllCypressErrors = {
         You can safely remove this option from your config.
 
         https://on.cypress.io/session
-        https://on.cypress.io/origin`
+        https://on.cypress.io/origin
+    `
   },
   EXPERIMENTAL_SINGLE_TAB_RUN_MODE: () => {
     return errTemplate`\
@@ -1302,7 +1304,8 @@ export const AllCypressErrors = {
 
         Cypress Studio is now available for all users.
 
-        You can safely remove this option from your config.`
+        You can safely remove this option from your config.
+    `
   },
   EXPERIMENTAL_ORIGIN_DEPENDENCIES_E2E_ONLY: () => {
     const code = errPartial`
@@ -1323,7 +1326,8 @@ export const AllCypressErrors = {
 
         \`cy.prompt\` is now available for all users.
 
-        You can safely remove this option from your config.`
+        You can safely remove this option from your config.
+    `
   },
   EXPERIMENTAL_SOURCE_REWRITING_REMOVED: () => {
     return errTemplate`\
@@ -1331,7 +1335,8 @@ export const AllCypressErrors = {
 
         The experimental AST-based source rewriting was removed in favor of the default regex-based source rewriting.
 
-        You can safely remove this option from your config.`
+        You can safely remove this option from your config.
+    `
   },
   JIT_COMPONENT_TESTING: () => {
     return errTemplate`\
@@ -1348,19 +1353,22 @@ export const AllCypressErrors = {
     return errTemplate`\
       The ${fmt.highlight('experimentalFastVisibility')} configuration option has been removed. The modern visibility algorithm is now the default.
 
-      Please remove ${fmt.highlight('experimentalFastVisibility')} from your configuration. To use the legacy algorithm instead, set ${fmt.highlightSecondary(`visibilityStrategy: 'legacy'`)}.`
+      Please remove ${fmt.highlight('experimentalFastVisibility')} from your configuration. To use the legacy algorithm instead, set ${fmt.highlightSecondary(`visibilityStrategy: 'legacy'`)}.
+    `
   },
   EXPERIMENTAL_MEMORY_MANAGEMENT_REMOVED: () => {
     return errTemplate`\
       The ${fmt.highlight('experimentalMemoryManagement')} configuration option was removed in ${fmt.cypressVersion('16.0.0')}. Memory management is now enabled by default under the ${fmt.highlight('manageBrowserMemory')} option.
 
-      Please remove ${fmt.highlight('experimentalMemoryManagement')} from your configuration. To keep memory management disabled, set ${fmt.highlightSecondary('manageBrowserMemory: false')}.`
+      Please remove ${fmt.highlight('experimentalMemoryManagement')} from your configuration. To keep memory management disabled, set ${fmt.highlightSecondary('manageBrowserMemory: false')}.
+    `
   },
   VISIBILITY_STRATEGY_DEPRECATION: () => {
     return errTemplate`\
       ${fmt.highlightSecondary('Warning:')} The ${fmt.highlight(`visibilityStrategy: 'legacy'`)} option is deprecated. The legacy visibility algorithm will be removed in a future version of Cypress.
 
-      Remove the ${fmt.highlight('visibilityStrategy')} option from your configuration to use the modern algorithm.`
+      Remove the ${fmt.highlight('visibilityStrategy')} option from your configuration to use the modern algorithm.
+    `
   },
   ALLOW_CYPRESS_ENV_REMOVED: () => {
     return errTemplate`\
@@ -1379,7 +1387,8 @@ export const AllCypressErrors = {
 
       Remove it from your configuration to use the default network path.
 
-      Read the documentation for the forceHttp1 configuration option: https://docs.cypress.io/app/references/configuration#forceHttp1`
+      Read the documentation for the forceHttp1 configuration option: https://docs.cypress.io/app/references/configuration#forceHttp1
+    `
   },
   INJECT_DOCUMENT_DOMAIN_DEPRECATION: () => {
     return errTemplate`\
@@ -1447,7 +1456,8 @@ export const AllCypressErrors = {
 
         You can safely remove this option from your config.
 
-        https://on.cypress.io/migration-guide`
+        https://on.cypress.io/migration-guide
+    `
   },
 
   CONFIG_FILE_INVALID_ROOT_CONFIG: (errShape: BreakingErrResult) => {

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_FAST_VISIBILITY_RENAMED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_FAST_VISIBILITY_RENAMED.ansi
@@ -1,3 +1,4 @@
 [31mThe [33mexperimentalFastVisibility[39m[31m configuration option has been removed. The modern visibility algorithm is now the default.[39m
 [31m[39m
 [31mPlease remove [33mexperimentalFastVisibility[39m[31m from your configuration. To use the legacy algorithm instead, set [95mvisibilityStrategy: 'legacy'[39m[31m.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_JIT_COMPILE_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_JIT_COMPILE_REMOVED.ansi
@@ -1,3 +1,4 @@
 [31mThe [33mexperimentalJustInTimeCompile[39m[31m configuration option was removed in Cypress version 14.0.0.[39m
 [31mA new [95mjustInTimeCompile[39m[31m configuration option is available and is now [95mtrue[39m[31m by default.[39m
 [31mYou can safely remove this option from your config.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_MEMORY_MANAGEMENT_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_MEMORY_MANAGEMENT_REMOVED.ansi
@@ -1,3 +1,4 @@
 [31mThe [33mexperimentalMemoryManagement[39m[31m configuration option was removed in Cypress version 16.0.0. Memory management is now enabled by default under the [33mmanageBrowserMemory[39m[31m option.[39m
 [31m[39m
 [31mPlease remove [33mexperimentalMemoryManagement[39m[31m from your configuration. To keep memory management disabled, set [95mmanageBrowserMemory: false[39m[31m.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_PROMPT_COMMAND_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_PROMPT_COMMAND_REMOVED.ansi
@@ -3,3 +3,4 @@
 [31m`cy.prompt` is now available for all users.[39m
 [31m[39m
 [31mYou can safely remove this option from your config.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_SESSION_AND_ORIGIN_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_SESSION_AND_ORIGIN_REMOVED.ansi
@@ -4,3 +4,4 @@
 [31m[39m
 [31mhttps://on.cypress.io/session[39m
 [31mhttps://on.cypress.io/origin[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_SOURCE_REWRITING_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_SOURCE_REWRITING_REMOVED.ansi
@@ -3,3 +3,4 @@
 [31mThe experimental AST-based source rewriting was removed in favor of the default regex-based source rewriting.[39m
 [31m[39m
 [31mYou can safely remove this option from your config.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/EXPERIMENTAL_STUDIO_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/EXPERIMENTAL_STUDIO_REMOVED.ansi
@@ -3,3 +3,4 @@
 [31mCypress Studio is now available for all users.[39m
 [31m[39m
 [31mYou can safely remove this option from your config.[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/FORCE_HTTP1_DEPRECATION.ansi
+++ b/packages/errors/test/__snapshots__/FORCE_HTTP1_DEPRECATION.ansi
@@ -3,3 +3,4 @@
 [31mRemove it from your configuration to use the default network path.[39m
 [31m[39m
 [31mRead the documentation for the forceHttp1 configuration option: https://docs.cypress.io/app/references/configuration#forceHttp1[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/VIDEO_UPLOAD_ON_PASSES_REMOVED.ansi
+++ b/packages/errors/test/__snapshots__/VIDEO_UPLOAD_ON_PASSES_REMOVED.ansi
@@ -3,3 +3,4 @@
 [31mYou can safely remove this option from your config.[39m
 [31m[39m
 [31mhttps://on.cypress.io/migration-guide[39m
+[31m[39m

--- a/packages/errors/test/__snapshots__/VISIBILITY_STRATEGY_DEPRECATION.ansi
+++ b/packages/errors/test/__snapshots__/VISIBILITY_STRATEGY_DEPRECATION.ansi
@@ -1,3 +1,4 @@
 [31m[95mWarning:[39m[31m The [33mvisibilityStrategy: 'legacy'[39m[31m option is deprecated. The legacy visibility algorithm will be removed in a future version of Cypress.[39m
 [31m[39m
 [31mRemove the [33mvisibilityStrategy[39m[31m option from your configuration to use the modern algorithm.[39m
+[31m[39m

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -24,10 +24,10 @@ const electronDeprecationWarningRe = /Warning: The Electron browser is deprecate
 // Strip the forceHttp1 deprecation warning, printed ahead of the run header on
 // every run whose config sets forceHttp1 -- including CI jobs that set it for the
 // whole job. Matches the FORCE_HTTP1_DEPRECATION template in
-// packages/errors/src/errors.ts. Unlike the Electron warning above, this leaves
-// the trailing blank line: snapshots already have one before the `====` divider.
+// packages/errors/src/errors.ts. Like the Electron warning above, the whole block
+// goes: snapshots already have a blank line before the `====` divider.
 // DELETE THIS when the forceHttp1 option is removed -- it is easy to miss here.
-const forceHttp1DeprecationWarningRe = /Warning: The forceHttp1 option is deprecated and will be removed in a future version of Cypress\.\n\nRemove it from your configuration to use the default network path\.\n\nRead the documentation for the forceHttp1 configuration option: https:\/\/docs\.cypress\.io\/app\/references\/configuration#forceHttp1\n/g
+const forceHttp1DeprecationWarningRe = /Warning: The forceHttp1 option is deprecated and will be removed in a future version of Cypress\.\n\nRemove it from your configuration to use the default network path\.\n\nRead the documentation for the forceHttp1 configuration option: https:\/\/docs\.cypress\.io\/app\/references\/configuration#forceHttp1\n\n/g
 const crossOriginErrorRe = /(Blocked a frame .* from accessing a cross-origin frame.*|Permission denied.*cross-origin object.*)/gm
 const whiteSpaceBetweenNewlines = /\n\s+\n/
 const retryDuration = /Timed out retrying after (\d+)ms/g


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34654

### Additional details

Several removed and deprecated configuration options can be warned about in the same run, and when two of those warnings printed back to back the messages ran together with no blank line between them.

Whether a warning was separated from whatever printed next came down to an invisible detail: whether its `errTemplate` happened to end with a newline before the closing backtick. `stripIndent` only trims *leading* whitespace, so a template that closes on its own line emits a trailing blank line and one that closes at the end of the last sentence does not — and roughly half the templates were missing it. `ALLOW_CYPRESS_ENV_REMOVED` had the trailing newline, `EXPERIMENTAL_MEMORY_MANAGEMENT_REMOVED` and `VISIBILITY_STRATEGY_DEPRECATION` did not, which is the collision in the issue.

This terminates every breaking-option warning that can be printed consecutively with a blank line, matching `ALLOW_CYPRESS_ENV_REMOVED`, `INJECT_DOCUMENT_DOMAIN_DEPRECATION`, and `BROWSER_ELECTRON_DEPRECATED`, which already did. Since the convention is invisible in the source, a test in `@packages/config` walks every `breakingOptions` / `breakingRootOptions` / `testingTypeBreakingOptions` entry with `isWarning` and asserts the rendered message is blank-line terminated, so the next 16.0.0 removal can't reintroduce this.

I deliberately did not enforce the spacing in `logWarning` instead: callers already own the surrounding blank lines ad hoc (`run.ts` and `print-run.ts` print `console.log('')` before a warning), so a printer-level rule would double-space those and churn unrelated `record_spec` / `issue_7217` snapshots for no gain.

One system-test change comes along with this: `normalizeStdout` strips the `forceHttp1` deprecation warning from run output, and its regex hard-coded the block's exact trailing newlines, so it now consumes the new blank line as well. Normalized stdout is byte-identical to before, so no run snapshots change. `system-tests-chrome-force-http1-smoke` covers this on the PR and is green; the full forceHttp1 suite stays opt-in behind `run-force-http1-tests`. I also verified the regex locally with a negative control — reverting just the regex makes the snapshot fail with a stray blank line.

No changelog entry: these warnings ship unreleased in 16.0.0, so no released version ever printed the broken spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic warning-message spacing only; no runtime, config, or security behavior changes.
> 
> **Overview**
> Consecutive removed/deprecated config warnings no longer run together in the terminal. Templates that previously closed on the last sentence now end with a trailing blank line, matching warnings that already did.
> 
> A config test walks every `isWarning` breaking option and asserts the rendered message is newline-terminated so future removals keep the spacing. `normalizeStdout` now strips the extra blank line on the `forceHttp1` deprecation block so system-test snapshots stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caea7fb91b713c51029f1ccd892385e657b20002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

1. Point a project's config at more than one removed or deprecated option, for example:

    ```js
    module.exports = {
      experimentalMemoryManagement: false,
      allowCypressEnv: true,
      visibilityStrategy: 'legacy',
      e2e: { supportFile: false },
    }
    ```

2. Run `yarn cypress:run -- --project <path> --spec <spec> --browser electron` (or open the project) and read the warnings printed before the run header — every warning should be separated from the next by exactly one blank line.

Unit coverage: `yarn workspace @packages/errors test` (regenerated `.ansi` visual snapshots) and `yarn workspace @packages/config test -- test/index.spec.ts` (the new `breaking option warnings` block).

### How has the user experience changed?

Before — the `visibilityStrategy` warning runs straight into the `experimentalMemoryManagement` one:

```
Warning: The visibilityStrategy: 'legacy' option is deprecated. The legacy visibility algorithm will be removed in a future version of Cypress.

Remove the visibilityStrategy option from your configuration to use the modern algorithm.
The experimentalMemoryManagement configuration option was removed in Cypress version 16.0.0. Memory management is now enabled by default under the manageBrowserMemory option.

Please remove experimentalMemoryManagement from your configuration. To keep memory management disabled, set manageBrowserMemory: false.
```

After:

```
Warning: The visibilityStrategy: 'legacy' option is deprecated. The legacy visibility algorithm will be removed in a future version of Cypress.

Remove the visibilityStrategy option from your configuration to use the modern algorithm.

The experimentalMemoryManagement configuration option was removed in Cypress version 16.0.0. Memory management is now enabled by default under the manageBrowserMemory option.

Please remove experimentalMemoryManagement from your configuration. To keep memory management disabled, set manageBrowserMemory: false.
```

In run mode there are now two blank lines between the last config warning and the `(Run Starting)` divider, because `displayRunStarting` prints its own top margin. That already happened for the warnings that self-terminated (`allowCypressEnv`, the Electron deprecation); it is now uniform.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

