### PR TITLE
chore: fix verify-release-readiness OOM by bumping resources and capping lerna concurrency

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -2124,7 +2124,7 @@ jobs:
 
   verify-release-readiness:
     <<: *defaults
-    resource_class: small.gen2
+    resource_class: medium.gen2
     parallelism: 1
     environment:
       GITHUB_TOKEN: $GH_TOKEN

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test-debug": "lerna exec yarn test-debug --ignore=@packages/{driver,root,static,web-config}",
     "test-integration": "lerna exec yarn test-integration --ignore=@packages/{driver,root,static,web-config}",
     "test-mocha": "mocha --reporter spec scripts/spec.js",
-    "test-npm-package-release-script": "npx lerna exec --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
+    "test-npm-package-release-script": "npx lerna exec --concurrency 4 --scope=@cypress/* -- npx --no-install semantic-release --dry-run",
     "test-scripts": "mocha -r packages/ts/register --reporter spec 'scripts/unit/**/*spec.js'",
     "test-scripts-watch": "yarn test-scripts --watch --watch-extensions 'ts,js'",
     "test-system": "yarn workspace @tooling/system-tests test",


### PR DESCRIPTION
- Closes N/A (purely mechanical CI fix — details below)

### Additional details

`verify-release-readiness` has failed on every develop run since the v16 merge (9c03be0b7b). The failing step, `yarn test-npm-package-release-script`, dies ~34s in with no error output, a null exit code, and the step marked "canceled" — the container-OOM signature. It had passed all day before the merge (~220s runs) and fails identically on rerun.

Why the merge broke it: the job runs `lerna exec` across 14 `@cypress/*` packages, and lerna defaults concurrency to the host's core count (the container sees the CircleCI host's cores, not its provisioned vCPUs), so all 14 semantic-release process trees run at once. The merge bumped Node 22→24, semantic-release 22.0.12→25.0.8 (with plugin majors), and npm 10→11, fattening every process in those trees by enough to push peak usage over the `small.gen2` container's 2GB limit. Importing semantic-release 25 alone costs ~88MB RSS per process on Node 24, before plugins or npm children.

Fix, both halves of the multiplication:
- `verify-release-readiness` moves to `medium.gen2` (2 vCPU / 4GB)
- `lerna exec` is capped at `--concurrency 4`, making peak memory deterministic instead of host-dependent (little wall-clock cost on a 2 vCPU box)

`yarn pack-ci --validate` passes.

### Steps to test

`verify-release-readiness` on this PR's pipeline should pass; on develop the step currently dies silently ~34s in (e.g. https://app.circleci.com/pipelines/gh/cypress-io/cypress/85993).

### How has the user experience changed?

No change (CI-only).

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- mechanical CI fix -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to job sizing and lerna parallelism; no application, auth, or release logic changes.
> 
> **Overview**
> Fixes **silent OOM failures** in the `verify-release-readiness` CircleCI job (notably on `yarn test-npm-package-release-script` after heavier Node/semantic-release tooling).
> 
> The job moves from **`small.gen2` to `medium.gen2`** (more memory). The root **`test-npm-package-release-script`** script now runs **`lerna exec` with `--concurrency 4`** so semantic-release dry-runs across `@cypress/*` packages do not all spawn at once and blow the container limit.
> 
> No runtime or user-facing behavior changes—CI resource and parallelism tuning only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013835034c6a8e0cd25bb189e57c532b4d92bd60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->