### PR TITLE
chore: remove dead code from @packages/extension

### DIFF
--- a/packages/extension/.eslintignore
+++ b/packages/extension/.eslintignore
@@ -1,6 +1,6 @@
-**/dist
+/app-dist
+/lib-dist
 **/*.d.ts
 **/package-lock.json
 **/tsconfig.json
-**/cypress/fixtures
 /test/helpers/background.js

--- a/packages/extension/.npmignore
+++ b/packages/extension/.npmignore
@@ -1,2 +1,0 @@
-theme/Cached Theme.pak
-theme/Cached Theme Material Design.pak

--- a/packages/extension/AGENTS.md
+++ b/packages/extension/AGENTS.md
@@ -1,6 +1,11 @@
 # @packages/extension
 
-The WebExtension loaded by Chrome and Firefox during Cypress test runs. It automates the browser at the extension level — handling new-tab interception and communicating back to the Cypress server via `socket.io`. Supports both Manifest V2 (`app/v2/`) and Manifest V3 (`app/v3/`).
+The WebExtension loaded by Chrome and Firefox during Cypress test runs. It automates the browser at the extension level, reaching APIs that CDP and BiDi don't cover.
+
+The two bundles are not two builds of the same thing — each is loaded by exactly one browser and does a different job:
+
+- **`app/v2/` (Manifest V2) — Firefox only**, loaded via `utils.writeExtension` from `@packages/server`'s `firefox.ts`. Connects back to the Cypress server over `socket.io`, pushes cookie and download events, and handles `reset:browser:state` (which BiDi deliberately delegates here).
+- **`app/v3/` (Manifest V3) — Chrome only**, loaded via `getPathToV3Extension` from `@packages/server`'s `chrome.ts`. Tracks the main Cypress tab's URL and re-activates that tab, used by `@cypress/puppeteer`. No socket connection.
 
 ## Key Commands
 
@@ -22,13 +27,13 @@ yarn workspace @packages/extension check-ts
 
 ```
 app/
-  v2/
-    background.ts       MV2 background page: socket connection, tab management
-    client.ts           Content script injected into pages
-    init.ts             Extension initialisation logic
+  v2/                   Firefox
+    background.ts       MV2 background page: cookie/download events, reset:browser:state
+    client.ts           socket.io connection wrapper used by the background page
+    init.ts             Connects the background page to the server on load
     manifest.json       MV2 manifest
-  v3/
-    content.ts          Content script for MV3
+  v3/                   Chrome
+    content.ts          Content script bridging the Cypress page and the service worker
     service-worker.ts   MV3 service worker replacing the background page
     manifest.json       MV3 manifest
   newtab.html / popup.html   Extension UI pages

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -6,7 +6,7 @@ This is the WebExtension responsible for automating the browser
 
 ### Watching
 
-Kicks off the gulp watcher that rebuilds the app/lib directories on change.
+Kicks off a `chokidar` watcher that rebuilds the app/lib directories on change.
 
 ```bash
 yarn workspace @packages/extension watch
@@ -36,12 +36,14 @@ yarn workspace @packages/extension test-debug
 
 ### In Chrome
 
+Chrome loads the v3 bundle, whose background script runs in a service worker.
+
 1. Open Chrome
 2. Go into Extensions (`chrome://extensions`)
 3. Check **Developer Mode** (top right of screen)
 4. Click **Load unpacked extension...** (top left of screen)
-5. Choose **packages/extension/dist** directory (v2)
-6. Click **background page** to debug `background.js` (inspect views `background page`)
+5. Choose **packages/extension/app-dist/v3** directory
+6. Click **service worker** to debug `service-worker.js` (inspect views `service worker`)
 7. Click **Reload (⌘R)** to pull in changes to `manifest.json`
 
 ### In Firefox

--- a/packages/extension/app/v2/background.ts
+++ b/packages/extension/app/v2/background.ts
@@ -14,7 +14,7 @@ const checkIfFirefox = async () => {
   return name === 'Firefox'
 }
 
-const connect = function (host: string, path: string, extraOpts?: any) {
+const connect = function (host: string, path: string) {
   const listenToCookieChanges = once(() => {
     return browser.cookies.onChanged.addListener((info: any) => {
       if (info.cause !== 'overwrite') {
@@ -71,7 +71,7 @@ const connect = function (host: string, path: string, extraOpts?: any) {
     })
   }
 
-  const ws = clientConnect(host, path, extraOpts)
+  const ws = clientConnect(host, path)
 
   ws.on('automation:request', (id: number, msg: string, data: any) => {
     switch (msg) {
@@ -82,7 +82,7 @@ const connect = function (host: string, path: string, extraOpts?: any) {
     }
   })
 
-  ws.on('automation:config', async (config: any) => {
+  ws.on('automation:config', async () => {
     const isFirefox = await checkIfFirefox()
 
     listenToCookieChanges()

--- a/packages/extension/app/v2/client.ts
+++ b/packages/extension/app/v2/client.ts
@@ -1,9 +1,8 @@
 import { client } from '@packages/socket/browser/client'
 
-export const connect = (host: string, path: string, extraOpts: any = {}) => {
+export const connect = (host: string, path: string) => {
   return client(host, {
     path,
     transports: ['websocket'],
-    ...extraOpts,
   })
 }

--- a/packages/extension/app/v2/manifest.json
+++ b/packages/extension/app/v2/manifest.json
@@ -10,14 +10,10 @@
     "cookies",
     "browsingData",
     "downloads",
-    "tabs",
-    "webRequest",
-    "webRequestBlocking",
     "http://*/*",
     "https://*/*",
     "<all_urls>"
   ],
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugoxpSqfoblTYUGvyXZpmBgjYQUY9k2Hx3PaDwquyaTH6GBxitwVMSu5sZuDYgPHpGYoF4ol6A4PZHhd6JvfuUDS9ZrxTW0XzP+dSS9AwmJo3uLuP88zBs4mhpje1+WE5NGM0pTzyCXYTPoyzyPRmToALWD96cahSGuhG8bSmaBw3py+16qNKm8SOlANbUvHtEaTpmrSWBUIq7YV8SIPLtR8G47vjqPTE1yEsBQ3GAgllhi0cJolwk/629fRLr3KVckICmU6spXD/jVhIgAeyHhFuFGYNuubzbel8trBVw5Q/HE5F6j66sBvEvW64tH4lPxnM5JPv0qie5wouPiT0wIDAQAB",
   "icons": {
     "16": "icons/icon_16x16.png",
     "48": "icons/icon_48x48.png",

--- a/packages/extension/gulpfile.ts
+++ b/packages/extension/gulpfile.ts
@@ -79,9 +79,3 @@ export const build = gulp.series(
     buildLib,
   ),
 )
-
-const watchBuild = () => {
-  return gulp.watch('app/**/*', build)
-}
-
-export const watch = gulp.series(build, watchBuild)

--- a/packages/extension/lib/index.ts
+++ b/packages/extension/lib/index.ts
@@ -15,10 +15,6 @@ export const getPathToTheme = () => {
   return path.join(__dirname, '..', 'theme')
 }
 
-export const getPathToRoot = () => {
-  return path.join(__dirname, '..')
-}
-
 export const setHostAndPath = async (host: string, path: string) => {
   const src = getPathToExtension('background.js')
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -18,7 +18,7 @@
     "test-debug": "vitest --inspect-brk --no-file-parallelism --test-timeout=0 --hook-timeout=0",
     "test-unit": "vitest run",
     "test-watch": "yarn test-unit --watch",
-    "tslint": "tslint --config ../ts/tslint.json --project . --exclude ./dist/v2/background.js",
+    "tslint": "tslint --config ../ts/tslint.json --project .",
     "watch": "yarn build && chokidar 'app/**/*.*' 'app/*.*' -c 'yarn build'"
   },
   "dependencies": {

--- a/packages/extension/test/.eslintrc.json
+++ b/packages/extension/test/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "extends": [
     "plugin:@cypress/dev/tests"
-  ],
-  "globals": {
-    "sinon": true
-  }
+  ]
 }

--- a/packages/extension/test/integration/v2/background.spec.ts
+++ b/packages/extension/test/integration/v2/background.spec.ts
@@ -47,7 +47,7 @@ const PORT = 12345
 describe('app/background', () => {
   let httpSrv: http.Server
   let server: http.Server
-  let connectWrapper: (options?: Record<string, unknown>) => Promise<SocketShape>
+  let connectWrapper: () => Promise<SocketShape>
 
   beforeEach(async () => {
     vi.resetAllMocks()
@@ -69,12 +69,12 @@ describe('app/background', () => {
 
     browser.runtime.getBrowserInfo = vi.fn().mockResolvedValue({ name: 'Firefox' })
 
-    connectWrapper = async (options = {}) => {
+    connectWrapper = async () => {
       const ws = automation.connect(`http://localhost:${PORT}`, '/__socket.io')
 
       // skip 'connect' and 'automation:client:connected' and trigger
       // the handler that kicks everything off
-      ws.emit('automation:config', options)
+      ws.emit('automation:config')
 
       await new Promise<void>((resolve) => setTimeout(resolve, 1))
 

--- a/packages/extension/test/unit/extension.spec.ts
+++ b/packages/extension/test/unit/extension.spec.ts
@@ -58,12 +58,6 @@ describe('Extension', () => {
     })
   })
 
-  describe('.getPathToRoot', () => {
-    it('returns path to root', () => {
-      expect(extension.getPathToRoot()).toEqual(cwd)
-    })
-  })
-
   describe('.setHostAndPath', () => {
     let src: string
 
@@ -92,7 +86,7 @@ describe('Extension', () => {
 
   describe('manifest', () => {
     it('has a key that resolves to the static extension ID', async () => {
-      const manifest = await fs.readJson(path.join(cwd, 'app/v2/manifest.json'))
+      const manifest = await fs.readJson(path.join(cwd, 'app/v3/manifest.json'))
       const cmd = `echo \"${manifest.key}\" | openssl base64 -d -A | shasum -a 256 | head -c32 | tr 0-9a-f a-p`
 
       const stdout = await new Promise((resolve, reject) => {


### PR DESCRIPTION
- Closes N/A — internal cleanup, no associated issue. See the note under PR Tasks.

### Additional details

An audit of `@packages/extension` for code and tests that no longer have a caller.

The context for most of it: the **v2 bundle is loaded only by Firefox** (via `utils.writeExtension` from `firefox.ts`) and the **v3 bundle only by Chrome** (via `getPathToV3Extension` from `chrome.ts`). Electron and WebKit load neither. Several things left over from when both browsers shared the v2 bundle no longer have any caller.

Every removal below was confirmed unreferenced across **both** `cypress` and `cypress-services` — the latter has zero coupling to this package (swept for `@packages/extension`, all `lib/index.ts` export names, both extension IDs, the wire messages `automation:push:request` / `automation:config` / `cypress:extension:*` / `main:tab:activated` / `mostRecentUrl`, `webextension-polyfill`, `browsingData`, and the dist dir names).

**Removed**

- `getPathToRoot` — no consumer in either repo.
- The `extraOpts` parameter threaded from `background.connect` through `client.connect` into the socket options. No call site ever passed it.
- The `automation:config` payload parameter. `socket-base.ts` emits this event with a literal `{}` (`// only send the necessary config`) and the handler ignored the argument.
- The `sinon` global declared for the test suite, which uses vitest.
- `webRequest`, `webRequestBlocking` and `tabs` from the v2 manifest. No v2 code touches those APIs; only the v3 service worker uses `tabs`, and it declares its own permission.
- The `key` from the v2 manifest — a Chrome-only field for pinning the extension ID, while Firefox identifies the extension by `applications.gecko.id`.
- The gulp `watch` task, superseded by the chokidar-based `watch` script. Nothing invoked `gulp watch` in this package.
- Stale paths: a `dist/v2` tslint exclude and an `.npmignore` naming two theme files that do not exist.

**Two changes worth a reviewer's attention**

1. **The manifest-key test now reads the v3 manifest.** Removing the v2 `key` forced this, and it is the right target anyway: the ID it asserts (`caljajdfkjjjdehjdoimjkkakekklcck`) is the one `npm/puppeteer`'s README tells users to allowlist in their security policy, and that ID comes from whichever manifest Chrome loads — v3. The two keys were byte-identical, so no assertion changes today, but previously a change to the v3 key would have left the test green while silently breaking the documented ID.

2. **`.eslintignore` got a fix, not just a deletion.** `**/dist` was dead because it never matched `app-dist`/`lib-dist`. Verified: with the original file restored, `yarn lint` on a built tree produced 11,977 errors, all in generated output. Dropping the pattern outright would have preserved that, so it is replaced with `/app-dist` and `/lib-dist`. `yarn lint` now passes on a built tree, which it did not before. This is the one change that goes slightly beyond removing dead code — happy to split it out if preferred.

**Documentation** is corrected to match the code: which browser loads which bundle, that `client.ts` is a socket.io wrapper rather than a content script, that the watcher is chokidar rather than gulp, and that debugging in Chrome means loading `app-dist/v3` and inspecting a service worker (the old steps pointed at a `dist` directory that is no longer produced, for the manifest version Chrome no longer loads).

### Steps to test

Automated coverage is sufficient here; all of the following pass locally on Node 24.15.0:

```bash
yarn workspace @packages/extension build      # v2 + v3 + lib artifacts
yarn workspace @packages/extension test       # 33/33 across 4 spec files
yarn workspace @packages/extension check-ts
yarn lint --scope @packages/extension

# consumers of the package
yarn workspace @packages/server test-unit browsers/firefox_spec.ts   # 30 passing (v2 consumer)
yarn workspace @packages/server test-unit browsers/chrome_spec.ts    # 81 passing (v3 consumer)
```

Note that the extension specs require `@packages/socket`, `@packages/icons`, and the extension itself to be built first, otherwise two specs fail on missing artifacts.

The manifest permission removal is the one change not covered by a unit test, since no test asserts on manifest permissions. Worth a smoke run of the Firefox driver suite — which path-based CI filtering already selects for `packages/extension/*` changes — to confirm cookie events, downloads, and `reset:browser:state` still work.

### How has the user experience changed?

No change. The only externally observable difference is that the Firefox extension declares three fewer permissions, none of which it used.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No issue: this is a mechanical dead-code removal with no behavior change, matching the template's carve-out for purely mechanical changes. Details and per-item justification are in the description above. -->
- [x] Have tests been added/updated? <!-- Removed the test for the deleted `getPathToRoot`, repointed the manifest-key test at the v3 manifest, and dropped the unused `connectWrapper` parameter. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- `@packages/extension` is private and not part of the public API surface. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131GcjXbB4z9sqPNRFC14Bv

---
_Generated by [Claude Code](https://claude.ai/code/session_0131GcjXbB4z9sqPNRFC14Bv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly deletion and docs; the only runtime-facing tweak is fewer Firefox extension permissions that were unused, plus eslintignore fixing lint on build artifacts.
> 
> **Overview**
> Removes unused `@packages/extension` surface area after splitting **Firefox (v2)** and **Chrome (v3)** responsibilities: drops `getPathToRoot`, unused socket `extraOpts` / `automation:config` payload handling, the gulp `watch` export, stale `.npmignore` entries, and the vitest `sinon` global.
> 
> The **Firefox v2 manifest** no longer declares unused `tabs` / `webRequest*` permissions or Chrome’s `key` field. **Lint ignore** now targets `/app-dist` and `/lib-dist` instead of a non-matching `**/dist`, so `yarn lint` skips generated bundles. **Tests/docs** follow: manifest ID assertion reads **v3**, integration tests drop the unused connect options, and README/AGENTS describe chokidar watch, Chrome `app-dist/v3` debugging, and per-browser bundle roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7112626c116fd1b244ad30cb911dbef5898b09c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->