### PR TITLE
chore: remove find-up from @packages/scaffold-config

### DIFF
--- a/.circleci/cache-version.txt
+++ b/.circleci/cache-version.txt
@@ -1,2 +1,2 @@
 # Bump this version to force CI to re-create the cache from scratch.
-07-30-2026
+08-30-2026

--- a/packages/scaffold-config/package.json
+++ b/packages/scaffold-config/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "debug": "^4.3.4",
     "dedent": "^0.7.0",
-    "find-up": "^5.0.0",
     "fs-extra": "^9.1.0",
     "globby": "^11.0.1",
     "resolve-package-path": "^4.0.3",

--- a/packages/scaffold-config/src/ct-detect-third-party.ts
+++ b/packages/scaffold-config/src/ct-detect-third-party.ts
@@ -3,7 +3,6 @@ import globby from 'globby'
 import { z } from 'zod'
 import fs from 'fs-extra'
 import Debug from 'debug'
-import findUp from 'find-up'
 
 const debug = Debug('cypress:scaffold-config:ct-detect-third-party')
 
@@ -58,6 +57,23 @@ async function hasWorkspacePackageJson (directory: string) {
   }
 }
 
+function* directoryAndAncestors (from: string): Generator<string> {
+  let directory = path.resolve(from)
+
+  while (true) {
+    yield directory
+
+    const parent = path.dirname(directory)
+
+    // `path.dirname` returns the same path once we reach the filesystem root
+    if (parent === directory) {
+      return
+    }
+
+    directory = parent
+  }
+}
+
 export async function isRepositoryRoot (directory: string) {
   if (ROOT_PATHS.some((rootPath) => fs.existsSync(path.join(directory, rootPath)))) {
     return true
@@ -94,13 +110,12 @@ export async function detectThirdPartyCTFrameworks (
   const erroredFrameworks: ErroredFramework[] = []
 
   try {
-    let fullPathGlobs
     let packageJsonPaths: string[] = []
 
     // Start at the project root and check each directory above it until we see
     // an indication that the current directory is the root of the repository.
-    await findUp(async (directory: string): Promise<findUp.Match> => {
-      fullPathGlobs = [
+    for (const directory of directoryAndAncestors(projectRoot)) {
+      const fullPathGlobs = [
         path.join(directory, CT_FRAMEWORK_GLOBAL_GLOB),
         path.join(directory, CT_FRAMEWORK_NAMESPACED_GLOB),
       ].map((x) => x.replaceAll('\\', '/'))
@@ -115,17 +130,12 @@ export async function detectThirdPartyCTFrameworks (
 
       packageJsonPaths = [...packageJsonPaths, ...newPackagePaths]
 
-      const isCurrentRepositoryRoot = await isRepositoryRoot(directory)
-
-      if (isCurrentRepositoryRoot) {
+      if (await isRepositoryRoot(directory)) {
         debug('stopping search at %s because it is believed to be the repository root', directory)
 
-        return findUp.stop
+        break
       }
-
-      // Return undefined to keep searching
-      return undefined
-    }, { cwd: projectRoot })
+    }
 
     if (packageJsonPaths.length === 0) {
       debug('no third-party dependencies detected')

--- a/packages/scaffold-config/test/ct-detect-third-party.spec.ts
+++ b/packages/scaffold-config/test/ct-detect-third-party.spec.ts
@@ -153,6 +153,43 @@ describe('detectThirdPartyCTFrameworks', () => {
     expect(thirdPartyFrameworks.frameworks[0].type).toEqual('cypress-ct-qwik')
   })
 
+  describe('repository root boundary', () => {
+    const TEMP_DIR = path.join(os.tmpdir(), 'ct-detect-third-party-boundary-tmp')
+    const repositoryRoot = path.join(TEMP_DIR, 'repo')
+    const projectRoot = path.join(repositoryRoot, 'packages', 'foo')
+
+    beforeEach(async () => {
+      const scaffolded = await scaffoldMigrationProject('ct-monorepo-unconfigured')
+
+      await fs.mkdirp(projectRoot)
+      await fs.writeJson(path.join(repositoryRoot, 'package.json'), {
+        name: 'boundary-repo',
+        private: true,
+        workspaces: ['packages/*'],
+      })
+
+      await fs.writeJson(path.join(projectRoot, 'package.json'), { name: 'foo' })
+
+      // The only copy of the module sits one directory above the repository root,
+      // where `require.resolve` from the project can still reach it
+      await fs.copy(
+        path.join(scaffolded, 'cypress-ct-qwik'),
+        path.join(TEMP_DIR, 'node_modules', 'cypress-ct-qwik'),
+      )
+    })
+
+    afterEach(async () => {
+      await fs.rm(TEMP_DIR, { recursive: true, force: true })
+    })
+
+    it('ignores third party frameworks installed above the repository root', async () => {
+      const { frameworks, erroredFrameworks } = await detectThirdPartyCTFrameworks(projectRoot)
+
+      expect(frameworks).toEqual([])
+      expect(erroredFrameworks).toEqual([])
+    })
+  })
+
   it('validates third party module', () => {
     expect(() => validateThirdPartyModule(solidJs)).not.toThrow()
 


### PR DESCRIPTION
- Closes N/A — no associated issue. This is an internal refactor with no user-facing impact; happy to open one if maintainers would prefer.

### Additional details

**Why was this change necessary?**

This started as an investigation into updating `find-up` to latest (8.0.0). `find-up` has been ESM-only since 6.0.0, and `@packages/scaffold-config` was the one consumer still on the CommonJS 5.x line, imported with a default import.

Updating it in place would have meant pulling an ESM-only package into the V8 snapshot. `find-up@5` is currently baked into the snapshot as *healthy* — `tooling/v8-snapshot/cache/*/snapshot-meta.json` lists `packages/scaffold-config/node_modules/{find-up,locate-path,p-locate}/index.js` — and the snapshot bundle is a CommonJS-only registry (`module.exports = __commonJS` in `create-snapshot-bundle.ts`). There is no ESM handling anywhere in `tooling/packherd/src` or `tooling/v8-snapshot/src`, and no ESM-only package in the snapshot graph today.

The usage didn't justify that risk. The only call was a walk from the project root up through its ancestors with a matcher that never returned a path — `find-up` was doing directory iteration and nothing else, none of its actual file-locating. So this removes the dependency rather than updating it.

**What is affected by this change?**

`detectThirdPartyCTFrameworks` in `@packages/scaffold-config`, reached through `WizardActions` in `@packages/data-context` (the component-testing setup wizard). The matcher is replaced by a generator:

```ts
function* directoryAndAncestors (from: string): Generator<string> {
  let directory = path.resolve(from)

  while (true) {
    yield directory

    const parent = path.dirname(directory)

    // `path.dirname` returns the same path once we reach the filesystem root
    if (parent === directory) {
      return
    }

    directory = parent
  }
}
```

`findUp.stop` becomes `break`, and `fullPathGlobs` moves inside the loop as a `const` — it was only hoisted because of the callback.

This drops `find-up`, `locate-path` and `p-locate` from the V8 snapshot graph. `yarn.lock` is unchanged: `find-up@^5.0.0` is still required by `babel-loader@10.0.0`, `eslint@^8.56.0` and `eslint@^9.22.0`, so the lockfile entry stays. What goes away is the nested `packages/scaffold-config/node_modules/find-up` copy the snapshot was picking up.

**Implementation details**

Traversal is identical to `find-up@5`. It stopped when `directory === path.parse(resolve(cwd)).root`; this stops when `path.dirname(d) === d`. I compared the two across 26 inputs — POSIX absolute/root/trailing-slash/doubled-slash/`.`/`..`/relative/empty/non-ASCII, and Windows drive paths, bare `C:\`, lowercase drive letters, forward slashes, UNC, extended-length `\\?\` and `\\?\UNC\`, and device `\\.\` — with identical directory sequences in every case.

The `.circleci/cache-version.txt` bump is included to force a cold dependency cache. Note this is global — the next run on `develop` and every open PR will do a full install on every platform. The node_modules cache key already changes on this branch on its own (`scripts/circle-cache.js --action cacheKey` hashes each workspace package.json's dependency blocks alongside `yarn.lock`, and it moves from `881a7fc0…` to `c1472691…`), so this bump is belt-and-braces rather than strictly required. Say the word and I'll drop it.

Not included here: `@cypress/vite-dev-server` and `@cypress/webpack-dev-server` are still pinned to `find-up@6.3.0`. Bumping those to 8.0.0 is a pin change in each `package.json` with no code edits — vite's is real ESM, webpack's keeps its existing `tsImport` workaround — and belongs in its own PR.

### Steps to test

Covered by unit tests, but to verify by hand:

1. Create a monorepo with a workspaces root and a package at `packages/foo`.
2. Install a third-party CT plugin (e.g. `cypress-ct-qwik`) hoisted to the monorepo root's `node_modules`.
3. Open Cypress in `packages/foo` and start component testing setup. The third-party framework should be offered, found via the walk up to the monorepo root.
4. Move that module to `node_modules` one level *above* the monorepo root. It should no longer be offered — the search stops at the repository root.

### How has the user experience changed?

No change. Same detection behavior, same directories searched, same stopping point.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal refactor, no user-facing change. See note at the top of the description. -->
- [x] Have tests been added/updated? <!-- See below -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

**On tests** — one was added, because the existing suite did not cover the behavior this PR rewrites. I mutation-tested both branches of the walk:

| Mutation | Before this PR |
|---|---|
| Delete the stop (walk past the repository root to `/`) | **All 55 tests passed** |
| Never walk up past the project directory | 1 test failed |

Walking up was covered by `detects third party frameworks in monorepos with hoisted dependencies`; stopping at the repository root was not covered at all. The reason it slipped through: fixtures are scaffolded into `os.tmpdir()/cy-projects/<name>`, and nothing above that path contains a `cypress-ct-*` module, so an unbounded walk finds nothing extra and every assertion still holds. That gap predates this change — `findUp.stop` was equally untested — but this PR rewrites that exact line.

`repository root boundary` puts the only copy of the module one directory above the repository root, positioned so `require.resolve` from the project can still reach it, and asserts nothing is detected. Verified in both directions: passes against the real code, fails when the stop is removed.

**Verification run**

- `yarn workspace @packages/scaffold-config test` — 56/56 pass
- `yarn workspace @packages/scaffold-config check-ts` — clean
- `yarn lint` (full monorepo) — clean
- `yarn build` then `yarn build-v8-snapshot-dev` — snapshot generated and verified successfully

Not run in my environment: the launchpad E2E (`launchpad/cypress/e2e/scaffold-component-testing.cy.ts`) and system tests. Worth noting that `packages/scaffold-config/*` path filtering sets only `launchpad_tests` and `system_tests` — not `v8_tests` — so `v8-integration-tests` will not run on this PR unless the branch is added to `&full-workflow-filters`. Happy to add that if reviewers want the snapshot validated pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017b1Nm3DXfa4sDN7G7DSaqC

---
_Generated by [Claude Code](https://claude.ai/code/session_017b1Nm3DXfa4sDN7G7DSaqC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of third-party CT discovery with equivalent traversal and new boundary coverage; no auth, data, or payment paths.
> 
> **Overview**
> Removes the **`find-up`** dependency from `@packages/scaffold-config` and reimplements the ancestor directory walk in **`detectThirdPartyCTFrameworks`** with a local **`directoryAndAncestors`** generator and a **`for`/`break`** loop instead of **`findUp.stop`**.
> 
> Behavior is intended to stay the same: still glob for third-party **`cypress-ct-*`** packages from the project root upward and stop at the repository root, which trims **`find-up`** (and related snapshot packages) from this workspace without changing the component-testing setup wizard path that calls this API.
> 
> A new **`repository root boundary`** test asserts frameworks installed **above** the monorepo root are not detected. **`.circleci/cache-version.txt`** is bumped to force a cold CI dependency cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad5a071849517f0b9af11c703b674e46f927054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->