### PR TITLE
docs: tie the changelog requirement to the PR title prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,8 @@ Verify an API against the relevant floor (node.green for Node, caniuse/MDN for b
 
 ### Changelog & Template
 
-- For user-facing changes shipping with the next Cypress version, add a changelog entry to [`cli/CHANGELOG.md`](./cli/CHANGELOG.md) — see the [Writing the Cypress Changelog Guide](./guides/writing-the-cypress-changelog.md).
+- The semantic title prefix decides whether a changelog entry is required. `breaking`, `dependency`, `deprecation`, `feat`, `fix`, `misc`, and `perf` each need an entry in [`cli/CHANGELOG.md`](./cli/CHANGELOG.md); `chore`, `docs`, `refactor`, `revert`, and `test` do not. Choosing `fix` already asserts the change ships to users, so do not then skip the entry because the impact looks internal — the "no user-facing impact" exemption in the [Writing the Cypress Changelog Guide](./guides/writing-the-cypress-changelog.md) describes the second group of prefixes.
+- Verify a changelog entry with `GH_TOKEN="$(gh auth token)" node ./scripts/semantic-commits/validate-binary-changelog.js`, the same check CI's `verify-release-readiness` job runs. It fails without that token.
 - Fill out the [Pull Request Template](./.github/PULL_REQUEST_TEMPLATE.md) completely. Use `N/A` for irrelevant sections rather than deleting them — PRs will not be reviewed if the template is not filled in.
 
 ## CI/CD


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

One bullet in `AGENTS.md` becomes two.

The old wording asked for a changelog entry "for user-facing changes shipping with the next Cypress version." That leaves the decision to a separate judgment about visibility, when the PR title prefix has already made it. `CONTRIBUTING.md` groups the prefixes into "Changes has user-facing impact" (`breaking`, `dependency`, `deprecation`, `feat`, `fix`, `misc`, `perf`) and "no user-facing impact" (`chore`, `docs`, `refactor`, `revert`, `test`), so the answer is mechanical: the first group needs an entry, the second does not.

Read alongside rule 6 of the changelog guide — "If a change has no user-facing impact, it does not belong in the changelog" — the old bullet invites a wrong call on a `fix` whose impact looks internal. That exemption is describing the second group of prefixes, not offering an escape hatch for the first. I made exactly that mistake on #34815, skipping the entry for a bug fix in cohort selection because the only non-generated caller was an example component. The prefix was `fix`, so the entry was required regardless.

The second bullet records how to check an entry locally: `scripts/semantic-commits/validate-binary-changelog.js` is what CI's `verify-release-readiness` job runs, and it throws `The GH_TOKEN env is not set.` without a token, which is not obvious from the failure.

Every claim in the new text is checked against the repo: the prefix lists match `CONTRIBUTING.md` lines 523-537, the script path matches `.circleci/src/pipeline/@pipeline.yml` line 2140 under `verify-release-readiness`, and the token requirement is `scripts/semantic-commits/get-binary-release-data.js` line 14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidance in `AGENTS.md`; no product or runtime behavior changes.
> 
> **Overview**
> Updates **Pull Requests → Changelog & Template** in `AGENTS.md` so changelog expectations follow the semantic-release title prefix instead of a separate “user-facing” judgment.
> 
> The old single bullet is replaced by two: one lists which prefixes require a `cli/CHANGELOG.md` entry (`breaking`, `dependency`, `deprecation`, `feat`, `fix`, `misc`, `perf` vs `chore`, `docs`, `refactor`, `revert`, `test`) and clarifies that a `fix` title still requires an entry even when impact looks internal; the other documents local verification via `GH_TOKEN="$(gh auth token)" node ./scripts/semantic-commits/validate-binary-changelog.js` (same as CI `verify-release-readiness`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ee900e06fa98e9e5aaa8d5dbd9ada7602775ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Documentation only — nothing to run. To confirm the second bullet is accurate:

```
GH_TOKEN="$(gh auth token)" node ./scripts/semantic-commits/validate-binary-changelog.js
```

It prints "It appears at a high-level your changelog entry is correct!" and exits 0. Dropping `GH_TOKEN` makes it throw.

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

No change. `AGENTS.md` is contributor and agent guidance; nothing ships to users.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. --> Documentation correction to contributor guidance, no product change.
- [na] Have tests been added/updated? Documentation only.
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here --> `AGENTS.md` is internal contributor guidance, not user documentation.
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? No API change.
