### PR TITLE
chore: remove unreachable driver error messages

### DIFF
--- a/packages/driver/src/cypress/error_messages.ts
+++ b/packages/driver/src/cypress/error_messages.ts
@@ -117,10 +117,6 @@ const cyStripIndent = (str, indentSize) => {
 }
 
 export default {
-  add: {
-    type_missing: '`Cypress.add(key, fn, type)` must include a type!',
-  },
-
   alias: {
     invalid: 'Invalid alias: `{{name}}`.\nYou forgot the `@`. It should be written as: `@{{displayName}}`.',
     not_registered_with_available: `${cmd('{{cmd}}')} could not find a registered alias for: \`@{{displayName}}\`.\nAvailable aliases are: \`{{availableAliases}}\`.`,
@@ -152,9 +148,6 @@ export default {
     },
     no_focused_element: {
       message: `${cmd('blur')} can only be called when there is a currently focused element.`,
-    },
-    timed_out: {
-      message: `${cmd('blur')} timed out because your browser did not receive any \`blur\` events. This is a known bug in Chrome when it is not the currently focused window.`,
     },
     wrong_focused_element: {
       message: `${cmd('blur')} can only be called on the focused element. Currently the focused element is a: \`{{node}}\``,
@@ -342,12 +335,6 @@ export default {
     invalid_domain (obj) {
       return {
         message: `${cmd('{{cmd}}')} must be passed a valid domain name. You passed: \`{{domain}}\``,
-        docsUrl: `https://on.cypress.io/${_.toLower(obj.cmd)}`,
-      }
-    },
-    invalid_name (obj) {
-      return {
-        message: `${cmd('{{cmd}}')} must be passed an RFC-6265-compliant cookie name. You passed:\n\n\`{{name}}\``,
         docsUrl: `https://on.cypress.io/${_.toLower(obj.cmd)}`,
       }
     },
@@ -599,10 +586,6 @@ export default {
     },
     multiple_elements: {
       message: `${cmd('focus')} can only be called on a single element. Your subject contained {{num}} elements.`,
-      docsUrl: 'https://on.cypress.io/focus',
-    },
-    timed_out: {
-      message: `${cmd('focus')} timed out because your browser did not receive any \`focus\` events. This is a known bug in Chrome when it is not the currently focused window.`,
       docsUrl: 'https://on.cypress.io/focus',
     },
   },
@@ -892,22 +875,6 @@ export default {
         docsUrl: 'https://on.cypress.io/returning-promise-and-commands-in-test',
       }
     },
-    dangling_commands: {
-      message: stripIndent`\
-        Oops, Cypress detected something wrong with your test code.
-
-        The test has finished but Cypress still has commands in its queue.
-        The {{numCommands}} queued commands that have not yet run are:
-
-        {{commands}}
-
-        In every situation we've seen, this has been caused by programmer error.
-
-        Most often this indicates a race condition due to a forgotten 'return' or from commands in a previously run test bleeding into the current test.
-
-        For a much more thorough explanation including examples please review this error here:`,
-      docsUrl: 'https://on.cypress.io/command-queue-ended-early',
-    },
     invalid_command: {
       message: 'Could not find a command for: `{{name}}`.\n\nAvailable commands are: {{cmds}}.\n',
       docsUrl: 'https://on.cypress.io/api',
@@ -1008,7 +975,6 @@ export default {
   mocha: {
     async_timed_out: 'Timed out after `{{ms}}ms`. The `done()` callback was never invoked!',
     invalid_interface: 'Invalid mocha interface `{{name}}`',
-    timed_out: 'Cypress command timeout of `{{ms}}ms` exceeded.',
     overspecified: {
       message: stripIndent`\
         Cypress detected that you returned a promise in a test, but also invoked a done callback. Return a promise -or- invoke a done callback, not both.
@@ -1233,10 +1199,6 @@ export default {
     },
   },
 
-  ng: {
-    no_global: `Angular global (\`window.angular\`) was not found in your window. You cannot use ${cmd('ng')} methods without angular.`,
-  },
-
   origin: {
     docsUrl: 'https://on.cypress.io/origin',
     invalid_url_argument: {
@@ -1377,12 +1339,6 @@ export default {
       `,
       docsUrl: 'https://on.cypress.io/press',
     },
-    unsupported_browser_version: {
-      message: stripIndent`\
-        ${cmd('press')} is not supported in {{browser}} version {{version}}. Upgrade to version {{minimumVersion}} to use \`cy.press()\`.
-      `,
-      docsUrl: 'https://on.cypress.io/press',
-    },
     unsupported_browser: {
       message: stripIndent`\
       ${cmd('press')} is not supported in {{family}} browsers.
@@ -1425,18 +1381,6 @@ export default {
       `,
       docsUrl: 'https://on.cypress.io/proxy-configuration',
     },
-  },
-
-  proxy: {
-    js_rewriting_failed: stripIndent`\
-      An error occurred in the Cypress proxy layer while rewriting your source code. This is a bug in Cypress. Open an issue if you see this message.
-
-      JS URL: {{url}}
-
-      Original error:
-
-      {{errMessage}}
-      {{errStack}}`,
   },
 
   reload: {
@@ -1920,26 +1864,12 @@ export default {
         `,
         docsUrl: 'https://on.cypress.io/session',
       },
-      not_found: {
-        message: stripIndent`
-        No session is defined with the name
-          **{{id}}**
-        In order to use ${cmd('session')}, provide a \`setup\` as the second argument:
-
-        \`cy.session(id, setup)\`
-        `,
-        docsUrl: 'https://on.cypress.io/session',
-      },
     },
   },
 
   setCookie: {
     invalid_arguments: {
       message: `${cmd('setCookie')} must be passed two string arguments for \`name\` and \`value\`.`,
-      docsUrl: 'https://on.cypress.io/setcookie',
-    },
-    invalid_value: {
-      message: `${cmd('setCookie')} must be passed an RFC-6265-compliant cookie value. You passed:\n\n\`{{value}}\``,
       docsUrl: 'https://on.cypress.io/setcookie',
     },
     invalid_samesite: ({ validValues, value }) => {
@@ -2008,20 +1938,6 @@ export default {
   },
 
   subject: {
-    not_dom (obj) {
-      return stripIndent`\
-        ${cmd(obj.name)} failed because it requires a valid DOM object.
-
-        The subject received was:
-
-          > \`${obj.subject}\`
-
-        The previous command that ran was:
-
-          > ${cmd(obj.previous)}
-
-        Cypress only considers the \`window\`, \`document\`, or any \`element\` to be valid DOM objects.`
-    },
     detached_during_actionability (obj) {
       return {
         message: stripIndent`\
@@ -2251,10 +2167,6 @@ export default {
           \`iframe\`
           \`[tabindex]\`
           \`[contenteditable]\``,
-      docsUrl: 'https://on.cypress.io/type',
-    },
-    readonly: {
-      message: `${cmd('type')} cannot type into an element with a \`readonly\` attribute. The element typed into was: \`{{node}}\``,
       docsUrl: 'https://on.cypress.io/type',
     },
     tab: {
@@ -2558,11 +2470,5 @@ export default {
       `,
       docsUrl: 'https://on.cypress.io/wrap',
     },
-  },
-
-  xhr: {
-    aborted: 'This XHR was aborted by your code -- check this stack trace below.',
-    missing: '`XMLHttpRequest#xhr` is missing.',
-    network_error: 'The network request for this XHR could not be made. Check your console for the reason.',
   },
 }


### PR DESCRIPTION
- Closes N/A

### Additional details

Removes 16 error message keys from `packages/driver/src/cypress/error_messages.ts` that no code path can reach. This is a dead-code cleanup only — 94 lines deleted, zero lines added, no behavior change.

**Keys removed:**

| Key | Why it is dead |
| --- | --- |
| `add.type_missing` | `Cypress.add` no longer exists anywhere in the repo |
| `blur.timed_out` | no thrower |
| `focus.timed_out` | no thrower |
| `cookies.invalid_name` | no thrower (`cookies.timed_out` / `invalid_domain` / `backend_error` remain live) |
| `miscellaneous.dangling_commands` | no thrower |
| `mocha.timed_out` | `getErrPath()` in `cypress/mocha.ts` only ever returns `mocha.async_timed_out` or `miscellaneous.test_stopped` |
| `ng.no_global` | `cy.ng()` no longer exists |
| `press.unsupported_browser_version` | `press.ts` throws `press.unsupported_browser`, never the `_version` variant |
| `proxy.js_rewriting_failed` | no thrower in driver, proxy, server, or errors packages |
| `sessions.session.not_found` | `sessions/index.ts` throws only `wrongArg*` / `duplicateId` / `validate_callback_false` |
| `setCookie.invalid_value` | no thrower (`invalid_arguments` / `invalid_samesite` / prefix errors remain live) |
| `subject.not_dom` | `cypress/ensure.ts` uses `not_element`, `not_window_or_document`, `not_element_empty_subject` |
| `type.readonly` | superseded by `dom.readonly`, which is thrown from `cypress/ensure.ts` |
| `xhr.aborted`, `xhr.missing`, `xhr.network_error` | no throwers |

The `add`, `ng`, `proxy`, and `xhr` groups had no remaining members and were removed entirely.

**How reachability was established.** A plain text search is not sufficient here, because several error paths in this file are built dynamically. Each dynamic construction site was checked by hand to confirm it cannot produce any of the removed keys:

- `cypress/mocha.ts` `getErrPath()` — only `mocha.async_timed_out` / `miscellaneous.test_stopped`
- `cy/aliases.ts` — only `alias.not_registered_{with,without}_available`
- `cy/commands/navigation.ts` — only `visit.loading_{file,http}_failed` / `visit.loading_invalid_content_type`
- `cypress/error_utils.ts` `createUncaughtException` — only `uncaught.fromSpec` / `uncaught.fromApp`
- `util/config.ts` — six literal `config.*` paths
- `cy/commands/connectors.ts` — `${cmd}.subject_null_or_undefined`, `${cmd}.null_or_undefined_prop_value`
- `cy/commands/querying/querying.ts` — `${queryCommand}.invalid_option_timeout`
- `cy/net-stubbing/events/network-error.ts` — `net_stubbing.request_error.${errorName}`
- `cypress/commands.ts` `internalError()` — all 8 call sites pass literal `miscellaneous.*` strings
- `cypress/utils.ts` `throwErrByPath` passthrough — has zero callers
- the cy-prompt driver's injected `throwErrByPath` — typed `` `cloudPrompt.${string}` ``

The whole monorepo was then searched for both the key paths and a distinctive fragment of each message body, with no file-type filter so `system-tests/`, `cli/`, `npm/`, and `__snapshots__` fixtures were included. No hits outside `error_messages.ts` itself.

One note for reviewers: `packages/driver/src/cypress.ts` assigns `errorMessages = $errorMessages`, so this object is public API on the `Cypress` global. Nothing in the repo reads the removed keys, but a consumer reaching in via `Cypress.errorMessages` is outside what a repo search can prove. These are paths that could never be produced in the first place, so no user-visible message disappears.

### Steps to test

No behavior change to exercise — the removed entries had no reachable throw site. Reviewers can spot-check the reasoning by grepping for any removed key or message fragment across the monorepo, and by confirming the live near-misses are untouched: `dom.readonly` (thrown from `cypress/ensure.ts`), `press.unsupported_browser` (thrown from `cy/commands/actions/press.ts`), and `cookies.timed_out`.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical dead-code removal; no behavior change. -->
- [na] Have tests been added/updated? <!-- Deletion of unreachable code; no test asserted on any removed key or message body. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01THuxno5TgLtASeLjk6g9bA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only deletion of unreachable `Cypress.errorMessages` keys; no throw sites or tests depend on the removed paths.
> 
> **Overview**
> Dead-code cleanup in **`packages/driver/src/cypress/error_messages.ts`**: deletes **16** error-message entries (~94 lines) that no driver throw path can reach, with **no runtime behavior change**.
> 
> Removed keys span legacy APIs (`add`, `ng`, `xhr`), superseded messages (`type.readonly` → `dom.readonly`, `press.unsupported_browser_version` → `press.unsupported_browser`), and entries with no throw sites (`blur`/`focus` `timed_out`, `miscellaneous.dangling_commands`, `mocha.timed_out`, `proxy.js_rewriting_failed`, `sessions.session.not_found`, `setCookie.invalid_value`, `subject.not_dom`, `cookies.invalid_name`). Empty top-level groups **`add`**, **`ng`**, **`proxy`**, and **`xhr`** are dropped entirely.
> 
> Live near-miss messages (e.g. `dom.readonly`, `press.unsupported_browser`, `cookies.timed_out`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47b831712dae51f6233f4139e98baf802bf88e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->