### PR TITLE
chore: disable `ServiceWorkerAutoPreload` on the browser network path

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -439,11 +439,14 @@ export = {
     // which the CDP transport always enables (crbug.com/1196004). Web fonts do
     // not load at all on the browser (CDP) network path unless this flag stays —
     // do not remove it.
+    // These features are launch-time-only: connectToExisting attaches to an
+    // already-running browser and inherits the flags of whatever launched it.
     if (options.useBrowserNetworkInterception) {
       const disableFeaturesIndex = args.findIndex((arg) => arg.startsWith('--disable-features='))
 
       // ServiceWorkerAutoPreload serves navigations that cold-start a service
-      // worker from a browser-issued request no CDP session can pause (#34709)
+      // worker from a browser-issued request no CDP session can pause
+      // https://github.com/cypress-io/cypress/issues/34709
       const features = 'WebFontsCacheAwareTimeoutAdaption,ServiceWorkerAutoPreload'
 
       if (disableFeaturesIndex === -1) {

--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -442,10 +442,14 @@ export = {
     if (options.useBrowserNetworkInterception) {
       const disableFeaturesIndex = args.findIndex((arg) => arg.startsWith('--disable-features='))
 
+      // ServiceWorkerAutoPreload serves navigations that cold-start a service
+      // worker from a browser-issued request no CDP session can pause (#34709)
+      const features = 'WebFontsCacheAwareTimeoutAdaption,ServiceWorkerAutoPreload'
+
       if (disableFeaturesIndex === -1) {
-        args.push('--disable-features=WebFontsCacheAwareTimeoutAdaption')
+        args.push(`--disable-features=${features}`)
       } else {
-        args[disableFeaturesIndex] += ',WebFontsCacheAwareTimeoutAdaption'
+        args[disableFeaturesIndex] += `,${features}`
       }
     }
 

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -1204,6 +1204,22 @@ describe('lib/browsers/chrome', () => {
         expect(disableFeatures).to.include('HttpsUpgrades')
       })
     })
+
+    context('service worker auto preload', () => {
+      it('disables ServiceWorkerAutoPreload on the browser (CDP) network path', () => {
+        const args = chrome._getArgs({}, { useBrowserNetworkInterception: true })
+        const disableFeatures = args.find((arg) => arg.startsWith('--disable-features='))
+
+        expect(disableFeatures).to.include('ServiceWorkerAutoPreload')
+        expect(args.filter((arg) => arg.startsWith('--disable-features='))).to.have.length(1)
+      })
+
+      it('keeps it on the MITM path', () => {
+        const args = chrome._getArgs({}, { useBrowserNetworkInterception: false })
+
+        expect(args.find((arg) => arg.startsWith('--disable-features='))).not.to.include('ServiceWorkerAutoPreload')
+      })
+    })
   })
 
   describe('#_normalizeHostResolverRules', () => {

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -1217,6 +1217,7 @@ describe('lib/browsers/chrome', () => {
       it('keeps it on the MITM path', () => {
         const args = chrome._getArgs({}, { useBrowserNetworkInterception: false })
 
+        expect(args.filter((arg) => arg.startsWith('--disable-features='))).to.have.length(1)
         expect(args.find((arg) => arg.startsWith('--disable-features='))).not.to.include('ServiceWorkerAutoPreload')
       })
     })


### PR DESCRIPTION
- Addresses #34709
- Stacked on #34702 (base branch `cacie/34674-interception-escape-tripwire`); do not merge before it

### Additional details

Chrome's `ServiceWorkerAutoPreload` (default-on in 152) serves navigations that cold-start a service worker from a browser-issued speculative request that no CDP session can pause, so those documents escape Fetch interception entirely — invisible to `cy.intercept`, header stripping, and Test Replay. Disabling the feature routes the navigation through the worker's own `fetch(e.request)`, which pauses on the worker session.

Gated on `useBrowserNetworkInterception` (the `forceHttp1: false` path) and Chrome only, appended to the existing `--disable-features=` block alongside `WebFontsCacheAwareTimeoutAdaption` — Chromium honors only the last occurrence of the flag. The MITM path still sees the speculative request through the proxy and needs no change. Firefox/BiDi is unaffected (Chrome feature). Standalone before/after evidence in #34709.

### Steps to test

`yarn workspace @packages/server test-unit -- browsers/chrome_spec.ts` (88 passing locally)

### How has the user experience changed?

On the browser network path, documents that cold-start a service worker are now intercepted instead of escaping (previously: no `cy.intercept` match, no Test Replay entry, and a possible `cy.visit` timeout if the escaped response carried framebusting headers). Service-worker navigation timing under test differs slightly from stock Chrome, consistent with the other features Cypress already disables.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34709 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Chrome launch flags for the CDP network path and alters service-worker navigation behavior under test, but scope is gated and covered by new unit tests.
> 
> **Overview**
> On Chrome launches that use **browser (CDP) network interception** (`useBrowserNetworkInterception`), Cypress now also disables **`ServiceWorkerAutoPreload`** via `--disable-features`, alongside the existing `WebFontsCacheAwareTimeoutAdaption` entry. That stops cold-start service worker navigations from being served by a speculative browser request CDP Fetch cannot pause, which previously let those documents bypass `cy.intercept`, header stripping, and Test Replay (#34709).
> 
> The **MITM proxy path** is unchanged: `ServiceWorkerAutoPreload` stays enabled because the proxy still sees the speculative request. Comments note these flags apply only at launch (not when attaching with `connectToExisting`). Unit tests in `chrome_spec.ts` assert the feature is disabled on the CDP path and omitted on the MITM path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9034d3f7a3d035227495cc698fb1a4d3047b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->