### PR TITLE
misc: recommend disk space and directory checks when Test Replay fails to initialize

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -49,6 +49,10 @@
 - Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).
 - Fixed an issue where `cypress tap specs` and `cypress tap run` failed against a Cypress session whose project sets the internal `namespace` configuration option, reporting that the session was older than the CLI when it was not. Addresses [#34660](https://github.com/cypress-io/cypress/pull/34660).
 
+**Misc:**
+
+- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#XXXXX](https://github.com/cypress-io/cypress/pull/XXXXX).
+
 **Dependency Updates:**
 
 - Upgraded `electron` from `37.6.0` to `41.7.0`.

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 **Misc:**
 
-- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#XXXXX](https://github.com/cypress-io/cypress/pull/XXXXX).
+- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#34763](https://github.com/cypress-io/cypress/pull/34763).
 
 ## 16.0.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 **Misc:**
 
-- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#34763](https://github.com/cypress-io/cypress/pull/34763).
+- When a Test Replay recording fails while being prepared for a spec during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#34763](https://github.com/cypress-io/cypress/pull/34763).
 
 ## 16.0.0
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Fixed a memory leak in the Cypress server where every service worker started by the application under test held onto state until the browser closed, so memory use climbed over the course of a run in Chrome, Chromium, Edge, and Electron. Addressed in [#34721](https://github.com/cypress-io/cypress/pull/34721).
 
+**Misc:**
+
+- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#XXXXX](https://github.com/cypress-io/cypress/pull/XXXXX).
+
 ## 16.0.0
 
 **Breaking Changes:**
@@ -50,10 +54,6 @@
 - Fixed an issue where the [`after:run`](https://on.cypress.io/after-run-api) event handler would not run when a project was closed in `cypress open` mode and [`experimentalInteractiveRunEvents`](https://docs.cypress.io/app/references/configuration#Experiments) was set. Addressed in [#34700](https://github.com/cypress-io/cypress/pull/34700).
 - Fixed an issue where a single cleanup step that stalled while Cypress shut down, such as waiting on a browser that was slow to close, could hold up the rest of shutdown. Addressed in [#34699](https://github.com/cypress-io/cypress/pull/34699).
 - Fixed an issue where `cypress tap specs` and `cypress tap run` failed against a Cypress session whose project sets the internal `namespace` configuration option, reporting that the session was older than the CLI when it was not. Addresses [#34660](https://github.com/cypress-io/cypress/pull/34660).
-
-**Misc:**
-
-- When a Test Replay recording fails to initialize during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#XXXXX](https://github.com/cypress-io/cypress/pull/XXXXX).
 
 **Dependency Updates:**
 

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -574,9 +574,8 @@ export const AllCypressErrors = {
         ${fmt.highlightSecondary(apiErr)}`
   },
   CLOUD_PROTOCOL_INITIALIZATION_FAILURE: (error: Error, captureMethod?: ProtocolCaptureMethod) => {
-    // `beforeSpec` is the only initialization step that touches the filesystem - it opens the
-    // recording's SQLite database - so it is the only one where disk space and directory
-    // permissions are worth suggesting.
+    // `beforeSpec` opens the recording's SQLite database beneath the temporary directory. The
+    // other initialization steps never touch the filesystem, so the advice would only mislead.
     const recommendation = captureMethod === 'beforeSpec' ? testReplayDirectoryRecommendation() : null
 
     return errTemplate`\

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import _ from 'lodash'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
-import type { BreakingErrResult, TestingType } from '@packages/types'
+import type { BreakingErrResult, ProtocolCaptureMethod, TestingType } from '@packages/types'
 import { logError, parseResolvedPattern, pluralize } from './errorUtils'
 import { errPartial, errTemplate, fmt, theme } from './errTemplate'
 import { stackWithoutMessage } from './stackUtils'
@@ -43,6 +43,15 @@ It also looks like you also passed in an explicit ${fmt.flag('--ci-build-id')} f
 This is only necessary if you are NOT running in one of our supported CI providers.
 
 This flag must be unique for each new run, but must also be identical for each machine you are trying to --group or run in --parallel.\
+`
+}
+
+const testReplayDirectoryRecommendation = (): ReturnType<typeof errPartial> => {
+  return errPartial`\
+This can happen for many reasons. If this problem persists:
+
+- Try increasing the available disk space.
+- Ensure that ${fmt.path(path.join(os.tmpdir(), 'cypress', 'protocol'))} is both readable and writable.\
 `
 }
 
@@ -564,11 +573,18 @@ export const AllCypressErrors = {
 
         ${fmt.highlightSecondary(apiErr)}`
   },
-  CLOUD_PROTOCOL_INITIALIZATION_FAILURE: (error: Error) => {
+  CLOUD_PROTOCOL_INITIALIZATION_FAILURE: (error: Error, captureMethod?: ProtocolCaptureMethod) => {
+    // `beforeSpec` is the only initialization step that touches the filesystem - it opens the
+    // recording's SQLite database - so it is the only one where disk space and directory
+    // permissions are worth suggesting.
+    const recommendation = captureMethod === 'beforeSpec' ? testReplayDirectoryRecommendation() : null
+
     return errTemplate`\
         Warning: We encountered an error while initializing the Test Replay recording for this spec.
 
         These results will not display Test Replay recordings.
+
+        ${recommendation}
 
         This error will not affect or change the exit code.
 
@@ -580,10 +596,7 @@ export const AllCypressErrors = {
 
         These results will not display Test Replay recordings.
 
-        This can happen for many reasons. If this problem persists:
-
-        - Try increasing the available disk space.
-        - Ensure that ${fmt.path(path.join(os.tmpdir(), 'cypress', 'protocol'))} is both readable and writable.
+        ${testReplayDirectoryRecommendation()}
 
         This error will not affect or change the exit code.
 

--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -574,8 +574,9 @@ export const AllCypressErrors = {
         ${fmt.highlightSecondary(apiErr)}`
   },
   CLOUD_PROTOCOL_INITIALIZATION_FAILURE: (error: Error, captureMethod?: ProtocolCaptureMethod) => {
-    // `beforeSpec` opens the recording's SQLite database beneath the temporary directory. The
-    // other initialization steps never touch the filesystem, so the advice would only mislead.
+    // `beforeSpec` is where the recording's SQLite database is opened and the capture script
+    // first writes beneath the temporary directory. The other initialization steps never touch
+    // the filesystem, so the advice would only mislead.
     const recommendation = captureMethod === 'beforeSpec' ? testReplayDirectoryRecommendation() : null
 
     return errTemplate`\

--- a/packages/errors/test/__snapshots__/CLOUD_PROTOCOL_INITIALIZATION_FAILURE - beforeSpec.ansi
+++ b/packages/errors/test/__snapshots__/CLOUD_PROTOCOL_INITIALIZATION_FAILURE - beforeSpec.ansi
@@ -1,0 +1,12 @@
+[31mWarning: We encountered an error while initializing the Test Replay recording for this spec.[39m
+[31m[39m
+[31mThese results will not display Test Replay recordings.[39m
+[31m[39m
+[31mThis can happen for many reasons. If this problem persists:[39m
+[31m[39m
+[31m- Try increasing the available disk space.[39m
+[31m- Ensure that [94m/os/tmpdir/cypress/protocol[39m[31m is both readable and writable.[39m
+[31m[39m
+[31mThis error will not affect or change the exit code.[39m
+[31m[39m
+[31m[95mError: fail whale[39m[31m[39m

--- a/packages/errors/test/visualSnapshotErrors.spec.ts
+++ b/packages/errors/test/visualSnapshotErrors.spec.ts
@@ -515,6 +515,7 @@ describe('visual error templates', () => {
 
       return {
         default: [err],
+        beforeSpec: [err, 'beforeSpec'],
       }
     },
     CLOUD_PROTOCOL_CAPTURE_FAILURE: () => {

--- a/packages/server/lib/cloud/artifacts/upload_artifacts.ts
+++ b/packages/server/lib/cloud/artifacts/upload_artifacts.ts
@@ -191,7 +191,7 @@ export const uploadArtifacts = async (options: UploadArtifactOptions) => {
     if (postArtifactExtractionFatalError.captureMethod === 'protocolUploadUrl') {
       errors.warning('CLOUD_PROTOCOL_CANNOT_UPLOAD_ARTIFACT', postArtifactExtractionFatalError.error)
     } else if (isProtocolInitializationError(postArtifactExtractionFatalError)) {
-      errors.warning('CLOUD_PROTOCOL_INITIALIZATION_FAILURE', postArtifactExtractionFatalError.error)
+      errors.warning('CLOUD_PROTOCOL_INITIALIZATION_FAILURE', postArtifactExtractionFatalError.error, postArtifactExtractionFatalError.captureMethod)
     } else {
       errors.warning('CLOUD_PROTOCOL_CAPTURE_FAILURE', postArtifactExtractionFatalError.error)
     }

--- a/system-tests/__snapshots__/record_spec.js
+++ b/system-tests/__snapshots__/record_spec.js
@@ -2932,6 +2932,11 @@ Warning: We encountered an error while initializing the Test Replay recording fo
 
 These results will not display Test Replay recordings.
 
+This can happen for many reasons. If this problem persists:
+
+- Try increasing the available disk space.
+- Ensure that /os/tmpdir/cypress/protocol is both readable and writable.
+
 This error will not affect or change the exit code.
 
 Error: Error in beforeSpec


### PR DESCRIPTION
- Closes N/A — no public issue. This came out of a support investigation into Test Replay recordings that consistently fail to start in CI; tracked internally.

### Additional details

When a Test Replay recording fails to start, the only thing printed is the underlying error, most often:

```
Warning: We encountered an error while initializing the Test Replay recording for this spec.

These results will not display Test Replay recordings.

This error will not affect or change the exit code.

SqliteError: unable to open database file
```

That message has been in place since `13.9.0` (#29312) and is unchanged since — this is not a regression. It is simply the least useful of the three warnings that PR introduced. `CLOUD_PROTOCOL_CAPTURE_FAILURE` and the `CLOUD_PROTOCOL_UPLOAD_*` warnings all carry actionable guidance; `CLOUD_PROTOCOL_INITIALIZATION_FAILURE` carries none.

The guidance is also attached to the wrong branch for this particular failure. `unable to open database file` is thrown when the recording's SQLite database is opened beneath the OS temporary directory, which is captured as `captureMethod: 'beforeSpec'` and classified as an initialization error. So the one failure that is definitionally a disk-space or permissions problem on that directory gets the warning that never mentions the directory, while `prepareProtocol`'s `ensureDir` failure — which falls through to the capture warning — gets the full guidance.

This routes the existing recommendation to where it belongs, keyed off `captureMethod` rather than a heuristic on the error:

- Extracts the disk-space and directory block into a shared `testReplayDirectoryRecommendation()` partial, so the two warnings cannot drift apart.
- `CLOUD_PROTOCOL_INITIALIZATION_FAILURE` takes an optional `captureMethod` and includes the recommendation only for `beforeSpec`. `setupProtocol` and `getCaptureProtocolScript` keep the current copy — the latter is a network download, where disk advice would only mislead.
- The call site in `upload_artifacts.ts` passes the `captureMethod` it already holds.

No new error key is added, so `packages/data-context/schemas/schema.graphql` is unaffected.

### Steps to test

```bash
yarn workspace @packages/errors test-unit
yarn workspace @packages/errors check-ts
yarn workspace @packages/server check-ts
```

All three initialization branches are already covered by system tests, including the `beforeSpec` case via `system-tests/lib/protocol-stubs/protocolStubWithBeforeSpecError.ts`:

```bash
cd system-tests && node ./scripts/run.js --glob-in-dir="record_spec"
```

### How has the user experience changed?

Only `cypress run` with Test Replay recording to Cypress Cloud is affected, and only when the recording fails to start.

Before:

```
Warning: We encountered an error while initializing the Test Replay recording for this spec.

These results will not display Test Replay recordings.

This error will not affect or change the exit code.

SqliteError: unable to open database file
```

After:

```
Warning: We encountered an error while initializing the Test Replay recording for this spec.

These results will not display Test Replay recordings.

This can happen for many reasons. If this problem persists:

- Try increasing the available disk space.
- Ensure that /tmp/cypress/protocol is both readable and writable.

This error will not affect or change the exit code.

SqliteError: unable to open database file
```

Initialization failures that are not filesystem-related (a capture script that fails to download or instantiate) are unchanged.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No public issue; this is a message-only change surfaced by a support investigation. -->
- [x] Have tests been added/updated? <!-- New `beforeSpec` variant in the visual snapshot spec, plus the updated `record_spec` system-test snapshot. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7mpfwEHpDcLMNojjtaBrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7mpfwEHpDcLMNojjtaBrQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warning text only; no API, GraphQL, or recording logic changes beyond routing existing guidance to the correct failure path.
> 
> **Overview**
> When Test Replay fails during **`beforeSpec`** initialization (e.g. SQLite `unable to open database file`), Cypress now appends the same actionable guidance already shown for capture failures: increase disk space and verify the temp protocol directory under `os.tmpdir()/cypress/protocol` is readable and writable.
> 
> The recommendation is extracted into **`testReplayDirectoryRecommendation()`** and reused by **`CLOUD_PROTOCOL_CAPTURE_FAILURE`**. **`CLOUD_PROTOCOL_INITIALIZATION_FAILURE`** accepts an optional **`captureMethod`** and only includes that block for **`beforeSpec`**, so non-filesystem init steps (e.g. capture script download) stay unchanged. **`upload_artifacts.ts`** passes through the fatal error’s **`captureMethod`**. Changelog, error snapshot tests, and **`record_spec`** system-test output are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9a7d2d82e699bf42c0ca35a62a30c550930cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->