### PR TITLE
chore: type-check @packages/reporter in CI

### DIFF
--- a/packages/app/src/store/automation-status.ts
+++ b/packages/app/src/store/automation-status.ts
@@ -1,0 +1,8 @@
+export const automation = {
+  CONNECTING: 'CONNECTING',
+  MISSING: 'MISSING',
+  CONNECTED: 'CONNECTED',
+  DISCONNECTED: 'DISCONNECTED',
+} as const
+
+export type AutomationStatus = keyof typeof automation

--- a/packages/app/src/store/index.ts
+++ b/packages/app/src/store/index.ts
@@ -1,5 +1,7 @@
 import { createPinia as _createPinia } from 'pinia'
 
+export * from './automation-status'
+
 export * from './specs-store'
 
 export * from './aut-store'

--- a/packages/app/src/store/mobx-runner-store.ts
+++ b/packages/app/src/store/mobx-runner-store.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 import { action, observable, makeObservable } from 'mobx'
-import type { AutomationStatus } from '../store'
+import type { AutomationStatus } from './automation-status'
 
 const defaults = {
   url: '',

--- a/packages/app/src/store/runner-ui-store.ts
+++ b/packages/app/src/store/runner-ui-store.ts
@@ -1,14 +1,7 @@
 import { defineStore } from 'pinia'
 import { runnerConstants } from '../runner/runner-constants'
-
-export const automation = {
-  CONNECTING: 'CONNECTING',
-  MISSING: 'MISSING',
-  CONNECTED: 'CONNECTED',
-  DISCONNECTED: 'DISCONNECTED',
-} as const
-
-export type AutomationStatus = keyof typeof automation
+import { automation } from './automation-status'
+import type { AutomationStatus } from './automation-status'
 
 /**
  * Store for reactive properties used in the runner UI.

--- a/packages/reporter/cypress/e2e/agents.cy.ts
+++ b/packages/reporter/cypress/e2e/agents.cy.ts
@@ -1,5 +1,14 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from './../../src/runnables/runnables-store'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo',
+  absolute: '/foo/bar',
+  relative: 'foo/bar',
+})
 
 describe('agents', () => {
   let runner: EventEmitter
@@ -16,13 +25,7 @@ describe('agents', () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/aliases.cy.ts
+++ b/packages/reporter/cypress/e2e/aliases.cy.ts
@@ -1,6 +1,15 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from './../../src/runnables/runnables-store'
 import { addCommand } from '../support/utils'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo',
+  absolute: '/foo/bar',
+  relative: 'foo/bar',
+})
 
 describe('aliases', () => {
   let runner: EventEmitter
@@ -16,13 +25,7 @@ describe('aliases', () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/commands.cy.ts
+++ b/packages/reporter/cypress/e2e/commands.cy.ts
@@ -1,7 +1,17 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from '../../src/runnables/runnables-store'
 import { addCommand } from '../support/utils'
+import type { CommandIndicator } from '../../src/commands/command-model'
 import { MAX_VISIBILITY_CHECK_ELEMENTS } from '@packages/types'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo',
+  absolute: '/foo/bar',
+  relative: 'foo/bar',
+})
 
 describe('commands', { viewportHeight: 1000 }, () => {
   let runner: EventEmitter
@@ -18,13 +28,7 @@ describe('commands', { viewportHeight: 1000 }, () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 
@@ -150,7 +154,7 @@ describe('commands', { viewportHeight: 1000 }, () => {
       wallClockStartedAt: inProgressStartedAt,
     })
 
-    const indicators = ['successful', 'pending', 'aborted', 'bad']
+    const indicators: CommandIndicator[] = ['successful', 'pending', 'aborted', 'bad']
 
     indicators.forEach((indicator, index) => {
       addCommand(runner, {
@@ -300,7 +304,7 @@ describe('commands', { viewportHeight: 1000 }, () => {
   })
 
   it('shows message indicator when specified', () => {
-    const indicators = ['successful', 'pending', 'aborted', 'bad']
+    const indicators: CommandIndicator[] = ['successful', 'pending', 'aborted', 'bad']
 
     indicators.forEach((indicator) => {
       addCommand(runner, {
@@ -323,7 +327,7 @@ describe('commands', { viewportHeight: 1000 }, () => {
   })
 
   it('shows message indicator when specified and request went to origin', () => {
-    const indicators = ['successful', 'pending', 'aborted', 'bad']
+    const indicators: CommandIndicator[] = ['successful', 'pending', 'aborted', 'bad']
 
     indicators.forEach((indicator) => {
       addCommand(runner, {
@@ -1337,13 +1341,7 @@ describe('cy.prompt command buttons', { viewportHeight: 1000 }, () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/commands.cy.ts
+++ b/packages/reporter/cypress/e2e/commands.cy.ts
@@ -2,8 +2,10 @@ import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from '../../src/runnables/runnables-store'
 import { addCommand } from '../support/utils'
-import type { CommandIndicator } from '../../src/commands/command-model'
+import type { RenderProps } from '../../src/commands/command-model'
 import { MAX_VISIBILITY_CHECK_ELEMENTS } from '@packages/types'
+
+type CommandIndicator = NonNullable<RenderProps['indicator']>
 
 const runnerStore = new MobxRunnerStore('e2e')
 

--- a/packages/reporter/cypress/e2e/header.cy.ts
+++ b/packages/reporter/cypress/e2e/header.cy.ts
@@ -1,6 +1,15 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { TestFilter } from '@packages/types'
 import { EventEmitter } from 'events'
 import { RootRunnable } from '../../src/runnables/runnables-store'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo',
+  absolute: '/foo/bar',
+  relative: 'foo/bar',
+})
 
 const { _ } = Cypress
 
@@ -22,13 +31,7 @@ describe('header', () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/hooks.cy.ts
+++ b/packages/reporter/cypress/e2e/hooks.cy.ts
@@ -1,6 +1,15 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from '../../src/runnables/runnables-store'
 import { itHandlesFileOpening } from '../support/utils'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo.js',
+  relative: 'relative/path/to/foo.js',
+  absolute: '/absolute/path/to/foo.js',
+})
 
 describe('hooks', () => {
   let runner: EventEmitter
@@ -16,13 +25,7 @@ describe('hooks', () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo.js',
-            relative: 'relative/path/to/foo.js',
-            absolute: '/absolute/path/to/foo.js',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/routes.cy.ts
+++ b/packages/reporter/cypress/e2e/routes.cy.ts
@@ -1,5 +1,14 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from './../../src/runnables/runnables-store'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo',
+  absolute: '/foo/bar',
+  relative: 'foo/bar',
+})
 
 describe('routes', () => {
   let runner: EventEmitter
@@ -16,13 +25,7 @@ describe('routes', () => {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo',
-            absolute: '/foo/bar',
-            relative: 'foo/bar',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/runnables.cy.ts
+++ b/packages/reporter/cypress/e2e/runnables.cy.ts
@@ -78,7 +78,7 @@ describe('runnables', () => {
     start({ error })
 
     cy.contains(error.title)
-    cy.contains(error.callout)
+    cy.contains(error.callout!)
     cy.contains(error.message)
 
     cy.get('.error a').should('have.attr', 'href', error.link)

--- a/packages/reporter/cypress/e2e/runnables.cy.ts
+++ b/packages/reporter/cypress/e2e/runnables.cy.ts
@@ -4,7 +4,7 @@ import { itHandlesFileOpening } from '../support/utils'
 import type { BaseReporterProps } from '../../src/main'
 import type { RunnablesErrorModel } from '../../src/runnables/runnable-error'
 import appState from '../../src/lib/app-state'
-import { MobxRunnerStore } from '@packages/app/src/store'
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import scroller from '../../src/lib/scroller'
 
 const runnerStore = new MobxRunnerStore('e2e')

--- a/packages/reporter/cypress/e2e/shortcuts.cy.ts
+++ b/packages/reporter/cypress/e2e/shortcuts.cy.ts
@@ -1,5 +1,14 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import sinon, { SinonStub, SinonSpy } from 'sinon'
 import { EventEmitter } from 'events'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo.js',
+  relative: 'relative/path/to/foo.js',
+  absolute: '/absolute/path/to/foo.js',
+})
 
 type EventEmitterStub = EventEmitter & Stub
 
@@ -26,13 +35,7 @@ describe('shortcuts', function () {
     cy.visit('/').then((win) => {
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo.js',
-            relative: 'relative/path/to/foo.js',
-            absolute: '/absolute/path/to/foo.js',
-          },
-        },
+        runnerStore,
       })
     })
 

--- a/packages/reporter/cypress/e2e/spec_title.cy.ts
+++ b/packages/reporter/cypress/e2e/spec_title.cy.ts
@@ -1,3 +1,4 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { itHandlesFileOpening } from '../support/utils'
 
@@ -9,8 +10,12 @@ describe('spec title', () => {
     runner = new EventEmitter()
 
     start = (spec: Cypress.Cypress['spec']) => {
+      const runnerStore = new MobxRunnerStore('e2e')
+
+      runnerStore.setSpec(spec)
+
       cy.visit('/').then((win) => {
-        win.render({ runner, runnerStore: { spec } })
+        win.render({ runner, runnerStore })
       })
 
       cy.get('.reporter.mounted').then(() => {

--- a/packages/reporter/cypress/e2e/suites.cy.ts
+++ b/packages/reporter/cypress/e2e/suites.cy.ts
@@ -1,4 +1,4 @@
-import { MobxRunnerStore } from '@packages/app/src/store'
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { RootRunnable } from '../../src/runnables/runnables-store'
 

--- a/packages/reporter/cypress/e2e/test_errors.cy.ts
+++ b/packages/reporter/cypress/e2e/test_errors.cy.ts
@@ -1,7 +1,16 @@
+import { MobxRunnerStore } from '@packages/app/src/store/mobx-runner-store'
 import { EventEmitter } from 'events'
 import { itHandlesFileOpening } from '../support/utils'
 import Err from '../../src/errors/err-model'
 import { RootRunnable } from '../../src/runnables/runnables-store'
+
+const runnerStore = new MobxRunnerStore('e2e')
+
+runnerStore.setSpec({
+  name: 'foo.js',
+  relative: 'relative/path/to/foo.js',
+  absolute: '/absolute/path/to/foo.js',
+})
 
 describe('test errors', () => {
   let commandErr: Partial<Err>
@@ -28,13 +37,7 @@ describe('test errors', () => {
 
       win.render({
         runner,
-        runnerStore: {
-          spec: {
-            name: 'foo.js',
-            relative: 'relative/path/to/foo.js',
-            absolute: '/absolute/path/to/foo.js',
-          },
-        },
+        runnerStore,
       })
     })
   })

--- a/packages/reporter/cypress/e2e/unit/command_model.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/command_model.cy.ts
@@ -155,7 +155,7 @@ describe('Command model', () => {
       let command: CommandModel
 
       beforeEach(() => {
-        command = new CommandModel(commandProps({ state: null }))
+        command = new CommandModel(commandProps({ state: null } as unknown as Partial<CommandProps>))
         clock.tick(300)
         command.update({ state: 'pending' } as CommandProps)
       })

--- a/packages/reporter/cypress/e2e/unit/runnables_store.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/runnables_store.cy.ts
@@ -202,7 +202,7 @@ describe('runnables store', () => {
     it('finishes the test with the given id', () => {
       instance.setRunnables({ tests: [createTest('1')], suites: [] })
       instance.runnableStarted({ id: '1' } as TestProps)
-      instance.runnableFinished({ id: '1' } as TestProps)
+      instance.runnableFinished({ id: '1' } as TestProps, false)
       expect((instance.runnables[0] as TestModel).isActive).to.be.false
     })
   })

--- a/packages/reporter/cypress/e2e/unit/test_model.cy.ts
+++ b/packages/reporter/cypress/e2e/unit/test_model.cy.ts
@@ -1,4 +1,4 @@
-import Err from '../../../src/errors/err-model'
+import type { ErrProps } from '../../../src/errors/err-model'
 import TestModel, { TestProps, UpdatableTestProps } from '../../../src/test/test-model'
 import CommandModel, { CommandProps } from '../../../src/commands/command-model'
 import { RouteProps } from '../../../src/routes/route-model'
@@ -296,15 +296,15 @@ describe('Test model', () => {
     it('updates the test err', () => {
       const test = createTest()
 
-      test.finish({ err: { name: 'SomeError' } as Err } as UpdatableTestProps, false)
-      expect(test.err.name).to.equal('SomeError')
+      test.finish({ err: { name: 'SomeError' } as ErrProps } as unknown as UpdatableTestProps, false)
+      expect(test.err!.name).to.equal('SomeError')
     })
 
     it('sets the hook to failed if it exists', () => {
       const test = createTest({ hooks: [{ hookId: 'h1', hookName: 'before each' }] })
 
       test.addLog(createCommand({ instrument: 'command' }))
-      test.finish({ state: 'failed', failedFromHookId: 'h1', err: { message: 'foo' } as Err } as UpdatableTestProps, false)
+      test.finish({ state: 'failed', failedFromHookId: 'h1', err: { message: 'foo' } as ErrProps } as unknown as UpdatableTestProps, false)
       expect(test.lastAttempt.hooks[1].failed).to.be.true
     })
 
@@ -319,21 +319,21 @@ describe('Test model', () => {
 
   context('#commandMatchingErr', () => {
     it('returns last command matching the error', () => {
-      const test = createTest({ err: { message: 'SomeError' } as Err, hooks: [
+      const test = createTest({ err: { message: 'SomeError' } as ErrProps, hooks: [
         { hookId: 'h1', hookName: 'before each' },
         { hookId: 'h2', hookName: 'before each' },
       ] })
 
-      test.addLog(createCommand({ err: { message: 'SomeError' } as Err, hookId: 'h1' }))
-      test.addLog(createCommand({ err: {} as Err, hookId: 'h1' }))
-      test.addLog(createCommand({ err: { message: 'SomeError' } as Err, hookId: 'h1' }))
-      test.addLog(createCommand({ err: {} as Err, hookId: 'h2' }))
-      test.addLog(createCommand({ name: 'The One', err: { message: 'SomeError' } as Err, hookId: 'h2' }))
+      test.addLog(createCommand({ err: { message: 'SomeError' } as ErrProps, hookId: 'h1' }))
+      test.addLog(createCommand({ err: {} as ErrProps, hookId: 'h1' }))
+      test.addLog(createCommand({ err: { message: 'SomeError' } as ErrProps, hookId: 'h1' }))
+      test.addLog(createCommand({ err: {} as ErrProps, hookId: 'h2' }))
+      test.addLog(createCommand({ name: 'The One', err: { message: 'SomeError' } as ErrProps, hookId: 'h2' }))
       expect(test.commandMatchingErr()!.name).to.equal('The One')
     })
 
     it('returns undefined if there are no commands with errors', () => {
-      const test = createTest({ err: { message: 'SomeError' } as Err, hooks: [
+      const test = createTest({ err: { message: 'SomeError' } as ErrProps, hooks: [
         { hookId: 'h1', hookName: 'before each' },
         { hookId: 'h2', hookName: 'before each' },
         { hookId: 'h3', hookName: 'before each' },

--- a/packages/reporter/index.d.ts
+++ b/packages/reporter/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../driver/types/internal-types-lite.d.ts" />
+
 /// <reference path="../../cli/types/cy-blob-util.d.ts" />
 /// <reference path="../../cli/types/cy-bluebird.d.ts" />
 /// <reference path="../../cli/types/cy-minimatch.d.ts" />
@@ -17,7 +19,7 @@ declare namespace Cypress {
   }
 }
 
-declare module "*.svg" {
-  const content: any;
-  export default content;
+declare module '*.svg' {
+  const content: any
+  export default content
 }

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -5,7 +5,7 @@
   "browser": "src/main.tsx",
   "scripts": {
     "build-for-tests": "node ../../scripts/run-webpack",
-    "check-ts": "yarn -s tslint",
+    "check-ts": "tsc --noEmit && yarn -s tslint",
     "clean-deps": "rimraf node_modules",
     "cypress:open": "node ../../scripts/cypress open --project .",
     "cypress:run": "node ../../scripts/cypress run --project .",

--- a/packages/reporter/src/commands/command-model.ts
+++ b/packages/reporter/src/commands/command-model.ts
@@ -11,11 +11,9 @@ const LONG_RUNNING_THRESHOLD = 1000
 type InterceptStatuses = 'req modified' | 'req + res modified' | 'res modified'
 type XHRStatuses = '---' | '(canceled)' | '(aborted)' | string // string = any xhr status
 
-export type CommandIndicator = 'successful' | 'pending' | 'aborted' | 'bad'
-
 export interface RenderProps {
   message?: string
-  indicator?: CommandIndicator
+  indicator?: 'successful' | 'pending' | 'aborted' | 'bad'
   interceptions?: Array<{
     command: 'intercept' | 'route'
     alias?: string

--- a/packages/reporter/src/commands/command-model.ts
+++ b/packages/reporter/src/commands/command-model.ts
@@ -11,9 +11,11 @@ const LONG_RUNNING_THRESHOLD = 1000
 type InterceptStatuses = 'req modified' | 'req + res modified' | 'res modified'
 type XHRStatuses = '---' | '(canceled)' | '(aborted)' | string // string = any xhr status
 
+export type CommandIndicator = 'successful' | 'pending' | 'aborted' | 'bad'
+
 export interface RenderProps {
   message?: string
-  indicator?: 'successful' | 'pending' | 'aborted' | 'bad'
+  indicator?: CommandIndicator
   interceptions?: Array<{
     command: 'intercept' | 'route'
     alias?: string

--- a/packages/reporter/src/commands/command.tsx
+++ b/packages/reporter/src/commands/command.tsx
@@ -250,7 +250,7 @@ const Aliases: React.FC<AliasesProps> = observer(({ model }: AliasesProps) => {
 
         return (
           <Tag
-            key={alias}
+            key={String(alias)}
             content={aliases.join(', ')}
             type={model.aliasType}
             tooltipMessage={`${model.displayMessage} aliased as: ${aliases.map((alias) => `'${alias}'`).join(', ')}`}

--- a/packages/reporter/src/errors/test-error.tsx
+++ b/packages/reporter/src/errors/test-error.tsx
@@ -54,7 +54,7 @@ const TriggerAction = ({ triggerAction }: { triggerAction: 'loginModal' | 'proje
 }
 
 interface TestErrorProps {
-  err: Err
+  err?: Err
   testId?: string
   commandId?: number
   // the command group level to nest the recovered in-test error

--- a/packages/reporter/src/header/stats-store.ts
+++ b/packages/reporter/src/header/stats-store.ts
@@ -1,9 +1,8 @@
 import _ from 'lodash'
 import { action, computed, observable, makeObservable } from 'mobx'
-import { TestState } from '../test/test-model'
 import type { IntervalID } from '../lib/types'
 
-import type { StatsStoreStartInfo } from '@packages/types'
+import type { StatsStoreStartInfo, TestState } from '@packages/types'
 
 const defaults = {
   numPassed: 0,

--- a/packages/reporter/src/hooks/hooks.cy.tsx
+++ b/packages/reporter/src/hooks/hooks.cy.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import { Hook } from './hooks'
+import type HookModel from './hook-model'
 
 import '../main.scss'
 
 describe('hooks/hooks.tsx', () => {
   it('should mount', () => {
+    // a stub of only what Hook renders; hookName is deliberately not a real
+    // HookName so the assertion below matches the rendered text verbatim
     const model = {
       failed: false,
       hookName: 'TEST BODY',
-    }
+    } as unknown as HookModel
 
     cy.mount(<div className="runnable suite">
       <div className="hooks-container">
-        <Hook model={model} showNumber={false} />
+        <Hook model={model} showNumber={false} scrollIntoView={() => {}} />
       </div>
     </div>)
 

--- a/packages/reporter/src/instruments/instrument-model.ts
+++ b/packages/reporter/src/instruments/instrument-model.ts
@@ -9,12 +9,14 @@ export interface AliasObject {
 
 export type Alias = string | Array<string> | null | AliasObject | Array<AliasObject>
 
+export type AliasType = 'agent' | 'dom' | 'primitive' | 'route'
+
 type DefaultCollapsedState = 'closed' | 'open'
 
 export interface InstrumentProps {
   id: number
   alias?: Alias
-  aliasType?: 'agent' | 'dom' | 'primitive' | 'route'
+  aliasType?: AliasType
   displayName?: string
   name?: string
   message?: string
@@ -30,7 +32,7 @@ export interface InstrumentProps {
 
 export default class Log {
   alias?: Alias
-  aliasType?: string
+  aliasType?: AliasType
   displayName?: string
   id?: number
   name?: string

--- a/packages/reporter/src/lib/tag.cy.tsx
+++ b/packages/reporter/src/lib/tag.cy.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import Tag from './tag'
+import type { TagType } from './tag'
 
 describe('Tag', () => {
-  const aliases = [
+  const aliases: TagType[] = [
     'route',
     'agent',
     'primitive',
     'dom',
   ]
 
-  const statuses = [
+  const statuses: TagType[] = [
     'successful-status',
     'warned-status',
     'failed-status',
   ]
 
-  const misc = [
+  const misc: TagType[] = [
     'count',
   ]
 

--- a/packages/reporter/src/lib/tag.tsx
+++ b/packages/reporter/src/lib/tag.tsx
@@ -2,8 +2,10 @@ import cs from 'classnames'
 import React from 'react'
 import Tooltip from './tooltip'
 
+export type TagType = 'agent' | 'count' | 'dom' | 'failed-status' | 'primitive' | 'route' | 'successful-status' | 'warned-status'
+
 interface TagProps {
-  type?: 'agent' | 'count' | 'dom' | 'failed-status' | 'primitive' | 'route' | 'successful-status' | 'warned-status'
+  type?: TagType
   content: React.ReactNode | string
   count?: number
   tooltipMessage?: React.ReactNode | string

--- a/packages/reporter/src/lib/tag.tsx
+++ b/packages/reporter/src/lib/tag.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import Tooltip from './tooltip'
 
 interface TagProps {
-  type?: 'agent' | 'count' | 'dom' | 'failed-status' | 'primitive' | 'route' | 'successful-status'
+  type?: 'agent' | 'count' | 'dom' | 'failed-status' | 'primitive' | 'route' | 'successful-status' | 'warned-status'
   content: React.ReactNode | string
   count?: number
   tooltipMessage?: React.ReactNode | string

--- a/packages/reporter/src/routes/routes.tsx
+++ b/packages/reporter/src/routes/routes.tsx
@@ -23,7 +23,9 @@ const Route = observer(({ model }: RouteProps) => (
         tooltipMessage={`Aliased this route as: '${model.alias}'`}
         type='route'
         customClassName='route-alias-name'
-        content={model.alias}
+        // a route's alias is always the string passed to cy.intercept, never
+        // one of the object/array shapes the shared Alias type also allows
+        content={model.alias as string}
       />
     </td>
     <td className='route-num-responses'>{model.numResponses || '-'}</td>

--- a/packages/reporter/src/sessions/sessions-model.ts
+++ b/packages/reporter/src/sessions/sessions-model.ts
@@ -2,6 +2,7 @@ import { observable, makeObservable } from 'mobx'
 import Instrument, { InstrumentProps } from '../instruments/instrument-model'
 import { determineTagType } from './utils'
 import type { SessionStatus } from './utils'
+import type { TagType } from '../lib/tag'
 
 export interface SessionProps extends InstrumentProps {
   name: string
@@ -22,7 +23,7 @@ export default class Session extends Instrument {
   // reporter is embedded into test-replay as a submodule.
   status: string
   isGlobalSession: boolean = false
-  tagType: string
+  tagType: TagType
 
   constructor (props: SessionProps) {
     super(props)

--- a/packages/reporter/src/sessions/sessions.cy.tsx
+++ b/packages/reporter/src/sessions/sessions.cy.tsx
@@ -5,7 +5,7 @@ import events from '../lib/events'
 
 describe('sessions instrument panel', { viewportWidth: 400 }, () => {
   it('renders null when no sessions have been added', () => {
-    cy.mount(<Sessions model={[]}/>)
+    cy.mount(<Sessions model={{}}/>)
 
     cy.get('.sessions-container').should('not.exist')
 
@@ -70,7 +70,7 @@ describe('sessions instrument panel', { viewportWidth: 400 }, () => {
     })
 
     beforeEach(() => {
-      cy.mount(<Sessions model={[specSession, globalSession, warnedSpecSession, failedSpecSession]}/>)
+      cy.mount(<Sessions model={{ specSession, globalSession, warnedSpecSession, failedSpecSession }}/>)
 
       cy.get('.sessions-container').should('exist')
       cy.get('.hook-header > .collapsible-header').as('header')

--- a/packages/reporter/src/sessions/sessions.tsx
+++ b/packages/reporter/src/sessions/sessions.tsx
@@ -13,7 +13,9 @@ interface SessionPanelProps {
   model: Record<string, SessionsModel>
 }
 
-const SessionRow: React.FC<SessionsModel> = (model) => {
+type SessionRowProps = Pick<SessionsModel, 'name' | 'isGlobalSession' | 'id' | 'status' | 'testId' | 'tagType'>
+
+const SessionRow: React.FC<SessionRowProps> = (model) => {
   const { name, isGlobalSession, id, status, testId } = model
 
   const printToConsole = (id) => {

--- a/packages/reporter/src/sessions/utils.ts
+++ b/packages/reporter/src/sessions/utils.ts
@@ -1,4 +1,6 @@
-function determineTagType (state: string) {
+import type { TagType } from '../lib/tag'
+
+function determineTagType (state: string): TagType {
   switch (state) {
     case 'failed':
       return 'failed-status'

--- a/packages/reporter/src/test/test.cy.tsx
+++ b/packages/reporter/src/test/test.cy.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import Test from './test'
+import type TestModel from './test-model'
+import type { AppState } from '../lib/app-state'
 
 describe('test/test.tsx', () => {
   it('should mount', () => {
@@ -20,8 +22,8 @@ describe('test/test.tsx', () => {
 
     cy.mount(<div className="runnable suite">
       <Test
-        model={model}
-        appState={appState}
+        model={model as unknown as TestModel}
+        appState={appState as unknown as AppState}
         studioEnabled={false}
       />
     </div>)
@@ -51,8 +53,8 @@ describe('test/test.tsx', () => {
 
     cy.mount(<div className="runnable suite">
       <Test
-        model={model}
-        appState={appState}
+        model={model as unknown as TestModel}
+        appState={appState as unknown as AppState}
         studioEnabled
       />
     </div>)

--- a/packages/reporter/src/test/test.tsx
+++ b/packages/reporter/src/test/test.tsx
@@ -66,7 +66,7 @@ const Test: React.FC<TestProps> = observer(({ model, events: eventsProps = event
           key={`studio-command-${model}`}
           content={
             <div className='flex items-center py-[8px] px-[8px]'>
-              <div><IconCypressStudio strokeColor="gray-500" className="mr-[10px]" /></div>
+              <div><IconCypressStudio className="mr-[10px]" /></div>
               <div className='text-sm text-gray-700'>Edit in Studio</div>
             </div>
           }


### PR DESCRIPTION
- Closes N/A — no associated issue. Internal type-safety work; no user-facing change.

### Additional details

`@packages/reporter` was not type-checked anywhere in CI. Its `check-ts` script was `tslint --config ../ts/tslint.json --project .`, and while tslint builds a TS Program, it never reports type errors. CI runs `yarn check-ts` (`yarn lerna run check-ts`); it never runs `yarn type-check`, the script that actually invokes `tsc --noEmit` per package. So the package compiled through webpack but nothing ever checked its types.

`check-ts` is now `tsc --noEmit && yarn -s tslint`, matching the pattern already used by `data-context`, `driver`, `launcher`, `net-stubbing`, `proxy`, `packherd-require` and `v8-snapshot-require`. tslint is retained.

Turning `tsc` on surfaced **73 errors**. Fixing them fell into three parts.

**1. 20 errors were in `@packages/app`, not reporter.**

Reporter's program reached app's entire runner subtree and then checked it under *reporter's* config (ES2018 lib, no `@cy/*` paths, no `.vue` shims) rather than app's, so code that is correct under app's own `vue-tsc` check-ts reported as broken — `replaceAll` missing, `__CYPRESS_CONFIG__` undeclared, unresolvable `./Highlight.ce.vue` and `@cy/i18n`.

The reach came from one type import: `mobx-runner-store` pulled `AutomationStatus` from the store barrel, and that barrel re-exports `aut-store`, `runner-ui-store` and everything behind them. The `automation` constant and its `keyof` type need none of that, so they move to `automation-status.ts`. The barrel re-exports them, so `event-manager`'s `import { automation } from '../store'` is unchanged. Two reporter specs that imported `MobxRunnerStore` through the barrel now import the module directly.

That removes `@packages/app` from reporter's program entirely. Raising reporter's target to ES2022 instead was tried and cleared only 3 of 24; restricting `include` to `src/**` cleared none.

**2. Six were real defects in reporter's production code.**

- `Log` widened `aliasType` to `string`, discarding the union `InstrumentProps` declares. `Session` did the same to `tagType`, discarding what `determineTagType` returns. Both are the same class of bug as the `'warned-status'` omission this PR fixes — a precise union silently widened. `tag.tsx` now owns `TagType` and its consumers conform, so a missing member fails at the point the value is produced.
- `stats-store.ts` imported `TestState` from `../test/test-model`, which does not export it (`TS2614`). It now comes from `@packages/types`, as it does in the six other files that use it.
- `TestError` returned `null` for a missing `err` at runtime but typed the prop as required.
- `IconCypressStudio` takes fill colors, not stroke; React dropped the unknown `strokeColor` attribute, so removing it leaves rendering unchanged. **If the icon was meant to be grey, the fix is `fillColor` — flagging rather than changing appearance here.**
- Reporter now references the driver's `internal-types-lite.d.ts`, as app does, for the internal `Cypress.state` and `backendRequestHandler` APIs.

**3. The rest were specs mounting partial literals.**

Ten e2e specs passed an inline `{ spec }` literal as the runner store; they now build a real `MobxRunnerStore` and `setSpec`, which is what `suites.cy.ts` already did. The sessions spec passed an array where the panel takes `Record<string, Session>` — it renders via `Object.values`, so the array worked by accident. Where a spec is deliberately a stub it stays one, cast at the point of use.

Note for anyone reproducing these numbers locally: they only hold against a **built** workspace. The CI postinstall path skips `yarn build`, so a plain `yarn` install leaves `@packages/types` unbuilt and inflates the count with ~20 phantom `TS2307`s. Run `node ./scripts/lerna-build.js` first.

### Steps to test

1. `node ./scripts/lerna-build.js`
2. `yarn workspace @packages/reporter check-ts` → passes.
3. Reintroduce the original bug: delete `| 'warned-status'` from `TagType` in `packages/reporter/src/lib/tag.tsx`.
4. Re-run `yarn workspace @packages/reporter check-ts` → exits `2` and reports the error at `src/sessions/utils.ts`, where `determineTagType` returns the value, plus `src/lib/tag.cy.tsx`. Restore the union.

Verified before opening:

| Check | Result |
| --- | --- |
| `tsc --noEmit` on reporter | 73 → 0 |
| `yarn workspace @packages/reporter check-ts` | exit 0 |
| `yarn workspace @packages/app check-ts` | exit 0, before and after the store refactor |
| `yarn lint` (reporter + app) | clean |
| `yarn check-ts --concurrency=1` (CI's command, 41 projects) | exit 0 |

Not run in this environment: the reporter's own component and e2e specs. The ten specs that now construct a real `MobxRunnerStore` are the ones worth exercising — `yarn workspace @packages/reporter cypress:run:ct` and the reporter e2e suite.

### How has the user experience changed?

No change. The only change reaching rendered output is the removal of the `strokeColor` attribute React was already discarding, so the Studio icon renders exactly as it does today.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal tooling/type-safety change with no user-facing impact; explained above. -->
- [x] Have tests been added/updated? <!-- Existing reporter specs updated to construct real models rather than partial literals; no new behavioral tests, as this PR adds type checking rather than behavior. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_017jns7zHyHR6wQRJvjVj1Xi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/type-safety and test harness updates only; the only runtime UI tweak is dropping an unused React prop on the Studio icon.
> 
> **Overview**
> **`@packages/reporter` is now type-checked in CI** by changing `check-ts` to `tsc --noEmit && yarn -s tslint`, matching other packages. That surfaced ~73 errors, addressed without intended user-facing behavior change.
> 
> **Store import boundary:** `automation` / `AutomationStatus` move from `runner-ui-store` into new `automation-status.ts` and are re-exported from the app store barrel. `mobx-runner-store` imports the type from that module directly so reporter specs that import `MobxRunnerStore` no longer drag the full `@packages/app` store (Vue/Pinia) into reporter’s `tsc` program.
> 
> **Reporter production typing:** Introduces shared unions (`TagType`, `AliasType`) so session/instrument tag types aren’t widened to `string`; adds `'warned-status'` to `TagType`. `TestError`’s `err` prop is optional; `TestState` is imported from `@packages/types` in `stats-store`. Driver `internal-types-lite.d.ts` is referenced from `index.d.ts`. Removes invalid `strokeColor` on `IconCypressStudio` (React was already ignoring it).
> 
> **Tests:** Reporter e2e/component specs use a real `MobxRunnerStore` with `setSpec` instead of inline `runnerStore` literals; sessions panel tests pass a `Record` instead of an array; remaining fixes are casts and API arity (e.g. `runnableFinished(..., false)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ab30933e693f15c89907a7faf856ddda543fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->