### PR TITLE
chore: enable typescript-lsp plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,9 +6,16 @@
         "source": "github",
         "repo": "cypress-io/ai-toolkit"
       }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
     }
   },
   "enabledPlugins": {
-    "cypress@cypress": true
+    "cypress@cypress": true,
+    "typescript-lsp@claude-plugins-official": true
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,7 @@ You must have the following installed on your system to contribute locally:
 - [`Yarn v1 Classic`](https://yarnpkg.com/en/docs/install) (See also [Corepack](#corepack) below.)
 - [`python`](https://www.python.org/downloads/) (since we use `node-gyp`. See their [repo](https://github.com/nodejs/node-gyp) for Python version requirements.)
 - [`circleci CLI`](https://circleci.com/docs/guides/toolkit/local-cli/) if you intend on editing the CI configuration.
+- [`typescript-language-server`](https://github.com/typescript-language-server/typescript-language-server) (`npm install -g typescript-language-server typescript`) if you use Claude Code locally. The repo enables the `typescript-lsp` plugin in [.claude/settings.json](.claude/settings.json), which gives Claude type errors and go-to-definition across the monorepo, but the plugin does not install the binary for you. If `/plugin` reports the plugin as not installed, run `claude plugin install typescript-lsp@claude-plugins-official`.
 
 #### Debian/Ubuntu
 


### PR DESCRIPTION
- Closes N/A

### Additional details

Enables the official `typescript-lsp` code intelligence plugin for everyone who clones this repo, via the checked-in `.claude/settings.json`. The plugin gives Claude Code real type errors and go-to-definition across the monorepo instead of relying on text search alone.

Two files change:

- **`.claude/settings.json`** — adds `"typescript-lsp@claude-plugins-official": true` to `enabledPlugins`, and declares the `claude-plugins-official` marketplace in `extraKnownMarketplaces`. Claude Code auto-registers that marketplace on first interactive launch, but that misses machines which ran non-interactively first or hit a blocking policy once, so declaring it makes the result deterministic. The existing `cypress@cypress` plugin and `cypress` marketplace entry are untouched.
- **`CONTRIBUTING.md`** — adds one bullet to the `### Requirements` list. The plugin does *not* install the `typescript-language-server` binary, so contributors who use Claude Code locally need to install it themselves; the bullet is phrased conditionally to match the neighboring `circleci CLI` entry.

Deliberately not included:

- **No root `tsconfig.json`.** The repo has ~199 per-package tsconfigs and no root one by design; `tsserver` resolves the nearest one per file. The plugin docs note monorepos can surface false-positive unresolved-import diagnostics, which do not block editing. The tsconfig layout is left alone.
- **No `SessionStart` hook** or any other mechanism to auto-install the plugin or the binary.

Per `CONTRIBUTING.md`, the `chore` prefix requires no `cli/CHANGELOG.md` entry, so none was added.

### Steps to test

1. Install the binary: `npm install -g typescript-language-server typescript`.
2. Start Claude Code from the repo root.
3. Run `/plugin` and confirm `typescript-lsp@claude-plugins-official` is listed as installed and enabled. If it reports not installed, `claude plugin install typescript-lsp@claude-plugins-official`.
4. Ask Claude something that needs type resolution in a `.ts` file — a go-to-definition across packages, for instance — and confirm it resolves symbols rather than grepping.

One caveat worth flagging for the reviewer: Claude Code does not start plugin language servers in cloud sessions, so this was **not** verified end-to-end. What is verified is that `.claude/settings.json` parses (`node -p "require('./.claude/settings.json')"`) and that `enabledPlugins` contains both plugin entries. Step 3 above is the real check and needs a local session.

### How has the user experience changed?

No change. This affects the contributor development environment only — nothing in the shipped binary, CLI, or any published package.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Tooling/config change to the contributor dev environment; no product code affected. -->
- [na] Have tests been added/updated? <!-- JSON config and Markdown only; the repo lints and type-checks neither of these paths. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change; contributor setup is documented in CONTRIBUTING.md, which this PR updates. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No API surface change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dac9dTArdzRMwp5cqWAyEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dac9dTArdzRMwp5cqWAyEV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-only Claude Code and documentation changes; no shipped product, CI, or runtime behavior is affected.
> 
> **Overview**
> **Turns on Claude Code TypeScript intelligence for everyone who clones the repo** by enabling the official `typescript-lsp` plugin in checked-in `.claude/settings.json`, alongside the existing `cypress@cypress` plugin.
> 
> The settings file also registers the `claude-plugins-official` marketplace (`anthropics/claude-plugins-official`) so the plugin source is explicit rather than depending on first-launch auto-registration.
> 
> `CONTRIBUTING.md` gains a conditional **Requirements** bullet: contributors who use Claude Code locally should install `typescript-language-server` and `typescript` globally, since the plugin does not ship that binary. It points to `.claude/settings.json` and the `claude plugin install` fallback if `/plugin` shows the plugin as missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821a0e39a54c556cbf99e215862da19c4a4ccbeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->