### PR TITLE
chore: bump devtools-protocol to 0.0.1687809

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
     "@definitelytyped/typescript-versions": "0.1.9",
     "@types/react": "18.3.12",
     "browserify-sign": "4.2.5",
-    "devtools-protocol": "0.0.1575685",
+    "devtools-protocol": "0.0.1687809",
     "eslint-plugin-import": "2.29.1",
     "node-abi": "4.28.0",
     "vue-template-compiler": "2.6.12",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -42,7 +42,7 @@
     "@packages/types": "0.0.0-development",
     "@types/express": "4.17.2",
     "@types/supertest": "2.0.16",
-    "devtools-protocol": "0.0.1575685",
+    "devtools-protocol": "0.0.1687809",
     "express": "4.21.0",
     "supertest": "6.0.1",
     "typescript": "~5.4.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -166,7 +166,7 @@
     "chai-subset": "1.6.0",
     "chai-uuid": "1.0.6",
     "chrome-har-capturer": "0.14.2",
-    "devtools-protocol": "0.0.1575685",
+    "devtools-protocol": "0.0.1687809",
     "esbuild": "^0.28.1",
     "eslint": "^9.31.0",
     "eventsource": "2.0.2",

--- a/packages/socket/package.json
+++ b/packages/socket/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@packages/types": "0.0.0-development",
-    "devtools-protocol": "0.0.1575685",
+    "devtools-protocol": "0.0.1687809",
     "resolve-pkg": "2.0.0",
     "rimraf": "6.1.1",
     "vitest": "^3.2.4"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -24,7 +24,7 @@
     "@types/node": "24.10.1",
     "axios": "^1.15.1",
     "better-sqlite3": "12.8.0",
-    "devtools-protocol": "0.0.1575685",
+    "devtools-protocol": "0.0.1687809",
     "express": "4.21.0",
     "rimraf": "^6.1.1",
     "socket.io": "4.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15307,10 +15307,10 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
-devtools-protocol@0.0.1159816, devtools-protocol@0.0.1575685, devtools-protocol@0.0.927104:
-  version "0.0.1575685"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1575685.tgz#8ae6db509c572d3a64b62e2f2a486aa3ea1fcd4c"
-  integrity sha512-5dS9wazW8h5VoY3wx8GkZH1EJMv4y90WISi5OnYi6aWzSoC8kwXlxcnnETz95KdlPjNbOuL9TWBE7xDUVYTOew==
+devtools-protocol@0.0.1159816, devtools-protocol@0.0.1687809, devtools-protocol@0.0.927104:
+  version "0.0.1687809"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1687809.tgz#871dac8265503b23ddf55b74128ffe0361b55d03"
+  integrity sha512-t7kSb+UKYdyxcmqy98U2P86ne6rCve3DIJ4+lp54i/hhClgFuG35JrLj23rO14Jw3sWDsp7i+22QhNU0+/qk8g==
 
 didyoumean@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
- Closes N/A

### Additional details

Bumps `devtools-protocol` from `0.0.1575685` to `0.0.1687809` (latest). Updated in the root `resolutions` block and in the four packages that depend on it directly: `@packages/types`, `@packages/server`, `@packages/socket`, `@packages/proxy`.

`devtools-protocol` is a types-only package (`.d.ts` plus the raw protocol JSON/PDL). Every import in this repo is `import type`, so there is no runtime footprint — nothing from this package executes in or ships with the binary. The value of the bump is compile-time accuracy against the CDP that current Chrome actually speaks.

**Why now:** the previous pin had drifted far enough that CDP fields Chrome genuinely sends were not typed, which pushes anyone writing new automation code toward `as any` casts in `cdp_automation.ts` and friends. This is routine hygiene so the gap never grows large enough that a needed field forces a risky jump.

#### Notable protocol changes in this range

Added surface that is relevant to code in this repo:

- `Page.startScreencast` gained `maxFramesInFlight` (frames sent before an ack is required, defaults to 3) and `sendLastFrame` (buffers the last produced frame and sends it immediately on ack, trading throughput for latency). `@packages/server` drives video capture through `Page.startScreencast` / `Page.screencastFrameAck`, so these are now available for frame-pacing work. Not used by this PR.
- `Page.startScreenRecording` / `Page.stopScreenRecording` are new — native browser-side recording returning an `IO.StreamHandle` rather than assembling frames from a screencast.
- `Network.emulateNetworkConditions`: `offline` became optional, and a new `emulateOfflineServiceWorker` param was added.

Renames, none of which are referenced in this repo:

- `Network.PrivateNetworkRequestPolicy` → `Network.LocalNetworkAccessRequestPolicy`
- `Page.AdScriptId` / `Page.AdScriptAncestry` → `Network.AdScriptIdentifier` / `Network.AdAncestry`

Removals — 34 commands/events, verified unused (see testing below):

- The deprecated `Network` interception family: `setRequestInterception`, `continueInterceptedRequest`, `getResponseBodyForInterception`, `takeResponseBodyForInterceptionAsStream`, and the `requestIntercepted` event. Cypress intercepts via the `Fetch` domain, not this legacy path.
- ~28 Privacy Sandbox `Storage.*` commands (Shared Storage, Attribution Reporting, Interest Groups).

The `Fetch`, `Input`, and `Runtime` domains changed by zero non-comment lines. Those cover interception, key dispatch, and frame evaluation — the bulk of what this repo relies on.

**Caveat worth noting for reviewers:** these types track Chromium tip-of-tree, not the Chrome that Cypress ships (Electron 41) or that a user has installed. The types are now more permissive than reality — `Page.startScreenRecording` and the new `WebMCP.*` domain type-check but would fail at runtime on Electron 41. This was equally true before the bump, just at a smaller offset. Any future use of newly-added surface still needs a runtime capability check.

No changelog entry: `chore` is a non-releasing type and this has no user-facing effect.

### Steps to test

No behavior change to exercise manually. Verification performed:

- `lerna run check-ts` across the full monorepo — passes on all 41 projects. This is the meaningful check for a types-only bump: it proves no removed or renamed CDP type is referenced anywhere.
- Grepped every one of the 34 removed command/event names across `packages/`, `npm/`, `cli/`, and `system-tests/` — zero references.
- Grepped the renamed types (`PrivateNetworkRequestPolicy`, `AdScriptId`, `AdScriptAncestry`, `InterceptionId`, `CookieExemptionReason`, `ContentEncoding`) — no CDP-typed usages.
- `yarn.lock` regenerated via `yarn install`; the single hoisted `devtools-protocol` entry resolves to `0.0.1687809`.

E2E and packaged-binary tests were not run locally; leaving those to CI.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical dependency bump with no runtime or user-facing effect; the package contributes TypeScript definitions only. -->
- [na] Have tests been added/updated? <!-- Types-only dependency change; no behavior to cover. Full-monorepo type checking is the applicable verification and passes. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No change to Cypress's public API surface; these are internal CDP types. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDgYysSZ6vyWeKCtThbKcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDgYysSZ6vyWeKCtThbKcD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and lockfile-only change with no application logic edits; risk is limited to TypeScript compile compatibility, which the monorepo typecheck is intended to catch.
> 
> **Overview**
> Bumps the pinned **`devtools-protocol`** version from `0.0.1575685` to `0.0.1687809` in the root Yarn **`resolutions`** entry and in **`@packages/types`**, **`@packages/server`**, **`@packages/socket`**, and **`@packages/proxy`**, with **`yarn.lock`** updated to hoist the new release.
> 
> This is a **types-only** CDP definition refresh (repo usage is **`import type`** only), so there is **no runtime or user-facing behavior change**—only more accurate compile-time typing for Chrome DevTools Protocol automation code. The newer schema adds optional screencast/recording and network-emulation fields and drops deprecated types the repo does not reference; existing **`check-ts`** coverage is the meaningful verification gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1b6259b2704295220c75ec8c814873996eaf25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->