### PR TITLE
chore: remove shadowing and unused ambient declarations from @packages/ts

### DIFF
--- a/packages/ts/.eslintignore
+++ b/packages/ts/.eslintignore
@@ -1,6 +1,2 @@
-**/dist
 **/*.d.ts
-**/package-lock.json
 **/tsconfig.json
-**/cypress/fixtures
-**/__snapshots__

--- a/packages/ts/AGENTS.md
+++ b/packages/ts/AGENTS.md
@@ -9,11 +9,9 @@ yarn workspace @packages/ts test
 
 **Architecture**
 
-- `index.js` — Entry point; re-exports the configured ts-node/typescript-cached-transpile setup
 - `register.js` — Registers ts-node for require-time TypeScript transpilation in a single directory
 - `registerDir.js` — Registers ts-node for an entire directory tree
 - `tsconfig.json` — Base TypeScript config shared across the monorepo
-- `tsconfig.dom.json` — TypeScript config variant for browser/DOM contexts
 - `tslint.json` — TSLint config (legacy linting) shared across packages
 
 **Gotchas / Notes**

--- a/packages/ts/index.d.ts
+++ b/packages/ts/index.d.ts
@@ -22,8 +22,6 @@ declare module 'http' {
       _implicitHeader: () => void
       output: string[]
       agent: Agent
-      insecureHTTPParser: boolean
-      maxHeaderSize?: number
     }
 
     interface RequestOptions extends ClientRequestArgs {
@@ -36,12 +34,6 @@ declare module 'http' {
       socket: Optional<Socket>
       uri?: Url
     }
-
-    interface OutgoingMessage {
-      destroy(error?: Error): this
-    }
-
-    export const CRLF: string
 }
 
 declare module 'https' {
@@ -56,21 +48,11 @@ declare interface InternalStream {
 
 declare module 'net' {
   type family = 4 | 6
-  type TCPSocket = {}
 
   interface Address {
     address: string
     family: family
   }
-
-  interface Socket {
-    _handle: TCPSocket | null
-  }
-
-}
-
-declare interface Object {
-  assign(...obj: any[]): any
 }
 
 declare type Optional<T> = T | void
@@ -81,10 +63,4 @@ declare module 'plist' {
   }
   const plist: Plist
   export = plist
-}
-
-declare module 'url' {
-  interface UrlWithStringQuery {
-    format(): string
-  }
 }

--- a/packages/ts/index.d.ts
+++ b/packages/ts/index.d.ts
@@ -87,10 +87,6 @@ declare module 'proxy-from-env' {
   const getProxyForUrl: (url: string) => string
 }
 
-declare interface SymbolConstructor {
-  for(str: string): SymbolConstructor
-}
-
 declare module 'url' {
   interface UrlWithStringQuery {
     format(): string

--- a/packages/ts/index.d.ts
+++ b/packages/ts/index.d.ts
@@ -83,10 +83,6 @@ declare module 'plist' {
   export = plist
 }
 
-declare module 'proxy-from-env' {
-  const getProxyForUrl: (url: string) => string
-}
-
 declare module 'url' {
   interface UrlWithStringQuery {
     format(): string

--- a/packages/ts/index.js
+++ b/packages/ts/index.js
@@ -1,3 +1,0 @@
-// gives anyone access to ts-node
-// https://github.com/TypeStrong/ts-node#programmatic-usage
-module.exports = require('ts-node')

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -2,7 +2,6 @@
   "name": "@packages/ts",
   "version": "0.0.0-development",
   "private": true,
-  "main": "index.js",
   "scripts": {
     "check-ts": "tsc --noEmit",
     "clean-deps": "rimraf node_modules",
@@ -21,9 +20,6 @@
   "files": [
     "register.js",
     "registerDir.js"
-  ],
-  "types": [
-    "index.d.ts"
   ],
   "license": "MIT",
   "nx": {}

--- a/packages/ts/tsconfig.dom.json
+++ b/packages/ts/tsconfig.dom.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "lib": [
-      "ESNext",
-      "DOM"
-    ]
-  }
-}


### PR DESCRIPTION
- Closes N/A — no associated issue; this is internal type-definition cleanup with no runtime or user-facing effect.

### Additional details

`packages/ts/index.d.ts` is shared into ten compilation units — `packages/{proxy,net-stubbing,launcher,network,data-context,server,reporter}` via tsconfig `files`, `packages/driver/index.ts` and `packages/runner/index.d.ts` via `/// <reference>`, and `system-tests/tsconfig.json` — so anything declared in it propagates widely. Two of its declarations were actively shadowing better types, and the rest had no consumers.

**Two shadowing bugs fixed**

1. `declare interface SymbolConstructor { for(str: string): SymbolConstructor }` declaration-merged into the real `SymbolConstructor`. Merged members from later declarations win overload resolution, so it shadowed `lib.es2015`'s `for(key: string): symbol` and made `Symbol.for('x')` type as `SymbolConstructor` instead of `unique symbol`. Introduced in c1a345dce (#3531, 2019) and never touched since.

2. `declare module 'proxy-from-env'` shadowed `@types/proxy-from-env`, which `packages/network` already depends on. Ambient module declarations take precedence over `node_modules` type resolution, so `packages/network` resolved the stub's `(url: string) => string` rather than the real `getProxyForUrl(url: string | Url): string`, rejecting `Url` arguments the library accepts.

**Unused declarations removed**

- `interface Object { assign }` — augmented the instance side, not `ObjectConstructor`, so it never affected `Object.assign()` call sites.
- `http.CRLF` — imported nowhere; `packages/network/lib/agent.ts` declares its own local const.
- `http.OutgoingMessage.destroy` — restates the signature `OutgoingMessage` already inherits from `stream.Writable`.
- `net.TCPSocket` and `net.Socket._handle` — no references outside this file. `net.family` and `net.Address` are kept; both are used by `packages/network`.
- `url.UrlWithStringQuery.format` — no references.
- `ClientRequest.insecureHTTPParser` / `maxHeaderSize` — never read off a `ClientRequest`; `@types/node` declares both on `ClientRequestArgs`, which this file's `RequestOptions` extends.

**Unused files and package.json fields removed**

- `tsconfig.dom.json` — no extenders; browser-facing packages declare their own `lib` inline.
- `index.js` and the `main` field — every consumer requires `@packages/ts/register`; no bare `require('@packages/ts')` exists.
- `"types": ["index.d.ts"]` — ignored outright, since the field takes a string, not an array. Dropped rather than corrected: `index.d.ts` is a global ambient script, not a module's type surface, and all consumers already reference it by path.
- `.eslintignore` trimmed to the two patterns that match files here. `**/tsconfig.json` is load-bearing — without it eslint warns on `tsconfig.json` via the json plugin.

`files` is deliberately kept: inert while the package is `private`, but it still records the intended consumer surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Development-time type declarations only; no runtime or shipped API changes, with net-positive type-checking fixes.
> 
> **Overview**
> **Internal cleanup of `@packages/ts` ambient types** so widely-referenced `index.d.ts` stops overriding real typings and drops dead declarations with no call sites.
> 
> The change **fixes two shadowing bugs**: a bad `SymbolConstructor.for` merge that made `Symbol.for()` type as `SymbolConstructor`, and a stub `proxy-from-env` module that blocked `@types/proxy-from-env` (e.g. `getProxyForUrl` no longer rejects `Url` arguments in `packages/network`). It also **removes unused augmentations** (`Object.assign`, extra `http`/`net`/`url` shapes) and **trims package surface**: deletes unused `index.js`, `tsconfig.dom.json`, invalid `package.json` `types` array and unused `main`, narrows `.eslintignore`, and updates `AGENTS.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0a2bf913901b61321e426446324b41ea9e9d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

No behavior to exercise at runtime — these are development-time type declarations, and the package emits nothing.

To confirm the two shadowing fixes, compile a probe against `packages/ts/index.d.ts` before and after this change:

```ts
// Symbol.for
const s = Symbol.for('x')
const bad: null = s
// before: Type 'SymbolConstructor' is not assignable to type 'null'
// after:  Type 'unique symbol' is not assignable to type 'null'
```

```ts
// proxy-from-env, compiled inside packages/network
import { getProxyForUrl } from 'proxy-from-env'
import { parse } from 'url'
getProxyForUrl(parse('https://example.com'))
// before: TS2345, Argument of type 'UrlWithStringQuery' is not assignable to parameter of type 'string'
// after:  compiles
```

To confirm the removals are inert, run `tsc` over the ten affected compilation units before and after; the output is byte-identical.

### How has the user experience changed?

No change. These declarations exist only for in-monorepo development-time type checking and are not part of any shipped artifact.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical cleanup of unused/shadowing type declarations; no behavior change. -->
- [na] Have tests been added/updated? <!-- Type-definition-only change with no runtime surface; verified by typechecking the ten consuming compilation units. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- These are internal ambient declarations, not the public `cypress.d.ts` surface. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_017znXdRR2dtDfy5uqPwE5bA)_