### PR TITLE
chore: use async fs APIs in trash_spec

### DIFF
--- a/packages/server/test/unit/util/trash_spec.ts
+++ b/packages/server/test/unit/util/trash_spec.ts
@@ -9,14 +9,14 @@ import { proxyquire } from '../../spec_helper'
 require('../../spec_helper')
 
 // Creates test directories and files for trash testing
-const populateDirectories = (basePath: string): void => {
-  fs.mkdirSync(basePath, { recursive: true })
-  fs.mkdirSync(path.resolve(basePath, 'bar'), { recursive: true })
-  fs.mkdirSync(path.resolve(basePath, 'bar', 'baz'), { recursive: true })
+const populateDirectories = async (basePath: string): Promise<void> => {
+  await fs.promises.mkdir(basePath, { recursive: true })
+  await fs.promises.mkdir(path.resolve(basePath, 'bar'), { recursive: true })
+  await fs.promises.mkdir(path.resolve(basePath, 'bar', 'baz'), { recursive: true })
 
-  fs.writeFileSync(path.resolve(basePath, 'a.txt'), '')
-  fs.writeFileSync(path.resolve(basePath, 'bar', 'b.txt'), '')
-  fs.writeFileSync(path.resolve(basePath, 'bar', 'baz', 'c.txt'), '')
+  await fs.promises.writeFile(path.resolve(basePath, 'a.txt'), '')
+  await fs.promises.writeFile(path.resolve(basePath, 'bar', 'b.txt'), '')
+  await fs.promises.writeFile(path.resolve(basePath, 'bar', 'baz', 'c.txt'), '')
 
   expect(fs.existsSync(path.resolve(basePath, 'a.txt'))).to.be.true
   expect(fs.existsSync(path.resolve(basePath, 'bar', 'b.txt'))).to.be.true
@@ -34,15 +34,13 @@ const expectDirectoriesExist = (basePath: string): void => {
 describe('lib/util/trash', () => {
   let tempDir: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tempDir = path.join(os.tmpdir(), `cypress-test-${Date.now()}`)
-    fs.mkdirSync(tempDir, { recursive: true })
+    await fs.promises.mkdir(tempDir, { recursive: true })
   })
 
-  afterEach(() => {
-    if (fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true, force: true })
-    }
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true })
   })
 
   context('.folder', () => {
@@ -50,11 +48,11 @@ describe('lib/util/trash', () => {
       sinon.stub(os, 'platform').returns('darwin')
       const basePath = path.join(tempDir, 'foo')
 
-      populateDirectories(basePath)
+      await populateDirectories(basePath)
 
       await trash.folder(basePath)
       expectDirectoriesExist(basePath)
-      fs.rmdirSync(basePath)
+      await fs.promises.rmdir(basePath)
     })
 
     it('doesn\'t fail if directory is non-existent', async () => {
@@ -70,11 +68,11 @@ describe('lib/util/trash', () => {
       sinon.stub(os, 'platform').returns('win32')
       const basePath = path.join(tempDir, 'foo')
 
-      populateDirectories(basePath)
+      await populateDirectories(basePath)
 
       const trashStub = sinon.stub().callsFake(async (paths: string[]) => {
         // the underlying implementation removes the items...
-        paths.forEach((p) => fs.rmSync(p, { recursive: true, force: true }))
+        await Promise.all(paths.map((p) => fs.promises.rm(p, { recursive: true, force: true })))
         // ...but then rejects with a non-zero exit error
         throw new Error('Command failed: windows-trash.exe')
       })
@@ -86,14 +84,14 @@ describe('lib/util/trash', () => {
       await trashModule.folder(basePath)
       expect(trashStub).to.have.been.called
       expectDirectoriesExist(basePath)
-      fs.rmdirSync(basePath)
+      await fs.promises.rmdir(basePath)
     })
 
     it('rethrows when trash fails and the item still exists', async () => {
       sinon.stub(os, 'platform').returns('win32')
       const basePath = path.join(tempDir, 'foo')
 
-      populateDirectories(basePath)
+      await populateDirectories(basePath)
 
       const trashStub = sinon.stub().rejects(new Error('Command failed: windows-trash.exe'))
 
@@ -110,18 +108,18 @@ describe('lib/util/trash', () => {
       }
 
       expect(thrown).to.be.an('error')
-      fs.rmSync(basePath, { recursive: true, force: true })
+      await fs.promises.rm(basePath, { recursive: true, force: true })
     })
 
     it('completely removes directory on Linux', async () => {
       sinon.stub(os, 'platform').returns('linux')
       const basePath = path.join(tempDir, 'foo')
 
-      populateDirectories(basePath)
+      await populateDirectories(basePath)
 
       await trash.folder(basePath)
       expectDirectoriesExist(basePath)
-      fs.rmdirSync(basePath)
+      await fs.promises.rmdir(basePath)
     })
   })
 })


### PR DESCRIPTION
- Closes N/A

### Additional details

The `linux-lint` job reports 13 `no-restricted-syntax` warnings ("Synchronous fs calls should not be used in Cypress. Use an async API instead") in `packages/server/test/unit/util/trash_spec.ts`. This is a straight sync → async translation of that spec so those warnings go away.

- `mkdirSync` / `writeFileSync` / `rmSync` / `rmdirSync` → their `fs.promises` equivalents
- `populateDirectories` is now `async`, so its five call sites are awaited, as are `beforeEach` and `afterEach`
- Inside the Windows trash stub, `paths.forEach(...rmSync)` became `await Promise.all(paths.map(...rm))`
- The `existsSync` guard in `afterEach` was dropped — `fs.promises.rm` with `force: true` already ignores a missing path, so the guard was a no-op

The `existsSync` assertions are unchanged; the lint rule exempts them deliberately.

Scope is intentionally this one file. The rest of the lint job still emits 162 warnings across `cli`, `server`, `frontend-shared`, `electron`, `schematic`, `vue`, and `internal-scripts` — worth a separate pass.

One note for anyone picking that up: the `no-var` warnings in `cli/types/*.d.ts` are **not** safely auto-fixable. `declare var` is what puts those globals on `globalThis`, so that group wants a config-level exemption for `.d.ts` files rather than an `eslint --fix`.

### Steps to test

```sh
yarn workspace @packages/server lint
yarn workspace @packages/server test-unit -- util/trash_spec.ts
yarn workspace @packages/server check-ts
```

Results locally:

- **lint** — `@packages/server` goes from 48 → 35 warnings, 0 errors. `trash_spec.ts` no longer appears in the output at all (exactly the 13 removed).
- **test-unit** — 5 passing.
- **check-ts** — clean.

### How has the user experience changed?

No change. Test-only.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Mechanical lint cleanup in a single test file; no behavior change. -->
- [na] Have tests been added/updated? <!-- This PR only rewrites how an existing spec performs its fs setup/teardown; the five tests and their assertions are unchanged. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)?
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)?

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7N9yiY7oUKVjznrqgsNg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7N9yiY7oUKVjznrqgsNg9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or user-facing behavior change.
> 
> **Overview**
> **Test-only lint cleanup** in `trash_spec.ts`: synchronous `fs` calls are replaced with `fs.promises` so `@packages/server` lint stops flagging `no-restricted-syntax` (13 warnings removed from this file).
> 
> Setup/teardown and helpers (`populateDirectories`, `beforeEach`, `afterEach`, and test cleanup) now `await` `mkdir`, `writeFile`, `rm`, and `rmdir`. The Windows trash stub uses `Promise.all` for parallel async removes. `afterEach` no longer checks `existsSync` before `rm` because `force: true` already tolerates a missing temp dir.
> 
> **Assertions and scenarios are unchanged** — same five tests, same `existsSync` expectations (still allowed by the rule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b30a058f5788477e47a6639304b435b0afc415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->