### PR TITLE
refactor: convert the @packages/data-context build script to TypeScript

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -321,11 +321,13 @@
     },
     "packages/data-context": {
       "entry": [
+        "scripts/**/*.{ts,js}",
         "test/**/*.{ts,tsx,js,jsx}"
       ],
       "project": [
         "src/**/*.{ts,tsx,js,jsx}",
         "graphql/**/*.{ts,tsx,js,jsx}",
+        "scripts/**/*.{ts,js}",
         "test/**/*.{ts,tsx,js,jsx}",
         "*.{ts,tsx,js,jsx}"
       ],

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "@types/underscore.string": "0.0.42",
     "@typescript-eslint/eslint-plugin": "7.2.0",
     "@typescript-eslint/parser": "7.2.0",
-    "@urql/introspection": "^0.3.3",
     "@vitest/coverage-v8": "^3.2.4",
     "autobarrel": "^1.1.0",
     "bluebird": "3.5.3",

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -100,6 +100,7 @@
     "@types/prettier": "2.4.3",
     "@types/server-destroy": "^1.0.4",
     "@types/stringify-object": "^3.0.0",
+    "@urql/introspection": "^0.3.3",
     "jest": "^30.1.3",
     "ts-jest": "^29.4.4",
     "tslint": "^6.1.3"

--- a/packages/data-context/package.json
+++ b/packages/data-context/package.json
@@ -8,7 +8,7 @@
     "build": "yarn build:schema && yarn build:graphql && yarn nexus-build",
     "build-prod": "tsc || echo 'built, with errors'",
     "build:graphql": "graphql-codegen --config ./graphql/graphql-codegen.yml",
-    "build:schema": "node ./scripts/build.js",
+    "build:schema": "ts-node ./scripts/build.ts",
     "check-ts": "tsc --noEmit && yarn -s tslint",
     "clean": "rimraf --glob \"./{src,test,graphql}/**/*.js\"",
     "clean-deps": "rimraf node_modules",

--- a/packages/data-context/scripts/build.ts
+++ b/packages/data-context/scripts/build.ts
@@ -1,22 +1,14 @@
 import fs from 'fs-extra'
 import path from 'path'
-import { buildSchema, introspectionFromSchema } from 'graphql'
-import { minifyIntrospectionQuery } from '@urql/introspection'
+import { buildSchema } from 'graphql'
+import { writeUrqlIntrospection } from './urqlIntrospection'
 
 const dataContextRoot = path.join(__dirname, '..')
 
 async function generateDataContextSchema () {
   const schemaContents = await fs.promises.readFile(path.join(dataContextRoot, 'schemas/schema.graphql'), 'utf8')
-  const schema = buildSchema(schemaContents, { assumeValid: true })
 
-  const URQL_INTROSPECTION_PATH = path.join(dataContextRoot, 'src/gen/urql-introspection.gen.ts')
-
-  await fs.ensureDir(path.dirname(URQL_INTROSPECTION_PATH))
-
-  await fs.promises.writeFile(
-    URQL_INTROSPECTION_PATH,
-    `/* eslint-disable */\nexport const urqlSchema = ${JSON.stringify(minifyIntrospectionQuery(introspectionFromSchema(schema)), null, 2)} as const`,
-  )
+  await writeUrqlIntrospection(buildSchema(schemaContents, { assumeValid: true }))
 }
 
 generateDataContextSchema()

--- a/packages/data-context/scripts/build.ts
+++ b/packages/data-context/scripts/build.ts
@@ -1,7 +1,7 @@
-const fs = require('fs-extra')
-const { buildSchema, introspectionFromSchema } = require('graphql')
-const path = require('path')
-const { minifyIntrospectionQuery } = require('@urql/introspection')
+import fs from 'fs-extra'
+import path from 'path'
+import { buildSchema, introspectionFromSchema } from 'graphql'
+import { minifyIntrospectionQuery } from '@urql/introspection'
 
 const dataContextRoot = path.join(__dirname, '..')
 

--- a/packages/data-context/scripts/urqlIntrospection.ts
+++ b/packages/data-context/scripts/urqlIntrospection.ts
@@ -1,0 +1,22 @@
+import fs from 'fs-extra'
+import path from 'path'
+import type { GraphQLSchema } from 'graphql'
+import { introspectionFromSchema } from 'graphql'
+import { minifyIntrospectionQuery } from '@urql/introspection'
+
+const URQL_INTROSPECTION_PATH = path.join(__dirname, '..', 'src/gen/urql-introspection.gen.ts')
+
+/**
+ * The urql GraphCache only needs type shape and nullability to resolve partial
+ * results, so the introspection is minified before it is written. This artifact
+ * is bundled into the frontend and baked into the V8 snapshot, where the
+ * descriptions and input metadata a full introspection carries would triple it.
+ */
+export async function writeUrqlIntrospection (schema: GraphQLSchema) {
+  await fs.ensureDir(path.dirname(URQL_INTROSPECTION_PATH))
+
+  await fs.promises.writeFile(
+    URQL_INTROSPECTION_PATH,
+    `/* eslint-disable */\nexport const urqlSchema = ${JSON.stringify(minifyIntrospectionQuery(introspectionFromSchema(schema)), null, 2)} as const`,
+  )
+}

--- a/packages/data-context/scripts/urqlIntrospection.ts
+++ b/packages/data-context/scripts/urqlIntrospection.ts
@@ -7,10 +7,10 @@ import { minifyIntrospectionQuery } from '@urql/introspection'
 const URQL_INTROSPECTION_PATH = path.join(__dirname, '..', 'src/gen/urql-introspection.gen.ts')
 
 /**
- * The urql GraphCache only needs type shape and nullability to resolve partial
- * results, so the introspection is minified before it is written. This artifact
- * is bundled into the frontend and baked into the V8 snapshot, where the
- * descriptions and input metadata a full introspection carries would triple it.
+ * The GraphCache resolves partial results from type shape and nullability
+ * alone. Minifying drops the descriptions and input metadata it never reads,
+ * which more than halves an artifact that ships in the frontend bundle and is
+ * baked into the V8 snapshot.
  */
 export async function writeUrqlIntrospection (schema: GraphQLSchema) {
   await fs.ensureDir(path.dirname(URQL_INTROSPECTION_PATH))

--- a/packages/data-context/test/unit/urqlIntrospection.spec.ts
+++ b/packages/data-context/test/unit/urqlIntrospection.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals'
+import { urqlSchema } from '../../src/gen/urql-introspection.gen'
+
+/**
+ * Keys a full introspection carries that `minifyIntrospectionQuery` drops. The
+ * GraphCache resolves partial results from type shape and nullability alone, so
+ * none of these should reach the generated artifact.
+ */
+const STRIPPED_BY_MINIFY = [
+  'defaultValue',
+  'deprecationReason',
+  'description',
+  'enumValues',
+  'inputFields',
+  'isDeprecated',
+  'isRepeatable',
+  'locations',
+  'specifiedByUrl',
+]
+
+function walk (value: unknown, seen = { keys: new Set<string>(), kinds: new Set<string>() }) {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => walk(entry, seen))
+  } else if (value && typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value)) {
+      seen.keys.add(key)
+
+      if (key === 'kind' && typeof nested === 'string') {
+        seen.kinds.add(nested)
+      }
+
+      walk(nested, seen)
+    }
+  }
+
+  return seen
+}
+
+describe('urql-introspection.gen', () => {
+  const { keys, kinds } = walk(urqlSchema)
+
+  it('is minified before it is written', () => {
+    expect(STRIPPED_BY_MINIFY.filter((key) => keys.has(key))).toEqual([])
+  })
+
+  it('keeps the type shape and nullability the GraphCache reads', () => {
+    expect(urqlSchema.__schema.types.length).toBeGreaterThan(0)
+    expect([...kinds]).toContain('NON_NULL')
+  })
+})

--- a/packages/data-context/test/unit/urqlIntrospection.spec.ts
+++ b/packages/data-context/test/unit/urqlIntrospection.spec.ts
@@ -2,9 +2,8 @@ import { describe, expect, it } from '@jest/globals'
 import { urqlSchema } from '../../src/gen/urql-introspection.gen'
 
 /**
- * Keys a full introspection carries that `minifyIntrospectionQuery` drops. The
- * GraphCache resolves partial results from type shape and nullability alone, so
- * none of these should reach the generated artifact.
+ * The exact set of keys `minifyIntrospectionQuery` drops; if the library's
+ * output changes, this list has to change with it.
  */
 const STRIPPED_BY_MINIFY = [
   'defaultValue',

--- a/packages/data-context/test/unit/urqlIntrospection.spec.ts
+++ b/packages/data-context/test/unit/urqlIntrospection.spec.ts
@@ -1,49 +1,31 @@
 import { describe, expect, it } from '@jest/globals'
+import fs from 'fs-extra'
+import path from 'path'
+import { buildSchema, introspectionFromSchema } from 'graphql'
+import { minifyIntrospectionQuery } from '@urql/introspection'
 import { urqlSchema } from '../../src/gen/urql-introspection.gen'
 
-/**
- * The exact set of keys `minifyIntrospectionQuery` drops; if the library's
- * output changes, this list has to change with it.
- */
-const STRIPPED_BY_MINIFY = [
-  'defaultValue',
-  'deprecationReason',
-  'description',
-  'enumValues',
-  'inputFields',
-  'isDeprecated',
-  'isRepeatable',
-  'locations',
-  'specifiedByUrl',
-]
-
-function walk (value: unknown, seen = { keys: new Set<string>(), kinds: new Set<string>() }) {
+function collectKeys (value: unknown, keys = new Set<string>()) {
   if (Array.isArray(value)) {
-    value.forEach((entry) => walk(entry, seen))
+    value.forEach((entry) => collectKeys(entry, keys))
   } else if (value && typeof value === 'object') {
     for (const [key, nested] of Object.entries(value)) {
-      seen.keys.add(key)
-
-      if (key === 'kind' && typeof nested === 'string') {
-        seen.kinds.add(nested)
-      }
-
-      walk(nested, seen)
+      keys.add(key)
+      collectKeys(nested, keys)
     }
   }
 
-  return seen
+  return [...keys].sort()
 }
 
 describe('urql-introspection.gen', () => {
-  const { keys, kinds } = walk(urqlSchema)
+  it('is minified before it is written', async () => {
+    const sdl = await fs.promises.readFile(path.join(__dirname, '../../schemas/schema.graphql'), 'utf8')
+    const minified = minifyIntrospectionQuery(introspectionFromSchema(buildSchema(sdl, { assumeValid: true })))
 
-  it('is minified before it is written', () => {
-    expect(STRIPPED_BY_MINIFY.filter((key) => keys.has(key))).toEqual([])
-  })
-
-  it('keeps the type shape and nullability the GraphCache reads', () => {
-    expect(urqlSchema.__schema.types.length).toBeGreaterThan(0)
-    expect([...kinds]).toContain('NON_NULL')
+    // Minification's whole effect is dropping keys, so comparing key sets pins
+    // it against whatever the library strips today, and fails as a short list
+    // rather than a diff of the whole artifact.
+    expect(collectKeys(urqlSchema)).toEqual(collectKeys(minified))
   })
 })

--- a/scripts/gulp/tasks/gulpGraphql.ts
+++ b/scripts/gulp/tasks/gulpGraphql.ts
@@ -5,8 +5,8 @@ import chalk from 'chalk'
 import fs from 'fs-extra'
 import type { GraphQLSchema } from 'graphql'
 import { buildSchema, extendSchema, introspectionFromSchema, isObjectType, parse } from 'graphql'
-import { minifyIntrospectionQuery } from '@urql/introspection'
 
+import { writeUrqlIntrospection } from '../../../packages/data-context/scripts/urqlIntrospection'
 import { nexusTypegen, watchNexusTypegen } from '../utils/nexusTypegenUtil'
 import { monorepoPaths } from '../monorepoPaths'
 import { spawned, universalSpawn } from '../utils/childProcessUtils'
@@ -112,16 +112,10 @@ export async function generateFrontendSchema () {
   const testExtensions = generateTestExtensions(schema)
   const extendedSchema = extendSchema(schema, parse(testExtensions))
 
-  const URQL_INTROSPECTION_PATH = path.join(monorepoPaths.pkgDataContext, 'src/gen/urql-introspection.gen.ts')
-
-  await fs.ensureDir(path.dirname(URQL_INTROSPECTION_PATH))
   await fs.ensureDir(path.join(monorepoPaths.pkgFrontendShared, 'src/generated'))
   await fs.writeFile(path.join(monorepoPaths.pkgFrontendShared, 'src/generated/schema-for-tests.gen.json'), JSON.stringify(introspectionFromSchema(extendedSchema), null, 2))
 
-  await fs.promises.writeFile(
-    URQL_INTROSPECTION_PATH,
-    `/* eslint-disable */\nexport const urqlSchema = ${JSON.stringify(minifyIntrospectionQuery(introspectionFromSchema(schema)), null, 2)} as const`,
-  )
+  await writeUrqlIntrospection(schema)
 }
 
 /**

--- a/scripts/gulp/tasks/gulpGraphql.ts
+++ b/scripts/gulp/tasks/gulpGraphql.ts
@@ -20,9 +20,6 @@ export async function nexusCodegen () {
   })
 }
 
-/**
- * Watches & regenerates the
- */
 export async function nexusCodegenWatch () {
   return watchNexusTypegen({
     cwd: monorepoPaths.pkgDataContext,
@@ -104,7 +101,9 @@ export async function syncRemoteGraphQL () {
 }
 
 /**
- * Generates the schema so the urql GraphCache is
+ * Regenerates both artifacts derived from the committed SDL, which live in
+ * different packages: the test-extended introspection `mountFragment` queries
+ * against, and the introspection the urql GraphCache reads.
  */
 export async function generateFrontendSchema () {
   const schemaContents = await fs.promises.readFile(path.join(monorepoPaths.pkgDataContext, 'schemas/schema.graphql'), 'utf8')
@@ -119,10 +118,8 @@ export async function generateFrontendSchema () {
 }
 
 /**
- * Adds two fields to the GraphQL types specific to testing
- *
- * @param schema
- * @returns
+ * Extends Query with two fields the component tests use to mount a fragment
+ * against any object type, via a union spanning all of them.
  */
 function generateTestExtensions (schema: GraphQLSchema) {
   const objects: string[] = []


### PR DESCRIPTION
- Closes N/A — no associated issue. Internal build tooling with no user-facing change; details below.

### Additional details

`packages/data-context/scripts/build.js` reads the committed `schemas/schema.graphql` and writes `src/gen/urql-introspection.gen.ts`, the minified introspection the urql GraphCache reads. Converting it turned up a few related things worth fixing while in here.

**Converted to TypeScript.** `build:schema` now runs `ts-node ./scripts/build.ts`, matching the `nexus-build` script sitting next to it. `ts-node` type-checks by default, so a type error in the script now fails `yarn build` rather than surfacing at runtime. The generated artifact is byte-identical to what the previous script produced — 182,901 bytes, verified by regenerating and diffing against a reproduction of the deleted file.

**Declared `@urql/introspection` where it is used.** The import resolved through a root `devDependency` rather than one in `packages/data-context`. It is now declared in the package that imports it, and removed from the root, which no longer imports it anywhere. `yarn.lock` is unchanged — the `^0.3.3` spec is still required by a workspace, so nothing re-resolves.

**Removed a duplicated writer.** `scripts/gulp/tasks/gulpGraphql.ts` carried a character-identical copy of the same write, so whichever ran last won: gulp during `yarn dev`, `build:schema` in CI. Both now call a shared `writeUrqlIntrospection`, and both were confirmed to emit the same bytes.

**Covered the minification step.** Nothing asserted that `minifyIntrospectionQuery` had actually been applied. Removing it grew the artifact from 183 KB to 437 KB with the entire suite still green — and that artifact ships in the frontend bundle and is baked into the V8 snapshot, so the regression would have been invisible. The new spec derives its expectation by minifying the same committed schema instead of hardcoding the keys minification drops, so it stays correct across `@urql/introspection` and `graphql` upgrades.

`knip.json` gains `scripts/**` for this package so knip analyses the file that actually imports the dependency, rather than being satisfied by the root declaration. That also brings `build.ts` and `nexus-build.ts` under knip for the first time.

One follow-up deliberately left out: `packages/data-context/tsconfig.json` does not `include` `scripts/`, so `yarn check-ts` and `tslint` skip these files statically (`ts-node` still catches type errors at build time). Adding `scripts` to `include` is a two-line change that I confirmed leaves `check-ts` green — happy to fold it in if reviewers would rather it land here than separately.

### Steps to test

```sh
# Both writers produce the same artifact
yarn workspace @packages/data-context build:schema
yarn gulp generateFrontendSchema

# Unit tests, type-check, dependency hygiene
yarn workspace @packages/data-context test-unit
yarn workspace @packages/data-context check-ts
yarn health-check
```

To confirm the new spec is doing its job, drop `minifyIntrospectionQuery` from `packages/data-context/scripts/urqlIntrospection.ts`, re-run `build:schema`, and `test/unit/urqlIntrospection.spec.ts` fails listing the keys that leaked through.

### How has the user experience changed?

No change. This is internal build tooling, and the generated artifact is byte-identical to what shipped before.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- No issue: internal build tooling, no user-facing or behavioral change. -->
- [x] Have tests been added/updated? <!-- packages/data-context/test/unit/urqlIntrospection.spec.ts -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LYKKqnoj69vYJriEcLHJM

---
_Generated by [Claude Code](https://claude.ai/code/session_013LYKKqnoj69vYJriEcLHJM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal build tooling only; generated urql introspection is intended to remain byte-identical with deduplicated writers and a new regression test.
> 
> **Overview**
> **Refactors `@packages/data-context` schema build to TypeScript** and centralizes how the urql GraphCache introspection file is generated.
> 
> `build:schema` now runs **`ts-node ./scripts/build.ts`** instead of the deleted **`build.js`**, with urql output moved into shared **`writeUrqlIntrospection`** in `urqlIntrospection.ts`. **`scripts/gulp/tasks/gulpGraphql.ts`** drops its duplicate writer and calls the same helper, so CI **`build:schema`** and dev **`generateFrontendSchema`** stay aligned.
> 
> **`@urql/introspection`** moves from the repo root to **`packages/data-context`** devDependencies; **`knip.json`** adds **`scripts/**`** for that package so those imports are analyzed correctly.
> 
> A new unit test asserts the committed **`urql-introspection.gen`** artifact matches minified introspection from the same SDL (key-set comparison), guarding against accidentally shipping an unminified blob in the frontend bundle / V8 snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f17d91e415a55fde33a612ab69eef7c5340d75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->