### PR TITLE
chore: update Firefox to 154.0

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -9,7 +9,7 @@ chrome-stable-version: &chrome-stable-version "151.0.7922.75"
 chrome-beta-version: &chrome-beta-version "152.0.7977.13"
 # Pin from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json (channels.Stable)
 chrome-for-testing-stable-version: &chrome-for-testing-stable-version "151.0.7922.76"
-firefox-stable-version: &firefox-stable-version "152.0.5"
+firefox-stable-version: &firefox-stable-version "154.0"
 base-internal-trixie: &base-internal-trixie cypress/base-internal:22.19.0-trixie
 base-internal-yarn-berry: &base-internal-yarn-berry cypress/base-internal:22.19.0-yarn-berry
 # Lowest Node.js version we support of the minimum major version supported


### PR DESCRIPTION
- Closes N/A

### Additional details

Bumps the pinned Firefox stable version used by CI from `152.0.5` to `154.0`, the current Firefox stable release (shipped 2026-08-18).

The change is a single value in `.circleci/src/pipeline/@pipeline.yml`:

```yaml
firefox-stable-version: &firefox-stable-version "154.0"
```

That anchor is the default for both `firefox-version` parameters — `install-browsers` and `run-driver-integration-tests` — which feed `browser-tools/install_firefox`. Parsing the packed config confirms both defaults now resolve to `154.0`.

Note the version string is two segments rather than three: Firefox 154 has no point release, and the string must match Mozilla's release directory name (`https://download-installer.cdn.mozilla.net/pub/firefox/releases/154.0/`), which is where the orb downloads from.

Two related notes for reviewers:

- `yarn pack-ci --validate` was not run — the CircleCI CLI was unavailable in the environment this was authored in. The file was verified to parse as valid YAML with the anchor resolving correctly, but a local `yarn pack-ci --validate` before merge is worth doing.
- The `update-browser-versions` workflow only tracks Chrome and Chrome for Testing, so the Firefox pin drifts until bumped by hand. Extending `scripts/github-actions/update-browser-versions.js` to also read Mozilla's `firefox_versions.json` would automate this; out of scope here.

### Steps to test

No behavior change to test manually. CI exercises it: the Firefox jobs (`system-tests-firefox`, `driver-integration-tests-firefox`, and the Firefox binary test jobs) should install and run against Firefox 154.0.

### How has the user experience changed?

No change. This only affects the Firefox version installed in CI.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical CI version bump. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_0182KxBKgeETJ1VXDz9979Gx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only browser bump, but Firefox 154 vs 152 can surface new driver/system-test failures across Firefox jobs.
> 
> **Overview**
> Bumps the CircleCI Firefox pin (`firefox-stable-version`) from `152.0.5` to `154.0`. That YAML anchor is the default for `install-browsers` and `run-driver-integration-tests`, so Firefox CI jobs (system tests, driver integration, binary tests) install from Mozilla’s `154.0` release directory.
> 
> No product or user-facing change. The two-segment version string is required to match Mozilla’s download path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb54e3bbfe55a7317ff27538699deb3aa5b6f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->