### PR TITLE
chore: add a check-ts script to the cli package

### DIFF
--- a/cli/lib/errors.ts
+++ b/cli/lib/errors.ts
@@ -150,7 +150,7 @@ const smokeTestFailure = (smokeTestCommand: string, timedOut: boolean): any => {
 const invalidSmokeTestDisplayError = {
   code: 'INVALID_SMOKE_TEST_DISPLAY_ERROR',
   description: 'Cypress verification failed.',
-  solution (msg: string): string {
+  solution (msg?: string): string {
     return stripIndent`
       Cypress failed to start after spawning a new Xvfb server.
 

--- a/cli/lib/util.ts
+++ b/cli/lib/util.ts
@@ -403,11 +403,11 @@ const util = {
     return elapsed * (1 / (percent / 100)) - elapsed
   },
 
-  convertPercentToPercentage (num: number): number {
+  convertPercentToPercentage (num: number | null): number {
     // convert a percent with values between 0 and 1
     // with decimals, so that it is between 0 and 100
     // and has no decimal places
-    return Math.round(_.isFinite(num) ? (num * 100) : 0)
+    return num !== null && _.isFinite(num) ? Math.round(num * 100) : 0
   },
 
   secsRemaining (eta: number): string {

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,6 +9,7 @@
     "postbuild": "yarn make-bin-executable && yarn sync-build-dist && yarn prepare-package-json && yarn bundle-ct-frameworks",
     "build-cli": "rollup -c && yarn postbuild",
     "bundle-ct-frameworks": "tsx ./scripts/bundle-ct-frameworks.ts",
+    "check-ts": "tsc -p tsconfig.check.json --noEmit",
     "clean-cli-build": "rimraf build dist \"types/[!tests]*/\" types/net-stubbing.d.ts --glob",
     "dtslint": "dtslint types",
     "postinstall": "patch-package && tsx ./scripts/sync-typedefs.ts",

--- a/cli/package.json
+++ b/cli/package.json
@@ -88,6 +88,7 @@
     "@types/jquery": "3.3.31",
     "@types/lodash": "4.17.21",
     "@types/minimatch": "3.0.5",
+    "@types/mocha": "8.0.3",
     "@types/shelljs": "^0.10.0",
     "@types/sinon": "9.0.9",
     "@types/sinon-chai": "3.2.12",

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,7 +9,7 @@
     "postbuild": "yarn make-bin-executable && yarn sync-build-dist && yarn prepare-package-json && yarn bundle-ct-frameworks",
     "build-cli": "rollup -c && yarn postbuild",
     "bundle-ct-frameworks": "tsx ./scripts/bundle-ct-frameworks.ts",
-    "check-ts": "tsc -p tsconfig.check.json --noEmit",
+    "check-ts": "tsc --noEmit",
     "clean-cli-build": "rimraf build dist \"types/[!tests]*/\" types/net-stubbing.d.ts --glob",
     "dtslint": "dtslint types",
     "postinstall": "patch-package && tsx ./scripts/sync-typedefs.ts",

--- a/cli/package.json
+++ b/cli/package.json
@@ -88,7 +88,6 @@
     "@types/jquery": "3.3.31",
     "@types/lodash": "4.17.21",
     "@types/minimatch": "3.0.5",
-    "@types/mocha": "8.0.3",
     "@types/shelljs": "^0.10.0",
     "@types/sinon": "9.0.9",
     "@types/sinon-chai": "3.2.12",

--- a/cli/package.json
+++ b/cli/package.json
@@ -9,7 +9,7 @@
     "postbuild": "yarn make-bin-executable && yarn sync-build-dist && yarn prepare-package-json && yarn bundle-ct-frameworks",
     "build-cli": "rollup -c && yarn postbuild",
     "bundle-ct-frameworks": "tsx ./scripts/bundle-ct-frameworks.ts",
-    "check-ts": "tsc --noEmit",
+    "check-ts": "tsc --noEmit && tsc -p tsconfig.esm.json --noEmit",
     "clean-cli-build": "rimraf build dist \"types/[!tests]*/\" types/net-stubbing.d.ts --glob",
     "dtslint": "dtslint types",
     "postinstall": "patch-package && tsx ./scripts/sync-typedefs.ts",

--- a/cli/test/lib/cli.spec.ts
+++ b/cli/test/lib/cli.spec.ts
@@ -1,3 +1,4 @@
+import type { MockInstance } from 'vitest'
 import { vi, describe, it, beforeEach, expect } from 'vitest'
 import os from 'os'
 import Debug from 'debug'
@@ -142,7 +143,7 @@ const flushPromises = () => {
 describe('cli', () => {
   const binaryDir = '/binary/dir'
   let exec: (args: string) => Promise<any>
-  let processExitSpy: ReturnType<typeof vi.spyOn>
+  let processExitSpy: MockInstance<typeof process.exit>
 
   beforeEach(() => {
     vi.unstubAllEnvs()

--- a/cli/test/lib/errors.spec.ts
+++ b/cli/test/lib/errors.spec.ts
@@ -120,6 +120,7 @@ describe('errors', function () {
         solution: 42,
       }
 
+      // @ts-expect-error - the invalid solution type is what this asserts on
       await expect(formErrorText(error)).rejects.toThrow()
     })
 

--- a/cli/test/lib/exec/spawn.spec.ts
+++ b/cli/test/lib/exec/spawn.spec.ts
@@ -69,6 +69,7 @@ vi.mock('process', async (importActual) => {
     // @ts-expect-error
     ...actual,
     stdin: {
+      // @ts-expect-error
       ...actual.stdin,
       on: vi.fn(),
       emit: vi.fn(),
@@ -238,13 +239,15 @@ describe('lib/exec/spawn', function () {
     vi.mocked(readline.createInterface).mockReturnValue(mockReadlineEventEmitter)
     vi.mocked(cp.spawn).mockReturnValue(spawnedProcess)
     vi.mocked(xvfb.start).mockResolvedValue(undefined)
-    vi.mocked(xvfb.stop).mockResolvedValue(undefined)
+    vi.mocked(xvfb.stop).mockResolvedValue(null)
     vi.mocked(xvfb.isNeeded).mockReturnValue(false)
     vi.mocked(state.getBinaryDir).mockReturnValue(defaultBinaryDir)
-    vi.mocked(state.getPathToExecutable).mockImplementation((args) => {
-      if (args === '/default/binary/dir') {
+    vi.mocked(state.getPathToExecutable).mockImplementation((binaryDir) => {
+      if (binaryDir === defaultBinaryDir) {
         return '/path/to/cypress'
       }
+
+      return path.join(binaryDir, 'cypress')
     })
 
     // Default: pass-through so tests that assert on stderr.write still see data; filtering behavior lives in @packages/stderr-filtering
@@ -274,7 +277,7 @@ describe('lib/exec/spawn', function () {
       vi.mocked(needsSandbox).mockReturnValue(false)
 
       // start the process
-      const startPromise = start('--foo', { foo: 'bar' })
+      const startPromise = start('--foo')
 
       await vi.waitFor(() => expect(spawnedProcess.on).toHaveBeenCalledWith('close', expect.any(Function)))
 
@@ -302,7 +305,7 @@ describe('lib/exec/spawn', function () {
     it('uses --no-sandbox when needed', async function () {
       vi.mocked(needsSandbox).mockReturnValue(true)
 
-      const startPromise = start('--foo', { foo: 'bar' })
+      const startPromise = start('--foo')
 
       await vi.waitFor(() => expect(spawnedProcess.on).toHaveBeenCalledWith('close', expect.any(Function)))
       spawnedProcess.emit('close', 0)
@@ -334,7 +337,7 @@ describe('lib/exec/spawn', function () {
     it('uses npm command when running in dev mode', async () => {
       vi.mocked(needsSandbox).mockReturnValue(false)
 
-      const startPromise = start('--foo', { dev: true, foo: 'bar' })
+      const startPromise = start('--foo', { dev: true })
 
       await vi.waitFor(() => expect(spawnedProcess.on).toHaveBeenCalledWith('close', expect.any(Function)))
       spawnedProcess.emit('close', 0)
@@ -363,7 +366,7 @@ describe('lib/exec/spawn', function () {
     it('does not pass --no-sandbox when running in dev mode', async function () {
       vi.mocked(needsSandbox).mockReturnValue(true)
 
-      const startPromise = start('--foo', { dev: true, foo: 'bar' })
+      const startPromise = start('--foo', { dev: true })
 
       await vi.waitFor(() => expect(spawnedProcess.on).toHaveBeenCalledWith('close', expect.any(Function)))
       spawnedProcess.emit('close', 0)
@@ -577,7 +580,7 @@ describe('lib/exec/spawn', function () {
       })
 
       it('waits for ready sentinel before unreffing and resolving', async () => {
-        const startPromise = start(null, { detached: true })
+        const startPromise = start([], { detached: true })
 
         await vi.waitFor(() => expect(stdoutDataHandler).toBeDefined())
 
@@ -593,7 +596,7 @@ describe('lib/exec/spawn', function () {
       })
 
       it('resolves with exit code if process exits before ready message', async () => {
-        const startPromise = start(null, { detached: true })
+        const startPromise = start([], { detached: true })
 
         await vi.waitFor(() => expect(spawnedProcess.on).toHaveBeenCalledWith('close', expect.any(Function)))
         spawnedProcess.emit('close', 1)
@@ -605,7 +608,7 @@ describe('lib/exec/spawn', function () {
       })
 
       it('uses piped stdio when detached so startup errors are visible', async () => {
-        const startPromise = start(null, { detached: true })
+        const startPromise = start([], { detached: true })
 
         await vi.waitFor(() => expect(stdoutDataHandler).toBeDefined())
         stdoutDataHandler!(Buffer.from('Cypress is ready\n'))
@@ -618,7 +621,7 @@ describe('lib/exec/spawn', function () {
       })
 
       it('passes --emit-when-ready to the Cypress process', async () => {
-        const startPromise = start(null, { detached: true })
+        const startPromise = start([], { detached: true })
 
         await vi.waitFor(() => expect(stdoutDataHandler).toBeDefined())
 
@@ -947,9 +950,7 @@ describe('lib/exec/spawn', function () {
         vi.mocked(stdin.emit).mockImplementation((event, ...args) => {
           console.log('spied emit')
 
-          stdinEmitter.emit(event, ...args)
-
-          return stdin
+          return stdinEmitter.emit(event, ...args)
         })
       })
 

--- a/cli/test/lib/exec/xvfb-integration.spec.ts
+++ b/cli/test/lib/exec/xvfb-integration.spec.ts
@@ -32,7 +32,7 @@ describe('lib/exec/xvfb-integration', function () {
     })
 
     it('outputs when enabled', function () {
-      const processStderrWriteSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(undefined)
+      const processStderrWriteSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
 
       Debug.enable(xvfb._debugXvfb.namespace)
 
@@ -43,7 +43,7 @@ describe('lib/exec/xvfb-integration', function () {
     })
 
     it('does not output when disabled', function () {
-      const processStderrWriteSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(undefined)
+      const processStderrWriteSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
 
       Debug.disable()
 

--- a/cli/test/lib/tap/build-program.spec.ts
+++ b/cli/test/lib/tap/build-program.spec.ts
@@ -390,7 +390,7 @@ describe('lib/tap/build-program', () => {
   it('treats a schema command that omits params as having no positionals', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram({
-      protocolVersion: 1,
+      schemaVersion: 1,
       cypressVersion: '15.0.0',
       commands: [{
         name: 'health',
@@ -408,7 +408,7 @@ describe('lib/tap/build-program', () => {
   })
 
   const dashedSchema: TapSchema = {
-    protocolVersion: 1,
+    schemaVersion: 1,
     cypressVersion: '15.0.0',
     commands: [{
       name: 'export',
@@ -451,7 +451,7 @@ describe('lib/tap/build-program', () => {
   it('forwards a dashed param name keyed by its raw schema name (positionals bypass camelCasing)', () => {
     const dispatch = vi.fn()
     const program = buildTapProgram({
-      protocolVersion: 1,
+      schemaVersion: 1,
       cypressVersion: '15.0.0',
       commands: [{
         name: 'show',

--- a/cli/test/lib/tasks/cache.spec.ts
+++ b/cli/test/lib/tasks/cache.spec.ts
@@ -408,6 +408,7 @@ describe('lib/tasks/cache', () => {
       })
 
       // the second binary has never been accessed
+      // @ts-expect-error mock arguments
       vi.mocked(fs.stat).mockResolvedValueOnce(undefined)
 
       await cache.list()
@@ -423,6 +424,7 @@ describe('lib/tasks/cache', () => {
       })
 
       // the second binary has never been accessed
+      // @ts-expect-error mock arguments
       vi.mocked(fs.stat).mockResolvedValueOnce(undefined)
 
       await cache.list(true)

--- a/cli/test/lib/tasks/dependency.spec.ts
+++ b/cli/test/lib/tasks/dependency.spec.ts
@@ -7,7 +7,6 @@ import { describe, it, expect } from 'vitest'
  */
 describe('dependencies', () => {
   it('process dependency exists in package.json and is available', async () => {
-    // @ts-expect-error resolveJsonModule is set to true in tsconfig.json
     const { dependencies } = (await import('../../../package.json')).default
 
     expect(dependencies.process).toBeDefined()
@@ -18,8 +17,6 @@ describe('dependencies', () => {
   })
 
   it('buffer dependency exists in package.json and is available', async () => {
-    // @ts-expect-error resolveJsonModule is set to true in tsconfig.json
-
     const { dependencies } = (await import('../../../package.json')).default
 
     expect(dependencies.buffer).toBeDefined()

--- a/cli/test/lib/tasks/download.spec.ts
+++ b/cli/test/lib/tasks/download.spec.ts
@@ -1,3 +1,4 @@
+import type { Mock } from 'vitest'
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest'
 import { stripVTControlCharacters as stripAnsi } from 'util'
 import os from 'os'
@@ -293,7 +294,7 @@ describe('lib/tasks/download', function () {
   describe('verify downloaded file', function () {
     let expectedChecksum: string
     let expectedFileSize: number
-    let onProgress: vi.Mock
+    let onProgress: Mock
 
     beforeEach(function () {
       expectedChecksum = hasha.fromFileSync(examplePath)
@@ -566,7 +567,7 @@ describe('lib/tasks/download', function () {
     try {
       await download.start(options)
       throw new Error('should have caught')
-    } catch (error) {
+    } catch (error: any) {
       expect(error).to.be.instanceof(Error)
       expect(error.message).to.contain('redirect loop')
     }
@@ -718,7 +719,7 @@ describe('lib/tasks/download', function () {
     try {
       await download.start(options)
       throw new Error('should have caught')
-    } catch (error) {
+    } catch (error: any) {
       expect(error.message).not.toEqual('should have caught')
       logger.error(error)
 

--- a/cli/tsconfig.check.json
+++ b/cli/tsconfig.check.json
@@ -1,0 +1,9 @@
+{
+  // `test/` is not type-checked yet: the specs predate strict typings and
+  // still carry type errors. Add "test/**/*.ts" here once they are resolved.
+  "extends": "./tsconfig.json",
+  "include": [
+    "lib/**/*.ts",
+    "*.ts"
+  ]
+}

--- a/cli/tsconfig.check.json
+++ b/cli/tsconfig.check.json
@@ -1,9 +1,0 @@
-{
-  // `test/` is not type-checked yet: the specs predate strict typings and
-  // still carry type errors. Add "test/**/*.ts" here once they are resolved.
-  "extends": "./tsconfig.json",
-  "include": [
-    "lib/**/*.ts",
-    "*.ts"
-  ]
-}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitAny": false,
     "noEmit": true,
     "types": [
-      "mocha"
+      "node"
     ]
   },
   "include": [

--- a/scripts/type_check.js
+++ b/scripts/type_check.js
@@ -20,7 +20,7 @@ program
       return path.join(packageRoot, name)
     }
 
-    throw new Error(`type-check command doesn't check cli types. Use "npm run dtslint" in "cli" directory instead.`)
+    throw new Error(`type-check command doesn't check cli types. Use "yarn check-ts" (source) or "yarn dtslint" (published type definitions) in the "cli" directory instead.`)
   }
   const addProject = (name) => {
     return projects.push({


### PR DESCRIPTION
- Closes N/A — no associated issue. This is an internal tooling change: `cli` was the only workspace without a `check-ts` script, so its source was never type-checked by the root `yarn check-ts` (`lerna run check-ts`) that the CircleCI `check-ts` job runs. Only the published type definitions were covered, via `dtslint`.

### Additional details

**Why was this change necessary?**

`cli` is marked complete in both Phase 1 (TypeScript) and Phase 2 (Vitest) of [`guides/esm-migration.md`](https://github.com/cypress-io/cypress/blob/develop/guides/esm-migration.md), but nothing enforced that state. Adding `check-ts` closes the gap and gives the later ESM phases a guard that will catch fallout when `cli`'s module output changes.

**What is affected by this change?**

Build tooling and test/type annotations. There is no runtime behavior change, so no `cli/CHANGELOG.md` entry.

**Implementation details**

The script covers both of the package's build configs, following the `@packages/socket` pattern:

```json
"check-ts": "tsc --noEmit && tsc -p tsconfig.esm.json --noEmit",
```

The second invocation matters: `cli/tsconfig.json`'s `lib/**/*.ts` include does not match `.mts`, so `lib/index.mts` — the ESM entry point rollup builds — would otherwise go unchecked.

Turning the check on surfaced 28 pre-existing type errors, all in `test/`. Most were test-side:

- a stale `protocolVersion` where `TapSchema` declares `schemaVersion` (the same file already used the correct name elsewhere)
- `vi.Mock` used as a type namespace
- untyped `catch` bindings
- a spy widened to `vi.spyOn`'s default signature
- mocks resolving `undefined` where the mocked signature returns `Stats` / `null` / `boolean`
- a `stdin.emit` mock returning the stream instead of `emit`'s boolean
- two `@ts-expect-error` directives that no longer suppressed anything

Two were inaccurate signatures in `lib/`, each contradicted by the function's own body. I corrected the types rather than casting at the call sites:

- `invalidSmokeTestDisplayError.solution` required `msg`, but `formErrorText` may invoke a solution with no message.
- `convertPercentToPercentage` declared `num: number`, while its `_.isFinite` guard exists precisely to return `0` for values that are not. The expression was restructured because lodash's `isFinite` is not a type guard and does not narrow; behavior is identical for every input, including `NaN` and `Infinity`.

Also dropped a vestigial `foo: 'bar'` from four `spawn` options objects — `start` reads only `dev`/`env`/`detached`/`stdio`, nothing forwards unknown keys, and no assertion looked for it.

**Mocha leftovers from the Vitest migration**

`cli/tsconfig.json` still pulled in the mocha ambient types and `package.json` still carried `@types/mocha`, though the specs moved to Vitest. The `types` array is now `["node"]` — what `lib/` actually needs, and what the sibling `tsconfig.esm.json` already declares. Deleting the key entirely would auto-include every `@types` package in scope, and `[]` would break `lib/`, which needs `process` and `NodeJS.*`.

The `types/mocha` entry in `exclude` is unrelated and stays: it refers to the vendored declarations under `cli/types/`, which `types/index.d.ts` references and `dtslint` checks with `types: []`.

Finally, the `cli` carve-out in `scripts/type_check.js` predated `cli` having any source type check, so its message pointed at `dtslint` alone; it now names both. The guard itself stays, since `cli` genuinely is not under `packages/`.

### Steps to test

```bash
cd cli
yarn check-ts     # passes
yarn types        # dtslint passes without @types/mocha
```

To confirm the ESM half of the check is real rather than vacuous, append a deliberate error to `cli/lib/index.mts` and re-run `yarn check-ts`:

```
lib/index.mts(19,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

From the repo root, `yarn lerna run check-ts --scope cypress` confirms lerna picks up the new target, and `yarn check-lockfile-drift` passes with `yarn.lock` unchanged — `@types/mocha@8.0.3` is still required by the root, `packages/types`, and `npm/cypress-schematic`, so the descriptor set did not move.

### How has the user experience changed?

No change. The only edits to shipped code are two type annotations whose runtime behavior is unchanged.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal build-tooling change with no user-facing effect; rationale is in the description above. -->
- [x] Have tests been added/updated? <!-- Existing specs updated for type correctness only — no assertions or behavior changed. `yarn test-unit` results match the pre-change baseline exactly. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C47yMsGebjMeYBa83YtcXa


---
_Generated by [Claude Code](https://claude.ai/code/session_01C47yMsGebjMeYBa83YtcXa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and type annotations only; the two lib edits align types with existing behavior and do not change runtime logic.
> 
> **Overview**
> Adds **`yarn check-ts`** to the `cli` package so CI’s root `lerna run check-ts` type-checks both CommonJS (`tsc --noEmit`) and ESM (`tsconfig.esm.json`) sources, not just published defs via `dtslint`.
> 
> Turning that on required **test-only typing fixes** (Vitest `Mock`/`MockInstance`, `TapSchema.schemaVersion`, mock return types, `catch` bindings, stale `@ts-expect-error`) and **`cli/tsconfig.json`** switching ambient types from Mocha to Node after the Vitest migration.
> 
> Two **lib signature corrections** match real usage with no runtime change: `invalidSmokeTestDisplayError.solution` takes optional `msg`, and `convertPercentToPercentage` accepts `number | null`. **`scripts/type_check.js`** now tells contributors to run `yarn check-ts` in `cli` instead of only `dtslint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6c7959cc14b3a4b6cfc41fdae58a961e96f125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->