### PR TITLE
fix: do not offer to translate the application under test

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 15.21.1
+
+**Bugfixes:**
+
+- Fixed an issue where Chrome and Firefox offered to translate the application under test, showing a translation prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
+
 ## 15.21.0
 
 **Deprecations:**
@@ -12,7 +18,6 @@
 
 **Bugfixes:**
 
-- Fixed an issue where Chrome and Firefox offered to translate the application under test, showing a translation prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
 - Fixed an issue where WebKit runs could hang indefinitely when more parallel requests than the browser's per-host connection pool were intercepted by a [`cy.intercept()`](https://on.cypress.io/intercept) route with a request handler. Fixes [#33926](https://github.com/cypress-io/cypress/issues/33926) and addresses [#23807](https://github.com/cypress-io/cypress/issues/23807).
 - Fixed an issue where overriding [`blockHosts`](https://on.cypress.io/configuration#blockHosts) with test configuration (for example `describe('...', { blockHosts: [...] }, ...)`) had no effect, so requests were still blocked or allowed according to the project-level value. Test-level `blockHosts` overrides now take effect at runtime and are restored between specs. Fixes [#21151](https://github.com/cypress-io/cypress/issues/21151).
 - Fixed an issue where `cypress run` printed the `(Attempt N of M)` line twice for the same attempt when a `beforeEach` and an `afterEach` hook both failed during that attempt. Fixes [#26143](https://github.com/cypress-io/cypress/issues/26143).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where Chrome offered to translate the application under test, showing a "Translate this page?" prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
 - Fixed an issue where WebKit runs could hang indefinitely when more parallel requests than the browser's per-host connection pool were intercepted by a [`cy.intercept()`](https://on.cypress.io/intercept) route with a request handler. Fixes [#33926](https://github.com/cypress-io/cypress/issues/33926) and addresses [#23807](https://github.com/cypress-io/cypress/issues/23807).
 - Fixed an issue where overriding [`blockHosts`](https://on.cypress.io/configuration#blockHosts) with test configuration (for example `describe('...', { blockHosts: [...] }, ...)`) had no effect, so requests were still blocked or allowed according to the project-level value. Test-level `blockHosts` overrides now take effect at runtime and are restored between specs. Fixes [#21151](https://github.com/cypress-io/cypress/issues/21151).
 - Fixed an issue where `cypress run` printed the `(Attempt N of M)` line twice for the same attempt when a `beforeEach` and an `afterEach` hook both failed during that attempt. Fixes [#26143](https://github.com/cypress-io/cypress/issues/26143).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue where Chrome offered to translate the application under test, showing a "Translate this page?" prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
+- Fixed an issue where Chrome and Firefox offered to translate the application under test, showing a translation prompt during the run. Fixes [#34662](https://github.com/cypress-io/cypress/issues/34662).
 - Fixed an issue where WebKit runs could hang indefinitely when more parallel requests than the browser's per-host connection pool were intercepted by a [`cy.intercept()`](https://on.cypress.io/intercept) route with a request handler. Fixes [#33926](https://github.com/cypress-io/cypress/issues/33926) and addresses [#23807](https://github.com/cypress-io/cypress/issues/23807).
 - Fixed an issue where overriding [`blockHosts`](https://on.cypress.io/configuration#blockHosts) with test configuration (for example `describe('...', { blockHosts: [...] }, ...)`) had no effect, so requests were still blocked or allowed according to the project-level value. Test-level `blockHosts` overrides now take effect at runtime and are restored between specs. Fixes [#21151](https://github.com/cypress-io/cypress/issues/21151).
 - Fixed an issue where `cypress run` printed the `(Attempt N of M)` line twice for the same attempt when a `beforeEach` and an `afterEach` hook both failed during that attempt. Fixes [#26143](https://github.com/cypress-io/cypress/issues/26143).

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -54,6 +54,11 @@ const _getDefaultChromePreferences = (): ChromePreferences => {
         profile_enabled: false, // Disable Chrome's "Save address" pop up
         credit_card_enabled: false, // Disable Chrome's "Save card" pop up
       },
+      // Chrome 138+ gates the "Translate this page?" bubble on this pref alone.
+      // https://github.com/cypress-io/cypress/issues/34662
+      translate: {
+        enabled: false,
+      },
     },
     defaultSecure: {},
     localState: {

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -55,7 +55,6 @@ const _getDefaultChromePreferences = (): ChromePreferences => {
         credit_card_enabled: false, // Disable Chrome's "Save card" pop up
       },
       // Chrome 138+ gates the "Translate this page?" bubble on this pref alone.
-      // https://github.com/cypress-io/cypress/issues/34662
       translate: {
         enabled: false,
       },

--- a/packages/server/lib/browsers/firefox.ts
+++ b/packages/server/lib/browsers/firefox.ts
@@ -106,6 +106,9 @@ const defaultPreferences = {
   // Do not warn when multiple tabs will be opened
   'browser.tabs.warnOnOpen': false,
 
+  // Do not offer to translate the page under test
+  'browser.translations.enable': false,
+
   // Disable the UI tour.
   'browser.uitour.enabled': false,
   // Turn off search suggestions in the location bar so as not to trigger

--- a/packages/server/lib/util/chromium_flags.ts
+++ b/packages/server/lib/util/chromium_flags.ts
@@ -47,7 +47,8 @@ const disabledFeatures = [
   // https://github.com/cypress-io/cypress/issues/29199
   'PrivacySandboxSettings4',
 
-  // Disable manual option and popup prompt of Chrome translation
+  // Disable manual option and popup prompt of Chrome translation. Applies
+  // below Chrome 138 only; 138+ is gated on the `translate.enabled` preference.
   // https://github.com/cypress-io/cypress/issues/28225
   'Translate',
 ]


### PR DESCRIPTION
- Closes #34662

### Additional details

**Why was this change necessary?**

Chrome offers to translate the AUT during a run, showing the "Translate this page?" bubble. #28225 previously fixed this by adding `Translate` to `--disable-features`, but **Chrome 138 removed that `base::Feature`**, and Chromium silently ignores unknown feature names — so the flag has been a no-op since then:

| Chrome | `BASE_FEATURE(kTranslate, "Translate", ...)` | gate in `translate_manager.cc` |
| --- | --- | --- |
| 137 | present, [`translate_prefs.cc:129`](https://raw.githubusercontent.com/chromium/chromium/137.0.7151.55/components/translate/core/browser/translate_prefs.cc) | `IsEnabled(translate::kTranslate)` **and** `IsOfferTranslateEnabled()` |
| 138+ | [removed](https://raw.githubusercontent.com/chromium/chromium/138.0.7204.49/components/translate/core/browser/translate_prefs.cc) | `IsOfferTranslateEnabled()` only |

The only remaining gate is the profile preference `kOfferTranslateEnabled` = `"translate.enabled"`, described in [`translate_pref_names.h`](https://raw.githubusercontent.com/chromium/chromium/main/components/translate/core/browser/translate_pref_names.h) as *"a boolean that is true when offering translate (i.e. the automatic Full Page Translate bubble) is enabled"*. This is the same preference ChromeDriver exposes through its `prefs` capability.

Firefox 118+ has the same problem via its own full-page translations feature, which offers automatically on pages whose language differs from the browser's. [`browser.translations.enable`](https://raw.githubusercontent.com/mozilla/gecko-dev/master/browser/app/profile/firefox.js) defaults to `true` on desktop and is read by `TranslationsParent.sys.mjs`, which drives the offer.

**What is affected by this change?**

- **Chrome/Chromium**: adds `translate: { enabled: false }` to `_getDefaultChromePreferences()`, alongside the existing `autofill` preferences that already suppress the "Save address"/"Save card" popups by the same mechanism. Cypress merges and writes these to the profile's `Default/Preferences` before launch.
- **Firefox**: adds `'browser.translations.enable': false` to `defaultPreferences`.

**Any implementation details to explain?**

- `--disable-features=Translate` is kept, since it is still effective on Chrome < 138 and Cypress does not gate on a minimum Chrome version. Its comment now states the version scope.
- Both are defaults, not overrides — users who want the translation prompt can re-enable it via `before:browser:launch`.
- Worth noting that Puppeteer and Playwright both still carry `Translate` in their disabled-features lists, so they are affected by the same Chrome 138 change.

### Steps to test

1. Run Cypress against a page whose language differs from the browser's UI language (e.g. a French page with an English-language browser), on Chrome 138 or newer:
   ```
   cypress open --e2e --browser chrome
   ```
2. Confirm no "Translate this page?" bubble appears during the run.
3. Repeat with `--browser firefox` and confirm no translations offer panel appears.
4. To confirm the preference is being written, inspect `translate.enabled` in the Chrome profile's `Default/Preferences` under the Cypress profile directory.

### How has the user experience changed?

The translation prompt no longer appears over the application under test during a run. There is no other visual change, and no new UI is introduced.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission?
- [na] Have tests been added/updated? <!-- Both changes set a literal in a static defaults object. A unit test asserting those literals would restate the implementation and would not catch this bug class — the regression here originated in Chrome, not in Cypress code. The existing `#open integration with preferences` tests already cover the merge-and-write path. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No documented behavior changes. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No public API surface changes. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpxHycDi6Eks3n6QVWV7dJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small default-preference changes that only suppress browser UI chrome; no auth, data, or launch-path logic is altered.
> 
> **Overview**
> Stops Chrome and Firefox from offering to translate the application under test during a run (fixes #34662).
> 
> Chrome 138 dropped the `Translate` feature flag, so `--disable-features=Translate` no longer works. Cypress now sets the `translate.enabled` profile preference to `false` (the remaining gate). The old flag is kept for Chrome &lt; 138. Firefox gets `browser.translations.enable` set to `false`. Users can still re-enable translation via `before:browser:launch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322098f738a055fcc72cac4e44341246cac92fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->