### PR TITLE
test: make cypress CLI unit suite pass on any host architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,7 @@ Verify an API against the relevant floor (node.green for Node, caniuse/MDN for b
 - **Primary CI**: CircleCI. Config lives in `.circleci/src/` (modular) and is compiled to `.circleci/packed/pipeline.yml`. See [`.circleci/AGENTS.md`](.circleci/AGENTS.md) for when to add a branch to the full-CI allowlist (binary tests, Windows jobs, v8 snapshot validation).
 - **Supplementary**: GitHub Actions for security scanning (Snyk), SBOM generation, browser version auto-updates, and PR validation.
 - **Base branch**: `develop` — all PRs target `develop`; release branches follow `release/X.Y.Z`.
-- **Multi-platform matrix**: Linux x64, Linux ARM64, macOS x64, macOS ARM64, Windows — all run in parallel.
+- **Multi-platform matrix**: Linux x64, Linux ARM64, macOS x64, macOS ARM64, Windows — all run in parallel. Coverage is per-job, not uniform: `unit-tests` runs only on linux-x64 and windows, so a unit test coupled to the host architecture passes CI and still fails locally on arm64. See [`cli/AGENTS.md`](./cli/AGENTS.md) for keeping specs host-independent.
 - **Release gate**: All tests must pass through the `ready-to-release` aggregation job before `npm-release` runs.
 - **External PRs**: Require manual approval via `approve-contributor-pr` gate before CI runs.
 - **Binary builds**: Triggered separately after npm release; cross-platform binaries are assembled and distributed via CDN.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -47,6 +47,19 @@ cd cli/react && yarn build
 cd cli/mount-utils && yarn build
 ```
 
+## Unit Tests
+
+The `unit-tests` CI job runs only on `linux-x64` and `windows` — there is no arm64 executor — so **a spec coupled to the host machine passes CI and still fails for contributors**, most often on Apple Silicon. Keep specs host-independent.
+
+- **Pin the architecture at both layers.** `util.getRealArch()` consults `os.arch()` only for its early returns; otherwise it falls through to the `arch` package, which reports the real machine. A spec asserting on output that carries an arch — `Platform:` lines, download URLs, `?arch=` query params, CDN build URLs — needs a file-scoped `vi.mock('arch', () => ({ default: () => 'x64' }))` alongside `vi.mocked(os.arch).mockReturnValue('x64')`. Mock it per file rather than globally through `setupFiles`: some specs exercise real-machine detection deliberately, and a shared mock hides the dependency from the file that relies on it.
+- **Keep test helpers generic.** Normalizers that scrub output before snapshotting must match the shape of a host value, not the value itself — `&arch=[\w-]+`, never `&arch=x64` — so the helper cannot re-couple a snapshot to the host.
+- **Never run `vitest -u` to clear a host-dependent failure.** Committed snapshots encode the canonical values; regenerating them on a different machine buries the coupling and breaks everyone else. Fix the mock instead.
+- **Treat other host facts the same way** — `os.platform()`, `os.release()`, `os.tmpdir()`, `os.homedir()`, cache directories, path separators. Assert against mocked values, never whatever the machine reports.
+
+Verify an arch or platform mock is load-bearing rather than decorative: flip its factory to the other value, run that spec, and confirm the expected tests fail. A mock wired to nothing is worse than no mock, because it reads as coverage.
+
+`util._cachedArch` is a module-level singleton. A file-scoped `vi.mock('arch')` is in place before the first call, so the cached value is already the mocked one; reset it (`util._cachedArch = undefined`) only in specs that vary the arch between tests.
+
 ## Notes
 
 - The main CLI build uses Rollup (configured in `rollup.config.mjs`). Entry points are `lib/index.ts`, `lib/cli.ts`, `lib/cypress.ts`, `lib/exec/xvfb.ts`, `lib/exec/spawn.ts`, and `lib/bin/cypress.ts`. Output goes to `dist/` and is copied to `build/` via `sync-build-dist.ts`.

--- a/cli/test/lib/errors.spec.ts
+++ b/cli/test/lib/errors.spec.ts
@@ -20,6 +20,10 @@ vi.mock('os', async (importActual) => {
   }
 })
 
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
+
 vi.mock('systeminformation', async (importActual) => {
   const actual = await importActual()
 

--- a/cli/test/lib/exec/spawn.spec.ts
+++ b/cli/test/lib/exec/spawn.spec.ts
@@ -50,6 +50,10 @@ vi.mock('os', async (importActual) => {
   }
 })
 
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
+
 vi.mock('readline', async (importActual) => {
   const actual = await importActual()
 

--- a/cli/test/lib/tasks/download.spec.ts
+++ b/cli/test/lib/tasks/download.spec.ts
@@ -37,7 +37,7 @@ const normalize = (str: string): string => {
     .map((str) => str.replace(/\s+$/g, ''))
     .join('\n')
     // replace download query with normalized platform and arch
-    .replace(/(\?platform=(darwin|linux|win32)&arch=x64)/, '?platform=OS&arch=ARCH'),
+    .replace(/(\?platform=(darwin|linux|win32)&arch=[\w-]+)/, '?platform=OS&arch=ARCH'),
   )
 }
 
@@ -67,6 +67,10 @@ vi.mock('os', async (importActual) => {
     },
   }
 })
+
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
 
 vi.mock('fs-extra', async (importActual) => {
   const actual = await importActual()

--- a/cli/test/lib/tasks/install.spec.ts
+++ b/cli/test/lib/tasks/install.spec.ts
@@ -40,6 +40,10 @@ vi.mock('os', async (importActual) => {
   }
 })
 
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
+
 vi.mock('timers/promises', async (importActual) => {
   const actual = await importActual()
 

--- a/cli/test/lib/tasks/unzip.spec.ts
+++ b/cli/test/lib/tasks/unzip.spec.ts
@@ -50,6 +50,10 @@ vi.mock('os', async (importActual) => {
   }
 })
 
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
+
 vi.mock('../../../lib/util', async (importActual) => {
   const actual = await importActual()
 

--- a/cli/test/lib/tasks/verify.spec.ts
+++ b/cli/test/lib/tasks/verify.spec.ts
@@ -87,6 +87,10 @@ vi.mock('os', async (importActual) => {
   }
 })
 
+// `getRealArch()` falls through to the `arch` package, which reports the real
+// machine, so pin it alongside the mocked `os.arch()`
+vi.mock('arch', () => ({ default: () => 'x64' }))
+
 vi.mock('../../../lib/exec/xvfb', async (importActual) => {
   const actual = await importActual()
 


### PR DESCRIPTION
- Closes N/A — no associated issue. This is a mechanical test-correctness fix: it makes existing specs assert what they already declare, and changes no product behavior.

### Additional details

**Why was this change necessary?**

`cli/lib/util.ts` `getRealArch()` consults `os.arch()` only for its early returns (the `arm64` check, the darwin Rosetta `sysctl` check, the linux `uname -m` check). When none of those fire it falls through to the `arch` npm package — which is not `os.arch()`, reports the real machine, and is mocked nowhere in `cli/test/`.

#### Before

<img width="968" height="1043" alt="Screenshot 2026-09-01 at 12 36 39 PM" src="https://github.com/user-attachments/assets/59b23907-a6b0-4ba7-86df-27d7fb47fb6f" />


#### After

<img width="437" height="166" alt="Screenshot 2026-09-01 at 12 36 13 PM" src="https://github.com/user-attachments/assets/b599e85f-d8cc-4932-8aa8-cb1b81315cbf" />


Six specs call `vi.mocked(os.arch).mockReturnValue('x64')`, declaring the intent to pin the architecture, but that only steers the early returns. On an arm64 host execution reaches `arch()`, and the real value lands in every `Platform:` line, the download URL's `?arch=`, and `_getBinaryUrlFromBuildInfo()`'s CDN URL. The result is 8 failures on a clean checkout of `develop` for every contributor on an M-series Mac.

CI never catches this: the `unit-tests` job defaults to `executor: linux-x64`, and the only override anywhere is `windows-unit-tests`. There is no arm64 executor for that job.

**What is affected by this change?**

Test files and agent instructions only. No production code and no snapshots were touched. `getRealArch()` consulting the real machine is deliberate — it exists to detect x64 Node running under Rosetta or on arm64 Linux — and the committed snapshots already encode the correct `x64` values, so the fix has to make them pass as-is.

**Implementation details**

- Added a file-scoped `vi.mock('arch', () => ({ default: () => 'x64' }))` to the six specs that pin an architecture, alongside their existing `os.arch()` mock.
- `spawn.spec.ts` and `verify.spec.ts` pass on arm64 today — no assertion in them currently reaches the fallback — but they declare the same intent, so they are included to stop a future assertion silently reintroducing the coupling.
- The mock is per-file rather than a shared `setupFiles` entry: it would otherwise apply to all 52 spec files including ones that may legitimately want the real value, and it would hide the mock from the file that depends on it.
- Generalised the arch segment of `download.spec.ts`'s `normalize()` helper (`&arch=x64` → `&arch=[\w-]+`) so the normalizer itself cannot be the next thing that couples a snapshot to the host. `[\w-]+` rather than a broader class because `normalize()` runs its replacements *before* `stripAnsi()`, so a greedy `[^&\s]+` would swallow a trailing ANSI escape into the capture.
- The second commit documents the hazard: a `## Unit Tests` section in `cli/AGENTS.md`, plus a note on the root `AGENTS.md` CI matrix bullet, which previously listed five platforms "all run in parallel" and so implied uniform coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no runtime CLI behavior is modified.
> 
> **Overview**
> Fixes **CLI unit tests that only passed on x64 CI** because specs mocked `os.arch()` but not the `arch` package, which `getRealArch()` still consults on Apple Silicon and similar hosts.
> 
> Adds a **file-scoped `vi.mock('arch')` returning `'x64'`** in six specs that already pin architecture (`errors`, `download`, `install`, `unzip`, `spawn`, `verify`). In `download.spec.ts`, the snapshot **normalizer** now strips any `&arch=…` segment (`[\w-]+`) instead of assuming `x64`.
> 
> **Docs:** new **Unit Tests** section in `cli/AGENTS.md` (host-independent mocks, no `vitest -u` for arch failures) and a **CI matrix** note in root `AGENTS.md` that `unit-tests` runs only on linux-x64 and windows. **No production code or snapshot updates.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176160efb75e973177566da4acb38314bc3253fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

On an Apple Silicon Mac (or linux-arm64), on `develop`:

```
yarn workspace cypress test-unit
```

8 failures: `errors.spec.ts` (4), `tasks/download.spec.ts` (1), `tasks/unzip.spec.ts` (2), `tasks/install.spec.ts` (1). On this branch the suite passes, with snapshots unchanged.

The mocks cannot be exercised from an x64 host directly, so each was verified to be load-bearing rather than decorative: flip its factory to `'arm64'`, run that spec alone, and diff the failure count against the same spec at `'x64'`.

| spec | x64 | arm64 | delta |
|---|---|---|---|
| `errors.spec.ts` | 0 | 4 | **+4** |
| `tasks/download.spec.ts` | 4 \* | 5 | **+1** |
| `tasks/unzip.spec.ts` | 0 | 2 | **+2** |
| `tasks/install.spec.ts` | 0 | 1 | **+1** |
| `exec/spawn.spec.ts` | 2 \* | 2 | **+0** (latent) |
| `tasks/verify.spec.ts` | 0 | 0 | **+0** (latent) |

\* Pre-existing failures in my sandbox caused by `HTTPS_PROXY` and `FORCE_COLOR` being set in that environment. They are identical with and without this change — the full-suite failure list diffs clean against a stashed baseline.

The deltas account for all 8 host-dependent failures. Also confirmed still green: the four `architecture detection` tests in `download.spec.ts`, which reach `arm64` through early returns (an `os.arch` mock, or a mocked `execa` returning `sysctl`/`uname` output) and must keep doing so; and the two `_getBinaryUrlFromBuildInfo` tests that pass an explicit arch argument.

`yarn lint --scope cypress` passes. `tsc -p cli/tsconfig.json --noEmit` reports only pre-existing errors, none introduced by these files.

### How has the user experience changed?

No change. Tests and repository documentation only — no product code, no API surface, no user-visible behavior.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-correctness fix with no product behavior change; explanation above per CONTRIBUTING.md. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tg6QMT8Hv1zx2BmKTSXPu

---
_Generated by [Claude Code](https://claude.ai/code/session_018tg6QMT8Hv1zx2BmKTSXPu)_