### PR TITLE
chore: point publish-binary-branch back to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
 parameters:
   publish-binary-branch:
     type: string
-    default: release/16.0.0
+    default: main
   force-persist-artifacts:
     type: boolean
     default: false

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -19,7 +19,7 @@ base-internal-minimum-node: &base-internal-minimum-node cypress/base-internal:22
 parameters:
   publish-binary-branch:
     type: string
-    default: release/16.0.0
+    default: main
   force-persist-artifacts:
     type: boolean
     default: false


### PR DESCRIPTION
- Closes N/A (purely mechanical CI config change — details below)

### Additional details

During v16 development the `publish-binary-branch` pipeline parameter pointed the packaging trigger at cypress-publish-binary's `release/16.0.0` branch. That branch is merging back to `main` in cypress-io/cypress-publish-binary#94, so the default should return to `main`.

**Merge this in sync with cypress-io/cypress-publish-binary#94** — merging either one alone leaves binary packaging pointed at the wrong branch.

The parameter is declared in two places — the setup entrypoint (`.circleci/config.yml`) and the continued pipeline (`.circleci/src/pipeline/@pipeline.yml`) — and both defaults are flipped. `yarn pack-ci --validate` and `circleci config validate` pass; no other `release/16` references remain in `.circleci/`.

### Steps to test

After both PRs merge, the next develop binary build should trigger the cypress-publish-binary pipeline on `main` (visible as `target-repo-branch` in the create-and-trigger-packaging-artifacts job).

### How has the user experience changed?

No change (CI-only).

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- mechanical CI config change -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only default change; the main risk is timing—merging without the companion publish-binary PR would briefly trigger packaging on the wrong branch.
> 
> **Overview**
> **Restores the default `publish-binary-branch` CircleCI pipeline parameter from `release/16.0.0` to `main`** in both the setup config (`.circleci/config.yml`) and the packed pipeline source (`.circleci/src/pipeline/@pipeline.yml`).
> 
> That parameter is forwarded as `target-repo-branch` when `create-and-trigger-packaging-artifacts` triggers the **cypress-publish-binary** pipeline, so develop binary builds again target **`main`** after the v16 release branch is merged there. **Merge in step with cypress-io/cypress-publish-binary#94** so packaging is not left pointing at a stale branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b050e09ccbd4209abb29b4b1566bf8dab68e6268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->