### PR TITLE
chore: remove dead code paths from @packages/network

### DIFF
--- a/packages/network/AGENTS.md
+++ b/packages/network/AGENTS.md
@@ -11,7 +11,7 @@ yarn workspace @packages/network test -- <path-to-spec>
 # Run tests matching a glob pattern
 yarn workspace @packages/network test -- "<glob-pattern>"
 
-# Build CJS and ESM outputs
+# Build the CJS output (and type-check the ESM target)
 yarn workspace @packages/network build
 
 # Type-check
@@ -22,24 +22,25 @@ yarn workspace @packages/network check-ts
 
 ```
 lib/
-  agent.ts               HTTP/HTTPS proxy-aware agent with keepalive support (uses node-forge for TLS)
+  agent.ts               HTTP/HTTPS proxy-aware agent: keepalive, upstream-proxy CONNECT tunnelling, per-URL client certs
   allow-destroy.ts       Wraps net.Server to add a .destroy() method that closes active sockets
   blocked.ts             Checks whether a URL is blocked by the Cypress blocklist config
-  ca.ts                  CA certificate loading and trust store management
+  ca.ts                  Resolves extra CAs from npm_config_cafile / npm_config_ca / NODE_EXTRA_CA_CERTS
   client-certificates.ts Manages per-origin client TLS certificate configuration
-  concat-stream.ts       Re-exports concat-stream for use in the proxy pipeline
-  connect.ts             HTTP CONNECT tunnel helpers
-  http-utils.ts          HTTP response/request utilities (header manipulation, stream helpers)
-  index.ts               Public entry point re-exporting all modules
+  concat-stream.ts       Wraps concat-stream so it always yields a Buffer, even for an empty stream
+  connect.ts             Socket helpers: DNS address resolution and retrying net/tls connections
+  http-utils.ts          responseMustHaveEmptyBody, plus the lenient HTTP parser options for real-world traffic
+  index.ts               Public entry point; re-exports every module except ca.ts, which is internal to agent.ts
 ```
 
 ## Gotchas / Notes
 
-- This package is **Node.js only** — it imports `node-forge`, `fs-extra`, and other Node.js APIs directly. For isomorphic networking utilities (browser + Node.js), use **@packages/network-tools** instead.
-- Builds to both `cjs/` and `esm/`; the `module` field points to the ESM build for modern bundlers.
+- This package is **Node.js only** — it uses `tls`, `dns`, `net`, `http`/`https` and `fs-extra` directly. For isomorphic networking utilities (browser + Node.js), use **@packages/network-tools** instead.
+- Only `cjs/` is emitted. `tsconfig.esm.json` sets `noEmit`, so `build:esm` is an ESM-compatibility type-check — the `module` field points at an `esm/` build that is never produced, since every consumer is CommonJS.
 - Tests use `vitest run`; the `test-debug` script enables `--inspect-brk` for breakpoint debugging.
+- `test/unit/agent.spec.ts` serves on port 443 and resolves `localhost` over both IPv4 and IPv6, so it needs root and an IPv6 loopback. CI's `unit-tests` job enables IPv6 in Docker and runs the suite under `sudo`; without both, much of the agent suite fails on `EACCES` / `EAFNOSUPPORT`.
 
 ## Integration Points
 
-- Consumed by **@packages/server**, **@packages/proxy**, and **@packages/https-proxy** for all Node.js HTTP networking.
-- **@packages/network-tools** depends on this package (dev dep) in its test suite.
+- Consumed by **@packages/server**, **@packages/proxy**, **@packages/net-stubbing**, **@packages/https-proxy**, and **@packages/data-context** for all Node.js HTTP networking.
+- Depends on **@packages/network-tools** for `stripProtocolAndDefaultPorts`, used by `blocked.ts`.

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -195,19 +195,8 @@ export class CombinedAgent {
 
   // called by Node.js whenever a new request is made internally
   // NOTE: this function has to be sync via callback because it is called by the Agent.addRequest method, which expect a sync function
-  addRequest (req: http.ClientRequest, options: http.RequestOptions, port?: number, localAddress?: string) {
+  addRequest (req: http.ClientRequest, options: http.RequestOptions) {
     _.merge(req, lenientOptions)
-
-    // Legacy API: addRequest(req, host, port, localAddress)
-    // https://github.com/nodejs/node/blob/cb68c04ce1bc4534b2d92bc7319c6ff6dda0180d/lib/_http_agent.js#L148-L155
-    if (typeof options === 'string') {
-      // @ts-ignore
-      options = {
-        host: options,
-        port: port!,
-        localAddress,
-      }
-    }
 
     // If the path property is a fully qualified URL, which is what as Axios appears to set,
     // parse the URL and set the href, path, and port based on this path

--- a/packages/network/lib/agent.ts
+++ b/packages/network/lib/agent.ts
@@ -141,13 +141,6 @@ export const isResponseStatusCode200 = (head: string) => {
 export const regenerateRequestHead = (req: http.ClientRequest) => {
   delete req._header
   req._implicitHeader()
-  if (req.output && req.output.length > 0) {
-    // the _header has already been queued to be written to the socket
-    const first = req.output[0]
-    const endOfHeaders = first.indexOf(_.repeat(CRLF, 2)) + 4
-
-    req.output[0] = req._header + first.substring(endOfHeaders)
-  }
 }
 
 // this function has to be sync via callback because it is called by the Agent.addRequest method, which expect a sync function
@@ -220,13 +213,12 @@ export class CombinedAgent {
     // parse the URL and set the href, path, and port based on this path
     if (typeof options.path === 'string' && /^http(s)?:\/\//.test(options.path)) {
       const pathUrl = new URL(options.path)
-      const portToSet = pathUrl.port ?? options.port
 
       options.href = options.path
       options.path = pathUrl.pathname
 
-      if (portToSet) {
-        options.port = Number(portToSet)
+      if (pathUrl.port) {
+        options.port = Number(pathUrl.port)
       }
     }
 

--- a/packages/network/lib/client-certificates.ts
+++ b/packages/network/lib/client-certificates.ts
@@ -59,7 +59,7 @@ export class UrlMatcher {
     }
 
     if (ret && rule.path) {
-      ret = rule.pathMatcher?.match(path ?? '')
+      ret = rule.pathMatcher.match(path ?? '')
     }
 
     return ret
@@ -132,10 +132,7 @@ export class ClientCertificateStore {
   }
 
   getClientCertificateAgentOptionsForUrl (requestUrl: Url): ClientCertificates | null {
-    if (
-      !this._urlClientCertificates ||
-      this._urlClientCertificates.length === 0
-    ) {
+    if (this._urlClientCertificates.length === 0) {
       return null
     }
 
@@ -144,28 +141,22 @@ export class ClientCertificateStore {
       return UrlMatcher.matchUrl(requestUrl.hostname, requestUrl.path, port, cert.matchRule)
     })
 
-    switch (matchingCerts.length) {
-      case 0:
-        debug(`not using client certificate(s) for url '${requestUrl.href}'`)
+    if (matchingCerts.length === 0) {
+      debug(`not using client certificate(s) for url '${requestUrl.href}'`)
 
-        return null
-      case 1:
-        debug(`using client certificate(s) for url '${requestUrl.href}'`)
-
-        return matchingCerts[0].clientCertificates
-      default:
-        matchingCerts.sort((a, b) => {
-          return b.pathnameLength - a.pathnameLength
-        })
-
-        debug(`using client certificate(s) for url '${requestUrl.href}'`)
-
-        return matchingCerts[0].clientCertificates
+      return null
     }
+
+    // the longest matching path is the most specific rule, so it wins
+    matchingCerts.sort((a, b) => b.pathnameLength - a.pathnameLength)
+
+    debug(`using client certificate(s) for url '${requestUrl.href}'`)
+
+    return matchingCerts[0].clientCertificates
   }
 
-  getCertCount (): Number {
-    return !this._urlClientCertificates ? 0 : this._urlClientCertificates.length
+  getCertCount (): number {
+    return this._urlClientCertificates.length
   }
 
   clear (): void {
@@ -183,6 +174,8 @@ export const clientCertificateStoreSingleton = new ClientCertificateStore()
  */
 
 type Config = {
+  // not read here, but it keeps `Config` from being a weak type that no caller
+  // structurally matches — every caller passes a full Cypress config
   projectRoot: string
   clientCertificates?: Array<{
     url: string

--- a/packages/network/test/support/servers.ts
+++ b/packages/network/test/support/servers.ts
@@ -7,7 +7,6 @@ import { SocketIOServer } from '@packages/socket'
 import { allowDestroy } from '../../lib/allow-destroy'
 
 export interface AsyncServer {
-  closeAsync: () => Promise<void>
   destroyAsync: () => Promise<void>
   listenAsync: (port) => Promise<void>
 }
@@ -61,7 +60,6 @@ export class Servers {
     const httpServer = allowDestroy(http.createServer(app))
 
     this.httpServer = Object.assign(httpServer, {
-      closeAsync: promisify(httpServer.close.bind(httpServer)),
       destroyAsync: promisify(httpServer.destroy.bind(httpServer)),
       listenAsync: promisify(httpServer.listen.bind(httpServer)),
     }) as http.Server & AsyncServer
@@ -73,7 +71,6 @@ export class Servers {
     const httpsServer = allowDestroy(https.createServer(this.https, <http.RequestListener>app))
 
     this.httpsServer = Object.assign(httpsServer, {
-      closeAsync: promisify(httpsServer.close.bind(httpsServer)),
       destroyAsync: promisify(httpsServer.destroy.bind(httpsServer)),
       listenAsync: promisify(httpsServer.listen.bind(httpsServer)),
     }) as https.Server & AsyncServer

--- a/packages/ts/index.d.ts
+++ b/packages/ts/index.d.ts
@@ -20,7 +20,6 @@ declare module 'http' {
     interface ClientRequest {
       _header?: { [key: string]: string }
       _implicitHeader: () => void
-      output: string[]
       agent: Agent
     }
 


### PR DESCRIPTION
- Closes N/A — no associated issue. Per [CONTRIBUTING](https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests), purely mechanical changes do not require one; details below. Follows the same sweep as #34724 (`@packages/types`) and #34729 (`packages/app`).

### Additional details

A dead-code audit of `@packages/network`. Unused *exports* in this package are already gated by `knip` (`yarn health-check`), which runs on every PR and has no `ignoreIssues` entries here — so everything below is what knip structurally cannot see: dead branches inside live functions, and a dead ambient type.

Every change is behavior-preserving.

**1. `regenerateRequestHead`'s `req.output` block (`lib/agent.ts`)**

`ClientRequest.output` was removed from Node in v12 (DEP0059, superseded by `outputData`). Verified against the runtime: `'output' in req === false` on Node 22 and 24. This package runs only in the Electron main process (Electron 41 → Node 22), and the lowest floor in the repo — `cli/package.json` `engines.node` (`^22 || ^24 || >=26`) — is far above 12. The `if (req.output && …)` guard has been permanently false, so the block never executed.

Its supporting `output: string[]` ambient declaration in `@packages/ts` had no other reference anywhere in the monorepo, so it goes too.

> Worth a follow-up, not fixed here: that block was *trying* to rewrite an already-queued request head for proxied HTTP requests. Because `CombinedAgent.addRequest` can defer to a DNS lookup, a caller's `write()`/`end()` can land first, at which point the head sits in `outputData` with `_headerSent = true` and the regenerated `_header` is discarded. That gap predates this PR (the branch was already inert); porting the logic to `outputData` needs a repro and a test.

**2. The legacy `addRequest` shim (`lib/agent.ts`)**

Node's `ClientRequest` always calls `agent.addRequest(req, options)` with two arguments and an options object, so the `typeof options === 'string'` branch never ran. Verified against the runtime across `http.request`, `https.request`, string URLs and requests with a body — every call arrived as `argc=2, typeof=object`. Also checked all 39 `.addRequest(` call sites in `node_modules`: all pass an options object, and all target their own agent via `super`.

It was also unusable if reached: it never sets `options.path`, so the `url.format(…) + options.path` below it produces hrefs like `http://example.com:8080undefined` — which Node itself rejects as invalid (DEP0170), leaving `options.uri` with a null port and a bogus pathname. A string caller now fails at the property access instead of silently issuing a malformed request. `port` and `localAddress` were only read by that branch.

**3. An unreachable `??` fallback (`lib/agent.ts`)**

`pathUrl.port ?? options.port` — `URL.port` is always a string (`''` when absent, including for default ports), so the `??` never fell through.

**4. Redundant branches in `lib/client-certificates.ts`**

- `_urlClientCertificates` is initialized to `[]` and only ever reassigned to `[]`, so the `!this._urlClientCertificates` half of the empty-store guard, and the same check in `getCertCount`, were unreachable. The remaining `length === 0` early return is kept deliberately — it skips the filter for the common no-certs-configured case, on a path that runs for every HTTPS request.
- `ParsedUrl` always assigns `pathMatcher` in its constructor, so the optional chain on it never short-circuited.
- The `matchingCerts` switch had `case 1` and `default` returning the same expression, differing only by a sort that is a no-op on a single element.
- `getCertCount` returned the boxed `Number` rather than `number`.
- `Config.projectRoot` is unread, but is **kept** and documented in place: without it `Config` has only optional members, and TypeScript's weak-type check then rejects the caller in `server-base.ts` with `TS2559`.

**5. Test helper and docs**

`AsyncServer.closeAsync` was assigned on both test servers and never called (teardown goes through `destroyAsync`).

`packages/network/AGENTS.md` had drifted: it credited `node-forge` to this package (it belongs to `@packages/https-proxy`), inverted the `@packages/network-tools` dependency direction, claimed an `esm/` build that `tsconfig.esm.json` never emits (`noEmit`), misdescribed `connect.ts` as HTTP CONNECT tunnelling (that lives in `agent.ts`) and `http-utils.ts` as having header/stream helpers, and omitted `net-stubbing`/`data-context` from the consumer list. Also adds a note that the agent suite needs root and an IPv6 loopback.

### Steps to test

No behavior change, so there is no user-visible path to walk. Reviewer verification:

```bash
yarn workspace @packages/network check-ts
yarn lint --scope @packages/network
yarn test --scope @packages/network        # needs root + IPv6 loopback, see below
```

Locally the suite was compared before and after: **91 passed / 52 failed, byte-identical failure set** (diffed via the JSON reporter against a pre-change baseline). Those 52 are environmental — `test/unit/agent.spec.ts` serves on port 443 and resolves `localhost` over both IPv4 and IPv6, which CI's `unit-tests` job provides (`sudo` + IPv6 enabled in Docker) and most local containers do not. The `client_certificates` suite, which covers everything in item 4, is 31/31 green.

`check-ts` was also run green on the downstream consumers `@packages/https-proxy`, `@packages/net-stubbing` and `@packages/proxy`, and `@packages/server` was checked specifically for the `Config` type change.

No CircleCI allowlist entry was added — there is no v8 snapshot, packaging or Windows-specific impact, so path-filtered jobs are sufficient per [`.circleci/AGENTS.md`](https://github.com/cypress-io/cypress/blob/develop/.circleci/AGENTS.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Unreachable or Node-version-inert branches only; agent and cert selection paths are unchanged for supported Node versions, with existing tests as the guard.
> 
> **Overview**
> Mechanical dead-code cleanup in `@packages/network` with **no intended runtime behavior change**.
> 
> **`CombinedAgent` / proxied HTTP:** Drops the legacy `addRequest(req, host, port, localAddress)` shim, the `regenerateRequestHead` logic that rewrote `ClientRequest.output` (removed in Node 12+), and a `pathUrl.port ?? options.port` fallback that never applied. The matching `ClientRequest.output` ambient type in `@packages/ts` is removed.
> 
> **Client certificates:** Simplifies store lookup (redundant null checks, optional `pathMatcher`, duplicate switch arms) and fixes `getCertCount` to return primitive `number`. Documents why `Config.projectRoot` stays on the loader type.
> 
> **Tests / docs:** Removes unused `closeAsync` from the network test server helper. Updates `AGENTS.md` for accurate build output, dependencies, consumers, and agent test env requirements (root + IPv6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5c98f02c7ef0ba84aff8c9a61eb0c6d723f2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### How has the user experience changed?

No change. All removals are unreachable branches or already-inert code; no runtime behavior is affected.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical dead-code cleanup; see the explanation above. -->
- [na] Have tests been added/updated? <!-- No behavior change. The existing suite is the guard — it was run before and after with an identical result. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- The only type change is an internal ambient declaration in @packages/ts; the public cypress.d.ts is untouched. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMxaXUJSMzKmirtqzdheqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMxaXUJSMzKmirtqzdheqV)_