### PR TITLE
chore: scope test git identity to the test project

### DIFF
--- a/packages/app/cypress/tasks/git.ts
+++ b/packages/app/cypress/tasks/git.ts
@@ -5,19 +5,18 @@ import fs from 'fs-extra'
 export async function initGitRepoForTestProject (projectPath: string) {
   const git = simpleGit({ baseDir: projectPath })
 
-  if (process.env.CI) {
-    // Set a user on CI. `git config --global` takes a lock on the global
-    // .gitconfig (a .gitconfig.lock file), and on Windows concurrent writes
-    // fail to acquire it with "could not lock config file ...: File exists",
-    // so these must not overlap.
-    await git.addConfig('user.name', 'Test User', true, 'global')
-    await git.addConfig('user.email', 'test-user@example.com', true, 'global')
-  }
-
   const e2eFolder = path.join(projectPath, 'cypress', 'e2e')
   const allSpecs = fs.readdirSync(e2eFolder)
 
   await git.init()
+
+  // scope the identity to this throwaway repo. Writing it to the global
+  // gitconfig would leave the machine committing as `Test User` afterwards,
+  // and signing is irrelevant here but fails without the machine's key
+  await git.addConfig('user.name', 'Test User')
+  await git.addConfig('user.email', 'test-user@example.com')
+  await git.addConfig('commit.gpgsign', 'false')
+
   await git.add(allSpecs.map((spec) => path.join(e2eFolder, spec)))
   await git.commit('add all specs')
 

--- a/packages/data-context/test/unit/sources/GitDataSource.spec.ts
+++ b/packages/data-context/test/unit/sources/GitDataSource.spec.ts
@@ -21,15 +21,15 @@ describe('GitDataSource', () => {
     e2eFolder = path.join(projectPath, 'cypress', 'e2e')
     const allSpecs = await fs.readdir(e2eFolder)
 
-    if (process.env.CI) {
-      // need to set a user on CI
-      // run sequentially: concurrent writes to ~/.gitconfig race on the
-      // .gitconfig.lock file and intermittently fail with "could not lock"
-      await git.addConfig('user.name', 'Test User', true, 'global')
-      await git.addConfig('user.email', 'test-user@example.com', true, 'global')
-    }
-
     await git.init()
+
+    // scope the identity to this throwaway repo. Writing it to the global
+    // gitconfig would leave the machine committing as `Test User` afterwards,
+    // and signing is irrelevant here but fails without the machine's key
+    await git.addConfig('user.name', 'Test User')
+    await git.addConfig('user.email', 'test-user@example.com')
+    await git.addConfig('commit.gpgsign', 'false')
+
     await git.add(allSpecs.map((spec) => path.join(e2eFolder, spec)))
     await git.commit('add all specs')
   })


### PR DESCRIPTION
- Closes N/A — no associated issue. Test-only fix for developer/CI environment pollution; see "Additional details".

### Additional details

**Why was this change necessary?**

Two test helpers configured a git identity with `git config --global --add`:

- `packages/data-context/test/unit/sources/GitDataSource.spec.ts:28-29`
- `packages/app/cypress/tasks/git.ts:13-14`

```ts
await git.addConfig('user.name', 'Test User', true, 'global')
```

Both problems are in that one call. Per `simple-git`'s source (`addConfig(key, value, append, scope)`), it emits `git config --global --add`:

1. **`'global'`** writes to the machine's `~/.gitconfig`. Git resolves `user.*` last-one-wins, and the appended block lands after the developer's real identity, so every subsequent commit on that machine is authored as `Test User <test-user@example.com>`. Where a signing key is still configured, the commit is signed by one identity and attributed to another, which GitHub reports as **Unverified**.
2. **`append: true`** is `--add`, which never replaces. The `beforeEach` runs per test, so entries accumulate on every run.

The `process.env.CI` guard is what makes this bite rather than what prevents it — `CI=true` is set in many containerized dev and agent environments, not just on CI runners.

**What is affected by this change?**

Test-only. No `src/` or shipped code changes, no user-facing behavior change.

**Implementation details**

The identity is now configured on the scaffolded throwaway project after `git init`, using `simple-git`'s default local scope (`git config --local`, replace rather than `--add`). That makes the CI guard unnecessary and removes the `.gitconfig.lock` contention its comment described: global writes serialize on a single shared `~/.gitconfig.lock`, whereas local writes take a per-repo `.git/config.lock`, and each test scaffolds its own project — so there is no shared file left to contend over. Note this last point is a structural argument; the Windows lock error itself was not reproduced.

A local `commit.gpgsign=false` is also set. This is defensive rather than required for the bug above: it keeps a throwaway test commit from invoking a developer's signing key, which would otherwise prompt for a passphrase or hit a hardware token.

### Steps to test

Run the spec with `CI=true` and confirm `~/.gitconfig` is unchanged:

```sh
md5sum ~/.gitconfig
yarn workspace @packages/data-context test-unit -- test/unit/sources/GitDataSource.spec.ts
md5sum ~/.gitconfig   # unchanged; on develop this gains 5 `Test User` lines
```

Running the same spec at this branch's parent commit vs. its tip, with `GIT_CONFIG_GLOBAL` pointed at a scratch copy so the old code cannot touch the real config:

| | global-scope `addConfig` calls | `test-user@example.com` lines appended | resulting global identity | tests |
|---|---|---|---|---|
| before | 2 | **5** | `Test User <test-user@example.com>` | 5 passed |
| after | 0 | **0** | (developer's own, unchanged) | 5 passed |

Checks run locally:

- `GitDataSource.spec.ts` under jest with `CI=true` — 5/5 pass, `~/.gitconfig` byte-identical before and after
- `yarn workspace @packages/data-context check-ts` — clean
- `yarn workspace @packages/app check-ts` — clean
- ESLint on both changed files — clean

`packages/app/cypress/tasks/git.ts` is exercised by app e2e tests, which were not run locally.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-only fix; no shipped code affected. -->
- [x] Have tests been added/updated? <!-- Existing GitDataSource spec and app e2e git task updated; no new coverage needed, the change is to the test setup itself. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMU8NUhMHC2vVdWWZarwCp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper changes with no shipped code or user-facing behavior impact.
> 
> **Overview**
> Test git setup in **`initGitRepoForTestProject`** and **`GitDataSource.spec.ts`** no longer writes `user.name` / `user.email` to the **global** `~/.gitconfig` behind a `CI` guard. After `git init`, those values (and **`commit.gpgsign=false`**) are set on the **local** throwaway repo instead.
> 
> This stops tests from overwriting a developer’s global identity, accumulating `--add` entries on repeated runs, and triggering GPG signing on test commits. The old global-config path and its Windows `.gitconfig.lock` contention comment are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da534bcfe5e99b5c9178704add07a7e66fbf4f75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->