### PR TITLE
fix: report native network failures promptly

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -36,6 +36,10 @@
 - Cypress now supports HTTP/2 and HTTP/3 in Chrome, Chromium, and Edge. Your application is tested over the same protocol it uses in production, with multiplexed requests and no six-connection ceiling, so modern apps load faster under test and behave the way your users actually experience them. Cypress also stops terminating TLS for the application under test, so the browser validates your origin's real certificate instead of one Cypress generates. See [Native network interception](https://docs.cypress.io/app/guides/native-network-interception). Addresses [#3708](https://github.com/cypress-io/cypress/issues/3708).
 - `Angular` version 22 is now supported within component testing, including Launchpad project detection and the `@cypress/schematic` Angular CLI integration. Addresses [#33753](https://github.com/cypress-io/cypress/issues/33753).
 
+**Bugfixes:**
+
+- Chrome, Chromium, and Edge test runs using native network interception now report the browser's failure reason promptly when an intercepted request fails, instead of waiting 30 seconds and reporting a timeout. Fixes [#34689](https://github.com/cypress-io/cypress/issues/34689).
+
 **Dependency Updates:**
 
 - Upgraded `electron` from `37.6.0` to `41.7.0`.

--- a/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-fetch-transport.ts
@@ -167,6 +167,7 @@ type ResponsePauseDeferred = PromiseWithResolvers<CdpFetchTransportResponse> & {
   headersReady: PromiseWithResolvers<void>
   // key into inFlightByNetworkId; absent when the pause carried no networkId
   networkKey?: string
+  requestUrl: string
   // Request-stage route-match result, stashed once the outbound request comes
   // back from the middleware onion — read by resolveResponse's shouldStreamBody
   // call so classification agrees with the interception that actually ran.
@@ -362,15 +363,12 @@ export class CdpFetchTransport {
    * flow still in request middleware (typically parked in pre-request
    * correlation, whose 2s timer would otherwise expire and log a warning), the
    * rejection covers one already continued and waiting on a response pause.
+   *
+   * A non-canceled failure normally has a Fetch response error pause, but when
+   * Chrome omits it, Network.loadingFailed is the only terminal signal and must
+   * reject the pending response with the browser's failure reason.
    */
   private onLoadingFailed = (event: Protocol.Network.LoadingFailedEvent, sessionId?: string): void => {
-    // A request that failed on the wire still gets a Fetch response pause
-    // carrying its error reason — resolveResponse owns those, and treating
-    // them as cancellations here would silence a real failure.
-    if (!event.canceled) {
-      return
-    }
-
     const networkKey = this.getNetworkKey(event.requestId, sessionId)
     const deferred = this.inFlightByNetworkId.get(networkKey)
 
@@ -378,9 +376,16 @@ export class CdpFetchTransport {
       return
     }
 
-    debug('browser canceled in-flight request %s', networkKey)
-
     this.inFlightByNetworkId.delete(networkKey)
+
+    if (!event.canceled) {
+      debug('browser failed in-flight request %s: %s', networkKey, event.errorText)
+      deferred.reject(toNetworkError(deferred.requestUrl, event.errorText))
+
+      return
+    }
+
+    debug('browser canceled in-flight request %s', networkKey)
     this.options.onRequestCanceled?.(`${this.requestIdPrefix}${event.requestId}`)
     deferred.reject(new Error(`CDP Fetch request canceled by the browser: ${networkKey}`))
   }
@@ -507,6 +512,7 @@ export class CdpFetchTransport {
       const responseDeferred: ResponsePauseDeferred = {
         ...Promise.withResolvers<CdpFetchTransportResponse>(),
         headersReady: Promise.withResolvers<void>(),
+        requestUrl: event.request.url,
         ...(event.networkId ? { networkKey: this.getNetworkKey(event.networkId, sessionId) } : {}),
       }
 
@@ -533,6 +539,7 @@ export class CdpFetchTransport {
         // resolveResponse instead of re-matching against a possibly
         // handler-mutated request at response time.
         responseDeferred.hadMatchingRoutes = outbound.hadMatchingRoutes
+        responseDeferred.requestUrl = outbound.url
 
         const headers = await this.continueRequestHeaders(event, outbound)
 

--- a/packages/server/lib/browsers/cdp-protocol/cdp-network-error.ts
+++ b/packages/server/lib/browsers/cdp-protocol/cdp-network-error.ts
@@ -60,8 +60,8 @@ function formatAddress (url: string, address?: NodeNetworkError['address']): str
  * Builds the error a failed CDP Fetch response pause rejects with, shaped like
  * the Node error the MITM path would have produced for the same condition.
  */
-export function toNetworkError (url: string, errorReason: Protocol.Network.ErrorReason): Error {
-  const mapped = NODE_NETWORK_ERRORS[errorReason]
+export function toNetworkError (url: string, errorReason: string): Error {
+  const mapped = NODE_NETWORK_ERRORS[errorReason as Protocol.Network.ErrorReason]
 
   if (!mapped) {
     return new Error(`CDP Fetch response failed for ${url}: ${errorReason}`)

--- a/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
+++ b/packages/server/test/unit/browsers/cdp-fetch-transport_spec.ts
@@ -3503,7 +3503,7 @@ describe('CdpFetchTransport', () => {
     })
   })
 
-  describe('browser request cancellation', () => {
+  describe('browser request failures and cancellation', () => {
     // Parks a flow in the middleware onion the way pre-request correlation
     // does, so the cancellation arrives while the request pause is still held.
     function parkedIntercept () {
@@ -3513,6 +3513,25 @@ describe('CdpFetchTransport', () => {
       httpIntercept.use(async () => parked.promise)
 
       return { httpIntercept, parked }
+    }
+
+    function capturingIntercept () {
+      let capturedError: (Error & { code?: string }) | undefined
+      const errorCaptured = Promise.withResolvers<Error & { code?: string }>()
+      const httpIntercept = new HttpIntercept(createCdpFetchCodec())
+
+      httpIntercept.use(async (request, next) => {
+        try {
+          return await next(request)
+        } catch (err) {
+          capturedError = err as Error & { code?: string }
+          errorCaptured.resolve(capturedError)
+
+          throw err
+        }
+      })
+
+      return { httpIntercept, errorCaptured: errorCaptured.promise, getCapturedError: () => capturedError }
     }
 
     it('aborts a flow still paused in the middleware onion', async () => {
@@ -3571,26 +3590,67 @@ describe('CdpFetchTransport', () => {
       expect(client.send).not.to.have.been.calledWith('Fetch.fulfillRequest')
     })
 
-    it('leaves a genuine network failure to the response error pause', async () => {
+    it('rejects a non-canceled network failure when no response pause arrives', async () => {
       const client = createClient()
-      const { httpIntercept, parked } = parkedIntercept()
+      const { httpIntercept, errorCaptured } = capturingIntercept()
       const onRequestCanceled = sinon.stub()
       const { transport } = createTransport(client, { httpIntercept, onRequestCanceled })
       const onRequestPaused = await startTransport(transport, client)
 
-      onRequestPaused(createPausedRequest({
+      const handled = onRequestPaused(createPausedRequest({
         requestId: 'fetch-request',
         networkId: 'network-1',
+        url: 'https://example.test/failed',
       }))
 
       await tick()
 
       onLoadingFailed(client, { requestId: 'network-1', canceled: false, errorText: 'net::ERR_CONNECTION_REFUSED' })
 
-      expect(onRequestCanceled).not.to.have.been.called
+      try {
+        const capturedError = await Promise.race([
+          errorCaptured,
+          new Promise<undefined>((resolve) => setImmediate(() => resolve(undefined))),
+        ])
 
-      parked.reject(new Error('unparked'))
+        expect(capturedError, 'LOADING_FAILED_PENDING_SENTINEL: non-canceled loadingFailed did not reject the pending response').to.not.be.undefined
+        expect(capturedError?.message).to.equal('CDP Fetch response failed for https://example.test/failed: net::ERR_CONNECTION_REFUSED')
+        expect(onRequestCanceled).not.to.have.been.called
+      } finally {
+        transport.reset()
+        await handled
+      }
+    })
+
+    it('keeps the response error pause reason when loadingFailed follows', async () => {
+      const client = createClient()
+      const { httpIntercept, getCapturedError } = capturingIntercept()
+      const onRequestCanceled = sinon.stub()
+      const { transport } = createTransport(client, { httpIntercept, onRequestCanceled })
+      const onRequestPaused = await startTransport(transport, client)
+      const handled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        url: 'http://127.0.0.1:3333/failed',
+      }))
+
       await tick()
+
+      const responseHandled = onRequestPaused(createPausedRequest({
+        requestId: 'fetch-request',
+        networkId: 'network-1',
+        url: 'http://127.0.0.1:3333/failed',
+        responseErrorReason: 'ConnectionRefused',
+      }))
+
+      onLoadingFailed(client, { requestId: 'network-1', canceled: false, errorText: 'net::ERR_FAILED' })
+
+      await responseHandled
+      await handled
+
+      expect(getCapturedError()?.message).to.equal('connect ECONNREFUSED 127.0.0.1:3333')
+      expect(getCapturedError()?.code).to.equal('ECONNREFUSED')
+      expect(onRequestCanceled).not.to.have.been.called
     })
 
     it('ignores a cancellation for a request it never paused', async () => {


### PR DESCRIPTION
- Closes https://github.com/cypress-io/cypress/issues/34689

### Additional details

When Chrome omits a Fetch response-error pause, the CDP transport currently ignores the only terminal signal, `Network.loadingFailed`, and leaves the intercepted request waiting for its 30-second response-pause timeout. This change rejects an in-flight non-canceled request from that signal using the browser-provided `errorText`.

The existing canceled-request path remains unchanged. A Fetch response-error pause that settles first also keeps precedence, and both request lookup maps are cleaned through the existing rejection path.

### Steps to test

1. Run `yarn workspace @packages/server test-unit -- cdp-fetch-transport_spec.ts`.
2. Run `yarn check-ts --scope @packages/server`.
3. Run `yarn workspace @packages/server lint -- lib/browsers/cdp-protocol/cdp-fetch-transport.ts lib/browsers/cdp-protocol/cdp-network-error.ts test/unit/browsers/cdp-fetch-transport_spec.ts`.

### How has the user experience changed?

Before, an intercepted request that failed without a Fetch response pause waited 30 seconds and surfaced a timeout. After, Cypress promptly reports the failure reason supplied by the browser. This is a behavioral error-reporting change with no visual UI change.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? The collaborator-authored issue explicitly defines this remediation and target branch.
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? No documentation changes are needed for this bug fix.
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? No public API changes.