### PR TITLE
chore: document why packages/electron/app/index.js exists

### DIFF
--- a/packages/electron/AGENTS.md
+++ b/packages/electron/AGENTS.md
@@ -32,7 +32,8 @@ src/
   paths.ts             Resolves paths to the Electron binary and resources
   print-node-version.ts  Utility to print Node.js version bundled in Electron
 app/
-  index.js             Minimal Electron `main` process entry injected into the packaged app
+  index.js             Comment-only stub; satisfies `@electron/packager`'s entry-point check
+  package.json         Empty manifest; marks this as the app dir `@electron/packager` packages
 bin/
   cypress-electron     CLI script: delegates to install or open based on arguments
 ```
@@ -42,6 +43,7 @@ bin/
 - After `yarn install`, this package requires an explicit `yarn build` before it is usable — the `postinstall` script prints a reminder but does not build automatically.
 - The `build:esm` target exists but is not part of the default `build` target for daily use; it is available for testing ESM compatibility.
 - `@electron/fuses` is used to set Electron security fuses (e.g., disabling Node.js integration in renderers) during binary packaging.
+- `app/` is a placeholder, not a runnable app, and neither file in it may be deleted. `install.ts` passes it to `@electron/packager` as `dir: 'app'`, which resolves against the cwd — so `build-binary` has to be run from this package's root, as `yarn workspace` does. The packager's `validateElectronApp` then requires both a `package.json` and the `main` it names; since that manifest declares no `main`, the entry point it looks for is exactly `index.js`. Both are stubs on purpose — nothing in `app/` ever executes, because `packageAndExit()` deletes the packaged `resources/app` right after packaging and `open()` symlinks the real app over that path at launch.
 
 ## Integration Points
 

--- a/packages/electron/app/index.js
+++ b/packages/electron/app/index.js
@@ -1,0 +1,5 @@
+// `@electron/packager` refuses to package an app directory whose `main` entry
+// point is missing, and the sibling `package.json` declares no `main`, so it
+// looks for this exact filename. Nothing here is ever executed: `packageAndExit`
+// deletes the packaged `resources/app` as soon as packaging finishes, and `open`
+// symlinks the real Cypress app over that path at launch.


### PR DESCRIPTION
- Closes N/A

### Additional details

`packages/electron/app/index.js` was zero bytes, and nothing in the repo referenced it — no source, tests, build scripts, or CI. It read as dead weight left behind by an old refactor. It is not.

`install.ts` points `@electron/packager` at the directory with `dir: 'app'`, and the packager's `validateElectronApp` (`platform.js:126`) rejects an app directory whose `main` entry point is missing. `app/package.json` is `{}` and declares no `main`, so the filename the packager looks for is exactly `index.js`.

Deleting it fails `yarn workspace @packages/electron build-binary` — and with it the root `yarn build` and the CI binary job — on `The main entry point to your app was not found`. Confirmed by calling the validator directly against the real directory:

```
index.js present=true:  PACKAGING OK
index.js present=false: THROWS -> The main entry point to your app was not
                        found. Make sure "app/index.js" exists ...
```

Nothing in `app/` ever executes, which is why the emptiness looked suspicious in the first place: `packageAndExit()` removes the packaged `resources/app` as soon as packaging finishes, and `open()` symlinks the real Cypress app over that path at launch. For the distributed binary, `scripts/binary/meta.ts` copies the real app into the same location.

So the stub stays, and now says why. This adds a five-line comment to `index.js` explaining the packager precondition and why the file never runs.

A `.ts` stub was considered and ruled out: the tsconfigs include only `src`, `lib`, `bin` and `test`, and both build targets emit to `dist/`, so a file in `app/` is never compiled and could not emit next to itself.

This also corrects `packages/electron/AGENTS.md`, which described the file as a "Minimal Electron `main` process entry injected into the packaged app". That description is what makes the file look either broken or deletable, and it is neither. The Gotchas section now records the packager coupling.

No production code paths change — the only `.js` change is a comment, in a file that is never loaded.

### Steps to test

No behavior to test. Verified locally on the branch:

- `yarn workspace @packages/electron build` — passes
- `yarn lint --scope @packages/electron` — 0 errors (1 pre-existing warning in `test/open.spec.ts`, unrelated)
- `yarn workspace @packages/electron test` — 53 tests across 3 files pass

To confirm the finding independently, delete `packages/electron/app/index.js` and run `yarn workspace @packages/electron build-binary`; it fails with the error quoted above.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical change: a code comment and a docs correction, no behavior change. -->
- [na] Have tests been added/updated? <!-- Comment-only change; the package's existing 53 unit tests still pass. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvRAb6ggkWjPTym6UU5B1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvRAb6ggkWjPTym6UU5B1a)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation only; no runtime or build logic changes.
> 
> **Overview**
> Documents why the empty-looking **`packages/electron/app/`** stubs must stay, so they are not mistaken for dead code or removed.
> 
> **`app/index.js`** gains a short comment-only explanation: `@electron/packager` requires a `main` entry (`index.js` when `package.json` has no `main`), but that file never runs because packaging strips `resources/app` and launch symlinks the real Cypress app in.
> 
> **`AGENTS.md`** is corrected to describe `index.js` and `package.json` as packager placeholders (not a real Electron main), and adds a Gotchas note on `dir: 'app'`, `validateElectronApp`, and the `build-binary` cwd requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d471ce641939d3280f3ee54e5ba9bc249117ded5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->