### PR TITLE
fix: tolerate transient AUT-context gaps in Firefox BiDi automation

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 **Bugfixes:**
 
+- Fixed an issue where Firefox tests could intermittently fail with errors like `Cannot get AUT url: no AUT context initialized` when a command ran while Cypress was still identifying the application frame — for example right after a reload, a navigation, or moving to the next spec. Cypress now waits for the frame to be identified, and re-derives it if the browser event announcing it was missed. Fixes [#34705](https://github.com/cypress-io/cypress/issues/34705).
 - Fixed an issue where a run in which every test passed could still exit with code `1`, indistinguishable from a single failing test. Cleanup that fails or takes too long while Cypress shuts down no longer changes the exit code, and is reported in the run output instead. Fixed in [#34686](https://github.com/cypress-io/cypress/pull/34686).
 - Fixed an issue where the [`after:run`](https://on.cypress.io/after-run-api) event handler would not run when a project was closed in `cypress open` mode and [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) was set. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
 - Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -126,6 +126,15 @@ export class BidiAutomation {
   // set in firefox-utils when creating the webdriver session initially and in the 'reset:browser:tabs:for:next:spec' automation hook for subsequent tests when the top level context is recreated
   private topLevelContextId: string | undefined = undefined
   private interceptId: string | undefined = undefined
+  private autContextDeferred: PromiseWithResolvers<string> | undefined = undefined
+  private autContextRecovery: Promise<string | undefined> | undefined = undefined
+  // AUT context identification needs a scriptEvaluate round trip, and reloads /
+  // navigations destroy and recreate the context, so an AUT-dependent automation
+  // request can legitimately arrive while no context is tracked. Requests wait
+  // up to this long for the context to (re)resolve before failing (#34705).
+  // Instance fields rather than constants so unit tests can shrink the wait.
+  private autContextResolveTimeoutMs = 4000
+  private autContextPollIntervalMs = 250
 
   private constructor (webDriverClient: WebDriverClient, automation: Automation) {
     debug('initializing bidi automation')
@@ -155,6 +164,31 @@ export class BidiAutomation {
       return
     }
 
+    await this.identifyAndSetAutContext(params.context, params.parent)
+  }
+
+  private setAndResolveAutContextId (contextId: string) {
+    this.autContextId = contextId
+    this.autContextDeferred?.resolve(contextId)
+    this.autContextDeferred = undefined
+  }
+
+  // A promise that settles when the AUT context is (re)identified, shared by
+  // every request waiting on it and re-armed after each resolution.
+  private whenAutContextResolves (): Promise<string> {
+    if (this.autContextId) {
+      return Promise.resolve(this.autContextId)
+    }
+
+    this.autContextDeferred ??= Promise.withResolvers<string>()
+
+    return this.autContextDeferred.promise
+  }
+
+  // Determines whether `contextId` is the AUT iframe and records it if so.
+  // Shared by the contextCreated event and the on-demand recovery path in
+  // ensureAutContextId. Returns true when the context was the AUT.
+  private identifyAndSetAutContext = async (contextId: string, parentContextId: string): Promise<boolean> => {
     // The top-level context has more than one direct child iframe — the AUT and
     // the reporter iframe — and their creation order is not guaranteed, so
     // identify the AUT by its window.name (seeded with AUT_FRAME_NAME_IDENTIFIER
@@ -165,42 +199,141 @@ export class BidiAutomation {
     try {
       contextName = (await this.webDriverClient.scriptEvaluate({
         expression: 'window.name',
-        target: { context: params.context },
+        target: { context: contextId },
         awaitPromise: false,
         // @ts-expect-error - result is not typed
       }))?.result?.value ?? ''
     } catch (err) {
-      debug(`could not read window.name for browsing context ${params.context}; skipping AUT identification for it: %o`, err)
+      debug(`could not read window.name for browsing context ${contextId}; skipping AUT identification for it: %o`, err)
 
-      return
+      return false
     }
 
     if (!contextName.startsWith(AUT_FRAME_NAME_IDENTIFIER)) {
-      debug(`browsing context ${params.context} (name: '${contextName}') is not the AUT; skipping.`)
+      debug(`browsing context ${contextId} (name: '${contextName}') is not the AUT; skipping.`)
 
-      return
+      return false
     }
 
-    debug(`new browsing context ${params.context} (name: '${contextName}' created within top-level parent context ${params.parent}.`)
-    debug(`setting browsing context ${params.context} as the AUT context.`)
+    // The event path and the on-demand recovery path can identify concurrently
+    // (the window.name read yields); the first one to finish wins.
+    if (this.autContextId) {
+      return this.autContextId === contextId
+    }
 
-    this.autContextId = params.context
+    debug(`browsing context ${contextId} (name: '${contextName}') identified within top-level parent context ${parentContextId}.`)
+    debug(`setting browsing context ${contextId} as the AUT context.`)
+
+    this.setAndResolveAutContextId(contextId)
 
     // in the case of top reloads for setting the url between specs, the AUT context gets destroyed but the top level context still exists.
     // in this case, we do NOT have to redefine the top level context intercept but instead update the autContextId to properly identify the
     // AUT in the request interceptor.
     if (!this.interceptId) {
-      debug(`no interceptor defined for top-level context ${params.parent}.`)
+      debug(`no interceptor defined for top-level context ${parentContextId}.`)
       debug(`creating interceptor to determine if a request belongs to the AUT.`)
       // BiDi can only intercept top level tab contexts (i.e., not iframes), so the intercept needs to be defined on the top level parent, which is the AUTs
       // direct parent in ALL cases. This gets cleaned up in the 'reset:browser:tabs:for:next:spec' automation hook.
       // error looks something like: Error: WebDriver Bidi command "network.addIntercept" failed with error: invalid argument - Context with id 123456789 is not a top-level browsing context
-      const { intercept } = await this.webDriverClient.networkAddIntercept({ phases: ['beforeRequestSent'], contexts: [params.parent] })
+      const { intercept } = await this.webDriverClient.networkAddIntercept({ phases: ['beforeRequestSent'], contexts: [parentContextId] })
 
-      debug(`created network intercept ${intercept} for top-level browsing context ${params.parent}`)
+      debug(`created network intercept ${intercept} for top-level browsing context ${parentContextId}`)
 
       // save a reference to the intercept ID to be cleaned up in the 'reset:browser:tabs:for:next:spec' automation hook.
       this.interceptId = intercept
+    }
+
+    return true
+  }
+
+  // A contextCreated event can be missed for good: it can arrive before
+  // setTopLevelContextId records its parent, and its window.name read can fail
+  // while the frame is mid-navigation. Nothing replays those events, so
+  // re-derive the AUT from the live context tree instead. Concurrent callers
+  // share one in-flight recovery.
+  private recoverAutContextFromTree = (): Promise<string | undefined> => {
+    this.autContextRecovery ??= this.queryTreeForAutContext().finally(() => {
+      this.autContextRecovery = undefined
+    })
+
+    return this.autContextRecovery
+  }
+
+  // When a top-level context exists but no AUT context is tracked, the AUT
+  // iframe may well be live with its identification unobserved (see
+  // recoverAutContextFromTree) — so re-derive it: walk the top-level context's
+  // direct children in the live tree and identify the AUT by its window.name,
+  // exactly as the contextCreated event path would have.
+  private queryTreeForAutContext = async (): Promise<string | undefined> => {
+    const topLevelContextId = this.topLevelContextId
+
+    if (this.autContextId || !topLevelContextId) {
+      return this.autContextId
+    }
+
+    try {
+      const { contexts } = await this.webDriverClient.browsingContextGetTree({ root: topLevelContextId })
+      const children = contexts?.[0]?.children ?? []
+
+      for (const child of children) {
+        if (await this.identifyAndSetAutContext(child.context, topLevelContextId)) {
+          return this.autContextId
+        }
+      }
+    } catch (err) {
+      debug('could not recover the AUT context from the browsing context tree: %o', err)
+    }
+
+    return undefined
+  }
+
+  // Resolves the AUT context for an automation request, tolerating the windows
+  // where none is tracked: the identification round trip after contextCreated,
+  // the gap between a context being destroyed and recreated (reloads, top
+  // navigations, spec transitions), and missed contextCreated events.
+  private ensureAutContextId = async (failureMessage: string): Promise<string> => {
+    if (this.autContextId) {
+      return this.autContextId
+    }
+
+    // With no top-level context there is no tab to wait on or recover from.
+    if (!this.topLevelContextId) {
+      throw new Error(failureMessage)
+    }
+
+    // One immediate recovery attempt heals events missed before this request;
+    // the interval below heals ones dropped while we wait.
+    const recovered = await this.recoverAutContextFromTree()
+
+    if (recovered) {
+      return recovered
+    }
+
+    // Wait for the AUT context id to be regrabbed — either the contextCreated
+    // event path identifies it (settling whenAutContextResolves) or one of the
+    // interval's recovery attempts re-derives it from the live tree — for at
+    // most autContextResolveTimeoutMs. If neither lands in time, throw.
+    const recoveryInterval = setInterval(() => {
+      void this.recoverAutContextFromTree()
+    }, this.autContextPollIntervalMs)
+    let timeout!: NodeJS.Timeout
+
+    try {
+      const contextId = await Promise.race([
+        this.whenAutContextResolves(),
+        new Promise<undefined>((resolve) => {
+          timeout = setTimeout(() => resolve(undefined), this.autContextResolveTimeoutMs)
+        }),
+      ])
+
+      if (contextId) {
+        return contextId
+      }
+
+      throw new Error(failureMessage)
+    } finally {
+      clearInterval(recoveryInterval)
+      clearTimeout(timeout)
     }
   }
 
@@ -615,14 +748,14 @@ export class BidiAutomation {
 
           return
         case 'key:press':
-          if (this.autContextId) {
-            debug(`key:press %s`, data.key)
-            await bidiKeyPress(toSupportedKey(data.key), this.webDriverClient, this.autContextId, this.topLevelContextId)
-          } else {
-            throw new Error('Cannot emit key press: no AUT context initialized')
-          }
+        {
+          const autContextId = await this.ensureAutContextId('Cannot emit key press: no AUT context initialized')
+
+          debug(`key:press %s`, data.key)
+          await bidiKeyPress(toSupportedKey(data.key), this.webDriverClient, autContextId, this.topLevelContextId)
 
           return
+        }
         case 'perform:user:gesture':
           // Firefox 93+ requires a transient user activation before display capture is allowed,
           // which the driver needs in order to record video via getUserMedia. We grant it by
@@ -637,40 +770,32 @@ export class BidiAutomation {
           return
         case 'get:aut:url':
         {
-          if (this.autContextId) {
-            return bidiGetUrl(this.webDriverClient, this.autContextId)
-          }
+          const autContextId = await this.ensureAutContextId('Cannot get AUT url: no AUT context initialized')
 
-          throw new Error('Cannot get AUT url: no AUT context initialized')
+          return bidiGetUrl(this.webDriverClient, autContextId)
         }
 
         case 'reload:aut:frame':
         {
-          if (this.autContextId) {
-            await bidiReloadFrame(this.webDriverClient, this.autContextId, data.forceReload)
+          const autContextId = await this.ensureAutContextId('Cannot reload AUT frame: no AUT context initialized')
 
-            return
-          }
+          await bidiReloadFrame(this.webDriverClient, autContextId, data.forceReload)
 
-          throw new Error('Cannot reload AUT frame: no AUT context initialized')
+          return
         }
         case 'navigate:aut:history':
         {
-          if (this.autContextId) {
-            await bidiNavigateHistory(this.webDriverClient, this.autContextId, data.historyNumber)
+          const autContextId = await this.ensureAutContextId('Cannot navigate AUT frame history: no AUT context initialized')
 
-            return
-          }
+          await bidiNavigateHistory(this.webDriverClient, autContextId, data.historyNumber)
 
-          throw new Error('Cannot navigate AUT frame history: no AUT context initialized')
+          return
         }
         case 'get:aut:title':
         {
-          if (this.autContextId) {
-            return bidiGetFrameTitle(this.webDriverClient, this.autContextId)
-          }
+          const autContextId = await this.ensureAutContextId('Cannot get AUT title no AUT context initialized')
 
-          throw new Error('Cannot get AUT title no AUT context initialized')
+          return bidiGetFrameTitle(this.webDriverClient, autContextId)
         }
         default:
           debug('BiDi automation not implemented for message: %s', message)

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -220,6 +220,15 @@ export class BidiAutomation {
       return false
     }
 
+    // The window.name read yields; if the top-level context changed or was
+    // destroyed while it was in flight, this identification belongs to a dead
+    // tab and must not be recorded.
+    if (this.topLevelContextId !== parentContextId) {
+      debug(`browsing context ${contextId} was identified against a stale top-level context ${parentContextId}; discarding.`)
+
+      return false
+    }
+
     // The event path and the on-demand recovery path can identify concurrently
     // (the window.name read yields); the first one to finish wins.
     if (this.autContextId) {

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -180,7 +180,12 @@ export class BidiAutomation {
       return Promise.resolve(this.autContextId)
     }
 
-    this.autContextDeferred ??= Promise.withResolvers<string>()
+    if (!this.autContextDeferred) {
+      this.autContextDeferred = Promise.withResolvers<string>()
+      // The rejection on top-level destroy must not crash the process when no
+      // request happens to be awaiting the promise at that moment.
+      this.autContextDeferred.promise.catch(() => {})
+    }
 
     return this.autContextDeferred.promise
   }
@@ -301,18 +306,18 @@ export class BidiAutomation {
       throw new Error(failureMessage)
     }
 
-    // One immediate recovery attempt heals events missed before this request;
-    // the interval below heals ones dropped while we wait.
-    const recovered = await this.recoverAutContextFromTree()
-
-    if (recovered) {
-      return recovered
-    }
+    // Subscribe before kicking off recovery so an identification that lands
+    // immediately still settles the race below.
+    const contextResolved = this.whenAutContextResolves()
 
     // Wait for the AUT context id to be regrabbed — either the contextCreated
-    // event path identifies it (settling whenAutContextResolves) or one of the
-    // interval's recovery attempts re-derives it from the live tree — for at
-    // most autContextResolveTimeoutMs. If neither lands in time, throw.
+    // event path identifies it or one of the recovery attempts re-derives it
+    // from the live tree (a successful recovery settles contextResolved via
+    // setAndResolveAutContextId) — for at most autContextResolveTimeoutMs. If
+    // nothing lands in time, or the top-level context is destroyed while
+    // waiting, throw. Recovery attempts are deliberately not awaited so a hung
+    // tree query cannot hold a request past the bound.
+    void this.recoverAutContextFromTree()
     const recoveryInterval = setInterval(() => {
       void this.recoverAutContextFromTree()
     }, this.autContextPollIntervalMs)
@@ -320,7 +325,7 @@ export class BidiAutomation {
 
     try {
       const contextId = await Promise.race([
-        this.whenAutContextResolves(),
+        contextResolved,
         new Promise<undefined>((resolve) => {
           timeout = setTimeout(() => resolve(undefined), this.autContextResolveTimeoutMs)
         }),
@@ -329,12 +334,14 @@ export class BidiAutomation {
       if (contextId) {
         return contextId
       }
-
-      throw new Error(failureMessage)
+    } catch (err) {
+      debug('stopped waiting for the AUT context: %o', err)
     } finally {
       clearInterval(recoveryInterval)
       clearTimeout(timeout)
     }
+
+    throw new Error(failureMessage)
   }
 
   private onBrowsingContextDestroyed = async (params: BrowsingContextInfo) => {
@@ -345,6 +352,11 @@ export class BidiAutomation {
       debug(`top level browsing context ${params.context} destroyed`)
       // if the top level context is destroyed, we can imply that the AUT context is destroyed along with it
       this.autContextId = undefined
+      // Fail any requests still waiting on an AUT context: the tab they belong
+      // to is gone, and the AUT of a subsequently created tab must not satisfy
+      // them.
+      this.autContextDeferred?.reject(new Error(`top-level browsing context ${params.context} was destroyed`))
+      this.autContextDeferred = undefined
       this.setTopLevelContextId(undefined)
       if (this.interceptId) {
         // since we either have:

--- a/packages/server/lib/browsers/bidi_automation.ts
+++ b/packages/server/lib/browsers/bidi_automation.ts
@@ -128,6 +128,11 @@ export class BidiAutomation {
   private interceptId: string | undefined = undefined
   private autContextDeferred: PromiseWithResolvers<string> | undefined = undefined
   private autContextRecovery: Promise<string | undefined> | undefined = undefined
+  // autContextId is unset while an identification's window.name read is in
+  // flight, so the match-based clear in onBrowsingContextDestroyed cannot catch
+  // a destroy of the candidate frame itself; these entries let the destroy mark
+  // the identification stale so a dead frame is never recorded.
+  private inFlightIdentifications = new Set<{ contextId: string, destroyed: boolean }>()
   // AUT context identification needs a scriptEvaluate round trip, and reloads /
   // navigations destroy and recreate the context, so an AUT-dependent automation
   // request can legitimately arrive while no context is tracked. Requests wait
@@ -201,6 +206,10 @@ export class BidiAutomation {
     // created.
     let contextName = ''
 
+    const identification = { contextId, destroyed: false }
+
+    this.inFlightIdentifications.add(identification)
+
     try {
       contextName = (await this.webDriverClient.scriptEvaluate({
         expression: 'window.name',
@@ -212,6 +221,8 @@ export class BidiAutomation {
       debug(`could not read window.name for browsing context ${contextId}; skipping AUT identification for it: %o`, err)
 
       return false
+    } finally {
+      this.inFlightIdentifications.delete(identification)
     }
 
     if (!contextName.startsWith(AUT_FRAME_NAME_IDENTIFIER)) {
@@ -220,9 +231,17 @@ export class BidiAutomation {
       return false
     }
 
-    // The window.name read yields; if the top-level context changed or was
-    // destroyed while it was in flight, this identification belongs to a dead
-    // tab and must not be recorded.
+    // The window.name read yields; if the frame itself was destroyed while it
+    // was in flight, this identification is for a dead frame and must not be
+    // recorded.
+    if (identification.destroyed) {
+      debug(`browsing context ${contextId} was destroyed while being identified; discarding.`)
+
+      return false
+    }
+
+    // Likewise if the top-level context changed or was destroyed during the
+    // read, this identification belongs to a dead tab.
     if (this.topLevelContextId !== parentContextId) {
       debug(`browsing context ${contextId} was identified against a stale top-level context ${parentContextId}; discarding.`)
 
@@ -355,6 +374,14 @@ export class BidiAutomation {
 
   private onBrowsingContextDestroyed = async (params: BrowsingContextInfo) => {
     debugVerbose('received browsingContext.contextDestroyed %o', params)
+
+    // A frame with an identification round trip in flight has no autContextId
+    // to match against below, so mark the identification stale directly.
+    for (const identification of this.inFlightIdentifications) {
+      if (identification.contextId === params.context) {
+        identification.destroyed = true
+      }
+    }
 
     // if the top level context gets destroyed, we need to clear the AUT context and destroy the interceptor as it is no longer applicable
     if (params.context === this.topLevelContextId) {

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -2570,6 +2570,30 @@ describe('lib/browsers/bidi_automation', () => {
           expect(Date.now() - start).to.be.lessThan(1000)
         })
 
+        it('discards an identification that lands after the top-level context was destroyed', async () => {
+          let resolveName!: (value: unknown) => void
+
+          mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [{ context: 'aut' }] }] })
+          mockWebdriverClient.scriptEvaluate = sinon.stub().returns(new Promise((res) => {
+            resolveName = res
+          }))
+
+          mockWebdriverClient.networkAddIntercept = sinon.stub().resolves({ intercept: 'intercept-1' })
+
+          const request = bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)
+
+          setTimeout(() => {
+            mockWebdriverClient.emit('browsingContext.contextDestroyed', { context: 'top' })
+            resolveName({ result: { value: AUT_NAME } })
+          }, 30)
+
+          await expect(request).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+
+          //@ts-expect-error
+          expect(bidiAutomationInstance.autContextId).to.be.undefined
+          expect(mockWebdriverClient.networkAddIntercept).not.to.have.been.called
+        })
+
         it('fails a waiting request when the top-level context is destroyed instead of waiting out the timeout', async () => {
           mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [] }] })
 

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -2472,6 +2472,104 @@ describe('lib/browsers/bidi_automation', () => {
         // @ts-expect-error
         await expect(bidiAutomationInstance.automationMiddleware.onRequest('foo:bar:baz', {})).to.be.rejectedWith('Automation command \'foo:bar:baz\' not implemented by BiDiAutomation')
       })
+
+      describe('AUT context resolution', () => {
+        const AUT_NAME = `${AUT_FRAME_NAME_IDENTIFIER}-spec`
+
+        beforeEach(() => {
+          bidiAutomationInstance.setTopLevelContextId('top')
+          //@ts-expect-error
+          bidiAutomationInstance.autContextResolveTimeoutMs = 500
+          //@ts-expect-error
+          bidiAutomationInstance.autContextPollIntervalMs = 20
+        })
+
+        it('waits for the AUT context to be identified instead of failing during the identification window', async () => {
+          const getTree = sinon.stub()
+
+          getTree.withArgs({ root: 'top' }).resolves({ contexts: [{ context: 'top', children: [] }] })
+          getTree.withArgs({ root: 'aut' }).resolves({ contexts: [{ context: 'aut', url: 'http://localhost:3500/index.html' }] })
+          mockWebdriverClient.browsingContextGetTree = getTree
+          mockWebdriverClient.scriptEvaluate = sinon.stub().resolves({ result: { value: AUT_NAME } })
+          mockWebdriverClient.networkAddIntercept = sinon.stub().resolves({ intercept: 'intercept-1' })
+
+          const request = bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)
+
+          setTimeout(() => {
+            mockWebdriverClient.emit('browsingContext.contextCreated', { context: 'aut', parent: 'top' })
+          }, 50)
+
+          expect(await request).to.equal('http://localhost:3500/index.html')
+        })
+
+        it('heals a missed contextCreated by re-deriving the AUT from the browsing context tree', async () => {
+          const getTree = sinon.stub()
+
+          getTree.withArgs({ root: 'top' }).resolves({ contexts: [{ context: 'top', children: [{ context: 'reporter' }, { context: 'aut' }] }] })
+          getTree.withArgs({ root: 'aut' }).resolves({ contexts: [{ context: 'aut', url: 'http://localhost:3500/healed.html' }] })
+          mockWebdriverClient.browsingContextGetTree = getTree
+
+          const scriptEvaluate = sinon.stub()
+
+          scriptEvaluate.withArgs(sinon.match({ target: { context: 'reporter' } })).resolves({ result: { value: 'reporter-frame' } })
+          scriptEvaluate.withArgs(sinon.match({ target: { context: 'aut' } })).resolves({ result: { value: AUT_NAME } })
+          mockWebdriverClient.scriptEvaluate = scriptEvaluate
+          mockWebdriverClient.networkAddIntercept = sinon.stub().resolves({ intercept: 'intercept-1' })
+
+          const url = await bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)
+
+          expect(url).to.equal('http://localhost:3500/healed.html')
+          // the healed AUT still needs the top-level request intercept
+          expect(mockWebdriverClient.networkAddIntercept).to.have.been.calledWith({ phases: ['beforeRequestSent'], contexts: ['top'] })
+        })
+
+        it('resolves a request issued in the gap between the AUT context being destroyed and recreated', async () => {
+          //@ts-expect-error
+          bidiAutomationInstance.autContextId = 'old-aut'
+
+          mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [] }] })
+
+          const scriptEvaluate = sinon.stub()
+
+          scriptEvaluate.withArgs(sinon.match({ expression: 'window.name' })).resolves({ result: { value: AUT_NAME } })
+          scriptEvaluate.withArgs(sinon.match({ expression: 'window.location.reload(false)' })).resolves()
+          mockWebdriverClient.scriptEvaluate = scriptEvaluate
+          mockWebdriverClient.networkAddIntercept = sinon.stub().resolves({ intercept: 'intercept-1' })
+
+          mockWebdriverClient.emit('browsingContext.contextDestroyed', { context: 'old-aut', parent: 'top' })
+
+          const request = bidiAutomationInstance.automationMiddleware.onRequest('reload:aut:frame', { forceReload: false })
+
+          setTimeout(() => {
+            mockWebdriverClient.emit('browsingContext.contextCreated', { context: 'new-aut', parent: 'top' })
+          }, 50)
+
+          await request
+
+          expect(scriptEvaluate).to.have.been.calledWith({
+            expression: 'window.location.reload(false)',
+            target: {
+              context: 'new-aut',
+            },
+            awaitPromise: false,
+          })
+        })
+
+        it('fails with the original error when the AUT context never resolves within the bounded wait', async () => {
+          mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [] }] })
+
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+        })
+
+        it('fails immediately when there is no top-level context to recover from', async () => {
+          bidiAutomationInstance.setTopLevelContextId(undefined)
+
+          const start = Date.now()
+
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+          expect(Date.now() - start).to.be.lessThan(100)
+        })
+      })
     })
   })
 })

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -2561,6 +2561,29 @@ describe('lib/browsers/bidi_automation', () => {
           await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
         })
 
+        it('stays bounded by the timeout when the tree query hangs', async () => {
+          mockWebdriverClient.browsingContextGetTree = sinon.stub().returns(new Promise(() => {}))
+
+          const start = Date.now()
+
+          await expect(bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+          expect(Date.now() - start).to.be.lessThan(1000)
+        })
+
+        it('fails a waiting request when the top-level context is destroyed instead of waiting out the timeout', async () => {
+          mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [] }] })
+
+          const start = Date.now()
+          const request = bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)
+
+          setTimeout(() => {
+            mockWebdriverClient.emit('browsingContext.contextDestroyed', { context: 'top' })
+          }, 30)
+
+          await expect(request).to.be.rejectedWith('Cannot get AUT url: no AUT context initialized')
+          expect(Date.now() - start).to.be.lessThan(400)
+        })
+
         it('fails immediately when there is no top-level context to recover from', async () => {
           bidiAutomationInstance.setTopLevelContextId(undefined)
 

--- a/packages/server/test/unit/browsers/bidi_automation_spec.ts
+++ b/packages/server/test/unit/browsers/bidi_automation_spec.ts
@@ -2594,6 +2594,44 @@ describe('lib/browsers/bidi_automation', () => {
           expect(mockWebdriverClient.networkAddIntercept).not.to.have.been.called
         })
 
+        it('discards an identification whose candidate frame was destroyed during the window.name read and identifies the recreated frame', async () => {
+          let resolveName!: (value: unknown) => void
+
+          const getTree = sinon.stub()
+
+          getTree.withArgs({ root: 'top' }).resolves({ contexts: [{ context: 'top', children: [{ context: 'aut' }] }] })
+          getTree.withArgs({ root: 'new-aut' }).resolves({ contexts: [{ context: 'new-aut', url: 'http://localhost:3500/recreated.html' }] })
+          mockWebdriverClient.browsingContextGetTree = getTree
+
+          const scriptEvaluate = sinon.stub()
+
+          scriptEvaluate.withArgs(sinon.match({ target: { context: 'aut' } })).returns(new Promise((res) => {
+            resolveName = res
+          }))
+
+          scriptEvaluate.withArgs(sinon.match({ target: { context: 'new-aut' } })).resolves({ result: { value: AUT_NAME } })
+          mockWebdriverClient.scriptEvaluate = scriptEvaluate
+          mockWebdriverClient.networkAddIntercept = sinon.stub().resolves({ intercept: 'intercept-1' })
+
+          const request = bidiAutomationInstance.automationMiddleware.onRequest('get:aut:url', undefined)
+
+          setTimeout(() => {
+            // the frame is torn down while its window.name read is in flight;
+            // the read still resolving with the AUT name must not record it
+            mockWebdriverClient.emit('browsingContext.contextDestroyed', { context: 'aut', parent: 'top' })
+            getTree.withArgs({ root: 'top' }).resolves({ contexts: [{ context: 'top', children: [] }] })
+            resolveName({ result: { value: AUT_NAME } })
+          }, 30)
+
+          setTimeout(() => {
+            mockWebdriverClient.emit('browsingContext.contextCreated', { context: 'new-aut', parent: 'top' })
+          }, 60)
+
+          expect(await request).to.equal('http://localhost:3500/recreated.html')
+          //@ts-expect-error
+          expect(bidiAutomationInstance.autContextId).to.equal('new-aut')
+        })
+
         it('fails a waiting request when the top-level context is destroyed instead of waiting out the timeout', async () => {
           mockWebdriverClient.browsingContextGetTree = sinon.stub().resolves({ contexts: [{ context: 'top', children: [] }] })
 


### PR DESCRIPTION
- Closes #34705

### Additional details

Firefox automation tracks the AUT iframe in `BidiAutomation.autContextId`, and the AUT-dependent automation handlers (`get:aut:url`, `get:aut:title`, `reload:aut:frame`, `navigate:aut:history`, `key:press`) threw `no AUT context initialized` the moment it was unset. Three windows leave it unset while tests are actively issuing commands:

1. **Identification round trip** — `onBrowsingContextCreated` identifies the AUT by evaluating `window.name` over the wire before setting `autContextId`; requests arriving during that round trip threw.
2. **Destroy→recreate gap** — `onBrowsingContextDestroyed` clears `autContextId`; until the recreated context is re-identified (reloads, top navigations, spec transitions), requests threw.
3. **Missed events, never retried** — the guard in `onBrowsingContextCreated` drops the AUT's `contextCreated` when it arrives before `setTopLevelContextId` is updated, and the `window.name` read can fail while the frame is mid-navigation; nothing re-resolved the context afterward.

The fix replaces throw-on-unset with wait, heal, then fail:

- `ensureAutContextId` waits (bounded: 4s, with recovery attempts every 250ms that are never awaited past the bound) for the context to resolve. It fails fast when there is no top-level context at all (the tab itself is gone — the old behavior for that case), and a top-level context destroyed mid-wait rejects the shared deferred so waiting requests fail immediately rather than timing out or resolving against a subsequently created tab.
- Identification is extracted into `identifyAutContext`, shared by the `contextCreated` event path and a new `recoverAutContextFromTree` path that re-derives the AUT from `browsingContext.getTree` + the seeded `window.name` — healing permanently missed events. A first-wins guard covers the two paths racing.
- Waiters resolve the moment identification lands, so the common windows cost only the actual identification latency.

Observed in the wild on the Cypress 16 pre-release validation runs (cypress-io/cypress-example-recipes#938): the `test-examples-firefox` job failed 2 of 2 runs with different victim specs (`cy.reload()`/`cy.go('back')` in one, `cy.request()` URL normalization via `get:aut:url` in the other), while the same specs pass on a fast local machine — a timing race slow CI containers lose. The race predates 16 (this code is unchanged since July), so it can also hit released 15.x Firefox users.

### Steps to test

Unit coverage exercises each window directly (`yarn workspace @packages/server test-unit bidi_automation_spec` — 71 passing): a request during the identification round trip resolving once identified, healing a missed `contextCreated` via `getTree` (including intercept creation), a request in the destroy→recreate gap resolving against the recreated context, the bounded-timeout error, and the immediate failure with no top-level context. The Firefox driver jobs in CI exercise the real path on every spec.

### How has the user experience changed?

No visible change on the happy path. Firefox runs no longer intermittently fail with `Cannot get AUT url / reload AUT frame / navigate AUT frame history: no AUT context initialized` when a command races frame identification.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34705 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Firefox BiDi frame targeting and timing for core AUT commands; bounded waits add latency only during gaps, but wrong identification could affect the wrong iframe if guards fail.
> 
> **Overview**
> Fixes intermittent Firefox failures (`Cannot get AUT url: no AUT context initialized` and similar) when commands run while the application-under-test iframe is not yet tracked—after reloads, navigation, spec changes, or during the `window.name` identification round trip.
> 
> **`BidiAutomation`** no longer fails immediately when `autContextId` is unset. **`ensureAutContextId`** waits (up to 4s, with 250ms tree-recovery polls) for identification or **re-derives** the AUT via `browsingContext.getTree` and the seeded frame name when `contextCreated` was missed. In-flight identifications are invalidated if the frame or tab is destroyed mid-read; destroying the top-level context rejects waiters so a new tab cannot satisfy stale requests. AUT-dependent handlers (`get:aut:url`, reload/history/title, `key:press`) route through this path.
> 
> Changelog documents the fix (#34705). Unit tests cover wait, heal, destroy→recreate, timeouts, and stale-frame edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfef7558ee86338f2a5165c93b83c05254098a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


