### PR TITLE
test: convert debugging.cy.js to TypeScript

### DIFF
--- a/packages/driver/cypress/e2e/commands/debugging.cy.ts
+++ b/packages/driver/cypress/e2e/commands/debugging.cy.ts
@@ -130,8 +130,10 @@ describe('src/cy/commands/debugging', () => {
     it('can pause in run mode with --headed and --no-exit', function () {
       let didPause = false
 
+      // @ts-expect-error - runtime config, not a test config override
       Cypress.config('isInteractive', false)
       Cypress.config('browser').isHeaded = true
+      // @ts-expect-error - runtime config, not a test config override
       Cypress.config('exit', false)
 
       cy.once('paused', (name) => {

--- a/packages/driver/types/internal-types.d.ts
+++ b/packages/driver/types/internal-types.d.ts
@@ -70,6 +70,7 @@ declare namespace Cypress {
   interface CypressUtils {
     getDistanceBetween: (point1: { x: number, y: number }, point2: { x: number, y: number }) => number
     isInstanceOf: (instance: any, constructor: any) => boolean
+    log: (...msgs: any[]) => void
     throwErrByPath: (path: string, obj?: { args: object }) => void
     warnByPath: (path: string, obj?: { args: object }) => void
     warning: (message: string) => void


### PR DESCRIPTION
- Closes N/A — purely mechanical change (spec file conversion to TypeScript), so no associated issue.

### Additional details

Renames `packages/driver/cypress/e2e/commands/debugging.cy.js` to `.ts` as part of the ongoing driver spec migration to TypeScript. No test logic changed — the rename is recorded as a rename so the history stays intact.

Only two type errors surfaced, and both are addressed at the root rather than papered over:

**1. `Cypress.utils.log` was missing from `CypressUtils`**

`beforeEach` stubs it via `cy.stub(Cypress.utils, 'log')`, which failed to type check:

```
error TS2345: Argument of type '"log"' is not assignable to parameter of type 'keyof CypressUtils'.
```

The method genuinely exists (`packages/driver/src/cypress/utils.ts`) and is called by the very command under test (`packages/driver/src/cy/commands/debugging.ts`), but the hand-maintained `CypressUtils` interface in `types/internal-types.d.ts` never listed it. Declaring it is more accurate than casting at the call site, and it types the production call sites too.

**2. `isInteractive` / `exit` are runtime config, not test config overrides**

`Cypress.config(key, value)` is typed against `TestConfigOverrides`, which does not include these runtime keys:

```
error TS2345: Argument of type '"exit"' is not assignable to parameter of type 'keyof TestConfigOverrides'.
```

Suppressed with `@ts-expect-error`, matching the existing precedent in `cypress/e2e/issues/28527.cy.ts`.

Everything else was already typed and needed no changes: `cy.state('isProtocolEnabled' | 'onPaused')`, the `'paused'` event payload, `this.lastLog` / `this.hiddenLog` off the Mocha context, and sinon-chai's `calledWithMatch`.

### Steps to test

```bash
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/commands/debugging.cy.ts
```

All 8 tests pass:

```
src/cy/commands/debugging
  #debug
    ✓ does not change the subject
    ✓ logs current subject
    ✓ logs previous command
    ✓ logs undefined on being parent
    .log
      ✓ can turn off logging when protocol is disabled
      ✓ can send hidden log when protocol is enabled
  #pause
    ✓ can pause between each command and skips assertions
    ✓ can pause in run mode with --headed and --no-exit

8 passing (567ms)   ✔ All specs passed!
```

Type checking and linting were also verified:

- `tsc --noEmit` in `packages/driver` produces **byte-identical output before and after** this change (128 pre-existing errors either way, all unrelated `Cannot find module '@packages/*'` failures). The conversion introduces no new type errors.
- Each of the two fixes was temporarily reverted to confirm the error it suppresses actually surfaces — neither is decorative.
- `eslint` passes clean on both changed files.

### How has the user experience changed?

No change. This touches a driver spec file and an internal, non-published type declaration only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical spec conversion; explained above. -->
- [x] Have tests been added/updated? <!-- The converted spec itself; all 8 tests pass unchanged. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- The type change is in the driver's internal `types/internal-types.d.ts`, not the public `cli/types/cypress.d.ts`. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgG18zidUTRpTXWhDLiJJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgG18zidUTRpTXWhDLiJJu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical spec conversion and internal type declarations only; no production or public API behavior changes.
> 
> **Overview**
> Migrates the driver **#debug** / **#pause** e2e spec from JavaScript to TypeScript as part of the ongoing driver spec migration. **Test behavior is unchanged**; the only edits beyond the rename are type fixes.
> 
> **`CypressUtils`** in `internal-types.d.ts` now declares **`log`**, so stubs like `cy.stub(Cypress.utils, 'log')` type-check and match the real utility used by the debugging command.
> 
> In the headed run-mode pause test, **`@ts-expect-error`** is added on `Cypress.config('isInteractive', …)` and `Cypress.config('exit', …)` because those keys are runtime config, not `TestConfigOverrides`—same pattern as other driver specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a72c0ef590d0319dad73b87fdebb325958b4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->