### PR TITLE
chore: scope eslint graphql rules to packages that use gql

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
   root: true,
   plugins: [
     '@cypress/dev',
-    'graphql',
   ],
   extends: [
     'plugin:@cypress/dev/general',
@@ -81,6 +80,27 @@ module.exports = {
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
       },
     },
+    {
+      // `eslint-plugin-graphql` pays its per-file cost on every linted file, not
+      // just the ones holding a `gql` template, and that cost dominates lint time.
+      // Scope it to the packages that actually use `gql` — add a package here if
+      // it starts using it.
+      files: [
+        'packages/{app,frontend-shared,launchpad,data-context}/**/*.{js,jsx,ts,tsx,vue}',
+      ],
+      plugins: [
+        'graphql',
+      ],
+      rules: {
+        'graphql/capitalized-type-name': ['warn', graphqlOpts],
+        'graphql/no-deprecated-fields': ['error', graphqlOpts],
+        'graphql/template-strings': ['error', { ...graphqlOpts, validators }],
+        'graphql/required-fields': [
+          'error',
+          { ...graphqlOpts, requiredFields: ['id'] },
+        ],
+      },
+    },
   ],
   rules: {
     'no-duplicate-imports': 'off',
@@ -110,13 +130,6 @@ module.exports = {
         selector: `MemberExpression[object.name='fs'][property.name=/^[A-z]+Sync$/]:not(MemberExpression[property.name='existsSync']), MemberExpression[property.name=/^[A-z]+Sync$/]:not(MemberExpression[property.name='existsSync']):has(MemberExpression[property.name='fs'])`,
         message: 'Synchronous fs calls should not be used in Cypress. Use an async API instead.',
       },
-    ],
-    'graphql/capitalized-type-name': ['warn', graphqlOpts],
-    'graphql/no-deprecated-fields': ['error', graphqlOpts],
-    'graphql/template-strings': ['error', { ...graphqlOpts, validators }],
-    'graphql/required-fields': [
-      'error',
-      { ...graphqlOpts, requiredFields: ['id'] },
     ],
   },
   settings: {


### PR DESCRIPTION
- Closes N/A — internal lint tooling change, no associated issue. Raised from a review of CI lint timings.

### Additional details

**Why was this change necessary?**

The four `graphql/*` rules were configured at the root of `.eslintrc.js`, so they ran against every linted file in the monorepo. `eslint-plugin-graphql` pays its per-file cost whether or not a file contains a `gql` template, and it dominated lint time in packages with no GraphQL at all.

`TIMING=15 eslint packages/driver/src` on `develop`:

| Rule | Relative |
|---|---|
| `graphql/capitalized-type-name` | 20.7% |
| `graphql/required-fields` | 20.3% |
| `graphql/no-deprecated-fields` | 20.1% |
| `graphql/template-strings` | 20.0% |
| `@typescript-eslint/indent` | 4.4% |
| `import/no-duplicates` | 2.7% |

81% of all rule time in a package with zero `gql` templates. `@packages/server/lib` shows the same shape at 62%.

**What is affected by this change?**

An exhaustive search for `` gql` `` tagged templates (all extensions, excluding `node_modules`/build output) finds them in only four packages: `app` (87 files), `frontend-shared` (28), `launchpad` (14), `data-context` (6). The plugin and its four rules move into an `overrides` block scoped to those packages. Every other package stops loading the plugin entirely.

Measured locally (4-core box, warm FS):

| | before | after | |
|---|---|---|---|
| `system-tests` (lint critical path) | 67.9s | **11.5s** | 5.9x |
| `driver/src` + `server/lib` | 24.0s | **7.4s** | 3.2x |
| `yarn lint --scope @packages/driver` (end-to-end) | 31.7s | **17.2s** | 1.8x |

The end-to-end figure is lower because roughly 7s of it is lerna/nx overhead this change doesn't touch. In CI, `@tooling/system-tests` is currently the lint critical path at 1m 42s of a 3m 44s job, so the wall-clock saving should be substantial.

**Implementation details**

`require('graphql')` and the 66 KB schema read still happen once per ESLint process, since the override object is built eagerly. That is tens of milliseconds; the expensive part was always rule execution.

**Trade-off:** a package that starts using `gql` without being added to the glob will silently lose schema validation — no error, just unenforced queries. The inline comment calls this out. This is the accepted cost of the change and is verified below.

### Steps to test

**1. No behavior change on existing code.** Lint findings are byte-identical before and after across seven packages, comparing `-f json` output (file:line:column, rule, severity) with each config actually in place so the nested config cascade applies:

| Package | findings before | findings after | |
|---|---|---|---|
| `data-context` | 89 | 89 | identical |
| `launchpad` | 0 | 0 | identical |
| `frontend-shared` | 6 | 6 | identical |
| `app` | 6 | 6 | identical |
| `driver` | 2337 | 2337 | identical |
| `proxy` | 0 | 0 | identical |
| `reporter` | 6 | 6 | identical |

**2. Rules still fire where they should.** A probe file containing three distinct violations was planted in each scoped package, then each package's real lint script was run:

```ts
gql`query { thisFieldDoesNotExistOnQuery }`                    // template-strings
gql`query { baseError { errorName } }`                          // required-fields ('id' not selected)
gql`fragment F on CloudProjectSpec { id specRuns(fromBranch: "main") { __typename } }`  // no-deprecated-fields
```

| Package | `template-strings` | `required-fields` | `no-deprecated-fields` | exit |
|---|---|---|---|---|
| `@packages/app` | caught | caught | caught | 1 |
| `@packages/frontend-shared` | caught | caught | caught | 1 |
| `@packages/launchpad` | caught | caught | caught | 1 |
| `@packages/data-context` | caught | caught | caught | 1 |

All four exit `1`, so CI fails on them.

`graphql/capitalized-type-name` could not be probed: it flags uncapitalized type names, but every type in the schema is capitalized, so referencing a lowercase one yields a `template-strings` "unknown type" error instead. It is configured `warn` and is unreachable via a query against this schema, both before and after this change.

**3. The trade-off is what is expected.** The same probes in three packages that previously ran these rules:

| Package | before | after |
|---|---|---|
| `@packages/driver` | 3 findings, exit 1 | 0 findings, exit 0 |
| `@packages/proxy` | 3 findings, exit 1 | 0 findings, exit 0 |
| `@packages/reporter` | 3 findings, exit 1 | 0 findings, exit 0 |

All probe files were removed afterwards; the branch contains only the `.eslintrc.js` change.

`yarn check-ts` was not run — the sandbox install used `--ignore-scripts`, so workspace packages have no build output and it fails on unrelated `Cannot find module '@packages/*'` errors. `.eslintrc.js` is not part of any tsconfig, so TypeScript is unaffected. CI will confirm.

### How has the user experience changed?

No change. This only affects how ESLint is configured for this repository's own development; nothing ships to users.

### Unrelated issue found while testing

Not addressed here, flagged for follow-up: `@packages/app` and `@packages/launchpad` omit `.vue` from their lint `--ext` lists, so their `.vue` files are not linted at all. That means the GraphQL rules have never validated 74 of `app`'s 87 `gql` files, or 13 of `launchpad`'s 14. Confirmed identical on `develop`, so it predates this PR. `frontend-shared` does include `.vue` and is unaffected. Worth its own PR, since adding the extension will likely surface unrelated Vue lint failures alongside real schema violations.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical lint-config change; rationale and measurements are in this description. -->
- [na] Have tests been added/updated? <!-- ESLint config change; verified by the before/after finding diffs and rule probes documented above. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xz9toU6DEGMbhPWjVyiQk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only ESLint configuration; behavior is unchanged for the four scoped packages, with the accepted trade-off that unlisted packages would not get GraphQL lint rules until the glob is updated.
> 
> **Overview**
> Moves **`eslint-plugin-graphql`** and its four rules out of the global ESLint config into an **`overrides`** block limited to `packages/{app,frontend-shared,launchpad,data-context}`.
> 
> Packages without `` gql` `` templates (e.g. driver, server) no longer load or run those rules on every file, which cuts lint time sharply while keeping the same rule settings where GraphQL is used. An inline comment documents that new `` gql` `` usage in other packages must add the package to the glob or schema checks will be skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e802897f6fd51124bed81b7c8e1df0a890b2b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->