### PR TITLE
refactor: remove dead code and duplication from @packages/network-tools

### DIFF
--- a/packages/network-tools/lib/cors.ts
+++ b/packages/network-tools/lib/cors.ts
@@ -9,7 +9,7 @@ export type Policy = 'same-origin' | 'same-super-domain-origin' | 'schemeful-sam
 const debug = debugModule('cypress:network:cors')
 
 export function getSuperDomain (url: string) {
-  return getDomainNameFromParsedHost(parseUrlIntoHostProtocolDomainTldPort(url))
+  return getSuperDomainFromParsedHost(parseUrlIntoHostProtocolDomainTldPort(url))
 }
 
 export function parseUrlIntoHostProtocolDomainTldPort (str: string) {
@@ -74,7 +74,7 @@ export function parseUrlIntoHostProtocolDomainTldPort (str: string) {
   return obj
 }
 
-export function getDomainNameFromParsedHost (parsedHost: ParsedHost) {
+export function getSuperDomainFromParsedHost (parsedHost: ParsedHost) {
   return _.compact([parsedHost.domain, parsedHost.tld]).join('.')
 }
 

--- a/packages/network-tools/lib/cors.ts
+++ b/packages/network-tools/lib/cors.ts
@@ -9,9 +9,7 @@ export type Policy = 'same-origin' | 'same-super-domain-origin' | 'schemeful-sam
 const debug = debugModule('cypress:network:cors')
 
 export function getSuperDomain (url: string) {
-  const parsed = parseUrlIntoHostProtocolDomainTldPort(url)
-
-  return _.compact([parsed.domain, parsed.tld]).join('.')
+  return getDomainNameFromParsedHost(parseUrlIntoHostProtocolDomainTldPort(url))
 }
 
 export function parseUrlIntoHostProtocolDomainTldPort (str: string) {
@@ -74,12 +72,6 @@ export function parseUrlIntoHostProtocolDomainTldPort (str: string) {
   debug('Parsed URL %o', obj)
 
   return obj
-}
-
-export function getDomainNameFromUrl (url: string) {
-  const parsedHost = parseUrlIntoHostProtocolDomainTldPort(url)
-
-  return getDomainNameFromParsedHost(parsedHost)
 }
 
 export function getDomainNameFromParsedHost (parsedHost: ParsedHost) {

--- a/packages/network-tools/lib/parse-domain.ts
+++ b/packages/network-tools/lib/parse-domain.ts
@@ -6,17 +6,16 @@ export type ParsedDomainParts = {
   tld: string
 }
 
-export type ParseDomainOptions = {
-  privateTlds?: boolean
-}
-
 // `extractHostname: false` means tldts parses the input verbatim as a hostname —
 // it does NOT pull the host out of a URL. Callers must pass a hostname (e.g.
 // `www.example.com`), not a full URL (`https://www.example.com`), or tldts will
 // silently return wrong results.
-const TLDT_OPTS_BASE = {
+// `allowPrivateDomains` keeps a private suffix (e.g. `herokuapp.com`) as the tld, so
+// two customers' apps on one host resolve to different super domains.
+const TLDTS_OPTS = {
   extractHostname: false,
   mixedInputs: false,
+  allowPrivateDomains: true,
 } as const
 
 /**
@@ -44,14 +43,11 @@ function legacyCustomTldSplit (hostname: string): ParsedDomainParts | null {
     }
   }
 
+  // the `\.[^.]+$` alternation is what matched (the digit/dot one returned above),
+  // so the hostname holds a dot and a non-empty final segment
   const segments = hostname.split('.')
-
-  if (segments.length < 2) {
-    return null
-  }
-
-  const tld = segments[segments.length - 1] || ''
-  const domain = segments[segments.length - 2] || ''
+  const tld = segments[segments.length - 1]
+  const domain = segments[segments.length - 2]
   const subdomain = segments.length > 2 ? segments.slice(0, -2).join('.') : ''
 
   return { subdomain, domain, tld }
@@ -89,22 +85,14 @@ function tldtsToLegacy (hostname: string, r: ReturnType<typeof tldtsParse>): Par
  * legacy `customTlds` regexp the old cors wrapper always passed so host-only cookie logic
  * still sees a parsed shape where applicable.
  */
-export function parseDomain (input: string, options: ParseDomainOptions = {}): ParsedDomainParts | null {
-  const merged: ParseDomainOptions & { privateTlds: boolean } = {
-    privateTlds: true,
-    ...options,
-  }
-
+export function parseDomain (input: string): ParsedDomainParts | null {
   const hostname = input.trim().replace(/^\.+/, '')
 
   if (!hostname) {
     return null
   }
 
-  const r = tldtsParse(hostname, {
-    ...TLDT_OPTS_BASE,
-    allowPrivateDomains: merged.privateTlds !== false,
-  })
+  const r = tldtsParse(hostname, TLDTS_OPTS)
 
   const fromTld = tldtsToLegacy(hostname, r)
 

--- a/packages/network-tools/lib/remote-states.ts
+++ b/packages/network-tools/lib/remote-states.ts
@@ -1,4 +1,4 @@
-import { getDomainNameFromParsedHost, parseUrlIntoHostProtocolDomainTldPort } from './cors'
+import { getSuperDomainFromParsedHost, parseUrlIntoHostProtocolDomainTldPort } from './cors'
 import Debug from 'debug'
 import _ from 'lodash'
 import type { DocumentDomainInjection } from './document-domain-injection'
@@ -154,7 +154,7 @@ export class RemoteStates {
       origin: remoteOrigin,
       strategy: 'http',
       fileServer: null,
-      domainName: getDomainNameFromParsedHost(remoteProps),
+      domainName: getSuperDomainFromParsedHost(remoteProps),
       props: remoteProps,
     }
   }

--- a/packages/network-tools/package.json
+++ b/packages/network-tools/package.json
@@ -8,7 +8,7 @@
     "build-prod": "yarn build",
     "build:cjs": "rimraf cjs && tsc -p tsconfig.cjs.json",
     "build:esm": "rimraf esm && tsc -p tsconfig.esm.json",
-    "check-ts": "tsc -p tsconfig.cjs.json --noEmit && yarn -s tslint -p tsconfig.cjs.json",
+    "check-ts": "tsc -p tsconfig.check.json && yarn -s tslint -p tsconfig.cjs.json",
     "clean": "rimraf cjs esm",
     "clean-deps": "rimraf node_modules",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, .",

--- a/packages/network-tools/test/remote-states.spec.ts
+++ b/packages/network-tools/test/remote-states.spec.ts
@@ -87,7 +87,7 @@ describe('remote states', () => {
         },
       })
 
-      originalState.auth = { username: 'u', password: 'p' }
+      originalState!.auth = { username: 'u', password: 'p' }
 
       const currentState = remoteStates.get('http://localhost:3500/foobar')
 

--- a/packages/network-tools/test/unit/cors.spec.ts
+++ b/packages/network-tools/test/unit/cors.spec.ts
@@ -5,7 +5,7 @@ import type { ParsedHostWithProtocolAndHost } from '../../lib/types'
 
 describe('lib/cors', () => {
   describe('.parseUrlIntoHostProtocolDomainTldPort', () => {
-    const expectUrlToBeParsedCorrectly = (url, obj) => {
+    const expectUrlToBeParsedCorrectly = (url: string, obj: ParsedHostWithProtocolAndHost) => {
       expect(parseUrlIntoHostProtocolDomainTldPort(url)).toEqual(obj)
     }
 
@@ -500,7 +500,7 @@ describe('lib/cors', () => {
       expect(urlMatchesOriginProtectionSpace(urlStr, origin), `the url: '${urlStr}' did not match origin protection space '${origin}' when it should have`).toBe(true)
     }
 
-    const assertDoesNotMatchOriginProtectionSpace = (urlStr, origin) => {
+    const assertDoesNotMatchOriginProtectionSpace = (urlStr: string, origin: string) => {
       expect(urlMatchesOriginProtectionSpace(urlStr, origin), `the url: '${urlStr}' matched origin protection space '${origin}' when it should not have`).toBe(false)
     }
 

--- a/packages/network-tools/test/unit/parse-domain.spec.ts
+++ b/packages/network-tools/test/unit/parse-domain.spec.ts
@@ -91,19 +91,11 @@ describe('lib/parse-domain', () => {
       })
     })
 
-    it('treats herokuapp.com as the public suffix when privateTlds is true (default)', () => {
+    it('treats a private suffix such as herokuapp.com as the tld', () => {
       expect(parseDomain('example.herokuapp.com')).toEqual({
         subdomain: '',
         domain: 'example',
         tld: 'herokuapp.com',
-      })
-    })
-
-    it('treats herokuapp as the registrable label when privateTlds is false', () => {
-      expect(parseDomain('example.herokuapp.com', { privateTlds: false })).toEqual({
-        subdomain: 'example',
-        domain: 'herokuapp',
-        tld: 'com',
       })
     })
 

--- a/packages/network-tools/tsconfig.check.json
+++ b/packages/network-tools/tsconfig.check.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  },
+  "include": [
+    "lib/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/proxy/lib/adapters/inject-html.ts
+++ b/packages/proxy/lib/adapters/inject-html.ts
@@ -1,7 +1,7 @@
 import iconv from 'iconv-lite'
 import { PassThrough } from 'stream'
 import { concatStream } from '@packages/network'
-import { getDomainNameFromUrl, DocumentDomainInjection } from '@packages/network-tools'
+import { getSuperDomain, DocumentDomainInjection } from '@packages/network-tools'
 import { telemetry } from '@packages/telemetry'
 import { isVerboseTelemetry as isVerbose } from '../http'
 import * as rewriter from '../http/util/rewriter'
@@ -40,7 +40,7 @@ export async function injectHtml (mw: ResponseInterceptionMiddlewareCtx): Promis
     const decodedBody = iconv.decode(body, nodeCharset)
     const injectedBody = await rewriter.html(decodedBody, {
       cspNonce: mw.res.injectionNonce,
-      domainName: getDomainNameFromUrl(mw.req.proxiedUrl),
+      domainName: getSuperDomain(mw.req.proxiedUrl),
       wantsInjection,
       wantsSecurityRemoved: mw.res.wantsSecurityRemoved,
       modifyObstructiveThirdPartyCode: mw.config.experimentalModifyObstructiveThirdPartyCode && !mw.remoteStates.isPrimarySuperDomainOrigin(mw.req.proxiedUrl),


### PR DESCRIPTION
- Closes N/A — no associated issue. This is an internal cleanup of `@packages/network-tools` with no user-facing impact; see the explanation under PR Tasks.

### Additional details

An audit of `@packages/network-tools` for dead code and unreachable paths, cross-checked against every consumer in this repo and against `cypress-services` (which has no dependency on this package and no reference to any of its exports).

**1. The `test/` directory was never type-checked.** `tsconfig.json` scopes `include` to `lib/*.ts`, and `check-ts` ran `tsc -p tsconfig.cjs.json`, which inherits that `include`. So no spec was checked, despite the package running `strict`, `noImplicitAny`, and `noUnusedLocals`. Adding `test/` to the existing configs is not possible — the cjs and esm build configs set `rootDir: ./lib`. Added `tsconfig.check.json` covering `lib` + `test` with `noEmit` and pointed `check-ts` at it, mirroring how `@packages/types` solves the same problem. The build configs are untouched.

That surfaced two real errors, fixed here: two assertion helpers in `cors.spec.ts` had implicit `any` parameters, and `remote-states.spec.ts` assigned through the possibly-undefined result of `RemoteStates#get`.

**2. `getSuperDomain` and `getDomainNameFromUrl` were duplicate implementations** — both `compact([domain, tld]).join('.')` over `parseUrlIntoHostProtocolDomainTldPort(url)`. Kept `getSuperDomain` (two call sites, and it names the concept `getSuperDomainOrigin` and the `same-super-domain-origin` policy are built on), dropped `getDomainNameFromUrl`, and moved its one call site — the proxy's html injection — across. `getSuperDomain` now routes through `getSuperDomainFromParsedHost`, so that expression lives in one place instead of three.

**3. Renamed `getDomainNameFromParsedHost` → `getSuperDomainFromParsedHost`.** It returns the super domain, so after the dedup a single expression held two names for one concept. The rename also makes `RemoteState` construction state something that previously took reading three functions to establish: the `domainName` field holds the super domain. The `domainName` field itself is deliberately unchanged — it is public API in `cli/types/cypress.d.ts`.

**4. Three unreachable pieces of `parse-domain.ts` removed:**
- `legacyCustomTldSplit`'s `segments.length < 2` guard. Reaching it means the `\.[^.]+$` alternation of `LEGACY_CUSTOM_TLDS_RE` matched, since the `^[\d.]+$` alternation returns earlier, so the hostname holds a dot and `split('.')` cannot yield fewer than two segments.
- The `|| ''` fallbacks on `tld` and `domain` — both index a `string[]` at an index that same match guarantees is in range.
- The `options` parameter, `ParseDomainOptions`, and the `privateTlds` plumbing. The one production caller, `isHostOnlyCookie` in `@packages/server`, passes no options, so `allowPrivateDomains` was always `true`. It is now set directly on the tldts options.

Note on why `yarn health-check` never flagged any of this: `knip.json` declares `lib/index.ts` as this package's entry, so everything re-exported from index counts as used regardless of whether a consumer imports it.

### Steps to test

No behavior change, so there is nothing to exercise by hand. The two substantive changes were each verified by diffing behavior before and after:

- `getSuperDomain` was compared against both prior implementations over 26 urls spanning subdomains, public and private suffixes, localhost, IPv4/IPv6 literals, explicit and default ports, out-of-range ports, and relative / `<root>` inputs. No mismatches.
- `parseDomain` output was snapshotted before the change and re-compared after, over 56 hostnames covering ICANN and private suffixes, IPv4/IPv6 literals, localhost forms, leading/trailing/repeated dots, digit-and-dot strings, single-label hosts, and empty input. No mismatches.

To re-run the package suite and the newly widened type-check:

```
yarn workspace @packages/network-tools test
yarn workspace @packages/network-tools check-ts
```

153 tests pass (154 before, minus the one test that existed solely to exercise the removed `privateTlds` option).

### How has the user experience changed?

No change. Every change is internal to `@packages/network-tools` and its one proxy call site; no public API, type definition, or runtime behavior is affected.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No issue. This is a mechanical dead-code and duplication cleanup with no behavior change, verified by before/after behavioral diffs. Happy to open one if the team would prefer it tracked. -->
- [x] Have tests been added/updated? <!-- Test files are now type-checked for the first time, and the two errors that surfaced are fixed. One test was removed alongside the `privateTlds` option it existed to exercise; its sibling still covers the private-suffix behavior. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing changes. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No changes to public types. `RemoteState.domainName` was deliberately left alone for this reason — only the internal helper that computes it was renamed. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01BM7k3rfnAsrxP9wm14nXGg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only in domain parsing and CORS helpers with before/after behavioral verification; touches proxy injection only via a renamed-equivalent helper call.
> 
> **Overview**
> Internal cleanup in `@packages/network-tools` with **no intended runtime or public API changes** (`RemoteState.domainName` and exports stay the same aside from removing the duplicate `getDomainNameFromUrl`).
> 
> **Super-domain naming and deduplication:** `getDomainNameFromUrl` is removed; its only consumer (proxy HTML injection) now uses `getSuperDomain`. `getSuperDomain` delegates to a single shared helper, renamed from `getDomainNameFromParsedHost` to **`getSuperDomainFromParsedHost`**, and `remote-states` uses that name when populating `domainName`.
> 
> **`parseDomain` simplification:** Drops `ParseDomainOptions` / `privateTlds` (production always used private suffixes); `allowPrivateDomains: true` is fixed on tldts options. Removes unreachable guards in `legacyCustomTldSplit` that the PR author argues cannot fire given the legacy regexp.
> 
> **Tooling:** Adds `tsconfig.check.json` so `check-ts` type-checks `lib` and `test` (previously only `lib` was in build tsconfigs). Fixes implicit-`any` in `cors.spec.ts` and a possibly-undefined assignment in `remote-states.spec.ts`; removes the test for `privateTlds: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458be87daa12bee0b04186287952c8570b507227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->