### PR TITLE
chore: give the downloads system test headroom under its correlation canary

### DIFF
--- a/system-tests/projects/downloads/cypress/e2e/downloads.cy.ts
+++ b/system-tests/projects/downloads/cypress/e2e/downloads.cy.ts
@@ -8,25 +8,22 @@ describe('downloads', () => {
   it('handles csv file download', () => {
     cy.get('[data-cy=download-csv]').click()
     cy
-    // Note that this timeout is less than the proxy correlation timeout. It needs to be less than that timeout
-    // to ensure that we don't paper over a bug in the proxy correlation logic.
-    .readFile(`${Cypress.config('downloadsFolder')}/records.csv`, { timeout: 1000 })
+    // Must stay under the 2000ms proxy correlation timeout, or a correlation bug passes unnoticed.
+    .readFile(`${Cypress.config('downloadsFolder')}/records.csv`, { timeout: 1500 })
     .should('contain', '"Joe","Smith"')
   })
 
   it('handles zip file download', () => {
     cy.get('[data-cy=download-zip]').click()
     // not worth adding a dependency to read contents, just ensure it's there
-    // Note that this timeout is less than the proxy correlation timeout. It needs to be less than that timeout
-    // to ensure that we don't paper over a bug in the proxy correlation logic.
-    cy.readFile(`${Cypress.config('downloadsFolder')}/files.zip`, { timeout: 1000 })
+    // Must stay under the 2000ms proxy correlation timeout, or a correlation bug passes unnoticed.
+    cy.readFile(`${Cypress.config('downloadsFolder')}/files.zip`, { timeout: 1500 })
   })
 
   it('handles xlsx file download', () => {
     cy.get('[data-cy=download-xlsx]').click()
     // not worth adding a dependency to read contents, just ensure it's there
-    // Note that this timeout is less than the proxy correlation timeout. It needs to be less than that timeout
-    // to ensure that we don't paper over a bug in the proxy correlation logic.
-    cy.readFile(`${Cypress.config('downloadsFolder')}/people.xlsx`, { timeout: 1000 })
+    // Must stay under the 2000ms proxy correlation timeout, or a correlation bug passes unnoticed.
+    cy.readFile(`${Cypress.config('downloadsFolder')}/people.xlsx`, { timeout: 1500 })
   })
 })


### PR DESCRIPTION
- Closes n/a — flaky test cleanup, no associated issue.

### Additional details

`e2e downloads handles various file downloads [chrome]` failed in [this `system-tests-chrome` run](https://app.circleci.com/pipelines/github/cypress-io/cypress/86076/workflows/69fc5d70-0659-46f2-b5cb-27f6a3dfb1ed/jobs/3957059/parallel-runs/2) on the xlsx download: `Timed out retrying after 1000ms: cy.readFile(".../people.xlsx") failed because the file does not exist`. Despite the outer `Process errored: Exit code 1` wrapper this is not the graceful-exit teardown flake — the inner run genuinely failed, and the job logged `[teardown-budget] exceeded in 0 of 28 Cypress runs`.

The 1000ms timeouts in the downloads project fixture are deliberate. They were added in #27976 as a canary: they must stay below the proxy pre-request correlation timeout so that a correlation regression fails the test rather than being papered over by a generous wait. That correlation timeout is the `PreRequests` constructor default of 2000ms in `packages/proxy/lib/http/util/prerequests.ts` — `new PreRequests()` in `http/index.ts` passes no argument, and `setPreRequestTimeout` has no callers.

The problem is that the canary no longer has room for the machines it runs on. The decisive evidence is the sibling test in the same job: immediately after the failure, `allows changing the downloads folder [chrome]` ran the same spec and passed, with `handles csv file download (1096ms)` — a *passing* download whose test duration exceeds the entire readFile budget. Across those two runs the durations were 365, 646, 1096, 746 and 868ms against a 1000ms limit. One sample crossing the line is unremarkable.

Worth noting for anyone triaging a future occurrence: the failure output cannot tell you whether the cause was a genuine correlation miss or just a slow container. Both abort at the same readFile budget, so a correlation miss does *not* show up as an extra 2000ms in the reported test or spec duration.

This raises the budget to 1500ms, which still sits below the 2000ms correlation timeout, and collapses the repeated two-line comment to a single line that names the bound so the next reader does not have to go find it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture change with no runtime or user-facing impact.
> 
> **Overview**
> Reduces flakiness in the **downloads** system-test project by increasing `cy.readFile` wait time from **1000ms to 1500ms** for CSV, ZIP, and XLSX download cases.
> 
> The tests still act as a **correlation canary**: the comment now states explicitly that the budget must stay **below the 2000ms** proxy `PreRequests` timeout so a correlation regression fails instead of being masked by a long wait. Only comments and timeouts change—no product behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e62b321ff2ffc83426e5559ae531c8985d12f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

The canary was verified in both directions by forcing a correlation miss for the xlsx request only — returning `undefined` from both `pendingPreRequests.shift(key)` and `pendingUrlsWithoutPreRequests.shift(key)` in `PreRequests.get` when the key contains `.xlsx`:

- Unmodified proxy, new 1500ms budget: 3 passing (downloads land in 106-144ms locally).
- Forced correlation miss, new 1500ms budget: `1) handles xlsx file download` — `Timed out retrying after 1500ms`. The canary still has teeth at the higher budget.

The full system test also passes locally:

```
node ./scripts/run.js test/downloads_spec.ts --browser chrome
```

2 passing, 0 failing, `[teardown-budget] exceeded in 0 of 2 Cypress runs`.

Note that this raises headroom rather than removing the race — the test is still a wall-clock canary. A non-racy version would assert on the correlation directly; `prerequests.ts` already tracks `metrics.unmatchedRequests`, which increments exactly when the 2000ms timer fires, but it is only reachable via `debug` today.

### How has the user experience changed?

No change. Test-only change to a system-test project fixture.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Flaky test cleanup in a system-test fixture; no product change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
