### PR TITLE
chore: drop unused typescript-cached-transpile from the ts-node require hook

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -193,9 +193,6 @@
     "packages/ts": {
       "project": [
         "*.{ts,tsx,js,jsx}"
-      ],
-      "ignoreDependencies": [
-        "typescript-cached-transpile"
       ]
     },
     "packages/extension": {

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "ts-node": "^10.9.2",
-    "tslib": "2.3.1",
-    "typescript-cached-transpile": "^0.0.6"
+    "tslib": "2.3.1"
   },
   "devDependencies": {},
   "files": [

--- a/packages/ts/registerDir.js
+++ b/packages/ts/registerDir.js
@@ -1,6 +1,5 @@
 // @ts-check
 const debug = require('debug')('cypress:ts')
-const path = require('path')
 
 // in development we should have TypeScript hook installed
 // in production or staging we are likely to be running
@@ -21,10 +20,7 @@ module.exports = function (scopeDir) {
         // https://github.com/TypeStrong/ts-node#programmatic-usage
         const project = require('path').join(__dirname, 'tsconfig.json')
 
-        process.env.TS_CACHED_TRANSPILE_CACHE = path.join(__dirname, 'node_modules', '.ts-cache')
-
         tsNode.register({
-          compiler: 'typescript-cached-transpile',
           project,
           transpileOnly: true,
           preferTsExts: true, // Helps when the files are compiled locally, resolves the TS file

--- a/scripts/gulp/tasks/gulpCypress.ts
+++ b/scripts/gulp/tasks/gulpCypress.ts
@@ -96,7 +96,6 @@ async function spawnCypressWithMode (
   const finalEnv: Record<string, string | undefined> = {
     ...process.env,
     ...env,
-    TS_NODE_COMPILER: 'typescript-cached-transpile',
   }
 
   return await forked(`cy:${mode}:${type}`, pathToCli, [mode, ...argv], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9193,7 +9193,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@16.9.1", "@types/node@24.10.1", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^12.12.29", "@types/node@^12.12.7", "@types/node@^20.1.0", "@types/node@^22.18.7", "@types/node@^24.10.1", "@types/node@^24.9.0", "@types/node@^8.0.7":
+"@types/node@*", "@types/node@16.9.1", "@types/node@24.10.1", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^12.12.29", "@types/node@^20.1.0", "@types/node@^22.18.7", "@types/node@^24.10.1", "@types/node@^24.9.0", "@types/node@^8.0.7":
   version "24.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.10.1.tgz#91e92182c93db8bd6224fca031e2370cef9a8f01"
   integrity sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==
@@ -31214,7 +31214,7 @@ tslib@2.3.1, tslib@~2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
-tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -31494,15 +31494,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript-cached-transpile@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typescript-cached-transpile/-/typescript-cached-transpile-0.0.6.tgz#1d1f0620ebb29cf8d8c11e5353c2b4f43dfafc01"
-  integrity sha512-bfPc7YUW0PrVkQHU0xN0ANRuxdPgoYYXtZEW6PNkH5a97/AOM+kPPxSTMZbpWA3BG1do22JUkfC60KoCKJ9VZQ==
-  dependencies:
-    "@types/node" "^12.12.7"
-    fs-extra "^8.1.0"
-    tslib "^1.10.0"
 
 typescript-eslint@^8.37.0:
   version "8.37.0"


### PR DESCRIPTION
- Closes N/A — no associated issue. This started as a compatibility check of the `@packages/ts` require hook against TypeScript 5.9.3 ahead of normalizing onto that version, and turned into the removal of a dependency that is already dead code.

### Additional details

**Why:** `packages/ts/registerDir.js` passed `compiler: 'typescript-cached-transpile'` to `ts-node`, a wrapper (last published in 2020) whose sole function is to patch `ts.transpileModule` with a filesystem cache. That patch is never reached.

`ts-node@10.9.2` routes the `transpileOnly` path through its own `createTsTranspileModule` for any TypeScript `>= 4.7` ([`dist/index.js:657`](https://github.com/TypeStrong/ts-node/blob/v10.9.2/src/index.ts)), so `ts.transpileModule` — the one function the wrapper overrides — is never called. Instrumenting the wrapper across a real `yarn test-scripts` run gives **0 calls** and no `.ts-cache` directory written, on both TypeScript 5.4.5 and 5.9.3. This is not a 5.9.3 regression; the cache has been inert since the ts-node 10.9 upgrade.

What remained was cost without benefit: the wrapper returns `{ ...require('typescript'), transpileModule }`, eagerly materializing the entire TypeScript namespace at require time — roughly 25-35 ms per process, and ~10-15 ms measurably slower end-to-end for `register()` plus the first `.ts` require.

**What is affected:** every dev-time entry point that loads `@packages/ts/register` — `gulpfile.js`, `scripts/binary.js`, `packages/server/hook-require.js` (only when the V8 snapshot is disabled), `@packages/data-context`, `@packages/proxy`, `@packages/frontend-shared`, the `system-tests` and `tooling/*` mocharc files. Behavior is unchanged, because plain ts-node `transpileOnly` is what already ran.

**Implementation note:** the four references had to move together. `scripts/gulp/tasks/gulpCypress.ts` set `TS_NODE_COMPILER: 'typescript-cached-transpile'` for the forked Cypress CLI. Removing the dependency while leaving that env var set would make ts-node throw on an unresolvable module — and `registerDir.js` swallows registration errors in a bare `catch`, so TypeScript transpilation would have been silently disabled rather than failing loudly.

**Separately verified for the TypeScript 5.9.3 normalization** (no `package.json` version was changed; `node_modules/typescript` was swapped by tarball to test):

- `packages/ts/tsconfig.json` yields **0 config errors** on 5.9.3 — ts-node surfaces these even under `transpileOnly`. Verified outside `registerDir.js`'s `catch`, since that would otherwise mask a failure.
- Every TypeScript internal that ts-node's `createTsTranspileModule` destructures still exists on 5.9.3. Only `getEntries` is absent, and it is equally absent on 5.4.5, on a branch ts-node never takes.
- All 386 `.ts` files under `packages/server/lib`, `packages/data-context/src`, `packages/config/lib`, `packages/proxy/lib`, `packages/net-stubbing/lib` and `scripts/gulp` transpile through the real ts-node path with 0 diagnostics, 0 throws, and all emitted JS parses.
- TypeScript 5.9.3 transpiles that corpus ~45% faster than 5.4.5 (2375 ms vs 4313 ms).

### Steps to test

The hook is dev-time infrastructure, so the existing suites exercise it directly:

1. `yarn workspace @packages/ts test` — registers the hook and requires a `.ts` file.
2. `yarn test-scripts` — mocha with `-r packages/ts/register`; pushes 4 `.ts` modules through the hook.
3. `yarn dev` — the path that used `TS_NODE_COMPILER`.

Ran on this branch, on Node 24.15.0, at both TypeScript versions and with `typescript-cached-transpile` genuinely pruned from `node_modules` by `yarn install --frozen-lockfile`:

| | TS 5.4.5 | TS 5.9.3 |
|---|---|---|
| `yarn test-scripts` | 147 passing | 147 passing |
| `yarn workspace @packages/ts test` | pass | pass |

`yarn lint --scope @packages/ts` and `--scope internal-scripts` are clean, as is `yarn workspace @packages/ts check-ts`.

Two gaps a reviewer should know about. `scripts/gulp/tasks/gulpCypress.ts` is **not** covered by `yarn check-ts` — `internal-scripts` has no `check-ts` script, so lerna skips it; the edit removes one property from a `Record<string, string | undefined>` literal and lint passed, but no compiler checked it. And E2E and packaged-binary tests were not run, so step 3 above is unverified — `yarn dev` is worth a local smoke test.

### How has the user experience changed?

No change. This is development-time tooling only; `@packages/ts` is a no-op in production builds, where TypeScript is pre-compiled.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical removal of a dependency that is provably never invoked; rationale and measurements are in the description above. -->
- [na] Have tests been added/updated? <!-- No behavior change; the existing suites already cover this hook and were run at both TypeScript versions. -->
- [na] Has a PR for user-facing changes been opened in `cypress-documentation`? <!-- No user-facing change. -->
- [na] Have API changes been updated in the `type definitions`? <!-- No API change. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01R92rtovZzJQn9qc4PUdDNz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-time tooling only; removes dead dependency and env vars with existing test coverage on the require hook.
> 
> **Overview**
> Removes the **`typescript-cached-transpile`** dependency and all wiring that pointed **`ts-node`** at it. **`packages/ts/registerDir.js`** now registers **`ts-node`** with default **`transpileOnly`** only (no custom **`compiler`**, no **`TS_CACHED_TRANSPILE_CACHE`**). **`scripts/gulp/tasks/gulpCypress.ts`** no longer sets **`TS_NODE_COMPILER`** on the forked Cypress CLI env, so dev runs do not reference a missing module. **`knip.json`** and **`yarn.lock`** are updated accordingly.
> 
> **No intended runtime behavior change** for dev-time TypeScript requires: the cached compiler was not exercised under current **`ts-node@10.9.2`**; this is dependency and startup cleanup ahead of TypeScript version work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45bb9e81b880770a56041517d8def1bfd887d078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->