### PR TITLE
fix: honor a zero weight in weightedChoice and deflake its distribution test

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fixed an issue where adding a `--disable-features` argument in [`before:browser:launch`](https://docs.cypress.io/api/node-events/browser-launch-api) silently dropped every feature Cypress disables in Chrome, Chromium, and Edge, because the browser honors only the last occurrence of that argument. Cypress now merges its own values with yours. Fixes [#34775](https://github.com/cypress-io/cypress/issues/34775).
 - Fixed a regression in [16.0.0](#16-0-0) where, in `cypress open` on Chrome, Chromium, and Edge, testing a site that registers an origin-wide service worker could render the site's own content — such as its 404 page — in place of the Cypress app after clicking a spec or reloading the browser tab. A service worker registered by the site under test can no longer answer for Cypress's own pages and assets. Fixes [#34789](https://github.com/cypress-io/cypress/issues/34789). Addressed in [#34762](https://github.com/cypress-io/cypress/pull/34762).
+- Fixed an issue where a variant of A/B tested content in the Cypress app that was weighted never to be shown could become the only variant shown. Fixes [#34814](https://github.com/cypress-io/cypress/issues/34814).
 
 **Misc:**
 

--- a/packages/data-context/src/util/weightedChoice.ts
+++ b/packages/data-context/src/util/weightedChoice.ts
@@ -17,18 +17,11 @@ const weightedChoice = (weights: number[], values: any[]) => {
     throw new Error('The length of the weights and values must be the same and greater than zero')
   }
 
+  // `?? 0` rather than a falsy check on the previous total: a weight of 0 is a
+  // valid instruction never to pick that value, so it must extend the array
+  // like any other weight instead of ending it.
   const cumulativeWeights = weights.reduce<number[]>((acc, curr) => {
-    if (acc.length === 0) {
-      return [curr]
-    }
-
-    const last = acc[acc.length - 1]
-
-    if (!last) {
-      return acc
-    }
-
-    return [...acc, last + curr]
+    return [...acc, (acc[acc.length - 1] ?? 0) + curr]
   }, [])
 
   const randomNumber = Math.random() * (cumulativeWeights[cumulativeWeights.length - 1] ?? 1)

--- a/packages/data-context/test/unit/util/weightedChoice.spec.ts
+++ b/packages/data-context/test/unit/util/weightedChoice.spec.ts
@@ -84,5 +84,11 @@ describe('weightedChoice', () => {
     it('should return an even split when weights are equal', () => {
       expect(tally(WEIGHTED_EVEN(['A', 'B']), ['A', 'B'])).toEqual({ A: 500, B: 500 })
     })
+
+    it('should never return a value weighted zero', () => {
+      expect(tally(WEIGHTED([0, 1]), ['A', 'B'])).toEqual({ A: 0, B: 1000 })
+      expect(tally(WEIGHTED([50, 0, 50]), ['A', 'B', 'C'])).toEqual({ A: 500, B: 0, C: 500 })
+      expect(tally(WEIGHTED([0, 0, 1]), ['A', 'B', 'C'])).toEqual({ A: 0, B: 0, C: 1000 })
+    })
   })
 })

--- a/packages/data-context/test/unit/util/weightedChoice.spec.ts
+++ b/packages/data-context/test/unit/util/weightedChoice.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 
 import { WEIGHTED, WEIGHTED_EVEN } from '../../../src/util/weightedChoice'
 
@@ -56,20 +56,33 @@ describe('weightedChoice', () => {
   })
 
   describe('randomness', () => {
-    it('should return values close to supplied weights', () => {
-      const results = {}
-      const options = ['A', 'B']
-      const algorithm = WEIGHTED_EVEN(options)
+    // Sweeping `Math.random` across the unit interval makes the split exact.
+    // Sampling it instead only pins the split to within a few standard
+    // deviations of the weights, which flakes at CI volume.
+    const tally = (algorithm: { pick: (values: string[]) => string }, options: string[], draws = 1000) => {
+      const random = jest.spyOn(Math, 'random')
+      const results: Record<string, number> = Object.fromEntries(options.map((option) => [option, 0]))
 
-      for (let i = 0; i < 1000; i++) {
-        const selected = algorithm.pick(options)
-
-        results[selected] ? results[selected]++ : results[selected] = 1
+      try {
+        for (let i = 0; i < draws; i++) {
+          // Bucket midpoints, so no draw lands on the inclusive boundary
+          // between two adjacent weight ranges
+          random.mockReturnValue((i + 0.5) / draws)
+          results[algorithm.pick(options)]++
+        }
+      } finally {
+        random.mockRestore()
       }
 
-      Object.keys(results).forEach((key) => {
-        expect(Math.round(results[key] / 100)).toEqual(5)
-      })
+      return results
+    }
+
+    it('should return each option in proportion to its weight', () => {
+      expect(tally(WEIGHTED([20, 30, 50]), ['A', 'B', 'C'])).toEqual({ A: 200, B: 300, C: 500 })
+    })
+
+    it('should return an even split when weights are equal', () => {
+      expect(tally(WEIGHTED_EVEN(['A', 'B']), ['A', 'B'])).toEqual({ A: 500, B: 500 })
     })
   })
 })


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #34814

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Two commits against `packages/data-context`'s `weightedChoice`: a flaky test, and a real bug the flaky test was hiding.

**1. `test:` the distribution test was a coin flip.**

The `randomness` test drew 1000 real `Math.random()` samples and asserted the even split rounded to 500 per option. `Math.round(count / 100) === 5` passes only for counts in `[451, 549]`, because `Math.round(4.5)` is 5 but `Math.round(5.5)` is 6. For `Binomial(1000, 0.5)`, sigma is 15.81, so that window is +/-3.1 sigma. Measured over 200,000 simulated trials: **0.171% failure rate, about one run in 585.** It failed the `unit-tests` job on an unrelated PR, which is how this was found.

`Math.random` is now swept across the unit interval with `jest.spyOn` at bucket midpoints `(i + 0.5) / draws`, so the split is exact and the assertion is an equality. Midpoints matter: they keep every draw off the inclusive `value >= randomNumber` boundary between two adjacent weight ranges.

**2. `fix:` a zero weight inverted the outcome.**

The cumulative-weights reduce narrowed `number | undefined` (`noUncheckedIndexedAccess` is on for this package) with `if (!last) return acc`. `!0` is also true, so a running total of zero ended the array. A leading zero weight truncated the cumulative weights, which zeroed the total, which made `randomNumber` zero, which matched index 0 on the first iteration every time:

| call | expected | before |
| --- | --- | --- |
| `WEIGHTED([0, 1]).pick(['A', 'B'])` | `{ A: 0, B: 1000 }` | `{ A: 1000, B: 0 }` |

Exactly inverted — the option weighted never-pick was picked always. `?? 0` narrows the same type without treating a zero total as absent. Reachable from `determineCohort(name, cohorts, weights)`, where zeroing a cohort's weight to disable it produced the opposite. Full analysis in #34814.

**Why the old tests missed it.** The four `WeightedAlgorithm` tests assert only that the returned value is a member of `options`. Nothing asserted proportions. I confirmed the gap by breaking the range comparison in `weightedChoice` outright — all four still passed. The new assertions fail against that same mutation.

**On PR scope.** CONTRIBUTING asks that a PR address one concern and that an unrelated bug found along the way get its own PR. These two are coupled in one place: the zero-weight regression test reuses the deterministic `tally` helper that the flake fix introduces, and both are corrections to the same function's distribution behavior. Splitting them would mean landing the helper twice or landing a test that cannot assert the bug. Happy to split if you would rather review them separately.

**Changelog.** Added under Bugfixes in `16.0.1`. `scripts/semantic-commits/validate-binary-changelog.js` passes against it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to internal weighted cohort/experiment picking in the data-context layer; no public API or runner behavior change beyond fixing incorrect variant selection when zero weights are used.
> 
> **Overview**
> Fixes **weighted random selection** when a cohort or variant has weight `0`: cumulative totals are built with `(previous ?? 0) + weight` instead of bailing out on a falsy running total, so a “never show” weight no longer becomes the **only** option selected (the previous behavior inverted the outcome).
> 
> **Tests** replace a flaky 1000-draw statistical check with a deterministic sweep of mocked `Math.random` at bucket midpoints, and add explicit assertions for proportional weights and zero-weight exclusion.
> 
> The **16.0.1 changelog** documents the related Cypress app A/B variant bug ([#34814](https://github.com/cypress-io/cypress/issues/34814)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c797fed9115e81c457bdb59418d5f1b5aefc1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

```
cd packages/data-context && npx jest test/unit/util/weightedChoice.spec.ts
```

8 passing. To confirm the new tests are not vacuous, revert either change on its own:

- Restore the old reduce in `src/util/weightedChoice.ts` and `should never return a value weighted zero` fails, reporting `{ A: 1000, B: 0 }` for `WEIGHTED([0, 1])`.
- Change `value >= randomNumber` to anything that breaks range selection and both proportionality tests fail, while the five pre-existing tests keep passing.

`CohortsActions.spec.ts` also passes (11 tests across both files).

Two pre-existing local failures to expect in the full `@packages/data-context` run, unrelated to this PR: four `ProjectConfigIpc > tsx generic loader` cases fail on untouched `develop` in a local worktree and pass in CI. I confirmed the count is identical with and without these changes across four full-suite runs.

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

No change. Cohort weights are set internally, not by users, and no shipped configuration reaches the fixed path with a zero weight today.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. --> #34814
- [x] Have tests been added/updated? Deterministic proportionality and zero-weight assertions in `weightedChoice.spec.ts`.
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> No user-facing change.
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? No public API change.
