### PR TITLE
misc: add keystrokeDelay to ConfigOptions typings

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 **Misc:**
 
+- Fixed an issue where setting [`keystrokeDelay`](https://docs.cypress.io/app/references/configuration#Keyboard) in a TypeScript configuration file failed to compile with `'keystrokeDelay' does not exist in type 'ConfigOptions'`, even though Cypress read and validated the option at runtime. Fixes [#34796](https://github.com/cypress-io/cypress/issues/34796).
 - When a Test Replay recording fails while being prepared for a spec during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#34763](https://github.com/cypress-io/cypress/pull/34763).
 
 ## 16.0.0

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 **Misc:**
 
-- Fixed an issue where setting [`keystrokeDelay`](https://docs.cypress.io/app/references/configuration#Keyboard) in a TypeScript configuration file failed to compile with `'keystrokeDelay' does not exist in type 'ConfigOptions'`, even though Cypress read and validated the option at runtime. Fixes [#34796](https://github.com/cypress-io/cypress/issues/34796).
+- Fixed an issue where setting [`keystrokeDelay`](https://docs.cypress.io/app/references/configuration#Keyboard) in a TypeScript configuration file failed to compile with `'keystrokeDelay' does not exist in type 'ConfigOptions'`, even though Cypress read and validated the option at runtime. Fixes [#34796](https://github.com/cypress-io/cypress/issues/34796). Addressed in [#34798](https://github.com/cypress-io/cypress/pull/34798).
 - When a Test Replay recording fails while being prepared for a spec during `cypress run`, Cypress now recommends increasing available disk space and confirming that the temporary directory used for Test Replay recordings is readable and writable, instead of printing only the underlying error such as `SqliteError: unable to open database file`. Addressed in [#34763](https://github.com/cypress-io/cypress/pull/34763).
 
 ## 16.0.0

--- a/cli/types/cypress.d.ts
+++ b/cli/types/cypress.d.ts
@@ -3196,6 +3196,12 @@ declare namespace Cypress {
      */
     scrollBehavior: scrollBehaviorOptions
     /**
+     * Time, in milliseconds, between each keystroke when typing with [cy.type()](https://on.cypress.io/type).
+     * When `null`, the value set with [Cypress.Keyboard.defaults()](https://on.cypress.io/keyboard-api) is used, falling back to `0`.
+     * @default null
+     */
+    keystrokeDelay: number | null
+    /**
      * Indicates whether Cypress should allow CSP header directives from the application under test.
      * - When this option is set to `false`, Cypress will strip the entire CSP header.
      * - When this option is set to `true`, Cypress will only to strip directives that would interfere

--- a/cli/types/tests/cypress-npm-api-test.ts
+++ b/cli/types/tests/cypress-npm-api-test.ts
@@ -47,7 +47,16 @@ cypress.run().then(results => {
 })
 
 const config = defineConfig({
-  modifyObstructiveCode: true
+  modifyObstructiveCode: true,
+  keystrokeDelay: 10
+})
+
+const configWithUnsetKeystrokeDelay = defineConfig({
+  keystrokeDelay: null
+})
+
+const configWithInvalidKeystrokeDelay = defineConfig({
+  keystrokeDelay: false // $ExpectError
 })
 
 const solid = {

--- a/cli/types/tests/cypress-tests.ts
+++ b/cli/types/tests/cypress-tests.ts
@@ -44,6 +44,7 @@ namespace CypressConfigTests {
 
   Cypress.config('taskTimeout') // $ExpectType number
   Cypress.config('includeShadowDom') // $ExpectType boolean
+  Cypress.config('keystrokeDelay') // $ExpectType number | null
 }
 
 namespace CypressEnvTests {


### PR DESCRIPTION
- Closes [#34796](https://github.com/cypress-io/cypress/issues/34796)

### Additional details

`keystrokeDelay` is a real root configuration option — it is declared in [`packages/config/src/options.ts`](https://github.com/cypress-io/cypress/blob/develop/packages/config/src/options.ts) with `overrideLevel: 'any'` and validated with `isNumberOrFalse` — but it was never added to `ResolvedConfigOptions` in `cli/types/cypress.d.ts`. The same config that works in `cypress.config.js` therefore fails to compile in `cypress.config.ts`:

```
error TS2353: Object literal may only specify known properties,
and 'keystrokeDelay' does not exist in type 'ConfigOptions<any>'.
```

That header comment in `options.ts` lists "Add the type definition to `/cli/types/cypress.d.ts`" as a required step when adding an option; this one slipped through.

This matters more in 16 than it used to. #33523 changed the `.type()` default from 10ms to 0ms, and both the changelog and the docs point upgraders at `keystrokeDelay` as the way to opt back into the previous behavior — so TypeScript users are directed at an option they cannot set where the docs say to set it.

**On the type chosen.** The issue suggests `number | false`. I used `number | null` instead:

- `false` passes config validation, but `cy.type()` re-validates in [`type.ts`](https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/cy/commands/actions/type.ts) and throws `invalid_per_test_delay` on every typing command, so `number | false` would advertise a value that is guaranteed to break at runtime. The existing type tests already treat `keystrokeDelay: false` as `$ExpectError` in three places (`SuiteConfigOverrides`, `TestConfigOverrides`, `Cypress.Keyboard.defaults()`), so excluding it is also the consistent choice.
- `null` is the actual default and is meaningful: it is what makes the documented precedence work — configuration file, then `Cypress.Keyboard.defaults()`, falling back to `0`. Typing it as plain `number` would mislead anyone reading the value back with `Cypress.config('keystrokeDelay')`, which genuinely returns `null` when unset.

Scoped to `ResolvedConfigOptions` only. `SuiteConfigOverrides` and `TestConfigOverrides` already declare `keystrokeDelay?: number` and are left untouched, so per-test and per-suite override types are unchanged.

No runtime code changed — this is a types-only gap.

### Steps to test

Covered by the `dtslint` suite (`cd cli && yarn types`), which is green on this branch. The added assertions were each verified to be load-bearing by deliberately breaking them:

- Reverting only the `cypress.d.ts` change reproduces the exact error from the issue: `'keystrokeDelay' does not exist in type 'ConfigOptions<any>'`
- Changing `$ExpectType number | null` to `number` fails with the real resolved type
- Removing the `$ExpectError` on `keystrokeDelay: false` fails to compile

To reproduce manually, in any TypeScript Cypress project:

```ts
// cypress.config.ts
import { defineConfig } from 'cypress'

export default defineConfig({
  keystrokeDelay: 10,
})
```

`tsc --noEmit` errors on `develop` and compiles on this branch.

### How has the user experience changed?

No visual or behavioral change. TypeScript users can now set `keystrokeDelay` in their configuration file without a compile error, and without the workarounds the issue describes (locally augmenting `Cypress.ResolvedConfigOptions`, or moving the value into a support file via `Cypress.Keyboard.defaults()`, which is the lower-precedence path).

### PR Tasks

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- #34796 is open and triaged by the team with `type: typings` and `v16.0.0 🐛` labels -->
- [x] Have tests been added/updated? <!-- dtslint assertions in cli/types/tests/ -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- The configuration reference already documents keystrokeDelay under Keyboard, including its precedence; this PR brings the typings in line with the existing docs rather than changing documented behavior. -->
- [x] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- This is the change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BsMvK6pq3BGp1XBFNCYc4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsMvK6pq3BGp1XBFNCYc4v)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Types-only and changelog update; no runtime or config validation changes.
> 
> **Overview**
> **Adds `keystrokeDelay` to Cypress TypeScript config types** so `defineConfig({ keystrokeDelay: … })` and `Cypress.config('keystrokeDelay')` type-check. The option already worked at runtime but was missing from `ResolvedConfigOptions`, which caused TS2353 in `cypress.config.ts`.
> 
> The new field is typed as **`number | null`** (default `null` for the documented precedence: config → `Cypress.Keyboard.defaults()` → `0`). **dtslint** coverage was extended for valid values and to reject `false` in `defineConfig`.
> 
> The **16.0.1 changelog** notes the fix for [#34796]. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b931776bdf0627f752d639f5727fb866006fa7ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->