### PR TITLE
chore: path-filter CI jobs on develop merges

### DIFF
--- a/.circleci/AGENTS.md
+++ b/.circleci/AGENTS.md
@@ -45,8 +45,10 @@ After editing `.circleci/src/`, run `yarn pack-ci --validate` before committing.
 
 ### What runs with only `&full-workflow-filters`
 
-- **`linux-x64`**: most develop CI (build, system tests, `v8-integration-tests`, packaging, etc.) — subject to path filtering unless overridden
-- **`windows`**: Windows build, binary artifacts, v8 integration tests, and selected integration/unit jobs
-- **`linux-arm64` / `darwin-*`**: platform builds, packaging, and v8 integration tests where supported
+The `run-*` guards live in the shared job definitions in `@pipeline.yml` (via `halt-if-skipped`), not in the workflow files, so they apply to every workflow below — not just the PR one.
+
+- **`linux-x64`**: `build`, lint, and type checks always run, as do the binary/packaging chain and release gating (`create-and-trigger-packaging-artifacts`, `get-published-artifacts`, `test-binary-*`, `verify-release-readiness`, `ready-to-release`, `npm-release`). Per-package integration/unit jobs, system tests, and `v8-integration-tests` are guarded, so a webhook push to `develop` runs only the ones its changed paths select.
+- **`windows`**: Windows build, binary artifacts, v8 integration tests, and selected integration/unit jobs. Unaffected by develop path filtering — this workflow excludes plain `develop`/`release/*` pushes and runs on a schedule instead.
+- **`linux-arm64` / `darwin-*`**: platform builds and packaging always run. `v8-integration-tests`, `driver-integration-memory-tests`, and `server-unit-tests-cloud-environment` are guarded, so they are path-filtered on a develop push; the scheduled pipeline runs them unfiltered.
 
 `npm-release` still runs only on `develop`, not on allowlisted feature branches.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,8 @@ jobs:
               environment:
                 RUN_ALL_JOBS: << pipeline.parameters.run-all-jobs >>
                 PERCY_ENABLED: << pipeline.parameters.percy-enabled >>
+                TRIGGER_SOURCE: "<< pipeline.trigger_source >>"
+                BASE_REVISION: "<< pipeline.git.base_revision >>"
               command: |
                 bash .circleci/scripts/generate-pipeline-parameters.sh \
                   > /tmp/pipeline-parameters.json

--- a/.circleci/scripts/generate-pipeline-parameters.sh
+++ b/.circleci/scripts/generate-pipeline-parameters.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 # Generates a JSON object of CircleCI pipeline parameters based on changed files.
-# Used in launch-primary-workflow to enable path-based job filtering on PRs.
+# Used in launch-primary-workflow to enable path-based job filtering on PR
+# branches and on genuine webhook pushes to develop.
 #
 # Output: JSON written to stdout, consumed by continuation/continue pipeline_parameters.
 #
-# All run-* params default to true so that develop/release branches and
-# API-triggered pipelines run everything without needing to pass explicit params.
+# Every path a job could care about must map to a run-* param below: a path
+# that matches nothing is an error rather than a silent skip.
+#
+# release/* branches, the update-v8-snapshot-cache-on-develop branch, the
+# run-all-jobs manual trigger, and any develop run that isn't a webhook push
+# (scheduled pipelines, API triggers, or an unset/unknown trigger source) skip
+# path inspection entirely and run everything.
+#
+# The corresponding pipeline parameters in @pipeline.yml default to true, so a
+# continuation that omits them runs everything rather than nothing.
 
 set -euo pipefail
 
@@ -80,14 +89,36 @@ emit_all_true() {
 }
 
 # ----- branch override --------------------------------------------------------
-# On develop/release branches all jobs must run.
+# On release branches and the v8 snapshot cache branch all jobs must run.
 BRANCH="${CIRCLE_BRANCH:-}"
-if [[ "$BRANCH" == "develop" ]] || \
-   [[ "$BRANCH" =~ ^release/ ]] || \
+if [[ "$BRANCH" =~ ^release/ ]] || \
    [[ "$BRANCH" == "update-v8-snapshot-cache-on-develop" ]]; then
   echo "Branch '$BRANCH' — running all tests" >&2
   emit_all_true
   exit 0
+fi
+
+# ----- develop trigger-source exemption ---------------------------------------
+# The nightly platform cron runs *on* the develop branch (CIRCLE_BRANCH=develop),
+# so a branch check alone can't tell it apart from a real push - it must stay
+# unfiltered, or path-filtering would silently gut the nightly full sweep down
+# to the last merge's diff. Scoping filtering to genuine webhook pushes also
+# covers manual "Trigger Pipeline" reruns and run-windows-workflow=true
+# triggers for free, since those report a non-webhook trigger source too -
+# no separate check is needed for them.
+#
+# filtering_develop_push is threaded through the rest of the script instead of
+# re-testing $BRANCH at each site (diff base resolution, the empty-diff check,
+# the unrecognized-path guard) that needs to behave differently for a develop
+# push than for a PR.
+filtering_develop_push=false
+if [[ "$BRANCH" == "develop" ]]; then
+  if [[ "${TRIGGER_SOURCE:-}" != "webhook" ]]; then
+    echo "Develop trigger source '${TRIGGER_SOURCE:-<unset>}' is not a webhook push — running all tests" >&2
+    emit_all_true
+    exit 0
+  fi
+  filtering_develop_push=true
 fi
 
 # ----- manual trigger override -----------------------------------------------
@@ -100,25 +131,71 @@ if [[ "$RUN_ALL_RAW" == "true" || "$RUN_ALL_RAW" == "1" ]]; then
 fi
 
 # ----- compute changed files --------------------------------------------------
-# Fetch develop from the upstream project repo using CIRCLE_PROJECT_USERNAME/REPONAME,
-# which CircleCI always sets to the canonical upstream (cypress-io/cypress), not the
-# contributor's fork. This ensures fork PRs compare against the real develop branch.
-UPSTREAM_URL="https://github.com/${CIRCLE_PROJECT_USERNAME:-cypress-io}/${CIRCLE_PROJECT_REPONAME:-cypress}.git"
-MERGE_BASE=""
-if git fetch "$UPSTREAM_URL" develop 2>/dev/null; then
-  MERGE_BASE=$(git merge-base HEAD FETCH_HEAD 2>/dev/null || echo "")
-else
-  echo "Could not fetch upstream develop" >&2
-fi
+# --no-renames on every diff below: with rename detection on, `--name-only`
+# reports only a rename's destination, so moving a file out of a globally
+# triggering package (say packages/config/) would escape that trigger.
+#
+# Resolves the base commit for a develop push. Prefers BASE_REVISION
+# (<< pipeline.git.base_revision >>) since it also covers a push that lands
+# multiple commits at once; falls back to HEAD~1, which is correct for both
+# squash merges and true merge commits landing on develop (first-parent).
+# Tolerates a missing/garbage BASE_REVISION under `set -e` via the `if` guards.
+resolve_develop_base() {
+  local base="${BASE_REVISION:-}"
 
-if [[ -n "$MERGE_BASE" ]]; then
-  CHANGED=$(git -c core.quotepath=false diff --name-only "$MERGE_BASE" HEAD)
+  if [[ -n "$base" ]] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
+    echo "$base"
+    return 0
+  fi
+
+  if git cat-file -e "HEAD~1^{commit}" 2>/dev/null; then
+    echo "HEAD~1"
+    return 0
+  fi
+
+  return 1
+}
+
+if [[ "$filtering_develop_push" == "true" ]]; then
+  # A develop push's merge-base against upstream develop is HEAD itself (the
+  # push already landed), so the upstream-fetch logic below would always see
+  # an empty diff. Diff against the previous tip instead. The checkout in this
+  # job is blobless (full commit/tree history, blobs filtered), so this needs
+  # no extra fetch.
+  if DEVELOP_BASE=$(resolve_develop_base); then
+    echo "Diffing develop push against $DEVELOP_BASE" >&2
+    CHANGED=$(git -c core.quotepath=false diff --no-renames --name-only "$DEVELOP_BASE" HEAD)
+  else
+    echo "Warning: could not resolve a base revision for develop push (BASE_REVISION='${BASE_REVISION:-<unset>}', HEAD~1 unavailable) — running all tests" >&2
+    emit_all_true
+    exit 0
+  fi
 else
-  echo "Could not find merge base with upstream develop, falling back to HEAD~1" >&2
-  CHANGED=$(git -c core.quotepath=false diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+  # Fetch develop from the upstream project repo using CIRCLE_PROJECT_USERNAME/REPONAME,
+  # which CircleCI always sets to the canonical upstream (cypress-io/cypress), not the
+  # contributor's fork. This ensures fork PRs compare against the real develop branch.
+  UPSTREAM_URL="https://github.com/${CIRCLE_PROJECT_USERNAME:-cypress-io}/${CIRCLE_PROJECT_REPONAME:-cypress}.git"
+  MERGE_BASE=""
+  if git fetch "$UPSTREAM_URL" develop 2>/dev/null; then
+    MERGE_BASE=$(git merge-base HEAD FETCH_HEAD 2>/dev/null || echo "")
+  else
+    echo "Could not fetch upstream develop" >&2
+  fi
+
+  if [[ -n "$MERGE_BASE" ]]; then
+    CHANGED=$(git -c core.quotepath=false diff --no-renames --name-only "$MERGE_BASE" HEAD)
+  else
+    echo "Could not find merge base with upstream develop, falling back to HEAD~1" >&2
+    CHANGED=$(git -c core.quotepath=false diff --no-renames --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+  fi
 fi
 
 if [[ -z "$CHANGED" ]]; then
+  if [[ "$filtering_develop_push" == "true" ]]; then
+    echo "Warning: no changed files detected for develop push — running all tests" >&2
+    emit_all_true
+    exit 0
+  fi
   echo "Error: no changed files detected" >&2
   exit 1
 fi
@@ -348,8 +425,17 @@ while IFS= read -r file; do
       # No CI jobs are associated with these packages — no tests to run
       ;;
     *)
-      # Unrecognized path — fail loudly so the mapping is kept up to date.
-      # Add the new path to one of the cases above rather than silently skipping tests.
+      # Unrecognized path. On a PR, fail loudly so the mapping is kept up to
+      # date — add the new path to one of the cases above rather than
+      # silently skipping tests. On a develop push, the merge already passed
+      # PR CI, so failing the merge pipeline over an unmapped path is worse
+      # than over-running it — fall back to running everything instead.
+      if [[ "$filtering_develop_push" == "true" ]]; then
+        echo "Warning: unrecognized path '$file' has no mapping in generate-pipeline-parameters.sh — running all tests" >&2
+        echo "Add it to the targeted path mapping section when convenient." >&2
+        emit_all_true
+        exit 0
+      fi
       echo "Error: unrecognized path '$file' has no mapping in generate-pipeline-parameters.sh" >&2
       echo "Add it to the targeted path mapping section before merging." >&2
       exit 1

--- a/.circleci/src/pipeline/@pipeline.yml
+++ b/.circleci/src/pipeline/@pipeline.yml
@@ -42,8 +42,9 @@ parameters:
   run-windows-workflow:
     type: boolean
     default: false
-  # Path-filtering parameters — set by generate-pipeline-parameters.sh on PRs.
-  # Default true so develop/release branches run everything without explicit params.
+  # Path-filtering parameters — set by generate-pipeline-parameters.sh on PR
+  # branches and on webhook pushes to develop. Default true so that any pipeline
+  # whose continuation omits them runs everything.
   run-driver-tests:
     type: boolean
     default: true
@@ -1748,7 +1749,7 @@ commands:
             ssh-keyscan github.com >> ~/.ssh/known_hosts
 
   # Halts a job immediately if its guard parameter is false.
-  # Used to skip jobs that are not relevant to the changed files in a PR.
+  # Used to skip jobs that are not relevant to the changed files.
   # The job still exits with "success" so downstream jobs and all-jobs-passed
   # are not blocked.
   halt-if-skipped:
@@ -2125,6 +2126,11 @@ jobs:
             - sanitize-verify-and-store-mocha-results:
                 expectedResultCount: 3
 
+  # Unguarded: a release gate rather than a test group, and the only check on
+  # either release train. `test-npm-package-release-script` is the dry run of
+  # the @cypress/* publish that `npm-release` performs for real later in this
+  # same pipeline; `validate-binary-changelog.js` validates cli/CHANGELOG.md
+  # for the binary release. Neither depends on which paths changed.
   verify-release-readiness:
     <<: *defaults
     resource_class: medium.gen2
@@ -2132,8 +2138,6 @@ jobs:
     environment:
       GITHUB_TOKEN: $GH_TOKEN
     steps:
-      - halt-if-skipped:
-          guard: << pipeline.parameters.run-unit-tests >>
       - restore_cached_workspace
       - update_known_hosts
       - run: yarn test-npm-package-release-script

--- a/guides/continuous-integration.md
+++ b/guides/continuous-integration.md
@@ -27,6 +27,8 @@ Runs on PRs targeting `develop` or `release/*` branches (excluding draft PRs).
 
 Runs on pushes to `develop` and `release/*` branches. Includes everything from the PR workflow plus:
 
+**Note:** a webhook push to `develop` is path-filtered the same way PRs are — only the job groups touched by the merge's changed files run. Everything else runs unfiltered: `release/*` pushes, and, on `develop`, the scheduled nightly cron and any manually triggered run. Filtering never skips the binary/packaging chain, `npm-release`, or `verify-release-readiness`.
+
 | Stage | What It Does |
 |-------|--------------|
 | Multi-Platform Builds | Linux x64, Linux ARM64, macOS Intel, macOS Apple Silicon, Windows |
@@ -39,9 +41,10 @@ Runs on pushes to `develop` and `release/*` branches. Includes everything from t
 | Trigger | Workflow | Notes |
 |---------|----------|-------|
 | PR opened/updated | Pull Request | Skipped for draft PRs |
-| Push to `develop` | Full | Runs complete test suite + binary builds |
-| Push to `release/*` | Full | Same as develop |
-| Manual (CircleCI UI) | Configurable | Can run full workflow on any branch |
+| Push to `develop` | Full | Path-filtered by changed files; binary builds and release gating always run |
+| Push to `release/*` | Full | Runs complete test suite + binary builds, unfiltered |
+| Scheduled pipeline | Full | Nightly cron; always unfiltered, even though it runs on `develop` |
+| Manual (CircleCI UI) | Configurable | Can run full workflow on any branch; `run-all-jobs=true` forces everything |
 
 ### Key Jobs
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Before writing any code, confirm an open issue exists for this work and that you have commented on it to indicate your intent. See: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#pull-requests
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes #34780 <!-- link to the issue here, if there is one -->

### Additional details
<!-- Examples:
- Why was this change necessary?
- What is affected by this change?
- Any implementation details to explain?
-->

Path filtering already worked on PR branches. A branch override in `generate-pipeline-parameters.sh` forced `develop` to run every job regardless of what changed. This drops that override so develop gets the same filtering PRs already have.

The issue's proposed mechanism is wrong, and this PR doesn't follow it. It says `@main.yml`'s jobs read no parameters and need guards threaded in. They already have them. `halt-if-skipped` lives in the shared job definitions in `@pipeline.yml`, which both `pull-request.yml` and `@main.yml` use. No workflow file changes here.

Three behavior changes:

1. `develop` is removed from the branch override. `release/*` and `update-v8-snapshot-cache-on-develop` are unchanged.
2. Filtering only applies to real pushes (`trigger_source == webhook`). The nightly cron runs on the `develop` branch, so a branch check alone can't tell it apart from a merge. Scoping to webhook pushes keeps the cron, manual triggers, and API triggers unfiltered, in one check instead of three. Verified against the CircleCI API: pushes report `webhook`, the cron reports `scheduled_pipeline`.
3. A develop push diffs against `pipeline.git.base_revision`, falling back to `HEAD~1`. The old merge-base logic returns HEAD itself on a push, which would produce an empty diff and fail the pipeline.

Two bugs found while testing this, fixed here:

- `verify-release-readiness` was gated on `run-unit-tests`. It's the only pre-flight check before `npm-release` publishes `@cypress/*`, and a driver-only merge doesn't set `run-unit-tests`. That would have let a publish go out with its dry run skipped. Removed the gate — it's a release gate, not a test group.
- `git diff --name-only` drops a rename's source path, so moving a file out of a globally-triggering directory escaped that trigger. Added `--no-renames` to all three diff calls.

Known tradeoff: filtering also covers the arm64/darwin jobs (`v8-integration-tests`, `driver-integration-memory-tests`, `server-unit-tests-cloud-environment`), since they share the same guards. The nightly scheduled pipeline runs those unfiltered, so coverage isn't lost, just deferred by up to a day.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-pipeline gating and which tests run on every develop merge; a bug in trigger-source or base-revision logic could skip tests or weaken nightly sweeps, though fallbacks favor running everything.
> 
> **Overview**
> **Webhook pushes to `develop` now use the same path-based job filtering as PRs**, instead of always running the full Linux x64 test matrix. Scheduled/API/manual pipelines on `develop`, plus `release/*` and the v8 snapshot cache branch, still run everything unfiltered.
> 
> `generate-pipeline-parameters.sh` drops `develop` from the all-jobs branch override, gates filtering on `pipeline.trigger_source == webhook`, and diffs develop merges against `pipeline.git.base_revision` (fallback `HEAD~1`) with `--no-renames` on all diffs. Unmapped paths and empty diffs on develop **warn and run all jobs** rather than failing the pipeline.
> 
> Setup config forwards **`TRIGGER_SOURCE`** and **`BASE_REVISION`** into that script. **`verify-release-readiness`** no longer honors `run-unit-tests`, so npm publish dry-run and changelog checks always run before release.
> 
> Docs in **`.circleci/AGENTS.md`** and **`guides/continuous-integration.md`** describe which jobs stay unguarded and how platform workflows interact with filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53096372a857552e5704f3bdaf7e8f2863abdd9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test
<!--
For non-trivial behavior changes, list the steps that a reviewer should follow to validate the new behavior.
This is not meant to be the only testing performed by a reviewer, just the "happy path" that leads to the new behavior.
-->

Develop's behavior can't be exercised from a PR branch, so it was verified with a synthetic-repo harness against the real script (17/17 cases pass):

| Case | Result |
|---|---|
| develop + webhook, server-only change | server/system/unit on, GUI/npm off |
| develop + webhook, docs-only change | everything off |
| develop + webhook, app-only change | app-ui/system on, server/driver off |
| develop + webhook, `yarn.lock` | everything on (global trigger) |
| develop + webhook, unmapped path | everything on, warns, exits 0 |
| develop + webhook, no/garbage `BASE_REVISION` | falls back to `HEAD~1` |
| develop + `scheduled_pipeline` / `api` / unset | everything on, no diff computed |
| `release/*`, v8-snapshot-cache branch | everything on |
| PR branch, unmapped path | still exits 1 |
| PR branch, engine-only change | output byte-identical to the old script |
| rename out of a global-trigger path | still trips the trigger |

`yarn pack-ci --validate` passes. `shellcheck` is clean at default settings.

**After merge**, someone needs to:
1. Watch an engine-only merge — GUI jobs should halt in seconds, `ready-to-release` and `percy-finalize` should still complete.
2. Watch a GUI-only merge — the GUI block should run.
3. Trigger the nightly schedule manually and confirm it still emits all-true. This is the one that matters most — a bug here silently guts the nightly sweep.
4. Push a `release/*` branch and confirm all-true.
5. After two weeks, compare develop-branch credits in Insights against baseline.

If a filtered develop run looks wrong, `run-all-jobs=true` on Trigger Pipeline reruns everything.

### How has the user experience changed?
<!--
For any change that affects what a user sees or interacts with, or changes behavior, include before/after screenshots or a short video.
Screenshots or videos are strongly preferred — they make it much faster for reviewers to verify the change.
If there is no visual or behavioral change, write "No change" to confirm this section was considered.
-->

No change.

### PR Tasks
<!-- 
These tasks must be completed before a PR is merged.
If a task does not apply, write [na] instead of checking the box.
DO NOT DELETE the PR checklist.
-->

- [x] Is there an associated issue with maintainer approval for PR submission? <!-- Not required for purely mechanical changes (typo fixes, documentation corrections) — explain in the PR description instead. --> #34780
- [na] Have tests been added/updated? <!-- No test harness exists for `.circleci/scripts`; verified with the synthetic-repo matrix above. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

