### PR TITLE
test(launchpad): de-flake choose-a-browser browser status tests

### DIFF
--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -249,6 +249,12 @@ describe('Choose a browser page', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
+
+      // `visitLaunchpad` resolves before the browser list has rendered, and the list only
+      // learns about later status changes through the subscription it opens once mounted.
+      // Wait for the closed-browser state to be on screen so the change has a subscriber.
+      cy.contains('button', 'Start E2E Testing in Chrome').should('be.visible')
+
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
       })
@@ -260,16 +266,18 @@ describe('Choose a browser page', () => {
       cy.wait('@closeBrowser')
     })
 
-    it('performs mutation to focus open browser when focus button is pressed', { retries: 15 }, () => {
+    it('performs mutation to focus open browser when focus button is pressed', () => {
       cy.openProject('launchpad', ['--e2e'])
 
       cy.visitLaunchpad()
 
+      cy.get('h1').should('contain', 'Choose a browser')
+
+      cy.contains('button', 'Start E2E Testing in Chrome').should('be.visible')
+
       cy.withCtx((ctx) => {
         ctx.actions.app.setBrowserStatus('open')
       })
-
-      cy.get('h1').should('contain', 'Choose a browser')
 
       cy.contains('button', 'Running Chrome').as('launchButton')
 

--- a/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
+++ b/packages/launchpad/cypress/e2e/choose-a-browser.cy.ts
@@ -250,9 +250,8 @@ describe('Choose a browser page', () => {
 
       cy.visitLaunchpad()
 
-      // `visitLaunchpad` resolves before the browser list has rendered, and the list only
-      // learns about later status changes through the subscription it opens once mounted.
-      // Wait for the closed-browser state to be on screen so the change has a subscriber.
+      // `visitLaunchpad` resolves before the browser list mounts, and the list only learns
+      // about status changes through the subscription it opens on mount.
       cy.contains('button', 'Start E2E Testing in Chrome').should('be.visible')
 
       cy.withCtx((ctx) => {


### PR DESCRIPTION
- Closes <!-- no issue; internal test-only flake fix, analysis below -->

### Additional details

Two tests in `choose-a-browser.cy.ts` flake with `Timed out retrying after 4000ms: Expected to find content: 'Running Chrome' within the selector: 'button' but never did.` They show up as flaky in most recent `develop` runs (e.g. runs 74209, 74213, 74215).

**Why was this change necessary?**

Both tests call `setBrowserStatus('open')` immediately after `cy.visitLaunchpad()`. `visitLaunchpad` waits for `[data-e2e]` and then `cy.get('.spinner').should('not.exist')` — that second assertion passes vacuously when the spinner has not rendered yet, so it can resolve ~50ms after `cy.visit`, before the Choose a browser page exists.

`OpenBrowserList` learns about browser status changes through the `browserStatusChange` GraphQL subscription it opens on mount. When the mutation fires before the component mounts, `emitter.browserStatusChange()` reaches zero subscribers and the update is dropped.

Test Replay for run 74215 shows this directly. The Choose a browser page first renders at t=0.761s, while the `setBrowserStatus` task runs 0.727s → 0.771s — the page did not exist when the status changed. Across all 8 attempts of the two tests, `Running Chrome` reaches the DOM **if and only if** an incidental `graphql-refetch` re-ran `query-OpenBrowser` after the mutation:

```
test  attempt  query-OpenBrowser responses      "Running Chrome" rendered
r12   1        [closed, closed]                 no    (failed)
r12   2        [closed, open]                   yes   (passed)
r13   1-5      [closed, closed]                 no    (failed x5)
r13   6        [closed, closed, open]           yes   (passed)
```

The two responses in the failing attempt are byte-identical; the passing attempt differs only in `"browserStatus": "open"`. The margin is small — in the failing attempt the last `query-OpenBrowser` landed 4ms before the mutation completed, in the passing attempt 11ms after.

The control case is the sibling test `subscribes to changes to browserStatus/activeBrowser…`, which already waits for the rendered page before mutating. It renders `Running Chrome` with *every* query response still reporting `closed` — the subscription delivers correctly when the component is mounted first, and that test does not appear in the flaky lists.

**What is affected by this change?**

`packages/launchpad/cypress/e2e/choose-a-browser.cy.ts` only. No product code changes.

- `performs mutation to close browser` and `performs mutation to focus open browser when focus button is pressed` now wait for the closed-browser state to be on screen before changing the status, matching what the other browser status tests in this spec already do.
- Dropped `{ retries: 15 }` from the focus test (added in #24124 in 2022 to paper over this exact flake). It falls back to the package default of 2 retries in run mode, so the test gives a real signal again.

These were the only two `setBrowserStatus` calls in the repo not already preceded by a page-ready wait.

### Steps to test

```bash
yarn workspace @packages/launchpad cypress:run:e2e -- --spec cypress/e2e/choose-a-browser.cy.ts
```

Worth running several times — the pre-fix failure rate was roughly 50% per attempt on the two affected tests.

### How has the user experience changed?

No change. Test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Test-only flake fix, no product behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_013sacjnqwcSgqRYTFgxGQxk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cypress spec changes only; no runtime or production behavior affected.
> 
> **Overview**
> Fixes flaky E2E in `choose-a-browser.cy.ts` where **`setBrowserStatus('open')` ran before the Choose a browser UI (and its `browserStatusChange` subscription) was mounted**, so updates were dropped and assertions on **Running Chrome** timed out.
> 
> The **close browser** and **focus open browser** tests now wait for the closed-state UI (**Start E2E Testing in Chrome**, and for focus also the **Choose a browser** heading) before simulating an open browser, consistent with the subscription test in the same file. The focus test **removes `{ retries: 15 }`** so failures surface with normal retry behavior instead of masking the race.
> 
> **Test-only** — no launchpad product code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f3891bbdc44085ecc0a5306d873ac2c3a321db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->