### PR TITLE
chore: add tests pinning interception.error for netstack-rejected loads proxy-off

### DIFF
--- a/packages/driver/cypress/e2e/e2e/encoding.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/encoding.cy.ts
@@ -178,6 +178,8 @@ describe('encoding', () => {
 
       // The request will be successful but since the content-encoding is br,
       // the browser will fail to decode
+      let brJsInterception
+
       cy.wait('@brJs').then((interception) => {
         if (usesBrowserNetworkPath) {
           // NOTE: accepted MITM → CDP drift (#34384): the netstack rejects this br
@@ -185,15 +187,38 @@ describe('encoding', () => {
           // can only observe the request phase.
           expect(interception.request).to.exist
           expect(interception.response).to.be.undefined
+
+          // #34565: the browser knows the load failed and why, so the
+          // rejection must surface as interception.error. cy.wait resolves
+          // at the request phase and network:error arrives asynchronously —
+          // retry against the interception, which is mutated in place when
+          // it lands.
+          cy.wrap(interception).should((errored) => {
+            expect(errored.state).to.eq('Errored')
+            expect(errored.error, 'interception.error').to.exist
+          })
         } else {
           expect(interception.response?.statusCode).to.eq(200)
           expect(interception.response?.headers?.['content-encoding']).to.eq('br')
           expect(interception.request.headers['accept-encoding']).to.eq('gzip, deflate')
+
+          brJsInterception = interception
         }
       })
 
       // Assert that the encoding-js element is still gzip since br failed to decode
       cy.get('#encoding-js').should('have.text', 'encoding-gzip-js')
+
+      cy.then(() => {
+        if (!usesBrowserNetworkPath) {
+          // MITM observes the response directly and never routes it through
+          // the network:error path, so the interception reaches Complete
+          // with interception.error unset — the asymmetry with the
+          // proxy-off branch above is the point.
+          expect(brJsInterception.state).to.eq('Complete')
+          expect(brJsInterception.error).to.be.undefined
+        }
+      })
     })
 
     it('fails when brotli is requested due to insecure host', (done) => {

--- a/packages/proxy/test/integration/net-stubbing.spec.ts
+++ b/packages/proxy/test/integration/net-stubbing.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, beforeEach, afterEach, it, vi } from 'vitest'
-import { NetworkProxy } from '../../'
+import { NetworkProxy, createSyntheticProxyCodec } from '../../'
 import {
   netStubbingState as _netStubbingState,
   NetStubbingState,
@@ -26,6 +26,7 @@ describe('network stubbing', () => {
   let server
   let destinationPort
   let socket
+  let proxy: NetworkProxy
   let documentDomainInjection: DocumentDomainInjection
 
   const serverPort = 3030
@@ -52,7 +53,7 @@ describe('network stubbing', () => {
     app = express()
     netStubbingState = _netStubbingState()
 
-    const proxy = new NetworkProxy({
+    proxy = new NetworkProxy({
       socket,
       netStubbingState,
       networkInterceptionCore: createProxyNetworkInterception({
@@ -68,6 +69,7 @@ describe('network stubbing', () => {
       serverBus: new EventEmitter(),
       getCurrentBrowser: vi.fn(),
     })
+
     const httpIntercept = new HttpIntercept(proxy.codec)
 
     httpIntercept.use(proxy.http.createLegacyProxyPipeline(proxy.codec))
@@ -365,6 +367,55 @@ describe('network stubbing', () => {
 
     expect(resp2.status).toEqual(200)
     expect(resp2.text).toEqual('foo')
+  })
+
+  describe('proxy disabled (CDP Fetch transport shape)', () => {
+    // Mirrors createCdpFetchRuntime: the legacy pipeline runs over the
+    // synthetic codec, and the origin call is the transport's `next`. When
+    // the browser knows a load failed (e.g. a netstack-rejected br
+    // response), CdpFetchTransport rejects that call with a
+    // toNetworkError()-shaped error, and that rejection must reach the
+    // driver as a network:error event (#34565).
+    it('emits network:error to the driver when the origin call rejects on a matched request', async () => {
+      netStubbingState.routes.push({
+        id: '1',
+        routeMatcher: {
+          url: '*',
+        },
+        hasInterceptor: false,
+        getFixture,
+        matches: 1,
+      })
+
+      const syntheticCodec = createSyntheticProxyCodec({
+        createMiddlewareContext: (req, res) => proxy.http.createMiddlewareContext(req, res),
+      })
+
+      const pipeline = proxy.http.createLegacyProxyPipeline(syntheticCodec)
+
+      const url = `http://localhost:${destinationPort}/`
+      const originError = new Error(`origin rejection for ${url}`)
+
+      await expect(pipeline({
+        id: 'cdp-fetch-1',
+        url,
+        method: 'GET',
+        headers: { host: `localhost:${destinationPort}` },
+        resourceType: 'xhr',
+      }, () => Promise.reject(originError))).rejects.toThrow()
+
+      expect(socket.toDriver).toHaveBeenCalledWith(
+        'net:stubbing:event',
+        'network:error',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            error: expect.objectContaining({
+              message: originError.message,
+            }),
+          }),
+        }),
+      )
+    })
   })
 
   describe('CSP Headers', () => {


### PR DESCRIPTION

<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://github.com/cypress-io/cypress/issues/34565

### Additional details
Tests written to prove or disprove #34565; they disprove it on the current release/16.0.0 tip — the CDP Fetch path already populates interception.error — so these land as green pins of the contract:

- encoding.cy.ts (proxy-off branch): after the accepted #34384 drift assertions, require interception.state === 'Errored' and interception.error populated, retried via cy.wrap().should() since network:error arrives after cy.wait resolves at the request phase. The MITM branch pins the asymmetry: state 'Complete' and no error, observed in a trailing cy.then() after the page assertions so a late event would be caught.

- proxy integration net-stubbing.spec.ts: mirrors the CDP Fetch runtime composition (legacy pipeline over createSyntheticProxyCodec) with the origin next() rejecting the way CdpFetchTransport does, asserting the driver receives net:stubbing:event network:error carrying the rejection's message. Mutation-checked: killed by an error-middleware early return and by a blanked error payload.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that lock in existing network-stubbing contracts; no production code paths are modified.
> 
> **Overview**
> Adds **regression tests for #34565** that document how failed loads show up on `cy.intercept` when brotli is rejected on an insecure host—without changing runtime behavior.
> 
> On the **browser/CDP network path**, the encoding e2e now waits for the async `network:error` and asserts the interception ends in **`Errored`** with **`interception.error` set**, since `cy.wait` can resolve before the error is attached. On the **MITM proxy path**, it pins the opposite: **`Complete`** with **no `error`**, because the response is observed directly.
> 
> A new **proxy integration** case runs the legacy pipeline over **`createSyntheticProxyCodec`** (same shape as CDP Fetch) and checks that when the origin `next()` rejects, the driver gets **`net:stubbing:event` / `network:error`** with the rejection message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d366298fc9e5575d0bcec6dced0f554c4d0850df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
