### PR TITLE
chore: register the Cypress AI Toolkit plugin for Claude Code

### DIFF
--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -152,7 +152,7 @@ while IFS= read -r file; do
     .percy.yml|.releaserc.js|renovate.json|docker-compose.yml|lerna.json|\
     electron-builder.json|knip.json|nx.json|jsconfig.json|autobarrel.json|\
     mocha-reporter-config.json|apollo.config.js|\
-    .husky/*|.vscode/*|.cursor/*|__snapshots__/*)
+    .husky/*|.vscode/*|.cursor/*|.claude/*|__snapshots__/*)
       ;;
     packages/driver/*)
       driver_tests=true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "cypress": {
+      "source": {
+        "source": "github",
+        "repo": "cypress-io/ai-toolkit"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "cypress@cypress": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -411,6 +411,7 @@ system-tests/lib/validations
 settings.local.json
 
 .claude/*
+!.claude/settings.json
 
 # chunk active sidecar tracking
 .chunk/sidecar.json


### PR DESCRIPTION
- Closes N/A

### Additional details

Registers the [`cypress-io/ai-toolkit`](https://github.com/cypress-io/ai-toolkit) marketplace and enables its `cypress` plugin (currently v1.3.0) for anyone working in this repo with Claude Code. The plugin bundles the `cypress-author`, `cypress-explain`, `cypress-docs`, `cypress-tap` and `cypress-cloud-cli` skills plus the Cypress Cloud MCP server.

**Why `.gitignore` had to change:** `.claude/*` was ignored with no exception, so no Claude Code project settings could be committed at all. The new negation mirrors the `.cursor/*` block four lines above, which already allowlists `.cursor/skills`. Only `settings.json` is allowlisted — `settings.local.json` and everything else under `.claude/` stay ignored, so personal overrides and scratch files remain private.

**Why project settings rather than a setup script:** declaring the plugin here is the documented route for it to reach [Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) sessions, where the interactive `/plugin` panel isn't available. It also covers local checkouts and needs no per-person setup.

**Known wrinkle:** since Claude Code v2.1.195, a plugin that only project settings enable, coming from an external source such as a GitHub repo, does not auto-install. Contributors will see it reported as not installed alongside the `claude plugin install` command to run. The marketplace registration itself does land automatically once the repo folder is trusted.

The marketplace tracks the toolkit's default branch. The toolkit's tags are inconsistently named (`1.3.0` alongside `v1.2.0`), which makes a pin easy to leave stale — but a `ref` can be added to the source entry if we'd rather freeze a version.

### Steps to test

1. Check out this branch in Claude Code and trust the folder when prompted.
2. Run `/plugin` and open the **Marketplaces** tab — `cypress` should be listed, sourced from `cypress-io/ai-toolkit`.
3. In the **Installed** tab, confirm `cypress@cypress` is enabled, or run the `claude plugin install` command Claude Code reports (see the wrinkle above).
4. Confirm `git status` is clean, and that `.claude/settings.local.json` is still ignored while `.claude/settings.json` is tracked.

### How has the user experience changed?

No change. This affects the contributor tooling experience only — nothing in the shipped Cypress binary, CLI, or any published package.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Contributor-tooling config only; no product code changes. -->
- [na] Have tests been added/updated? <!-- Config and .gitignore only; no runtime code to test. Verified by hand: JSON parses and matches the settings schema, and `git check-ignore` confirms settings.json is trackable while settings.local.json and other .claude/ paths stay ignored. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzuRogjUsnWsh7E8pUxUrN


---
_Generated by [Claude Code](https://claude.ai/code/session_01HzuRogjUsnWsh7E8pUxUrN)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-only IDE/Claude config and CI skip rules; no product runtime, auth, or published package behavior changes.
> 
> **Overview**
> Adds committed **Claude Code** project config so contributors get the **Cypress AI Toolkit** (`cypress-io/ai-toolkit`) marketplace and the enabled **`cypress@cypress`** plugin without per-person setup, including for Claude Code on the web.
> 
> **`.gitignore`** now allowlists **`.claude/settings.json`** (like the existing `.cursor/*` exceptions) so shared settings can be tracked while other `.claude/` paths and `settings.local.json` stay ignored.
> 
> **CircleCI path filtering** treats **`.claude/*`** as docs/metadata-only, so changes under `.claude/` do not flip on test jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd06f03e178965ce9ff8881873041c4b5f7a92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->