### PR TITLE
fix: fire after:run when a project is closed in global open mode

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,6 +39,7 @@
 **Bugfixes:**
 
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
+- Switching projects in `cypress open` no longer hangs when [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled and the project registers an [`after:run`](https://on.cypress.io/after-run-api) or [`after:spec`](https://on.cypress.io/after-spec-api) handler. Addressed in [#34689](https://github.com/cypress-io/cypress/pull/34689).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,7 +39,7 @@
 **Bugfixes:**
 
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
-- When [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled, the [`after:run`](https://on.cypress.io/after-run-api) handler now runs when a project is closed in `cypress open`, as documented. Previously it never ran. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
+- Fixed an issue where the [`after:run`](https://on.cypress.io/after-run-api) event handler would not run when a project was closed in `cypress open` mode and [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) was set. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,7 +39,7 @@
 **Bugfixes:**
 
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
-- Switching projects in `cypress open` no longer hangs when [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled and the project registers an [`after:run`](https://on.cypress.io/after-run-api) or [`after:spec`](https://on.cypress.io/after-spec-api) handler. Addressed in [#34689](https://github.com/cypress-io/cypress/pull/34689).
+- Switching projects in `cypress open` no longer hangs when [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled and the project registers an [`after:run`](https://on.cypress.io/after-run-api) or [`after:spec`](https://on.cypress.io/after-spec-api) handler. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
 
 **Dependency Updates:**
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,7 +39,7 @@
 **Bugfixes:**
 
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
-- Switching projects in `cypress open` no longer hangs when [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled and the project registers an [`after:run`](https://on.cypress.io/after-run-api) or [`after:spec`](https://on.cypress.io/after-spec-api) handler. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
+- When [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) is enabled, the [`after:run`](https://on.cypress.io/after-run-api) handler now runs when a project is closed in `cypress open`, as documented. Previously it never ran. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
 
 **Dependency Updates:**
 

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -125,9 +125,12 @@ export class ProjectActions {
     // Also clear any data associated with the linked cloud project
     this.ctx.actions.cloudProject.clearCloudProject()
 
-    await this.ctx.lifecycleManager.clearCurrentProject()
-    resetIssuedWarnings()
+    // Close the project before tearing down the lifecycle: `after:run` is dispatched
+    // from the project server's close, and the config manager owns the plugins process
+    // that has to answer it.
     await this.api.closeActiveProject()
+    resetIssuedWarnings()
+    await this.ctx.lifecycleManager.clearCurrentProject()
   }
 
   private set projects (projects: ProjectShape[]) {

--- a/packages/data-context/src/actions/ProjectActions.ts
+++ b/packages/data-context/src/actions/ProjectActions.ts
@@ -129,8 +129,8 @@ export class ProjectActions {
     // from the project server's close, and the config manager owns the plugins process
     // that has to answer it.
     await this.api.closeActiveProject()
-    resetIssuedWarnings()
     await this.ctx.lifecycleManager.clearCurrentProject()
+    resetIssuedWarnings()
   }
 
   private set projects (projects: ProjectShape[]) {

--- a/packages/data-context/src/data/ProjectConfigManager.ts
+++ b/packages/data-context/src/data/ProjectConfigManager.ts
@@ -174,9 +174,7 @@ export class ProjectConfigManager {
       return loadConfigReply.initialConfig
     } catch (error) {
       debug(`catch %o`, error)
-      if (this._eventsIpc) {
-        this._eventsIpc.cleanupIpc()
-      }
+      this.cleanupEventsIpc()
 
       this._state = 'errored'
       await this.closeWatchers()
@@ -295,9 +293,7 @@ export class ProjectConfigManager {
     } catch (error) {
       debug(`catch setupNodeEvents %o`, error)
       this._state = 'errored'
-      if (this._eventsIpc) {
-        this._eventsIpc.cleanupIpc()
-      }
+      this.cleanupEventsIpc()
 
       await this.closeWatchers()
 
@@ -399,9 +395,7 @@ export class ProjectConfigManager {
   private loadConfig () {
     if (!this._loadConfigPromise) {
       // If there's already a dangling IPC from the previous switch of testing type, we want to clean this up
-      if (this._eventsIpc) {
-        this._eventsIpc.cleanupIpc()
-      }
+      this.cleanupEventsIpc()
 
       this._eventsIpc = new ProjectConfigIpc(
         this.options.ctx.coreData.app.nodePath,
@@ -704,15 +698,22 @@ export class ProjectConfigManager {
     this._pathToWatcherRecord = {}
   }
 
-  async destroy () {
+  /**
+   * Every registered handler resolves off a reply from the events ipc, and that reply has
+   * no timeout. Handlers must never outlive the ipc they are bound to, or a later
+   * `after:run`/`after:spec` awaits a reply that can never arrive.
+   */
+  private cleanupEventsIpc () {
     if (this._eventsIpc) {
       this._eventsIpc.cleanupIpc()
     }
 
-    // Every registered handler resolves off a reply from the ipc killed above, and that
-    // reply has no timeout. Leaving them registered means a later `after:run`/`after:spec`
-    // awaits a reply that can never arrive.
     this.options.eventRegistrar.reset()
+  }
+
+  async destroy () {
+    this.cleanupEventsIpc()
+    this._eventsIpc = undefined
 
     this._state = 'pending'
     this._cachedLoadConfig = undefined

--- a/packages/data-context/src/data/ProjectConfigManager.ts
+++ b/packages/data-context/src/data/ProjectConfigManager.ts
@@ -709,6 +709,11 @@ export class ProjectConfigManager {
       this._eventsIpc.cleanupIpc()
     }
 
+    // Every registered handler resolves off a reply from the ipc killed above, and that
+    // reply has no timeout. Leaving them registered means a later `after:run`/`after:spec`
+    // awaits a reply that can never arrive.
+    this.options.eventRegistrar.reset()
+
     this._state = 'pending'
     this._cachedLoadConfig = undefined
     this._cachedFullConfig = undefined

--- a/packages/data-context/test/unit/actions/ProjectActions.spec.ts
+++ b/packages/data-context/test/unit/actions/ProjectActions.spec.ts
@@ -315,4 +315,24 @@ describe('ProjectActions', () => {
       expect(ctx._apis.projectApi.routeToDebug).toHaveBeenCalled()
     })
   })
+
+  describe('clearCurrentProject', () => {
+    // `after:run` is dispatched from the project server's close and has to be answered by
+    // the plugins process the config manager owns, so the project must close first
+    it('closes the active project before tearing down the lifecycle', async () => {
+      const calls: string[] = []
+
+      ;(ctx._apis.projectApi.closeActiveProject as jest.Mock).mockImplementation(async () => {
+        calls.push('closeActiveProject')
+      })
+
+      jest.spyOn(ctx.lifecycleManager, 'clearCurrentProject').mockImplementation(async () => {
+        calls.push('lifecycleManager.clearCurrentProject')
+      })
+
+      await actions.clearCurrentProject()
+
+      expect(calls).toEqual(['closeActiveProject', 'lifecycleManager.clearCurrentProject'])
+    })
+  })
 })

--- a/packages/data-context/test/unit/actions/ProjectActions.spec.ts
+++ b/packages/data-context/test/unit/actions/ProjectActions.spec.ts
@@ -322,17 +322,25 @@ describe('ProjectActions', () => {
     it('closes the active project before tearing down the lifecycle', async () => {
       const calls: string[] = []
 
+      // closeActiveProject yields before resolving, so running the two concurrently would
+      // interleave the markers rather than just reordering them
       ;(ctx._apis.projectApi.closeActiveProject as jest.Mock).mockImplementation(async () => {
-        calls.push('closeActiveProject')
+        calls.push('closeActiveProject:start')
+        await new Promise((resolve) => setImmediate(resolve))
+        calls.push('closeActiveProject:end')
       })
 
       jest.spyOn(ctx.lifecycleManager, 'clearCurrentProject').mockImplementation(async () => {
-        calls.push('lifecycleManager.clearCurrentProject')
+        calls.push('clearCurrentProject:start')
       })
 
       await actions.clearCurrentProject()
 
-      expect(calls).toEqual(['closeActiveProject', 'lifecycleManager.clearCurrentProject'])
+      expect(calls).toEqual([
+        'closeActiveProject:start',
+        'closeActiveProject:end',
+        'clearCurrentProject:start',
+      ])
     })
   })
 })

--- a/packages/data-context/test/unit/data/ProjectConfigManager.spec.ts
+++ b/packages/data-context/test/unit/data/ProjectConfigManager.spec.ts
@@ -4,10 +4,13 @@ import { ProjectConfigManager } from '../../../src/data/ProjectConfigManager'
 import { EventRegistrar } from '../../../src/data/EventRegistrar'
 
 let configManager: ProjectConfigManager
+let eventRegistrar: EventRegistrar
 
 describe('ProjectConfigManager', () => {
   beforeEach(() => {
     const ctx = createTestDataContext('open')
+
+    eventRegistrar = new EventRegistrar()
 
     configManager = new ProjectConfigManager({
       ctx,
@@ -15,7 +18,7 @@ describe('ProjectConfigManager', () => {
       projectRoot: 'test/root',
       handlers: [],
       hasCypressEnvFile: false,
-      eventRegistrar: new EventRegistrar(),
+      eventRegistrar,
       onError: (error) => {},
       onInitialConfigLoaded: () => {},
       onFinalConfigLoaded: () => Promise.resolve(),
@@ -68,6 +71,22 @@ describe('ProjectConfigManager', () => {
       await expect(configManager.mainProcessWillDisconnect()).rejects.toThrow('timed out')
 
       expect(Date.now() - started).toBeLessThan(2000)
+    })
+  })
+
+  describe('#destroy', () => {
+    it('unregisters plugin events bound to the ipc it kills', async () => {
+      const configManagerInternals = configManager as any
+
+      configManagerInternals._eventsIpc = { cleanupIpc: () => {} }
+
+      eventRegistrar.registerEvent('after:run', () => new Promise(() => {}))
+
+      expect(eventRegistrar.hasNodeEvent('after:run')).toBe(true)
+
+      await configManager.destroy()
+
+      expect(eventRegistrar.hasNodeEvent('after:run')).toBe(false)
     })
   })
 

--- a/packages/data-context/test/unit/data/ProjectConfigManager.spec.ts
+++ b/packages/data-context/test/unit/data/ProjectConfigManager.spec.ts
@@ -77,14 +77,30 @@ describe('ProjectConfigManager', () => {
   describe('#destroy', () => {
     it('unregisters plugin events bound to the ipc it kills', async () => {
       const configManagerInternals = configManager as any
+      let cleanedUp = false
 
-      configManagerInternals._eventsIpc = { cleanupIpc: () => {} }
+      configManagerInternals._eventsIpc = {
+        cleanupIpc: () => {
+          cleanedUp = true
+        },
+      }
 
-      eventRegistrar.registerEvent('after:run', () => new Promise(() => {}))
+      eventRegistrar.registerEvent('after:run', () => {})
 
       expect(eventRegistrar.hasNodeEvent('after:run')).toBe(true)
 
       await configManager.destroy()
+
+      expect(cleanedUp).toBe(true)
+      expect(eventRegistrar.hasNodeEvent('after:run')).toBe(false)
+      // the killed ipc must not be reachable afterwards
+      expect(configManager.eventProcessPid).toBeUndefined()
+    })
+
+    it('does not throw when there is no ipc', async () => {
+      eventRegistrar.registerEvent('after:run', () => {})
+
+      await expect(configManager.destroy()).resolves.toBeUndefined()
 
       expect(eventRegistrar.hasNodeEvent('after:run')).toBe(false)
     })


### PR DESCRIPTION
### Additional details

[The docs for `after:run`](https://docs.cypress.io/api/plugins/after-run-api) state that with [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) enabled, "When running cypress via `cypress open`, the event will fire when closing a project." It never did.

`ProjectActions.clearCurrentProject()` — the action behind the "back to projects" button in the global-mode header — tore down the lifecycle before closing the project. `lifecycleManager.clearCurrentProject()` destroys the config manager, which kills the plugins process, and `after:run` is dispatched later, from `ProjectBase.close()`. So the dispatch always went to a dead ipc. Because the reply to an `execute:plugins` message deliberately has no timeout, the returned promise never settled: the user's handler never ran, and teardown never completed.

This PR makes two changes:

1. **`ProjectActions.clearCurrentProject()` closes the active project before tearing down the lifecycle**, so the plugins process is still alive to answer `after:run`. This is what restores the documented behavior.
2. **`ProjectConfigManager.destroy()` resets the event registrar** alongside the `cleanupIpc()` that invalidates those handlers. Every registered handler resolves off a reply from that ipc, so they must not outlive it. This is the safety net for every other teardown path — notably `DataContext.reinitializeCypress()`, which runs `lifecycleManager.destroy()` and `clearCurrentProject()` concurrently, so ordering alone cannot save it there.

Both are needed. The reorder alone still hangs on the concurrent `reinitializeCypress` path; the registrar reset alone turns the hang into a silent no-op without firing the handler.

The `reinitializeCypress` path is what the `@packages/app` e2e suite hits between specs, where this surfaced as a flaky `` cy.task('__internal__beforeEach') timed out after waiting 10000ms `` in a `"before each" hook` ([example](https://app.circleci.com/pipelines/github/cypress-io/cypress/86041/workflows/d24c939f-50c3-4cba-a70e-3e8326b1370a/jobs/3954388)). It hit whichever spec followed `runner/pluginEvents.cy.ts` in a parallel container — that fixture project (`system-tests/projects/plugin-run-events`) is the one that leaves an `after:run` handler registered with `experimentalInteractiveRunEvents: true`. The hang became fatal rather than silent once [#34275](https://github.com/cypress-io/cypress/pull/34275) changed `closeOpenProjectAndBrowsers` to `await this.projectBase?.close()`.

Note `results` is `undefined` for `after:run` in interactive mode, which is already documented and unchanged here — handlers that destructure it will now see that, since the event actually fires.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive project teardown and plugin IPC/event registration order; wrong ordering could regress open-mode shutdown or leave stale handlers, but scope is narrow with targeted unit tests.
> 
> **Overview**
> Fixes **`after:run` not running** (and teardown hanging) when you close a project in **`cypress open`** with **`experimentalInteractiveRunEvents`** enabled.
> 
> **`ProjectActions.clearCurrentProject()`** now **`await`s `closeActiveProject()` before** `lifecycleManager.clearCurrentProject()`, so the project server can dispatch **`after:run`** while the plugins IPC process is still alive instead of after the config manager has already killed it.
> 
> **`ProjectConfigManager`** centralizes IPC teardown in **`cleanupEventsIpc()`**, which **`cleanupIpc()`s and resets the event registrar** so handlers do not wait forever on a dead IPC (e.g. concurrent **`reinitializeCypress`** teardown). **`destroy()`** uses that helper and clears **`_eventsIpc`**.
> 
> Changelog and unit tests cover close ordering and registrar cleanup on destroy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4048c6fd20d30b471e1e7a799c68cdfcf737805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

Two unit tests cover the change; each fails without its corresponding fix:

```
yarn workspace @packages/data-context test -- test/unit/actions/ProjectActions.spec.ts
```

```
yarn workspace @packages/data-context test -- test/unit/data/ProjectConfigManager.spec.ts
```

To confirm `after:run` really reaches user code (verified manually — see below), add a file write to the open-mode branch of the `after:run` handler in `system-tests/projects/plugin-run-events/cypress.config.js`, then in an app e2e spec open that project, run a spec, call `ctx.actions.project.clearCurrentProject()` via `cy.withCtx`, and assert the file exists. It does not exist on `develop` and does with this change.

That probe is deliberately not committed: closing a project mid-spec leaves residue that breaks the *next* spec file in the same run (the inner spec file goes missing — `Module not found ... simple-fail.retries.mochaEvents.cy.js`). Committing it would introduce a new cross-spec flake of exactly the kind this PR fixes, so the committed coverage is the deterministic unit tests instead. Worth a follow-up to make cy-in-cy project-close teardown safe for a following spec.

For the original flake, this pairs the two specs the way the CI container ordered them — 5/5 failures before, 0/5 after:

```
cd packages/app && yarn cypress:run:e2e --browser chrome --spec "cypress/e2e/runner/pluginEvents.cy.ts,cypress/e2e/runner/retries.mochaEvents.cy.ts"
```

`runner/retries.mochaEvents.cy.ts` passes in isolation either way — the preceding spec is what sets up the hang.

### How has the user experience changed?

With `experimentalInteractiveRunEvents` enabled, closing a project in `cypress open` now runs the `after:run` handler as documented, instead of hanging teardown and never running it. No visual change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Found while investigating a CI flake in the `app-e2e` job; no user-reported issue. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Documented behavior already matches; this makes the implementation match the docs. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
