### PR TITLE
chore: give multiline arrow bodies block statements and enforce the rule

### DIFF
--- a/cli/lib/tap/commands/dom.ts
+++ b/cli/lib/tap/commands/dom.ts
@@ -26,34 +26,36 @@ export const extractDom = (
   selector: string,
   maxChars: number,
   at?: number,
-): Promise<FrameDomResult | FrameAmbiguousResult> => withAmbiguous(connection, frame, selector, at, async (): Promise<FrameDomResult> => {
-  const { client, sessionId } = connection
-  const executionContextId = await createFrameIsolatedWorld(connection, frame)
+): Promise<FrameDomResult | FrameAmbiguousResult> => {
+  return withAmbiguous(connection, frame, selector, at, async (): Promise<FrameDomResult> => {
+    const { client, sessionId } = connection
+    const executionContextId = await createFrameIsolatedWorld(connection, frame)
 
-  const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
-    functionDeclaration: readDom.toString(),
-    executionContextId,
-    arguments: [{ value: selector }, { value: maxChars }, { value: at ?? 0 }],
-    returnByValue: true,
-  }, sessionId)
+    const { result, exceptionDetails } = await client.Runtime.callFunctionOn({
+      functionDeclaration: readDom.toString(),
+      executionContextId,
+      arguments: [{ value: selector }, { value: maxChars }, { value: at ?? 0 }],
+      returnByValue: true,
+    }, sessionId)
 
-  if (exceptionDetails) {
-    throw new TapError('FRAME_READ_FAILED', { message: `reading the app-under-test DOM failed: ${exceptionDetails.exception?.description || exceptionDetails.text}` })
-  }
+    if (exceptionDetails) {
+      throw new TapError('FRAME_READ_FAILED', { message: `reading the app-under-test DOM failed: ${exceptionDetails.exception?.description || exceptionDetails.text}` })
+    }
 
-  const value = result.value as DomReadResult
+    const value = result.value as DomReadResult
 
-  // Only a selector the reader was given can come back rejected.
-  if (value.invalidSelector) {
-    throw invalidSelectorError(selector!)
-  }
+    // Only a selector the reader was given can come back rejected.
+    if (value.invalidSelector) {
+      throw invalidSelectorError(selector!)
+    }
 
-  return {
-    ...(value.found !== undefined ? { found: value.found } : {}),
-    ...(value.html !== undefined ? { html: value.html } : {}),
-    ...(value.truncated ? { truncated: true } : {}),
-  }
-})
+    return {
+      ...(value.found !== undefined ? { found: value.found } : {}),
+      ...(value.html !== undefined ? { html: value.html } : {}),
+      ...(value.truncated ? { truncated: true } : {}),
+    }
+  })
+}
 
 // The options are read before a session is resolved, so a value this command
 // cannot use is reported as itself rather than as whatever the search for a

--- a/cli/lib/tap/commands/inspect.ts
+++ b/cli/lib/tap/commands/inspect.ts
@@ -95,43 +95,45 @@ export const extractInspect = (
   frame: AutFrame,
   selector: string,
   at?: number,
-): Promise<FrameInspectResult | FrameAmbiguousResult> => withAmbiguous(connection, frame, selector, at, async (): Promise<FrameInspectResult> => {
-  const { client, sessionId } = connection
+): Promise<FrameInspectResult | FrameAmbiguousResult> => {
+  return withAmbiguous(connection, frame, selector, at, async (): Promise<FrameInspectResult> => {
+    const { client, sessionId } = connection
 
-  await client.DOM.enable({}, sessionId)
-  await client.Accessibility.enable(sessionId)
+    await client.DOM.enable({}, sessionId)
+    await client.Accessibility.enable(sessionId)
 
-  const base: FrameInspectResult = { selector, found: false }
-  const objectId = await querySelectorObjectId(connection, frame, selector, at ?? 0)
+    const base: FrameInspectResult = { selector, found: false }
+    const objectId = await querySelectorObjectId(connection, frame, selector, at ?? 0)
 
-  if (!objectId) {
-    return base
-  }
+    if (!objectId) {
+      return base
+    }
 
-  const info = await client.Runtime.callFunctionOn({
-    functionDeclaration: readElementInfo.toString(),
-    objectId,
-    arguments: [{ value: REPORTED_STYLES }],
-    returnByValue: true,
-  }, sessionId)
+    const info = await client.Runtime.callFunctionOn({
+      functionDeclaration: readElementInfo.toString(),
+      objectId,
+      arguments: [{ value: REPORTED_STYLES }],
+      returnByValue: true,
+    }, sessionId)
 
-  if (info.exceptionDetails) {
-    throw new TapError('FRAME_READ_FAILED', { message: `inspecting the element failed: ${info.exceptionDetails.exception?.description || info.exceptionDetails.text}` })
-  }
+    if (info.exceptionDetails) {
+      throw new TapError('FRAME_READ_FAILED', { message: `inspecting the element failed: ${info.exceptionDetails.exception?.description || info.exceptionDetails.text}` })
+    }
 
-  const { tag, attributes, styles, box } = info.result.value as ElementInfo
-  const aria = await readAriaNode(connection, objectId)
+    const { tag, attributes, styles, box } = info.result.value as ElementInfo
+    const aria = await readAriaNode(connection, objectId)
 
-  return {
-    ...base,
-    found: true,
-    tag,
-    attributes,
-    ...(aria ? { aria } : {}),
-    box,
-    styles,
-  }
-})
+    return {
+      ...base,
+      found: true,
+      tag,
+      attributes,
+      ...(aria ? { aria } : {}),
+      box,
+      styles,
+    }
+  })
+}
 
 export const inspectCommand = defineNativeCommand('inspect', (options, _args, commandOptions) => {
   const at = parseIndex(commandOptions.at)

--- a/cli/lib/tap/commands/sessions.ts
+++ b/cli/lib/tap/commands/sessions.ts
@@ -58,15 +58,17 @@ const listSessions = async (options: TapCliOptions): Promise<number> => {
   const timeoutMs = options.timeout ?? FIND_SESSION_TIMEOUT_MS
   const responsive = await Promise.all(sessions.map((session) => probeRenderer(session, timeoutMs)))
 
-  const summaries: TapSessionSummary[] = sessions.map((session, index) => ({
-    pid: session.pid,
-    projectRoot: session.projectRoot,
-    testingType: session.testingType,
-    browserAttached: session.cdpBrowserWsUrl !== null,
-    browserName: session.browserName,
-    browserSupported: isTapSupportedBrowser(session.browserFamily),
-    ...(responsive[index] === undefined ? {} : { rendererResponsive: responsive[index] }),
-  }))
+  const summaries: TapSessionSummary[] = sessions.map((session, index) => {
+    return {
+      pid: session.pid,
+      projectRoot: session.projectRoot,
+      testingType: session.testingType,
+      browserAttached: session.cdpBrowserWsUrl !== null,
+      browserName: session.browserName,
+      browserSupported: isTapSupportedBrowser(session.browserFamily),
+      ...(responsive[index] === undefined ? {} : { rendererResponsive: responsive[index] }),
+    }
+  })
 
   renderOutcome('sessions', summaries, options.json)
 

--- a/cli/lib/tap/events.ts
+++ b/cli/lib/tap/events.ts
@@ -47,12 +47,14 @@ interface TapTrace {
   errorCode?: string
 }
 
-const newTrace = (command = 'none', flags: string[] = []): TapTrace => ({
-  messageId: randomUUID(),
-  startedAt: Date.now(),
-  command,
-  flags,
-})
+const newTrace = (command = 'none', flags: string[] = []): TapTrace => {
+  return {
+    messageId: randomUUID(),
+    startedAt: Date.now(),
+    command,
+    flags,
+  }
+}
 
 let trace = newTrace()
 

--- a/cli/lib/tap/render/command.ts
+++ b/cli/lib/tap/render/command.ts
@@ -79,11 +79,13 @@ const snapshotsBlock = (snapshots: TapCommandSnapshot[]): string[] => {
     return [heading('SNAPSHOTS', 0), `${indent(1)}${emptyState('[NO SNAPSHOTS]')}`]
   }
 
-  const rows = snapshots.map((snapshot) => [
-    String(snapshot.index),
-    snapshot.name ?? '—',
-    snapshotTime(snapshot.timestamp),
-  ])
+  const rows = snapshots.map((snapshot) => {
+    return [
+      String(snapshot.index),
+      snapshot.name ?? '—',
+      snapshotTime(snapshot.timestamp),
+    ]
+  })
 
   // Mute from the snapshot rather than the padded cell: what reads as absent is
   // the field being unset, which only the row's own data knows.

--- a/cli/lib/tap/render/sessions.ts
+++ b/cli/lib/tap/render/sessions.ts
@@ -58,19 +58,23 @@ const browserColor = (session: SessionRow) => {
 // accept via `--session` — and an attached browser reads green by its name, an
 // absent one (or testing type) as a muted dash.
 export const sessionColumns = (sessions: SessionRow[]): string[] => {
-  const rows = sessions.map((session) => [
-    String(session.pid),
-    session.projectRoot,
-    session.testingType ?? '—',
-    browserCell(session),
-  ])
+  const rows = sessions.map((session) => {
+    return [
+      String(session.pid),
+      session.projectRoot,
+      session.testingType ?? '—',
+      browserCell(session),
+    ]
+  })
 
-  return columns(['PID', 'PROJECT', 'TYPE', 'BROWSER'], rows, (cells, index) => [
-    chalk.bold(cells[0]),
-    cells[1],
-    cells[2],
-    browserColor(sessions[index])(cells[3]),
-  ])
+  return columns(['PID', 'PROJECT', 'TYPE', 'BROWSER'], rows, (cells, index) => {
+    return [
+      chalk.bold(cells[0]),
+      cells[1],
+      cells[2],
+      browserColor(sessions[index])(cells[3]),
+    ]
+  })
 }
 
 // The reachable open-mode sessions under a counted heading.

--- a/cli/lib/tap/reported-invocation.ts
+++ b/cli/lib/tap/reported-invocation.ts
@@ -18,10 +18,12 @@ export interface ReportedInvocation {
  * `cypress tap` handles itself rather than passing to a command. The flags a
  * command declares are reported once commander has parsed them, by noteTapCommand.
  */
-export const reportedInvocation = (command: string | undefined, wantsHelp: boolean, options: TapCliOptions): ReportedInvocation => ({
-  command: command ? getKnownCommand(command) : undefined,
-  flags: [
-    ...wantsHelp ? ['help'] : [],
-    ...Object.keys(options),
-  ],
-})
+export const reportedInvocation = (command: string | undefined, wantsHelp: boolean, options: TapCliOptions): ReportedInvocation => {
+  return {
+    command: command ? getKnownCommand(command) : undefined,
+    flags: [
+      ...wantsHelp ? ['help'] : [],
+      ...Object.keys(options),
+    ],
+  }
+}

--- a/cli/test/lib/exec/tap-fixtures.ts
+++ b/cli/test/lib/exec/tap-fixtures.ts
@@ -51,20 +51,22 @@ export const mockConnection = (connectionSchema: unknown = schema, execOutcome: 
   return call
 }
 
-export const readySession = (overrides: Partial<ReadySessionState> = {}): ReadySessionState => ({
-  schemaVersion: 1,
-  pid: 4242,
-  projectRoot: '/projects/app',
-  serverPort: 49200,
-  sessionId: 'inst-1',
-  testingType: 'e2e',
-  cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-  browserName: 'Chrome',
-  browserFamily: 'chromium',
-  machineId: null,
-  userId: null,
-  ...overrides,
-})
+export const readySession = (overrides: Partial<ReadySessionState> = {}): ReadySessionState => {
+  return {
+    schemaVersion: 1,
+    pid: 4242,
+    projectRoot: '/projects/app',
+    serverPort: 49200,
+    sessionId: 'inst-1',
+    testingType: 'e2e',
+    cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+    browserName: 'Chrome',
+    browserFamily: 'chromium',
+    machineId: null,
+    userId: null,
+    ...overrides,
+  }
+}
 
 export const mockResolved = (overrides: Partial<SessionSelection> = {}): SessionSelection => {
   const selection: SessionSelection = { session: readySession(), reason: 'only', candidateCount: 1, ...overrides }

--- a/cli/test/lib/exec/tap.spec.ts
+++ b/cli/test/lib/exec/tap.spec.ts
@@ -393,20 +393,22 @@ describe('lib/exec/tap', () => {
   })
 
   describe('the CLI-native sessions command', () => {
-    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
-      schemaVersion: 1,
-      pid: 54321,
-      projectRoot: '/projects/app',
-      serverPort: 49200,
-      sessionId: 'inst-1',
-      testingType: 'e2e',
-      cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-      browserName: 'Chrome',
-      browserFamily: 'chromium',
-      machineId: null,
-      userId: null,
-      ...overrides,
-    })
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => {
+      return {
+        schemaVersion: 1,
+        pid: 54321,
+        projectRoot: '/projects/app',
+        serverPort: 49200,
+        sessionId: 'inst-1',
+        testingType: 'e2e',
+        cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+        browserName: 'Chrome',
+        browserFamily: 'chromium',
+        machineId: null,
+        userId: null,
+        ...overrides,
+      }
+    }
 
     // Reporting whether the runner page answers takes a session, so this command
     // opens one — bounded, and only where there is a browser to ask.
@@ -529,20 +531,22 @@ describe('lib/exec/tap', () => {
   })
 
   describe('the CLI-native status command', () => {
-    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
-      schemaVersion: 1,
-      pid: 4242,
-      projectRoot: '/projects/app',
-      serverPort: 49200,
-      sessionId: 'inst-1',
-      testingType: 'e2e',
-      cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-      browserName: 'Chrome',
-      browserFamily: 'chromium',
-      machineId: null,
-      userId: null,
-      ...overrides,
-    })
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => {
+      return {
+        schemaVersion: 1,
+        pid: 4242,
+        projectRoot: '/projects/app',
+        serverPort: 49200,
+        sessionId: 'inst-1',
+        testingType: 'e2e',
+        cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+        browserName: 'Chrome',
+        browserFamily: 'chromium',
+        machineId: null,
+        userId: null,
+        ...overrides,
+      }
+    }
 
     const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
       const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }
@@ -774,20 +778,22 @@ describe('lib/exec/tap', () => {
   })
 
   describe('the CLI-native specs command', () => {
-    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
-      schemaVersion: 1,
-      pid: 4242,
-      projectRoot: '/projects/app',
-      serverPort: 49200,
-      sessionId: 'inst-1',
-      testingType: 'e2e',
-      cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-      browserName: 'Chrome',
-      browserFamily: 'chromium',
-      machineId: null,
-      userId: null,
-      ...overrides,
-    })
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => {
+      return {
+        schemaVersion: 1,
+        pid: 4242,
+        projectRoot: '/projects/app',
+        serverPort: 49200,
+        sessionId: 'inst-1',
+        testingType: 'e2e',
+        cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+        browserName: 'Chrome',
+        browserFamily: 'chromium',
+        machineId: null,
+        userId: null,
+        ...overrides,
+      }
+    }
 
     const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
       const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }
@@ -966,20 +972,22 @@ describe('lib/exec/tap', () => {
   })
 
   describe('the CLI-native run command', () => {
-    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => ({
-      schemaVersion: 1,
-      pid: 4242,
-      projectRoot: '/projects/app',
-      serverPort: 49200,
-      sessionId: 'inst-1',
-      testingType: 'e2e',
-      cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
-      browserName: 'Chrome',
-      browserFamily: 'chromium',
-      machineId: null,
-      userId: null,
-      ...overrides,
-    })
+    const liveSession = (overrides: Partial<LiveSessionState> = {}): LiveSessionState => {
+      return {
+        schemaVersion: 1,
+        pid: 4242,
+        projectRoot: '/projects/app',
+        serverPort: 49200,
+        sessionId: 'inst-1',
+        testingType: 'e2e',
+        cdpBrowserWsUrl: 'ws://127.0.0.1:9222/devtools/browser/abc',
+        browserName: 'Chrome',
+        browserFamily: 'chromium',
+        machineId: null,
+        userId: null,
+        ...overrides,
+      }
+    }
 
     const mockLiveResolved = (session: LiveSessionState): LiveSessionSelection => {
       const selection: LiveSessionSelection = { session, reason: 'only', candidateCount: 1 }

--- a/cli/test/lib/tap/frame-scripts.spec.ts
+++ b/cli/test/lib/tap/frame-scripts.spec.ts
@@ -62,12 +62,14 @@ describe('lib/tap/aut/scripts countMatches', () => {
 })
 
 describe('lib/tap/aut/scripts readElementInfo', () => {
-  const fakeElement = (overrides: Record<string, unknown> = {}) => ({
-    tagName: 'INPUT',
-    attributes: [{ name: 'data-testid', value: 'username' }, { name: 'name', value: 'username' }],
-    getBoundingClientRect: () => ({ x: 8.4, y: 40.6, width: 200.2, height: 30.9 }),
-    ...overrides,
-  })
+  const fakeElement = (overrides: Record<string, unknown> = {}) => {
+    return {
+      tagName: 'INPUT',
+      attributes: [{ name: 'data-testid', value: 'username' }, { name: 'name', value: 'username' }],
+      getBoundingClientRect: () => ({ x: 8.4, y: 40.6, width: 200.2, height: 30.9 }),
+      ...overrides,
+    }
+  }
 
   it('reports the tag, attributes, rounded box, and every reported style verbatim', () => {
     // Zero-valued (`margin: 0px`, `opacity: 0`) and empty (`content`) styles
@@ -80,9 +82,11 @@ describe('lib/tap/aut/scripts readElementInfo', () => {
       content: '',
     }
 
-    vi.stubGlobal('getComputedStyle', () => ({
-      getPropertyValue: (name: string) => computed[name] ?? '',
-    }))
+    vi.stubGlobal('getComputedStyle', () => {
+      return {
+        getPropertyValue: (name: string) => computed[name] ?? '',
+      }
+    })
 
     const result = readElementInfo.call(fakeElement() as any, ['display', 'color', 'margin', 'opacity', 'content'])
 

--- a/cli/test/lib/tap/session-gql.spec.ts
+++ b/cli/test/lib/tap/session-gql.spec.ts
@@ -4,10 +4,12 @@ import { querySessionGraphql } from '../../../lib/tap/session-gql'
 import { verifySessionRecord } from '../../../lib/cypress-sessions'
 import type { LiveSessionState } from '../../../lib/cypress-sessions'
 
-vi.mock('../../../lib/cypress-sessions', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../lib/cypress-sessions')>()),
-  verifySessionRecord: vi.fn(),
-}))
+vi.mock('../../../lib/cypress-sessions', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('../../../lib/cypress-sessions')>()),
+    verifySessionRecord: vi.fn(),
+  }
+})
 
 const session: LiveSessionState = {
   schemaVersion: 1,

--- a/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.ts
+++ b/npm/webpack-batteries-included-preprocessor/test/unit/index.spec.ts
@@ -18,11 +18,13 @@ vi.mock('@cypress/webpack-preprocessor', async (importOriginal) => {
   }
 })
 
-vi.mock('get-tsconfig', () => ({
-  default: {
-    getTsconfig: vi.fn(),
-  },
-}))
+vi.mock('get-tsconfig', () => {
+  return {
+    default: {
+      getTsconfig: vi.fn(),
+    },
+  }
+})
 
 describe('webpack-batteries-included-preprocessor', () => {
   let preprocessor: typeof import('../../index')

--- a/packages/server/lib/adapters/serve-internal-routes.ts
+++ b/packages/server/lib/adapters/serve-internal-routes.ts
@@ -192,48 +192,50 @@ export function createServeInternalRoutesMiddleware ({
     // loopback header for setProxiedUrl to restore.
     const method = (request.method ?? 'GET').toUpperCase()
 
-    const sendLoopback = () => serverRequest.create({
-      url: toLoopbackUrl(request.url, config),
-      method,
-      headers: {
-        ...filterHeaders(request.headers),
-        // In Cypress-in-Cypress runs this loopback takes a second hop, and
-        // that hop gzips the response:
-        //
-        //   1. The child project's app (the AUT, http://localhost:4455) asks
-        //      for /__cypress-studio/app-studio.js on its own origin.
-        //   2. The parent Cypress's CDP interception pauses the request, and
-        //      this middleware (the parent's instance) loops it back to the
-        //      parent's own Express server.
-        //   3. The parent has no studio routes of its own — its cy-in-cy
-        //      passthrough (routes.ts) re-enters the proxy pipeline to
-        //      forward the request to the child at 4455, where the real
-        //      cloud-bundle routes live.
-        //   4. StripUnsupportedAcceptEncoding runs on that forwarding hop and
-        //      rewrites a MISSING accept-encoding (filterHeaders strips it
-        //      above) to 'gzip,identity', so the child's studio route
-        //      responds gzipped.
-        //
-        // Fetch.fulfillRequest bodies are identity-only — the browser runs no
-        // decoders on fulfilled responses — so a gzipped body reaches the
-        // page as unparseable bytes. An explicit 'identity' survives the
-        // rewrite (only br/gzip tokens are kept, with 'identity' as the
-        // fallback), so every hop in the chain serves an unencoded body.
-        // Single-hop loopbacks (real users) already serve identity for an
-        // absent header, so this is only needed where the second hop exists.
-        ...(process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE || process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
-          ? { 'accept-encoding': 'identity' }
-          : {}),
-        [CYPRESS_INTERNAL_LOOPBACK_HEADER]: url.href,
-        [CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]: cypressInternalLoopbackToken,
-      },
-      ...(shouldSendBody(request) ? { body: request.body } : {}),
-      encoding: null,
-      followRedirect: false,
-      gzip: false,
-      resolveWithFullResponse: true,
-      simple: false,
-    }, true)
+    const sendLoopback = () => {
+      return serverRequest.create({
+        url: toLoopbackUrl(request.url, config),
+        method,
+        headers: {
+          ...filterHeaders(request.headers),
+          // In Cypress-in-Cypress runs this loopback takes a second hop, and
+          // that hop gzips the response:
+          //
+          //   1. The child project's app (the AUT, http://localhost:4455) asks
+          //      for /__cypress-studio/app-studio.js on its own origin.
+          //   2. The parent Cypress's CDP interception pauses the request, and
+          //      this middleware (the parent's instance) loops it back to the
+          //      parent's own Express server.
+          //   3. The parent has no studio routes of its own — its cy-in-cy
+          //      passthrough (routes.ts) re-enters the proxy pipeline to
+          //      forward the request to the child at 4455, where the real
+          //      cloud-bundle routes live.
+          //   4. StripUnsupportedAcceptEncoding runs on that forwarding hop and
+          //      rewrites a MISSING accept-encoding (filterHeaders strips it
+          //      above) to 'gzip,identity', so the child's studio route
+          //      responds gzipped.
+          //
+          // Fetch.fulfillRequest bodies are identity-only — the browser runs no
+          // decoders on fulfilled responses — so a gzipped body reaches the
+          // page as unparseable bytes. An explicit 'identity' survives the
+          // rewrite (only br/gzip tokens are kept, with 'identity' as the
+          // fallback), so every hop in the chain serves an unencoded body.
+          // Single-hop loopbacks (real users) already serve identity for an
+          // absent header, so this is only needed where the second hop exists.
+          ...(process.env.CYPRESS_INTERNAL_SIMULATE_OPEN_MODE || process.env.CYPRESS_INTERNAL_E2E_TESTING_SELF_PARENT_PROJECT
+            ? { 'accept-encoding': 'identity' }
+            : {}),
+          [CYPRESS_INTERNAL_LOOPBACK_HEADER]: url.href,
+          [CYPRESS_INTERNAL_LOOPBACK_TOKEN_HEADER]: cypressInternalLoopbackToken,
+        },
+        ...(shouldSendBody(request) ? { body: request.body } : {}),
+        encoding: null,
+        followRedirect: false,
+        gzip: false,
+        resolveWithFullResponse: true,
+        simple: false,
+      }, true)
+    }
 
     let response
 

--- a/packages/server/lib/browsers/cdp-protocol/body-digest.ts
+++ b/packages/server/lib/browsers/cdp-protocol/body-digest.ts
@@ -5,10 +5,12 @@ export type BodyDigest = { length: number, sha256: string }
 // Runs once per response body (twice when lengths match, behind the length
 // short-circuit). sha256 sustains ~GB/s, so even rare multi-MB bodies add
 // negligible drag next to the base64 decode the CDP transit already costs.
-export const digestBody = (body: Buffer): BodyDigest => ({
-  length: body.length,
-  sha256: createHash('sha256').update(body).digest('hex'),
-})
+export const digestBody = (body: Buffer): BodyDigest => {
+  return {
+    length: body.length,
+    sha256: createHash('sha256').update(body).digest('hex'),
+  }
+}
 
 /**
  * Whether a body the intercept pipeline produced is byte-identical to the

--- a/packages/server/lib/modes/results.ts
+++ b/packages/server/lib/modes/results.ts
@@ -106,32 +106,36 @@ const createPublicTest = (test: TestResult): CypressCommandLine.TestResult => {
   }
 }
 
-const createPublicRun = (run: RunResult): CypressCommandLine.RunResult => ({
-  error: run.error,
-  reporter: run.reporter,
-  reporterStats: run.reporterStats,
-  screenshots: _.map(run.screenshots, (screenshot) => ({
-    height: screenshot.height,
-    name: screenshot.name,
-    path: screenshot.path,
-    takenAt: screenshot.takenAt,
-    width: screenshot.width,
-  })),
-  spec: createPublicSpec(run.spec),
-  stats: {
-    duration: run.stats.wallClockDuration,
-    endedAt: run.stats.wallClockEndedAt,
-    failures: run.stats.failures,
-    passes: run.stats.passes,
-    pending: run.stats.pending,
-    skipped: run.stats.skipped,
-    startedAt: run.stats.wallClockStartedAt,
-    suites: run.stats.suites,
-    tests: run.stats.tests,
-  },
-  tests: _.map(run.tests, createPublicTest),
-  video: run.video,
-})
+const createPublicRun = (run: RunResult): CypressCommandLine.RunResult => {
+  return {
+    error: run.error,
+    reporter: run.reporter,
+    reporterStats: run.reporterStats,
+    screenshots: _.map(run.screenshots, (screenshot) => {
+      return {
+        height: screenshot.height,
+        name: screenshot.name,
+        path: screenshot.path,
+        takenAt: screenshot.takenAt,
+        width: screenshot.width,
+      }
+    }),
+    spec: createPublicSpec(run.spec),
+    stats: {
+      duration: run.stats.wallClockDuration,
+      endedAt: run.stats.wallClockEndedAt,
+      failures: run.stats.failures,
+      passes: run.stats.passes,
+      pending: run.stats.pending,
+      skipped: run.stats.skipped,
+      startedAt: run.stats.wallClockStartedAt,
+      suites: run.stats.suites,
+      tests: run.stats.tests,
+    },
+    tests: _.map(run.tests, createPublicTest),
+    video: run.video,
+  }
+}
 
 /**
  * Normalize browser object to remove private props and make it more consistent
@@ -196,26 +200,28 @@ export const createPublicConfig = (config: Cfg): CypressCommandLine.PublicConfig
  * Normalize results for module API/after:run to remove private props and make
  * them more consistent and user-friendly
  */
-export const createPublicRunResults = (results: CypressRunResult): CypressCommandLine.CypressRunResult => ({
-  browserName: results.browserName,
-  browserPath: results.browserPath,
-  browserVersion: results.browserVersion,
-  config: createPublicConfig(results.config),
-  cypressVersion: results.cypressVersion,
-  endedTestsAt: results.endedTestsAt,
-  osName: results.osName,
-  osVersion: results.osVersion,
-  runs: _.map(results.runs, createPublicRun),
-  runUrl: results.runUrl,
-  startedTestsAt: results.startedTestsAt,
-  totalDuration: results.totalDuration,
-  totalFailed: results.totalFailed,
-  totalPassed: results.totalPassed,
-  totalPending: results.totalPending,
-  totalSkipped: results.totalSkipped,
-  totalSuites: results.totalSuites,
-  totalTests: results.totalTests,
-})
+export const createPublicRunResults = (results: CypressRunResult): CypressCommandLine.CypressRunResult => {
+  return {
+    browserName: results.browserName,
+    browserPath: results.browserPath,
+    browserVersion: results.browserVersion,
+    config: createPublicConfig(results.config),
+    cypressVersion: results.cypressVersion,
+    endedTestsAt: results.endedTestsAt,
+    osName: results.osName,
+    osVersion: results.osVersion,
+    runs: _.map(results.runs, createPublicRun),
+    runUrl: results.runUrl,
+    startedTestsAt: results.startedTestsAt,
+    totalDuration: results.totalDuration,
+    totalFailed: results.totalFailed,
+    totalPassed: results.totalPassed,
+    totalPending: results.totalPending,
+    totalSkipped: results.totalSkipped,
+    totalSuites: results.totalSuites,
+    totalTests: results.totalTests,
+  }
+}
 
 /**
  * Normalize spec object to remove private props and make it more consistent

--- a/packages/server/test/unit/cloud/bundles/stream_download_verify_extract_spec.ts
+++ b/packages/server/test/unit/cloud/bundles/stream_download_verify_extract_spec.ts
@@ -138,11 +138,13 @@ describe('streamDownloadVerifyExtract', () => {
     it('wraps a filesystem-class syscall (ENOSPC) from the pipeline as BundleError(stage=extract) and does NOT retry', async () => {
       const enospc = Object.assign(new Error('no space left on device'), { code: 'ENOSPC', errno: -28 })
 
-      const makeBody = () => new Readable({
-        read () {
-          this.destroy(enospc)
-        },
-      })
+      const makeBody = () => {
+        return new Readable({
+          read () {
+            this.destroy(enospc)
+          },
+        })
+      }
 
       const response = {
         ok: true,
@@ -181,11 +183,13 @@ describe('streamDownloadVerifyExtract', () => {
     it('still treats network-class syscalls (ECONNRESET) mid-pipeline as stage=network and retries', async () => {
       const econnreset = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET', errno: -54 })
 
-      const makeBody = () => new Readable({
-        read () {
-          this.destroy(econnreset)
-        },
-      })
+      const makeBody = () => {
+        return new Readable({
+          read () {
+            this.destroy(econnreset)
+          },
+        })
+      }
 
       const response = {
         ok: true,

--- a/packages/server/test/unit/cloud/studio/studio_spec.ts
+++ b/packages/server/test/unit/cloud/studio/studio_spec.ts
@@ -83,9 +83,11 @@ describe('lib/cloud/studio', () => {
         '../api/studio/report_studio_error': { reportStudioError: sinon.stub() },
         './StudioElectron': { StudioElectron: class {} },
         '../require_script': {
-          requireScript: () => ({
-            default: { createStudioServer: createStudioServerStub },
-          }),
+          requireScript: () => {
+            return {
+              default: { createStudioServer: createStudioServerStub },
+            }
+          },
         },
       }) as typeof import('@packages/server/lib/cloud/studio/studio')).StudioManager
 
@@ -123,9 +125,11 @@ describe('lib/cloud/studio', () => {
         '../api/studio/report_studio_error': { reportStudioError: sinon.stub() },
         './StudioElectron': { StudioElectron: class {} },
         '../require_script': {
-          requireScript: () => ({
-            default: { createStudioServer: createStudioServerStub },
-          }),
+          requireScript: () => {
+            return {
+              default: { createStudioServer: createStudioServerStub },
+            }
+          },
         },
       }) as typeof import('@packages/server/lib/cloud/studio/studio')).StudioManager
 

--- a/packages/server/test/unit/routes_spec.ts
+++ b/packages/server/test/unit/routes_spec.ts
@@ -26,9 +26,11 @@ describe('lib/routes', () => {
           namespace: 'namespace',
         } as Cfg,
         getSpec: sinon.stub().returns({}),
-        getNetworkProxy: () => ({
-          handleHttpRequest: () => {},
-        } as unknown as NetworkProxy),
+        getNetworkProxy: () => {
+          return {
+            handleHttpRequest: () => {},
+          } as unknown as NetworkProxy
+        },
         nodeProxy: {} as HttpProxy,
         onError: () => {},
         // @ts-expect-error
@@ -308,9 +310,11 @@ describe('lib/routes', () => {
           namespace: '__cypress',
         } as Cfg,
         getSpec: sinon.stub().returns({}),
-        getNetworkProxy: () => ({
-          handleHttpRequest: () => {},
-        } as unknown as NetworkProxy),
+        getNetworkProxy: () => {
+          return {
+            handleHttpRequest: () => {},
+          } as unknown as NetworkProxy
+        },
         nodeProxy: {} as HttpProxy,
         onError: () => {},
         // @ts-expect-error

--- a/packages/server/test/unit/util/graceful_exit_spec.ts
+++ b/packages/server/test/unit/util/graceful_exit_spec.ts
@@ -323,9 +323,11 @@ describe('lib/util/graceful-exit', () => {
 
     try {
       // rejects after its own bound expires, when flushSteps is no longer awaiting it
-      GracefulExit.addStep(() => new Promise((_resolve, reject) => {
-        setTimeout(() => reject(new Error('late teardown failure')), 150)
-      }), 'rejects-after-its-bound')
+      GracefulExit.addStep(() => {
+        return new Promise((_resolve, reject) => {
+          setTimeout(() => reject(new Error('late teardown failure')), 150)
+        })
+      }, 'rejects-after-its-bound')
 
       await GracefulExit.exitGracefully(0)
 


### PR DESCRIPTION
- Closes N/A

### Additional details

`yarn lint` reported 28 `@cypress/dev/arrow-body-multiline-braces` warnings. Each one is a multiline arrow function that returned an expression instead of using a block body. This clears all of them, then raises the rule from `warn` to `error` so new ones cannot land.

**Why now:** the rule sat at `warn` only because these sites predated it. `packages/eslint-config/src/baseConfig.ts` carried a note saying to raise it to `error` once they were cleaned up — that precondition is now met. The eslintrc preset in `@cypress/eslint-plugin-dev` already used `error`, so the two configs now agree rather than diverge.

The two commits are kept separate so the severity change can be reverted or split off independently of the cleanup.

**Commit 1 — `ecea870`, the cleanup (28 warnings, 19 files).** Every change is the same mechanical shape, an expression body becoming a block body with an explicit `return`, so none of it can alter behavior:

| Package | Before | After |
|---|---|---|
| `cypress` (cli) | 118 warnings | 102 (−16) |
| `@packages/server` | 48 warnings | 36 (−12) |
| `@cypress/webpack-batteries-included-preprocessor` | 1 warning | 0 (−1) |

**Commit 2 — `b29d0c1`, the severity flip.** One line in `packages/eslint-config/src/baseConfig.ts`. The stale comment explaining the `warn` is removed rather than updated, per the `AGENTS.md` convention that comments describe present state.

Note this rule is `off` for `.jsx/.tsx` but **on** for `.vue`. That override is untouched, but it means the Vue files recently brought into scope by #34830 are now held to the rule strictly. They are clean today.

### Steps to test

`yarn lint` — passes across all 46 projects with 0 errors.

To confirm the severity change is load-bearing rather than inert, add a multiline arrow with an expression body to any `.ts` file on the flat config and lint it; it reports `error` and exits 1.

### How has the user experience changed?

No change. This is a lint-only refactor with no runtime effect.

One CI-facing change worth flagging for reviewers: `linux-lint` now **fails** on a violation of this rule instead of passing with a warning.

### PR Tasks

- [na] Is there an associated issue with maintainer approval for PR submission? <!-- Purely mechanical lint cleanup with no behavior change, per the template's exemption for mechanical changes. -->
- [na] Have tests been added/updated? <!-- No behavior change to cover. Existing suites were run to confirm nothing regressed: server unit 124 passing, cli 990 passing, webpack-batteries-included-preprocessor 37/37. -->
- [na] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- No user-facing change. -->
- [na] Have API changes been updated in the [`type definitions`](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts)? <!-- No API change. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVTdyMDnUtKr3eFR4ThnHG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVTdyMDnUtKr3eFR4ThnHG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only formatting refactors with no runtime logic changes; the only operational impact is stricter CI lint failure on future violations.
> 
> **Overview**
> This PR clears existing `@cypress/dev/arrow-body-multiline-braces` violations and **tightens enforcement** so multiline arrow functions must use block bodies with an explicit `return` instead of expression bodies.
> 
> Across **cli** (tap commands like `extractDom` / `extractInspect`, render helpers, telemetry), **@packages/server** (loopback middleware, public run results shaping, `digestBody`), and related **tests/mocks**, the change is the same mechanical rewrite—no intended behavior change.
> 
> In `packages/eslint-config/src/baseConfig.ts`, the rule goes from **`warn` to `error`** (still **off** for `.jsx`/`.tsx`). **`linux-lint` will fail** on new violations rather than passing with warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29d0c1718c35b0cf247c2f64a2dc9e5eaa771da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->