### PR TITLE
chore: lint Vue files in app and launchpad

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,7 @@
     "cypress:run:e2e": "yarn cypress:run-cypress-in-cypress node ../../scripts/cypress run --project . --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true",
     "cypress:run:e2e:update:snapshots": "CYPRESS_SNAPSHOT_UPDATE=1 yarn cypress:run-cypress-in-cypress node ../../scripts/cypress run --project . --spec **/*mochaEvents* --browser chrome --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT",
     "dev": "yarn cypress:run-cypress-in-cypress gulp dev --project . --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true",
-    "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, .",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json,.vue .",
     "start": "echo \"run 'yarn dev' or 'yarn watch' from the root\" && exit 1",
     "test": "echo 'ok'",
     "tslint": "tslint --config ../ts/tslint.json --project .",

--- a/packages/app/src/debug/DebugContainer.vue
+++ b/packages/app/src/debug/DebugContainer.vue
@@ -103,6 +103,7 @@ import DebugNoRuns from './empty/DebugNoRuns.vue'
 import DebugError from './empty/DebugError.vue'
 import DebugBranchError from './empty/DebugBranchError.vue'
 import DebugSpecLimitBanner from './DebugSpecLimitBanner.vue'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- rendered in the template, which the rule cannot see; a type-only import would drop the binding at runtime
 import DebugRunNavigation from './DebugRunNavigation.vue'
 import { specsList } from './utils/DebugMapping'
 import type { CloudRunHidingReason } from './DebugOverLimit.vue'

--- a/packages/app/src/specs/banners/TrackedBanner.vue
+++ b/packages/app/src/specs/banners/TrackedBanner.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script setup lang="ts">
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- rendered in the template, which the rule cannot see; a type-only import would drop the binding at runtime
 import Alert from '@packages/frontend-shared/src/components/Alert.vue'
 import { computed, onMounted, ref, watchEffect, watch } from 'vue'
 import { gql, useMutation, useQuery } from '@urql/vue'

--- a/packages/app/src/studio/StudioErrorPanel.vue
+++ b/packages/app/src/studio/StudioErrorPanel.vue
@@ -79,5 +79,6 @@ const props = withDefaults(defineProps<{
       'secondary-stroke-color': 'red-500',
     })
   },
+  learnMoreUrl: undefined,
 })
 </script>

--- a/packages/frontend-shared/.eslintrc.json
+++ b/packages/frontend-shared/.eslintrc.json
@@ -26,6 +26,7 @@
       "files": "**/*.vue",
       "rules": {
         "vue/no-v-html": "off",
+        "vue/require-default-prop": "error",
         "no-spaced-func": "off",
         "no-restricted-imports": [
           "error",

--- a/packages/frontend-shared/.eslintrc.json
+++ b/packages/frontend-shared/.eslintrc.json
@@ -28,11 +28,18 @@
         "vue/no-v-html": "off",
         "vue/require-default-prop": "error",
         "no-spaced-func": "off",
-        "no-restricted-imports": [
+        "no-restricted-imports": "off",
+        "@typescript-eslint/no-restricted-imports": [
           "error",
           {
             "patterns": [
-              "@packages/data-context/*"
+              {
+                "group": [
+                  "@packages/data-context/*"
+                ],
+                "allowTypeImports": true,
+                "message": "data-context is server-side; a Vue component may only borrow its types."
+              }
             ]
           }
         ]

--- a/packages/frontend-shared/src/gql-components/Auth.vue
+++ b/packages/frontend-shared/src/gql-components/Auth.vue
@@ -104,7 +104,9 @@ const props = withDefaults(defineProps<{
   utmMedium: string
   utmContent?: string
 }>(), {
+  authFlow: 'login',
   autoStartAuth: false,
+  utmContent: undefined,
 })
 
 gql`
@@ -261,12 +263,10 @@ const browserOpened = computed(() => {
   return props.gql.authState.browserOpened
 })
 
-const authFlow = computed(() => props.authFlow || 'login')
-
 const executeAuthMutation = () => {
   const variables = { utmMedium: props.utmMedium, utmContent: props.utmContent || null, utmSource: getUtmSource() }
 
-  return authFlow.value === 'signup' ? signup.executeMutation(variables) : login.executeMutation(variables)
+  return props.authFlow === 'signup' ? signup.executeMutation(variables) : login.executeMutation(variables)
 }
 
 // We determine that a login is pending if there is no current cloudViewer and
@@ -321,7 +321,7 @@ const buttonText = computed(() => {
     return strings.continue
   }
 
-  return authFlow.value === 'signup' ? strings.signup : strings.login
+  return props.authFlow === 'signup' ? strings.signup : strings.login
 })
 
 const buttonPrefixIcon = computed(() => {

--- a/packages/frontend-shared/src/gql-components/modals/LoginModal.vue
+++ b/packages/frontend-shared/src/gql-components/modals/LoginModal.vue
@@ -78,7 +78,7 @@
         >
           <Auth
             :gql="props.gql"
-            :auth-flow="authFlow"
+            :auth-flow="props.authFlow"
             :auto-start-auth="props.autoStartAuth"
             :show-retry="!!error"
             :utm-medium="props.utmMedium"
@@ -126,6 +126,8 @@ const props = withDefaults(defineProps<{
   utmContent?: string
   autoStartAuth?: boolean
 }>(), {
+  authFlow: 'login',
+  utmContent: undefined,
   autoStartAuth: true,
 })
 
@@ -138,7 +140,6 @@ fragment LoginModal on Query {
 hideAllPoppers()
 
 const { t } = useI18n()
-const authFlow = computed(() => props.authFlow || 'login')
 
 const viewer = computed(() => props.gql?.cloudViewer)
 

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -13,7 +13,7 @@
     "cypress:run:ct": "yarn cypress:run-cypress-in-cypress node ../../scripts/cypress run --component --project . --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true",
     "cypress:run:e2e": "yarn cypress:run-cypress-in-cypress node ../../scripts/cypress run --e2e --project . --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true",
     "dev": "yarn cypress:run-cypress-in-cypress gulp dev --project . --expose INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT=true",
-    "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, .",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx,.json,.vue .",
     "start": "echo 'run yarn dev from the root' && exit 1",
     "test": "yarn cypress:run:ct",
     "tslint": "tslint --config ../ts/tslint.json --project . --exclude ../graphql/src/gen/nxs.gen.ts",


### PR DESCRIPTION
- Closes N/A — see below.

### Additional details

This started as a cleanup of the four `vue/require-default-prop` warnings in the `linux-lint` job, and turned up the reason nobody had seen them before.

**1. Give the auth components' optional props explicit defaults**

`Auth.vue` and `LoginModal.vue` each declared `authFlow` and `utmContent` inside `withDefaults()` without a default. Both then carried `const authFlow = computed(() => props.authFlow || 'login')` — the very default the rule was asking for, just expressed in the wrong place. Declaring `authFlow: 'login'` at the prop site makes that computed redundant, so both now read `props.authFlow` directly.

`utmContent: undefined` is the canonical way to say "optional, genuinely no default". It keeps the type honest — Vue's `PropsWithDefaults` has a dedicated branch for it (`Defaults[K] extends undefined ? Base[K] : NotUndefined<Base[K]>`), so `props.utmContent` stays `string | undefined` while `props.authFlow` correctly narrows to `AuthFlow`. It also matches how `user-project-status-store.ts` already writes the same field.

No behavior change: the only caller passes `userProjectStatusStore.authFlow`, which is typed non-optional.

**2. Promote `vue/require-default-prop` to an error**

With `frontend-shared` clean, the rule inherited as a warning from `plugin:vue/vue3-recommended` is now an error, so a missing default fails the lint job instead of scrolling past in CI output.

**3. Lint the Vue files in `app` and `launchpad`**

Both packages extend `frontend-shared`'s ESLint config — including its Vue-only rules — but their lint scripts had dropped `.vue` from `--ext` and left a dangling comma behind:

```
"lint": "eslint --ext .js,.jsx,.ts,.tsx,.json, ."
```

So 226 components (199 in `app`, 27 in `launchpad`) were going unchecked, not just for this rule but for all of `vue3-recommended`. Restoring the extension found `launchpad` already clean and seven errors in `app`:

- **`no-restricted-imports` ×4.** All four are type-only imports of generated data-context types. The ban exists to keep server-side code out of the browser bundle, which a type import cannot do — and `debugArtifacts.ts` plus both `.cy.tsx` specs already import the same types the same way and pass lint today. Rather than four identical disable comments, this swaps in the typescript-eslint variant so `allowTypeImports` can express that, with a message naming what the rule protects. A runtime import from a `.vue` file still errors.
- **`consistent-type-imports` ×2.** `Alert` and `DebugRunNavigation` are rendered in their templates *and* referenced via `InstanceType<typeof X>` in the script. The rule only analyzes the script block, so its autofix rewrites them to `import type` and drops the binding the template renders — verified on a scratch copy. Disabled at the two sites with an inline reason, rather than turning the rule off for all ~290 Vue files where it is correct.
- **`require-default-prop` ×1.** `StudioErrorPanel`'s `learnMoreUrl`, same treatment as the auth components.

Worth a reviewer's eye: `allowTypeImports` loosens a rule shared by `frontend-shared`, `app` and `launchpad`. The intent is to make the rule say what it means rather than what it currently over-says, but the data-context boundary owner may want an opinion — reverting to four disable comments is a one-line change.

### Steps to test

```bash
yarn lint --scope @packages/frontend-shared --scope @packages/app --scope @packages/launchpad
```

All three pass. The guards were also checked adversarially with throwaway components, since two of the three changes relax or re-scope a rule:

| Probe | Expected | Result |
| --- | --- | --- |
| `regressed?: string` with no default | error | `vue/require-default-prop` ✓ |
| `import { DataContext } from '@packages/data-context/src/DataContext'` | error | `@typescript-eslint/no-restricted-imports` ✓ |
| `import type { FileParts } from '@packages/data-context/src/gen/...'` | allowed | no error ✓ |
| `flagged?: boolean` with no default | allowed | no error ✓ |

Before/after was confirmed by stashing: `frontend-shared` reports the original 4 warnings on `develop` and 0 with this branch. `check-ts` for both `app` and `frontend-shared` is unchanged (identical error lists before and after, all pre-existing missing-GraphQL-artifact errors in a non-built checkout).

Note this puts 226 previously unlinted components under the full `vue3-recommended` rule set, so it widens CI coverage rather than only tidying formatting.

### How has the user experience changed?

No change. Internal lint configuration and prop declarations only; no runtime behavior is affected.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Internal lint tooling cleanup with no user-facing behavior, requested directly by a maintainer. -->
- [na] Have tests been added/updated? <!-- Lint configuration change; the lint job is the test. Rule behavior was verified with the throwaway probes in "Steps to test". -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149BngyEWHb9SiTh2Ld4ccT

---
_Generated by [Claude Code](https://claude.ai/code/session_0149BngyEWHb9SiTh2Ld4ccT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and prop-default declarations only; auth flow logic is unchanged aside from reading defaults from `withDefaults` instead of inline fallbacks.
> 
> **Overview**
> **Expands Vue lint coverage** by fixing `lint` scripts in `@packages/app` and `@packages/launchpad` so ESLint includes `.vue` files (they previously omitted the extension), bringing hundreds of components under the shared `vue3-recommended` rules in CI.
> 
> **Tightens shared ESLint for Vue:** `vue/require-default-prop` is now an **error**, and `@packages/data-context/*` restrictions use `@typescript-eslint/no-restricted-imports` with **`allowTypeImports`** so type-only imports from data-context are allowed while runtime imports still fail.
> 
> **Prop/default cleanup (no intended behavior change):** `Auth.vue` and `LoginModal.vue` declare defaults for `authFlow` (`'login'`) and `utmContent` (`undefined`) in `withDefaults` and use `props.authFlow` directly instead of a fallback computed. `StudioErrorPanel.vue` adds an explicit default for optional `learnMoreUrl`. Two app Vue files get targeted `consistent-type-imports` disables where components are used in templates and as `InstanceType` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d8a902e4c1aafd01aad46dcb22a6b58c15e60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->