### PR TITLE
test: convert skipping specs to TypeScript

### DIFF
--- a/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
@@ -18,11 +18,11 @@ Screenshot.defaults({ onAfterScreenshot: () => {
 const pendingTests: Cypress.ObjectLike[] = []
 const passedTests: Cypress.ObjectLike[] = []
 
-Cypress.on('test:after:run', (test) => {
-  if (test.state === 'pending') {
-    pendingTests.push(test)
-  } else if (test.state === 'passed') {
-    passedTests.push(test)
+Cypress.on('test:after:run', (attributes) => {
+  if (attributes.state === 'pending') {
+    pendingTests.push(attributes)
+  } else if (attributes.state === 'passed') {
+    passedTests.push(attributes)
   }
 })
 

--- a/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
@@ -1,10 +1,12 @@
+export {} // make typescript see this as a module
+
 const { Screenshot } = Cypress
 
 let failedEventFired = false
 
 Cypress.on('fail', (error) => {
   failedEventFired = true
-  throw new Error(error)
+  throw new Error(`${error}`)
 })
 
 let screenshotTaken = false
@@ -13,16 +15,14 @@ Screenshot.defaults({ onAfterScreenshot: () => {
   screenshotTaken = true
 } })
 
-const pendingTests = []
-const passedTests = []
+const pendingTests: Cypress.ObjectLike[] = []
+const passedTests: Cypress.ObjectLike[] = []
 
 Cypress.on('test:after:run', (test) => {
   if (test.state === 'pending') {
-    return pendingTests.push(test)
-  }
-
-  if (test.state === 'passed') {
-    return passedTests.push(test)
+    pendingTests.push(test)
+  } else if (test.state === 'passed') {
+    passedTests.push(test)
   }
 })
 
@@ -32,25 +32,17 @@ beforeEach(() => {
   Cypress.config('isInteractive', false)
 })
 
-describe('generally skipped test', () => {
-  before(function () {
-    this.skip()
-  })
-
+describe('skipped test', () => {
   it('does not fail', function () {
-    expect(true).to.be.false
-  })
-})
-
-describe('individually skipped tests', () => {
-  it('does not fail when using this.skip', function () {
-    this.skip()
-    expect(true).to.be.false
+    cy.then(() => {
+      this.skip()
+    }).then(() => {
+      expect(true).to.be.false
+    })
   })
 
-  // NOTE: We are skipping this test in order to test skip functionality
-  it.skip('does not fail when using it.skip', () => {
-    expect(true).to.be.false
+  it('does not prevent subsequent tests from running', () => {
+    expect(true).to.be.true
   })
 })
 
@@ -64,7 +56,7 @@ describe('skipped test side effects', () => {
   })
 
   it('does still mark all tests with the correct state', () => {
-    expect(pendingTests).to.have.length(3)
-    expect(passedTests).to.have.length(2)
+    expect(pendingTests).to.have.length(1)
+    expect(passedTests).to.have.length(3)
   })
 })

--- a/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
@@ -6,7 +6,7 @@ let failedEventFired = false
 
 Cypress.on('fail', (error) => {
   failedEventFired = true
-  throw new Error(`${error}`)
+  throw error
 })
 
 let screenshotTaken = false
@@ -28,9 +28,8 @@ Cypress.on('test:after:run', (test) => {
 
 beforeEach(() => {
   // Set isInteractive to false to ensure that screenshots will be
-  // triggered in both run and open mode. It is not a test override, so the
-  // types reject it even though the driver applies it at runtime.
-  // @ts-expect-error
+  // triggered in both run and open mode
+  // @ts-expect-error - isInteractive is not a test override, but the driver applies it at runtime
   Cypress.config('isInteractive', false)
 })
 

--- a/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_async.cy.ts
@@ -28,7 +28,9 @@ Cypress.on('test:after:run', (test) => {
 
 beforeEach(() => {
   // Set isInteractive to false to ensure that screenshots will be
-  // triggered in both run and open mode
+  // triggered in both run and open mode. It is not a test override, so the
+  // types reject it even though the driver applies it at runtime.
+  // @ts-expect-error
   Cypress.config('isInteractive', false)
 })
 

--- a/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
@@ -18,11 +18,11 @@ Screenshot.defaults({ onAfterScreenshot: () => {
 const pendingTests: Cypress.ObjectLike[] = []
 const passedTests: Cypress.ObjectLike[] = []
 
-Cypress.on('test:after:run', (test) => {
-  if (test.state === 'pending') {
-    pendingTests.push(test)
-  } else if (test.state === 'passed') {
-    passedTests.push(test)
+Cypress.on('test:after:run', (attributes) => {
+  if (attributes.state === 'pending') {
+    pendingTests.push(attributes)
+  } else if (attributes.state === 'passed') {
+    passedTests.push(attributes)
   }
 })
 

--- a/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
@@ -6,7 +6,7 @@ let failedEventFired = false
 
 Cypress.on('fail', (error) => {
   failedEventFired = true
-  throw new Error(`${error}`)
+  throw error
 })
 
 let screenshotTaken = false
@@ -28,9 +28,8 @@ Cypress.on('test:after:run', (test) => {
 
 beforeEach(() => {
   // Set isInteractive to false to ensure that screenshots will be
-  // triggered in both run and open mode. It is not a test override, so the
-  // types reject it even though the driver applies it at runtime.
-  // @ts-expect-error
+  // triggered in both run and open mode
+  // @ts-expect-error - isInteractive is not a test override, but the driver applies it at runtime
   Cypress.config('isInteractive', false)
 })
 

--- a/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
@@ -1,10 +1,12 @@
+export {} // make typescript see this as a module
+
 const { Screenshot } = Cypress
 
 let failedEventFired = false
 
 Cypress.on('fail', (error) => {
   failedEventFired = true
-  throw new Error(error)
+  throw new Error(`${error}`)
 })
 
 let screenshotTaken = false
@@ -13,16 +15,14 @@ Screenshot.defaults({ onAfterScreenshot: () => {
   screenshotTaken = true
 } })
 
-const pendingTests = []
-const passedTests = []
+const pendingTests: Cypress.ObjectLike[] = []
+const passedTests: Cypress.ObjectLike[] = []
 
 Cypress.on('test:after:run', (test) => {
   if (test.state === 'pending') {
-    return pendingTests.push(test)
-  }
-
-  if (test.state === 'passed') {
-    return passedTests.push(test)
+    pendingTests.push(test)
+  } else if (test.state === 'passed') {
+    passedTests.push(test)
   }
 })
 
@@ -32,17 +32,25 @@ beforeEach(() => {
   Cypress.config('isInteractive', false)
 })
 
-describe('skipped test', () => {
-  it('does not fail', function () {
-    cy.then(() => {
-      this.skip()
-    }).then(() => {
-      expect(true).to.be.false
-    })
+describe('generally skipped test', () => {
+  before(function () {
+    this.skip()
   })
 
-  it('does not prevent subsequent tests from running', () => {
-    expect(true).to.be.true
+  it('does not fail', function () {
+    expect(true).to.be.false
+  })
+})
+
+describe('individually skipped tests', () => {
+  it('does not fail when using this.skip', function () {
+    this.skip()
+    expect(true).to.be.false
+  })
+
+  // NOTE: We are skipping this test in order to test skip functionality
+  it.skip('does not fail when using it.skip', () => {
+    expect(true).to.be.false
   })
 })
 
@@ -56,7 +64,7 @@ describe('skipped test side effects', () => {
   })
 
   it('does still mark all tests with the correct state', () => {
-    expect(pendingTests).to.have.length(1)
-    expect(passedTests).to.have.length(3)
+    expect(pendingTests).to.have.length(3)
+    expect(passedTests).to.have.length(2)
   })
 })

--- a/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
+++ b/packages/driver/cypress/e2e/cy/skipping_sync.cy.ts
@@ -28,7 +28,9 @@ Cypress.on('test:after:run', (test) => {
 
 beforeEach(() => {
   // Set isInteractive to false to ensure that screenshots will be
-  // triggered in both run and open mode
+  // triggered in both run and open mode. It is not a test override, so the
+  // types reject it even though the driver applies it at runtime.
+  // @ts-expect-error
   Cypress.config('isInteractive', false)
 })
 


### PR DESCRIPTION
- Closes N/A — mechanical TypeScript conversion of two existing driver specs.

### Additional details

Renames `packages/driver/cypress/e2e/cy/skipping_async.cy.js` and `skipping_sync.cy.js` to `.ts` and fixes the resulting type errors. No other spec imports either file, so this lands on its own.

Beyond the rename:

| Change | Why |
| --- | --- |
| `export {}` | Both files declare the same top-level names (`Screenshot`, `failedEventFired`, `pendingTests`, `passedTests`). As global scripts in one `tsc` program they collide with duplicate-identifier errors. Follows the existing convention in `visibility_shadow_dom.cy.ts`. |
| `throw error`, was `throw new Error(error)` | `error` is a `CypressError`, not a string. The old form stringified it, losing the stack and double-prefixing the message. |
| `Cypress.ObjectLike[]` on `pendingTests` / `passedTests` | Matches the `test:after:run` attributes type. |
| `if` / `else if` instead of `return arr.push(...)` | Returning a value from only some code paths trips `noImplicitReturns`. The handler's return value is discarded — `cypress.ts` emits this event via `this.emit`, not `emitMap`/`emitThen`. |
| `@ts-expect-error` on `Cypress.config('isInteractive', false)` | `isInteractive` exists on `Config` but not on `TestConfigOverrides`, and the two-argument overload is keyed to the latter. The driver applies it at runtime, which is what these specs rely on to force run-mode screenshot behavior. |
| `attributes` instead of `test` for the `test:after:run` parameter | The handler receives the test attributes object; the `Mocha.Test` is the second parameter. |

`throw error` is the only change that is not byte-for-byte faithful to the JS. The line had to change to type-check, so it was a choice between two rewrites rather than an unprompted edit. Both forms converge here: neither spec uses a `done` callback and neither fail site passes `{ async: true }`, so `cy.fail()` ends in `throw err` either way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mechanical TypeScript conversion of two driver specs; the only intentional behavior tweak is rethrowing the original fail error instead of wrapping it.
> 
> **Overview**
> Converts **`skipping_async`** and **`skipping_sync`** driver e2e specs from JavaScript to TypeScript with typing and small fixes required for `tsc`.
> 
> Both files add **`export {}`** so top-level bindings do not collide in the shared compile, annotate **`pendingTests`** / **`passedTests`** as **`Cypress.ObjectLike[]`**, and rename the **`test:after:run`** callback argument to **`attributes`** with **`if` / `else if`** pushes instead of **`return arr.push(...)`** for **`noImplicitReturns`**. The **`fail`** handler now **`throw error`** instead of wrapping in **`new Error(error)`** so **`CypressError`** stacks are preserved. **`Cypress.config('isInteractive', false)`** gets a **`@ts-expect-error`** because the typed config overload does not include that key even though the driver sets it at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79151983a376603503983748d5bae3024d9ceff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/cy/skipping_async.cy.ts,cypress/e2e/cy/skipping_sync.cy.ts"
```

Both specs pass, with the same counts as before the conversion:

```
skipping_async.cy.ts   5 tests   4 passing   1 pending
skipping_sync.cy.ts    6 tests   3 passing   3 pending
```

Those counts are what the specs assert internally — `pendingTests` 1 / `passedTests` 3 for async, 3 / 2 for sync. Each passing figure is one higher because it includes the assertion test itself.

`tsc --noEmit` and `eslint` are both clean for the two files.

### How has the user experience changed?

No change. This is a test-only change to two driver specs.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical file-format conversion with no behavior change. -->
- [x] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzhoEs3hrvhrrgVc6KwtQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzhoEs3hrvhrrgVc6KwtQG)_