### PR TITLE
chore: correct 16.0.0 release date in launchpad welcome screen

### DIFF
--- a/packages/launchpad/src/welcome/MajorVersionWelcome.cy.tsx
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.cy.tsx
@@ -33,18 +33,18 @@ describe('<MajorVersionWelcome />', { viewportWidth: 1280, viewportHeight: 1400 
   })
 
   it('renders correct time for releases and overflows correctly', () => {
-    cy.clock(Date.UTC(2026, 4, 5))
+    cy.clock(Date.UTC(2026, 8, 1))
     cy.mount(<MajorVersionWelcome />)
     cy.contains('16.0.0 Released just now')
-    cy.contains('15.0.0 Released 9 months ago')
-    cy.contains('14.0.0 Released last year')
+    cy.contains('15.0.0 Released last year')
+    cy.contains('14.0.0 Released 2 years ago')
     cy.contains('13.0.0 Released 3 years ago')
-    cy.contains('12.0.0 Released 3 years ago')
+    cy.contains('12.0.0 Released 4 years ago')
     cy.tick(interval('1 minute'))
     cy.contains('16.0.0 Released 1 minute ago')
     cy.tick(interval('1 month'))
     cy.contains('16.0.0 Released last month')
-    cy.contains('15.0.0 Released 10 months ago')
+    cy.contains('15.0.0 Released last year')
 
     cy.viewport(1280, 500)
 

--- a/packages/launchpad/src/welcome/MajorVersionWelcome.vue
+++ b/packages/launchpad/src/welcome/MajorVersionWelcome.vue
@@ -226,7 +226,7 @@ const versionReleaseDates = computed(() => {
     '13': useTimeAgo(Date.UTC(2023, 7, 29)).value,
     '14': useTimeAgo(Date.UTC(2025, 0, 16)).value,
     '15': useTimeAgo(Date.UTC(2025, 7, 20)).value,
-    '16': useTimeAgo(Date.UTC(2026, 4, 5)).value,
+    '16': useTimeAgo(Date.UTC(2026, 8, 1)).value,
   }
 })
 


### PR DESCRIPTION
- Closes N/A

### Additional details

`versionReleaseDates` in `MajorVersionWelcome.vue` had `'16': useTimeAgo(Date.UTC(2026, 4, 5)).value`. Since `Date.UTC` months are zero-indexed, that's May 5, 2026, not the actual 16.0.0 release date of September 1, 2026 — likely a placeholder left over from when the release date was still TBD.

Fixed to `Date.UTC(2026, 8, 1)`. Updated the component test's frozen clock to match and recomputed the relative-time assertions for 12.0.0–15.0.0, which shift because the clock moved ~4 months later (e.g. 15.0.0 goes from "9 months ago" to "last year"). Verified by running the spec locally — all 3 tests pass with the new expected strings.

### Steps to test

- `yarn workspace @packages/launchpad cypress:run:ct -- --spec "src/welcome/MajorVersionWelcome.cy.tsx"`
- Or manually: run `cypress open` after a 16.0.0 build and confirm the welcome splash shows "Released just now" / a recent relative time for 16.0.0 rather than a several-months-old one.

### How has the user experience changed?

The "What's New in Cypress" welcome screen shown on first launch after upgrading to 16.0.0 will now display the correct relative release date (e.g. "Released just now" / "Released N days ago") instead of one computed from an incorrect May 5, 2026 date.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission?
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`?
- [na] Have API changes been updated in the `type definitions`?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only date constant and matching test expectations in the launchpad welcome UI; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Fixes the **16.0.0** release timestamp in `MajorVersionWelcome.vue` from `Date.UTC(2026, 4, 5)` (May 5, 2026) to **`Date.UTC(2026, 8, 1)`** (September 1, 2026), so the splash screen’s “Released …” copy for 16.0.0 and older majors uses the real ship date.
> 
> The Cypress component test now freezes time on that date and updates expected relative-time strings for 12.0.0–15.0.0 after the clock moved ~four months later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0689f87ec55b398fff4a68075019ed0690af399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->