### PR TITLE
chore: remove Firefox version guards below the supported floor

### DIFF
--- a/packages/driver/src/cy/commands/actions/type.ts
+++ b/packages/driver/src/cy/commands/actions/type.ts
@@ -175,11 +175,6 @@ export default function (Commands, Cypress, cy, state, config) {
     }
 
     const type = function () {
-      const isFirefoxBefore91 = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() < 91
-      const isFirefoxBefore98 = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() < 98
-      const isFirefox106OrLater = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 106
-      const isFirefox129OrLater = Cypress.isBrowser('firefox') && Cypress.browserMajorVersion() >= 129
-
       const simulateSubmitHandler = function () {
         const form = options.$el.parents('form')
 
@@ -237,14 +232,9 @@ export default function (Commands, Cypress, cy, state, config) {
           return
         }
 
-        // Before Firefox 98, submit event is automatically fired
-        // when we send {Enter} KeyboardEvent to the input fields.
-        // Because of that, we don't have to click the submit buttons.
-        // Otherwise, we trigger submit events twice.
-        //
         // WebKit will send the submit with an Enter keypress event,
         // so we do need to click the default button in this case.
-        if (!isFirefoxBefore98 && !Cypress.isBrowser('webkit')) {
+        if (!Cypress.isBrowser('webkit')) {
           // issue the click event to the 'default button' of the form
           // we need this to be synchronous so not going through our
           // own click command
@@ -344,17 +334,11 @@ export default function (Commands, Cypress, cy, state, config) {
 
           if (
             (
-              // Before Firefox 91, it sends a click event automatically on the
-              // 'keyup' event for a Space key and we don't want to send it twice
               !Cypress.isBrowser('firefox') ||
-              // Starting with Firefox 91, click events are no longer sent
-              // automatically for <button> elements
+              // Firefox no longer sends click events automatically for <button>
+              // and <input> elements, so we have to send them ourselves.
               // event.target is null when the element is within the shadow DOM
-              (!isFirefoxBefore91 && event.target && $elements.isButton(event.target)) ||
-              // Starting with Firefox 98, click events are no longer sent
-              // automatically for <input> elements
-              // event.target is null when the element is within the shadow DOM
-              (!isFirefoxBefore98 && event.target && $elements.isInput(event.target))
+              (event.target && ($elements.isButton(event.target) || $elements.isInput(event.target)))
             ) &&
             // Click event is sent after keyup event with space key.
             event.type === 'keyup' && event.code === 'Space' &&
@@ -371,16 +355,6 @@ export default function (Commands, Cypress, cy, state, config) {
             fireClickEvent(event.target)
 
             keydownEvents = []
-
-            // After Firefox 98 and before 129
-            // Firefox doesn't update checkbox automatically even if the click event is sent.
-            if (Cypress.isBrowser('firefox') && !isFirefox129OrLater) {
-              if (event.target.type === 'checkbox') {
-                event.target.checked = !event.target.checked
-              } else if (event.target.type === 'radio') { // when checked is false, here cannot be reached because of the above condition
-                event.target.checked = true
-              }
-            }
           }
         },
 
@@ -434,16 +408,11 @@ export default function (Commands, Cypress, cy, state, config) {
           // Send click event on type('{enter}')
           if (sendClickEvent) {
             if (
-              // Before Firefox 98, it sends a click event automatically on
-              // simulated keypress events and we don't want to send it twice
               !Cypress.isBrowser('firefox') ||
-              // Starting with Firefox 98, click events are no longer sent
-              // automatically for <input> elements, but are still sent for
-              // other element types
-              (!isFirefoxBefore98 && $elements.isInput(el)) ||
-              // Starting with Firefox 106, click events are no longer sent
-              // automatically for <button> elements
-              (isFirefox106OrLater && $elements.isButton(el))
+              // Firefox no longer sends click events automatically for <input>
+              // and <button> elements, so we have to send them ourselves.
+              $elements.isInput(el) ||
+              $elements.isButton(el)
             ) {
               fireClickEvent(el)
             }


### PR DESCRIPTION
- Closes N/A — mechanical dead-code removal, no associated issue.

### Additional details

Cypress refuses to run Firefox older than 140: `firefoxValidatorFn` (`packages/launcher/lib/known-browsers.ts:8`) marks anything below that unsupported, and `packages/server/lib/modes/run.ts:1218` throws `UNSUPPORTED_BROWSER_VERSION`. Every Firefox version check in `type()` therefore had a constant value:

| Constant | Always | Effect on its call sites |
| --- | --- | --- |
| `isFirefoxBefore91` | `false` | keyup-handler guard always satisfied |
| `isFirefoxBefore98` | `false` | submit-handler and keyup/`{enter}` guards always satisfied |
| `isFirefox106OrLater` | `true` on Firefox | `{enter}` guard reduces to the browser check |
| `isFirefox129OrLater` | `true` on Firefox | keyup-handler condition always `false` → block unreachable |

All four constants are removed and collapsed into their call sites, in `packages/driver/src/cy/commands/actions/type.ts`:

- **`simulateSubmitHandler`** — `if (!isFirefoxBefore98 && !Cypress.isBrowser('webkit'))` → `if (!Cypress.isBrowser('webkit'))`, dropping the stale Firefox-98 comment.
- **`onEvent` keyup handler** — the three-way disjunction collapses to `!Cypress.isBrowser('firefox') || (event.target && (isButton || isInput))`. Still a real filter, just no longer version-gated.
- **`onEvent` keyup handler** — the manual checkbox/radio `checked` fix-up for Firefox 98–128 was unreachable and is removed outright. This is the only substantive deletion.
- **`onEnterPressed`** — `(!isFirefoxBefore98 && $elements.isInput(el)) || (isFirefox106OrLater && $elements.isButton(el))` → `$elements.isInput(el) || $elements.isButton(el)`.

Net −39/+8 lines, all in one file. Every remaining branch is reachable and behavior is unchanged on any Firefox version Cypress will actually launch.

Two notes for the reviewer:

1. In `onEnterPressed`, the surrounding `sendClickEvent` is only true when `isInputType()` matched, and that helper returns `false` unless the element is an `<input>` or `<button>` — so `isInput(el) || isButton(el)` is *also* always true there, and the Firefox guard could be deleted entirely. I kept it explicit because it documents why Firefox needs the manual click and stays correct if `sendClickEvent` ever broadens. Happy to collapse it if you'd prefer.
2. This comment above the submit handler is left verbatim: `// WebKit will send the submit with an Enter keypress event, so we do need to click the default button in this case.` It reads backwards against a condition that *skips* WebKit — likely a long-standing "do **not**" typo. Not touched here, since fixing the wording means asserting behavior I haven't verified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical simplification of keyboard/submit simulation in `type.ts` with no intended behavior change on supported Firefox, Chrome, or WebKit.
> 
> **Overview**
> Removes **Firefox major-version branching** in `cy.type()` now that Cypress only launches Firefox **140+**, so those checks were always constant and the related comments were misleading.
> 
> **Form submit on Enter** — `simulateSubmitHandler` no longer special-cases pre-98 Firefox; non-WebKit browsers still click the default submit button (or fire submit) as before.
> 
> **Space key / `{enter}`** — keyup and enter handlers collapse to “non-Firefox **or** Firefox on `<input>` / `<button>`” when Cypress must synthesize clicks Firefox no longer auto-fires.
> 
> **Deleted path** — the manual checkbox/radio `checked` toggling for Firefox 98–128 is removed as unreachable on supported Firefox; behavior on 140+ is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53379edb2331055759c21b3e2d229fb34cdef54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

No behavior change is expected on any supported Firefox (140+), so the value here is regression coverage of the `type()` paths that were touched. Against a real Firefox:

```
yarn workspace @packages/driver cypress:run -- --browser firefox --spec cypress/e2e/commands/actions/type.cy.js
```

Worth exercising specifically: `{enter}` on inputs inside a form (submit fires once, not twice), space-key clicks on `<button>` / `<input type="checkbox">` / `<input type="radio">` (click fires once and the checked state still lands correctly without the removed manual fix-up), and the same paths in Chrome and WebKit to confirm the non-Firefox branches are untouched.

### How has the user experience changed?

No change. Every guard removed was constant-valued for all Firefox versions Cypress is willing to launch, so no supported configuration takes a different path than before.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical dead-code removal; no user-facing behavior change. -->
- [na] Have tests been added/updated? <!-- No behavior change to cover; existing type() specs already exercise these paths. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYYS95Gkz1U7ePeJmZzuZi)_