### PR TITLE
chore: resolve get-next-version CI deps from package.json

### DIFF
--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -1229,8 +1229,11 @@ commands:
             git clone --depth 1 --no-single-branch https://github.com/cypress-io/<<parameters.repo>>.git .
 
             cd ~/cypress/..
-            # install some deps for get-next-version
-            npm i semver@7.3.2 conventional-recommended-bump@6.1.0 conventional-changelog-angular@5.0.12 minimist@1.2.5
+            # get-next-version runs before the workspace dependencies are
+            # unpacked, so install what it needs at the versions
+            # cypress/package.json pins.
+            NEXT_VERSION_DEPS=$(node -p "const deps = require('./cypress/package.json').devDependencies; ['semver', 'conventional-recommended-bump', 'minimist'].map((name) => name + '@' + deps[name]).join(' ')")
+            npm i $NEXT_VERSION_DEPS
             NEXT_VERSION=$(node ./cypress/scripts/get-next-version.js)
             cd -
 


### PR DESCRIPTION
- Closes N/A — no associated issue; CI tooling maintenance.

### Additional details

The `clone-repo-and-checkout-branch` command installs the dependencies `scripts/get-next-version.js` needs, because it runs before the workspace dependencies are unpacked (`restore_cached_binary` only does `attach_workspace`, not `unpack-dependencies`). Those versions were hardcoded in the CircleCI config and had drifted years behind the repo:

| package | pinned in CI | root `package.json` |
|---|---|---|
| `semver` | `7.3.2` | `^7.7.3` |
| `minimist` | `1.2.5` | `1.2.8` |
| `conventional-recommended-bump` | `6.1.0` | `6.1.0` |

`npm audit` against that exact install command reports two advisories, both from the stale pins:

- `minimist@1.2.5` — **critical**, prototype pollution ([GHSA-xvch-5gv4-984h](https://github.com/advisories/GHSA-xvch-5gv4-984h)), fixed in `1.2.6`
- `semver@7.3.2` — **high**, ReDoS ([GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)), fixed in `7.5.2`

Reading the versions out of `cypress/package.json` makes the root `package.json` the single source of truth, so the two stay in step rather than needing a second edit every time a version moves.

Two smaller changes in the same line:

- **`conventional-changelog-angular` is dropped.** `get-next-version.js` passes no `preset` or `config` to `conventional-recommended-bump`, so no preset is ever loaded and nothing requires this package. Verified by running the script to completion with only the other three installed.
- **The spec list is assigned before `npm i`.** CircleCI runs steps under `bash -eo pipefail`, where a failing command substitution inside a simple command does not abort the step — an empty `npm i` would silently no-op and resurface as a `MODULE_NOT_FOUND` from `get-next-version` two lines later. As an assignment, the substitution's exit status is the statement's, so a failure to read `package.json` stops the step where it happens.

Only `.circleci/src/` is edited; `packed/` is gitignored and built at CI runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CircleCI config only; no product runtime or release artifact logic changes beyond which npm versions are installed for one script.
> 
> **Overview**
> Updates **`clone-repo-and-checkout-branch`** so the pre-unpack `npm i` for `get-next-version.js` no longer uses hardcoded package versions. A **`node -p`** step reads **`semver`**, **`conventional-recommended-bump`**, and **`minimist`** from **`cypress/package.json`** `devDependencies`, keeping CI aligned with repo pins and clearing stale **`minimist`** / **`semver`** audit issues.
> 
> **`conventional-changelog-angular`** is removed from that install list because the script does not load a conventional-changelog preset. The dependency list is assigned to **`NEXT_VERSION_DEPS`** before **`npm i`** so a failed **`package.json`** read fails the step under **`bash -eo pipefail`** instead of running an empty install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa0fa82a4844f695c381bb50b55d033a65e372c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

This runs inside `clone-repo-and-checkout-branch`, so it is exercised by any job that uses it (`test-kitchensink`, `test-against-staging`, `test-full-typescript-project`, `test-binary-as-specific-user`, and the binary-against-repo/staging commands). Those need a full CI run, so it was verified locally against a reconstruction of the CI layout (`~/cypress/` holding the script, `npm i` one level up):

1. The resolution one-liner returns `semver@^7.7.3 conventional-recommended-bump@6.1.0 minimist@1.2.8`.
2. `npm i` of that list succeeds, and `npm audit` on the result reports **0 vulnerabilities** — both advisories above are cleared.
3. All three modules resolve from `cypress/scripts/` up into the parent `node_modules`, which is what makes this layout work.
4. `node ./scripts/get-next-version.js` runs to completion against this checkout with only those three packages reachable, confirming `conventional-changelog-angular` is unused.
5. A deliberately failing `node -p` exits non-zero before `npm i` under `bash -eo pipefail`.
6. The edited config parses as YAML and the extracted command block passes `bash -n`.

One gap worth flagging: `yarn pack-ci --validate` was not run — the CircleCI CLI is not available in the environment this was written in. Nothing generated is missing from the commit (`packed/` is gitignored), but it is worth running before merge.

### How has the user experience changed?

No change. CI tooling only; no runtime, binary, or user-facing code is touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical CI maintenance: refreshes stale dependency pins in a CircleCI command and removes an unused package. No product behavior changes. -->
- [na] Have tests been added/updated? <!-- CircleCI config; no unit-test harness covers it. Verification steps are listed above. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKinoeaqkcdrTnJGuqowYS)_