### PR TITLE
chore: serve the studio AI route namespaces on the browser network path

### DIFF
--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -84,10 +84,6 @@ export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
 
 const CLOUD_BUNDLE_ROUTES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
 
-// A bare prefix, not matchesPathPrefix: the bundles ship independently of the
-// binary and hang sibling namespaces off these bases
-// (`/__cypress-studio-ai`, `/__cypress-studio-ai-anon`), which a path-boundary
-// match would send to the AUT's origin instead.
 export function isCloudBundleRoute (pathname: string): boolean {
   return CLOUD_BUNDLE_ROUTES.some((route) => pathname.startsWith(route))
 }

--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -84,22 +84,12 @@ export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
 
 const CLOUD_BUNDLE_ROUTES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
 
-// The bundles ship independently of the binary and hang sibling namespaces off
-// these bases (`/__cypress-studio-ai`, `/__cypress-studio-ai-anon`), so match
-// the whole family: an unmatched one escapes to the AUT's origin, which is
-// where the runner document's root-relative fetches land.
-function matchesRouteFamily (pathname: string, route: string): boolean {
-  if (!pathname.startsWith(route)) {
-    return false
-  }
-
-  const boundary = pathname[route.length]
-
-  return boundary === undefined || boundary === '/' || boundary === '-'
-}
-
+// A bare prefix, not matchesPathPrefix: the bundles ship independently of the
+// binary and hang sibling namespaces off these bases
+// (`/__cypress-studio-ai`, `/__cypress-studio-ai-anon`), which a path-boundary
+// match would send to the AUT's origin instead.
 export function isCloudBundleRoute (pathname: string): boolean {
-  return CLOUD_BUNDLE_ROUTES.some((route) => matchesRouteFamily(pathname, route))
+  return CLOUD_BUNDLE_ROUTES.some((route) => pathname.startsWith(route))
 }
 
 // `isBrowserNetworkMode` is a property of the runtime that installed the caller,

--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -82,10 +82,10 @@ export const CYPRESS_STUDIO_ROUTE = '/__cypress-studio'
 
 export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
 
-const CLOUD_BUNDLE_ROUTES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
+const CLOUD_BUNDLE_NAMESPACES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
 
-export function isCloudBundleRoute (pathname: string): boolean {
-  return CLOUD_BUNDLE_ROUTES.some((route) => pathname.startsWith(route))
+export function isCloudBundleNamespace (pathname: string): boolean {
+  return CLOUD_BUNDLE_NAMESPACES.some((namespace) => pathname.startsWith(namespace))
 }
 
 // `isBrowserNetworkMode` is a property of the runtime that installed the caller,
@@ -98,7 +98,7 @@ export function isInternalCypressRoute (pathname: string, config: InternalRouteC
     return false
   }
 
-  if (isBrowserNetworkMode && isCloudBundleRoute(pathname)) {
+  if (isBrowserNetworkMode && isCloudBundleNamespace(pathname)) {
     return true
   }
 

--- a/packages/server/lib/adapters/internal-routes.ts
+++ b/packages/server/lib/adapters/internal-routes.ts
@@ -84,8 +84,22 @@ export const CYPRESS_CY_PROMPT_ROUTE = '/__cypress-cy-prompt'
 
 const CLOUD_BUNDLE_ROUTES = [CYPRESS_STUDIO_ROUTE, CYPRESS_CY_PROMPT_ROUTE]
 
+// The bundles ship independently of the binary and hang sibling namespaces off
+// these bases (`/__cypress-studio-ai`, `/__cypress-studio-ai-anon`), so match
+// the whole family: an unmatched one escapes to the AUT's origin, which is
+// where the runner document's root-relative fetches land.
+function matchesRouteFamily (pathname: string, route: string): boolean {
+  if (!pathname.startsWith(route)) {
+    return false
+  }
+
+  const boundary = pathname[route.length]
+
+  return boundary === undefined || boundary === '/' || boundary === '-'
+}
+
 export function isCloudBundleRoute (pathname: string): boolean {
-  return CLOUD_BUNDLE_ROUTES.some((route) => matchesPathPrefix(pathname, route))
+  return CLOUD_BUNDLE_ROUTES.some((route) => matchesRouteFamily(pathname, route))
 }
 
 // `isBrowserNetworkMode` is a property of the runtime that installed the caller,
@@ -98,12 +112,15 @@ export function isInternalCypressRoute (pathname: string, config: InternalRouteC
     return false
   }
 
+  if (isBrowserNetworkMode && isCloudBundleRoute(pathname)) {
+    return true
+  }
+
   const internalRoutes = [
     config.namespace ? `/${config.namespace}` : undefined,
     config.clientRoute,
     config.socketIoRoute,
     config.socketIoRoute ? `${config.socketIoRoute}-graphql` : undefined,
-    ...(isBrowserNetworkMode ? CLOUD_BUNDLE_ROUTES : []),
   ].filter((route): route is string => Boolean(route))
 
   return internalRoutes.some((route) => matchesPathPrefix(pathname, route))

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -1,7 +1,7 @@
 import { toIdentityResponse } from '@packages/proxy'
 import type { HttpHeaders, HttpRequest, InterceptMiddleware } from '@packages/network-interception'
 import type { Request as ServerRequest } from '../request'
-import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, isCloudBundleRoute, isCypressServerOrigin, isInternalCypressRoute, isTrustedInternalLoopback, matchesPathPrefix, resolveProxyUrlBase } from './internal-routes'
+import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, isCloudBundleNamespace, isCypressServerOrigin, isInternalCypressRoute, isTrustedInternalLoopback, matchesPathPrefix, resolveProxyUrlBase } from './internal-routes'
 import type { InternalRouteConfig } from './internal-routes'
 
 type ServeInternalRoutesConfig = InternalRouteConfig
@@ -81,12 +81,12 @@ export function createServeInternalRoutesMiddleware ({
     // Re-entry after our own Express loopback. Require the process token —
     // AUT content can forge the URL header alone.
     if (isTrustedInternalLoopback(request.headers)) {
-      // Cloud-bundle routes re-enter on purpose: the cypress-in-cypress parent's
+      // Cloud-bundle namespaces re-enter on purpose: the cypress-in-cypress parent's
       // Express handlers forward them through the proxy to the child project.
       // Hand them to the legacy pipeline instead of swallowing the forward.
       // The token authenticates re-entry and must not reach the child project
       // or the AUT.
-      if (isCloudBundleRoute(url.pathname)) {
+      if (isCloudBundleNamespace(url.pathname)) {
         const headers = { ...request.headers }
 
         delete headers[CYPRESS_INTERNAL_LOOPBACK_HEADER]

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -116,9 +116,6 @@ export const createCommonRoutes = ({
   // If we are in cypress in cypress we need to pass along the studio and cy-prompt routes
   // to the child project. We also add a utility route for testing HTTP status code UI
   if (process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT) {
-    // `*` rather than `/*` to cover the bundles' sibling namespaces
-    // (/__cypress-studio-ai, /__cypress-studio-ai-anon), and `all` because
-    // those are POST routes.
     router.all(`${CYPRESS_STUDIO_ROUTE}*`, async (req, res) => {
       await getNetworkProxy().handleHttpRequest(req, res)
     })

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -116,11 +116,14 @@ export const createCommonRoutes = ({
   // If we are in cypress in cypress we need to pass along the studio and cy-prompt routes
   // to the child project. We also add a utility route for testing HTTP status code UI
   if (process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT) {
-    router.get(`${CYPRESS_STUDIO_ROUTE}/*`, async (req, res) => {
+    // `*` rather than `/*` to cover the bundles' sibling namespaces
+    // (/__cypress-studio-ai, /__cypress-studio-ai-anon), and `all` because
+    // those are POST routes.
+    router.all(`${CYPRESS_STUDIO_ROUTE}*`, async (req, res) => {
       await getNetworkProxy().handleHttpRequest(req, res)
     })
 
-    router.get(`${CYPRESS_CY_PROMPT_ROUTE}/*`, async (req, res) => {
+    router.all(`${CYPRESS_CY_PROMPT_ROUTE}*`, async (req, res) => {
       await getNetworkProxy().handleHttpRequest(req, res)
     })
 

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -341,9 +341,6 @@ describe('lib/adapters/serve-internal-routes', () => {
   })
 
   it('loops studio AI requests made from the AUT origin back to the local Express router', async () => {
-    // The runner document is served on the AUT's superdomain, so the studio
-    // panel's root-relative fetches land there. Without the loopback they hit
-    // the user's own application server.
     const { middleware, serverRequest } = createMiddleware({
       statusCode: 200,
       headers: { 'content-type': 'application/json' },

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -51,7 +51,6 @@ describe('lib/adapters/internal-routes', () => {
   it('does not match internal route lookalikes', () => {
     for (const isBrowserNetworkMode of [true, false]) {
       expect(isInternalCypressRoute('/__cypress-other/foo', config, isBrowserNetworkMode)).to.be.false
-      expect(isInternalCypressRoute('/__cypress-studiolookalike/foo', config, isBrowserNetworkMode)).to.be.false
       expect(isInternalCypressRoute('/app/__cypress/xhrs/foo', config, isBrowserNetworkMode)).to.be.false
     }
   })

--- a/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
+++ b/packages/server/test/unit/adapters/serve-internal-routes_spec.ts
@@ -33,16 +33,25 @@ describe('lib/adapters/internal-routes', () => {
     expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config, true)).to.be.true
   })
 
+  it('matches the studio and cy-prompt sibling namespaces on the browser (CDP) network path', () => {
+    expect(isInternalCypressRoute('/__cypress-studio-ai-anon/session', config, true)).to.be.true
+    expect(isInternalCypressRoute('/__cypress-studio-ai-anon/token', config, true)).to.be.true
+    expect(isInternalCypressRoute('/__cypress-studio-ai/generate', config, true)).to.be.true
+    expect(isInternalCypressRoute('/__cypress-cy-prompt-ai/generate', config, true)).to.be.true
+  })
+
   it('does not match studio or cy-prompt module-federation entries under the MITM proxy', () => {
     // The legacy pipeline already delivers these to Express; looping them back
     // skips later intercept stages and breaks studio.
     expect(isInternalCypressRoute('/__cypress-studio/app-studio.js', config, false)).to.be.false
+    expect(isInternalCypressRoute('/__cypress-studio-ai-anon/session', config, false)).to.be.false
     expect(isInternalCypressRoute('/__cypress-cy-prompt/app.js', config, false)).to.be.false
   })
 
   it('does not match internal route lookalikes', () => {
     for (const isBrowserNetworkMode of [true, false]) {
       expect(isInternalCypressRoute('/__cypress-other/foo', config, isBrowserNetworkMode)).to.be.false
+      expect(isInternalCypressRoute('/__cypress-studiolookalike/foo', config, isBrowserNetworkMode)).to.be.false
       expect(isInternalCypressRoute('/app/__cypress/xhrs/foo', config, isBrowserNetworkMode)).to.be.false
     }
   })
@@ -330,6 +339,38 @@ describe('lib/adapters/serve-internal-routes', () => {
       },
       body: Buffer.from('created'),
     })
+  })
+
+  it('loops studio AI requests made from the AUT origin back to the local Express router', async () => {
+    // The runner document is served on the AUT's superdomain, so the studio
+    // panel's root-relative fetches land there. Without the loopback they hit
+    // the user's own application server.
+    const { middleware, serverRequest } = createMiddleware({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: Buffer.from('{"token":"abc"}'),
+    })
+    const next = sinon.stub()
+
+    const response = await middleware({
+      id: 'req-1',
+      url: 'https://example.cypress.io/__cypress-studio-ai-anon/session',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        host: 'example.cypress.io',
+      },
+      body: '{}',
+    }, next)
+
+    expect(next).not.to.have.been.called
+    expect(serverRequest.create).to.have.been.calledWithMatch({
+      url: 'http://127.0.0.1:1234/__cypress-studio-ai-anon/session',
+      method: 'POST',
+      body: '{}',
+    }, true)
+
+    expect(response.statusCode).to.equal(200)
   })
 
   it('asks the loopback for an identity-encoded response in cypress-in-cypress', async () => {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34651

### Additional details

The studio panel fetches `/__cypress-studio-ai-anon/*` and `/__cypress-studio-ai/*` root-relative from the runner document, and in e2e that document is served on the AUT's superdomain (`https://example.cypress.io/__/#/specs/runner?...`). Under the legacy MITM path the browser sends everything to the Cypress server as an HTTP proxy, so Express answers those paths for any origin. On the browser (CDP) network path the requests go straight to the real host, and only paths that `isInternalCypressRoute` recognizes are looped back to Express.

Only `/__cypress-studio` and `/__cypress-cy-prompt` were listed as cloud-bundle paths, and the shared `matchesPathPrefix` requires an exact or `/`-boundary match — so `/__cypress-studio-ai-anon/token` and `/__cypress-studio-ai-anon/session` matched neither and escaped to the user's own application server. Confirmed against the AUT in the issue: `GET /__cypress-studio-ai-anon/token` → 404 and `POST /__cypress-studio-ai-anon/session` → 405, exactly the console errors in the report. Since Chrome, Chromium, and Edge use the browser network path by default in 16.0.0, Studio AI could not be enabled at all there; `forceHttp1: true` was the only way around it. Worth noting for severity: the `generate` payload carries the user's test code, test title, and the anon bearer token, so an unmatched path does not just 405 — it sends that payload to whatever server hosts the application under test.

`isCloudBundleNamespace` now matches those two bases with a bare `startsWith`, so sibling namespaces are recognized without the binary having to name them. That matters because the bundles ship independently of the binary: a hardcoded list silently regresses the next time a namespace is added, which is exactly what happened here. The constant and predicate are named for namespaces rather than routes since that is what they match — prefixes, covering API paths and not just the bundle entry.

Loosening the shared `matchesPathPrefix` instead is not an option, and it is worth spelling out why. `clientRoute` normalizes to `/__`, so dropping the boundary there would claim every AUT path beneath it — `/__nuxt/`, `/__next/`, `/__webpack_hmr`, `/__vite_ping`, SvelteKit's `/__data.json` — looping them back to our Express and 404ing instead of reaching the user's app. And the `namespace` match is mode-independent, so `/__cypress` would claim the studio namespaces on the MITM path too; that is the regression the final commit of #34578 had to go back and fix.

Two secondary effects, both intentional. The cypress-in-cypress passthrough in `routes.ts` forwarded only `GET` on `/__cypress-studio/*`, which covers neither the sibling namespaces nor the POSTs they are built on, so it now forwards the same prefixes with `all`. And in `serve-internal-routes.ts` the widened predicate also governs which token-bearing re-entries are delegated to the legacy pipeline rather than answered with the synthetic 404 — a re-entry only happens when Express had no handler, which for the AI namespaces cannot occur before the bundle registers its routes, since the panel issuing those fetches is the bundle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens which AUT-origin requests are intercepted and looped to the Cypress server, including POSTs that carry tokens and test source. Matching is prefix-based (`startsWith`), so extra paths under those namespaces are now treated as internal.
> 
> **Overview**
> Studio AI requests (`/__cypress-studio-ai*`, `/__cypress-cy-prompt-ai*`) now loop back to Express on the browser (CDP) network path instead of hitting the AUT origin.
> 
> `isInternalCypressRoute` treats the whole cloud-bundle **prefix family** (`startsWith` `/__cypress-studio` / `/__cypress-cy-prompt`) as internal in CDP mode, so sibling namespaces match without a hardcoded list. Cypress-in-cypress passthrough in `routes.ts` now uses `router.all` on those prefixes so POSTs and AI paths forward to the child project.
> 
> This stops generate/session payloads (test code, titles, anon tokens) from being sent to the application under test when Chrome/Edge use CDP Fetch by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054cf595613f80bcb1485b03ca0096d79faff1f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Unit coverage is in `packages/server/test/unit/adapters/serve-internal-routes_spec.ts`; both new tests fail on `release/16.0.0` without the `internal-routes.ts` change.

To verify by hand in Chrome (which uses the browser network path by default, so no config is needed):

1. `yarn dev` and open a Studio-enabled project.
2. Launch Studio on a spec that has visited a site on a different superdomain than the Cypress server.
3. Click **Turn on** on the "Turn on AI recommendations" banner.
4. In DevTools, confirm `GET /__cypress-studio-ai-anon/token` and `POST /__cypress-studio-ai-anon/session` return 200 from the Cypress server rather than 404/405 from the AUT's origin, and that the panel enables AI assertions.

Setting `forceHttp1: true` should keep working the same way it does today.

### How has the user experience changed?

Before: on Chrome/Chromium/Edge, turning on Studio AI failed — the anon session mint returned 405 from the application under test's server, the panel stayed on "AI Assertions: Disabled", and the console filled with 404/405 errors (see the screenshot in #34651). After: the requests reach the Cypress server and Studio AI enables normally, as it already did under `forceHttp1`.


https://github.com/user-attachments/assets/9c6194b9-61a0-4376-b1a5-e51d1112cf20


### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34651 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Restores behavior the 16.0.0 docs already describe; no documented behavior changes. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

