### PR TITLE
chore: update cypress-example-kitchensink to 6.1.0

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -14,7 +14,7 @@
     "test-unit": "echo 'no unit tests'"
   },
   "devDependencies": {
-    "cypress-example-kitchensink": "6.0.3",
+    "cypress-example-kitchensink": "6.1.0",
     "gh-pages": "5.0.0",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14742,10 +14742,10 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-cypress-example-kitchensink@6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-6.0.3.tgz#159085f0a6f0a555c64e81b27d190fecabc4f1b8"
-  integrity sha512-OPDAm8+mJd0b5HnUbB3eSekoQzDAD+N84BRFpuRdCWOPJtbnpb1rzdXCvJK/jD5wwRmqwjZZMIPD3/lWeByt4Q==
+cypress-example-kitchensink@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cypress-example-kitchensink/-/cypress-example-kitchensink-6.1.0.tgz#3e697649228947077362ca94191ce5c01132f2c8"
+  integrity sha512-eNkXeuG9Y9+2EfPkjYevIghqj0hxFot5NHczNNmnZXcaG+J+BaPUgiN9Zm348W4GsxF6ZGScqyks8R0+g5CkVQ==
   dependencies:
     npm-run-all2 "8.0.4"
     serve "14.2.6"


### PR DESCRIPTION
- Closes N/A — release-day checklist item on #33529 (mechanical dependency bump)

### Additional details

Bumps `cypress-example-kitchensink` in `packages/example` from `6.0.3` to `6.1.0` and refreshes the lockfile. The scaffolded example specs that `cypress open` creates in a new project are vendored from this package, and [v6.1.0](https://github.com/cypress-io/cypress-example-kitchensink/releases/tag/v6.1.0) carries the Cypress 16 scaffold changes — it removes the `cy.exec()` example (cypress-io/cypress-example-kitchensink#1189), the companion to the `cy.exec()` removal in #34697. Without this bump, a Cypress 16 binary would scaffold an `exec.cy.js` that calls a removed command.

Safe to land ahead of #34697: a scaffold that merely lacks the exec example breaks nothing on current `develop`. This covers the "Ensure kitchensink is built (there are changes to our scaffolded tests!)" item on the release-day checklist.

Part of the Cypress 16 release-day checklist: cypress-io/cypress#33529

### Steps to test

CI's binary build + `test-kitchensink` jobs exercise the vendored examples. To check locally: build the binary, scaffold a new project with `cypress open`, and confirm the examples include no `exec.cy.js`.

### How has the user experience changed?

Newly scaffolded example specs no longer include the `cy.exec()` example. No other change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical dependency bump from the release-day checklist on #33529 -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical devDependency and lockfile-only change in the example package; no runtime Cypress product code paths are modified in this diff.
> 
> **Overview**
> **Bumps** `cypress-example-kitchensink` in `@packages/example` from **6.0.3** to **6.1.0** and updates `yarn.lock`.
> 
> That version carries the Cypress 16 scaffold updates (including dropping the `cy.exec()` example), so after the usual `yarn build` on this package, newly scaffolded example specs stay aligned with `cy.exec()` removal in Cypress 16 instead of shipping an `exec.cy.js` that calls a removed command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef08ef20746ef26483a09fccb140923121b60265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->