### PR TITLE
chore: keep the app's service worker off Cypress's runner document

### DIFF
--- a/packages/server/lib/browsers/chrome.ts
+++ b/packages/server/lib/browsers/chrome.ts
@@ -683,6 +683,10 @@ export = {
       browserCriClient.waitForChildTargetInterception = (targetId) => pageCriClient.whenChildTargetHandled(targetId)
       browserCriClient.reenableChildTargetInterception = (targetId) => pageCriClient.reenableChildTargetInterception(targetId)
 
+      // With a baseUrl on the AUT's own superdomain, this runner URL is served
+      // from that origin, so the app's service worker would serve it.
+      await options.onBeforeRunnerNavigation?.()
+
       await this._navigateUsingCRI(pageCriClient, url)
     } else {
       await this._navigateUsingCRI(pageCriClient, url)

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -28,6 +28,14 @@ import { CYPRESS_INTERNAL_LOOPBACK_HEADER, CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADE
 
 const debug = Debug('cypress:server:network-runtime')
 
+// An armed service worker bypass ends when the runner document commits, which
+// some navigations never do: an aborted one, or the hash-only navigation
+// experimentalSingleTabRunMode makes between specs. Cypress serves the runner
+// document itself, so a real commit lands in milliseconds - this only bounds
+// how long a bypass nothing will clear can keep the app's service worker out
+// of the AUT.
+const SERVICE_WORKER_BYPASS_MAX_MS = 10000
+
 export type CreateProxyRuntimeDeps = {
   config: CyServer.Config & Cypress.Config
   shouldCorrelatePreRequests?: () => boolean
@@ -360,15 +368,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
   // through the app's worker. The AUT frame navigates after the bypass is
   // cleared and keeps its worker.
   let serviceWorkerBypassed = false
-  // The main frame keeps its id across navigations, so one commit is enough to
-  // recognize the runner's own frame for the rest of this runtime.
-  let mainFrameId: string | undefined
-
-  const recordMainFrame = (params: Protocol.Page.FrameNavigatedEvent) => {
-    if (!params.frame.parentId) {
-      mainFrameId = params.frame.id
-    }
-  }
+  let serviceWorkerBypassExpiry: NodeJS.Timeout | undefined
 
   const disarmServiceWorkerBypass = () => {
     if (!serviceWorkerBypassed) {
@@ -376,8 +376,9 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     }
 
     serviceWorkerBypassed = false
+    clearTimeout(serviceWorkerBypassExpiry)
+    serviceWorkerBypassExpiry = undefined
     deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
-    deps.client.off('Page.navigatedWithinDocument', onNavigatedWithinDocumentForBypass)
 
     return true
   }
@@ -403,29 +404,20 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     clearServiceWorkerBypass().catch(() => {})
   }
 
-  // experimentalSingleTabRunMode keeps the runner tab between specs, so the
-  // next spec's navigation differs only by hash - it fetches nothing and fires
-  // no frameNavigated. Without this the bypass would never be cleared and
-  // every later AUT load would skip the app's worker.
-  function onNavigatedWithinDocumentForBypass (params: Protocol.Page.NavigatedWithinDocumentEvent) {
-    // The AUT is live during a superdomain switch and can change its own hash,
-    // which must not end the runner's bypass. Before the first commit there is
-    // no AUT yet, so an unknown main frame is the runner.
-    if (mainFrameId && params.frameId !== mainFrameId) {
-      return
-    }
-
-    clearServiceWorkerBypass().catch(() => {})
-  }
-
   const bypassServiceWorkerForTopNavigation = async () => {
     if (stopped || serviceWorkerBypassed) {
       return
     }
 
     serviceWorkerBypassed = true
+    serviceWorkerBypassExpiry = setTimeout(() => {
+      debug('no navigation committed within %dms; ending the service worker bypass', SERVICE_WORKER_BYPASS_MAX_MS)
+      clearServiceWorkerBypass().catch(() => {})
+    }, SERVICE_WORKER_BYPASS_MAX_MS)
+
+    serviceWorkerBypassExpiry.unref?.()
+
     deps.client.on('Page.frameNavigated', onFrameNavigatedForBypass)
-    deps.client.on('Page.navigatedWithinDocument', onNavigatedWithinDocumentForBypass)
 
     try {
       await deps.client.send('Network.setBypassServiceWorker', { bypass: true })
@@ -495,7 +487,6 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     },
     async start () {
       unsubscribeAUTFrameNavigated = deps.onAUTFrameNavigated?.(onAUTFrameNavigated)
-      deps.client.on('Page.frameNavigated', recordMainFrame)
 
       // Service workers and out-of-process iframes have their own CDP
       // session — without enabling Fetch there, a worker's script fetch and an
@@ -517,7 +508,6 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
         escapeDetector.stop()
         unsubscribeAUTFrameNavigated?.()
         unsubscribeAUTFrameNavigated = undefined
-        deps.client.off('Page.frameNavigated', recordMainFrame)
 
         throw err
       }
@@ -538,7 +528,6 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
       escapeDetector.stop()
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
-      deps.client.off('Page.frameNavigated', recordMainFrame)
 
       // State only: a send here would be enqueued rather than rejected while
       // the client is reconnecting, and stop() must not be able to hang

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -361,13 +361,21 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
   // cleared and keeps its worker.
   let serviceWorkerBypassed = false
 
-  const clearServiceWorkerBypass = async () => {
+  const disarmServiceWorkerBypass = () => {
     if (!serviceWorkerBypassed) {
-      return
+      return false
     }
 
     serviceWorkerBypassed = false
     deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
+
+    return true
+  }
+
+  const clearServiceWorkerBypass = async () => {
+    if (!disarmServiceWorkerBypass()) {
+      return
+    }
 
     try {
       await deps.client.send('Network.setBypassServiceWorker', { bypass: false })
@@ -504,9 +512,11 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
 
-      // The next spec can reuse this page client, so don't leave a bypass
-      // behind for someone else's navigation to clear.
-      await clearServiceWorkerBypass()
+      // State only: a send here would be enqueued rather than rejected while
+      // the client is reconnecting, and stop() must not be able to hang
+      // teardown. The next runtime arms before its own navigation, so the
+      // browser-side flag corrects itself.
+      disarmServiceWorkerBypass()
 
       // Not awaited, for the same reason _onTargetDestroyed and
       // closeExtraTargets do not await detach: a dead extra-target socket may

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -360,6 +360,15 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
   // through the app's worker. The AUT frame navigates after the bypass is
   // cleared and keeps its worker.
   let serviceWorkerBypassed = false
+  // The main frame keeps its id across navigations, so one commit is enough to
+  // recognize the runner's own frame for the rest of this runtime.
+  let mainFrameId: string | undefined
+
+  const recordMainFrame = (params: Protocol.Page.FrameNavigatedEvent) => {
+    if (!params.frame.parentId) {
+      mainFrameId = params.frame.id
+    }
+  }
 
   const disarmServiceWorkerBypass = () => {
     if (!serviceWorkerBypassed) {
@@ -398,7 +407,14 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
   // next spec's navigation differs only by hash - it fetches nothing and fires
   // no frameNavigated. Without this the bypass would never be cleared and
   // every later AUT load would skip the app's worker.
-  function onNavigatedWithinDocumentForBypass () {
+  function onNavigatedWithinDocumentForBypass (params: Protocol.Page.NavigatedWithinDocumentEvent) {
+    // The AUT is live during a superdomain switch and can change its own hash,
+    // which must not end the runner's bypass. Before the first commit there is
+    // no AUT yet, so an unknown main frame is the runner.
+    if (mainFrameId && params.frameId !== mainFrameId) {
+      return
+    }
+
     clearServiceWorkerBypass().catch(() => {})
   }
 
@@ -479,6 +495,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     },
     async start () {
       unsubscribeAUTFrameNavigated = deps.onAUTFrameNavigated?.(onAUTFrameNavigated)
+      deps.client.on('Page.frameNavigated', recordMainFrame)
 
       // Service workers and out-of-process iframes have their own CDP
       // session — without enabling Fetch there, a worker's script fetch and an
@@ -500,6 +517,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
         escapeDetector.stop()
         unsubscribeAUTFrameNavigated?.()
         unsubscribeAUTFrameNavigated = undefined
+        deps.client.off('Page.frameNavigated', recordMainFrame)
 
         throw err
       }
@@ -520,6 +538,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
       escapeDetector.stop()
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
+      deps.client.off('Page.frameNavigated', recordMainFrame)
 
       // State only: a send here would be enqueued rather than rejected while
       // the client is reconnecting, and stop() must not be able to hang

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -368,6 +368,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
 
     serviceWorkerBypassed = false
     deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
+    deps.client.off('Page.navigatedWithinDocument', onNavigatedWithinDocumentForBypass)
 
     return true
   }
@@ -393,6 +394,14 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     clearServiceWorkerBypass().catch(() => {})
   }
 
+  // experimentalSingleTabRunMode keeps the runner tab between specs, so the
+  // next spec's navigation differs only by hash - it fetches nothing and fires
+  // no frameNavigated. Without this the bypass would never be cleared and
+  // every later AUT load would skip the app's worker.
+  function onNavigatedWithinDocumentForBypass () {
+    clearServiceWorkerBypass().catch(() => {})
+  }
+
   const bypassServiceWorkerForTopNavigation = async () => {
     if (stopped || serviceWorkerBypassed) {
       return
@@ -400,14 +409,14 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
 
     serviceWorkerBypassed = true
     deps.client.on('Page.frameNavigated', onFrameNavigatedForBypass)
+    deps.client.on('Page.navigatedWithinDocument', onNavigatedWithinDocumentForBypass)
 
     try {
       await deps.client.send('Network.setBypassServiceWorker', { bypass: true })
       debug('service worker bypassed for the next top-level navigation')
     } catch (err) {
       debug('arming the service worker bypass failed: %s', (err as Error)?.message)
-      serviceWorkerBypassed = false
-      deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
+      disarmServiceWorkerBypass()
     }
   }
 

--- a/packages/server/lib/network-runtime.ts
+++ b/packages/server/lib/network-runtime.ts
@@ -93,6 +93,12 @@ export type CdpFetchNetworkRuntime = {
    * extra-target marker. Returns detach() to stop that transport.
    */
   attachExtraTarget (client: Pick<ICriClient, 'send' | 'on' | 'off'>): Promise<ExtraTargetDetach>
+  /**
+   * Hides the next top-level navigation from the AUT origin's service worker so
+   * it cannot serve Cypress's own runner document. Stays armed until that
+   * navigation commits.
+   */
+  bypassServiceWorkerForTopNavigation (): Promise<void>
   start (): Promise<void>
   reset (): void
   stop (): Promise<void>
@@ -345,6 +351,58 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
 
   let unsubscribeAUTFrameNavigated: (() => void) | undefined
 
+  // Cypress serves its runner document from the AUT's own origin
+  // (resolveOriginRedirect above), so an app service worker scoped at / serves
+  // it too. If that worker is not running yet, it serves the document from the
+  // app's real origin, and no CDP session can pause that first navigation.
+  // This covers the runner's own document only: nested documents match the
+  // worker's scope by their own URL, so a spec frame loaded later still goes
+  // through the app's worker. The AUT frame navigates after the bypass is
+  // cleared and keeps its worker.
+  let serviceWorkerBypassed = false
+
+  const clearServiceWorkerBypass = async () => {
+    if (!serviceWorkerBypassed) {
+      return
+    }
+
+    serviceWorkerBypassed = false
+    deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
+
+    try {
+      await deps.client.send('Network.setBypassServiceWorker', { bypass: false })
+    } catch (err) {
+      debug('clearing the service worker bypass failed: %s', (err as Error)?.message)
+    }
+  }
+
+  function onFrameNavigatedForBypass (params: Protocol.Page.FrameNavigatedEvent) {
+    // Subframe commits are the AUT; only the runner's own commit ends this.
+    if (params.frame.parentId) {
+      return
+    }
+
+    clearServiceWorkerBypass().catch(() => {})
+  }
+
+  const bypassServiceWorkerForTopNavigation = async () => {
+    if (stopped || serviceWorkerBypassed) {
+      return
+    }
+
+    serviceWorkerBypassed = true
+    deps.client.on('Page.frameNavigated', onFrameNavigatedForBypass)
+
+    try {
+      await deps.client.send('Network.setBypassServiceWorker', { bypass: true })
+      debug('service worker bypassed for the next top-level navigation')
+    } catch (err) {
+      debug('arming the service worker bypass failed: %s', (err as Error)?.message)
+      serviceWorkerBypassed = false
+      deps.client.off('Page.frameNavigated', onFrameNavigatedForBypass)
+    }
+  }
+
   return {
     networkProxy,
     netStubbingState: stubbingState,
@@ -352,6 +410,7 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
     networkInterceptionCore,
     networkInterception,
     fetchTransport,
+    bypassServiceWorkerForTopNavigation,
     async attachExtraTarget (client) {
       if (stopped) {
         throw new Error(RUNTIME_STOPPED_ERROR)
@@ -444,6 +503,10 @@ export function createCdpFetchRuntime (deps: CreateCdpFetchRuntimeDeps): CdpFetc
       escapeDetector.stop()
       unsubscribeAUTFrameNavigated?.()
       unsubscribeAUTFrameNavigated = undefined
+
+      // The next spec can reuse this page client, so don't leave a bypass
+      // behind for someone else's navigation to clear.
+      await clearServiceWorkerBypass()
 
       // Not awaited, for the same reason _onTargetDestroyed and
       // closeExtraTargets do not await detach: a dead extra-target socket may

--- a/packages/server/lib/open_project.ts
+++ b/packages/server/lib/open_project.ts
@@ -120,6 +120,9 @@ export class OpenProject extends EventEmitter {
         onExtraTargetCriClientReady: (client) => {
           return this.projectBase!.server.attachCdpFetchExtraTarget(client)
         },
+        onBeforeRunnerNavigation: () => {
+          return this.projectBase!.server.bypassServiceWorkerForTopNavigation()
+        },
       } : {
         proxyServer: ensureProxyServer(cfg),
         // the AUT is served over loopback by our own proxy, so subtract Chromium's

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -63,6 +63,12 @@ import { CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER, cypressInternalLoopbackToken, g
 
 const debug = Debug('cypress:server:server-base')
 
+// How long to wait for the browser to acknowledge the service worker bypass
+// before navigating anyway. A CDP send is enqueued rather than rejected while
+// the connection is reconnecting, and the driver blocks on this before it
+// navigates, so a stuck send must not be able to hang the visit.
+const SERVICE_WORKER_BYPASS_TIMEOUT_MS = 2000
+
 const fullyQualifiedRe = /^https?:\/\//
 const htmlContentTypesRe = /^(text\/html|application\/xhtml)/i
 
@@ -737,13 +743,34 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
 
   /**
    * Hides the next top-level navigation from the AUT origin's service worker.
-   * No-op on the MITM path, where the proxy sees worker traffic.
+   * No-op on the MITM path, where the proxy sees worker traffic. Fails open:
+   * an unprotected navigation is a bad page load, a stuck one is a hung run.
    */
   async bypassServiceWorkerForTopNavigation () {
+    if (!this._cdpFetchRuntime) {
+      return
+    }
+
+    const timedOut = Symbol('serviceWorkerBypassTimedOut')
+    let timeout: NodeJS.Timeout | undefined
+
     try {
-      await this._cdpFetchRuntime?.bypassServiceWorkerForTopNavigation()
+      const outcome = await Promise.race([
+        this._cdpFetchRuntime.bypassServiceWorkerForTopNavigation(),
+        new Promise((resolve) => {
+          timeout = setTimeout(() => resolve(timedOut), SERVICE_WORKER_BYPASS_TIMEOUT_MS)
+        }),
+      ])
+
+      if (outcome === timedOut) {
+        debug('the service worker bypass was not acknowledged within %dms; navigating anyway', SERVICE_WORKER_BYPASS_TIMEOUT_MS)
+      }
     } catch (err) {
       debug('arming the service worker bypass failed: %s', err?.stack || err)
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
     }
   }
 

--- a/packages/server/lib/server-base.ts
+++ b/packages/server/lib/server-base.ts
@@ -735,6 +735,18 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
     return this._cdpFetchRuntime?.attachExtraTarget(client)
   }
 
+  /**
+   * Hides the next top-level navigation from the AUT origin's service worker.
+   * No-op on the MITM path, where the proxy sees worker traffic.
+   */
+  async bypassServiceWorkerForTopNavigation () {
+    try {
+      await this._cdpFetchRuntime?.bypassServiceWorkerForTopNavigation()
+    } catch (err) {
+      debug('arming the service worker bypass failed: %s', err?.stack || err)
+    }
+  }
+
   private resetCdpFetchRuntime () {
     try {
       this._cdpFetchRuntime?.reset()
@@ -795,6 +807,7 @@ export class ServerBase<TSocket extends SocketE2E | SocketCt> {
     options.onResolveUrl = this._onResolveUrl.bind(this)
 
     options.onRequest = this._onRequest.bind(this)
+    options.onPreserveRunState = this.bypassServiceWorkerForTopNavigation.bind(this)
     options.interceptRegistration = new DriverInterceptRegistrationAdapter({
       state: this.netStubbingState,
       socket: this.socket,

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -156,6 +156,7 @@ export class SocketBase implements SocketBroadcaster {
       onConnect () {},
       onRequest () {},
       onResolveUrl () {},
+      onPreserveRunState: async () => {},
       onFocusTests () {},
       onSpecChanged () {},
       onChromiumRun () {},
@@ -516,7 +517,9 @@ export class SocketBase implements SocketBroadcaster {
               case 'preserve:run:state':
                 runState = args[0]
 
-                return null
+                // The driver navigates the top frame to the new superdomain
+                // right after this, so await the bypass first.
+                return options.onPreserveRunState().then(() => null)
               case 'resolve:url': {
                 const [url, resolveOpts] = args
 

--- a/packages/server/test/unit/browsers/chrome_spec.ts
+++ b/packages/server/test/unit/browsers/chrome_spec.ts
@@ -812,6 +812,67 @@ describe('lib/browsers/chrome', () => {
     })
   })
 
+  describe('#attachListeners service worker bypass', () => {
+    const attachOptions = (overrides: Record<string, any> = {}) => {
+      const pageCriClient = {
+        send: sinon.stub().resolves(),
+        on: sinon.stub(),
+        off: sinon.stub(),
+        targetId: '1234',
+        whenChildTargetHandled: sinon.stub().resolves(),
+        reenableChildTargetInterception: sinon.stub().resolves(),
+      }
+
+      const browserCriClient = {
+        currentlyAttachedTarget: pageCriClient,
+        host: 'http://localhost',
+        port: 1234,
+      }
+
+      sinon.stub(chrome, '_getBrowserCriClient').returns(browserCriClient)
+      sinon.stub(chrome, '_navigateUsingCRI').resolves()
+      sinon.stub(chrome, '_handleDownloads').resolves()
+
+      return {
+        pageCriClient,
+        options: {
+          ...openOpts,
+          url: 'https://www.google.com/__/',
+          downloadsFolder: '/tmp/folder',
+          browser: {},
+          ...overrides,
+        },
+      }
+    }
+
+    // baseUrl alone puts the runner URL on the AUT's own origin, so the launch
+    // navigation needs the bypass too, not just a cy.visit() superdomain switch.
+    it('arms the bypass before navigating to the runner url', async function () {
+      const onBeforeRunnerNavigation = sinon.stub().resolves()
+      const { pageCriClient, options } = attachOptions({
+        useBrowserNetworkInterception: true,
+        onBeforeRunnerNavigation,
+      })
+
+      await chrome.attachListeners(options.url, pageCriClient, { use: sinon.stub() } as any, options, { majorVersion: 354 } as any)
+
+      expect(onBeforeRunnerNavigation).to.have.been.calledOnce
+      expect(onBeforeRunnerNavigation).to.have.been.calledBefore(chrome._navigateUsingCRI as any)
+    })
+
+    it('does not arm the bypass on the HTTP/1 proxy path', async function () {
+      const onBeforeRunnerNavigation = sinon.stub().resolves()
+      const { pageCriClient, options } = attachOptions({
+        useBrowserNetworkInterception: false,
+        onBeforeRunnerNavigation,
+      })
+
+      await chrome.attachListeners(options.url, pageCriClient, { use: sinon.stub() } as any, options, { majorVersion: 354 } as any)
+
+      expect(onBeforeRunnerNavigation).not.to.have.been.called
+    })
+  })
+
   describe('#connectProtocolToBrowser', () => {
     it('connects to the browser cri client', async function () {
       const protocolManager = {

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -397,12 +397,6 @@ describe('lib/network-runtime', () => {
       })
     }
 
-    const navigatedWithinDocument = (client: { on: sinon.SinonStub }, frameId: string) => {
-      client.on.withArgs('Page.navigatedWithinDocument').getCalls().forEach((call) => {
-        call.args[1]({ frameId } as Protocol.Page.NavigatedWithinDocumentEvent)
-      })
-    }
-
     it('bypasses the service worker until the top-level navigation commits', async () => {
       const client = createCdpClient()
       const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
@@ -428,48 +422,6 @@ describe('lib/network-runtime', () => {
 
       expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
       expect(client.off).to.have.been.calledWith('Page.frameNavigated')
-    })
-
-    // experimentalSingleTabRunMode reuses the runner tab, so the next spec's
-    // navigation differs only by hash and fires no frameNavigated.
-    it('ends the bypass on a same-document runner navigation', async () => {
-      const client = createCdpClient()
-      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
-
-      await runtime.start()
-      await runtime.bypassServiceWorkerForTopNavigation()
-      client.send.resetHistory()
-
-      navigatedWithinDocument(client, 'runner')
-
-      await flush()
-
-      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
-    })
-
-    // The AUT is live during a superdomain switch and can change its own hash.
-    it('ignores a same-document navigation in the AUT', async () => {
-      const client = createCdpClient()
-      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
-
-      await runtime.start()
-      // the runner's own commit is what teaches the runtime which frame is the
-      // main one
-      frameNavigated(client, { id: 'runner' })
-      await runtime.bypassServiceWorkerForTopNavigation()
-      client.send.resetHistory()
-
-      navigatedWithinDocument(client, 'aut')
-
-      await flush()
-
-      expect(client.send).not.to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
-
-      navigatedWithinDocument(client, 'runner')
-
-      await flush()
-
-      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
     })
 
     it('arms once while a bypass is already outstanding', async () => {
@@ -538,6 +490,32 @@ describe('lib/network-runtime', () => {
 
       expect(client.off).to.have.been.calledWith('Page.frameNavigated')
       expect(arming).to.be.a('promise')
+    })
+
+    // Some navigations never commit: an aborted one, or the hash-only
+    // navigation experimentalSingleTabRunMode makes between specs. Without an
+    // upper bound the bypass would keep the app's worker out of the AUT for the
+    // rest of the run.
+    it('ends a bypass whose navigation never commits', async () => {
+      const clock = sinon.useFakeTimers({ shouldAdvanceTime: true })
+
+      try {
+        const client = createCdpClient()
+        const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+        await runtime.start()
+        await runtime.bypassServiceWorkerForTopNavigation()
+        client.send.resetHistory()
+
+        clock.tick(10000)
+
+        await flush()
+
+        expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+        expect(client.off).to.have.been.calledWith('Page.frameNavigated')
+      } finally {
+        clock.restore()
+      }
     })
 
     it('does not arm on a stopped runtime', async () => {

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -390,6 +390,100 @@ describe('lib/network-runtime', () => {
     expect(client.send).to.have.been.calledWith('Fetch.disable')
   })
 
+  describe('service worker bypass for the top-level navigation', () => {
+    const frameNavigated = (client: { on: sinon.SinonStub }, frame: { id: string, parentId?: string }) => {
+      client.on.withArgs('Page.frameNavigated').getCalls().forEach((call) => {
+        call.args[1]({ frame } as Protocol.Page.FrameNavigatedEvent)
+      })
+    }
+
+    it('bypasses the service worker until the top-level navigation commits', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      client.send.resetHistory()
+
+      await runtime.bypassServiceWorkerForTopNavigation()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: true })
+
+      client.send.resetHistory()
+      // Subframe commits are the AUT; only the runner's own commit ends this.
+      frameNavigated(client, { id: 'aut', parentId: 'runner' })
+
+      await flush()
+
+      expect(client.send).not.to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+
+      frameNavigated(client, { id: 'runner' })
+
+      await flush()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+      expect(client.off).to.have.been.calledWith('Page.frameNavigated')
+    })
+
+    it('arms once while a bypass is already outstanding', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      client.send.resetHistory()
+
+      await runtime.bypassServiceWorkerForTopNavigation()
+      await runtime.bypassServiceWorkerForTopNavigation()
+
+      expect(client.send.withArgs('Network.setBypassServiceWorker', { bypass: true })).to.have.been.calledOnce
+    })
+
+    it('leaves nothing subscribed when the browser refuses the bypass', async () => {
+      const client = createCdpClient()
+
+      client.send.withArgs('Network.setBypassServiceWorker').rejects(new Error('nope'))
+
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+
+      await runtime.bypassServiceWorkerForTopNavigation()
+
+      expect(client.off).to.have.been.calledWith('Page.frameNavigated')
+
+      // A failed arm must not latch: the next navigation gets another attempt.
+      client.send.resetHistory()
+      await runtime.bypassServiceWorkerForTopNavigation()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: true })
+    })
+
+    it('clears an armed bypass on stop, so a reused page client never inherits it', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      await runtime.bypassServiceWorkerForTopNavigation()
+      client.send.resetHistory()
+
+      await runtime.stop()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+    })
+
+    it('does not arm on a stopped runtime', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      await runtime.stop()
+      client.send.resetHistory()
+
+      await runtime.bypassServiceWorkerForTopNavigation()
+
+      expect(client.send).not.to.have.been.calledWith('Network.setBypassServiceWorker')
+    })
+  })
+
   it('createCdpFetchRuntime records the AUT URL when the automation layer reports an AUT navigation commit', async () => {
     const client = {
       send: sinon.stub().resolves({}),

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -424,6 +424,23 @@ describe('lib/network-runtime', () => {
       expect(client.off).to.have.been.calledWith('Page.frameNavigated')
     })
 
+    // experimentalSingleTabRunMode reuses the runner tab, so the next spec's
+    // navigation differs only by hash and fires no frameNavigated.
+    it('ends the bypass on a same-document runner navigation', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      await runtime.bypassServiceWorkerForTopNavigation()
+      client.send.resetHistory()
+
+      client.on.withArgs('Page.navigatedWithinDocument').getCalls().forEach((call) => call.args[1]({ frameId: 'runner' }))
+
+      await flush()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+    })
+
     it('arms once while a bypass is already outstanding', async () => {
       const client = createCdpClient()
       const runtime = createCdpFetchRuntime({ ...baseDeps(), client })

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -457,7 +457,9 @@ describe('lib/network-runtime', () => {
       expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: true })
     })
 
-    it('clears an armed bypass on stop, so a reused page client never inherits it', async () => {
+    // A send on a client whose renderer crashed is enqueued, not rejected, and
+    // stop() runs ahead of HTTP server teardown.
+    it('drops an armed bypass on stop without waiting on the browser', async () => {
       const client = createCdpClient()
       const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
 
@@ -467,7 +469,27 @@ describe('lib/network-runtime', () => {
 
       await runtime.stop()
 
-      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+      expect(client.send).not.to.have.been.calledWith('Network.setBypassServiceWorker')
+      expect(client.off).to.have.been.calledWith('Page.frameNavigated')
+    })
+
+    it('does not hang stop() when the browser never answers the bypass', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+
+      client.send.withArgs('Network.setBypassServiceWorker').returns(new Promise(() => {}))
+
+      // left outstanding on purpose: the arm registers its listener before it
+      // sends, so stop() has a bypass to drop while the browser stays silent
+      const arming = runtime.bypassServiceWorkerForTopNavigation()
+
+      await flush()
+      await runtime.stop()
+
+      expect(client.off).to.have.been.calledWith('Page.frameNavigated')
+      expect(arming).to.be.a('promise')
     })
 
     it('does not arm on a stopped runtime', async () => {

--- a/packages/server/test/unit/network-runtime_spec.ts
+++ b/packages/server/test/unit/network-runtime_spec.ts
@@ -397,6 +397,12 @@ describe('lib/network-runtime', () => {
       })
     }
 
+    const navigatedWithinDocument = (client: { on: sinon.SinonStub }, frameId: string) => {
+      client.on.withArgs('Page.navigatedWithinDocument').getCalls().forEach((call) => {
+        call.args[1]({ frameId } as Protocol.Page.NavigatedWithinDocumentEvent)
+      })
+    }
+
     it('bypasses the service worker until the top-level navigation commits', async () => {
       const client = createCdpClient()
       const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
@@ -434,7 +440,32 @@ describe('lib/network-runtime', () => {
       await runtime.bypassServiceWorkerForTopNavigation()
       client.send.resetHistory()
 
-      client.on.withArgs('Page.navigatedWithinDocument').getCalls().forEach((call) => call.args[1]({ frameId: 'runner' }))
+      navigatedWithinDocument(client, 'runner')
+
+      await flush()
+
+      expect(client.send).to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+    })
+
+    // The AUT is live during a superdomain switch and can change its own hash.
+    it('ignores a same-document navigation in the AUT', async () => {
+      const client = createCdpClient()
+      const runtime = createCdpFetchRuntime({ ...baseDeps(), client })
+
+      await runtime.start()
+      // the runner's own commit is what teaches the runtime which frame is the
+      // main one
+      frameNavigated(client, { id: 'runner' })
+      await runtime.bypassServiceWorkerForTopNavigation()
+      client.send.resetHistory()
+
+      navigatedWithinDocument(client, 'aut')
+
+      await flush()
+
+      expect(client.send).not.to.have.been.calledWith('Network.setBypassServiceWorker', { bypass: false })
+
+      navigatedWithinDocument(client, 'runner')
 
       await flush()
 

--- a/packages/server/test/unit/open_project_spec.ts
+++ b/packages/server/test/unit/open_project_spec.ts
@@ -223,6 +223,7 @@ describe('lib/open_project', () => {
 
           expect(browsers.open.lastCall.args[1].useBrowserNetworkInterception).to.be.true
           expect(browsers.open.lastCall.args[1].onPageCriClientReady).to.be.a('function')
+          expect(browsers.open.lastCall.args[1].onBeforeRunnerNavigation).to.be.a('function')
         })
 
         it('passes the MITM path to the launcher when forceHttp1 is set', async function () {
@@ -232,6 +233,7 @@ describe('lib/open_project', () => {
 
           expect(browsers.open.lastCall.args[1].useBrowserNetworkInterception).to.be.false
           expect(browsers.open.lastCall.args[1].onPageCriClientReady).to.be.undefined
+          expect(browsers.open.lastCall.args[1].onBeforeRunnerNavigation).to.be.undefined
         })
 
         it('passes the MITM path to the launcher for a non-chromium browser', async function () {

--- a/packages/server/test/unit/socket_spec.ts
+++ b/packages/server/test/unit/socket_spec.ts
@@ -823,6 +823,24 @@ describe('lib/socket', () => {
         expect(bypassServiceWorkerForTopNavigation).to.be.calledOnce
       })
 
+      // The driver blocks on this ack before it navigates, and a CDP send is
+      // enqueued rather than rejected while the connection is reconnecting.
+      it('still acknowledges when the browser never answers the bypass', async function () {
+        this.timeout(10000)
+
+        this.server['_cdpFetchRuntime'] = {
+          bypassServiceWorkerForTopNavigation: sinon.stub().returns(new Promise(() => {})),
+          stop: sinon.stub().resolves(),
+          networkProxy: { dispose: sinon.stub() },
+        } as any
+
+        const response = await new Promise((resolve) => {
+          this.client.emit('backend:request', 'preserve:run:state', { currentId: 'test' }, resolve)
+        })
+
+        expect(response).to.have.property('response', null)
+      })
+
       it('still acknowledges when there is no CDP Fetch runtime', async function () {
         this.server['_cdpFetchRuntime'] = undefined
 

--- a/packages/server/test/unit/socket_spec.ts
+++ b/packages/server/test/unit/socket_spec.ts
@@ -803,6 +803,37 @@ describe('lib/socket', () => {
       })
     })
 
+    describe('on(backend:request, preserve:run:state)', () => {
+      // The driver navigates the top frame to a new superdomain right after
+      // this, onto an origin whose service worker could serve our runner.
+      it('bypasses the service worker before acknowledging', async function () {
+        const bypassServiceWorkerForTopNavigation = sinon.stub().resolves()
+
+        // stop/networkProxy are what the server's close path reaches for
+        this.server['_cdpFetchRuntime'] = {
+          bypassServiceWorkerForTopNavigation,
+          stop: sinon.stub().resolves(),
+          networkProxy: { dispose: sinon.stub() },
+        } as any
+
+        await new Promise((resolve) => {
+          this.client.emit('backend:request', 'preserve:run:state', { currentId: 'test' }, resolve)
+        })
+
+        expect(bypassServiceWorkerForTopNavigation).to.be.calledOnce
+      })
+
+      it('still acknowledges when there is no CDP Fetch runtime', async function () {
+        this.server['_cdpFetchRuntime'] = undefined
+
+        const response = await new Promise((resolve) => {
+          this.client.emit('backend:request', 'preserve:run:state', { currentId: 'test' }, resolve)
+        })
+
+        expect(response).to.have.property('response', null)
+      })
+    })
+
     describe('on(get:cached:test:state)', () => {
       it('returns cached test state', async function () {
         await new Promise((resolve) => {

--- a/packages/types/src/server.ts
+++ b/packages/types/src/server.ts
@@ -100,6 +100,12 @@ export type BrowserLaunchOpts = {
   protocolManager?: ProtocolManagerShape
   onPageCriClientReady?: (client: CdpClientShape, isAUTFrame?: (frameId: string) => Promise<boolean>, onAUTFrameNavigated?: (listener: (url: string) => void) => () => void) => Promise<void>
   /**
+   * Called just before the main frame is pointed at a Cypress runner URL, which
+   * `baseUrl` alone can put on the AUT's own origin. Only set on the browser
+   * (CDP) network path.
+   */
+  onBeforeRunnerNavigation?: () => Promise<void>
+  /**
    * When the MITM proxy is disabled, called for each extra-target (popup /
    * `_blank`) CDP session so the CDP Fetch runtime can attach shared request
    * middleware. Returns an optional detach callback invoked when the target


### PR DESCRIPTION
- Closes #34652

### Additional details

Visiting `amazon.com` in open mode still failed after the navigation-preload work in #34652 landed, for a different reason. The runner tab ended up showing amazon's **"Page Not Found"** page and the spec never ran.

The cause is that on the browser network path Cypress serves its own runner document from the AUT's superdomain — the top frame really is at `https://www.amazon.com/__/#/specs/runner?file=…`, and a Fetch pause is what redirects that request to Cypress's server. Amazon registers a service worker scoped at `/`, so that worker serves our runner document too. When that navigation is the one that starts the worker, its fetch pauses on **no** CDP session, so the request goes to the real amazon.com, which answers 404. That is the end of the run: no spec bundle, no AUT, nothing to time out against.

Two things worth calling out, because they shaped the fix:

**The #34674 hold cannot close this.** The hold defers `Runtime.runIfWaitingForDebugger` on a paused service worker until the page connection confirms it enabled Fetch on that worker's session. But the page connection never receives `Target.attachedToTarget` for a worker while it is paused — raising the 4s timeout to 45s showed its `Fetch.enable` still arriving only *after* the release, with the page-side attach logged as "attached already running". So the hold can only ever fail open, and today it just adds 4s to every cold-started worker. Worth removing separately.

**No amount of session attachment helps either.** I reproduced this in a standalone harness with no Cypress involved: a service worker's main-resource fetch for the navigation that starts it pauses on no session — not the page's, not the worker's own, even with `Fetch.enable` confirmed on it while it is still debugger-paused. Subresource fetches from that same worker pause normally, and so do navigations served by an already-running worker. So the document has to be kept away from the worker rather than intercepted.

The fix is `Network.setBypassServiceWorker`, armed for exactly the navigation that puts the main frame on a runner URL and cleared as soon as that document commits. There are two such navigations and both are covered:

- **The launch navigation**, in `attachListeners` right before `_navigateUsingCRI`, via a new `onBeforeRunnerNavigation` launch option. This one matters more than it looks: with a `baseUrl` on the AUT's own superdomain there is no superdomain switch at all — the browser is launched straight at `https://www.amazon.com/__/#/specs` — so this is the only hook that fires.
- **The superdomain switch**, on `preserve:run:state`, which the driver sends immediately before `$utils.locHref` moves the top frame. It is awaited so the bypass is in place before the browser navigates.

Everything else that reaches a runner URL was checked and needs nothing: `changeToUrl` (spec change, debug redirect) emits a hash-only same-document URL, `rerunSpec` does not navigate, and `connectToExisting` attaches to an already-loaded page. Studio's protocol-cleanup `window.location.reload()` is a real main-frame navigation but is deliberately left alone — it only happens after the AUT has loaded, when the worker is attached and covered and its navigations pause normally, and its `studio:destroy` round trip fires whether or not the reload follows, so arming there would strand the bypass on and quietly disable the app's worker for later AUT navigations.

The app's service worker is unaffected. Only the runner's own navigation is bypassed; the AUT frame navigates after the bypass is cleared, and in a verified run the AUT document came back `fromServiceWorker: true` with a matching Fetch pause — worker-served *and* intercepted.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CDP network behavior for runner loads only on the browser-interception path; designed to fail open with timeouts, but incorrect bypass timing could still affect AUT service worker behavior until cleared.
> 
> **Overview**
> Fixes open-mode failures where the runner tab shows the site's 404 because a **root-scoped service worker** serves Cypress's `__/…` runner URL from the real origin on the **CDP Fetch** network path (Fetch cannot intercept that first worker-started navigation).
> 
> On that path only, the PR arms **`Network.setBypassServiceWorker`** for the **next top-level navigation** to the runner and clears it when the **main frame** commits (not AUT subframes), with a **10s** safety timeout if the navigation never commits. Arming runs **before launch navigation** via new **`onBeforeRunnerNavigation`** and **before superdomain switches** by awaiting bypass on **`preserve:run:state`** (`onPreserveRunState`). **`server-base`** races arming against **2s** so a stuck CDP send cannot hang the run. The MITM proxy path is unchanged (no-op).
> 
> Unit tests cover Chrome attach order, runtime bypass lifecycle, socket ack behavior, and launcher wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1fe7638054b1103bcbcabd630ba58ff2c71bf3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

Reproducing the original bug needs open mode and a service worker already registered for the site in the browser profile — that is why run mode never sees it: it uses a fresh `run-<pid>` profile and clears service workers between specs, while open mode reuses the persistent `interactive` profile.

1. Make a project with a spec that runs `cy.visit('https://www.amazon.com')`.
2. `yarn cypress:open --project <path> --e2e --browser chrome`, click the spec, let it finish. This registers amazon's service worker in the open-mode Chrome profile.
3. Quit Cypress and repeat step 2.

On `develop` the second run leaves the runner tab on `https://www.amazon.com/__/#/specs/runner?file=…` showing amazon's "Page Not Found", and the server logs `A document served by a service worker was not intercepted by Cypress: https://www.amazon.com/__/`. With this PR the runner loads and the spec passes.

The `baseUrl` variant is quicker and needs no second run — set `baseUrl: 'https://www.amazon.com'` and visit `/`. It fails on `develop` because the launch navigation is already on the AUT's origin.

Unit tests:

```
yarn workspace @packages/server test-unit -- network-runtime_spec.ts
yarn workspace @packages/server test-unit -- browsers/chrome_spec.ts
yarn workspace @packages/server test-unit -- open_project_spec.ts
```

The existing service-worker system tests are unaffected: `yarn test-system proxy_disabled_framebusting_spec.ts` and `yarn test-system service_worker_protocol_spec.js`.

### How has the user experience changed?

Before, in open mode on Chrome/Chromium/Edge, visiting a site whose service worker is scoped at `/` (amazon.com and youtube.com were both reported) replaced the Cypress runner with the site's own 404 page and the spec never ran. After, the runner loads and the spec runs normally, and the app's service worker still serves the app.

Verified by hand against the live sites: amazon.com passes on 3 of 3 open-mode runs with 0 interception escapes, youtube.com passes, and both pass with a `baseUrl` pointed at the AUT's origin. Disabling only the new arming brings the failure back verbatim, so the change is what fixes it.

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34652 -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
