### PR TITLE
test: convert the driver support and plugin files to TypeScript

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -259,8 +259,8 @@
       "entry": [
         "src/main.ts",
         "src/cypress/commands.ts",
-        "cypress/plugins/server.js",
-        "cypress/plugins/index.js",
+        "cypress/plugins/server.ts",
+        "cypress/plugins/index.ts",
         "cypress.config.ts",
         "cypress/**/*.{ts,tsx,js,jsx}"
       ],

--- a/packages/driver/cypress/e2e/e2e/origin/snapshots.cy.ts
+++ b/packages/driver/cypress/e2e/e2e/origin/snapshots.cy.ts
@@ -30,7 +30,7 @@ describe('cy.origin - snapshots', { browser: '!webkit' }, () => {
     cy.get('a[data-cy="xhr-fetch-requests-onload"]').click()
 
     cy.origin('http://www.foobar.com:3500', () => {
-      // need to set isInteractive in the spec bridge in order to take snapshots in run mode, similar to how isInteractive is set within support/defaults.js
+      // need to set isInteractive in the spec bridge in order to take snapshots in run mode, similar to how isInteractive is set within support/defaults.ts
       // @ts-ignore
       Cypress.config('isInteractive', true)
       cy.get(`[data-cy="assertion-header"]`)
@@ -86,7 +86,7 @@ describe('cy.origin - snapshots', { browser: '!webkit' }, () => {
     // TODO: fix failing test: https://github.com/cypress-io/cypress/issues/23840
     // it.skip('verifies XHR requests made while a secondary origin is active eventually update with snapshots of the secondary origin', () => {
     //   cy.origin('http://www.foobar.com:3500', () => {
-    //     // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.js
+    //     // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.ts
     //     // @ts-ignore
     //     Cypress.config('isInteractive', true)
     //     cy.visit('http://www.foobar.com:3500/fixtures/xhr-fetch-requests.html')
@@ -112,7 +112,7 @@ describe('cy.origin - snapshots', { browser: '!webkit' }, () => {
     // // TODO: fix failing test: https://github.com/cypress-io/cypress/issues/23840
     // it.skip('verifies fetch requests made while a secondary origin is active eventually update with snapshots of the secondary origin', () => {
     //   cy.origin('http://www.foobar.com:3500', () => {
-    //     // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.js
+    //     // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.ts
     //     // @ts-ignore
     //     Cypress.config('isInteractive', true)
     //     cy.visit('http://www.foobar.com:3500/fixtures/xhr-fetch-requests.html')
@@ -158,7 +158,7 @@ describe('cy.origin - snapshots', { browser: '!webkit' }, () => {
       cy.task('log', 'test after visit')
 
       cy.origin('http://www.barbaz.com:3500', () => {
-        // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.js
+        // need to set isInteractive in the spec bridge in order to take xhr snapshots in run mode, similar to how isInteractive is set within support/defaults.ts
         // @ts-ignore
         Cypress.config('isInteractive', true)
 

--- a/packages/driver/cypress/plugins/index.ts
+++ b/packages/driver/cypress/plugins/index.ts
@@ -1,18 +1,18 @@
-// only required to read in webpack config, since it is .ts
-require('@packages/ts/register')
-require('./server')
-const _ = require('lodash')
-const path = require('path')
-const fs = require('fs-extra')
-const Promise = require('bluebird')
-const wp = require('@cypress/webpack-preprocessor')
-const Jimp = require('jimp')
-const webpackConfig = require('@packages/runner/webpack.config.ts')
+import './server'
+import _ from 'lodash'
+import path from 'path'
+import fs from 'fs-extra'
+import Promise from 'bluebird'
+import wp from '@cypress/webpack-preprocessor'
+import Jimp from 'jimp'
+
+// required rather than imported: @packages/runner's check-ts is tslint only, so importing
+// its webpack config would make this package's tsc run the only gate on that file and on
+// @packages/web-config's base config, under stricter options than either package uses
+const webpackConfig = require('@packages/runner/webpack.config')
 
 async function getWebpackOptions () {
-  const opts = await webpackConfig.default()
-
-  const webpackOptions = opts[0]
+  const webpackOptions = (await webpackConfig.default())[0]
 
   // set mode to development which overrides
   // the 'none' value of the base webpack config
@@ -34,10 +34,8 @@ async function getWebpackOptions () {
 
   return webpackOptions
 }
-/**
- * @type {Cypress.PluginConfig}
- */
-module.exports = async (on, config) => {
+
+const setupNodeEvents: Cypress.PluginConfig = async (on, config) => {
   const webpackOptions = await getWebpackOptions()
 
   on('file:preprocessor', wp({ webpackOptions }))
@@ -100,3 +98,5 @@ module.exports = async (on, config) => {
 
   return config
 }
+
+export = setupNodeEvents

--- a/packages/driver/cypress/plugins/server.ts
+++ b/packages/driver/cypress/plugins/server.ts
@@ -1,15 +1,29 @@
-const fs = require('fs-extra')
-const zlib = require('zlib')
-const auth = require('basic-auth')
-const bodyParser = require('body-parser')
-const express = require('express')
-const http = require('http')
+import fs from 'fs-extra'
+import zlib from 'zlib'
+import auth from 'basic-auth'
+import bodyParser from 'body-parser'
+import compression from 'compression'
+import cookieParser from 'cookie-parser'
+import cors from 'cors'
+import errorhandler from 'errorhandler'
+import express from 'express'
+import http from 'http'
+import methodOverride from 'method-override'
+import multer from 'multer'
+import path from 'path'
+import Promise from 'bluebird'
+import { authCreds } from '../fixtures/auth_creds'
+
+// required rather than imported: @packages/https-proxy leaves its test directory out
+// of type checking, so importing this helper would pull its latent type errors into
+// the driver's program
 const { create: createHttpsServer } = require('@packages/https-proxy/test/helpers/https_server')
-const path = require('path')
-const Promise = require('bluebird')
-const multer = require('multer')
+
 const upload = multer({ dest: 'cypress/_test-output/' })
-const { authCreds } = require('../fixtures/auth_creds')
+
+// express types `query` values as a union of string, array and nested object; these
+// fixture routes are only ever called with plain strings, so they read them as such
+type QueryRequest = express.Request<Record<string, string>, any, any, Record<string, string>>
 
 const PATH_TO_SERVER_PKG = path.dirname(require.resolve('@packages/server'))
 
@@ -27,13 +41,13 @@ const createApp = (port) => {
     res.end(req.method)
   })
 
-  app.use(require('cors')())
-  app.use(require('cookie-parser')())
-  app.use(require('compression')())
+  app.use(cors())
+  app.use(cookieParser())
+  app.use(compression())
   app.use(bodyParser.urlencoded({ extended: false }))
   app.use(bodyParser.json())
   app.use(bodyParser.raw())
-  app.use(require('method-override')())
+  app.use(methodOverride())
 
   app.head('/', (req, res) => {
     return res.sendStatus(200)
@@ -43,9 +57,9 @@ const createApp = (port) => {
     return res.send('<html><body>root page</body></html>')
   })
 
-  app.get('/timeout', (req, res) => {
+  app.get('/timeout', (req: QueryRequest, res) => {
     return Promise
-    .delay(req.query.ms || 0)
+    .delay(Number(req.query.ms) || 0)
     .then(() => {
       return res.send('<html><body>timeout</body></html>')
     })
@@ -64,15 +78,18 @@ const createApp = (port) => {
     .send('<html><body>hello there</body></html>')
   })
 
-  app.get('/status-code', (req, res) => {
+  app.get('/status-code', (req: QueryRequest, res) => {
     if (req.query.message) {
       res.statusMessage = req.query.message
     }
 
-    res.sendStatus(req.query.code || 200)
+    // deliberately uncoerced: express only strips the body headers when `statusCode` is
+    // the number 204 or 304, so a numeric code here would change the response the
+    // net_stubbing 204 spy (#8999) was written against
+    res.sendStatus((req.query.code || 200) as unknown as number)
   })
 
-  app.all('/redirect', (req, res) => {
+  app.all('/redirect', (req: QueryRequest, res) => {
     if (req.query.chunked) {
       res.setHeader('transfer-encoding', 'chunked')
       res.removeHeader('content-length')
@@ -143,7 +160,7 @@ const createApp = (port) => {
     .sendStatus(401)
   })
 
-  app.get('/json-content-type', (req, res) => {
+  app.get('/json-content-type', (req: QueryRequest, res) => {
     res.setHeader('content-type', req.query.contentType || 'application/json')
 
     return res.end('{}')
@@ -190,7 +207,10 @@ const createApp = (port) => {
   })
 
   app.all('/dump-form-data', upload.single('file'), (req, res) => {
-    return res.send(`<html><body>it worked!<br>request body:<br>${JSON.stringify(req.body)}<br>original name:<br>${req.file.originalname}</body></html>`)
+    // @types/multer is not installed, so the upload middleware's `req.file` is untyped
+    const { originalname } = (req as any).file
+
+    return res.send(`<html><body>it worked!<br>request body:<br>${JSON.stringify(req.body)}<br>original name:<br>${originalname}</body></html>`)
   })
 
   app.get('/status-404', (req, res) => {
@@ -205,7 +225,7 @@ const createApp = (port) => {
     .send('<html><body>server error</body></html>')
   })
 
-  app.get('/prelogin', (req, res) => {
+  app.get('/prelogin', (req: QueryRequest, res) => {
     const { redirect, override } = req.query
     let cookie = 'prelogin=true'
 
@@ -220,7 +240,7 @@ const createApp = (port) => {
     .redirect(302, redirect)
   })
 
-  app.get('/cookie-login', (req, res) => {
+  app.get('/cookie-login', (req: QueryRequest, res) => {
     const { cookie, localhostCookie, username, redirect } = req.query
 
     res
@@ -232,7 +252,7 @@ const createApp = (port) => {
     return req.cookies.user || req.cookies['__Host-user'] || req.cookies['__Secure-user']
   }
 
-  app.get('/verify-cookie-login', (req, res) => {
+  app.get('/verify-cookie-login', (req: QueryRequest, res) => {
     if (!getUserCookie(req)) {
       return res
       .send('<html><body><h1>Not logged in</h1></body></html>')
@@ -240,7 +260,7 @@ const createApp = (port) => {
 
     const { cookie, username, redirect } = req.query
 
-    res.send(`
+    return res.send(`
       <html>
         <body>
           <h1>Redirecting ${username}...</h1>
@@ -254,7 +274,7 @@ const createApp = (port) => {
     `)
   })
 
-  app.get('/login', (req, res) => {
+  app.get('/login', (req: QueryRequest, res) => {
     const { cookie, username } = req.query
 
     if (!username) {
@@ -267,7 +287,7 @@ const createApp = (port) => {
 
     const decodedCookie = decodeURIComponent(cookie)
 
-    res
+    return res
     .append('Set-Cookie', decodedCookie)
     .append('Set-Cookie', 'prelogin=verified')
     .redirect(302, '/welcome')
@@ -290,14 +310,14 @@ const createApp = (port) => {
       return res.send('<html><body><h1>Login not verified</h1></body></html>')
     }
 
-    res.send(`<html><body><h1>Welcome, ${user}!</h1></body></html>`)
+    return res.send(`<html><body><h1>Welcome, ${user}!</h1></body></html>`)
   })
 
   app.get('/test-request', (req, res) => {
     res.sendStatus(200)
   })
 
-  app.get('/set-cookie', (req, res) => {
+  app.get('/set-cookie', (req: QueryRequest, res) => {
     const { cookie } = req.query
 
     res
@@ -305,7 +325,7 @@ const createApp = (port) => {
     .sendStatus(200)
   })
 
-  app.get('/set-same-site-none-cookie-on-redirect', (req, res) => {
+  app.get('/set-same-site-none-cookie-on-redirect', (req: QueryRequest, res) => {
     const { redirect, cookie } = req.query
     const cookieDecoded = decodeURIComponent(cookie)
 
@@ -317,7 +337,7 @@ const createApp = (port) => {
   })
 
   app.get('/test-request-credentials', (req, res) => {
-    const { origin } = new URL(req.headers.referer)
+    const { origin } = new URL(req.headers.referer!)
 
     res
     .setHeader('Access-Control-Allow-Origin', origin)
@@ -325,9 +345,9 @@ const createApp = (port) => {
     .sendStatus(200)
   })
 
-  app.get('/set-cookie-credentials', (req, res) => {
+  app.get('/set-cookie-credentials', (req: QueryRequest, res) => {
     const { cookie } = req.query
-    const { origin } = new URL(req.headers.referer)
+    const { origin } = new URL(req.headers.referer!)
 
     res
     .setHeader('Access-Control-Allow-Origin', origin)
@@ -338,7 +358,7 @@ const createApp = (port) => {
 
   let _var = ''
 
-  app.get('/set-var', (req, res) => {
+  app.get('/set-var', (req: QueryRequest, res) => {
     _var = req.query.v
     res.sendStatus(200)
   })
@@ -464,14 +484,14 @@ const createApp = (port) => {
 
   app.use(express.static(path.join(__dirname, '..')))
 
-  app.use(require('errorhandler')())
+  app.use(errorhandler())
 
   return app
 }
 
 httpPorts.forEach((port) => {
   const app = createApp(port)
-  const server = http.Server(app)
+  const server = http.createServer(app)
 
   return server.listen(app.get('port'), () => {
     // eslint-disable-next-line no-console

--- a/packages/driver/cypress/support/defaults.ts
+++ b/packages/driver/cypress/support/defaults.ts
@@ -1,8 +1,6 @@
-const { $ } = Cypress
-
 const isActuallyInteractive = Cypress.config('isInteractive')
 
-window.top.__cySkipValidateConfig = true
+window.top!.__cySkipValidateConfig = true
 
 if (!isActuallyInteractive) {
   // we want to only enable retries in runMode
@@ -17,6 +15,7 @@ beforeEach(function () {
   // always set that we're interactive so we
   // get consistent passes and failures when running
   // from CI and when running in GUI mode
+  // @ts-expect-error - isInteractive is read-only to users, but the driver tests need it
   Cypress.config('isInteractive', true)
 
   if (!isActuallyInteractive) {
@@ -30,11 +29,11 @@ beforeEach(function () {
   // this could fail if this window
   // is a cross origin window
   try {
-    $(cy.state('window')).off()
+    Cypress.$(cy.state('window')).off()
   } catch (error) {} // eslint-disable-line no-empty
 
   // only want to run this as part of the privileged commands spec
-  if (cy.config('spec').baseName === 'privileged_commands.cy.ts') {
+  if (Cypress.spec.baseName === 'privileged_commands.cy.ts') {
     cy.visit('/fixtures/files-form.html')
 
     // it only needs to run once per spec run

--- a/packages/driver/cypress/support/e2e.js
+++ b/packages/driver/cypress/support/e2e.js
@@ -1,1 +1,0 @@
-require('./defaults')

--- a/packages/driver/cypress/support/e2e.ts
+++ b/packages/driver/cypress/support/e2e.ts
@@ -1,0 +1,1 @@
+import './defaults'

--- a/packages/driver/cypress/support/helpers.ts
+++ b/packages/driver/cypress/support/helpers.ts
@@ -1,13 +1,18 @@
 const { _ } = Cypress
 
-const getQueueNames = () => {
+// declared locally because the webpack runtime has no types; overriding `d` gives
+// each export a setter so a spec can stub the exports of a TypeScript module
+declare const __webpack_require__: {
+  d: (...args: any[]) => void
+  o: (exports: object, name: string) => boolean
+}
+
+export const getQueueNames = () => {
   return _.map(cy.queue, 'name')
 }
 
-function allowTsModuleStubbing () {
-  // eslint-disable-next-line no-undef
+export function allowTsModuleStubbing () {
   __webpack_require__.d = function (exports, name, getter) {
-  // eslint-disable-next-line no-undef
     if (!__webpack_require__.o(exports, name)) {
       let stub
 
@@ -20,9 +25,4 @@ function allowTsModuleStubbing () {
       })
     }
   }
-}
-
-module.exports = {
-  getQueueNames,
-  allowTsModuleStubbing,
 }

--- a/packages/driver/src/util/config.ts
+++ b/packages/driver/src/util/config.ts
@@ -86,7 +86,7 @@ export const preprocessConfig = (config: Cypress.Config) => {
 /**
  * Prepares config to initialize a cross-origin spec bridge.
  * isInteractive is read-only and must reflect the server-computed run/open mode value
- * from bootstrap, not testing overrides on the primary origin (e.g. defaults.js).
+ * from bootstrap, not testing overrides on the primary origin (e.g. defaults.ts).
  */
 export const preprocessConfigForSpecBridge = (
   config: Cypress.Config,


### PR DESCRIPTION
- Closes N/A — internal test-infrastructure conversion, no associated issue (see the note on the first PR task below).

### Additional details

`packages/driver/cypress/support/{e2e,defaults,helpers}.js` and `packages/driver/cypress/plugins/{index,server}.js` become `.ts`. The five have to move together: every spec loads the support file and `cypress.config.ts` loads the plugins, so renaming them one at a time would leave the suite unable to resolve either.

`require('@packages/ts/register')` is gone with the conversion. The config/plugins child process is launched with the tsx loader (`ProjectConfigIpc.forkConfigProcess` puts it in `NODE_OPTIONS`), and tsx transpiles the `.ts` requires this file makes — `./server`, which in turn pulls in `@packages/https-proxy/test/helpers/https_server.ts`, and the runner's webpack config.

The pieces that are more than a rename:

- **`plugins/index.ts`** keeps `export =`, so `require('./cypress/plugins')(on, config)` in `cypress.config.ts` is unchanged, and the JSDoc `@type` becomes a real `Cypress.PluginConfig` annotation. Two modules stay `require`s on purpose: neither `@packages/runner`'s webpack config nor `@packages/https-proxy`'s test helper is covered by its own package's `check-ts` (runner's is tslint only; https-proxy's tsconfig includes `lib` alone), so importing them would make this package's `tsc` run the only CI gate on files their owners don't gate on, under stricter options than either package sets. Importing the https helper fails outright today for that reason.
- **`plugins/server.ts`** promotes the inline middleware `require`s to imports and adds a `QueryRequest` alias for the routes that read query params as plain strings. `/status-code` deliberately keeps handing `sendStatus` the raw string: express only strips the body headers for a numeric 204 or 304, so coercing it would change the response the `net_stubbing` 204 spy (#8999) was written against. `/timeout` does coerce, which is a no-op — bluebird's `delay` already applies `+ms`. `http.createServer(app)` replaces calling `http.Server` without `new`, and three handlers gained a `return` for `noImplicitReturns`; express ignores a handler's return value.
- **`support/defaults.ts`** reads `Cypress.$` at its one call site rather than binding `$` at the top level, which in a non-module file collides with the global jQuery, and reads `Cypress.spec` instead of `cy.config('spec')` — `$Cy` is constructed with `Cypress.config`, so the two are the same object, and the public type of `Cypress.spec` is non-null. The `isInteractive` override gets `@ts-expect-error`, matching how `28527.cy.ts` and `snapshots.cy.ts` already write it.
- **`support/helpers.ts`** declares the webpack runtime locally in place of the two `no-undef` disables.

knip's driver entry paths follow the rename, as do the comments that pointed at `support/defaults.js`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal driver test infrastructure only; no published API or user-facing behavior, with intentional parity on fixture-server routes used by existing specs.
> 
> **Overview**
> Converts the driver package’s Cypress **support** and **plugin** entrypoints from JavaScript to TypeScript in one coordinated rename (`e2e`, `defaults`, `helpers`, `plugins/index`, `plugins/server`), with **knip** entry paths and a few comments updated to match.
> 
> **Plugins:** `index.ts` drops `require('@packages/ts/register')` (tsx handles `.ts` in the config child process), switches to ES imports, and types the setup as `Cypress.PluginConfig` while keeping `export =` so `cypress.config.ts`’s `require('./cypress/plugins')` is unchanged. Runner webpack config and the https-proxy test helper stay as `require()` so driver `tsc` does not become the gate on loosely typed upstream files.
> 
> **Fixture server (`server.ts`):** Inline middleware `require`s become imports; query-driven routes get a `QueryRequest` alias and light typing. Runtime behavior is preserved where tests depend on it (e.g. `/status-code` still passes an uncoerced query string to `sendStatus` for net-stubbing #8999).
> 
> **Support:** `e2e.ts` imports `defaults.ts`; `defaults.ts` uses `Cypress.$`, `Cypress.spec`, and `@ts-expect-error` for the `isInteractive` override; `helpers.ts` uses named exports and a local `__webpack_require__` declaration for stubbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fefd1fcaeeac60b3849399ac93985c8c98679545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

`yarn check-ts`, `yarn lint --scope @packages/driver` and `yarn health-check` are clean. Driver specs, run against the built dev runner from `packages/driver`:

```bash
node ../../scripts/cypress.js run --config-file ./cypress.config.ts --spec cypress/e2e/memory/memory.cy.js
node ../../scripts/cypress.js run --config-file ./cypress.config.ts --spec cypress/e2e/cypress/error_utils.cy.ts
node ../../scripts/cypress.js run --config-file ./cypress.config.ts --spec cypress/e2e/e2e/privileged_commands.cy.ts
node ../../scripts/cypress.js run --config-file ./cypress.config.ts --spec "cypress/e2e/commands/request.cy.js,cypress/e2e/issues/573.cy.js"
```

Results so far: memory 50/50, `error_utils` 57/57 (the only consumer of `helpers.ts`), `privileged_commands` 111/111 (covers the `Cypress.spec` branch — that spec's own `beforeEach` depends on the visit the branch performs), `request` 81/81 and issue 573 2/2 (the multer and basic-auth routes in `server.ts`). `net_stubbing.cy.ts`, which exercises `/status-code?code=`, `/redirect?chunked=` and `/timeout?ms=`, is worth a look from CI as the broadest check of the fixture server.

### How has the user experience changed?

No change. These files are driver test infrastructure and ship in no published package.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical conversion of driver test infrastructure; no user-facing or API change. -->
- [na] Have tests been added/updated? <!-- The changed files are the driver suite's own support and plugin files; the existing driver specs are the coverage. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7pGs64XyNE24gtGbwjgMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7pGs64XyNE24gtGbwjgMp)_