### PR TITLE
chore: resolve the electron rebuild-skip check so --install stops re-packaging

### DIFF
--- a/packages/electron/src/install.ts
+++ b/packages/electron/src/install.ts
@@ -61,20 +61,25 @@ async function getFileHash (filePath: string): Promise<string> {
   return hash.digest('hex')
 }
 
-async function checkIconVersion () {
-  // TODO: this seems wrong, it's hard coding the check only for OSX and not windows or linux (!?)
+// `@electron/packager` only leaves a standalone icon file in the packaged app on
+// darwin. On win32 rcedit writes the icon into `Cypress.exe` and on linux none is
+// applied, so there is nothing to compare against there.
+async function checkIconVersion (platform: string) {
+  if (platform !== 'darwin') {
+    return
+  }
+
   const mainIconsPath = icons().getPathToIcon('cypress.icns')
-  const cachedIconsPath = path.join(
-    __dirname,
-    '../Cypress/Cypress.app/Contents/Resources/electron.icns',
-  )
+  const cachedIconsPath = getPathToResources('electron.icns')
 
   const [mainHash, cachedHash] = await Promise.all(
     [mainIconsPath, cachedIconsPath].map(getFileHash),
   )
 
   if (mainHash !== cachedHash) {
-    throw new Error('Icon mismatch')
+    throw new Error(
+      `cached icon '${cachedIconsPath}' does not match '${mainIconsPath}', binary needs rebuilding`,
+    )
   }
 }
 
@@ -205,7 +210,7 @@ async function pkgElectronApp (
   }
 }
 
-function ensure () {
+export function ensure () {
   const arch = os.arch()
   const platform = os.platform()
   const pathToExec = getPathToExec()
@@ -216,9 +221,7 @@ function ensure () {
     checkCurrentVersion(pathToVersion),
     // check if the dist folder exist and re-build if not
     fs.stat(pathToExec),
-    // Compare the icon in dist with the one in the icons
-    // package. If different, force the re-build.
-    checkIconVersion(),
+    checkIconVersion(platform),
   ]).then(() => {
     // check that the arch of the built binary matches our CPU
     return checkBinaryArchCpuArch(pathToExec, platform, arch)
@@ -228,7 +231,11 @@ function ensure () {
 }
 
 export function check () {
-  return ensure().catch((err) => {
-    packageAndExit()
+  return ensure().then(() => {
+    debug('existing electron binary is up to date, skipping rebuild')
+  }).catch((err) => {
+    debug('rebuilding electron binary: %s', (err as Error).message)
+
+    return packageAndExit()
   })
 }

--- a/packages/electron/test/install.spec.ts
+++ b/packages/electron/test/install.spec.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, afterEach, vi, MockInstance } from 'vitest'
+import os from 'os'
+import path from 'path'
+import fs from 'fs/promises'
+import { createReadStream } from 'fs'
+import { createRequire } from 'module'
+import { Readable } from 'stream'
+import execa from 'execa'
+import systeminformation from 'systeminformation'
+import { getPathToIcon } from '@packages/icons'
+import { getPathToExec, getPathToResources, getPathToVersion } from '../src/paths'
+
+const { ELECTRON_VERSION, packager } = vi.hoisted(() => {
+  return {
+    ELECTRON_VERSION: '35.0.0',
+    packager: vi.fn(),
+  }
+})
+
+// `install.ts` requires `@electron/packager` dynamically so mksnapshot cannot
+// discover it, which also puts it out of reach of `vi.mock`. Seeding node's own
+// module cache is what keeps a unit test from packaging a real binary.
+const installRequire = createRequire(new URL('../src/install.ts', import.meta.url))
+const packagerPath = installRequire.resolve('@electron/packager')
+
+installRequire.cache[packagerPath] = {
+  id: packagerPath,
+  filename: packagerPath,
+  loaded: true,
+  exports: packager,
+} as NodeJS.Module
+
+vi.mock('@packages/root', () => {
+  return {
+    default: {
+      devDependencies: {
+        electron: ELECTRON_VERSION,
+      },
+    },
+  }
+})
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os') & { default: typeof import('os') }>('os')
+
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      platform: vi.fn(),
+      arch: vi.fn(),
+    },
+  }
+})
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs') & { default: typeof import('fs') }>('fs')
+
+  return {
+    ...actual,
+    createReadStream: vi.fn(),
+    default: {
+      ...actual.default,
+      createReadStream: vi.fn(),
+    },
+  }
+})
+
+vi.mock('fs/promises', () => {
+  return {
+    default: {
+      readFile: vi.fn(),
+      stat: vi.fn(),
+    },
+  }
+})
+
+vi.mock('fs-extra', () => {
+  return {
+    move: vi.fn(),
+    remove: vi.fn(),
+  }
+})
+
+vi.mock('execa', () => {
+  return {
+    default: vi.fn(),
+  }
+})
+
+vi.mock('systeminformation', () => {
+  return {
+    default: {
+      cpu: vi.fn(),
+    },
+  }
+})
+
+vi.mock('@electron/fuses', () => {
+  return {
+    flipFuses: vi.fn(),
+    FuseVersion: { V1: 'v1' },
+    FuseV1Options: { LoadBrowserProcessSpecificV8Snapshot: 'LoadBrowserProcessSpecificV8Snapshot' },
+  }
+})
+
+import { check, ensure } from '../src/install'
+
+describe('install', () => {
+  // the only paths `getFileHash` can read, mapped to their contents
+  let files: Map<string, string>
+
+  const setUpToDateBinary = (platform: string, arch = 'x64') => {
+    vi.mocked(os.platform).mockReturnValue(platform as NodeJS.Platform)
+    vi.mocked(os.arch).mockReturnValue(arch as NodeJS.Architecture)
+
+    vi.mocked(fs.readFile).mockResolvedValue(`v${ELECTRON_VERSION}`)
+    vi.mocked(fs.stat).mockResolvedValue({} as any)
+
+    files.set(getPathToIcon('cypress.icns'), 'cypress icon')
+    files.set(getPathToResources('electron.icns'), 'cypress icon')
+
+    vi.mocked(execa).mockResolvedValue({ stdout: arch } as any)
+    vi.mocked(systeminformation.cpu).mockResolvedValue({ manufacturer: 'Intel' } as any)
+  }
+
+  beforeEach(() => {
+    files = new Map()
+    packager.mockReset()
+
+    vi.mocked(createReadStream).mockImplementation((filePath) => {
+      const contents = files.get(String(filePath))
+
+      if (contents === undefined) {
+        const missing = new Readable({ read () {} })
+
+        missing.destroy(Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), { code: 'ENOENT' }))
+
+        return missing as any
+      }
+
+      return Readable.from([contents]) as any
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('ensure', () => {
+    for (const platform of ['darwin', 'linux', 'win32']) {
+      it(`resolves on ${platform} when the binary is present and current`, async () => {
+        setUpToDateBinary(platform)
+
+        await expect(ensure()).resolves.toBeUndefined()
+      })
+    }
+
+    it('reads the version and the executable from the packaged binary', async () => {
+      setUpToDateBinary('linux')
+
+      await ensure()
+
+      expect(fs.readFile).toHaveBeenCalledWith(getPathToVersion(), 'utf8')
+      expect(fs.stat).toHaveBeenCalledWith(getPathToExec())
+    })
+
+    it('rejects when the installed version does not match the electron devDependency', async () => {
+      setUpToDateBinary('linux')
+      vi.mocked(fs.readFile).mockResolvedValue('v34.0.0')
+
+      await expect(ensure()).rejects.toThrow(`Currently installed version: '34.0.0' does not match electronVersion: '${ELECTRON_VERSION}`)
+    })
+
+    it('rejects when the executable is missing', async () => {
+      setUpToDateBinary('linux')
+      vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT: no such file or directory'))
+
+      await expect(ensure()).rejects.toThrow('ENOENT')
+    })
+
+    describe('icon check', () => {
+      it('compares against the icon cached inside the packaged app on darwin', async () => {
+        setUpToDateBinary('darwin')
+
+        await ensure()
+
+        expect(createReadStream).toHaveBeenCalledWith(getPathToIcon('cypress.icns'))
+        expect(createReadStream).toHaveBeenCalledWith(expect.stringContaining(
+          path.join('dist', 'Cypress', 'Cypress.app', 'Contents', 'Resources', 'electron.icns'),
+        ))
+      })
+
+      it('rejects on darwin when the cached icon differs from the icons package', async () => {
+        setUpToDateBinary('darwin')
+        files.set(getPathToResources('electron.icns'), 'a stale icon')
+
+        await expect(ensure()).rejects.toThrow('does not match')
+      })
+
+      it('rejects on darwin when the packaged app has no cached icon', async () => {
+        setUpToDateBinary('darwin')
+        files.delete(getPathToResources('electron.icns'))
+
+        await expect(ensure()).rejects.toThrow('ENOENT')
+      })
+
+      for (const platform of ['linux', 'win32']) {
+        it(`does not look for a cached icon on ${platform}`, async () => {
+          setUpToDateBinary(platform)
+          files.clear()
+
+          await expect(ensure()).resolves.toBeUndefined()
+          expect(createReadStream).not.toHaveBeenCalled()
+        })
+      }
+    })
+
+    describe('arch check', () => {
+      it('resolves on darwin x64 when the binary arch matches the CPU', async () => {
+        setUpToDateBinary('darwin', 'x64')
+
+        await expect(ensure()).resolves.toBeUndefined()
+        expect(execa).toHaveBeenCalledWith('lipo', ['-archs', getPathToExec()])
+      })
+
+      it('rejects on darwin x64 when an x64 binary is running on an Apple CPU', async () => {
+        setUpToDateBinary('darwin', 'x64')
+        vi.mocked(systeminformation.cpu).mockResolvedValue({ manufacturer: 'Apple' } as any)
+
+        await expect(ensure()).rejects.toThrow(`built binary arch: 'x64' does not match system CPU arch: 'arm64'`)
+      })
+
+      for (const { platform, arch } of [
+        { platform: 'darwin', arch: 'arm64' },
+        { platform: 'linux', arch: 'x64' },
+        { platform: 'win32', arch: 'x64' },
+      ]) {
+        it(`does not shell out to lipo on ${platform} ${arch}`, async () => {
+          setUpToDateBinary(platform, arch)
+
+          await expect(ensure()).resolves.toBeUndefined()
+          expect(execa).not.toHaveBeenCalled()
+        })
+      }
+    })
+  })
+
+  describe('check', () => {
+    let exit: MockInstance<typeof process.exit>
+
+    beforeEach(() => {
+      exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+      packager.mockResolvedValue(['/tmp/Cypress-out/Cypress'])
+    })
+
+    for (const platform of ['darwin', 'linux', 'win32']) {
+      it(`does not re-package on ${platform} when the binary is present and current`, async () => {
+        setUpToDateBinary(platform)
+
+        await check()
+
+        expect(packager).not.toHaveBeenCalled()
+        expect(exit).not.toHaveBeenCalled()
+      })
+    }
+
+    it('re-packages when the installed binary is out of date', async () => {
+      setUpToDateBinary('linux')
+      vi.mocked(fs.readFile).mockResolvedValue('v34.0.0')
+
+      await check()
+
+      expect(packager).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'Cypress',
+        electronVersion: ELECTRON_VERSION,
+        platform: 'linux',
+        arch: 'x64',
+      }))
+
+      expect(exit).toHaveBeenCalled()
+    })
+
+    it('re-packages when the binary is missing', async () => {
+      setUpToDateBinary('linux')
+      vi.mocked(fs.stat).mockRejectedValueOnce(new Error('ENOENT: no such file or directory'))
+
+      await check()
+
+      expect(packager).toHaveBeenCalled()
+      expect(exit).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
- Closes <!-- no associated issue; internal build-tooling fix, see Additional details -->

### Additional details

**Why was this change necessary?**

`ensure()` in `packages/electron/src/install.ts` could never resolve, so `check()` always fell through to `packageAndExit()` and every `--install` re-packaged Electron from scratch.

`checkIconVersion()` built the cached icon path from `__dirname`:

```js
path.join(__dirname, '../Cypress/Cypress.app/Contents/Resources/electron.icns')
```

`install.js` is emitted to `<pkg>/dist/` (`tsconfig.cjs.json` `outDir: "./dist"`), so that resolved to `<pkg>/Cypress/...` — one level above the real binary at `<pkg>/dist/Cypress/...` (`distPath = 'dist/Cypress'`, `paths.ts:5`). No such directory exists, so `getFileHash` always ENOENT'd, `checkIconVersion()` always rejected and `ensure()` always rejected. The `checkCurrentVersion`, `fs.stat(pathToExec)` and `checkBinaryArchCpuArch`/`getRealArch` checks alongside it therefore never gated anything.

**What is affected by this change?**

A full re-package on every local `yarn build`, and in the cypress-services CI job that runs `yarn workspace @packages/electron build-binary` directly (`.circleci/workflows.yml:1767`).

Note that the root `yarn build` path still re-packages regardless, because `@packages/electron`'s own `build` script rimrafs `dist/` — which contains `dist/Cypress`. That's left alone here; the saving lands on direct `build-binary` invocations.

**Any implementation details to explain?**

The cached icon now resolves through the existing `getPathToResources()` helper, and the check is platform-aware — which resolves the pre-existing `TODO` about the check being hard-coded for macOS.

A three-platform file comparison isn't possible: `@electron/packager` 18.3.6 only leaves a standalone icon file in the packaged app on darwin (`mac.js:277` copies it to `<Resources>/${CFBundleIconFile}`). On win32 the icon is embedded into `Cypress.exe` by rcedit (`win32.js:57`) and on linux no icon is applied at all — there is no artifact to hash. So the check is skipped where drift is impossible, rather than kept in a form that can only fail.

Also in this PR:

- The icon mismatch error names both paths instead of `'Icon mismatch'`.
- `check()` logs why it is rebuilding (or that it is skipping) under `DEBUG=cypress:electron:install`, so a repackage is no longer silent, and it returns `packageAndExit()` rather than leaving the promise floating.
- `ensure()` is exported so it can be unit tested.

### Steps to test

`packages/electron/test/install.spec.ts` is new and covers this; against the pre-fix code 16 of its 21 tests fail, including "does not re-package" on all three platforms.

```bash
yarn workspace @packages/electron test
yarn lint --scope @packages/electron
```

To verify the short-circuit end to end:

```bash
yarn workspace @packages/electron build
DEBUG=cypress:electron:install yarn workspace @packages/electron build-binary   # packages
DEBUG=cypress:electron:install yarn workspace @packages/electron build-binary   # should skip
```

Observed on linux, with the binary packaged and current:

| | 1st `--install` | 2nd `--install` |
|---|---|---|
| before | `Packaging app…` 5.0s | `Packaging app…` **5.6s** |
| after | `rebuilding electron binary: ENOENT … dist/Cypress/version` 5.4s | `existing electron binary is up to date, skipping rebuild` **0.79s** |

darwin and win32 could not be executed in this environment; they are covered by the unit tests with a mocked `os.platform()`.

One note for reviewers on the spec: `vi.mock` does not intercept `require()`, so `@electron/packager` — which `install.ts` requires dynamically to keep it out of the mksnapshot bundle — is stubbed by seeding node's own module cache. Without that, a unit test packages a real binary.

### How has the user experience changed?

No change. This is internal build tooling and ships nothing user-facing, so no changelog entry was added.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Build-tooling correctness fix with no user-facing behavior change. -->
- [x] Have tests been added/updated? <!-- New packages/electron/test/install.spec.ts; install.ts coverage 0% -> 91.66% stmts. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?


---
_Generated by [Claude Code](https://claude.ai/code/session_01QVtJNf2KeHanHQ6XpbNneC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal build-tooling only; changes when Electron is repackaged locally/CI, with no user-facing runtime behavior.
> 
> **Overview**
> Fixes **`ensure()`** so `--install` / `build-binary` can short-circuit instead of always re-packaging Electron.
> 
> The darwin icon freshness check now resolves the cached icon via **`getPathToResources('electron.icns')`** instead of a **`__dirname`-relative path** that pointed above **`dist/Cypress`**, which made **`getFileHash`** fail with ENOENT on every run. The check is **darwin-only** (win32 embeds the icon in the exe; linux has no standalone icon file), and mismatch errors include both paths.
> 
> **`check()`** logs skip vs rebuild under **`DEBUG=cypress:electron:install`** and **`return`s** **`packageAndExit()`** on failure; **`ensure()`** is **exported** for tests.
> 
> Adds **`packages/electron/test/install.spec.ts`** covering version, executable presence, icon behavior per platform, darwin arch/`lipo`, and that **`check()`** does not invoke **`@electron/packager`** when the binary is up to date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb1cccf7bd057826cae982f644ac995697ec290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->