### PR TITLE
chore: remove the unset `componentTesting` config key

### DIFF
--- a/packages/data-context/src/sources/HtmlDataSource.ts
+++ b/packages/data-context/src/sources/HtmlDataSource.ts
@@ -52,7 +52,6 @@ export class HtmlDataSource {
       'proxyUrl',
       'remote',
       'testingType',
-      'componentTesting',
       'reporterUrl',
       'namespace',
       'socketIoRoute',

--- a/packages/driver/src/cypress/cy.ts
+++ b/packages/driver/src/cypress/cy.ts
@@ -921,10 +921,10 @@ export class $Cy extends EventEmitter2 implements ITimeouts, IStability, IAssert
     // don't do anything if we don't have a current runnable
     if (!runnable) return
 
-    // uncaught exceptions should be only be catchable in the AUT (app)
-    // or if in component testing mode, since then the spec frame and
-    // AUT frame are the same
-    if (frameType === 'app' || this.config('componentTesting')) {
+    // uncaught exceptions should only be catchable in the AUT (app); errors
+    // from the spec fail the test outright. Component testing runs the spec
+    // inside the AUT frame, so its errors already arrive here as 'app'.
+    if (frameType === 'app') {
       try {
         const results = this.Cypress.action('app:uncaught:exception', err, runnable, promise)
 


### PR DESCRIPTION
- Closes N/A

### Additional details

`componentTesting` appeared in only two places in the monorepo: a read in the driver's uncaught-exception gate, and an entry in `HtmlDataSource`'s served-config key list. Nothing assigned it, so the read resolved to `undefined` and the gate collapsed to `frameType === 'app'`.

**Why it was unset.** The key was written by `ProjectBase.injectCtSpecificConfig`, which returned `{ ...cfg, componentTesting: true }` from `initializeConfig()`. That method was deleted in #24027 (2022-10-31). The gate itself dates to #15344 (2021-03-10), when the key was still live.

**Why the collapse is a no-op.** #23957 (2022-09-30) landed a month earlier and had already made the clause redundant. It stopped binding the spec-frame error handlers outside e2e (`runner.ts`), routing component-testing errors through `contentWindowListeners` instead — which passes `frameType: 'app'` unconditionally.

There are exactly three producers of `frameType: 'spec'`, and none is reachable in component testing:

1. `runner.ts` `onSpecError` — bound only `if (Cypress.testingType === 'e2e')`.
2. `cross-origin/events/spec_window.ts` — `cy.origin`, which is e2e-only.
3. `cy.ts` `setTopOnError` → `isSpecError()`, which tests whether `err.stack` contains `spec.relative`. Component testing serves the spec as a dev-server bundle, so raw stacks reference `__cypress/src/spec-0.js` and that path never appears — the check cannot match.

Conversely, component testing's single window is wired to the `'app'` path: `runSpecCT()` creates only the AUT iframe, and the CT client bootstrap calls `onSpecWindow(window)` and then `action('app:window:before:load', window)` on that same window, which reaches `cy.onBeforeAppWindowLoad` → `contentWindowListeners`.

The `HtmlDataSource` entry is inert for a second, independent reason: `makeServeConfig` spreads the full project config *underneath* the picked keys, so removing a key from the pick list cannot drop a value that is present in the project config.

### Steps to test

No behavior change, so there is nothing new to exercise. To confirm the existing behavior is preserved:

```bash
# component testing: uncaught:exception still fires for an error from the component
cd packages/driver
node ../../scripts/cypress.js run --component --config-file ./cypress.config.ts \
  --browser electron --spec cypress/component/spec.cy.ts

# e2e: the other side of the gate is unaffected
node ../../scripts/cypress.js run --config-file ./cypress.config.ts \
  --browser electron --spec cypress/e2e/e2e/uncaught_errors.cy.js
```

Both suites pass before and after this change (2/2 and 13/13 respectively, headless Electron). `yarn workspace @packages/driver check-ts`, `yarn workspace @packages/data-context check-ts`, and `yarn lint --scope @packages/driver --scope @packages/data-context` also pass.

`npm/react/cypress/component/basic/error-boundary.cy.jsx` provides additional coverage in CI: it mounts a component that throws during render and asserts inside a `cy.on('uncaught:exception')` handler, so it would fail if component-testing uncaught exceptions stopped reaching `app:uncaught:exception`.

### How has the user experience changed?

No change. The removed clause could not evaluate truthy, and the removed key could not affect the served config.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical removal of an unreachable branch and an unset config key; no behavior change. -->
- [na] Have tests been added/updated? <!-- No behavior change. Existing coverage (packages/driver/cypress/component/spec.cy.ts, cypress/e2e/e2e/uncaught_errors.cy.js) was run to confirm this. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- `componentTesting` was never a public config option. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_012zUAjqZxRbnmXkbujuDuVH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no intended behavior change; uncaught-exception paths for CT and e2e were already equivalent in practice.
> 
> **Overview**
> Removes the unused **`componentTesting`** config surface and simplifies uncaught-exception handling in the driver.
> 
> **`HtmlDataSource`** no longer includes `componentTesting` in the keys picked for the served client bootstrap config.
> 
> **`cy.onUncaughtException`** only treats **`frameType === 'app'`** as eligible for `app:uncaught:exception` (the `componentTesting` config check is removed). Comments now note that component tests run in the AUT frame, so those errors already use `frameType: 'app'`.
> 
> This is cleanup only: nothing set `componentTesting` after older CT config injection was removed, so the extra branch was unreachable and behavior should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fcaa860b7ac26ea7dd39529f80c41c970f3eae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->