### PR TITLE
chore: document the TypeScript-for-new-code convention in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,7 @@ yarn clean-deps && yarn
 
 ## Code Conventions
 
+- **TypeScript for all new code** — New source, specs, and test fixtures must be TypeScript, not JavaScript. This includes system-test project fixtures: use `cypress.config.ts` and `.cy.ts` specs (lightweight fixtures without their own `node_modules` should `export default { ... }` a plain object rather than importing `defineConfig` from `cypress`).
 - **No Prettier** — Formatting is enforced entirely through ESLint. The `.prettierignore` excludes all files.
 - **Single quotes** — `'single'` quote style required for all JS/TS.
 - **No semicolons** — Enforced via ESLint (`semi: 'never'`).


### PR DESCRIPTION
- Closes N/A

### Additional details

Adds one bullet under **Code Conventions** in the root `AGENTS.md`: new source, specs, and test fixtures are TypeScript, including system-test project fixtures (`cypress.config.ts`, `.cy.ts`), with the note that lightweight fixtures without their own `node_modules` should export a plain object rather than import `defineConfig` from `cypress`.

The bullet was drafted in #34791 and removed from that PR during review so the repo-wide convention lands on its own and is findable in history. Recent conversions such as #34809 and #34799 already follow it.

### Steps to test

N/A, documentation only.

### How has the user experience changed?

No change.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Documentation-only change, no issue. -->
- [na] Have tests been added/updated?
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime, API, or test behavior impact.
> 
> **Overview**
> Documents a repo-wide **Code Conventions** rule in root `AGENTS.md`: all new source, specs, and test fixtures must be TypeScript (not JavaScript).
> 
> The new bullet also spells out expectations for **system-test project fixtures**—`cypress.config.ts` and `.cy.ts` specs—and notes that lightweight fixtures without their own `node_modules` should `export default` a plain config object instead of importing `defineConfig` from `cypress`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e31230a5f06cc9ee8c8d910b0becaa2f0ec5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->