### PR TITLE
fix: bound the teardown work that waits on another process

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
+- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead, naming the cleanup step that stalled. `cypress run` also no longer waits without limit for the browser process to exit before finishing, which on a busy machine could add seconds to the end of every run. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -38,7 +38,8 @@
 
 **Bugfixes:**
 
-- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead, naming the cleanup step that stalled. A single stalled cleanup step, such as waiting on a browser that is slow to close, no longer holds up the rest of shutdown. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
+- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
+- Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Each cleanup step is now given its own time limit, and `cypress run` names any step that runs out of it. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 **Bugfixes:**
 
-- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead, naming the cleanup step that stalled. `cypress run` also no longer waits without limit for the browser process to exit before finishing, which on a busy machine could add seconds to the end of every run. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
+- Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead, naming the cleanup step that stalled. A single stalled cleanup step, such as waiting on a browser that is slow to close, no longer holds up the rest of shutdown. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,7 +39,7 @@
 **Bugfixes:**
 
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
-- Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Each cleanup step is now given its own time limit, and `cypress run` names any step that runs out of it. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).
+- Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).
 
 **Dependency Updates:**
 

--- a/packages/data-context/src/data/ProjectConfigManager.ts
+++ b/packages/data-context/src/data/ProjectConfigManager.ts
@@ -35,7 +35,9 @@ const EXECUTE_PLUGINS_REPLY_LOG_TIMEOUT_MS = 10000
 // this budget; data-context cannot import from the server, so the default is mirrored here
 const DEFAULT_TEARDOWN_TIMEOUT_MS = 5000
 // the disconnect ack has to give up well before the teardown budget expires, or the force-exit cuts
-// off the rest of teardown instead; derived so lowering the budget cannot invert the two
+// off the rest of teardown instead; derived so lowering the budget cannot invert the two. Keep equal
+// to PEER_WAIT_BUDGET_FRACTION in @packages/server lib/util/graceful-exit.ts, which bounds the other
+// wait on a process we do not control
 const TEARDOWN_BUDGET_FRACTION = 0.4
 
 function mainProcessWillDisconnectTimeoutMs (): number {

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -53,25 +53,24 @@ const kill = (options: KillOptions = {}) => {
   return new Promise<void>((resolve) => {
     let timer: NodeJS.Timeout | undefined
 
-    const done = () => {
+    instanceToKill.once('exit', () => {
       clearTimeout(timer)
 
       if (options.unbind) {
         instanceToKill.removeAllListeners()
       }
 
-      resolve()
-    }
-
-    instanceToKill.once('exit', () => {
       debug('browser process killed')
-      done()
+
+      resolve()
     })
 
     if (options.timeoutMs) {
+      // Stop waiting, but leave the listeners attached: the process is still alive, so its later
+      // `exit` and `error` events still need somewhere to go.
       timer = setTimeout(() => {
         debug('browser process did not exit within %dms, leaving the rest to the OS', options.timeoutMs)
-        done()
+        resolve()
       }, options.timeoutMs)
     }
 

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -25,7 +25,6 @@ interface KillOptions {
   nullOut?: boolean
   unbind?: boolean
   isOrphanedBrowserProcess?: boolean
-  /** Stop waiting on the browser's `exit` event after this long; it has been signalled regardless. */
   timeoutMs?: number
 }
 

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -25,6 +25,8 @@ interface KillOptions {
   nullOut?: boolean
   unbind?: boolean
   isOrphanedBrowserProcess?: boolean
+  /** Stop waiting on the browser's `exit` event after this long; it has been signalled regardless. */
+  timeoutMs?: number
 }
 
 const kill = (options: KillOptions = {}) => {
@@ -49,15 +51,29 @@ const kill = (options: KillOptions = {}) => {
   }
 
   return new Promise<void>((resolve) => {
-    instanceToKill.once('exit', () => {
+    let timer: NodeJS.Timeout | undefined
+
+    const done = () => {
+      clearTimeout(timer)
+
       if (options.unbind) {
         instanceToKill.removeAllListeners()
       }
 
-      debug('browser process killed')
-
       resolve()
+    }
+
+    instanceToKill.once('exit', () => {
+      debug('browser process killed')
+      done()
     })
+
+    if (options.timeoutMs) {
+      timer = setTimeout(() => {
+        debug('browser process did not exit within %dms, leaving the rest to the OS', options.timeoutMs)
+        done()
+      }, options.timeoutMs)
+    }
 
     debug('killing browser process')
 

--- a/packages/server/lib/browsers/index.ts
+++ b/packages/server/lib/browsers/index.ts
@@ -64,7 +64,7 @@ const kill = (options: KillOptions = {}) => {
       resolve()
     })
 
-    if (options.timeoutMs) {
+    if (options.timeoutMs != null) {
       // Stop waiting, but leave the listeners attached: the process is still alive, so its later
       // `exit` and `error` events still need somewhere to go.
       timer = setTimeout(() => {

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -16,6 +16,7 @@ import { DataContext, getCtx } from '@packages/data-context'
 import { autoBindDebug } from '@packages/data-context/src/util'
 import type { BrowserInstance, Browser } from './browsers/types'
 import { isBrowserNetworkMode, ensureProxyServer } from './util/network-mode'
+import { GracefulExit, getPeerWaitTimeoutMs } from './util/graceful-exit'
 import { translateEgressPolicyToLaunchOpts } from './util/egress-policy'
 
 const debug = Debug('cypress:server:open_project')
@@ -226,8 +227,8 @@ export class OpenProject extends EventEmitter {
     return this.relaunchBrowser()
   }
 
-  closeBrowser () {
-    return browsers.close()
+  closeBrowser (timeoutMs?: number) {
+    return browsers.close({ timeoutMs })
   }
 
   async resetBrowserTabsForNextSpec (shouldKeepTabOpen: boolean) {
@@ -255,7 +256,10 @@ export class OpenProject extends EventEmitter {
 
     this.resetOpenProject()
 
-    return this.closeBrowser()
+    // The browser is signalled either way; this only decides how long we wait for its process to be
+    // gone. A browser with several renderers takes seconds to reap on a loaded machine, and on the way
+    // out that wait sits inside the exit budget every teardown step shares, so bound it there.
+    return this.closeBrowser(GracefulExit.isShuttingDown ? getPeerWaitTimeoutMs() : undefined)
   }
 
   close () {

--- a/packages/server/lib/util/graceful-exit.ts
+++ b/packages/server/lib/util/graceful-exit.ts
@@ -54,6 +54,7 @@ export class GracefulExit {
   private forceExitTimeout: NodeJS.Timeout | undefined
   private steps: Map<string, ExitStep> = new Map()
   private pendingSteps: Map<string, string> = new Map()
+  private stepTimeouts: Set<NodeJS.Timeout> = new Set()
   private debug: Debug.Debugger
 
   /**
@@ -128,6 +129,7 @@ export class GracefulExit {
     }
 
     inst.clearForceExitTimeout()
+    inst.clearStepTimeouts()
 
     inst.steps.clear()
     inst.pendingSteps.clear()
@@ -170,6 +172,7 @@ export class GracefulExit {
           Promise.resolve(fn(code)).then(() => 'settled' as const),
           new Promise<'timedOut'>((resolve) => {
             timer = setTimeout(() => resolve('timedOut'), budget)
+            this.stepTimeouts.add(timer)
           }),
         ])
 
@@ -184,7 +187,11 @@ export class GracefulExit {
         console.log(`An error occurred during the "${name}" teardown step. This does not affect the exit code (${code}).`)
         console.log(error)
       } finally {
-        clearTimeout(timer)
+        if (timer) {
+          this.stepTimeouts.delete(timer)
+          clearTimeout(timer)
+        }
+
         this.pendingSteps.delete(key)
       }
     }))
@@ -195,6 +202,18 @@ export class GracefulExit {
       clearTimeout(this.forceExitTimeout)
       this.forceExitTimeout = undefined
     }
+  }
+
+  /**
+   * Cancels the bounds of steps still in flight. A step timer that outlives the teardown it belongs to
+   * settles that abandoned flush, whose `finally` then exits the process for real.
+   */
+  private clearStepTimeouts (): void {
+    for (const timer of this.stepTimeouts) {
+      clearTimeout(timer)
+    }
+
+    this.stepTimeouts.clear()
   }
 
   private async flushAndExit (code: number): Promise<number | void> {

--- a/packages/server/lib/util/graceful-exit.ts
+++ b/packages/server/lib/util/graceful-exit.ts
@@ -9,8 +9,8 @@ const SIGNAL_DEDUP_MS = 200
 /**
  * Share of the teardown budget one step may spend. Steps wait on peers we are about to outlive anyway
  * (the config child over IPC, the browser over CDP and signals), so without a per-step bound the first
- * to stall spends the whole budget and the force-exit cuts off every other step — including the lockfile
- * unlock, whose side effect outlives us. Below 1 so a stalled step yields in time for the rest to finish.
+ * to stall spends the whole budget and the force-exit cuts off every other step. Below 1 so a stalled
+ * step yields in time for the rest to finish.
  */
 const STEP_BUDGET_FRACTION = 0.8
 
@@ -53,7 +53,6 @@ export class GracefulExit {
   private teardownStartedAt: number | null = null
   private forceExitTimeout: NodeJS.Timeout | undefined
   private steps: Map<string, ExitStep> = new Map()
-  /** Names of steps that have started but not settled, so a blown budget can say what it was waiting on. */
   private pendingSteps: Map<string, string> = new Map()
   private debug: Debug.Debugger
 
@@ -137,10 +136,6 @@ export class GracefulExit {
     GracefulExit.instance = null
   }
 
-  /**
-   * @param timeoutMs bound for this step alone, for work whose result is worth less than a prompt exit;
-   * defaults to `STEP_BUDGET_FRACTION` of the teardown budget.
-   */
   static addStep (teardownFn: ExitStep['fn'], stepName?: string, timeoutMs?: number): ExitStepKey {
     GracefulExit.singleton.debug('adding step to graceful exit: %s', stepName)
 
@@ -157,8 +152,6 @@ export class GracefulExit {
   }
 
   static get isShuttingDown (): boolean {
-    // read from teardownStartedAt, not processTeardown: the first steps run before exitGracefully has
-    // finished assigning that promise, and a step that skips work on the way out has to see this
     return GracefulExit.singleton.teardownStartedAt != null
   }
 

--- a/packages/server/lib/util/graceful-exit.ts
+++ b/packages/server/lib/util/graceful-exit.ts
@@ -6,6 +6,14 @@ import os from 'os'
 /** Window after teardown starts in which extra signals are treated as duplicate delivery, not a second user interrupt. */
 const SIGNAL_DEDUP_MS = 200
 
+/**
+ * Share of the teardown budget one step may spend. Steps wait on peers we are about to outlive anyway
+ * (the config child over IPC, the browser over CDP and signals), so without a per-step bound the first
+ * to stall spends the whole budget and the force-exit cuts off every other step — including the lockfile
+ * unlock, whose side effect outlives us. Below 1 so a stalled step yields in time for the rest to finish.
+ */
+const STEP_BUDGET_FRACTION = 0.8
+
 function getTeardownTimeoutMs (): number {
   const n = Number(process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT)
 
@@ -13,9 +21,22 @@ function getTeardownTimeoutMs (): number {
   return Number.isFinite(n) && n > 0 ? n : 5000
 }
 
+function getDefaultStepTimeoutMs (): number {
+  return Math.max(1, Math.floor(getTeardownTimeoutMs() * STEP_BUDGET_FRACTION))
+}
+
+/**
+ * Bound for teardown work that waits on a process we do not control, so it settles well inside the
+ * step that shares its budget with the others rather than consuming that step whole.
+ */
+export function getPeerWaitTimeoutMs (): number {
+  return Math.max(1, Math.floor(getDefaultStepTimeoutMs() / 2))
+}
+
 export interface ExitStep {
   name: string
   fn: (code: number) => Promise<number | void> | void
+  timeoutMs?: number
 }
 
 export type ExitStepKey = string
@@ -32,6 +53,8 @@ export class GracefulExit {
   private teardownStartedAt: number | null = null
   private forceExitTimeout: NodeJS.Timeout | undefined
   private steps: Map<string, ExitStep> = new Map()
+  /** Names of steps that have started but not settled, so a blown budget can say what it was waiting on. */
+  private pendingSteps: Map<string, string> = new Map()
   private debug: Debug.Debugger
 
   /**
@@ -108,18 +131,23 @@ export class GracefulExit {
     inst.clearForceExitTimeout()
 
     inst.steps.clear()
+    inst.pendingSteps.clear()
     inst.processTeardown = null
     inst.teardownStartedAt = null
     GracefulExit.instance = null
   }
 
-  static addStep (teardownFn: ExitStep['fn'], stepName?: string): ExitStepKey {
+  /**
+   * @param timeoutMs bound for this step alone, for work whose result is worth less than a prompt exit;
+   * defaults to `STEP_BUDGET_FRACTION` of the teardown budget.
+   */
+  static addStep (teardownFn: ExitStep['fn'], stepName?: string, timeoutMs?: number): ExitStepKey {
     GracefulExit.singleton.debug('adding step to graceful exit: %s', stepName)
 
     const key = randomUUID()
     const name = stepName ?? teardownFn.name ?? key
 
-    GracefulExit.singleton.steps.set(key, { name, fn: teardownFn })
+    GracefulExit.singleton.steps.set(key, { name, fn: teardownFn, timeoutMs })
 
     return key
   }
@@ -129,21 +157,42 @@ export class GracefulExit {
   }
 
   static get isShuttingDown (): boolean {
-    return GracefulExit.singleton.processTeardown != null
+    // read from teardownStartedAt, not processTeardown: the first steps run before exitGracefully has
+    // finished assigning that promise, and a step that skips work on the way out has to see this
+    return GracefulExit.singleton.teardownStartedAt != null
   }
 
   private async flushSteps (code: number): Promise<void> {
-    await Promise.all(Array.from(this.steps.entries()).map(async ([key, { name, fn }]) => {
+    await Promise.all(Array.from(this.steps.entries()).map(async ([key, { name, fn, timeoutMs }]) => {
+      const startedAt = Date.now()
+      const budget = timeoutMs ?? getDefaultStepTimeoutMs()
+      let timer: NodeJS.Timeout | undefined
+
+      this.pendingSteps.set(key, name)
+
       try {
         this.debug(`<${key}> executing teardown step: %s`, name)
 
-        await fn(code)
+        const outcome = await Promise.race([
+          Promise.resolve(fn(code)).then(() => 'settled' as const),
+          new Promise<'timedOut'>((resolve) => {
+            timer = setTimeout(() => resolve('timedOut'), budget)
+          }),
+        ])
 
-        this.debug(`<${key}> teardown step completed: %s`, name)
+        if (outcome === 'timedOut') {
+          this.debug(`<${key}> teardown step abandoned after %dms: %s`, budget, name)
+          console.log(`The "${name}" teardown step did not finish within ${budget}ms. This does not affect the exit code (${code}).`)
+        } else {
+          this.debug(`<${key}> teardown step completed in %dms: %s`, Date.now() - startedAt, name)
+        }
       } catch (error) {
-        this.debug(`<${key}> Error executing teardown step: ${name}`, error)
+        this.debug(`<${key}> Error executing teardown step after ${Date.now() - startedAt}ms: ${name}`, error)
         console.log(`An error occurred during the "${name}" teardown step. This does not affect the exit code (${code}).`)
         console.log(error)
+      } finally {
+        clearTimeout(timer)
+        this.pendingSteps.delete(key)
       }
     }))
   }
@@ -166,6 +215,7 @@ export class GracefulExit {
       this.processTeardown = null
       this.teardownStartedAt = null
       this.steps.clear()
+      this.pendingSteps.clear()
       process.exit(code)
     }
   }
@@ -184,8 +234,10 @@ export class GracefulExit {
         exit.forceExitTimeout = setTimeout(() => {
           try {
             const ms = getTeardownTimeoutMs()
+            const pending = Array.from(new Set(exit.pendingSteps.values()))
+            const waitingOn = pending.length ? ` Still waiting on: ${pending.join(', ')}.` : ''
 
-            console.log(`Failed to gracefully exit after ${ms}ms. This does not affect the exit code (${code}).`)
+            console.log(`Failed to gracefully exit after ${ms}ms.${waitingOn} This does not affect the exit code (${code}).`)
           } catch (e) {
             console.log('Error forcing exit: ', e)
           } finally {

--- a/packages/server/lib/util/graceful-exit.ts
+++ b/packages/server/lib/util/graceful-exit.ts
@@ -25,12 +25,13 @@ function getDefaultStepTimeoutMs (): number {
   return Math.max(1, Math.floor(getTeardownTimeoutMs() * STEP_BUDGET_FRACTION))
 }
 
-/**
- * Bound for teardown work that waits on a process we do not control, so it settles well inside the
- * step that shares its budget with the others rather than consuming that step whole.
- */
+// Bound for teardown work that waits on a process we do not control, so it settles well inside the
+// step whose budget it shares. Kept equal to TEARDOWN_BUDGET_FRACTION in @packages/data-context
+// ProjectConfigManager, which bounds the other peer wait and cannot import from here.
+export const PEER_WAIT_BUDGET_FRACTION = 0.4
+
 export function getPeerWaitTimeoutMs (): number {
-  return Math.max(1, Math.floor(getDefaultStepTimeoutMs() / 2))
+  return Math.max(1, Math.floor(getTeardownTimeoutMs() * PEER_WAIT_BUDGET_FRACTION))
 }
 
 export interface ExitStep {
@@ -204,10 +205,7 @@ export class GracefulExit {
     }
   }
 
-  /**
-   * Cancels the bounds of steps still in flight. A step timer that outlives the teardown it belongs to
-   * settles that abandoned flush, whose `finally` then exits the process for real.
-   */
+  // A step timer outliving its teardown settles that abandoned flush, which then exits the process.
   private clearStepTimeouts (): void {
     for (const timer of this.stepTimeouts) {
       clearTimeout(timer)
@@ -254,6 +252,7 @@ export class GracefulExit {
             console.log('Error forcing exit: ', e)
           } finally {
             exit.clearForceExitTimeout()
+            exit.clearStepTimeouts()
             resolve()
             process.exit(code)
           }

--- a/packages/server/start-cypress.js
+++ b/packages/server/start-cypress.js
@@ -58,8 +58,6 @@ if (isRunningElectron) {
 
   telemetry.startSpan({ name: 'cypress', attachType: 'root', active: true, opts: { startTime: global.cypressBinaryStartTime } })
 
-  // The OTLP flush bounds itself at 10s (exporter) to 30s (batch processor) across up to 5 retries, so a
-  // slow collector would otherwise spend the whole exit budget. Dropped spans cost less than a late exit.
   GracefulExit.addStep(async (code) => {
     try {
       const span = telemetry.getSpan('cypress')

--- a/packages/server/start-cypress.js
+++ b/packages/server/start-cypress.js
@@ -4,7 +4,7 @@ const { telemetry, OTLPTraceExporterCloud } = require('@packages/telemetry')
 const { apiRoutes } = require('./lib/cloud/routes')
 const encryption = require('./lib/cloud/encryption')
 const { override: overrideTty } = require('./lib/util/tty')
-const { GracefulExit } = require('./lib/util/graceful-exit')
+const { GracefulExit, getPeerWaitTimeoutMs } = require('./lib/util/graceful-exit')
 const { NetProfiler } = require('./lib/util/net_profiler')
 const { debugElapsedTime } = require('./lib/util/performance_benchmark')
 const { suppress } = require('./lib/util/suppress_warnings')
@@ -12,8 +12,6 @@ const { suppress } = require('./lib/util/suppress_warnings')
 const { calculateCypressInternalEnv, configureLongStackTraces } = require('./lib/environment')
 
 const debug = Debug('cypress:server:start-cypress')
-
-const TELEMETRY_SHUTDOWN_TIMEOUT_MS = 1000
 
 process.env['CYPRESS_INTERNAL_ENV'] = calculateCypressInternalEnv()
 configureLongStackTraces(process.env['CYPRESS_INTERNAL_ENV'])
@@ -73,7 +71,7 @@ if (isRunningElectron) {
     } catch (error) {
       debug('Error during telemetry shutdown on exit: %o', error)
     }
-  }, 'finalize telemetry', TELEMETRY_SHUTDOWN_TIMEOUT_MS)
+  }, 'finalize telemetry', getPeerWaitTimeoutMs())
 
   const v8SnapshotSpan = telemetry.startSpan({ name: 'v8snapshot:startup', opts: { startTime: global.cypressServerStartTime } })
 

--- a/packages/server/start-cypress.js
+++ b/packages/server/start-cypress.js
@@ -13,6 +13,8 @@ const { calculateCypressInternalEnv, configureLongStackTraces } = require('./lib
 
 const debug = Debug('cypress:server:start-cypress')
 
+const TELEMETRY_SHUTDOWN_TIMEOUT_MS = 1000
+
 process.env['CYPRESS_INTERNAL_ENV'] = calculateCypressInternalEnv()
 configureLongStackTraces(process.env['CYPRESS_INTERNAL_ENV'])
 process.env['CYPRESS'] = 'true'
@@ -56,6 +58,8 @@ if (isRunningElectron) {
 
   telemetry.startSpan({ name: 'cypress', attachType: 'root', active: true, opts: { startTime: global.cypressBinaryStartTime } })
 
+  // The OTLP flush bounds itself at 10s (exporter) to 30s (batch processor) across up to 5 retries, so a
+  // slow collector would otherwise spend the whole exit budget. Dropped spans cost less than a late exit.
   GracefulExit.addStep(async (code) => {
     try {
       const span = telemetry.getSpan('cypress')
@@ -71,7 +75,7 @@ if (isRunningElectron) {
     } catch (error) {
       debug('Error during telemetry shutdown on exit: %o', error)
     }
-  }, 'finalize telemetry')
+  }, 'finalize telemetry', TELEMETRY_SHUTDOWN_TIMEOUT_MS)
 
   const v8SnapshotSpan = telemetry.startSpan({ name: 'v8snapshot:startup', opts: { startTime: global.cypressServerStartTime } })
 

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -474,10 +474,14 @@ describe('lib/browsers/index', () => {
 
       const startedAt = Date.now()
 
+      const removeAllListenersSpy = sinon.spy(browserInstance, 'removeAllListeners')
+
       await browsers.close({ timeoutMs: 50 })
 
       expect(Date.now() - startedAt).to.be.lessThan(1000)
       expect(browserInstance.kill).to.be.calledOnce
+      // the process is still alive, so its later events still need listeners
+      expect(removeAllListenersSpy).not.to.have.been.called
     })
 
     it('waits indefinitely when no timeoutMs is given', async () => {

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -484,6 +484,30 @@ describe('lib/browsers/index', () => {
       expect(removeAllListenersSpy).not.to.have.been.called
     })
 
+    it('waits indefinitely when timeoutMs is present but undefined', async () => {
+      const browserInstance = new EventEmitter() as BrowserInstance
+
+      browserInstance.kill = sinon.stub()
+
+      browsers._setInstance(browserInstance)
+
+      // open_project always passes the option object, so an absent bound arrives as an explicit
+      // undefined property; it has to keep waiting, the way a project switch relies on
+      let settled = false
+      const closed = browsers.close({ timeoutMs: undefined }).then(() => {
+        settled = true
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(settled).to.be.false
+
+      browserInstance.emit('exit')
+      await closed
+
+      expect(settled).to.be.true
+    })
+
     it('waits indefinitely when no timeoutMs is given', async () => {
       const browserInstance = new EventEmitter() as BrowserInstance
 

--- a/packages/server/test/unit/browsers/browsers_spec.ts
+++ b/packages/server/test/unit/browsers/browsers_spec.ts
@@ -463,6 +463,44 @@ describe('lib/browsers/index', () => {
         expect(browsers.getBrowserInstance()).to.eq(null)
       })
     })
+
+    it('stops waiting on a browser that never exits once timeoutMs elapses', async () => {
+      const browserInstance = new EventEmitter() as BrowserInstance
+
+      // never emits 'exit', as a browser whose process is slow to be reaped
+      browserInstance.kill = sinon.stub()
+
+      browsers._setInstance(browserInstance)
+
+      const startedAt = Date.now()
+
+      await browsers.close({ timeoutMs: 50 })
+
+      expect(Date.now() - startedAt).to.be.lessThan(1000)
+      expect(browserInstance.kill).to.be.calledOnce
+    })
+
+    it('waits indefinitely when no timeoutMs is given', async () => {
+      const browserInstance = new EventEmitter() as BrowserInstance
+
+      browserInstance.kill = sinon.stub()
+
+      browsers._setInstance(browserInstance)
+
+      let settled = false
+      const closed = browsers.close().then(() => {
+        settled = true
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(settled).to.be.false
+
+      browserInstance.emit('exit')
+      await closed
+
+      expect(settled).to.be.true
+    })
   })
 
   context('browserStatus', () => {

--- a/packages/server/test/unit/open_project_spec.ts
+++ b/packages/server/test/unit/open_project_spec.ts
@@ -6,6 +6,7 @@ import { openProject } from '../../lib/open_project'
 import preprocessor from '../../lib/plugins/preprocessor'
 import runEvents from '../../lib/plugins/run_events'
 import Fixtures from '@tooling/system-tests'
+import { GracefulExit } from '../../lib/util/graceful-exit'
 import delay from 'lodash/delay'
 
 const todosPath = Fixtures.projectPath('todos')
@@ -394,6 +395,37 @@ describe('lib/open_project', () => {
   })
 
   describe('#closeActiveProject', () => {
+    it('leaves the browser close unbounded when the process is not exiting', async function () {
+      sinon.stub(ProjectBase.prototype, 'close').resolves()
+      const closeBrowserStub = sinon.stub(browsers, 'close').resolves()
+
+      await openProject.closeActiveProject()
+
+      expect(closeBrowserStub).to.have.been.calledOnce
+      expect(closeBrowserStub.firstCall.args[0].timeoutMs, 'a project switch has to wait for the browser to really be gone').to.be.undefined
+    })
+
+    it('bounds the browser close when the process is exiting', async function () {
+      sinon.stub(ProjectBase.prototype, 'close').resolves()
+      const closeBrowserStub = sinon.stub(browsers, 'close').resolves()
+      const exitStub = sinon.stub(process, 'exit')
+
+      // exitGracefully flushes every registered step; drop the ones other specs left behind so this
+      // asserts on our own call
+      GracefulExit.resetForTesting()
+
+      // as a teardown step, the way it reaches this path in production (clearCtx -> ctx.destroy)
+      GracefulExit.addStep(() => openProject.closeActiveProject(), 'close project')
+
+      await GracefulExit.exitGracefully(0)
+
+      expect(closeBrowserStub).to.have.been.calledOnce
+      expect(closeBrowserStub.firstCall.args[0].timeoutMs, 'waiting on the browser unbounded spends the whole exit budget').to.be.a('number')
+
+      exitStub.restore()
+      GracefulExit.resetForTesting()
+    })
+
     it('awaits projectBase.close before resetting and closing the browser', async function () {
       let resolveClose
       const closePromise = new Promise((resolve) => {

--- a/packages/server/test/unit/open_project_spec.ts
+++ b/packages/server/test/unit/open_project_spec.ts
@@ -399,6 +399,9 @@ describe('lib/open_project', () => {
       sinon.stub(ProjectBase.prototype, 'close').resolves()
       const closeBrowserStub = sinon.stub(browsers, 'close').resolves()
 
+      // an earlier spec that stubbed process.exit can leave teardown marked as started
+      GracefulExit.resetForTesting()
+
       await openProject.closeActiveProject()
 
       expect(closeBrowserStub).to.have.been.calledOnce

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -315,31 +315,30 @@ describe('lib/util/graceful-exit', () => {
     const logStub = sinon.stub(console, 'log')
     const unhandled: unknown[] = []
     const onUnhandled = (reason: unknown) => unhandled.push(reason)
+
     // lib/unhandled_exceptions exits the process with code 1 on an unhandled rejection, which would
-    // overwrite a passing run's exit code; capture instead so a leak fails an assertion
-    const foreignListeners = process.listeners('unhandledRejection').slice()
+    // overwrite a passing run's exit code. Take the reports here instead, so a leak fails an
+    // assertion rather than killing the suite, and prepend so nothing else consumes them first.
+    process.prependListener('unhandledRejection', onUnhandled)
 
-    process.removeAllListeners('unhandledRejection')
-    process.on('unhandledRejection', onUnhandled)
+    try {
+      // rejects after its own bound expires, when flushSteps is no longer awaiting it
+      GracefulExit.addStep(() => new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error('late teardown failure')), 150)
+      }), 'rejects-after-its-bound')
 
-    // rejects after its own bound expires, when flushSteps is no longer awaiting it
-    GracefulExit.addStep(() => new Promise((_resolve, reject) => {
-      setTimeout(() => reject(new Error('late teardown failure')), 150)
-    }), 'rejects-after-its-bound')
+      await GracefulExit.exitGracefully(0)
 
-    await GracefulExit.exitGracefully(0)
-
-    await new Promise((r) => setTimeout(r, 300))
-
-    process.removeListener('unhandledRejection', onUnhandled)
-    foreignListeners.forEach((listener) => process.on('unhandledRejection', listener))
-    logStub.restore()
+      await new Promise((r) => setTimeout(r, 300))
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+      logStub.restore()
+      exitStub.restore()
+    }
 
     expect(unhandled, 'an abandoned step leaked an unhandled rejection').to.be.empty
     expect(exitStub).to.have.been.calledWith(0)
     expect(exitStub).not.to.have.been.calledWith(1)
-
-    exitStub.restore()
   })
 
   it('honors a step-specific timeout shorter than the shared budget', async function () {

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -40,6 +40,24 @@ describe('lib/util/graceful-exit', () => {
     expect(GracefulExit.isShuttingDown).to.be.false
   })
 
+  it('isShuttingDown is true for a step that reads it before its first await', async () => {
+    const exitStub = sinon.stub(process, 'exit')
+
+    let seenByStep: boolean | undefined
+
+    // exitGracefully starts the first step while it is still evaluating the Promise.race that assigns
+    // processTeardown, so anything a step reads before its first await sees no teardown in progress
+    GracefulExit.addStep(() => {
+      seenByStep = GracefulExit.isShuttingDown
+    }, 'reads-isShuttingDown-synchronously')
+
+    await GracefulExit.exitGracefully(0)
+
+    expect(seenByStep, 'a step cannot tell that the process is exiting').to.be.true
+
+    exitStub.restore()
+  })
+
   it('isShuttingDown is true while exitGracefully is in progress and false after teardown completes', async () => {
     const exitStub = sinon.stub(process, 'exit')
 

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -281,6 +281,31 @@ describe('lib/util/graceful-exit', () => {
     exitStub.restore()
   })
 
+  it('a reset cancels the step bounds of an in-flight teardown', async function () {
+    this.timeout(5000)
+
+    process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT = '200'
+
+    const exitStub = sinon.stub(process, 'exit')
+    const logStub = sinon.stub(console, 'log')
+
+    GracefulExit.addStep(() => new Promise(() => {}), 'hang')
+
+    void GracefulExit.exitGracefully(0)
+
+    GracefulExit.resetForTesting()
+
+    await new Promise((r) => setTimeout(r, 400))
+
+    logStub.restore()
+
+    // a step timer that outlives the reset settles the abandoned flush, and its `finally` exits the
+    // process for real once a spec restores the stub, taking the rest of the suite with it
+    expect(exitStub, 'a cancelled teardown still exited the process').not.to.have.been.called
+
+    exitStub.restore()
+  })
+
   it('does not leak an unhandled rejection when an abandoned step rejects later', async function () {
     this.timeout(5000)
 

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -281,6 +281,42 @@ describe('lib/util/graceful-exit', () => {
     exitStub.restore()
   })
 
+  it('does not leak an unhandled rejection when an abandoned step rejects later', async function () {
+    this.timeout(5000)
+
+    process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT = '100'
+
+    const exitStub = sinon.stub(process, 'exit')
+    const logStub = sinon.stub(console, 'log')
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => unhandled.push(reason)
+    // lib/unhandled_exceptions exits the process with code 1 on an unhandled rejection, which would
+    // overwrite a passing run's exit code; capture instead so a leak fails an assertion
+    const foreignListeners = process.listeners('unhandledRejection').slice()
+
+    process.removeAllListeners('unhandledRejection')
+    process.on('unhandledRejection', onUnhandled)
+
+    // rejects after its own bound expires, when flushSteps is no longer awaiting it
+    GracefulExit.addStep(() => new Promise((_resolve, reject) => {
+      setTimeout(() => reject(new Error('late teardown failure')), 150)
+    }), 'rejects-after-its-bound')
+
+    await GracefulExit.exitGracefully(0)
+
+    await new Promise((r) => setTimeout(r, 300))
+
+    process.removeListener('unhandledRejection', onUnhandled)
+    foreignListeners.forEach((listener) => process.on('unhandledRejection', listener))
+    logStub.restore()
+
+    expect(unhandled, 'an abandoned step leaked an unhandled rejection').to.be.empty
+    expect(exitStub).to.have.been.calledWith(0)
+    expect(exitStub).not.to.have.been.calledWith(1)
+
+    exitStub.restore()
+  })
+
   it('honors a step-specific timeout shorter than the shared budget', async function () {
     this.timeout(5000)
 

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -200,20 +200,94 @@ describe('lib/util/graceful-exit', () => {
     exitStub.restore()
   })
 
-  it('force exits with the requested code after teardown timeout when a step never completes', async function () {
+  it('force exits with the requested code and names the pending steps when the shared budget expires', async function () {
     this.timeout(5000)
 
     process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT = '50'
 
     const exitStub = sinon.stub(process, 'exit')
+    const logStub = sinon.stub(console, 'log')
 
-    GracefulExit.addStep(() => new Promise(() => {}), 'hang')
+    // a step timeout longer than the shared budget leaves the force-exit as the only way out
+    GracefulExit.addStep(() => new Promise(() => {}), 'hang', 10000)
 
     void GracefulExit.exitGracefully(0)
 
     await new Promise((r) => setTimeout(r, 200))
 
+    logStub.restore()
+
     expect(exitStub).to.have.been.calledWith(0)
+    expect(logStub.args.flat().join('\n')).to.contain('Still waiting on: hang')
+
+    exitStub.restore()
+  })
+
+  it('abandons a hung step on its own budget so the remaining steps still complete', async function () {
+    this.timeout(5000)
+
+    process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT = '1000'
+
+    const startedAt = Date.now()
+    let exitedAfter: number | undefined
+    const exitStub = sinon.stub(process, 'exit').callsFake(() => {
+      exitedAfter = exitedAfter ?? Date.now() - startedAt
+
+      return undefined as never
+    })
+    const logStub = sinon.stub(console, 'log')
+
+    let quickStepRan = false
+
+    GracefulExit.addStep(() => new Promise(() => {}), 'hang')
+    GracefulExit.addStep(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+      quickStepRan = true
+    }, 'quick')
+
+    void GracefulExit.exitGracefully(0)
+
+    await new Promise((r) => setTimeout(r, 1200))
+
+    logStub.restore()
+
+    const logged = logStub.args.flat().join('\n')
+
+    expect(quickStepRan, 'the quick step is not cut off by the hung one').to.be.true
+    // 0.8 of the 1000ms budget, so teardown settles before the shared force-exit timer can fire
+    expect(exitedAfter).to.be.within(800, 999)
+    expect(exitStub).to.have.been.calledWith(0)
+    expect(logged).to.contain('The "hang" teardown step did not finish within 800ms')
+    expect(logged).not.to.contain('Failed to gracefully exit')
+
+    exitStub.restore()
+  })
+
+  it('honors a step-specific timeout shorter than the shared budget', async function () {
+    this.timeout(5000)
+
+    process.env.CYPRESS_INTERNAL_TEARDOWN_TIMEOUT = '2000'
+
+    const startedAt = Date.now()
+    let exitedAfter: number | undefined
+    const exitStub = sinon.stub(process, 'exit').callsFake(() => {
+      exitedAfter = exitedAfter ?? Date.now() - startedAt
+
+      return undefined as never
+    })
+    const logStub = sinon.stub(console, 'log')
+
+    GracefulExit.addStep(() => new Promise(() => {}), 'best-effort', 100)
+
+    void GracefulExit.exitGracefully(0)
+
+    await new Promise((r) => setTimeout(r, 500))
+
+    logStub.restore()
+
+    expect(exitedAfter).to.be.within(100, 400)
+    expect(exitStub).to.have.been.calledWith(0)
+    expect(logStub.args.flat().join('\n')).to.contain('The "best-effort" teardown step did not finish within 100ms')
 
     exitStub.restore()
   })

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -128,8 +128,9 @@ export const replaceStackTraceLines = (str: string, browserName: 'electron' | 'f
   })
 }
 
-// Notices printed when a teardown step, or the whole teardown, outruns its budget.
-export const teardownBudgetNoticeRe = /^(?:Failed to gracefully exit after|The ".*" teardown step did not finish within).*\n?/gm
+// Notices printed when a teardown step, or the whole teardown, outruns its budget. A fresh regex per
+// call so the `g` flag's lastIndex is never shared between callers.
+export const teardownBudgetNoticeRe = () => /^(?:Failed to gracefully exit after|The ".*" teardown step did not finish within).*\n?/gm
 
 export const normalizeStdout = function (str: string, options: any = {}) {
   const { normalizeStdoutAvailableBrowsers } = options
@@ -191,7 +192,7 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   // Teardown exceeding its budget is a property of the machine, not the run, so these lines come
   // and go with CI load. The exit code the harness asserts is what matters here. `system-tests.ts`
   // tallies them so the trend stays visible without being able to fail a snapshot.
-  .replace(teardownBudgetNoticeRe, '')
+  .replace(teardownBudgetNoticeRe(), '')
   // Strip the Electron deprecation warning so run-mode snapshots don't need to capture it
   .replace(electronDeprecationWarningRe, '')
   // Strip the forceHttp1 deprecation warning so run-mode snapshots don't need to capture it

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -128,6 +128,9 @@ export const replaceStackTraceLines = (str: string, browserName: 'electron' | 'f
   })
 }
 
+/** Notices printed when a teardown step, or the whole teardown, outruns its budget. */
+export const teardownBudgetNoticeRe = /^(?:Failed to gracefully exit after|The ".*" teardown step did not finish within).*\n?/gm
+
 export const normalizeStdout = function (str: string, options: any = {}) {
   const { normalizeStdoutAvailableBrowsers } = options
 
@@ -185,9 +188,10 @@ export const normalizeStdout = function (str: string, options: any = {}) {
   .replace(crossOriginErrorRe, '[Cross origin error message]')
   // Replaces connection warning since Chrome or Firefox sometimes take longer to connect
   .replace(/Still waiting to connect to .+, retrying in 1 second \(attempt .+\/.+\)\n/g, '')
-  // Teardown exceeding its budget is a property of the machine, not the run, so this line comes
-  // and goes with CI load. The exit code the harness asserts is what matters here.
-  .replace(/^Failed to gracefully exit after .*\n?/gm, '')
+  // Teardown exceeding its budget is a property of the machine, not the run, so these lines come
+  // and go with CI load. The exit code the harness asserts is what matters here. `system-tests.ts`
+  // tallies them so the trend stays visible without being able to fail a snapshot.
+  .replace(teardownBudgetNoticeRe, '')
   // Strip the Electron deprecation warning so run-mode snapshots don't need to capture it
   .replace(electronDeprecationWarningRe, '')
   // Strip the forceHttp1 deprecation warning so run-mode snapshots don't need to capture it

--- a/system-tests/lib/normalizeStdout.ts
+++ b/system-tests/lib/normalizeStdout.ts
@@ -128,7 +128,7 @@ export const replaceStackTraceLines = (str: string, browserName: 'electron' | 'f
   })
 }
 
-/** Notices printed when a teardown step, or the whole teardown, outruns its budget. */
+// Notices printed when a teardown step, or the whole teardown, outruns its budget.
 export const teardownBudgetNoticeRe = /^(?:Failed to gracefully exit after|The ".*" teardown step did not finish within).*\n?/gm
 
 export const normalizeStdout = function (str: string, options: any = {}) {

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -14,6 +14,7 @@ import {
   pathUpToProjectName,
   normalizeStdout,
   browserNameVersionRe,
+  teardownBudgetNoticeRe,
 } from './normalizeStdout'
 
 const isCi = require('ci-info').isCI
@@ -570,6 +571,31 @@ cp = Bluebird.promisifyAll(cp)
 
 const processEnvCache = _.clone(process.env)
 
+// The budget notices are stripped from snapshots (see normalizeStdout) because whether teardown fits in
+// its budget depends on how loaded the machine is, not on the run. Tally them here so the trend stays
+// visible in the job output, and so a root-cause fix can be told apart from a quiet machine.
+const teardownBudget = { runs: 0, runsOverBudget: 0, notices: 0 }
+
+const recordTeardownBudget = (output: string) => {
+  const notices = output.match(teardownBudgetNoticeRe)
+
+  teardownBudget.runs++
+
+  if (notices) {
+    teardownBudget.runsOverBudget++
+    teardownBudget.notices += notices.length
+  }
+}
+
+process.on('exit', () => {
+  if (!teardownBudget.runs) {
+    return
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`[teardown-budget] exceeded in ${teardownBudget.runsOverBudget} of ${teardownBudget.runs} Cypress runs (${teardownBudget.notices} process notices)`)
+})
+
 Bluebird.config({
   longStackTraces: true,
 })
@@ -1053,6 +1079,8 @@ const systemTests = {
     let stderr = ''
 
     const exit = function (code: number | null, signal: NodeJS.Signals | null | undefined) {
+      recordTeardownBudget(stdout)
+
       if (interruptRequested) {
         return {
           code,

--- a/system-tests/lib/system-tests.ts
+++ b/system-tests/lib/system-tests.ts
@@ -577,7 +577,7 @@ const processEnvCache = _.clone(process.env)
 const teardownBudget = { runs: 0, runsOverBudget: 0, notices: 0 }
 
 const recordTeardownBudget = (output: string) => {
-  const notices = output.match(teardownBudgetNoticeRe)
+  const notices = output.match(teardownBudgetNoticeRe())
 
   teardownBudget.runs++
 
@@ -1079,8 +1079,6 @@ const systemTests = {
     let stderr = ''
 
     const exit = function (code: number | null, signal: NodeJS.Signals | null | undefined) {
-      recordTeardownBudget(stdout)
-
       if (interruptRequested) {
         return {
           code,
@@ -1089,6 +1087,8 @@ const systemTests = {
           stderr,
         }
       }
+
+      recordTeardownBudget(stdout)
 
       const { expectedExitCode, skipExitSignalAssertion } = options
 


### PR DESCRIPTION
- Closes n/a

### Additional details

Follow-up to #34686. That PR stopped a slow or failing shutdown from rewriting the exit code, which was producing the long-running `Process errored: Exit code 1: expected 1 to equal +0` system-test flake immediately after `All specs passed!`. It deliberately did not explain *why* shutdown was slow. This PR bounds the waits that made it slow.

**What was actually blocking.** `browsers.kill()` waited on the browser instance's `exit` event with no timeout at all. That wait sits inside the `clear data context` teardown step — `ctx.destroy()` → `clearCurrentProject()` → `openProject.closeActiveProject()` → `closeBrowser()` — and `clear data context` is the one step that owned the entire 5s graceful-exit budget. Probing each sub-phase under load on the 15.x lineage: `destroyGqlServer` 1ms, `lifecycleManager.destroy` 0ms, `cloud.reset` 0ms, `dev.dispose` 0ms, `projectBase.close` 2ms, and `closeBrowser` 905ms / 3548ms / over 4000ms. Idle it is ~60ms, which is why it never showed up on a quiet machine.

**Three changes, all bounding a wait rather than raising the budget:**

- `GracefulExit` bounds each step at `STEP_BUDGET_FRACTION` (0.8) of the teardown budget, so one stalled step cannot spend the whole thing. This matters beyond exit latency: when the shared force-exit fired, its `process.exit()` cut off every step still pending, including `unlock lockfile`, whose lockfile in the OS temp dir outlives the process and costs the next run a 2s wait on `lockFile.lockAsync`. Step durations are now in the debug log, and both timeout notices name the step, so the next occurrence says what it was waiting on rather than only that teardown was slow.
- `browsers.kill()` takes an optional `timeoutMs`. Only the teardown path passes one (`getPeerWaitTimeoutMs()`, 0.4 of the budget); every other caller — launch retry in run mode, testing-type switch in open mode — keeps waiting as before, because those genuinely need the profile directory and port released. When the bound is hit the listeners stay attached, since the process is still alive and its later `exit` and `error` events still need somewhere to go. The browser has already been signalled, and `process.once('exit', ...)` in `browsers/index.ts` is still a backstop, so nothing leaks.
- `finalize telemetry` gets a 1s bound of its own. The OTLP flush bounds itself at 10s (`DEFAULT_TRACE_TIMEOUT` in the exporter) to 30s (`OTEL_BSP_EXPORT_TIMEOUT` in `BatchSpanProcessor`) across up to 5 retries — 2 to 6 times the exit budget — so a slow collector could spend the whole thing on its own. This only bites in the jobs that enable telemetry (driver e2e and package CT on internal PRs, RWA); it is a no-op in system tests, where `ProjectConfigIpc.forkConfigProcess` strips `CYPRESS_INTERNAL_ENABLE_TELEMETRY` from the config child.

**Detection.** The budget notices are stripped from snapshots (added in #34686, extended here to cover the new step notice) because whether teardown fits its budget depends on machine load, not on the run — so they only appeared in raw CircleCI output that nobody reads. `system-tests/lib/system-tests.ts` now tallies them and prints `[teardown-budget] exceeded in N of M Cypress runs` at process exit. Non-blocking on purpose: making it fail the build would reintroduce exactly the machine-dependent flakiness the normalization was added to remove.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process shutdown timing and browser-close behavior during exit; mis-tuned bounds could leave browsers or lockfiles lingering, though exit codes stay unchanged by design.
> 
> **Overview**
> Follow-up to exit-code cleanup: shutdown could still stall when one teardown step waited forever on another process (especially **browser close** inside `clear data context`).
> 
> **Graceful exit** now caps each registered step at ~80% of `CYPRESS_INTERNAL_TEARDOWN_TIMEOUT` (default 5s). A step that overruns is abandoned, logged by name, and does not block other steps or change the exit code. Force-exit messaging lists steps still pending. `isShuttingDown` is true as soon as teardown starts (including before the first `await` in a step).
> 
> **Browser kill** accepts optional `timeoutMs`: on process exit, `closeActiveProject` passes `getPeerWaitTimeoutMs()` (~40% of the budget); project switches still wait unbounded. When the bound fires, Cypress stops awaiting `exit` but leaves listeners on the live process.
> 
> **Telemetry** finalization uses the same peer-wait bound so OTLP flush cannot consume the whole budget.
> 
> System tests strip the new console notices from snapshots and print a **`[teardown-budget]`** tally at the end of the harness run for visibility without flaky failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a33e3fa40e105de93d70b3d26fe71003c376da69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





### Steps to test

Per-step bound and diagnostics, deterministic:

```
yarn workspace @packages/server test-unit -- util/graceful_exit_spec
yarn workspace @packages/server test-unit -- browsers/browsers_spec
```

The tally, end to end. A healthy run reports zero:

```
yarn workspace @tooling/system-tests test:ci test/clean_process_exit_spec.ts test/config_modules_spec.ts test/deprecated_spec.ts
```

ends with `[teardown-budget] exceeded in 0 of 28 Cypress runs (0 process notices)`.

Forcing every run over budget still leaves snapshots green and exit codes correct, which is the property that keeps the notice from flaking the build:

```
CYPRESS_INTERNAL_TEARDOWN_TIMEOUT=2 yarn workspace @tooling/system-tests test:ci test/deprecated_spec.ts
```

passes 12/12 and reports `[teardown-budget] exceeded in 12 of 12 Cypress runs`.

To watch the bound actually fire, run a real-browser system test in a loop against roughly 48 busy-loop processes with `DEBUG='cypress:server:graceful-exit:*,cypress:data-context'` and read the `teardown step completed in Nms` / `teardown step abandoned after Nms` lines.

### How has the user experience changed?

No visual change. Behaviorally, in `cypress run`: a cleanup step that stalls is abandoned on its own bound instead of holding up the rest of shutdown, and the run output names it — `The "clear data context" teardown step did not finish within 4000ms. This does not affect the exit code (0).` If the shared budget expires anyway, the existing notice now names what it was waiting on: `Failed to gracefully exit after 5000ms. Still waiting on: clear data context. This does not affect the exit code (0).` Neither line affects the exit code.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Follow-up on the root cause behind #34686; the flake was tracked through the CircleCI flaky-test aggregate rather than a GitHub issue. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
