### PR TITLE
test: convert driver snapshot specs to TypeScript

### DIFF
--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -292,7 +292,7 @@ jobs:
       # mirrors run_driver_suite() in scripts/validate-proxy-middleware-transport.sh,
       # plus the MITM injection/interception-heavy specs (net_stubbing, security,
       # redirects, service-worker)
-      spec: cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/commands/net_stubbing.cy.ts,cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/e2e/service-worker.cy.js
+      spec: cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.ts,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/commands/net_stubbing.cy.ts,cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/e2e/service-worker.cy.js
       requires:
         - ready-to-test
   - system-tests-chrome:

--- a/.circleci/src/pipeline/workflows/pull-request.yml
+++ b/.circleci/src/pipeline/workflows/pull-request.yml
@@ -292,7 +292,7 @@ jobs:
       # mirrors run_driver_suite() in scripts/validate-proxy-middleware-transport.sh,
       # plus the MITM injection/interception-heavy specs (net_stubbing, security,
       # redirects, service-worker)
-      spec: cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.ts,cypress/e2e/cypress/downloads.cy.ts,cypress/e2e/commands/net_stubbing.cy.ts,cypress/e2e/e2e/security.cy.js,cypress/e2e/e2e/redirects.cy.js,cypress/e2e/e2e/service-worker.cy.js
+      spec: cypress/e2e/e2e/encoding.cy.*,cypress/e2e/e2e/csp_headers.cy.*,cypress/e2e/cypress/proxy-logging.cy.*,cypress/e2e/issues/3890.cy.*,cypress/e2e/cy/snapshot.cy.*,cypress/e2e/cypress/downloads.cy.*,cypress/e2e/commands/net_stubbing.cy.*,cypress/e2e/e2e/security.cy.*,cypress/e2e/e2e/redirects.cy.*,cypress/e2e/e2e/service-worker.cy.*
       requires:
         - ready-to-test
   - system-tests-chrome:

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.ts
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.ts
@@ -1,5 +1,11 @@
 const { $ } = Cypress
 
+// the fixture defines these on `window` so the tests can stub them
+type CustomElementsWindow = Window & {
+  customElementConstructor: () => void
+  customElementAttributeChanged: () => void
+}
+
 describe('driver/src/cy/snapshots', () => {
   context('invalid snapshot html', () => {
     beforeEach(() => {
@@ -13,9 +19,9 @@ describe('driver/src/cy/snapshots', () => {
     })
 
     it('does not err on snapshot', () => {
-      const { htmlAttrs } = cy.createSnapshot()
+      const { htmlAttrs } = cy.createSnapshot()!
 
-      const doc = cy.state('document')
+      const doc = cy.state('document')!
 
       doc.write('')
 
@@ -37,7 +43,7 @@ describe('driver/src/cy/snapshots', () => {
     it('does not clone scripts', function () {
       $('<script type=\'text/javascript\' />').appendTo(cy.$$('body'))
 
-      const { body } = cy.createSnapshot(null, this.$el)
+      const { body } = cy.createSnapshot(null, this.$el)!
 
       expect(body.get().find('script')).not.to.exist
     })
@@ -45,7 +51,7 @@ describe('driver/src/cy/snapshots', () => {
     it('does not clone css stylesheets', function () {
       $('<link rel=\'stylesheet\' />').appendTo(cy.$$('body'))
 
-      const { body } = cy.createSnapshot(null, this.$el)
+      const { body } = cy.createSnapshot(null, this.$el)!
 
       expect(body.get().find('link')).not.to.exist
     })
@@ -53,7 +59,7 @@ describe('driver/src/cy/snapshots', () => {
     it('does not clone style tags', function () {
       $('<style>.foo { color: blue }</style>').appendTo(cy.$$('body'))
 
-      const { body } = cy.createSnapshot(null, this.$el)
+      const { body } = cy.createSnapshot(null, this.$el)!
 
       expect(body.get().find('style')).not.to.exist
     })
@@ -65,7 +71,7 @@ describe('driver/src/cy/snapshots', () => {
       $html[0].id = 'baz'
       $html.css('margin', '10px')
 
-      const { htmlAttrs } = cy.createSnapshot(null, this.$el)
+      const { htmlAttrs } = cy.createSnapshot(null, this.$el)!
 
       expect(htmlAttrs).to.eql({
         class: 'foo bar',
@@ -120,7 +126,7 @@ describe('driver/src/cy/snapshots', () => {
         // e.g. cy.get('iframe').toMatchScreenshot()
 
         // For now we parse the src attr and assert on base64 encoded content
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe').length).to.equal(1)
         expect(body.get().find('iframe')[0].src).to.include(';base64')
@@ -130,7 +136,7 @@ describe('driver/src/cy/snapshots', () => {
       it('placeholders have same id', function () {
         $('<iframe id=\'foo-bar\' />').appendTo(cy.$$('body'))
 
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe')[0].id).to.equal('foo-bar')
       })
@@ -138,7 +144,7 @@ describe('driver/src/cy/snapshots', () => {
       it('placeholders have same classes', function () {
         $('<iframe class=\'foo bar\' />').appendTo(cy.$$('body'))
 
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe')[0].className).to.equal('foo bar')
       })
@@ -146,7 +152,7 @@ describe('driver/src/cy/snapshots', () => {
       it('placeholders have inline styles', function () {
         $('<iframe style=\'margin: 40px\' />').appendTo(cy.$$('body'))
 
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe').css('margin')).to.equal('40px')
       })
@@ -154,7 +160,7 @@ describe('driver/src/cy/snapshots', () => {
       it('placeholders have width set to outer width', function () {
         $('<iframe style=\'width: 40px; padding: 20px; border: solid 5px\' />').appendTo(cy.$$('body'))
 
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe').css('width')).to.equal('90px')
       })
@@ -162,7 +168,7 @@ describe('driver/src/cy/snapshots', () => {
       it('placeholders have height set to outer height', function () {
         $('<iframe style=\'height: 40px; padding: 10px; border: solid 5px\' />').appendTo(cy.$$('body'))
 
-        const { body } = cy.createSnapshot(null, this.$el)
+        const { body } = cy.createSnapshot(null, this.$el)!
 
         expect(body.get().find('iframe').css('height')).to.equal('70px')
       })
@@ -176,7 +182,7 @@ describe('driver/src/cy/snapshots', () => {
 
     // https://github.com/cypress-io/cypress/issues/7187
     it('does not trigger constructor', () => {
-      const constructor = cy.stub(cy.state('window'), 'customElementConstructor')
+      const constructor = cy.stub(cy.state('window') as CustomElementsWindow, 'customElementConstructor')
 
       cy.createSnapshot()
 
@@ -185,7 +191,7 @@ describe('driver/src/cy/snapshots', () => {
 
     // https://github.com/cypress-io/cypress/issues/7187
     it('does not trigger attributeChangedCallback', () => {
-      const attributeChanged = cy.stub(cy.state('window'), 'customElementAttributeChanged')
+      const attributeChanged = cy.stub(cy.state('window') as CustomElementsWindow, 'customElementAttributeChanged')
 
       cy.createSnapshot()
 
@@ -193,3 +199,5 @@ describe('driver/src/cy/snapshots', () => {
     })
   })
 })
+
+export {}

--- a/packages/driver/cypress/e2e/cy/snapshot.cy.ts
+++ b/packages/driver/cypress/e2e/cy/snapshot.cy.ts
@@ -1,6 +1,6 @@
 const { $ } = Cypress
 
-// the fixture defines these on `window` so the tests can stub them
+// the custom-elements fixture defines these on `window` so the tests can stub them
 type CustomElementsWindow = Window & {
   customElementConstructor: () => void
   customElementAttributeChanged: () => void

--- a/packages/driver/cypress/e2e/cy/snapshot_css.cy.ts
+++ b/packages/driver/cypress/e2e/cy/snapshot_css.cy.ts
@@ -1,20 +1,21 @@
-const { $ } = Cypress
-const { create } = require('../../../src/cy/snapshots_css')
+import { create } from '../../../src/cy/snapshots_css'
 
-const normalizeStyles = (styles) => {
+const { $ } = Cypress
+
+const normalizeStyles = (styles: string) => {
   return styles
   .replace(/\s+/gm, '')
   .replace(/['"]/gm, '\'')
 }
 
-const addStyles = (styles, to) => {
-  return new Promise((resolve) => {
-    $(styles).on('load', resolve).appendTo(cy.$$(to))
+const addStyles = (styles: string, to: string) => {
+  return new Promise<void>((resolve) => {
+    $(styles).on('load', () => resolve()).appendTo(cy.$$(to))
   })
 }
 
 describe('driver/src/cy/snapshots_css', () => {
-  let snapshotCss
+  let snapshotCss: ReturnType<typeof create>
 
   beforeEach(() => {
     snapshotCss = create(cy.$$, cy.state)
@@ -85,7 +86,7 @@ describe('driver/src/cy/snapshots_css', () => {
     it('returns new id if css has been modified', () => {
       const idsBefore = snapshotCss.getStyleIds()
 
-      cy.state('document').styleSheets[0].insertRule('.qux { color: orange; }')
+      cy.state('document')!.styleSheets[0].insertRule('.qux { color: orange; }')
       snapshotCss.onCssModified('http://localhost:3500/fixtures/generic_styles.css')
       const idsAfter = snapshotCss.getStyleIds()
 
@@ -97,7 +98,7 @@ describe('driver/src/cy/snapshots_css', () => {
     })
 
     it('returns same id after css has been modified until a new window', () => {
-      cy.state('document').styleSheets[0].insertRule('.qux { color: orange; }')
+      cy.state('document')!.styleSheets[0].insertRule('.qux { color: orange; }')
       snapshotCss.onCssModified('http://localhost:3500/fixtures/generic_styles.css')
       const ids1 = snapshotCss.getStyleIds()
       const ids2 = snapshotCss.getStyleIds()
@@ -107,7 +108,7 @@ describe('driver/src/cy/snapshots_css', () => {
       expect(ids1.headStyleIds[0]).to.equal(ids2.headStyleIds[0])
       expect(ids2.headStyleIds[0]).to.equal(ids3.headStyleIds[0])
 
-      cy.state('document').styleSheets[0].deleteRule(0) // need to change contents or they will map to same id
+      cy.state('document')!.styleSheets[0].deleteRule(0) // need to change contents or they will map to same id
       snapshotCss.onBeforeWindowLoad()
       const ids4 = snapshotCss.getStyleIds()
 
@@ -118,9 +119,9 @@ describe('driver/src/cy/snapshots_css', () => {
     it('returns same id if css has been modified but yields same contents', () => {
       const ids1 = snapshotCss.getStyleIds()
 
-      cy.state('document').styleSheets[0].insertRule('.qux { color: orange; }')
+      cy.state('document')!.styleSheets[0].insertRule('.qux { color: orange; }')
       snapshotCss.onCssModified('http://localhost:3500/fixtures/generic_styles.css')
-      cy.state('document').styleSheets[0].deleteRule(0)
+      cy.state('document')!.styleSheets[0].deleteRule(0)
       snapshotCss.onCssModified('http://localhost:3500/fixtures/generic_styles.css')
 
       const ids2 = snapshotCss.getStyleIds()
@@ -131,17 +132,14 @@ describe('driver/src/cy/snapshots_css', () => {
   })
 
   context('.getStylesByIds', () => {
-    let getStyles
+    const getStyles = () => {
+      const { headStyleIds, bodyStyleIds } = snapshotCss.getStyleIds()
 
-    beforeEach(() => {
-      getStyles = () => {
-        const { headStyleIds, bodyStyleIds } = snapshotCss.getStyleIds()
-        const headStyles = snapshotCss.getStylesByIds(headStyleIds)
-        const bodyStyles = snapshotCss.getStylesByIds(bodyStyleIds)
-
-        return { headStyles, bodyStyles }
+      return {
+        headStyles: snapshotCss.getStylesByIds(headStyleIds),
+        bodyStyles: snapshotCss.getStylesByIds(bodyStyleIds),
       }
-    })
+    }
 
     it('returns array of css styles for given ids', () => {
       const { headStyles, bodyStyles } = getStyles()
@@ -162,7 +160,7 @@ describe('driver/src/cy/snapshots_css', () => {
       const styleEl = document.createElement('style')
 
       $(styleEl).appendTo(cy.$$('head'))
-      styleEl.sheet.insertRule('.foo { color: red; }', 0)
+      styleEl.sheet!.insertRule('.foo { color: red; }', 0)
 
       const { headStyles } = getStyles()
 

--- a/scripts/validate-proxy-middleware-transport.sh
+++ b/scripts/validate-proxy-middleware-transport.sh
@@ -47,9 +47,9 @@ run_unit_suite() {
 
 run_driver_suite() {
   local force_http1="$1"
-  # `.cy.*` rather than a pinned extension so a spec's JS/TS conversion cannot
-  # silently drop it from this list -- Cypress ignores a --spec entry that
-  # matches nothing and still exits 0
+  # Cypress ignores a --spec entry that matches nothing and still exits 0, so
+  # glob the extension: a spec converted between JS and TS stays in this list
+  # instead of silently dropping out of the run
   local specs="cypress/e2e/e2e/encoding.cy.*,cypress/e2e/e2e/csp_headers.cy.*,cypress/e2e/cypress/proxy-logging.cy.*,cypress/e2e/issues/3890.cy.*,cypress/e2e/cy/snapshot.cy.*,cypress/e2e/cypress/downloads.cy.*"
 
   yarn workspace @packages/driver cypress:run -- \

--- a/scripts/validate-proxy-middleware-transport.sh
+++ b/scripts/validate-proxy-middleware-transport.sh
@@ -47,7 +47,7 @@ run_unit_suite() {
 
 run_driver_suite() {
   local force_http1="$1"
-  local specs="cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.js,cypress/e2e/cypress/downloads.cy.ts"
+  local specs="cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.ts,cypress/e2e/cypress/downloads.cy.ts"
 
   yarn workspace @packages/driver cypress:run -- \
     --browser "$BROWSER" --headless --spec "$specs" \

--- a/scripts/validate-proxy-middleware-transport.sh
+++ b/scripts/validate-proxy-middleware-transport.sh
@@ -47,7 +47,10 @@ run_unit_suite() {
 
 run_driver_suite() {
   local force_http1="$1"
-  local specs="cypress/e2e/e2e/encoding.cy.ts,cypress/e2e/e2e/csp_headers.cy.js,cypress/e2e/cypress/proxy-logging.cy.ts,cypress/e2e/issues/3890.cy.js,cypress/e2e/cy/snapshot.cy.ts,cypress/e2e/cypress/downloads.cy.ts"
+  # `.cy.*` rather than a pinned extension so a spec's JS/TS conversion cannot
+  # silently drop it from this list -- Cypress ignores a --spec entry that
+  # matches nothing and still exits 0
+  local specs="cypress/e2e/e2e/encoding.cy.*,cypress/e2e/e2e/csp_headers.cy.*,cypress/e2e/cypress/proxy-logging.cy.*,cypress/e2e/issues/3890.cy.*,cypress/e2e/cy/snapshot.cy.*,cypress/e2e/cypress/downloads.cy.*"
 
   yarn workspace @packages/driver cypress:run -- \
     --browser "$BROWSER" --headless --spec "$specs" \


### PR DESCRIPTION
- Closes N/A — no associated issue. Mechanical test-only conversion, with two follow-on fixes it surfaced (see below).

### Additional details

Converts `packages/driver/cypress/e2e/cy/snapshot.cy.js` and `snapshot_css.cy.js` to TypeScript. No test was added, removed, renamed, or reordered: the suites still run 16 and 15 tests respectively.

**The conversion itself**

The driver's root `tsconfig.json` type-checks `cypress/e2e/**` with `strictNullChecks: true`, so most of the diff is nullability:

- `cy.createSnapshot()` returns `null` when the document is unavailable, and `cy.state('document')` is `Document | undefined` — both take non-null assertions at the call sites.
- `HTMLStyleElement.sheet` is nullable, so `styleEl.sheet!.insertRule(...)`.
- The custom-elements tests stub two functions the fixture hangs off `window`. These get a small named `CustomElementsWindow` type rather than an `as any`.
- `const { $ } = Cypress` at top level collides with the global jQuery `$`. `export {}` makes the file a module, which is tidier than the `@ts-expect-error - this is being redeclared` used by some sibling specs.
- `require('../../../src/cy/snapshots_css')` becomes an `import`, and `snapshotCss` picks up `ReturnType<typeof create>`.

One non-mechanical change worth a reviewer's eye: in `snapshot_css.cy.ts`, the `getStyles` helper was being reassigned in a `beforeEach` for no reason, which left it implicitly `any`. It is now a plain context-scoped `const`. It still reads the current `snapshotCss` at call time, so behavior is identical — this is only to avoid an untyped `let`. Happy to revert that hunk if you would rather the diff stay purely mechanical.

**Two follow-on fixes the rename surfaced**

Renaming the spec broke two hardcoded `--spec` lists that still named `cypress/e2e/cy/snapshot.cy.js`:

- `.circleci/src/pipeline/workflows/pull-request.yml` — the `driver-integration-tests-chrome-force-http1-smoke` job
- `scripts/validate-proxy-middleware-transport.sh` — `run_driver_suite()`, which that job's comment says it mirrors

This fails silently, which is why it is worth fixing rather than just repointing. Verified against the real binary: given a `--spec` list where one entry matches nothing and the rest resolve, Cypress runs the rest, prints "All specs passed", and exits 0. Both call sites would have kept reporting green while quietly dropping snapshot coverage on the forceHttp1 MITM proxy path.

Both lists now match on `.cy.*` instead of a pinned extension, so a future JS↔TS conversion cannot reintroduce this. That matches the globbed driver spec selections already used elsewhere in the pipeline (`cypress/e2e/memory/*.cy.*`, the `**/*.cy.*` test-split glob), and the job parameter's own description already calls itself "optional Cypress --spec glob(s)".

**Known residual gap, deliberately left alone:** a glob survives a rename but does not restore a failure signal. If one of these specs is deleted or moved, `.cy.*` matches nothing, Cypress skips it, and the job still goes green. Closing that properly means a pre-flight guard asserting each entry matches at least one file, which is a real change to the job's run step rather than a one-line edit. Happy to add it here or in a follow-up if you want it.

**Note on the CircleCI change:** `.circleci/packed/` is gitignored and packed at CI runtime, so there is no packed artifact to commit. I could not run `yarn pack-ci --validate` locally (it requires the CircleCI CLI, which was not available in my environment) — the YAML does parse and the edit is confined to one quoted scalar, but that check is worth running before merge.

### Steps to test

Both specs pass locally against a dev binary:

```sh
yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/cy/snapshot.cy.ts --browser electron
# 16 passing

yarn workspace @packages/driver cypress:run -- --spec cypress/e2e/cy/snapshot_css.cy.ts --browser electron
# 15 passing
```

Also verified:

- `yarn workspace @packages/driver check-ts` — no errors in either file. To confirm the check was not silently skipping them, I injected a deliberate type error into each and confirmed `tsc` reported it.
- `yarn lint --scope @packages/driver` on both files — clean.
- All ten patterns in the CI spec list still resolve to exactly one spec each, with no accidental widening (`snapshot.cy.*` does not pull in `snapshot_css.cy.ts`).
- The CI job's external-PR branch passes `$TESTFILES` unquoted. The comma-joined glob string cannot match a path and `nullglob`/`failglob` are off, so bash hands it through intact for Cypress to expand.

### How has the user experience changed?

No change. Test and CI plumbing only — nothing ships to users, which is why the title uses the `test` prefix and no `cli/CHANGELOG.md` entry is included.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical TypeScript conversion of two existing specs, plus the stale spec-path references it surfaced. No behavior change. -->
- [x] Have tests been added/updated? <!-- The two specs are converted to TypeScript; test count and assertions are unchanged. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AofD6hFTHtcbcsjmahP3KV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AofD6hFTHtcbcsjmahP3KV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only typing and CI spec path updates; no production or user-facing behavior changes.
> 
> **Overview**
> Converts the driver snapshot e2e specs (`snapshot.cy` and `snapshot_css.cy`) from JavaScript to TypeScript so they pass `strictNullChecks`—non-null assertions on `cy.createSnapshot()` / `cy.state('document')`, typed helpers, ESM `import` for `snapshots_css`, a `CustomElementsWindow` type for fixture stubs, and `export {}` to avoid global `$` clashes.
> 
> Because the rename left hardcoded `snapshot.cy.js` paths in CI, the **forceHttp1** smoke spec lists in CircleCI (`driver-integration-tests-chrome-force-http1-smoke`) and `scripts/validate-proxy-middleware-transport.sh` now use `*.cy.*` globs so a JS↔TS rename cannot silently drop specs when Cypress ignores non-matching `--spec` entries and still exits 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5511e2ea6445f5c0981a4ea99b334f988e6802c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->