### PR TITLE
test: convert the driver commands spec to TypeScript

### DIFF
--- a/packages/driver/cypress/e2e/commands/commands.cy.ts
+++ b/packages/driver/cypress/e2e/commands/commands.cy.ts
@@ -1,5 +1,6 @@
-const { _ } = Cypress
 import { assertLogLength } from '../../support/utils'
+
+const { _ } = Cypress
 
 describe('src/cy/commands/commands', () => {
   beforeEach(() => {
@@ -40,13 +41,15 @@ describe('src/cy/commands/commands', () => {
 
   context('custom commands', () => {
     beforeEach(() => {
+      // @ts-expect-error - custom command names are not part of the Chainable types
       Cypress.Commands.add('dashboard.selectWindows', () => {
         cy
         .get('[contenteditable]')
         .first()
       })
 
-      Cypress.Commands.add('login', { prevSubject: true }, (subject, email, log = true) => {
+      // @ts-expect-error
+      Cypress.Commands.add('login', { prevSubject: true }, (subject: JQuery, email: string, log = true) => {
         cy
         .wrap(subject.find('input:first'), { log })
         .type(email, { log })
@@ -67,7 +70,7 @@ describe('src/cy/commands/commands', () => {
 
     it('we capture logs from custom commands', () => {
       cy.state('isProtocolEnabled', true)
-      const logs = []
+      const logs: Cypress.Log[] = []
       const addLogs = (attrs, log) => {
         logs.push(log)
       }
@@ -129,6 +132,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
+      // @ts-expect-error - a query must return a function, but this one is only ever rejected by name
       Cypress.Commands.addQuery('get', () => {
         cy
         .get('[contenteditable]')
@@ -139,15 +143,19 @@ describe('src/cy/commands/commands', () => {
     it('allows calling .add with hover / mount', () => {
       let calls = 0
 
+      // @ts-expect-error - `hover` and `mount` are reserved for the CT adapters, so they are not part of the Chainable types
       Cypress.Commands.add('hover', () => {
         calls++
       })
 
+      // @ts-expect-error
       Cypress.Commands.add('mount', () => {
         calls++
       })
 
+      // @ts-expect-error
       cy.mount()
+      // @ts-expect-error
       cy.hover()
       cy.then(() => {
         expect(calls).to.eq(2)
@@ -162,6 +170,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
+      // @ts-expect-error - `addCommand` is reserved internally, so it is not part of the Chainable types
       Cypress.Commands.add('addCommand', () => {
         cy
         .get('[contenteditable]')
@@ -177,6 +186,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
+      // @ts-expect-error
       Cypress.Commands.addQuery('addCommand', () => {
         cy
         .get('[contenteditable]')

--- a/packages/driver/cypress/e2e/commands/commands.cy.ts
+++ b/packages/driver/cypress/e2e/commands/commands.cy.ts
@@ -41,14 +41,14 @@ describe('src/cy/commands/commands', () => {
 
   context('custom commands', () => {
     beforeEach(() => {
-      // @ts-expect-error - custom command names are not part of the Chainable types
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.add('dashboard.selectWindows', () => {
         cy
         .get('[contenteditable]')
         .first()
       })
 
-      // @ts-expect-error
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.add('login', { prevSubject: true }, (subject: JQuery, email: string, log = true) => {
         cy
         .wrap(subject.find('input:first'), { log })
@@ -132,7 +132,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
-      // @ts-expect-error - a query must return a function, but this one is only ever rejected by name
+      // @ts-expect-error - a query must return a function, but this one is rejected by name first
       Cypress.Commands.addQuery('get', () => {
         cy
         .get('[contenteditable]')
@@ -143,19 +143,19 @@ describe('src/cy/commands/commands', () => {
     it('allows calling .add with hover / mount', () => {
       let calls = 0
 
-      // @ts-expect-error - `hover` and `mount` are reserved for the CT adapters, so they are not part of the Chainable types
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.add('hover', () => {
         calls++
       })
 
-      // @ts-expect-error
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.add('mount', () => {
         calls++
       })
 
-      // @ts-expect-error
+      // @ts-expect-error - custom command names are not in the Chainable types
       cy.mount()
-      // @ts-expect-error
+      // @ts-expect-error - custom command names are not in the Chainable types
       cy.hover()
       cy.then(() => {
         expect(calls).to.eq(2)
@@ -170,7 +170,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
-      // @ts-expect-error - `addCommand` is reserved internally, so it is not part of the Chainable types
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.add('addCommand', () => {
         cy
         .get('[contenteditable]')
@@ -186,7 +186,7 @@ describe('src/cy/commands/commands', () => {
         done()
       })
 
-      // @ts-expect-error
+      // @ts-expect-error - custom command names are not in the Chainable types
       Cypress.Commands.addQuery('addCommand', () => {
         cy
         .get('[contenteditable]')

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -59,12 +59,19 @@ declare namespace Cypress {
     isCrossOriginSpecBridge: boolean
     originalConfig: Cypress.ObjectLike
     cy: $Cy
+    Chainer: typeof import('../src/cypress/chainer').$Chainer
     Location: {
       create: (url: string) => ({ domain: string, superDomain: string })
     }
     $Cypress: {
       $: JQueryStatic
     }
+  }
+
+  interface Chainable {
+    // Invokes a command by name rather than by property access, so that specs can
+    // exercise commands whose names are not valid identifiers or not yet registered.
+    command(name: string, ...args: any[]): Chainable<any>
   }
 
   interface CypressUtils {


### PR DESCRIPTION
- Closes N/A

### Additional details

Converts `packages/driver/cypress/e2e/commands/commands.cy.js` to TypeScript. Git tracks it as a rename — only 16 of 204 lines moved, and no other spec imports it, so this lands on its own.

Two of the type errors were worth fixing properly rather than suppressing. `cy.command()` and `Cypress.Chainer` are both real driver APIs that were simply never declared:

- `Cypress.Chainer` is assigned `$Chainer` in `packages/driver/src/cypress.ts`
- `cy.command()` is registered in `packages/driver/src/cy/commands/commands.ts`

`cy.command()` alone appears nine times in this spec, so nine `@ts-expect-error` lines would have been noise papering over a real gap in the types. Both declarations went into `packages/driver/types/internal-types.d.ts` instead, which exists for exactly this — "internal Cypress types that we don't want exposed in the public API but want for development". That also unblocks `cypress/e2e/cypress/cy.cy.js`, which uses `cy.command()` twice, whenever that one gets converted.

The nine remaining `@ts-expect-error` directives cover names the spec *deliberately* registers outside the `Chainable` types — `dashboard.selectWindows`, `login`, `hover`/`mount`, `addCommand` — plus one `addQuery('get', …)` case where the name is valid but the callback shape isn't. Those aren't gaps in the types; they're the point of the tests. Each carries a description, matching the convention already dominant in this package (107 described vs. 34 bare).

Every directive is load-bearing: deleting all nine and re-running `tsc` produces exactly nine errors on exactly those lines, and each comment's stated reason matches the emitted diagnostic. An unnecessary one would trip `TS2578`, so they can't silently rot into no-ops.

No changelog entry — the `test` prefix does not require one.

### Steps to test

```
yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/commands/commands.cy.ts"
```

12 passing, 0 failing — the same 12 tests as the `.js` version, with no test bodies changed.

Type-checking is a real gate on this file: the driver's `tsconfig.json` has no `include`, so `cypress/**` is in the program (confirmed with `tsc --listFiles`).

```
yarn workspace @packages/driver check-ts
yarn lint --scope @packages/driver
```

### How has the user experience changed?

No change. Test-only; nothing ships to users.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-file conversion with no behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- The two added declarations are internal driver types in packages/driver/types/internal-types.d.ts, deliberately kept out of the public cli/types/cypress.d.ts surface. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X39847R6sBNqtb2xTEbUBR


---
_Generated by [Claude Code](https://claude.ai/code/session_01X39847R6sBNqtb2xTEbUBR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conversion plus internal type declarations; no runtime or public API surface changes.
> 
> **Overview**
> Converts the driver **commands** e2e spec from JavaScript to TypeScript so it type-checks under the driver `tsconfig` without changing any test behavior.
> 
> Instead of sprinkling `@ts-expect-error` on every `cy.command()` call, the PR adds **internal** declarations in `internal-types.d.ts` for `Chainable.command()` and `Cypress.Chainer`—driver APIs that already exist but were missing from types. Remaining `@ts-expect-error` comments are limited to cases the spec intentionally exercises (custom/namespaced commands, reserved names, invalid query shapes), each with a short reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa8f10329394c3d49c6e7bc1a093fcf1716c11b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->