### PR TITLE
test: convert removed_commands.cy.js to TypeScript

### DIFF
--- a/packages/driver/cypress/e2e/commands/removed_commands.cy.ts
+++ b/packages/driver/cypress/e2e/commands/removed_commands.cy.ts
@@ -7,6 +7,7 @@ context('cy.server', () => {
       done()
     })
 
+    // @ts-expect-error - cy.server() was removed
     cy.server()
   })
 })
@@ -20,6 +21,7 @@ context('cy.route', () => {
       done()
     })
 
+    // @ts-expect-error - cy.route() was removed
     cy.route('/foo')
   })
 })
@@ -33,6 +35,7 @@ context('cy.end', () => {
       done()
     })
 
+    // @ts-expect-error - cy.end() was removed
     cy.end()
   })
 
@@ -43,6 +46,7 @@ context('cy.end', () => {
       done()
     })
 
+    // @ts-expect-error - .end() was removed
     cy.wrap({}).end()
   })
 })
@@ -58,6 +62,7 @@ context('cy.exec', () => {
       done()
     })
 
+    // @ts-expect-error - cy.exec() was removed
     cy.exec('ls')
   })
 
@@ -69,6 +74,7 @@ context('cy.exec', () => {
     })
 
     cy.origin('http://www.foobar.com:3500', () => {
+      // @ts-expect-error - cy.exec() was removed
       cy.exec('ls')
     })
   })
@@ -83,6 +89,7 @@ context('Cypress.server.defaults', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.Server was removed
     Cypress.Server.defaults({})
   })
 })
@@ -96,6 +103,7 @@ context('Cypress.Cookies.defaults', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.Cookies.defaults() was removed
     Cypress.Cookies.defaults({})
   })
 })
@@ -109,6 +117,7 @@ context('Cypress.Cookies.preserveOnce', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.Cookies.preserveOnce() was removed
     Cypress.Cookies.preserveOnce({})
   })
 })
@@ -125,6 +134,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env('FOO')
   })
 
@@ -135,6 +145,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env('FOO', 'bar')
   })
 
@@ -145,6 +156,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env({ FOO: 'foo', BAR: 'bar' })
   })
 
@@ -155,6 +167,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env(['FOO', 'BAR'])
   })
 
@@ -165,6 +178,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env(['FOO'])
   })
 
@@ -175,6 +189,7 @@ context('Cypress.env', () => {
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env()
   })
 
@@ -182,14 +197,15 @@ context('Cypress.env', () => {
   it('points the code frame and stack at the call site', { browser: '!webkit' }, (done) => {
     cy.on('fail', (err) => {
       expect(err.codeFrame).to.exist
-      expect(err.codeFrame.relativeFile).to.include('removed_commands.cy.js')
-      expect(err.codeFrame.frame).to.include('Cypress.env')
+      expect(err.codeFrame!.relativeFile).to.include('removed_commands.cy.ts')
+      expect(err.codeFrame!.frame).to.include('Cypress.env')
       expect(err.stack).to.include('From Your Spec Code:')
       expect(err.stack).not.to.include('bluebird')
 
       done()
     })
 
+    // @ts-expect-error - Cypress.env() was removed
     Cypress.env('FOO')
   })
 
@@ -203,6 +219,7 @@ context('Cypress.env', () => {
     })
 
     cy.origin('http://www.foobar.com:3500', () => {
+      // @ts-expect-error - Cypress.env() was removed
       Cypress.env('FOO')
     })
   })


### PR DESCRIPTION
- Closes N/A — mechanical test-file conversion, no behavior change. Part of the ongoing effort to move `packages/driver/cypress/e2e` specs to TypeScript.

### Additional details

Renames `packages/driver/cypress/e2e/commands/removed_commands.cy.js` to `.cy.ts` (via `git mv`, so history follows the file) and resolves the resulting type errors. No other spec imports it, so it lands on its own.

Three kinds of change:

1. **17 `@ts-expect-error` directives**, one per call to a removed API — `cy.server()`, `cy.route()`, `cy.end()` (standalone and chained), `cy.exec()` (including inside the `cy.origin()` callback), `Cypress.Server.defaults()`, `Cypress.Cookies.defaults()`, `Cypress.Cookies.preserveOnce()`, and all eight `Cypress.env()` call sites. These commands were removed, so their type definitions are gone too.

   Worth noting for reviewers: the directives are load-bearing, not noise. TypeScript errors on an *unused* `@ts-expect-error`, so a clean compile is positive confirmation that every one of these APIs is genuinely absent from `cli/types/cypress.d.ts`. The spec now guards the type surface as well as the runtime errors — reintroduce any of them and this file stops compiling. Please don't "fix" a future type error here with an `(cy as any)` cast; that would still pass while silently dropping the guard.

2. **`err.codeFrame!`** on the two property reads. `codeFrame` is optional on `CypressError`, matching how `cypress/e2e/e2e/origin/origin.cy.ts` already handles it.

3. **The self-referential assertion** — the code-frame test asserts on its own filename, so `removed_commands.cy.js` became `removed_commands.cy.ts`.

The `{ browser: '!webkit' }` guards on the two stack-trace tests are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mechanical conversion with no production code changes; risk is limited to driver e2e coverage for removed-command error messages.
> 
> **Overview**
> Converts the driver e2e spec **`removed_commands.cy.js` → `removed_commands.cy.ts`** as part of migrating `packages/driver/cypress/e2e` to TypeScript. Runtime behavior and assertions are unchanged.
> 
> To compile while still invoking removed APIs under test, the PR adds **17 `@ts-expect-error` comments** at each call site (`cy.server`, `cy.route`, `cy.end`, `cy.exec`, `Cypress.Server.defaults`, cookie helpers, and all `Cypress.env` shapes, including inside `cy.origin()`). Those directives intentionally tie compile-time types to the removal guards—re-adding types for a removed API would fail the build.
> 
> Minor TypeScript fixes: **non-null assertions on `err.codeFrame`** after the existence check, and the code-frame test now expects **`removed_commands.cy.ts`** in `relativeFile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd30ed2340f8677ca6bf4e99954e788cb3d19ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Steps to test

```
yarn workspace @packages/driver cypress:run -- --spec "cypress/e2e/commands/removed_commands.cy.ts"
```

All 17 tests pass locally in Electron. Also verified:

- `tsc --noEmit` and `tslint` on `@packages/driver` — no errors in this spec
- `eslint` on the file — clean

Firefox, Chrome and WebKit coverage comes from the `driver-integration-tests-*` jobs, which are selected automatically by path filtering on `packages/driver/*` — no `.circleci` allowlist change needed.

### How has the user experience changed?

No change. This is a test-file conversion with no production code touched.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical test-file conversion, no behavior change. -->
- [x] Have tests been added/updated? <!-- The converted spec itself; assertions are unchanged apart from the filename it asserts on. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcqfa8esfuPHL35mgGDkih

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcqfa8esfuPHL35mgGDkih)_