### PR TITLE
chore: move perf changelog entry to next release (didn't make it into 16 commit/binary)

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
 <!-- See ../guides/writing-the-cypress-changelog.md for details on writing the changelog. -->
+## 16.0.1
+
+**Performance:**
+
+- Fixed a memory leak in the Cypress server where every service worker started by the application under test held onto state until the browser closed, so memory use climbed over the course of a run in Chrome, Chromium, Edge, and Electron. Addressed in [#34721](https://github.com/cypress-io/cypress/pull/34721).
+
 ## 16.0.0
 
 **Breaking Changes:**
@@ -31,10 +37,6 @@
 
 - Deprecated the Electron browser as a test browser. The Electron browser will be removed in a future major version of Cypress; switch to Chrome or another installed browser to avoid a breaking change when you upgrade. See [Migrating away from the Electron browser](https://docs.cypress.io/app/references/migration-guide#Migrating-away-from-the-Electron-browser). Addresses [#33560](https://github.com/cypress-io/cypress/issues/33560). Addressed in [#34074](https://github.com/cypress-io/cypress/pull/34074).
 - Added the [`forceHttp1`](https://docs.cypress.io/app/references/configuration#forceHttp1) configuration option, which routes every browser through the legacy network path. It is deprecated at introduction and prints a warning when set: it exists to give suites time to migrate to the native browser network, and will be removed once that path is supported long term in both Chrome and Firefox. Addresses [#33847](https://github.com/cypress-io/cypress/issues/33847).
-
-**Performance:**
-
-- Fixed a memory leak in the Cypress server where every service worker started by the application under test held onto state until the browser closed, so memory use climbed over the course of a run in Chrome, Chromium, Edge, and Electron. Addressed in [#34721](https://github.com/cypress-io/cypress/pull/34721).
 
 **Features:**
 


### PR DESCRIPTION
- Closes N/A

### Additional details

The commit used for Cypress 16 release (https://github.com/cypress-io/cypress/commit/9467a6e7f4645fe7a99a35fbc642d5e10d849cce) is before the commit that introduced this perf fix - so this changelog needs to moved to the next release log.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog reordering with no product or runtime behavior changes.
> 
> **Overview**
> **Changelog-only:** the **Performance** note for the Cypress server service-worker memory leak ([#34721](https://github.com/cypress-io/cypress/pull/34721)) is no longer listed under **16.0.0** and is documented under a new **16.0.1** section instead, so release notes match what actually shipped in the 16.0.0 binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b43658ed86cbe2f257b94b08ce071cbcdab70962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

### How has the user experience changed?

N/A

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [ ] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [ ] Have tests been added/updated?
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [ ] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
