### PR TITLE
chore: post-v16-merge CI and repo cleanup

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -148,7 +148,7 @@ while IFS= read -r file; do
     *.md|*.mdx|*.txt|*.png|*.jpg|*.gif|*.svg|*.ico|\
     LICENSE|.github/*|.gitignore|.gitattributes|.editorconfig|\
     guides/*|assets/*|\
-    .eslintrc.js|.prettierignore|.nvmrc|.node-version|.npmrc|.yarnclean|\
+    .eslintrc.js|.eslintignore|.prettierignore|.nvmrc|.node-version|.npmrc|.yarnclean|\
     .percy.yml|.releaserc.js|renovate.json|docker-compose.yml|lerna.json|\
     electron-builder.json|knip.json|nx.json|jsconfig.json|autobarrel.json|\
     mocha-reporter-config.json|apollo.config.js|\

--- a/.circleci/src/pipeline/workflows/@main.yml
+++ b/.circleci/src/pipeline/workflows/@main.yml
@@ -11,10 +11,6 @@ linux-x64:
           pattern: /^electron\/\d+\.\d+\.\d+$/
           value: << pipeline.git.branch >>
       - equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
-      # temporary branches that can be removed after merging
-      - equal: [ 'mschile/electron_41', << pipeline.git.branch >> ]
-      - equal: [ 'fix/windows-junction-safe-fixture-cleanup', << pipeline.git.branch >> ]
-      - equal: [ 'v8-snapshot-force-norewrite-all-bundles', << pipeline.git.branch >> ]
   jobs:
     - node_modules_install:
         build-better-sqlite3: true

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -17,9 +17,6 @@ when:
         equal: [ 'update-v8-snapshot-cache-on-develop', << pipeline.git.branch >> ]
     - not:
         equal: [ true, << pipeline.parameters.force-persist-artifacts >> ]
-    # temporary branches that can be removed after merging
-    - not:
-        equal: [ 'mschile/electron_41', << pipeline.git.branch >> ]
 
 jobs:
   # Internal PRs — install and build run immediately

--- a/npm/AGENTS.md
+++ b/npm/AGENTS.md
@@ -19,7 +19,7 @@ The `npm/` directory contains the publicly published npm packages for the Cypres
 - **@cypress/webpack-dev-server** — Implements the object-syntax `devServer` API for Cypress component testing backed by Webpack Dev Server
 - **@cypress/vite-dev-server** — Implements the object-syntax `devServer` API for Cypress component testing backed by Vite (supports Vite 5, 6, and 7)
 - **@cypress/webpack-preprocessor** — Cypress file preprocessor for bundling test files via Webpack 5; requires peer deps (`@babel/core`, `babel-loader`, etc.) to be installed by the consumer
-- **@cypress/webpack-batteries-included-preprocessor** — Wrapper around `@cypress/webpack-preprocessor` that bundles Babel, TypeScript, and CoffeeScript loaders so consumers do not need to configure them separately
+- **@cypress/webpack-batteries-included-preprocessor** — Wrapper around `@cypress/webpack-preprocessor` that bundles Babel and TypeScript loaders so consumers do not need to configure them separately
 - **@cypress/vite-plugin-cypress-esm** — Vite plugin (alpha) that wraps ES modules in a `Proxy` to allow mutation/mocking of ESM namespaces in component tests
 
 ### Plugins & Dev Tooling

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prestart": "yarn ensure-deps",
     "start": "cypress open --dev --global",
     "pretest": "yarn ensure-deps",
-    "test": "yarn lerna exec yarn test --scope=cypress --scope=@packages/{agent-info,config,data-context,driver,electron,errors,extension,https-proxy,icons,launcher,net-stubbing,network-interception,network,packherd-require,proxy,rewriter,scaffold-config,socket,v8-snapshot-require,telemetry,stderr-filtering,types} --scope=@tooling/{electron-mksnapshot,v8-snapshot}",
+    "test": "yarn lerna exec yarn test --scope=cypress --scope=@packages/{agent-info,config,data-context,driver,electron,errors,extension,https-proxy,icons,launcher,net-stubbing,network-interception,network,packherd-require,proxy,scaffold-config,socket,v8-snapshot-require,telemetry,stderr-filtering,types} --scope=@tooling/{electron-mksnapshot,v8-snapshot}",
     "test-debug": "lerna exec yarn test-debug --ignore=@packages/{driver,root,static,web-config}",
     "test-integration": "lerna exec yarn test-integration --ignore=@packages/{driver,root,static,web-config}",
     "test-mocha": "mocha --reporter spec scripts/spec.js",

--- a/packages/scaffold-config/README.md
+++ b/packages/scaffold-config/README.md
@@ -14,7 +14,7 @@ We will also attempt to scaffold a configuration file for projects using React a
 | React   | -          | Webpack    | 5           | React 18, 19           | `@cypress/vue@latest`     | [Link](../../system-tests/projects/react18)                        |
 | Vue     | -          | Vite       | 8           | Vue 3                  | `@cypress/vue@latest`   | [Link](../../system-tests/projects/vue3-vite-ts-configured)        |
 | Vue     | -          | Webpack    | 5           | Vue 3                  | `@cypress/vue@latest`     | [Link](../../system-tests/projects/vue3-webpack-ts-configured)     |
-| Angular | -          | Webpack    | 5           | Angular 21 | `@cypress/angular@latest`  | [Link](../../system-tests/projects/angular-21)                     |
+| Angular | -          | Webpack    | 5           | Angular 21, 22         | `@cypress/angular@latest`  | [Link](../../system-tests/projects/angular-21)                     |
 | Svelte  | -          | Vite       | 8           | Svelte 5               | `@cypress/svelte@latest`  | [Link](../../system-tests/projects/svelte-vite-configured)         |
 | Svelte  | -          | Webpack    | 5           | Svelte 5               | `@cypress/svelte@latest`  | [Link](../../system-tests/projects/svelte-webpack-configured)      |
 | Next.js | 15, 16     | Webpack    | 5           | React 18, 19           | `@cypress/react@latest`   | [Link](../../system-tests/projects/nextjs-configured)              |

--- a/system-tests/projects/http2-dual-stack/cypress.config.mjs
+++ b/system-tests/projects/http2-dual-stack/cypress.config.mjs
@@ -2,7 +2,6 @@
 // the project root, so this file must not import from 'cypress'.
 export default {
   retries: 0,
-  allowCypressEnv: false,
   // the expected browser protocol is public configuration — the proxy-enabled
   // contrast run overrides it with `--expose expectedBrowserProtocol=1.1`
   expose: {

--- a/system-tests/projects/tap-eviction/cypress.config.js
+++ b/system-tests/projects/tap-eviction/cypress.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'allowCypressEnv': false,
   // One test's details at a time, so every test but the latest reads as
   // `cleanedUp`.
   'numTestsKeptInMemory': 1,

--- a/system-tests/projects/tap-retries/cypress.config.js
+++ b/system-tests/projects/tap-retries/cypress.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  'allowCypressEnv': false,
   'e2e': {
     'supportFile': false,
   },

--- a/system-tests/test-binary/node_versions_node24plus_spec.ts
+++ b/system-tests/test-binary/node_versions_node24plus_spec.ts
@@ -3,7 +3,6 @@ import { beforePrePullImages } from '../lib/docker'
 
 const IMAGES = [
   'cypress/base:24.0.0',
-  'cypress/base:25.0.0',
   'cypress/base:26.0.0',
 ]
 

--- a/system-tests/test/block_hosts_override_spec.js
+++ b/system-tests/test/block_hosts_override_spec.js
@@ -29,7 +29,6 @@ describe('e2e blockHosts test config override', () => {
     settings: {
       blockHosts: 'localhost:3131',
       e2e: {
-        allowCypressEnv: false,
         baseUrl: 'http://localhost:3232',
       },
     },

--- a/system-tests/test/cookies_spec.ts
+++ b/system-tests/test/cookies_spec.ts
@@ -502,7 +502,6 @@ describe('OAuth/SSO redirect-back cookie', () => {
     browser: '!webkit', // TODO(webkit): fix+unskip (needs multidomain support)
     config: {
       baseUrl: `http://localhost:${primaryPort}`,
-      allowCypressEnv: false,
     },
     spec: 'oauth_redirect_cookie.cy.js',
   })


### PR DESCRIPTION
- Closes N/A — post-merge cleanup follow-ups from the review of #33529 (`release/16.0.0` → `develop`). No single tracking issue; each item is a mechanical correction listed below.

> [!IMPORTANT]
> **Base branch:** this targets `release/16.0.0` because that is where these items currently live. **Retarget to `develop` once #33529 merges** — every change here applies equally to `develop` post-merge, and rebasing onto `develop` afterwards should be conflict-free.

### Additional details

#### CI configuration

- **`.circleci/src/pipeline/workflows/@main.yml`** — removed the three temporary branch entries from the `&full-workflow-filters` allowlist (`mschile/electron_41`, `fix/windows-junction-safe-fixture-cleanup`, `v8-snapshot-force-norewrite-all-bundles`) along with the now-empty `# temporary branches` comment. All three branches are gone from origin, verified with `git ls-remote --heads origin <name>`:

  | branch | `git ls-remote --heads origin` |
  | --- | --- |
  | `mschile/electron_41` | no output (absent) |
  | `fix/windows-junction-safe-fixture-cleanup` | no output (absent) |
  | `v8-snapshot-force-norewrite-all-bundles` | no output (absent) |

  Per `.circleci/AGENTS.md`, this allowlist is meant to be appended to for in-flight work and pruned after merge; the four permanent entries (`develop`, `update-v8-snapshot-cache-on-develop`, the `release/*` and `electron/*` patterns, and `force-persist-artifacts`) are untouched.

- **`.circleci/src/pipeline/workflows/pull-request.yml`** — removed the matching `mschile/electron_41` exclusion and its comment. That exclusion existed only to stop the PR workflow running in parallel with the main workflows on that branch; with the branch gone it is dead config.

- **`.circleci/scripts/generate-pipeline-parameters.sh`** — added `.eslintignore` to the documentation/repo-metadata case arm that already lists `.eslintrc.js`, `.prettierignore`, `.nvmrc`, `.node-version`, etc. `.eslintignore` is new on this branch and had no mapping, so **any PR touching it hit the fatal unrecognized-path catch-all and failed `launch-primary-workflow` before any job could start.** A/B verified — see *Steps to test*.


#### Repo hygiene

- **`package.json`** — dropped `rewriter` from the root `test` script's `--scope=@packages/{...}` brace list. `packages/rewriter` is deleted on this branch, so the scope selected a package that no longer exists.
- **`npm/AGENTS.md`** — removed the CoffeeScript mention from the `@cypress/webpack-batteries-included-preprocessor` description. v16 removed the CoffeeScript loaders; it now bundles Babel and TypeScript only.
- **`packages/scaffold-config/README.md`** — Angular support row now reads `Angular 21, 22`, matching `WIZARD_DEPENDENCY_ANGULAR_*.minVersion` (`^21.0.0 || ^22.0.0`) in `packages/scaffold-config/src/dependencies.ts`. Also padded the cell to the table's column width, which was already ragged on that row.
- **`system-tests/test-binary/node_versions_node24plus_spec.ts`** — removed `'cypress/base:25.0.0'` from `IMAGES`. Node 25 is deliberately excluded from `cli/package.json` `engines.node` (`^22.0.0 || ^24.0.0 || >=26.0.0`, #33771 — Node 25 is EOL June 2026), so the binary suite should not certify a version we do not support. `24.0.0` and `26.0.0` remain.

#### Stray `allowCypressEnv` usages

`allowCypressEnv` was removed in v16 (#33963); it is now a `isWarning: true` removed-option entry in `packages/config/src/options.ts` that emits `ALLOW_CYPRESS_ENV_REMOVED`. Five usages survived the removal and only produce warnings:

- `system-tests/projects/http2-dual-stack/cypress.config.mjs`
- `system-tests/projects/tap-eviction/cypress.config.js`
- `system-tests/projects/tap-retries/cypress.config.js`
- `system-tests/test/block_hosts_override_spec.js` (inside `settings.e2e`)
- `system-tests/test/cookies_spec.ts` (inside a test's `config`)

<details>
<summary>Deviation: the empty <code>e2e: {}</code> blocks are left in place — they are load-bearing</summary>

The task that produced this PR also asked me to collapse the empty `e2e` blocks in `system-tests/test/visit_spec.js` and `cookies_spec.ts`. I did not, because they are not debris:

1. **They are required.** `systemTests.setup({ settings })` writes the whole `cypress.config.js` via `settings.writeForTesting`, replacing the fixture's own config. In run mode, `ProjectLifecycleManager.setCurrentTestingType` errors out when the testing type is not configured:

   ```ts
   // packages/data-context/src/data/ProjectLifecycleManager.ts:621
   if (this.ctx.isRunMode && this.loadedConfigFile && !this.isTestingTypeConfigured(testingType)) {
     return this.ctx.onError(getError('TESTING_TYPE_NOT_CONFIGURED', testingType))
   }
   ```

   and `isTestingTypeConfigured` is a bare key-presence check (`_.has(config, testingType)`). Dropping `e2e` from a `settings` block would therefore fail the spec with `TESTING_TYPE_NOT_CONFIGURED`, not silently do nothing.

2. **They predate the `allowCypressEnv` work.** `git log -S allowCypressEnv -- system-tests/test/visit_spec.js` shows three of the four blocks were already `e2e: {}` before #33181 added `allowCypressEnv` into them. The same empty-block shape appears independently in `browser_crash_handling_spec.js`, `form_submissions_spec.js`, `viewport_spec.js`, and four times in `cookies_spec.ts` — it is the suite's established way of marking the testing type as configured.

So the only change in those files is removing the `allowCypressEnv` key itself.
</details>

#### Deliberately excluded (tracked elsewhere)

- **`publish-binary-branch` defaults** (`.circleci/config.yml`, `@pipeline.yml`) — still `release/16.0.0`. Changing this is coordinated separately with the `cypress-publish-binary` repo.
- **`@cypress/grep` / `@cypress/puppeteer` peer ranges** — a semver decision for those packages, not a mechanical cleanup.
- **`percy-enabled` continuation forwarding** — the setup config re-passes an inherited pipeline parameter through the continuation JSON, the exact shape the `run-force-http1-tests` comment says CircleCI rejects (`Conflicting pipeline parameters`) when the parameter is supplied at trigger time — i.e. the Trigger Pipeline → `percy-enabled=true` flow Percy now depends on. Deferred to a separate PR into `develop`, where it can be verified end-to-end with a triggered pipeline.
- **`cli/CHANGELOG.md`** — untouched; two other in-flight PRs own it. No entry is needed here anyway (internal chore, no user-facing change).

### Steps to test

**1. `.eslintignore` path mapping (A/B against this branch's parent)**

Ran the real script in a throwaway git repo whose only `HEAD~1..HEAD` change is `.eslintignore`, with a bogus `CIRCLE_PROJECT_USERNAME` so it takes the `HEAD~1` fallback, and a non-`develop`/`release/*` `CIRCLE_BRANCH` so the branch override does not short-circuit:

```
# baseline (origin/release/16.0.0 version of the script)
exit=1
Error: unrecognized path '.eslintignore' has no mapping in generate-pipeline-parameters.sh
Add it to the targeted path mapping section before merging.

# this branch
exit=0
Changed files:
.eslintignore
Emitting pipeline parameters
```

Regression checks on the same harness:

- `packages/driver/foo.ts` still maps → `run-driver-tests: true`, `run-system-tests: true`
- an unmapped path (`totally-bogus-path.xyz`) still fails loudly → `exit=1`
- emitted JSON parses

**2. CircleCI config validation** — `circleci` CLI is installed (`0.1.33163`):

```
$ yarn pack-ci --validate --all
Config file at ./.circleci/config.yml is valid.
✅ Base configuration validated successfully
📦 Packing pipeline.yml configuration...
  ✅ Packed ./.circleci/packed/pipeline.yml
Config file at ./.circleci/packed/pipeline.yml is valid.
🎉 All CircleCI configurations packed and validated successfully!

$ circleci config process .circleci/packed/pipeline.yml   # exit 0, 17073 lines
```

The pre-commit hook independently re-ran `pack-ci --validate` and `circleci config validate` on the staged config and passed.

**3. Lint** — `yarn eslint` from the worktree root on all changed JS/TS files (the three fixture configs, `block_hosts_override_spec.js`, `cookies_spec.ts`, `node_versions_node24plus_spec.ts`) reported no problems. `bash -n` clean on `generate-pipeline-parameters.sh`; `package.json` still parses and no longer contains `rewriter`.

**4. Not run locally** — the `system-tests` and binary suites touched here were not run locally; CI covers them.

### How has the user experience changed?

No change. Internal CI configuration, repo documentation, and test-fixture cleanup only — no shipped code is modified.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical post-merge cleanup: dead CI branch entries, a missing path mapping, stale docs, and leftover usages of options already removed in v16. -->
- [na] Have tests been added/updated? <!-- No behavior change to test. Existing suites cover the touched fixtures; the script fix was A/B verified directly (see Steps to test). -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No user-facing change. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No shipped product code; changes are CI config, documentation, and test fixtures only.
> 
> **Overview**
> Post–v16 merge housekeeping: CI path mapping, workflow allowlists, docs, and removal of obsolete test config.
> 
> **CircleCI** adds `.eslintignore` to the repo-metadata path map in `generate-pipeline-parameters.sh` so PRs that only touch that file no longer fail `launch-primary-workflow` with an unrecognized path. **@main.yml** and **pull-request.yml** drop temporary branch entries for branches that no longer exist on origin.
> 
> **Repo scripts and docs:** root `package.json` `test` no longer scopes `@packages/rewriter` (package removed). **npm/AGENTS.md** and **scaffold-config/README.md** reflect v16 reality (no CoffeeScript in batteries-included preprocessor; Angular 21–22). Binary Node smoke tests drop `cypress/base:25.0.0`, aligned with supported Node engines.
> 
> **System tests** remove leftover `allowCypressEnv: false` from several fixture configs and spec `settings`/`config` blocks—the option was removed in v16 and only emitted warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99d98ffea8eb9b050c7c4ce027d9d0d438d2f7ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

