### PR TITLE
chore: run net_stubbing.cy.ts in the injectDocumentDomain driver suite

### DIFF
--- a/packages/driver/cypress.config-injectDocumentDomain.ts
+++ b/packages/driver/cypress.config-injectDocumentDomain.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   ...baseConfig,
   e2e: {
     ...baseConfig.e2e,
-    specPattern: '{cypress/**/origin/**/*.cy.{js,ts},cypress/**/cookies.cy.js,cypress/**/net_stubbing.cy.js}',
+    specPattern: '{cypress/**/origin/**/*.cy.{js,ts},cypress/**/cookies.cy.{js,ts},cypress/**/net_stubbing.cy.{js,ts}}',
     injectDocumentDomain: true,
   },
   component: undefined,


### PR DESCRIPTION
- Closes N/A — no associated issue. This is a CI coverage gap, not a reported bug.

### Additional details

**Why was this change necessary?**

`packages/driver/cypress.config-injectDocumentDomain.ts` set an e2e `specPattern` whose third entry asked for `cypress/**/net_stubbing.cy.js`, but the spec is `packages/driver/cypress/e2e/commands/net_stubbing.cy.ts` (TypeScript). That entry has matched zero files since the config was added, so `cy.intercept` has never been exercised with `injectDocumentDomain: true`.

Verified by resolving both patterns through the repo's own `globby` from `packages/driver`:

| | specs matched | `net_stubbing` matched |
|---|---|---|
| old glob | 42 | **none** |
| new glob | 43 | `cypress/e2e/commands/net_stubbing.cy.ts` |

No files are dropped — the change is purely additive. The `cookies.cy.js` entry was already correct (that file really is `.js`); it is widened to `{js,ts}` for the same reason as `net_stubbing`, not because it was broken.

**What is affected by this change?**

Three CI jobs run this config, and all three gain `net_stubbing.cy.ts` coverage:

- `driver-integration-tests-chrome-inject-document-domain`
- `driver-integration-tests-chrome-beta-inject-document-domain`
- `driver-integration-tests-webkit` — this one passes `inject-document-domain: true` because `cy.origin` is unsupported on WebKit, and it runs *only* this config. So `net_stubbing.cy.ts` has not run on WebKit in any mode.

**Implementation details**

Both the `cookies` and `net_stubbing` entries now match `*.cy.{js,ts}` rather than flipping `.js` → `.ts`, so a future rename between the two extensions cannot silently empty the glob again. This is the same shape the `origin/**` entry already uses.

The spec already contains `Cypress.config('injectDocumentDomain')` branches (`net_stubbing.cy.ts` lines 1102 and 1112) that were written for a mode that never actually ran. They run now, and pass.

### Steps to test

`net_stubbing.cy.ts` is ~4,500 lines, so this was treated as a coverage change rather than a typo fix and the spec was run before opening this PR. Each mode was run against the unmodified baseline config to separate pre-existing/environmental failures from regressions:

```
yarn workspace @packages/driver cypress:run:inject-document-domain \
  --spec cypress/e2e/commands/net_stubbing.cy.ts

# baseline for comparison
yarn workspace @packages/driver cypress:run \
  --spec cypress/e2e/commands/net_stubbing.cy.ts
```

| Browser | Config | Tests | Pass | Fail |
|---|---|---|---|---|
| Chromium 141 | `injectDocumentDomain` | 263 | 257 | 1 |
| Chromium 141 | baseline | 263 | 257 | 1 |
| WebKit 2311 | `injectDocumentDomain` | 263 | 254 | 1 |
| WebKit 2311 | baseline | 263 | 253 | 2 |

**No failure is attributable to this change** — every failure reproduces on the unmodified baseline config:

- **Chromium, `should handle aborted requests`** — byte-identical failure in both modes, same assertion and line. The fixture XHRs to `https://jsonplaceholder.cypress.io`; the host was reachable from the test environment and trusting the sandbox CA did not change the result. It passes on WebKit (MITM proxy path) and fails only on Chromium (CDP path), so it appears to be an artifact of the Playwright Chromium build used locally.
- **WebKit, `different origin with response interception (HTTPS)`** — self-signed local cert on `:3502`; fails in both modes.

The WebKit differential is the useful one: `injectDocumentDomain` is *strictly better* there (1 failure vs 2). The extra baseline failure is `can load transfer-encoding: chunked redirects` taking its `cy.origin` branch — exactly the case the `injectDocumentDomain` branch at line 1112 exists to handle.

Two caveats for the reviewer, since they are what CI will actually decide:

- Real Google Chrome and Chrome Beta could not be run locally (only Playwright Chromium 141), so the two Chrome jobs are unverified outside CI.
- CI runs this spec with `parallelism: 5` and the spec declares `retries: 15`, so flake that a single local run will not surface is still possible.

`yarn workspace @packages/driver check-ts` and `yarn lint --scope @packages/driver` both pass.

### How has the user experience changed?

No change. This affects CI spec selection only; no product code or user-facing behavior is touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical fix to a CI spec glob that matched no files; details in the description above. -->
- [na] Have tests been added/updated? <!-- No new tests; this turns an existing spec on in a mode where it was silently skipped. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9cpShRWewztMTH2XyaazK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI spec selection only; no application code or user-facing behavior is modified.
> 
> **Overview**
> Fixes the **`injectDocumentDomain`** Cypress config so CI actually picks up the TypeScript e2e specs it was meant to run.
> 
> The e2e **`specPattern`** now matches **`cookies.cy.{js,ts}`** and **`net_stubbing.cy.{js,ts}`** instead of hard-coded **`.js`** paths. **`net_stubbing`** lives at **`net_stubbing.cy.ts`**, so the old third glob matched nothing and **`cy.intercept`** never ran with **`injectDocumentDomain: true`** (including WebKit jobs that only use this config). The **`origin/**`** entry already used **`{js,ts}`**; this aligns the other entries and avoids silent skips if a spec is renamed between extensions.
> 
> No product or runtime behavior changes—only which specs run in the inject-document-domain driver integration jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490b0f033d98e83d2c35f68c0cc86ba30108cbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->