### PR TITLE
chore: upgrade which from 2.0.2 to 7.0.0 in @packages/launcher

### DIFF
--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -22,13 +22,14 @@
     "fs-extra": "9.1.0",
     "lodash": "^4.17.21",
     "plist": "3.1.0",
-    "which": "2.0.2",
+    "which": "7.0.0",
     "win-version-info": "^6.0.1"
   },
   "devDependencies": {
     "@packages/data-context": "0.0.0-development",
     "@packages/ts": "0.0.0-development",
     "@packages/types": "0.0.0-development",
+    "@types/which": "3.0.4",
     "mock-fs": "5.4.0",
     "typescript": "~5.4.5",
     "vitest": "^3.2.4"

--- a/packages/launcher/test/unit/linux.spec.ts
+++ b/packages/launcher/test/unit/linux.spec.ts
@@ -181,6 +181,63 @@ describe('linux browser detection', () => {
     })
   })
 
+  describe('leaves profilePath unset when firefox is not a snap', () => {
+    const expectedFirefox = {
+      channel: 'stable',
+      name: 'firefox',
+      family: 'firefox',
+      displayName: 'Firefox',
+      majorVersion: '140',
+      path: 'firefox',
+      version: '140.0.1',
+    }
+
+    beforeEach(() => {
+      cpSpawnCallback = (cmd, args, opts, cpSpawnMock) => {
+        if (cmd === 'firefox') {
+          setTimeout(() => {
+            cpSpawnMock.stdout.emit('data', 'Mozilla Firefox 140.0.1')
+          }, 0)
+        }
+      }
+
+      vi.mocked(os.homedir).mockReturnValue('/home/foo')
+    })
+
+    it('with a binary that is not a shim', async () => {
+      vi.stubEnv('PATH', '/bin')
+      mockFs({
+        '/bin/firefox': mockFs.file({ mode: 0o777, content: 'not a shim script' }),
+      })
+
+      const [browser] = await detect()
+
+      expect(browser).toEqual(expectedFirefox)
+    })
+
+    it('with a binary that is not on the PATH', async () => {
+      vi.stubEnv('PATH', '/bin')
+      mockFs({
+        '/usr/bin/firefox': mockFs.file({ mode: 0o777, content: 'exec /snap/bin/firefox\n' }),
+      })
+
+      const [browser] = await detect()
+
+      expect(browser).toEqual(expectedFirefox)
+    })
+
+    it('with a binary that is not executable', async () => {
+      vi.stubEnv('PATH', '/bin')
+      mockFs({
+        '/bin/firefox': mockFs.file({ mode: 0o644, content: 'exec /snap/bin/firefox\n' }),
+      })
+
+      const [browser] = await detect()
+
+      expect(browser).toEqual(expectedFirefox)
+    })
+  })
+
   // https://github.com/cypress-io/cypress/issues/6669
   it('detects browser if the --version stdout is multiline', async () => {
     cpSpawnCallback = (cmd, args, opts, cpSpawnMock) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9773,6 +9773,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/which@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-3.0.4.tgz#2c3a89be70c56a84a6957a7264639f39ae4340a1"
+  integrity sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==
+
 "@types/which@^2.0.1":
   version "2.0.2"
   resolved "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz#54541d02d6b1daee5ec01ac0d1b37cecf37db1ae"
@@ -33372,7 +33377,14 @@ which@1.3.1, which@^1.1.1, which@^1.2.14, which@^1.2.4, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@2.0.2, which@^2.0.1, which@^2.0.2:
+which@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-7.0.0.tgz#cdfdd7bfc31c5af050b97bc7c02b1844731fb8b2"
+  integrity sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==
+  dependencies:
+    isexe "^4.0.0"
+
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
- Closes N/A — dependency hygiene, no associated issue. See the note under PR Tasks.

### Additional details

`@packages/launcher` pinned `which` at `2.0.2`, which predates the removal of the callback API in `3.0.0`. There is exactly one import in the repo (`packages/launcher/lib/linux/index.ts`), called once as `await which(binary)` inside `isFirefoxSnap()`. It already uses the promise form, so no source change was needed.

**Why 7.0.0.** `which` ships an identical `lib/index.js` from `4.0.0` through `7.0.0` — a `diff -r` of the `6.0.1` and `7.0.0` tarballs reports only `version`, `engines`, and internal `@npmcli/template-oss` metadata. The later majors only raise the `engines` floor. `7.0.0` requires `^22.22.2 || ^24.15.0 || >=26.0.0`, and yarn fails an install outright on an engines mismatch rather than warning. The only gap in that range falling inside this repo's own `>=24.15.0` floor is Node 25.x, which reached end-of-life on 2026-06-01. Only contributors installing the monorepo resolve these engines — `which` is not a `cli` dependency, and the binary runs the Node embedded in Electron.

**What actually changes at runtime.** Nothing reachable. The one semantic difference arrives via `isexe` 2 → 4, which now consults supplementary groups when checking the executable bit. Reaching it requires a snap-packaged Firefox whose binary lacks the world-execute bit *and* is group-executable via a supplementary rather than primary group *and* is not owned by the user. Snap shims (`/snap/bin/firefox` → `/usr/bin/snap`) and distro Firefox shims are conventionally `0755`, where both versions agree.

**Test coverage.** `isFirefoxSnap` is the only consumer of `which`, and only its three positive snap paths were covered — nothing asserted `profilePath` is left unset otherwise. Mutating the function to return `true` unconditionally kept the entire suite green, so a bug handing every Linux Firefox user a snap profile path would have shipped silently. The second commit adds the negative cases; two of them drive the branch where `which` rejects, which is where the executable-bit check lives.

**`@types/which`.** Now declared explicitly. It was resolving off a transitive `@types/which@2.0.2` hoisted from `edge-paths`, whose definitions still describe the removed callback overloads.

No changelog entry: `which` is bundled in the binary rather than installed by users, carries no advisory, and has no reachable behavior change. Per `scripts/semantic-commits/change-categories.js`, the `chore:` prefix is exempt from changelog validation.

One thing for a reviewer to weigh: the lockfile change invalidates `deferredHash` in `tooling/v8-snapshot/cache/*/snapshot-meta.json`, whose healthy list still names `which/which.js` — a path that no longer exists in this layout. The doctor re-derives on a hash mismatch, and the `update-v8-snapshot-cache-on-develop` job normally handles the refresh, so this should self-heal. If you would rather validate it pre-merge, this branch needs adding to `&full-workflow-filters` per `.circleci/AGENTS.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with added tests; runtime impact is limited to Linux Firefox snap heuristics that use `which`/`isexe` executable checks.
> 
> **Overview**
> Bumps **`which`** in `@packages/launcher` from **2.0.2** to **7.0.0** and pins **`@types/which@3.0.4`** so TypeScript no longer picks up stale callback typings from a transitive dependency. Lockfile updates follow; **no launcher source changes** — Linux Firefox snap detection already calls `await which(binary)`.
> 
> Adds unit coverage ensuring **non-snap Firefox** on Linux does **not** get a `profilePath`: plain binary, shim off `PATH`, and non-executable shim cases. That guards `isFirefoxSnap()` so a false positive would not assign every Firefox install a snap profile directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58616fe8b3b191cb3ef305bc8e3dcdd71942e93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

No manual steps — the behavior is covered by unit tests:

```
yarn workspace @packages/launcher test-unit -- test/unit/linux.spec.ts
```

To confirm the new tests are load-bearing rather than vacuous, make `isFirefoxSnap` in `packages/launcher/lib/linux/index.ts` return `true` unconditionally: the three added cases fail while the pre-existing ten still pass. Making it return `false` fails the three original snap tests instead.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical dependency bump with no source change; explained above. -->
- [x] Have tests been added/updated? <!-- packages/launcher/test/unit/linux.spec.ts -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1kgwDbUQktWtbwHhKn6GV

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1kgwDbUQktWtbwHhKn6GV)_