### PR TITLE
chore: Skip cy.prompt bundle download in run mode when no project is configured

### DIFF
--- a/packages/server/lib/project-base.ts
+++ b/packages/server/lib/project-base.ts
@@ -173,13 +173,21 @@ export class ProjectBase extends EE {
 
     this._server = new ServerBase(cfg)
 
-    new CyPromptLifecycleManager().initializeCyPromptManager({
-      cloudDataSource: this.ctx.cloud,
-      ctx: this.ctx,
-      record: this.options.record,
-      key: this.options.key,
-      projectId: cfg.projectId,
-    })
+    const isSimulatedOpenMode = !!process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE
+
+    // cy.prompt requires both an authenticated user and a projectId. In open mode
+    // the user can still log in or add a projectId to their config, so we download
+    // the bundle eagerly. A run's config is fixed, so without a projectId there is
+    // no way to reach a usable state and downloading the bundle is wasted work.
+    if (!cfg.isTextTerminal || isSimulatedOpenMode || cfg.projectId || process.env.CYPRESS_LOCAL_CY_PROMPT_PATH) {
+      new CyPromptLifecycleManager().initializeCyPromptManager({
+        cloudDataSource: this.ctx.cloud,
+        ctx: this.ctx,
+        record: this.options.record,
+        key: this.options.key,
+        projectId: cfg.projectId,
+      })
+    }
 
     if ((!cfg.isTextTerminal || process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE) && this.testingType === 'e2e') {
       const studioLifecycleManager = new StudioLifecycleManager()

--- a/packages/server/lib/socket-base.ts
+++ b/packages/server/lib/socket-base.ts
@@ -585,8 +585,16 @@ export class SocketBase implements SocketBroadcaster {
                 })
               case 'close:extra:targets':
                 return options.closeExtraTargets()
-              case 'wait:for:prompt:ready':
-                return getCtx().coreData.cyPromptLifecycleManager?.getCyPrompt().then(async (cyPrompt) => {
+              case 'wait:for:prompt:ready': {
+                const cyPromptLifecycleManager = getCtx().coreData.cyPromptLifecycleManager
+
+                // The manager is not initialized when cy.prompt cannot possibly
+                // run, so report it as unavailable rather than returning nothing.
+                if (!cyPromptLifecycleManager) {
+                  return { success: false }
+                }
+
+                return cyPromptLifecycleManager.getCyPrompt().then(async (cyPrompt) => {
                   if (cyPrompt.cyPromptManager) {
                     await options.onCyPromptReady(cyPrompt.cyPromptManager)
                   }
@@ -596,6 +604,7 @@ export class SocketBase implements SocketBroadcaster {
                     error: cyPrompt.error ? errors.cloneErr(cyPrompt.error) : undefined,
                   }
                 })
+              }
               default:
                 throw new Error(`You requested a backend event we cannot handle: ${eventName}`)
             }

--- a/packages/server/test/unit/project-base_spec.ts
+++ b/packages/server/test/unit/project-base_spec.ts
@@ -580,6 +580,76 @@ This option will not have an effect in Some-other-name. Tests that rely on web s
           })
         })
       })
+
+      it('initializes cy prompt lifecycle manager in open mode without a projectId', function () {
+        this.config.projectId = undefined
+        this.config.isTextTerminal = false
+
+        initializeCyPromptManagerStub = sinon.stub(CyPromptLifecycleManager.prototype, 'initializeCyPromptManager')
+
+        return this.project.open()
+        .then(() => {
+          expect(initializeCyPromptManagerStub).to.be.called
+        })
+      })
+
+      it('does not initialize cy prompt lifecycle manager in run mode without a projectId', function () {
+        this.config.projectId = undefined
+        this.config.isTextTerminal = true
+
+        initializeCyPromptManagerStub = sinon.stub(CyPromptLifecycleManager.prototype, 'initializeCyPromptManager')
+
+        return this.project.open()
+        .then(() => {
+          expect(initializeCyPromptManagerStub).not.to.be.called
+        })
+      })
+
+      it('does not initialize cy prompt lifecycle manager when recording without a projectId', function () {
+        this.config.projectId = undefined
+        this.config.isTextTerminal = true
+        this.project.options.record = true
+        this.project.options.key = '123e4567-e89b-12d3-a456-426614174000'
+
+        initializeCyPromptManagerStub = sinon.stub(CyPromptLifecycleManager.prototype, 'initializeCyPromptManager')
+
+        return this.project.open()
+        .then(() => {
+          expect(initializeCyPromptManagerStub).not.to.be.called
+        })
+      })
+
+      it('initializes cy prompt lifecycle manager in run mode without a projectId when simulating open mode', function () {
+        this.config.projectId = undefined
+        this.config.isTextTerminal = true
+        process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE = '1'
+
+        initializeCyPromptManagerStub = sinon.stub(CyPromptLifecycleManager.prototype, 'initializeCyPromptManager')
+
+        return this.project.open()
+        .then(() => {
+          expect(initializeCyPromptManagerStub).to.be.called
+        })
+        .finally(() => {
+          delete process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE
+        })
+      })
+
+      it('initializes cy prompt lifecycle manager in run mode without a projectId when the bundle is local', function () {
+        this.config.projectId = undefined
+        this.config.isTextTerminal = true
+        process.env.CYPRESS_LOCAL_CY_PROMPT_PATH = '/path/to/cy-prompt'
+
+        initializeCyPromptManagerStub = sinon.stub(CyPromptLifecycleManager.prototype, 'initializeCyPromptManager')
+
+        return this.project.open()
+        .then(() => {
+          expect(initializeCyPromptManagerStub).to.be.called
+        })
+        .finally(() => {
+          delete process.env.CYPRESS_LOCAL_CY_PROMPT_PATH
+        })
+      })
     })
 
     describe('saved state', function () {

--- a/packages/server/test/unit/socket_spec.ts
+++ b/packages/server/test/unit/socket_spec.ts
@@ -361,6 +361,16 @@ describe('lib/socket', () => {
           return done()
         })
       })
+
+      it('returns false if the cy prompt lifecycle manager was never initialized', function (done) {
+        ctx.coreData.cyPromptLifecycleManager = undefined
+
+        return this.client.emit('backend:request', 'wait:for:prompt:ready', (resp) => {
+          expect(resp.response).to.deep.eq({ success: false })
+
+          return done()
+        })
+      })
     })
 
     describe('on(get:app:state)', () => {


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes https://cypress-io.atlassian.net/browse/RAP-303

### Additional details

A lot of the Sentry errors we get are errors with downloading the cy.prompt bundle. It is possible these errors are happening in a system not set up to run cy.prompt. We are currently always downloading the bundle in case users are on open mode and get their set up ready to run cy.prompt by logging in/adding their projectSlug to their config but if the user is recording a run this scenario is impossible so we shouldn’t try and download the cy.prompt bundle.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to when cy.prompt initializes; open mode and runs with a project ID are unchanged, with explicit handling when prompt is unavailable.
> 
> **Overview**
> **Skips eager cy.prompt bundle setup in headless runs** when there is no `projectId`, since run config cannot gain a project mid-run and downloading the bundle only adds noise (e.g. Sentry errors).
> 
> `ProjectBase.open()` now calls `CyPromptLifecycleManager.initializeCyPromptManager` only when interactive/open (`!isTextTerminal`), when `CYPRESS_INTERNAL_SIMULATE_OPEN_MODE` or `CYPRESS_LOCAL_CY_PROMPT_PATH` is set, or when `projectId` is present. Open mode still initializes without a project ID so users can log in or add a project later.
> 
> The `wait:for:prompt:ready` backend handler returns `{ success: false }` when the lifecycle manager was never created, instead of leaving callers without a clear unavailable signal. Unit tests cover run vs open, recording without project ID, simulate-open and local-bundle exceptions, and the socket path when the manager is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b411649c8019d13607f5d00e72c63fa6386957e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



### Steps to test

- Do a Cypress run without a project ID set up and `DEBUG=cypress:server:cy-prompt-lifecycle-manager,cypress:server:cloud:bundles:*` set
- Check the debug logs. Ensure you do **not** see `cypress:server:cy-prompt-lifecycle-manager` or `cypress:server:cloud:bundles:ensure-signed-bundle` logs at all.

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. -->
- [x] Have tests been added/updated?
- [N/A] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [N/A] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?
