### PR TITLE
refactor: replace runtime requires with imports in electron, runner, reporter

### DIFF
--- a/packages/electron/src/install.ts
+++ b/packages/electron/src/install.ts
@@ -15,6 +15,7 @@ import { pipeline } from 'stream/promises'
 import crypto from 'crypto'
 import { flipFuses, FuseVersion, FuseV1Options } from '@electron/fuses'
 import { move, remove } from 'fs-extra'
+import * as cyIcons from '@packages/icons'
 // @ts-ignore
 import pkg from '@packages/root'
 
@@ -34,7 +35,7 @@ export function getElectronVersion () {
 // returns icons package so that the caller code can find
 // paths to the icons without hard-coding them
 export const icons = () => {
-  return require('@packages/icons')
+  return cyIcons
 }
 
 function checkCurrentVersion (pathToVersion: string) {
@@ -69,7 +70,7 @@ async function checkIconVersion (platform: string) {
     return
   }
 
-  const mainIconsPath = icons().getPathToIcon('cypress.icns')
+  const mainIconsPath = cyIcons.getPathToIcon('cypress.icns')
   const cachedIconsPath = getPathToResources('electron.icns')
 
   const [mainHash, cachedHash] = await Promise.all(
@@ -161,9 +162,8 @@ async function pkgElectronApp (
   const e = 'electron'
   const p = 'packager'
   const pkgr = require(`@${e}/${p}`)
-  const icons = require('@packages/icons')
 
-  const iconPath = icons.getPathToIcon('cypress')
+  const iconPath = cyIcons.getPathToIcon('cypress')
 
   debug('package icon', iconPath)
 

--- a/packages/electron/test/install.spec.ts
+++ b/packages/electron/test/install.spec.ts
@@ -105,7 +105,7 @@ vi.mock('@electron/fuses', () => {
   }
 })
 
-import { check, ensure } from '../src/install'
+import { check, ensure, icons } from '../src/install'
 
 describe('install', () => {
   // the only paths `getFileHash` can read, mapped to their contents
@@ -146,6 +146,20 @@ describe('install', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  describe('icons', () => {
+    it('hands callers the path helpers from the icons package', () => {
+      expect(icons()).toEqual(expect.objectContaining({
+        getPathToIcon: expect.any(Function),
+        getPathToFavicon: expect.any(Function),
+        getPathToLogo: expect.any(Function),
+      }))
+    })
+
+    it('resolves icon paths to the same location as the icons package', () => {
+      expect(icons().getPathToIcon('cypress.icns')).toBe(getPathToIcon('cypress.icns'))
+    })
   })
 
   describe('ensure', () => {

--- a/packages/electron/test/install.spec.ts
+++ b/packages/electron/test/install.spec.ts
@@ -277,6 +277,7 @@ describe('install', () => {
         electronVersion: ELECTRON_VERSION,
         platform: 'linux',
         arch: 'x64',
+        icon: getPathToIcon('cypress'),
       }))
 
       expect(exit).toHaveBeenCalled()

--- a/packages/reporter/cypress.config.ts
+++ b/packages/reporter/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress'
+import express from 'express'
 import webpackConfig from './webpack.config'
 import WP from '../../npm/webpack-preprocessor'
 
@@ -18,8 +19,6 @@ export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:5006',
     setupNodeEvents (on, config) {
-      const express = require('express')
-
       express().use(express.static('dist')).listen(5006)
 
       on('file:preprocessor', WP({

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -33,6 +33,7 @@
     "cross-env": "7.0.3",
     "cypress-multi-reporters": "1.4.0",
     "cypress-real-events": "1.15.0",
+    "express": "4.21.0",
     "lodash": "^4.17.21",
     "markdown-it": "^14.0.0",
     "mobx": "6.13.6",

--- a/packages/runner/webpack.config.ts
+++ b/packages/runner/webpack.config.ts
@@ -82,7 +82,7 @@ const crossOriginInjectionConfig: webpack.Configuration = {
 export default async function () {
   await waitUntilIconsBuilt()
 
-  const cyIcons = require('@packages/icons')
+  const cyIcons = await import('@packages/icons')
 
   mainConfig.plugins = [
     // @ts-ignore


### PR DESCRIPTION
- Closes N/A — no associated issue. This is a mechanical step in the ongoing TypeScript migration, for which the contributing guide does not require one.

### Additional details

Replaces three runtime `require()` calls with static imports.

**`@packages/electron`** — `src/install.ts` had two `require('@packages/icons')` calls, one of them inside the exported `icons()` accessor that both `scripts/binary/build.ts` and `src/electron.ts` call through. Both are replaced by a single `import * as cyIcons from '@packages/icons'`, and `icons()` keeps its public shape (it now returns `cyIcons`). The local `const icons = require(...)` inside `pkgElectronApp` was also shadowing the module-level export; that shadowing is gone.

The `` require(`@${e}/${p}`) `` for `@electron/packager` is deliberately left alone — the NOTE above it explains it is obfuscated so `mksnapshot` cannot discover it, and `test/install.spec.ts` seeds Node's module cache through `createRequire` to mock it.

**`@packages/runner`** — `webpack.config.ts` uses `await import('@packages/icons')` rather than a top-level import. `@packages/icons`'s `index.js` is a gitignored build artifact, and the require deliberately sits after `await waitUntilIconsBuilt()` because `yarn dev` builds icons concurrently with the runner bundle. A static import would resolve at config-load time and could fail before icons has emitted. Under `module: commonjs` this downlevels to a deferred `require`, preserving the existing laziness.

**`@packages/reporter`** — `cypress.config.ts` hoists `express` to a top-level import. `express` was not declared in the package and resolved only by hoisting from the root, so it is now declared as a devDependency, pinned to `4.21.0` — the version the workspace already resolves and the pin used by most first-party packages. `yarn install --frozen-lockfile` passes and `yarn.lock` is byte-identical.

Two test gaps on the touched code were found and closed:

- The packager assertion checked `name`/`electronVersion`/`platform`/`arch` but not `icon`, so the icon path in `pkgElectronApp` was executed without ever being verified — swapping it for an unrelated path left all tests green.
- `icons()` had no direct test at all; stubbing it to return an empty object left the suite green.

On V8 snapshot impact, since this makes an import in `install.ts` eager: `./packages/electron/dist/install.js` and `./packages/icons/index.js` are both already listed as `deferred` in the `snapshot-meta.json` for all three platforms, so neither is initialized at snapshot time. The metadata's `deferredHashFile` is `yarn.lock`, whose hash is unchanged.

### Steps to test

No behavior change is intended, so this is covered by existing automation:

- `yarn workspace @packages/electron test` — 53 passing.
- `yarn workspace @packages/electron lint`, `yarn workspace @packages/reporter lint`, `yarn workspace @packages/runner check-ts` — clean.
- `yarn workspace @packages/reporter check-ts` — unchanged from before this branch (one pre-existing `cypress/react` error).

The reporter's express server is exercised indirectly by the reporter e2e suite, where every spec does `cy.visit('/')` against `baseUrl: http://localhost:5006`.

Verified on Linux x64 only; the macOS and Windows unit jobs have not been run against this branch.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical migration change; explained above. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No API change. -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gc4SNkEXTcn68JurHoQRMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc4SNkEXTcn68JurHoQRMf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only dependency loading and an explicit express devDependency; electron packager obfuscation and deferred icon loading behavior are preserved.
> 
> **Overview**
> Mechanical TypeScript migration: **runtime `require()` calls are replaced with static or dynamic imports** in three packages, with no intended behavior change.
> 
> **`@packages/electron`** — `@packages/icons` is loaded once via `import * as cyIcons`; the exported `icons()` accessor still exposes the same helpers, and packaging/icon checks use `cyIcons` directly (removing a shadowing inner `require`). The obfuscated dynamic `require` for `@electron/packager` is unchanged.
> 
> **`@packages/runner`** — After `waitUntilIconsBuilt()`, icons are loaded with **`await import('@packages/icons')`** so favicon copy still runs only once icons are built (avoids eager resolution at config load).
> 
> **`@packages/reporter`** — **`express` is a top-level import** in `cypress.config.ts` and is declared as a **pinned devDependency** (`4.21.0`) instead of relying on workspace hoisting.
> 
> Tests add coverage for **`icons()`** and assert the **packager `icon` path** when re-packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215bc2568271af26558513c4bb270efeca787f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->